### PR TITLE
Testsuite: use a salt proxy

### DIFF
--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -13,9 +13,9 @@ Apart from Cucumber, the testsuite relies on a number of [software components](d
 
 You can run the SUSE Manager testsuite [with sumaform](https://github.com/moio/sumaform/blob/master/README_ADVANCED.md#cucumber-testsuite).
 
-If you want to run the testsuite for [Uyuni](https://www.uyuni-project.org), you need to export the variable PRODUCTS with value Uyuni:
+If you want to run the testsuite for [Uyuni](https://www.uyuni-project.org), you need to export the variable PRODUCT with value Uyuni:
 ```bash
-export PRODUCTS=Uyuni
+export PRODUCT=Uyuni
 ```
 
 ## Core features, idempotency and tests order

--- a/testsuite/features/core_proxy_register_as_minion_with_gui.feature
+++ b/testsuite/features/core_proxy_register_as_minion_with_gui.feature
@@ -1,0 +1,42 @@
+# Copyright (c) 2017-2018 SUSE LLC
+# Licensed under the terms of the MIT license.
+#
+# The scenarios in this feature are skipped if there is no proxy
+# ($proxy is nil)
+#
+# Alternative: Bootstrap the proxy as Salt minion from GUI
+
+Feature: Setup SUSE Manager proxy
+  In order to use a proxy with the SUSE manager server
+  As the system administrator
+  I want to register the proxy to the server
+
+@proxy
+  Scenario: Bootstrap the proxy as a Salt minion
+    Given I am authorized
+    When I go to the bootstrapping page
+    Then I should see a "Bootstrap Minions" text
+    When I enter the hostname of "proxy" as hostname
+    And I enter "22" as "port"
+    And I enter "root" as "user"
+    And I enter "linux" as "password"
+    And I click on "Bootstrap"
+    And I wait until I see "Successfully bootstrapped host! " text
+    When I navigate to "rhn/systems/Overview.do" page
+    And I wait until I see the name of "proxy", refreshing the page
+
+@proxy
+  Scenario: Detect latest Salt changes on the proxy
+    When I query latest Salt changes on "proxy"
+
+@proxy
+  Scenario: Copy the keys and configure the proxy
+    When I copy server's keys to the proxy
+    And I configure the proxy
+    Then I should see "proxy" in spacewalk
+
+@proxy
+  Scenario: Check proxy system details
+    When I am on the Systems overview page of this "proxy"
+    Then I should see "proxy" hostname
+    And I wait until I see "$PRODUCT Proxy" text

--- a/testsuite/features/core_proxy_register_as_minion_with_script.feature
+++ b/testsuite/features/core_proxy_register_as_minion_with_script.feature
@@ -1,0 +1,48 @@
+# Copyright (c) 2017-2018 SUSE LLC
+# Licensed under the terms of the MIT license.
+#
+# The scenarios in this feature are skipped if there is no proxy
+# ($proxy is nil)
+#
+# Alternative: Bootstrap the proxy as a Salt minion from script
+
+Feature: Setup SUSE Manager proxy
+  In order to use a proxy with the SUSE manager server
+  As the system administrator
+  I want to register the proxy to the server
+
+@proxy
+  Scenario: Create the bootstrap script for the proxy and use it
+    When I execute mgr-bootstrap "--script=bootstrap-proxy.sh --no-up2date"
+    Then I should get "* bootstrap script (written):"
+    And I should get "    '/srv/www/htdocs/pub/bootstrap/bootstrap-proxy.sh'"
+    When I fetch "pub/bootstrap/bootstrap-proxy.sh" to "proxy"
+    And I run "sh ./bootstrap-proxy.sh" on "proxy"
+
+@proxy
+  Scenario: Accept the key for the proxy
+    Given I am authorized as "testing" with password "testing"
+    When I go to the minion onboarding page
+    Then I should see a "pending" text
+    When I accept "proxy" key
+
+@proxy
+  Scenario: Detect latest Salt changes on the proxy
+    When I query latest Salt changes on "proxy"
+
+@proxy
+  Scenario: Copy the keys and configure the proxy
+    When I copy server's keys to the proxy
+    And I configure the proxy
+    Then I should see "proxy" in spacewalk
+
+@proxy
+  Scenario: Check proxy system details
+    When I am on the Systems overview page of this "proxy"
+    Then I should see "proxy" hostname
+    And I wait until I see "$PRODUCT Proxy" text
+
+@proxy
+  Scenario: Cleanup: remove proxy bootstrap scripts
+    When I run "rm /srv/www/htdocs/pub/bootstrap/bootstrap-proxy.sh" on "server"
+    And I run "rm /root/bootstrap-proxy.sh" on "proxy"

--- a/testsuite/features/core_proxy_register_as_trad_with_script.feature
+++ b/testsuite/features/core_proxy_register_as_trad_with_script.feature
@@ -1,8 +1,10 @@
-# Copyright (c) 2017 SUSE LLC
+# Copyright (c) 2017-2018 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # The scenarios in this feature are skipped if there is no proxy
 # ($proxy is nil)
+#
+# Alternative: Bootstrap the proxy as a traditional client from script
 
 Feature: Setup SUSE Manager proxy
   In order to use a proxy with the SUSE manager server
@@ -10,16 +12,16 @@ Feature: Setup SUSE Manager proxy
   I want to register the proxy to the server
 
 @proxy
-  Scenario: Create the bootstrap script for the proxy
+  Scenario: Create the bootstrap script for the proxy and use it
     When I execute mgr-bootstrap "--script=bootstrap-proxy.sh --no-up2date --traditional"
     Then I should get "* bootstrap script (written):"
-     And I should get "    '/srv/www/htdocs/pub/bootstrap/bootstrap-proxy.sh'"
-
-@proxy
-  Scenario: Register the proxy, copy the keys and configure the proxy
+    And I should get "    '/srv/www/htdocs/pub/bootstrap/bootstrap-proxy.sh'"
     When I fetch "pub/bootstrap/bootstrap-proxy.sh" to "proxy"
     And I run "sh ./bootstrap-proxy.sh" on "proxy"
-    And I copy server's keys to the proxy
+
+@proxy
+  Scenario: Copy the keys and configure the proxy
+    When I copy server's keys to the proxy
     And I configure the proxy
     Then I should see "proxy" in spacewalk
 
@@ -27,9 +29,9 @@ Feature: Setup SUSE Manager proxy
   Scenario: Check proxy system details
     When I am on the Systems overview page of this "proxy"
     Then I should see "proxy" hostname
-    And I should see a "$PRODUCT Proxy" text
+    And I wait until I see "$PRODUCT Proxy" text
 
 @proxy
   Scenario: Cleanup: remove proxy bootstrap scripts
-   Then I run "rm /srv/www/htdocs/pub/bootstrap/bootstrap-proxy.sh" on "server"
-   And I run "rm /root/bootstrap-proxy.sh" on "proxy"
+    When I run "rm /srv/www/htdocs/pub/bootstrap/bootstrap-proxy.sh" on "server"
+    And I run "rm /root/bootstrap-proxy.sh" on "proxy"

--- a/testsuite/run_sets/testsuite.yml
+++ b/testsuite/run_sets/testsuite.yml
@@ -19,7 +19,10 @@
 - features/core_srv_osimage_profiles.feature
 - features/core_srv_docker_profiles.feature
 # initialize SUSE Manager proxy
-- features/core_proxy.feature
+  # one of: core_proxy_register_as_trad_with_script.feature
+  #         core_proxy_register_as_minion_with_script.feature
+  #         core_proxy_register_as_minion_with_gui.feature
+- features/core_proxy_register_as_trad_with_script.feature
 # initialize clients
 - features/core_trad_register_client.feature
 - features/core_min_bootstrap.feature


### PR DESCRIPTION
## What does this PR change?

It uses a Salt proxy instead of a traditional proxy in the test suite.

The feature to use a traditional proxy is not removed, it is just commented out in `testsuite.yaml`.


## Test coverage

Tested with full test suite on version 3.2 on my workstation. Test showed 24 failures, so we will activate the Salt proxy on 3.2 branch only.

This does not prevent this pull request from being accepted on Uyuni branch. On this branch, it will boil down to a no-op.


## Links

Fixes: SUSE/spacewalk#5413
Tracks: SUSE/spacewalk#5578 (3.2) and SUSE/spacewalk#5577 (3.1)
