### PR TITLE
Handle 2-phase saltboot minions registration

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/ApplyStatesEventMessage.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/ApplyStatesEventMessage.java
@@ -37,7 +37,9 @@ public class ApplyStatesEventMessage implements EventDatabaseMessage {
     public static final String CHANNELS_DISABLE_LOCAL_REPOS = "channels.disablelocalrepos";
     public static final String SALT_MINION_SERVICE = "services.salt-minion";
     public static final String SYNC_CUSTOM_ALL = "util.synccustomall";
+    public static final String SYNC_STATES = "util.syncstates";
     public static final String DISTUPGRADE = "distupgrade";
+    public static final String SALTBOOT = "saltboot";
 
     private final long serverId;
     private final Long userId;

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -171,6 +171,7 @@ public class RegisterMinionEventMessageAction extends AbstractDatabaseAction {
         //in so many places.
         String machineId = optMachineId.get();
         MinionServer minionServer;
+        Optional<User> creator = MinionPendingRegistrationService.getCreator(minionId);
 
         Optional<MinionServer> optMinion = MinionServerFactory.findByMachineId(machineId);
         if (optMinion.isPresent()) {
@@ -211,7 +212,7 @@ public class RegisterMinionEventMessageAction extends AbstractDatabaseAction {
                     }
                     else if (imageRedeployed) {
                         LOG.info("Finishing registration for minion " + minionId);
-                        finishRegistration(registeredMinion, empty(), empty(), !isSaltSSH);
+                        finishRegistration(registeredMinion, empty(), creator, !isSaltSSH);
                     }
                 });
             }
@@ -249,8 +250,6 @@ public class RegisterMinionEventMessageAction extends AbstractDatabaseAction {
                     activationKeyOverride : activationKeyFromGrains;
             Optional<ActivationKey> activationKey = activationKeyLabel
                     .map(ActivationKeyFactory::lookupByKey);
-
-            Optional<User> creator = MinionPendingRegistrationService.getCreator(minionId);
 
             org = activationKey.map(ActivationKey::getOrg)
                     .orElse(creator.map(User::getOrg)

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -413,7 +413,6 @@ public class RegisterMinionEventMessageAction extends AbstractDatabaseAction {
         String hwType = "HWTYPE:" + manufacturer.get() + "-" + productName.get();
         Optional<String> branchId = grains.getOptionalAsString("minion_id_prefix");
 
-        // todo org, user
         // todo rewrite
         lookupManagedServerGroupByNameAndOrg(hwType, org).ifPresent(sg -> {
             LOG.debug("Adding retail system + '" + minionId + " to group '" + sg + "'.");

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -202,15 +202,14 @@ public class RegisterMinionEventMessageAction extends AbstractDatabaseAction {
                     // otherwise the image has been already fully deployed and we want to finalize the registration
                     LOG.info("\"initrd\" present for minion " + minionId);
 
-                    // TODO this is to be implemented in the future
-                    // for now we don't have any means to detect if the image has been redeployed and we simply
-                    // call the 'finishRegistration' on every minion start
-                    boolean imageRedeployed = true;
                     if (initrd) {
                         LOG.info("Applying saltboot for minion " + minionId);
                         applySaltboot(registeredMinion);
                     }
-                    else if (imageRedeployed) {
+                    else {
+                        // TODO this is to be implemented in the future
+                        // for now we don't have any means to detect if the image has been redeployed and we simply
+                        // call the 'finishRegistration' on every minion start
                         LOG.info("Finishing registration for minion " + minionId);
                         finishRegistration(registeredMinion, empty(), creator, !isSaltSSH);
                     }

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -18,7 +18,6 @@ import static com.suse.manager.webui.controllers.utils.ContactMethodUtil.isSSHPu
 import static java.util.Optional.empty;
 import static java.util.Optional.ofNullable;
 
-import com.google.gson.reflect.TypeToken;
 import com.redhat.rhn.common.messaging.EventMessage;
 import com.redhat.rhn.common.messaging.MessageQueue;
 import com.redhat.rhn.common.util.RpmVersionComparator;
@@ -53,7 +52,6 @@ import com.redhat.rhn.domain.state.VersionConstraints;
 import com.redhat.rhn.domain.token.ActivationKey;
 import com.redhat.rhn.domain.token.ActivationKeyFactory;
 import com.redhat.rhn.domain.user.User;
-import com.redhat.rhn.frontend.dto.ActionMessage;
 import com.redhat.rhn.frontend.dto.EssentialChannelDto;
 import com.redhat.rhn.frontend.events.AbstractDatabaseAction;
 import com.redhat.rhn.manager.action.ActionManager;
@@ -69,7 +67,6 @@ import com.suse.manager.webui.services.SaltStateGeneratorService;
 import com.suse.manager.webui.services.impl.MinionPendingRegistrationService;
 import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.utils.salt.custom.PkgProfileUpdateSlsResult;
-import com.suse.salt.netapi.calls.LocalCall;
 import com.suse.salt.netapi.calls.modules.State;
 import com.suse.salt.netapi.calls.modules.Zypper;
 import com.suse.salt.netapi.calls.modules.Zypper.ProductInfo;

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -112,6 +112,8 @@ public class RegisterMinionEventMessageAction extends AbstractDatabaseAction {
                "osad")
     );
 
+    private static final String TERMINALS_GROUP_NAME = "TERMINALS";
+
     /**
      * Default constructor.
      */
@@ -395,7 +397,7 @@ public class RegisterMinionEventMessageAction extends AbstractDatabaseAction {
     private boolean isRetailMinion(MinionServer registeredMinion) {
         // for now, a retail minion is detected when it belongs to a compulsory "TERMINALS" group
         return registeredMinion.getManagedGroups().stream()
-                .anyMatch(group -> group.getName().equals("TERMINALS"));
+                .anyMatch(group -> group.getName().equals(TERMINALS_GROUP_NAME));
     }
 
     /**
@@ -419,15 +421,14 @@ public class RegisterMinionEventMessageAction extends AbstractDatabaseAction {
 
         String hwType = "HWTYPE:" + manufacturer.get() + "-" + productName.get();
 
-        String terminalsGroupName = "TERMINALS";
         String branchIdGroupName = branchId.get();
-        ManagedServerGroup terminalsGroup = ServerGroupFactory.lookupByNameAndOrg(terminalsGroupName, org);
+        ManagedServerGroup terminalsGroup = ServerGroupFactory.lookupByNameAndOrg(TERMINALS_GROUP_NAME, org);
         ManagedServerGroup branchIdGroup = ServerGroupFactory.lookupByNameAndOrg(branchIdGroupName, org);
         ManagedServerGroup hwGroup = ServerGroupFactory.lookupByNameAndOrg(hwType, org);
 
         if (terminalsGroup == null || branchIdGroup == null) {
-            throw new IllegalStateException("Missing required server groups (\"TERMINALS\" or \"" + branchIdGroupName +
-                    "\")! Aborting registration.");
+            throw new IllegalStateException("Missing required server groups (\"" + TERMINALS_GROUP_NAME + "\" or \"" +
+                    branchIdGroupName + "\")! Aborting registration.");
         }
 
         SystemManager.addServerToServerGroup(minion, terminalsGroup);

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -199,7 +199,7 @@ public class RegisterMinionEventMessageAction extends AbstractDatabaseAction {
             // todo don't get grains all the time!
             // todo maybe also check if minion is in a HW group and fail the process if it isn't
             ValueMap grains = new ValueMap(SALT_SERVICE.getGrains(minionId).orElseGet(HashMap::new));
-            if (grains.getOptionalAsBoolean("initrd")
+            if (grains.getOptionalAsBoolean("initrd") // todo extract string (maybe rename?), also in tests!
                     .map(initrd -> initrd == false)
                     .orElse(false)) {
                 LOG.info("POS registration: Finishing registration for minion " + minionId);
@@ -388,8 +388,8 @@ public class RegisterMinionEventMessageAction extends AbstractDatabaseAction {
                 LocalCall<List<String>> call = new LocalCall<>("saltutil.sync_states", Optional.empty(), // todo async!
                         Optional.empty(), new TypeToken<List<String>>() {
                 });
-                SaltService.INSTANCE.callSync(call, minionId);
-                SaltService.INSTANCE.applyState(minionId, "saltboot"); // todo do this async!
+                SALT_SERVICE.callSync(call, minionId);
+                SALT_SERVICE.applyState(minionId, "saltboot"); // todo do this async!
 
                 LOG.info("Finished initial POS registration for minion " + minionId);
                 return;

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -507,12 +507,6 @@ public class RegisterMinionEventMessageAction extends AbstractDatabaseAction {
         }
     }
 
-    private static Optional<ManagedServerGroup> lookupManagedServerGroupByNameAndOrg(String name, Org org) {
-        return ServerGroupFactory.listManagedGroups(org).stream()
-                .filter(grp -> grp.getName().equals(name))
-                .findFirst();
-    }
-
     /**
      * If exists, migrate a traditional Server instance to MinionServer.
      * Otherwise return a new MinionServer instance.

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -200,11 +200,16 @@ public class RegisterMinionEventMessageAction extends AbstractDatabaseAction {
                     // if we have the "initrd" grain we want to re-deploy an image via saltboot,
                     // otherwise the image has been already fully deployed and we want to finalize the registration
                     LOG.info("\"initrd\" present for minion " + minionId);
+
+                    // TODO this is to be implemented in the future
+                    // for now we don't have any means to detect if the image has been redeployed and we simply
+                    // call the 'finishRegistration' on every minion start
+                    boolean imageRedeployed = true;
                     if (initrd) {
-                        // todo verify that saltboot is defensive and checks for partitioning pillar
                         LOG.info("Applying saltboot for minion " + minionId);
                         applySaltboot(registeredMinion);
-                    } else if (imageRedeployed()) { // todo ask Vladimir how to find out an image has been redeployed
+                    }
+                    else if (imageRedeployed) {
                         LOG.info("Finishing registration for minion " + minionId);
                         finishRegistration(registeredMinion, empty(), empty(), isSaltSSH); // todo take care about the optional params
                     }
@@ -442,10 +447,6 @@ public class RegisterMinionEventMessageAction extends AbstractDatabaseAction {
         states.add(ApplyStatesEventMessage.SALTBOOT);
 
         MessageQueue.publish(new ApplyStatesEventMessage(minion.getId(), false, states));
-    }
-
-    private boolean imageRedeployed() {
-        return true;
     }
 
     /**

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -359,7 +359,7 @@ public class RegisterMinionEventMessageAction extends AbstractDatabaseAction {
 
             // Saltboot treatment - prepare and apply saltboot
             if (isNewMinion && grains.getOptionalAsBoolean("initrd").orElse(false)) {
-                prepareRetailMinionForSaltboot(minionId, minionServer, org, grains);
+                prepareRetailMinionForSaltboot(minionServer, org, grains);
                 applySaltboot(minionServer);
                 LOG.info("Applying saltboot for minion " + minionId);
                 return;
@@ -400,13 +400,11 @@ public class RegisterMinionEventMessageAction extends AbstractDatabaseAction {
      *  - assign needed groups
      *  - generate pillar
      *
-     * @param minionId - the minion id
-     * @param minionServer - the minion
-     * @param org - the org
+     * @param minion - the minion
+     * @param org - the organization in which minion is to be registered
      * @param grains - grains
      */
-    // todo org param needed ? mId needed?
-    private void prepareRetailMinionForSaltboot(String minionId, MinionServer minionServer, Org org, ValueMap grains) {
+    private void prepareRetailMinionForSaltboot(MinionServer minion, Org org, ValueMap grains) {
         Optional<String> manufacturer = grains.getOptionalAsString("manufacturer");
         Optional<String> productName = grains.getOptionalAsString("productname");
         Optional<String> branchId = grains.getOptionalAsString("minion_id_prefix");
@@ -429,14 +427,13 @@ public class RegisterMinionEventMessageAction extends AbstractDatabaseAction {
                     "\")! Aborting registration.");
         }
 
-        SystemManager.addServerToServerGroup(minionServer, terminalsGroup);
-        SystemManager.addServerToServerGroup(minionServer, branchIdGroup);
+        SystemManager.addServerToServerGroup(minion, terminalsGroup);
+        SystemManager.addServerToServerGroup(minion, branchIdGroup);
         if (hwGroup != null) {
-            SystemManager.addServerToServerGroup(minionServer, hwGroup);
+            SystemManager.addServerToServerGroup(minion, hwGroup);
         }
 
-        minionServer.asMinionServer().ifPresent(
-                SaltStateGeneratorService.INSTANCE::generatePillar);
+        minion.asMinionServer().ifPresent(SaltStateGeneratorService.INSTANCE::generatePillar);
     }
 
     private void applySaltboot(MinionServer minion) {

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -416,17 +416,17 @@ public class RegisterMinionEventMessageAction extends AbstractDatabaseAction {
         // todo org, user
         // todo rewrite
         lookupManagedServerGroupByNameAndOrg(hwType, org).ifPresent(sg -> {
+            LOG.debug("Adding retail system + '" + minionId + " to group '" + sg + "'.");
             SystemManager.addServerToServerGroup(minionServer, sg);
-            LOG.debug("Retail minion registration: system profile " + minionId + " added to HW group " + sg);
         });
         lookupManagedServerGroupByNameAndOrg("TERMINALS", org).ifPresent(sg -> {
+            LOG.debug("Adding retail system + '" + minionId + " to group '" + sg + "'.");
             SystemManager.addServerToServerGroup(minionServer, sg);
-            LOG.debug("Retail minion registration: system profile " + minionId + " added to HW group " + sg);
         });
         branchId.ifPresent(bid ->
                 lookupManagedServerGroupByNameAndOrg(bid, org).ifPresent(sg -> {
+                    LOG.debug("Adding retail system + '" + minionId + " to group '" + sg + "'.");
                     SystemManager.addServerToServerGroup(minionServer, sg);
-                    LOG.debug("Retail minion registration: system profile " + minionId + " added to HW group " + sg);
                 }));
 
         minionServer.asMinionServer().ifPresent(

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -363,9 +363,9 @@ public class RegisterMinionEventMessageAction extends AbstractDatabaseAction {
 
             // Saltboot treatment - prepare and apply saltboot
             if (isNewMinion && grains.getOptionalAsBoolean("initrd").orElse(false)) {
+                LOG.info("\"initrd\" grain set to true: Preparing & applying saltboot for minion " + minionId);
                 prepareRetailMinionForSaltboot(minionServer, org, grains);
                 applySaltboot(minionServer);
-                LOG.info("Applying saltboot for minion " + minionId);
                 return;
             }
 

--- a/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
@@ -938,7 +938,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
      * @throws Exception - if anything goes wrong
      */
     public void testRegisterRetailTerminal() throws Exception {
-        ManagedServerGroup hwGroup = ServerGroupFactory.create("HWTYPE:QEMU-EETCruncher", "HW group",
+        ManagedServerGroup hwGroup = ServerGroupFactory.create("HWTYPE:QEMU-CashDesk01", "HW group",
                 OrgFactory.getSatelliteOrg());
         ManagedServerGroup terminalsGroup = ServerGroupFactory.create("TERMINALS", "All terminals group",
                 OrgFactory.getSatelliteOrg());
@@ -958,7 +958,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                             .map(map -> {
                                 map.put("initrd", true);
                                 map.put("manufacturer", "QEMU");
-                                map.put("productname", "EETCruncher");
+                                map.put("productname", "CashDesk01");
                                 map.put("minion_id_prefix", "Branch001");
                                 return map;
                             })));
@@ -978,12 +978,12 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
     }
 
     /**
-     * Tests a first boot of a deployed terminal machine
+     * Tests a first boot of a deployed retail minion
      *
      * @throws Exception - if anything goes wrong
      */
     public void testFirstStartRetailTerminal() throws Exception {
-        ManagedServerGroup hwGroup = ServerGroupFactory.create("HWTYPE:QEMU-EETCruncher", "HW group",
+        ManagedServerGroup hwGroup = ServerGroupFactory.create("HWTYPE:QEMU-CashDesk02", "HW group",
                 OrgFactory.getSatelliteOrg());
         ManagedServerGroup terminalsGroup = ServerGroupFactory.create("TERMINALS", "All terminals group",
                 OrgFactory.getSatelliteOrg());
@@ -1010,7 +1010,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                             .map(map -> {
                                 map.put("initrd", false);
                                 map.put("manufacturer", "QEMU");
-                                map.put("productname", "EETCruncher");
+                                map.put("productname", "CashDesk02");
                                 map.put("minion_id_prefix", "Branch001");
                                 return map;
                             })));
@@ -1032,13 +1032,13 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
 
 
     /**
-     * Tests a redeploy of a terminal
+     * Tests a redeploy of a retail minion
      * (initrd grain == true, but the system profile already exists)
      *
      * @throws Exception - if anything goes wrong
      */
     public void testTerminalRedeploy() throws Exception {
-        ManagedServerGroup hwGroup = ServerGroupFactory.create("HWTYPE:QEMU-EETCruncher", "HW group",
+        ManagedServerGroup hwGroup = ServerGroupFactory.create("HWTYPE:QEMU-CashDesk03", "HW group",
                 OrgFactory.getSatelliteOrg());
         ManagedServerGroup terminalsGroup = ServerGroupFactory.create("TERMINALS", "All terminals group",
                 OrgFactory.getSatelliteOrg());
@@ -1065,7 +1065,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                             .map(map -> {
                                 map.put("initrd", true);
                                 map.put("manufacturer", "QEMU");
-                                map.put("productname", "EETCruncher");
+                                map.put("productname", "CashDesk03");
                                 map.put("minion_id_prefix", "Branch001");
                                 return map;
                             })));

--- a/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
@@ -965,7 +965,6 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                     allowing(saltServiceMock).callSync(
                             with(any(LocalCall.class)),
                             with(any(String.class)));
-                    exactly(1).of(saltServiceMock).applyState(MINION_ID, "saltboot");
                 }},
                 (contactMethod) -> null, // no AK
                 (optMinion, machineId, key) -> {
@@ -1013,7 +1012,6 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                         allowing(saltServiceMock).callSync(
                                 with(any(LocalCall.class)),
                                 with(any(String.class)));
-                        exactly(1).of(saltServiceMock).applyState(MINION_ID, "saltboot");
                     }},
                     (contactMethod) -> null, // no AK
                     (optMinion, machineId, key) -> {
@@ -1106,58 +1104,6 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                 },
                 null,
                 DEFAULT_CONTACT_METHOD);
-    }
-
-
-    /**
-     * Tests a redeploy of a retail minion
-     * (initrd grain == true, but the system profile already exists)
-     *
-     * @throws Exception - if anything goes wrong
-     */
-    public void testTerminalRedeploy() throws Exception {
-        ManagedServerGroup hwGroup = ServerGroupFactory.create("HWTYPE:QEMU-CashDesk03", "HW group",
-                OrgFactory.getSatelliteOrg());
-        ManagedServerGroup terminalsGroup = ServerGroupFactory.create("TERMINALS", "All terminals group",
-                OrgFactory.getSatelliteOrg());
-        ManagedServerGroup branchGroup = ServerGroupFactory.create("Branch001", "Branch group",
-                OrgFactory.getSatelliteOrg());
-        MinionServer server = MinionServerFactoryTest.createTestMinionServer(user);
-        server.setMinionId(MINION_ID);
-        server.setOrg(OrgFactory.getSatelliteOrg());
-        SystemManager.addServerToServerGroup(server, hwGroup);
-        SystemManager.addServerToServerGroup(server, terminalsGroup);
-        SystemManager.addServerToServerGroup(server, branchGroup);
-
-        executeTest(
-                (saltServiceMock, key) -> new Expectations() {{
-                    server.setMachineId(MACHINE_ID);
-                    allowing(saltServiceMock).getMasterHostname(MINION_ID);
-                    will(returnValue(Optional.of(MINION_ID)));
-                    allowing(saltServiceMock).getMachineId(MINION_ID);
-                    will(returnValue(Optional.of(MACHINE_ID)));
-                    allowing(saltServiceMock).syncGrains(with(any(MinionList.class)));
-                    allowing(saltServiceMock).syncModules(with(any(MinionList.class)));
-                    allowing(saltServiceMock).getGrains(MINION_ID);
-                    will(returnValue(getGrains(MINION_ID, null, "non-existent-key")
-                            .map(map -> {
-                                map.put("initrd", true);
-                                map.put("manufacturer", "QEMU");
-                                map.put("productname", "CashDesk03");
-                                map.put("minion_id_prefix", "Branch001");
-                                return map;
-                            })));
-                    List<ProductInfo> pil = new ArrayList<>();
-                    allowing(saltServiceMock).callSync(
-                            with(any(LocalCall.class)),
-                            with(any(String.class)));
-                    exactly(1).of(saltServiceMock).applyState(MINION_ID, "saltboot");
-                    will(returnValue(Optional.of(pil)));
-                }},
-                (contactMethod) -> null, // no AK
-                (optMinion, machineId, key) -> {
-                    // nothing to check here, we only check that "saltboot" state was applied in the expectations
-                }, DEFAULT_CONTACT_METHOD);
     }
 
     private Channel setupBaseAndRequiredChannels(ChannelFamily channelFamily,

--- a/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
@@ -930,8 +930,6 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         );
     }
 
-    // Retail tests below (todo extract them to a separate file, some test refactoring will be needed)
-
     /**
      * Initial test of a registering a terminal machine
      *
@@ -1215,7 +1213,6 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                     assertEquals(1, ActionFactory.listServerActionsForServer(minion).stream()
                                     .filter(sa -> ((ServerAction) sa).getParentAction().getActionType().equals(ActionFactory.TYPE_HARDWARE_REFRESH_LIST))
                                     .count());
-                    // todo research how to test a MessageQueue - i think there is currently nothing more to test here :/
                 },
                 null,
                 DEFAULT_CONTACT_METHOD);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Implement the 2-phase registration of saltbooted minions (SUMA for Retail)
 - Avoid an NPE on expired tokens (bsc#1104503)
 - Generate systemid certificate on suse/systemid/generate event (FATE#323069)
 - Fix system group overview patch status (bsc#1102478)

--- a/susemanager-utils/susemanager-sls/salt/util/syncstates.sls
+++ b/susemanager-utils/susemanager-sls/salt/util/syncstates.sls
@@ -1,0 +1,4 @@
+sync_states:
+  module.run:
+      - name: saltutil.sync_states
+

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- Implement the 2-phase registration of saltbooted minions (SUMA for Retail)
+
 -------------------------------------------------------------------
 Fri Aug 10 15:45:45 CEST 2018 - jgonzalez@suse.com
 


### PR DESCRIPTION
# What is this about?

For *SUMA for Retail* purposes we need to handle registration of "saltbooted" minions (aka minions which are booted via PXE, provisioned using `saltboot` state (partitions, image deployment, initial registration).

Registration of a saltbooted minion has 2 phases (in both of them salt-minion service is started):
- in the 1st one the salt-minion is running in rather limited environment (PXE booted into `linuxrc`, no partitions are mounted at this moment) and not all registration steps can be performed (e.g. refresh software is impossible to do)
- in the 2nd one the system is fully provisioned and the "leftover tasks" (refresh SW, HW...) can be performed

In past the saltboot-related behavior has been handled by a series of python reactors written by the Retail team. It turns out the this approach is not powerful enough to integrate the saltbooted minions (e.g. cash registers in the Retail scenario) in SUSE Manager (race conditions, need to use orchestration states that talk to SUMA via API).

This PR implements the handling of saltbooted minions in the Java reactor (https://etherpad.nue.suse.com/p/suma-image-boot).

More on this here: https://etherpad.nue.suse.com/p/suma-image-boot

In the moment the code is partially Retail-specific (registering a saltbooted minion assumes existence of at least 2 special server groups (branch group and a group with name `TERMINALS` in the organization in which minion is being registered). This assumption can be removed in the future to handle more general cases (autoinstallation?).

The PR extracts the code for "finishing registration" (HW refresh, SW refresh, applying channels etc.) to a separate method which is skipped for the initial boot of a saltbooted minion. It is invoked on the consecutive boots of it. The behavior doesn't affect normal (non-retail, non-saltboot) minions.

## Note for the Retail team
In order for this to work, parts of the "retail" salt reactor (python) needs to be disabled. The only part that still needs to be enabled is the `pxe_update` event handling.

## TODO
- [x] Rename the POS and retail in the PR to something more generic (saltboot?) - the code is not retail-specific!
- [x] Clarify the organization-related code (to which org the machines should register? (use the `creator` user - aka the user who accepts the minion from the web UI, it case like auto-accept, the default (`Satellite`) org is used)
- [x] Don't get grains every time for normal ("non-saltboot") minions
- [x] Implement the group assignment behavior as suggested in the discussion: assign minion to:
  - branch group, if it doesn't exist -> error
  - default group (`TERMINALS`?), if it doesn't exist -> error
  - HW group, if it doesn't exist -> ignore (maybe log)
- [x] Apply `saltboot` asynchronously
- [x] Javadocs
- [x] Get rid of all remaining TODOs in the code
- [x] Explore reacting to custom events in Java reactor (works for me)
- [x] Explore how to test `MessageQueue` - research done (preferred approach: make `MessageQueue` mockable, discussion pending on galaxy-devel ML)
- [x] Nice to have: Research about testing `MessageQueue` effect + reintroduce 
- [x] ~Activation key handling (it's rather over-complicated in the `registerMinion` method)~
- [x] ~Extraction of tests~
- [x] ~Image re-deployment detection (either grain or custom evt)~ separate PR will be made
- [x] ~Think about refactoring the code so that the handler is not so long/complex~

## GUI diff

No difference.

- [x] **DONE**

## Documentation
No uyuni doc repo.

- [x] **DONE**

## Test coverage
- Unit tests were added
- ~Cucumber tests were added~ our testsuite environment is not ready for that.

- [x] **DONE**
