### PR TITLE
Testsuite: remove docker scalability tests

### DIFF
--- a/testsuite/features/min_docker_build_image.feature
+++ b/testsuite/features/min_docker_build_image.feature
@@ -9,11 +9,11 @@ Feature: Build container images
   Scenario: Build the images with and without activation key
     Given I am on the Systems overview page of this "sle-minion"
     When I schedule the build of image "suse_key" via XML-RPC calls
-    Then I wait at most 300 seconds until event "Image Build suse_key scheduled by admin" is completed
+    Then I wait until event "Image Build suse_key scheduled by admin" is completed
     When I schedule the build of image "suse_simple" via XML-RPC calls
-    Then I wait at most 300 seconds until event "Image Build suse_simple scheduled by admin" is completed
+    Then I wait until event "Image Build suse_simple scheduled by admin" is completed
     When I schedule the build of image "suse_real_key" via XML-RPC calls
-    Then I wait at most 300 seconds until event "Image Build suse_real_key scheduled by admin" is completed
+    Then I wait until event "Image Build suse_real_key scheduled by admin" is completed
 
   Scenario: Build same images with different versions
     Given I am authorized as "admin" with password "admin"

--- a/testsuite/features/min_docker_xmlrpc.feature
+++ b/testsuite/features/min_docker_xmlrpc.feature
@@ -7,26 +7,9 @@ Feature: XML-RPC image namespace for containers
     Given I am authorized as "admin" with password "admin"
     Then I run image.store tests via XML-RPC
 
-  Scenario: Scalability tests for image store
-    Given I am authorized as "admin" with password "admin"
-    Then I create "500" random image stores
-    And I follow "Images" in the left menu
-    And I follow "Stores" in the left menu
-    Then I should see a "Registry" text
-
   Scenario: Test image.profiles namespace
     Given I am authorized as "admin" with password "admin"
     Then I run image.profiles tests via XML-RPC
-
-  Scenario: Cleanup image namespace tests
-    Given I am authorized as "admin" with password "admin"
-    Then I delete the random image stores
-
-  Scenario: Create and build multiple random images
-    Given I am authorized as "admin" with password "admin"
-    Then I create "5" random "suse_real_key" containers
-    And I wait for "240" seconds
-    And I wait until no Salt job is running on "sle-minion"
 
   Scenario: Cleanup: remove custom system info key
     Given I am authorized as "admin" with password "admin"

--- a/testsuite/features/step_definitions/docker_steps.rb
+++ b/testsuite/features/step_definitions/docker_steps.rb
@@ -4,7 +4,6 @@
 require 'xmlrpc/client'
 require 'time'
 require 'date'
-require 'securerandom'
 require 'timeout'
 
 # this module test image_profile
@@ -210,35 +209,5 @@ And(/^I run image.store tests via XML-RPC$/) do
   cont_op.delete_store('Norimberga')
 end
 
-And(/^I create "([^"]*)" random image stores$/) do |count|
-  cont_op.login('admin', 'admin')
-  $labels = []
-  count.to_i.times do
-    label = SecureRandom.urlsafe_base64(10)
-    $labels.push(label)
-    uri = SecureRandom.urlsafe_base64(13)
-    cont_op.create_store(label, uri, 'registry')
-  end
-end
-
-And(/^I delete the random image stores$/) do
-  cont_op.login('admin', 'admin')
-  $labels.each do |label|
-    cont_op.delete_store(label)
-  end
-end
-
 # Profiles tests using module
 And(/^I run image.profiles tests via XML-RPC$/, :image_profiles_xmlrpc)
-
-Then(/I create "([^"]*)" random "([^"]*)" containers$/) do |count, image_input|
-  cont_op.login('admin', 'admin')
-  image = image_input
-  build_hostid = retrieve_minion_id
-  count.to_i.times do
-    version_build = SecureRandom.urlsafe_base64(10)
-    now = DateTime.now
-    date_build = XMLRPC::DateTime.new(now.year, now.month, now.day, now.hour, now.min, now.sec)
-    cont_op.schedule_image_build(image, version_build, build_hostid, date_build)
-  end
-end


### PR DESCRIPTION
## What does this PR change?

The docker scalability tests had several practical problems:
 * the feature name let think it was about XML-RPC tests, they should have been in their own feature
 * with 5 or 4 images, the image build test is not a scalability test at all ;-)
    scalability would be at least, say, 100 containers
 * they are slow, by removing them we will win ~ 5 minutes
 * as far as I remember, these scalability tests never failed, proving to be useless in regular runs
 * but before recent fixes from MC, they made other tests fails, proving to be non-idempotent

Besides, there is a conceptual problem: I don't think we should do scalability tests in the cucumber testsuite, we should focus on functionalities and integration.

## Links

Fixes: testsuite runs

Relevant branches:
 - Manager-3.1
 - Manager-3.2: SUSE/spacewalk#5537
