### PR TITLE
Do not wrap output if stderr is not present (bsc#1105074)

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -1687,12 +1687,11 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 .stream()
                 .filter(res -> saScript.getServerId().equals(res.getServerId()))
                 .findFirst().get();
-        assertEquals("stdout:\n" +
-                "\n" +
+        assertEquals(
                 "total 12\n" +
                 "drwxr-xr-x  2 root root 4096 Sep 21  2014 bin\n" +
                 "-rwxr-xr-x  1 root root 1636 Sep 12 17:07 netcat.py\n" +
-                "drwxr-xr-x 14 root root 4096 Jul 25  2017 salt\n",
+                "drwxr-xr-x 14 root root 4096 Jul 25  2017 salt",
                 new String(scriptResult.getOutput()));
     }
 

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -1723,11 +1723,14 @@ public class SaltUtils {
             sb.append("stderr:\n\n");
             sb.append(stderr);
             sb.append("\n");
+            if (StringUtils.isNotEmpty(stdout)) {
+                sb.append("stdout:\n\n");
+                sb.append(stdout);
+                sb.append("\n");
+            }
         }
-        if (StringUtils.isNotEmpty(stdout)) {
-            sb.append("stdout:\n\n");
+        else {
             sb.append(stdout);
-            sb.append("\n");
         }
         return sb.toString();
     }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Do not wrap output if stderr is not present (bsc#1105074)
 - Store image size in image pillar as integer value
 - Reschedule Taskomatic jobs when the taskomatic.<job_type>.parallel_threads
   limit is reached (bsc#1105574)


### PR DESCRIPTION
## What does this PR change?

In case of a Salt minion client, the output of a script result is wrapped by the output of the Salt jid that actually run the script. By default if the `stderr` and `stdout` contains something, we wrap each one of them like the following:
```
stderr:

*the error message*
stdout:

*the output result*
```

but in case of no `stderr` value, there is no reason to wrap the `stdout` content. It also differs from the traditional client output, in that case there is no wrap for the `stdout` content.

## GUI diff

No difference.

Before:
![screenshot from 2018-08-22 16-07-08](https://user-images.githubusercontent.com/7080830/44468574-cd1c8800-a625-11e8-9d28-3d670f455c5a.png)

After:
![screenshot from 2018-08-22 16-08-06](https://user-images.githubusercontent.com/7080830/44468579-cf7ee200-a625-11e8-8f65-49ad8b30f179.png)

- [x] **DONE**


## Documentation
- No documentation needed: no need to mention the format of the output of the script in the docs

- [x] **DONE**

## Test coverage
- No tests: removing a script output wrapper in the string, no feature to be tested nor affected

- [x] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/5490
Tracks # https://github.com/SUSE/spacewalk/pull/5558

- [x] **DONE**
