### PR TITLE
Fix retrieving salt-ssh pub key (bsc#1105062)

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/SaltSSHController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/SaltSSHController.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Optional;
 
+import org.apache.log4j.Logger;
 import spark.Request;
 import spark.Response;
 
@@ -35,6 +36,9 @@ import spark.Response;
  * Generate and retrieve the salt-ssh public key.
  */
 public class SaltSSHController {
+
+    // Logger
+    private static final Logger LOG = Logger.getLogger(SaltSSHController.class);
 
     private SaltSSHController() { }
 
@@ -52,10 +56,12 @@ public class SaltSSHController {
                 .generateSSHKey(SaltSSHService.SSH_KEY_PATH);
 
         if (!res.isPresent()) {
-            halt(500, "Could not retrieve salt-ssh public key.");
+            LOG.error("Could not generate salt-ssh public key.");
+            halt(500, "Could not generate salt-ssh public key.");
         }
         if (!(res.get().getReturnCode() == 0 || res.get().getReturnCode() == -1)) {
-            halt(500, res.get().getStderr() + "");
+            LOG.error("Generating salt-ssh public key failed: " + res.get().getStderr());
+            halt(500, res.get().getStderr());
         }
 
         response.header("Content-Type", "application/octet-stream");
@@ -65,6 +71,7 @@ public class SaltSSHController {
             return IOUtils.toByteArray(fin);
         }
         catch (IOException e) {
+            LOG.error("Could not read salt-ssh public key " + pubKey, e);
             halt(500, e.getMessage());
         }
         return null;

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -1018,7 +1018,7 @@ public class SaltService {
             RunnerCall<MgrUtilRunner.ExecResult> call = MgrUtilRunner.generateSSHKey(path);
             return callSync(call);
         }
-        return Optional.empty();
+        return Optional.of(MgrUtilRunner.ExecResult.success());
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/services/impl/runner/MgrUtilRunner.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/runner/MgrUtilRunner.java
@@ -62,6 +62,16 @@ public class MgrUtilRunner {
         public String getStderr() {
             return stderr;
         }
+
+        /**
+         * Create an empty result with return code 0.
+         * @return a result with return code 0.
+         */
+        public static ExecResult success() {
+            ExecResult res = new ExecResult();
+            res.returnCode = 0;
+            return res;
+        }
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Fix retrieving salt-ssh pub key for proxy setup when key already exists
+  (bsc#105062)
 - Store activation key in the Kiwi built image
 - Do not wrap output if stderr is not present (bsc#1105074)
 - Store image size in image pillar as integer value


### PR DESCRIPTION
## What does this PR change?

Retrieving salt-ssh pub key failed if the already exists on the server.
Fix for https://github.com/SUSE/spacewalk/issues/5489 (https://bugzilla.suse.com/show_bug.cgi?id=1105062)

## GUI diff

No difference.

## Documentation
- No documentation needed: bugfixing

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/5489
Tracks https://github.com/SUSE/spacewalk/pull/5526

- [x] **DONE**
