### PR TITLE
Feat: store image size in image pillar as integer value

### DIFF
--- a/java/code/src/com/suse/manager/webui/utils/salt/custom/OSImageInspectSlsResult.java
+++ b/java/code/src/com/suse/manager/webui/utils/salt/custom/OSImageInspectSlsResult.java
@@ -40,7 +40,7 @@ public class OSImageInspectSlsResult {
         private String version;
         private String filename;
         private String arch;
-        private Double size;
+        private Long size;
 
         /**
          * @return the hash
@@ -115,7 +115,7 @@ public class OSImageInspectSlsResult {
         /**
          * @return the image size
          */
-        public Double getSize() {
+        public Long getSize() {
             return size;
         }
     }
@@ -138,7 +138,7 @@ public class OSImageInspectSlsResult {
             private String version;
             private String hash;
             private String filename;
-            private Double size;
+            private Long size;
 
             /**
              * @return the version
@@ -164,7 +164,7 @@ public class OSImageInspectSlsResult {
             /**
              * @return the size
              */
-            public Double getSize() {
+            public Long getSize() {
                 return size;
             }
         }
@@ -211,7 +211,7 @@ public class OSImageInspectSlsResult {
             private String version;
             private String hash;
             private String filename;
-            private Double size;
+            private Long size;
 
             /**
              * @return the version
@@ -237,7 +237,7 @@ public class OSImageInspectSlsResult {
             /**
              * @return the size
              */
-            public Double getSize() {
+            public Long getSize() {
                 return size;
             }
         }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Store image size in image pillar as integer value
 - Reschedule Taskomatic jobs when the taskomatic.<job_type>.parallel_threads
   limit is reached (bsc#1105574)
 - Implement the 2-phase registration of saltbooted minions (SUMA for Retail)


### PR DESCRIPTION
## What does this PR change?

Changes internal storage from Double to long for image size details gathered from image inspection.

## GUI diff

No difference.

## Documentation
- No documentation needed: internal data

## Test coverage
- No tests: change of type

- [x] **DONE**

## Links

Fixes #5386 

Relevant branches (GitHub automatic links expected below):
 - Manager-3.2 #5428

- [X] **DONE**
