### PR TITLE
Store activation key

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -75,6 +75,7 @@ import com.redhat.rhn.domain.server.ErrataInfo;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.MinionServerFactory;
 import com.redhat.rhn.domain.server.ServerFactory;
+import com.redhat.rhn.domain.token.ActivationKey;
 import com.redhat.rhn.domain.token.ActivationKeyFactory;
 import com.redhat.rhn.domain.server.VirtualInstance;
 import com.redhat.rhn.domain.server.VirtualInstanceFactory;
@@ -1327,13 +1328,15 @@ public class SaltServerActionService {
                         pillar.put("source", kiwiProfile.getPath());
                         pillar.put("build_id", "build" + actionId);
                         List<String> repos = new ArrayList<>();
-                        Set<Channel> channels = ActivationKeyFactory.lookupByToken(profile.getToken()).getChannels();
+                        final ActivationKey activationKey = ActivationKeyFactory.lookupByToken(profile.getToken());
+                        Set<Channel> channels = activationKey.getChannels();
                         for (Channel channel: channels) {
                             repos.add("https://" + host +
                                     "/rhn/manager/download/" + channel.getLabel() + "?" +
                                     token);
                         }
                         pillar.put("kiwi_repositories", repos);
+                        pillar.put("activation_key", activationKey.getKey());
                     });
 
                     String saltCall = "";

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Store activation key in the Kiwi built image
 - Do not wrap output if stderr is not present (bsc#1105074)
 - Store image size in image pillar as integer value
 - Reschedule Taskomatic jobs when the taskomatic.<job_type>.parallel_threads

--- a/susemanager-utils/susemanager-sls/salt/images/kiwi-image-build.sls
+++ b/susemanager-utils/susemanager-sls/salt/images/kiwi-image-build.sls
@@ -25,11 +25,21 @@ mgr_buildimage_prepare_source:
     - root: {{ root_dir }}
     - activation_key: {{ activation_key }}
 
+mgr_prepare_activation_key_in_source:
+  file.managed:
+    - name: {{root_dir}}/etc/salt/minion.d/kiwi_activation_key.conf
+    - makedirs: True
+    - contents: |
+        grains:
+          susemanager:
+            activation_key: {{ pillar['activation_key'] }}
+
 mgr_buildimage_kiwi_prepare:
   cmd.run:
     - name: "kiwi --nocolor --force-new-root --prepare {{ source_dir }} --root {{ chroot_dir }} {{ kiwi_params }}"
     - require:
       - module: mgr_buildimage_prepare_source
+      - module: mgr_prepare_activation_key_in_source
 
 mgr_buildimage_kiwi_create:
   cmd.run:

--- a/susemanager-utils/susemanager-sls/salt/images/kiwi-image-build.sls
+++ b/susemanager-utils/susemanager-sls/salt/images/kiwi-image-build.sls
@@ -23,23 +23,22 @@ mgr_buildimage_prepare_source:
     - name: kiwi_source.prepare_source
     - source: {{ source }}
     - root: {{ root_dir }}
-    - activation_key: {{ activation_key }}
 
-mgr_prepare_activation_key_in_source:
+mgr_buildimage_prepare_activation_key_in_source:
   file.managed:
-    - name: {{root_dir}}/etc/salt/minion.d/kiwi_activation_key.conf
+    - name: {{ source_dir }}/root/etc/salt/minion.d/kiwi_activation_key.conf
     - makedirs: True
     - contents: |
         grains:
           susemanager:
-            activation_key: {{ pillar['activation_key'] }}
+            activation_key: {{ activation_key }}
 
 mgr_buildimage_kiwi_prepare:
   cmd.run:
     - name: "kiwi --nocolor --force-new-root --prepare {{ source_dir }} --root {{ chroot_dir }} {{ kiwi_params }}"
     - require:
       - module: mgr_buildimage_prepare_source
-      - module: mgr_prepare_activation_key_in_source
+      - file: mgr_buildimage_prepare_activation_key_in_source
 
 mgr_buildimage_kiwi_create:
   cmd.run:

--- a/susemanager-utils/susemanager-sls/salt/images/kiwi-image-build.sls
+++ b/susemanager-utils/susemanager-sls/salt/images/kiwi-image-build.sls
@@ -12,6 +12,7 @@
 {%- set dest_dir   = root_dir + '/images.build' %}
 {%- set bundle_dir = root_dir + '/images/' %}
 {%- set bundle_id  = pillar.get('build_id') %}
+{%- set activation_key = pillar.get('activation_key') %}
 
 {%- set kiwi_params = '--add-repo ' + common_repo + ' --add-repo ' + pillar.get('kiwi_repositories')|join(' --add-repo ') %}
 mgr_buildimage_prepare_source:
@@ -22,6 +23,7 @@ mgr_buildimage_prepare_source:
     - name: kiwi_source.prepare_source
     - source: {{ source }}
     - root: {{ root_dir }}
+    - activation_key: {{ activation_key }}
 
 mgr_buildimage_kiwi_prepare:
   cmd.run:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Store activation key in the Kiwi built image
 - Implement the 2-phase registration of saltbooted minions (SUMA for Retail)
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Store the activation key in the built image as a Salt grain

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: internal (retail-use) only

- [X] **DONE**

## Test coverage
- No tests: cannot test grains inside the built image

- [X] **DONE**

## Links
