### PR TITLE
Remove traditional stack unless spacewalk-proxy-common is installed

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/bootstrap/remove_traditional_stack.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/remove_traditional_stack.sls
@@ -49,6 +49,7 @@ remove_traditional_stack:
     - require:
       - module: disable_repo*
 {%- endif %}
+    - unless: rpm -q spacewalk-proxy-common
 
 # disable all spacewalk:* repos
 {%- for alias in repos_to_disable %}


### PR DESCRIPTION
## What does this PR change?

Fixes removal of the traditional stack when applying highstate on a proxy minion.

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: it is just a fix

- [x] **DONE**

## Test coverage
- No tests: covered already

- [x] **DONE**

## Links

Fixes #

Relevant branches (GitHub automatic links expected below):
 - Manager-3.2
 - Uyuni

- [x] **DONE**