### PR TITLE
Adapt "susemanager/" directory to be Python 2/3 compatible

### DIFF
--- a/backend/Makefile.backend
+++ b/backend/Makefile.backend
@@ -42,8 +42,8 @@ unittest ::
 		unit2 discover -s satellite_tools/test/unit; \
 		unit2 discover -s common/test/unit-test; \
 	else \
-		python -munittest discover -s satellite_tools/test/unit; \
-		python -munittest discover -s common/test/unit-test; \
+		$(PYTHON_BIN) -munittest discover -s satellite_tools/test/unit; \
+		$(PYTHON_BIN) -munittest discover -s common/test/unit-test; \
 	fi
 
 docker_no_db_tests ::

--- a/backend/Makefile.defs
+++ b/backend/Makefile.defs
@@ -8,7 +8,7 @@ TOP		?= .
 ROOT		?= /usr/share/rhn
 export ROOT
 
-SPACEWALK_ROOT	?= $(shell python -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")/spacewalk
+SPACEWALK_ROOT	?= $(shell $(PYTHON_BIN) -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")/spacewalk
 export SPACEWALK_ROOT
 
 PREFIX		?=

--- a/backend/server/rhnAuthPAM.py
+++ b/backend/server/rhnAuthPAM.py
@@ -13,60 +13,23 @@
 # in this software or its documentation.
 #
 
-import PAM
+import pam
 import sys
 
 from spacewalk.common.usix import raise_with_tb
 from spacewalk.common.rhnLog import log_error
 from spacewalk.common.rhnException import rhnException
 
-__username = None
-__password = None
-
-
-def __pam_conv(auth, query_list):
-    global __username, __password
-    # Build a list of responses to be passed back to PAM
-    resp = []
-    for query, type in query_list:
-        if type == PAM.PAM_PROMPT_ECHO_ON:
-            # Prompt for a username
-            resp.append((__username, 0))
-        elif type == PAM.PAM_PROMPT_ECHO_OFF:
-            # Prompt for a password
-            resp.append((__password, 0))
-        else:
-            # Unknown PAM type
-            log_error("Got unknown PAM type %s (query=%s)" % (type, query))
-            return None
-
-    return resp
-
 
 def check_password(username, password, service):
-    global __username, __password
-    auth = PAM.pam()
-    auth.start(service, username, __pam_conv)
-
-    # Save the username and passwords in the globals, the conversation
-    # function needs access to them
-    __username = username
-    __password = password
-
     try:
-        try:
-            auth.authenticate()
-            auth.acct_mgmt()
-        finally:
-            # Something to be always executed - cleanup
-            __username = __password = None
-    except PAM.error:
-        e = sys.exc_info()[1]
-        resp, code = e.args[:2]
-        log_error("Password check failed (%s): %s" % (code, resp))
-        return 0
+        auth = pam.pam()
+        if not auth.authenticate(username, password, service=service):
+            e = sys.exc_info()[1]
+            resp, code = e.args[:2]
+            log_error("Password check failed (%s): %s" % (code, resp))
+            return 0
+        else:
+            return 1
     except:
         raise_with_tb(rhnException('Internal PAM error'), sys.exc_info()[2])
-    else:
-        # Good password
-        return 1

--- a/backend/server/rhnAuthPAM.py
+++ b/backend/server/rhnAuthPAM.py
@@ -25,9 +25,7 @@ def check_password(username, password, service):
     try:
         auth = pam.pam()
         if not auth.authenticate(username, password, service=service):
-            e = sys.exc_info()[1]
-            resp, code = e.args[:2]
-            log_error("Password check failed (%s): %s" % (code, resp))
+            log_error("Password check failed (%s): %s" % (auth.code, auth.reason))
             return 0
         else:
             return 1

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,6 @@
+- Prepare spacewalk-backend packages to build on Python 3
+- Replace PyPAM with python-python-pam
+
 -------------------------------------------------------------------
 Fri Aug 10 15:13:14 CEST 2018 - jgonzalez@suse.com
 

--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -27,9 +27,7 @@
 %endif
 
 %if 0%{?fedora} >= 23 || 0%{?suse_version} > 1320 || 0%{?rhel} >= 8
-%{!?python2_sitelib: %global python2_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
 %{!?python3_sitelib: %global python3_sitelib %(%{__python3} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
-%global python2rhnroot %{python2_sitelib}/spacewalk
 %global python3rhnroot %{python3_sitelib}/spacewalk
 %global pythonrhnroot %{python3_sitelib}/spacewalk
 %global build_py3 1
@@ -66,6 +64,8 @@
 %global python_prefix python
 %endif
 
+%{!?python2_sitelib: %global python2_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
+%global python2rhnroot %{python2_sitelib}/spacewalk
 %if !0%{?build_py3}
 %global pythonrhnroot %{python_sitelib}/spacewalk
 %endif
@@ -686,6 +686,7 @@ rm -f %{rhnconf}/rhnSecret.py*
 %dir %{rhnroot}
 %endif
 %if 0%{?build_py3}
+%dir %{pythonrhnroot}/__pycache__/
 %{pythonrhnroot}/__pycache__/*
 %{pythonrhnroot}/common/__pycache__/*
 %endif
@@ -897,52 +898,39 @@ rm -f %{rhnconf}/rhnSecret.py*
 %config(noreplace) %{_sysconfdir}/logrotate.d/spacewalk-backend-iss-export
 
 %files libs
-%if 0%{?build_py3}
-%define pythonrhnroot %{python2rhnroot}
-%endif
 %defattr(-,root,root)
 %doc LICENSE
-%{pythonrhnroot}/common/checksum.py*
-%{pythonrhnroot}/common/cli.py*
-%{pythonrhnroot}/common/fileutils.py*
-%{pythonrhnroot}/common/rhn_deb.py*
-%{pythonrhnroot}/common/rhn_mpm.py*
-%{pythonrhnroot}/common/rhn_pkg.py*
-%{pythonrhnroot}/common/rhn_rpm.py*
-%{pythonrhnroot}/common/stringutils.py*
-%{pythonrhnroot}/common/rhnLib.py*
-%{pythonrhnroot}/common/timezone_utils.py*
 %if 0%{?build_py3}
-%{pythonrhnroot}
-%{pythonrhnroot}/common
-%define pythonrhnroot %{python3rhnroot}
+%{python2rhnroot}
+%{python2rhnroot}/common
 %endif
+%{python2rhnroot}/common/checksum.py*
+%{python2rhnroot}/common/cli.py*
+%{python2rhnroot}/common/fileutils.py*
+%{python2rhnroot}/common/rhn_deb.py*
+%{python2rhnroot}/common/rhn_mpm.py*
+%{python2rhnroot}/common/rhn_pkg.py*
+%{python2rhnroot}/common/rhn_rpm.py*
+%{python2rhnroot}/common/stringutils.py*
+%{python2rhnroot}/common/rhnLib.py*
+%{python2rhnroot}/common/timezone_utils.py*
 
 %if 0%{?build_py3}
 %files -n python3-%{name}-libs
 %defattr(-,root,root)
 %doc LICENSE
-%dir %{pythonrhnroot}
-%dir %{pythonrhnroot}/common
-%dir %{pythonrhnroot}/common/__pycache__
-%{pythonrhnroot}/common/checksum.py
-%{pythonrhnroot}/common/cli.py
-%{pythonrhnroot}/common/fileutils.py
-%{pythonrhnroot}/common/rhn_deb.py
-%{pythonrhnroot}/common/rhn_mpm.py
-%{pythonrhnroot}/common/rhn_pkg.py
-%{pythonrhnroot}/common/rhn_rpm.py
-%{pythonrhnroot}/common/stringutils.py
-%{pythonrhnroot}/common/rhnLib.py*
-%{pythonrhnroot}/common/timezone_utils.py*
-%{pythonrhnroot}/common/__pycache__/*
-%if 0%{?suse_version}
-%dir %{pythonrhnroot}
-%dir %{pythonrhnroot}/common
-%dir %{pythonrhnroot}/__pycache__
-%endif
-%{pythonrhnroot}/common
-%{pythonrhnroot}/common/__pycache__
+%dir %{python3rhnroot}/common/__pycache__
+%{python3rhnroot}/common/checksum.py
+%{python3rhnroot}/common/cli.py
+%{python3rhnroot}/common/fileutils.py
+%{python3rhnroot}/common/rhn_deb.py
+%{python3rhnroot}/common/rhn_mpm.py
+%{python3rhnroot}/common/rhn_pkg.py
+%{python3rhnroot}/common/rhn_rpm.py
+%{python3rhnroot}/common/stringutils.py
+%{python3rhnroot}/common/rhnLib.py*
+%{python3rhnroot}/common/timezone_utils.py*
+%{python3rhnroot}/common
 %endif
 
 %files config-files-common

--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -21,15 +21,18 @@
 %global rhnconfigdefaults %{rhnroot}/config-defaults
 %global rhnconf %{_sysconfdir}/rhn
 %global m2crypto m2crypto
+
 %if 0%{?rhel} && 0%{?rhel} < 6
 %{!?python_sitelib: %global python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
 %endif
 
 %if 0%{?fedora} >= 23 || 0%{?suse_version} > 1320 || 0%{?rhel} >= 8
 %{!?python3_sitelib: %global python3_sitelib %(%{__python3} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
-%global python3rhnroot %{python3_sitelib}/spacewalk
+%global pythonrhnroot %{python3_sitelib}/spacewalk
 %global build_py3 1
 %endif
+
+%define pythonX %{?build_py3:python3}%{!?build_py3:python}
 
 %if 0%{?fedora} || 0%{?rhel} >= 7
 %{!?pylint_check: %global pylint_check 0}
@@ -60,7 +63,9 @@
 %global python_prefix python
 %endif
 
+%if !0%{?build_py3}
 %global pythonrhnroot %{python_sitelib}/spacewalk
+%endif
 
 Name:           spacewalk-backend
 Summary:        Common programs needed to be installed on the Spacewalk servers/proxies
@@ -75,13 +80,17 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 %endif
 
-Requires:       python
+Requires:       %{pythonX}
 Requires:       rpm-python
 # /etc/rhn is provided by spacewalk-proxy-common or by spacewalk-config
 Requires:       /etc/rhn
 Requires:       rhnlib >= 2.5.74
 # for Debian support
+%if 0%{?build_py3}
+Requires:       python3-%{name}-libs >= %{version}
+%else
 Requires:       %{name}-libs >= %{version}
+%endif
 Requires:       %{python_prefix}-debian
 %if 0%{?suse_version} > 1320
 Requires:       python-pyliblzma
@@ -96,7 +105,11 @@ BuildRequires:  spacewalk-python2-pylint
 BuildRequires:  /usr/bin/docbook2man
 BuildRequires:  /usr/bin/msgfmt
 BuildRequires:  docbook-utils
+%if 0%{?build_py3}
+BuildRequires:  python3-spacewalk-usix
+%else
 BuildRequires:  python2-spacewalk-usix
+%endif
 %if 0%{?fedora} || 0%{?rhel} > 5 || 0%{?suse_version} > 1310
 %if 0%{?build_py3}
 BuildRequires:  python3-gzipstream
@@ -107,7 +120,6 @@ BuildRequires:  python2-rhn-client-tools
 %endif
 BuildRequires:  rhnlib >= 2.5.74
 BuildRequires:  rpm-python
-#BuildRequires: %{python_prefix}-crypto
 BuildRequires:  %{python_prefix}-debian
 
 BuildRequires:  %{m2crypto}
@@ -115,7 +127,11 @@ BuildRequires:  yum
 %endif
 Requires(pre): %{apache_pkg}
 Requires:       %{apache_pkg}
+%if 0%{?build_py3}
+Requires:       python3-spacewalk-usix
+%else
 Requires:       python2-spacewalk-usix
+%endif
 
 %if 0%{?suse_version}
 Requires:       python-pycurl
@@ -142,7 +158,11 @@ Requires:       %{name} = %{version}-%{release}
 Obsoletes:      rhns-sql < 5.3.0
 Provides:       rhns-sql = 1:%{version}-%{release}
 Requires:       %{name}-sql-virtual = %{version}-%{release}
+%if 0%{?build_py3}
+Requires:       python3-spacewalk-usix
+%else
 Requires:       python2-spacewalk-usix
+%endif
 
 %description sql
 This package contains the basic code that provides SQL connectivity for
@@ -152,7 +172,11 @@ the Spacewalk backend modules.
 %package sql-oracle
 Summary:        Oracle backend for Spacewalk
 Group:          Applications/Internet
+%if 0%{?build_py3}
+Requires:       python3-spacewalk-usix
+%else
 Requires:       python2-spacewalk-usix
+%endif
 Requires:       python(:DBAPI:oracle)
 Provides:       %{name}-sql-virtual = %{version}-%{release}
 
@@ -165,7 +189,11 @@ modules.
 Summary:        Postgresql backend for Spacewalk
 Group:          Applications/Internet
 Requires:       python-psycopg2 >= 2.0.14-2
+%if 0%{?build_py3}
+Requires:       python3-spacewalk-usix
+%else
 Requires:       python2-spacewalk-usix
+%endif
 Provides:       %{name}-sql-virtual = %{version}-%{release}
 
 %description sql-postgresql
@@ -177,8 +205,12 @@ Summary:        Basic code that provides Spacewalk Server functionality
 Group:          Applications/Internet
 Requires(pre): %{name}-sql = %{version}-%{release}
 Requires:       %{name}-sql = %{version}-%{release}
-Requires:       PyPAM
+Requires:       python-python-pam
+%if 0%{?build_py3}
+Requires:       python3-spacewalk-usix
+%else
 Requires:       python2-spacewalk-usix
+%endif
 Requires:       spacewalk-config
 Obsoletes:      rhns-server < 5.3.0
 Provides:       rhns-server = 1:%{version}-%{release}
@@ -188,7 +220,11 @@ Conflicts:      python-sgmlop
 # cobbler-web is known to break our configuration
 Conflicts:      cobbler-web
 
+%if 0%{?build_py3}
+Requires:       apache2-mod_wsgi-python3
+%else
 Requires:       mod_wsgi
+%endif
 
 %description server
 This package contains the basic code that provides server/backend
@@ -200,7 +236,11 @@ receivers and get them enabled automatically.
 Summary:        Handler for /XMLRPC
 Group:          Applications/Internet
 Requires:       %{name}-server = %{version}-%{release}
+%if 0%{?build_py3}
+Requires:       python3-spacewalk-usix
+%else
 Requires:       python2-spacewalk-usix
+%endif
 Requires:       rpm-python
 Obsoletes:      rhns-server-xmlrpc < 5.3.0
 Obsoletes:      rhns-xmlrpc < 5.3.0
@@ -216,7 +256,11 @@ and the up2date clients.
 Summary:        Handler for /APPLET
 Group:          Applications/Internet
 Requires:       %{name}-server = %{version}-%{release}
+%if 0%{?build_py3}
+Requires:       python3-spacewalk-usix
+%else
 Requires:       python2-spacewalk-usix
+%endif
 Obsoletes:      rhns-applet < 5.3.0
 Provides:       rhns-applet = 1:%{version}-%{release}
 
@@ -228,7 +272,11 @@ provides the functions for the Spacewalk applet.
 Summary:        Handler for /APP
 Group:          Applications/Internet
 Requires:       %{name}-server = %{version}-%{release}
+%if 0%{?build_py3}
+Requires:       python3-spacewalk-usix
+%else
 Requires:       python2-spacewalk-usix
+%endif
 Obsoletes:      rhns-app < 5.3.0
 Obsoletes:      rhns-server-app < 5.3.0
 Provides:       rhns-app = 1:%{version}-%{release}
@@ -264,7 +312,11 @@ capability.
 Summary:        Listener for the Server XML dumper
 Group:          Applications/Internet
 Requires:       %{name}-xml-export-libs = %{version}-%{release}
+%if 0%{?build_py3}
+Requires:       python3-spacewalk-usix
+%else
 Requires:       python2-spacewalk-usix
+%endif
 Requires:       rpm-python
 
 %description iss-export
@@ -275,20 +327,31 @@ receivers and get them enabled automatically.
 
 This package contains listener for the Server XML dumper.
 
+%if !0%{?build_py3}
 %package libs
 Summary:        Spacewalk server and client tools libraries
 Group:          Applications/Internet
+%if 0%{?build_py3}
+Requires:       python3
+BuildRequires:  python3-devel
+%else
+Requires:       python
 %if 0%{?suse_version}
 BuildRequires:  python-devel
 %else
-Requires:       python
 BuildRequires:  python2-devel
 Conflicts:      %{name} < 1.7.0
 %endif
+%endif
+%if 0%{?build_py3}
+Requires:       python3-spacewalk-usix
+%else
 Requires:       python2-spacewalk-usix
+%endif
 
 %description libs
 Libraries required by both Spacewalk server and Spacewalk client tools.
+%endif
 
 %if 0%{?build_py3}
 
@@ -302,7 +365,11 @@ Requires:       python3-base
 %else
 Requires:       python3-libs
 %endif
+%if 0%{?build_py3}
 Requires:       python3-spacewalk-usix
+%else
+Requires:       python2-spacewalk-usix
+%endif
 
 %description -n python3-%{name}-libs
 Libraries required by Spacewalk client tools on Fedora 23.
@@ -313,7 +380,11 @@ Libraries required by Spacewalk client tools on Fedora 23.
 Summary:        Common files for the Configuration Management project
 Group:          Applications/Internet
 Requires:       %{name}-server = %{version}-%{release}
+%if 0%{?build_py3}
+Requires:       python3-spacewalk-usix
+%else
 Requires:       python2-spacewalk-usix
+%endif
 Obsoletes:      rhns-config-files-common < 5.3.0
 Provides:       rhns-config-files-common = 1:%{version}-%{release}
 
@@ -334,7 +405,11 @@ This package contains the server-side code for configuration management.
 Summary:        Handler for /CONFIG-MANAGEMENT-TOOL
 Group:          Applications/Internet
 Requires:       %{name}-config-files-common = %{version}-%{release}
+%if 0%{?build_py3}
+Requires:       python3-spacewalk-usix
+%else
 Requires:       python2-spacewalk-usix
+%endif
 Obsoletes:      rhns-config-files-tool < 5.3.0
 Provides:       rhns-config-files-tool = 1:%{version}-%{release}
 
@@ -384,7 +459,11 @@ Recommends:     cobbler20
 %endif
 Requires:       %{m2crypto}
 Requires:       python-requests
+%if 0%{?build_py3}
+Requires:       python3-spacewalk-usix
+%else
 Requires:       python2-spacewalk-usix
+%endif
 Requires:       rhnlib  >= 2.5.57
 %if 0%{?fedora} || 0%{?rhel} > 5
 BuildRequires:  python-requests
@@ -401,7 +480,11 @@ Various utilities for the Spacewalk Server.
 Summary:        Spacewalk XML data exporter
 Group:          Applications/Internet
 Requires:       %{name}-server = %{version}-%{release}
+%if 0%{?build_py3}
+Requires:       python3-spacewalk-usix
+%else
 Requires:       python2-spacewalk-usix
+%endif
 Obsoletes:      rhns-xml-export-libs < 5.3.0
 Provides:       rhns-xml-export-libs = 1:%{version}-%{release}
 
@@ -414,7 +497,11 @@ Group:          Applications/Internet
 Requires:       %{m2crypto}
 Requires:       %{name}-server = %{version}-%{release}
 Requires:       python-argparse
+%if 0%{?build_py3}
+Requires:       python3-spacewalk-usix
+%else
 Requires:       python2-spacewalk-usix
+%endif
 Requires:       subscription-manager
 
 %description cdn
@@ -424,27 +511,26 @@ Tools for syncing content from Red Hat CDN
 %setup -q
 
 %build
-make -f Makefile.backend all
+make -f Makefile.backend all PYTHON_BIN=%{pythonX}
+
+# Fixing shebang for Python 3
+%if 0%{?build_py3}
+for i in `find . -type f`;
+do
+	sed -i '1s=^#!/usr/bin/\(python\|env python\)[0-9.]*=#!/usr/bin/python3=' $i;
+done
+%endif
 
 %install
 install -d $RPM_BUILD_ROOT%{rhnroot}
 install -d $RPM_BUILD_ROOT%{pythonrhnroot}
 install -d $RPM_BUILD_ROOT%{rhnconf}
 make -f Makefile.backend install PREFIX=$RPM_BUILD_ROOT \
-    MANDIR=%{_mandir} APACHECONFDIR=%{apacheconfd}
+    MANDIR=%{_mandir} APACHECONFDIR=%{apacheconfd} PYTHON_BIN=%{pythonX}
 %if !0%{?with_oracle}
 rm -f $RPM_BUILD_ROOT%{pythonrhnroot}/server/rhnSQL/driver_cx_Oracle.py*
 %endif
 
-%if 0%{?build_py3}
-install -d $RPM_BUILD_ROOT%{python3rhnroot}/common
-cp $RPM_BUILD_ROOT%{pythonrhnroot}/__init__.py \
-    $RPM_BUILD_ROOT%{python3rhnroot}/
-cp $RPM_BUILD_ROOT%{pythonrhnroot}/common/__init__.py \
-    $RPM_BUILD_ROOT%{python3rhnroot}/common
-cp $RPM_BUILD_ROOT%{pythonrhnroot}/common/{checksum.py,cli.py,rhn_deb.py,rhn_mpm.py,rhn_pkg.py,rhn_rpm.py,stringutils.py,fileutils.py,rhnLib.py} \
-    $RPM_BUILD_ROOT%{python3rhnroot}/common
-%endif
 export PYTHON_MODULE_NAME=%{name}
 export PYTHON_MODULE_VERSION=%{version}
 
@@ -474,31 +560,26 @@ sed -i 's/#DOCUMENTROOT#/\/var\/www\/html/' $RPM_BUILD_ROOT%{rhnconfigdefaults}/
 %if 0%{?suse_version}
 sed -i 's/#LOGROTATE-3.8#.*/    su root www/' $RPM_BUILD_ROOT%{_sysconfdir}/logrotate.d/spacewalk-backend-*
 sed -i 's/#DOCUMENTROOT#/\/srv\/www\/htdocs/' $RPM_BUILD_ROOT%{rhnconfigdefaults}/rhn.conf
+%if !0%{?build_py3}
 pushd $RPM_BUILD_ROOT
 find -name '*.py' -print0 | xargs -0 python %py_libdir/py_compile.py
 popd
+%endif
 
 %if 0%{?build_py3}
-%py3_compile -O %{buildroot}/%{python3rhnroot}
-%endif
+%py3_compile -O %{buildroot}/%{pythonrhnroot}
 %endif
 
 # prevent file conflict with spacewalk-usix
 rm -f $RPM_BUILD_ROOT%{pythonrhnroot}/__init__.py*
 rm -f $RPM_BUILD_ROOT%{pythonrhnroot}/common/__init__.py*
-
-%if 0%{?build_py3}
-rm -f $RPM_BUILD_ROOT%{python3rhnroot}/__init__.py*
-rm -f $RPM_BUILD_ROOT%{python3rhnroot}/common/__init__.py*
-
-%if 0%{?suse_version}
-%py3_compile -O %{buildroot}/%{python3rhnroot}
-%endif
 %endif
 
 %check
+ls %{pythonrhnroot}/
+ls %{pythonrhnroot}/common/
 cp %{pythonrhnroot}/common/usix.py $RPM_BUILD_ROOT%{pythonrhnroot}/common
-make -f Makefile.backend PYTHONPATH=$RPM_BUILD_ROOT%{python_sitelib} test || :
+make -f Makefile.backend PYTHONPATH=$RPM_BUILD_ROOT%{python_sitelib} PYTHON_BIN=%{pythonX} test || :
 
 %if 0%{?pylint_check}
 # check coding style
@@ -513,11 +594,13 @@ spacewalk-python2-pylint $RPM_BUILD_ROOT%{pythonrhnroot}/common \
 
 rm -f $RPM_BUILD_ROOT%{pythonrhnroot}/common/usix.py*
 
+%if !0%{?build_py3}
 if [ -x %py_libdir/py_compile.py ]; then
     pushd %{buildroot}
     find -name '*.py' -print0 | xargs -0 python %py_libdir/py_compile.py
     popd
 fi
+%endif
 
 %pre server
 OLD_SECRET_FILE=%{_var}/www/rhns/server/secret/rhnSecret.py
@@ -559,7 +642,6 @@ rm -f %{rhnconf}/rhnSecret.py*
 %defattr(-,root,root)
 %doc LICENSE
 %dir %{pythonrhnroot}
-%dir %{pythonrhnroot}/common
 %{pythonrhnroot}/common/suseLib.py*
 %{pythonrhnroot}/common/apache.py*
 %{pythonrhnroot}/common/byterange.py*
@@ -590,6 +672,10 @@ rm -f %{rhnconf}/rhnSecret.py*
 %if 0%{?suse_version}
 %dir %{rhnroot}
 %endif
+%if 0%{?build_py3}
+%{pythonrhnroot}/__pycache__/*
+%{pythonrhnroot}/common/__pycache__/*
+%endif
 
 %files sql
 %defattr(-,root,root)
@@ -606,6 +692,12 @@ rm -f %{rhnconf}/rhnSecret.py*
 %{pythonrhnroot}/server/rhnSQL/dbi.py*
 %{pythonrhnroot}/server/rhnSQL/__init__.py*
 %{pythonrhnroot}/server/rhnSQL/sql_*.py*
+%if 0%{?build_py3}
+%dir %{pythonrhnroot}/server/__pycache__/
+%dir %{pythonrhnroot}/server/rhnSQL/__pycache__/
+%{pythonrhnroot}/server/__pycache__/*
+%{pythonrhnroot}/server/rhnSQL/__pycache__/*
+%endif
 
 %if 0%{?with_oracle}
 %files sql-oracle
@@ -674,6 +766,10 @@ rm -f %{rhnconf}/rhnSecret.py*
 %{pythonrhnroot}/server/importlib/contentSourcesImport.py*
 %{pythonrhnroot}/server/importlib/supportInformationImport.py*
 %{pythonrhnroot}/server/importlib/suseProductsImport.py*
+%if 0%{?build_py3}
+%dir %{pythonrhnroot}/server/importlib/__pycache__/
+%{pythonrhnroot}/server/importlib/__pycache__/*
+%endif
 %{rhnroot}/server/handlers/__init__.py*
 
 # Repomd stuff
@@ -683,6 +779,10 @@ rm -f %{rhnconf}/rhnSecret.py*
 %{pythonrhnroot}/server/repomd/mapper.py*
 %{pythonrhnroot}/server/repomd/repository.py*
 %{pythonrhnroot}/server/repomd/view.py*
+%if 0%{?build_py3}
+%dir %{pythonrhnroot}/server/repomd/__pycache__/
+%{pythonrhnroot}/server/repomd/__pycache__/*
+%endif
 
 # the cache
 %attr(755,%{apache_user},%{apache_group}) %dir %{_var}/cache/rhn
@@ -776,9 +876,14 @@ rm -f %{rhnconf}/rhnSecret.py*
 %{rhnroot}/satellite_exporter/__init__.py*
 %{rhnroot}/satellite_exporter/handlers/__init__.py*
 %{rhnroot}/satellite_exporter/handlers/non_auth_dumper.py*
+%if 0%{?build_py3}
+%dir %{pythonrhnroot}/satellite_exporter/__pycache__/
+%{pythonrhnroot}/satellite_exporter/__pycache__/*
+%endif
 # config files
 %config(noreplace) %{_sysconfdir}/logrotate.d/spacewalk-backend-iss-export
 
+%if !0%{?build_py3}
 %files libs
 %defattr(-,root,root)
 %doc LICENSE
@@ -792,35 +897,33 @@ rm -f %{rhnconf}/rhnSecret.py*
 %{pythonrhnroot}/common/stringutils.py*
 %{pythonrhnroot}/common/rhnLib.py*
 %{pythonrhnroot}/common/timezone_utils.py*
-#%{pythonrhnroot}/__init__.py*
-#%{pythonrhnroot}/common/__init__.py*
+%endif
 
 %if 0%{?build_py3}
 %files -n python3-%{name}-libs
 %defattr(-,root,root)
 %doc LICENSE
-%dir %{python3rhnroot}
-#%dir %{python3rhnroot}/__pycache__
-%dir %{python3rhnroot}/common
-%dir %{python3rhnroot}/common/__pycache__
-%{python3rhnroot}/common/checksum.py
-%{python3rhnroot}/common/cli.py
-%{python3rhnroot}/common/fileutils.py
-%{python3rhnroot}/common/rhn_deb.py
-%{python3rhnroot}/common/rhn_mpm.py
-%{python3rhnroot}/common/rhn_pkg.py
-%{python3rhnroot}/common/rhn_rpm.py
-%{python3rhnroot}/common/stringutils.py
-%{python3rhnroot}/common/rhnLib.py*
-#%{python3rhnroot}/__init__.py
-#%{python3rhnroot}/common/__init__.py
-#%{python3rhnroot}/__pycache__/__init__.*
-%{python3rhnroot}/common/__pycache__
+%dir %{pythonrhnroot}
+%dir %{pythonrhnroot}/common
+%dir %{pythonrhnroot}/common/__pycache__
+%{pythonrhnroot}/common/checksum.py
+%{pythonrhnroot}/common/cli.py
+%{pythonrhnroot}/common/fileutils.py
+%{pythonrhnroot}/common/rhn_deb.py
+%{pythonrhnroot}/common/rhn_mpm.py
+%{pythonrhnroot}/common/rhn_pkg.py
+%{pythonrhnroot}/common/rhn_rpm.py
+%{pythonrhnroot}/common/stringutils.py
+%{pythonrhnroot}/common/rhnLib.py*
+%{pythonrhnroot}/common/timezone_utils.py*
+%{pythonrhnroot}/common/__pycache__/*
 %if 0%{?suse_version}
-%dir %{python3rhnroot}
-%dir %{python3rhnroot}/common
-%dir %{python3rhnroot}/__pycache__
+%dir %{pythonrhnroot}
+%dir %{pythonrhnroot}/common
+%dir %{pythonrhnroot}/__pycache__
 %endif
+%{pythonrhnroot}/common
+%{pythonrhnroot}/common/__pycache__
 %endif
 
 %files config-files-common
@@ -923,6 +1026,14 @@ rm -f %{rhnconf}/rhnSecret.py*
 %{pythonrhnroot}/satellite_tools/repo_plugins/yum_src.py*
 %{pythonrhnroot}/satellite_tools/repo_plugins/uln_src.py*
 %{pythonrhnroot}/satellite_tools/repo_plugins/deb_src.py*
+%if 0%{?build_py3}
+%dir %{pythonrhnroot}/satellite_tools/__pycache__/
+%dir %{pythonrhnroot}/satellite_tools/disk_dumper/__pycache__/
+%dir %{pythonrhnroot}/satellite_tools/repo_plugins/__pycache__/
+%{pythonrhnroot}/satellite_tools/__pycache__/*
+%{pythonrhnroot}/satellite_tools/disk_dumper/__pycache__/*
+%{pythonrhnroot}/satellite_tools/repo_plugins/__pycache__/*
+%endif
 %config %attr(644,root,%{apache_group}) %{rhnconfigdefaults}/rhn_server_iss.conf
 %{_mandir}/man8/rhn-satellite-exporter.8*
 %{_mandir}/man8/rhn-charsets.8*
@@ -959,6 +1070,10 @@ rm -f %{rhnconf}/rhnSecret.py*
 %{pythonrhnroot}/satellite_tools/exporter/__init__.py*
 %{pythonrhnroot}/satellite_tools/exporter/exportLib.py*
 %{pythonrhnroot}/satellite_tools/exporter/xmlWriter.py*
+%if 0%{?build_py3}
+%dir %{pythonrhnroot}/satellite_tools/exporter/__pycache__/
+%{pythonrhnroot}/satellite_tools/exporter/__pycache__/*
+%endif
 
 %files cdn
 %defattr(-,root,root)
@@ -970,6 +1085,10 @@ rm -f %{rhnconf}/rhnSecret.py*
 %{_mandir}/man8/cdn-sync.8*
 %if 0%{?suse_version}
 %dir %{pythonrhnroot}/cdn_tools
+%if 0%{?build_py3}
+%dir %{pythonrhnroot}/cdn_tools/__pycache__/
+%{pythonrhnroot}/cdn_tools/__pycache__/*
+%endif
 %endif
 
 %changelog

--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -498,7 +498,7 @@ Requires:       subscription-manager
 Tools for syncing content from Red Hat CDN
 
 %prep
-%setup -q -n spacewalk-backend-4.0.1devel
+%setup -q
 
 %build
 make -f Makefile.backend all PYTHON_BIN=%{pythonX}

--- a/susemanager/Makefile.defs
+++ b/susemanager/Makefile.defs
@@ -9,7 +9,7 @@ TOP		?= .
 ROOT		?= /usr/share/rhn
 export ROOT
 
-SPACEWALK_ROOT	?= $(shell python -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")/spacewalk
+SPACEWALK_ROOT	?= $(shell $(PYTHON_BIN) -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")/spacewalk
 export SPACEWALK_ROOT
 
 PREFIX		?=

--- a/susemanager/Makefile.susemanager
+++ b/susemanager/Makefile.susemanager
@@ -4,7 +4,6 @@ DOCKER_REGISTRY       = registry.mgr.suse.de
 DOCKER_RUN_EXPORT     = "PYTHONPATH=/manager/client/rhel/rhnlib/:/manager/client/rhel/rhn-client-tools/src"
 DOCKER_VOLUMES        = -v "$(CURDIR)/../:/manager"
 
-
 pylint ::
 	pylint --errors-only --disable=W src/
 
@@ -12,7 +11,7 @@ unittest ::
 	if test -x /usr/bin/unit2 ; then \
                 unit2 discover -s src; \
         else \
-                python -munittest discover -s src; \
+                $(PYTHON_BIN) -munittest discover -s src; \
         fi
 
 unittest_inside_docker ::

--- a/susemanager/src/authenticator.py
+++ b/susemanager/src/authenticator.py
@@ -16,7 +16,10 @@
 from spacewalk.susemanager.helpers import cli_ask
 from spacewalk.susemanager.helpers import timeout
 
-import xmlrpclib
+try:
+    import xmlrpc.client as xmlrpc_client
+except ImportError:
+    import xmlrpclib as xmlrpc_client
 
 
 class MaximumNumberOfAuthenticationFailures(Exception):
@@ -67,7 +70,7 @@ class Authenticator(object):
 
             try:
                 self._token = self.connection.auth.login(self.user, self.password)
-            except xmlrpclib.Fault as ex:
+            except xmlrpc_client.Fault as ex:
                 if ex.faultCode == 2950 and "Either the password or username is incorrect" in ex.faultString:
                     if self.has_credentials() and not self.cached_credentials_used:
                         # Try to reuse the credentials stored into the configuration file

--- a/susemanager/src/authenticator.py
+++ b/susemanager/src/authenticator.py
@@ -67,7 +67,7 @@ class Authenticator(object):
 
             try:
                 self._token = self.connection.auth.login(self.user, self.password)
-            except xmlrpclib.Fault, ex:
+            except xmlrpclib.Fault as ex:
                 if ex.faultCode == 2950 and "Either the password or username is incorrect" in ex.faultString:
                     if self.has_credentials() and not self.cached_credentials_used:
                         # Try to reuse the credentials stored into the configuration file

--- a/susemanager/src/authenticator.py
+++ b/susemanager/src/authenticator.py
@@ -12,6 +12,7 @@
 # SUSE trademarks are not licensed under GPLv2. No permission is
 # granted to use or replicate SUSE trademarks that are incorporated
 # in this software or its documentation.
+from __future__ import print_function
 
 from spacewalk.susemanager.helpers import cli_ask
 from spacewalk.susemanager.helpers import timeout
@@ -121,7 +122,7 @@ class Authenticator(object):
         Get credentials from CLI interactively.
         """
 
-        print "Please enter the credentials of SUSE Manager Administrator."
+        print("Please enter the credentials of SUSE Manager Administrator.")
         self.user = cli_ask("Login")
         self.password = cli_ask("Password", password=True)
 

--- a/susemanager/src/errata_helper.py
+++ b/susemanager/src/errata_helper.py
@@ -56,7 +56,7 @@ def deleteErrata(errata_id):
     """)
     h.execute(errata_id=errata_id)
 
-    package_ids = map(lambda x: x['id'], h.fetchall_dict() or [])
+    package_ids = [x['id'] for x in h.fetchall_dict() or []]
     for package_id in package_ids:
         package_helper.delete_package(package_id)
 
@@ -130,7 +130,7 @@ def channelsWithErrata(errata_id):
     """)
     h.execute(errata_id=errata_id)
 
-    return map(lambda x: x['channel_id'], h.fetchall_dict() or [])
+    return [x['channel_id'] for x in h.fetchall_dict() or []]
 
 def findErrataClones(errata_id):
     """ Find all the clones of this errata.
@@ -143,7 +143,7 @@ def findErrataClones(errata_id):
     """)
     h.execute(errata_id=errata_id)
 
-    clones = map(lambda x: x['id'], h.fetchall_dict() or [])
+    clones = [x['id'] for x in h.fetchall_dict() or []]
     ret    = clones[:]
 
     for clone in clones:

--- a/susemanager/src/helpers.py
+++ b/susemanager/src/helpers.py
@@ -20,6 +20,10 @@ import errno
 import os
 import signal
 
+try:
+   input = raw_input
+except NameError:
+   pass
 
 def cli_ask(msg, password=False, validator=None):
     """
@@ -35,7 +39,7 @@ def cli_ask(msg, password=False, validator=None):
     msg += ": "
     value = None
     while True:
-        value = (password and getpass.getpass(msg) or raw_input(msg))
+        value = (password and getpass.getpass(msg) or input(msg))
         if not validator and value:
             break
         elif validator:

--- a/susemanager/src/mgr-clean-old-patchnames
+++ b/susemanager/src/mgr-clean-old-patchnames
@@ -41,5 +41,5 @@ def main():
 if __name__ == "__main__":
     try:
         main()
-    except IOError, e:
+    except IOError as e:
         print "ERROR: %s" % e

--- a/susemanager/src/mgr-clean-old-patchnames
+++ b/susemanager/src/mgr-clean-old-patchnames
@@ -14,6 +14,7 @@
 #   You should have received a copy of the GNU Lesser General Public
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+from __future__ import print_function
 
 import sys
 from optparse import OptionParser
@@ -42,4 +43,4 @@ if __name__ == "__main__":
     try:
         main()
     except IOError as e:
-        print "ERROR: %s" % e
+        print("ERROR: %s" % e)

--- a/susemanager/src/mgr-create-bootstrap-repo
+++ b/susemanager/src/mgr-create-bootstrap-repo
@@ -123,7 +123,7 @@ def list_labels():
     :return:
     """
     label_map = {}
-    synced_products = map(lambda x: x['id'], rhnSQL.fetchall_dict(_sql_synced_proucts) or [])
+    synced_products = [x['id'] for x in rhnSQL.fetchall_dict(_sql_synced_proucts) or []]
     label_index = 1
     for label in sorted(mgr_bootstrap_data.DATA.iterkeys()):
         if int(mgr_bootstrap_data.DATA[label]['PDID'][0]) in synced_products:
@@ -201,7 +201,7 @@ def create_repo(label, flush, additional=[]):
             print(m)
         if label.startswith('RES') and not options.usecustomchannels:
             print("If the installation media was imported into a custom channel, try to run again with --with-custom-channels option")
-        suggestions = list(filter(None, suggestions.values()))
+        suggestions = list([_f for _f in list(suggestions.values()) if _f])
         if suggestions:
             print("\nSuggestions:")
             for suggestion in suggestions:
@@ -240,9 +240,9 @@ try:
     mgr_bootstrap_data = __import__(modulename)
     for label in mgr_bootstrap_data.DATA:
         if not isinstance(mgr_bootstrap_data.DATA[label]['PDID'], usix.ListType):
-            mgr_bootstrap_data.DATA[label]['PDID'] = map(str, [int(mgr_bootstrap_data.DATA[label]['PDID'])])
+            mgr_bootstrap_data.DATA[label]['PDID'] = list(map(str, [int(mgr_bootstrap_data.DATA[label]['PDID'])]))
         else:
-            mgr_bootstrap_data.DATA[label]['PDID'] = map(str, [int(pdid) for pdid in mgr_bootstrap_data.DATA[label]['PDID']])
+            mgr_bootstrap_data.DATA[label]['PDID'] = list(map(str, [int(pdid) for pdid in mgr_bootstrap_data.DATA[label]['PDID']]))
 except ImportError as e:
     sys.stderr.write("Unable to load module '%s'\n" % modulename)
     sys.stderr.write(str(e) + "\n")

--- a/susemanager/src/mgr-create-bootstrap-repo
+++ b/susemanager/src/mgr-create-bootstrap-repo
@@ -243,7 +243,7 @@ try:
             mgr_bootstrap_data.DATA[label]['PDID'] = map(str, [int(mgr_bootstrap_data.DATA[label]['PDID'])])
         else:
             mgr_bootstrap_data.DATA[label]['PDID'] = map(str, [int(pdid) for pdid in mgr_bootstrap_data.DATA[label]['PDID']])
-except ImportError, e:
+except ImportError as e:
     sys.stderr.write("Unable to load module '%s'\n" % modulename)
     sys.stderr.write(str(e) + "\n")
     sys.exit(1)

--- a/susemanager/src/mgr-create-bootstrap-repo
+++ b/susemanager/src/mgr-create-bootstrap-repo
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#!/usr/bin/python
 from __future__ import print_function
 import sys
 import os

--- a/susemanager/src/mgr-create-bootstrap-repo
+++ b/susemanager/src/mgr-create-bootstrap-repo
@@ -158,7 +158,7 @@ def create_repo(label, flush, additional=[]):
         print("Creating bootstrap repo for latest Service Pack of {0}".format(label))
     else:
         print("Creating bootstrap repo for {0}".format(label))
-    print
+    print()
 
     if options.usecustomchannels:
         h = rhnSQL.prepare(rhnSQL.Statement(_sql_find_pkgs_with_custom_channels % (pdids, pdids)))

--- a/susemanager/src/mgr-create-bootstrap-repo
+++ b/susemanager/src/mgr-create-bootstrap-repo
@@ -10,6 +10,11 @@ from spacewalk.common.rhnConfig import CFG, initCFG
 from optparse import OptionParser
 import textwrap
 
+try:
+   input = raw_input
+except NameError:
+   pass
+
 msg_wrapper = textwrap.TextWrapper()
 msg_wrapper.initial_indent = '- '
 msg_wrapper.width = 75
@@ -261,7 +266,7 @@ if options.interactive:
     elabel = None
     while True:
         try:
-            elabel = label_map.get(int(raw_input("Enter a number of a product label: ")), '')
+            elabel = label_map.get(int(input("Enter a number of a product label: ")), '')
             break
         except Exception:
             print("Please enter a number.")

--- a/susemanager/src/mgr-create-bootstrap-repo
+++ b/susemanager/src/mgr-create-bootstrap-repo
@@ -125,7 +125,7 @@ def list_labels():
     label_map = {}
     synced_products = [x['id'] for x in rhnSQL.fetchall_dict(_sql_synced_proucts) or []]
     label_index = 1
-    for label in sorted(mgr_bootstrap_data.DATA.iterkeys()):
+    for label in sorted(mgr_bootstrap_data.DATA.keys()):
         if int(mgr_bootstrap_data.DATA[label]['PDID'][0]) in synced_products:
             print("{0}. {1}".format(label_index, label))
             label_map[label_index] = label

--- a/susemanager/src/mgr-delete-patch
+++ b/susemanager/src/mgr-delete-patch
@@ -53,5 +53,5 @@ clones.
 if __name__ == "__main__":
     try:
         main()
-    except IOError, e:
+    except IOError as e:
         print "ERROR: %s" % e

--- a/susemanager/src/mgr-delete-patch
+++ b/susemanager/src/mgr-delete-patch
@@ -14,6 +14,7 @@
 #   You should have received a copy of the GNU Lesser General Public
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+from __future__ import print_function
 
 import sys
 import textwrap
@@ -54,4 +55,4 @@ if __name__ == "__main__":
     try:
         main()
     except IOError as e:
-        print "ERROR: %s" % e
+        print("ERROR: %s" % e)

--- a/susemanager/src/mgr-sync
+++ b/susemanager/src/mgr-sync
@@ -25,15 +25,15 @@ options = get_options()
 
 try:
     sys.exit(MgrSync().run(options))
-except socket.error, ex:
+except socket.error as ex:
     sys.stderr.write("Network error: {0}\n".format(ex))
     if options.verbose:
         raise
     else:
         sys.exit(1)
-except KeyboardInterrupt, ex:
+except KeyboardInterrupt as ex:
     sys.stdout.write("\n")
-except Exception, ex:
+except Exception as ex:
     sys.stderr.write("General error: {0}\n".format(ex))
     if options.verbose:
         raise

--- a/susemanager/src/mgr_clean_old_patchnames.py
+++ b/susemanager/src/mgr_clean_old_patchnames.py
@@ -45,7 +45,7 @@ class Cleaner:
     def run(self):
         channels = []
         if self.all:
-            channels = rhnSQL.Table("RHNCHANNEL", "LABEL").keys()
+            channels = list(rhnSQL.Table("RHNCHANNEL", "LABEL").keys())
         else:
             channels = [self.channel]
 

--- a/susemanager/src/mgr_clean_old_patchnames.py
+++ b/susemanager/src/mgr_clean_old_patchnames.py
@@ -9,6 +9,8 @@
 # along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 #
+from __future__ import print_function
+
 import re
 import sys
 
@@ -27,7 +29,7 @@ class Cleaner:
         self.debug = debug
 
         if not all and not channel:
-            print "You need to specify either --all or --channel"
+            print("You need to specify either --all or --channel")
             sys.exit(1)
 
         initCFG("server.susemanager")
@@ -109,5 +111,5 @@ class Cleaner:
 
 def _printLog(msg):
     log_debug(0, msg)
-    print msg
+    print(msg)
 

--- a/susemanager/src/mgr_clean_old_patchnames.py
+++ b/susemanager/src/mgr_clean_old_patchnames.py
@@ -38,7 +38,7 @@ class Cleaner:
 
         try:
             rhnSQL.initDB()
-        except rhnSQL.SQLConnectError, e:
+        except rhnSQL.SQLConnectError as e:
             log_error("Could not connect to the database. %s" % e)
             raise Exception("Could not connect to the database. %s" % e)
 

--- a/susemanager/src/mgr_delete_patch.py
+++ b/susemanager/src/mgr_delete_patch.py
@@ -22,6 +22,11 @@ from spacewalk.susemanager import errata_helper
 
 DEFAULT_LOG_LOCATION = '/var/log/rhn/'
 
+try:
+   input = raw_input
+except NameError:
+   pass
+
 class Cleaner:
     def __init__(self, debug):
         self.debug = debug
@@ -65,7 +70,7 @@ class Cleaner:
 
         reply = None
         while not reply in ('y', 'n'):
-            reply = raw_input("Do you want to continue? (Y/n) ")
+            reply = input("Do you want to continue? (Y/n) ")
             if not reply:
                 reply = "y"
             reply = reply.lower()

--- a/susemanager/src/mgr_delete_patch.py
+++ b/susemanager/src/mgr_delete_patch.py
@@ -9,6 +9,8 @@
 # along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 #
+from __future__ import print_function
+
 import re
 import sys
 
@@ -51,15 +53,15 @@ class Cleaner:
             clones           = errata_helper.findErrataClones(parent_errata_id)
 
             _printLog("{0} is a clone of {1}".format(errata, parent_advisory))
-            print "The tool is going to remove '{0}' and all its clones:".format(parent_advisory)
+            print("The tool is going to remove '{0}' and all its clones:".format(parent_advisory))
         else:
             clones = errata_helper.findErrataClones(errata_id)
-            print "The tool is going to remove '{0}' and all its clones:".format(errata)
+            print("The tool is going to remove '{0}' and all its clones:".format(errata))
 
         for id in clones:
             clone_advisory       = errata_helper.getAdvisory(id)
             errata_to_remove[id] = clone_advisory
-            print "  -", clone_advisory
+            print("  -", clone_advisory)
 
         reply = None
         while not reply in ('y', 'n'):
@@ -122,5 +124,5 @@ class Cleaner:
 
 def _printLog(msg):
     log_debug(0, msg)
-    print msg
+    print(msg)
 

--- a/susemanager/src/mgr_delete_patch.py
+++ b/susemanager/src/mgr_delete_patch.py
@@ -27,7 +27,7 @@ class Cleaner:
 
         try:
             rhnSQL.initDB()
-        except rhnSQL.SQLConnectError, e:
+        except rhnSQL.SQLConnectError as e:
             log_error("Could not connect to the database. %s" % e)
             raise Exception("Could not connect to the database. %s" % e)
 

--- a/susemanager/src/mgr_sync/channel.py
+++ b/susemanager/src/mgr_sync/channel.py
@@ -100,11 +100,11 @@ def find_channel_by_label(label, channels, log):
 
     log.info("Searching for channels with label '{0}'".format(label))
 
-    if label in channels.keys():
+    if label in list(channels.keys()):
         log.debug("Found '{0}'".format(channels[label]))
         return channels[label]
 
-    for bc in channels.values():
+    for bc in list(channels.values()):
         matches = [c for c in bc.children if c.label == label]
         if len(matches) == 1:
             log.debug("Found '{0}'".format(matches[0]))

--- a/susemanager/src/mgr_sync/config.py
+++ b/susemanager/src/mgr_sync/config.py
@@ -72,7 +72,7 @@ class Config(object):
             self._config.merge(ConfigObj(Config.DOTFILE))
 
         # Remove unnesessary items
-        for key in self._config.keys():
+        for key in list(self._config.keys()):
             if not key.startswith(Config.K_PREF):
                 del self._config[key]
 

--- a/susemanager/src/mgr_sync/mgr_sync.py
+++ b/susemanager/src/mgr_sync/mgr_sync.py
@@ -60,7 +60,7 @@ class MgrSync(object):
         self.log = self.__init__logger(options.debug)
         self.log.info("Executing mgr-sync {0}".format(options))
 
-        if self.conn.sync.master.hasMaster() and not vars(options).has_key('refresh'):
+        if self.conn.sync.master.hasMaster() and 'refresh' not in vars(options):
             msg = """SUSE Manager is configured as slave server. Please use 'mgr-inter-sync' command.\n"""
             self.log.error(msg)
             sys.stderr.write(msg)
@@ -114,7 +114,7 @@ class MgrSync(object):
         self.quiet = not options.verbose
         self.exit_with_error = False
 
-        if vars(options).has_key('list_target'):
+        if 'list_target' in vars(options):
             if 'channel' in options.list_target:
                 self.log.info("Listing channels...")
                 self._list_channels(expand=options.expand,
@@ -128,7 +128,7 @@ class MgrSync(object):
                 self.log.info("Listing products...")
                 self._list_products(expand=options.expand,
                                     filter=options.filter)
-        elif vars(options).has_key('add_target'):
+        elif 'add_target' in vars(options):
             if 'channel' in options.add_target:
                 self._add_channels(channels=options.target,
                                    mirror=options.mirror,
@@ -137,12 +137,12 @@ class MgrSync(object):
                 self._add_credentials(options.primary, options.target)
             elif 'product' in options.add_target:
                 self._add_products(mirror="", no_recommends=options.no_recommends)
-        elif vars(options).has_key('refresh'):
+        elif 'refresh' in vars(options):
             self.exit_with_error = not self._refresh(
                 enable_reposync=options.refresh_channels,
                 mirror=options.mirror,
                 schedule=options.schedule)
-        elif vars(options).has_key('delete_target'):
+        elif 'delete_target' in vars(options):
             if 'credentials' in options.delete_target:
                 self._delete_credentials(options.target)
 

--- a/susemanager/src/mgr_sync/mgr_sync.py
+++ b/susemanager/src/mgr_sync/mgr_sync.py
@@ -330,7 +330,7 @@ class MgrSync(object):
                                         "syncRepo",
                                         self.auth.token(),
                                         channels)
-        except xmlrpclib.Fault, ex:
+        except xmlrpclib.Fault as ex:
             if ex.faultCode == 2802:
                 self.log.error("Error, unable to schedule channel reposync: Taskomatic is not responding.")
                 sys.stderr.write("Error, unable to schedule channel reposync: Taskomatic is not responding.\n")
@@ -618,7 +618,7 @@ class MgrSync(object):
         if self.conn.sync.master.hasMaster() or schedule:
             try:
                 self._schedule_taskomatic_refresh(enable_reposync)
-            except xmlrpclib.Fault, e:
+            except xmlrpclib.Fault as e:
                 self.log.error("Error scheduling refresh: {0}".format(e))
                 sys.stderr.write("Error scheduling refresh: {0}\n".format(e))
                 return False
@@ -642,7 +642,7 @@ class MgrSync(object):
                 self.log.info("Refreshing {0} succeeded".format(operation.rstrip()))
                 sys.stdout.write("[DONE]".rjust(text_width) + "\n")
                 sys.stdout.flush()
-            except Exception, ex:
+            except Exception as ex:
                 self.log.error("Refreshing {0} failed".format(operation.rstrip()))
                 self.log.error("Error: {0}".format(ex))
                 sys.stdout.write("[FAIL]".rjust(text_width) + "\n")
@@ -698,7 +698,7 @@ class MgrSync(object):
             self.log.debug("Invoking remote method {0} with auth_token {1}".format(
                 method, auth_token))
             return getattr(endpoint, method)(auth_token, *params)
-        except xmlrpclib.Fault, ex:
+        except xmlrpclib.Fault as ex:
             if retry_on_session_failure and self._check_session_fail(ex):
                 self.log.info("Retrying after session failure: {0}".format(ex))
                 self.auth.discard_token()

--- a/susemanager/src/mgr_sync/mgr_sync.py
+++ b/susemanager/src/mgr_sync/mgr_sync.py
@@ -456,10 +456,10 @@ class MgrSync(object):
         num_prod = interactive_data['num_prod']
         if num_prod:
             validator = lambda i: re.search("\d+", i) and \
-                int(i) in range(1, len(num_prod.keys()) + 1)
+                int(i) in range(1, len(list(num_prod.keys())) + 1)
             choice = cli_ask(
                 msg=("Enter product number (1-{0})".format(
-                    len(num_prod.keys()))),
+                    len(list(num_prod.keys())))),
                 validator=validator)
 
             self.log.info("Selecting product '{0} {1}' from choice '{2}'".format(

--- a/susemanager/src/mgr_sync/mgr_sync.py
+++ b/susemanager/src/mgr_sync/mgr_sync.py
@@ -12,6 +12,7 @@
 # SUSE trademarks are not licensed under GPLv2. No permission is
 # granted to use or replicate SUSE trademarks that are incorporated
 # in this software or its documentation.
+from __future__ import print_function
 
 import re
 import sys

--- a/susemanager/src/mgr_sync/product.py
+++ b/susemanager/src/mgr_sync/product.py
@@ -12,6 +12,7 @@
 # SUSE trademarks are not licensed under GPLv2. No permission is
 # granted to use or replicate SUSE trademarks that are incorporated
 # in this software or its documentation.
+from __future__ import print_function
 
 from enum import Enum
 

--- a/susemanager/src/test/helper.py
+++ b/susemanager/src/test/helper.py
@@ -20,7 +20,11 @@ try:
 except ImportError:
     from cStringIO import StringIO
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
 import os
 import sys
 
@@ -51,7 +55,10 @@ class FakeStdin():
         self.fake_input = fake_input
 
     def __enter__(self):
-        self.patcher = mock.patch('__builtin__.raw_input')
+        if sys.version_info < (3,):
+            self.patcher = mock.patch('__builtin__.raw_input')
+        else:
+            self.patcher = mock.patch('builtins.input')
         self.mock = self.patcher.start()
         self.mock.side_effect = fake_user_input(*self.fake_input)
         return self.mock

--- a/susemanager/src/test/helper.py
+++ b/susemanager/src/test/helper.py
@@ -16,9 +16,9 @@
 
 
 try:
-    from io import StringIO
-except ImportError:
     from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 try:
     from unittest import mock

--- a/susemanager/src/test/helper.py
+++ b/susemanager/src/test/helper.py
@@ -15,7 +15,11 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 
-from cStringIO import StringIO
+try:
+    from io import StringIO
+except ImportError:
+    from cStringIO import StringIO
+
 import mock
 import os
 import sys

--- a/susemanager/src/test/test_authenticator.py
+++ b/susemanager/src/test/test_authenticator.py
@@ -27,7 +27,10 @@ except ImportError:
 import os.path
 import sys
 
-from mock import MagicMock, call, patch
+try:
+    from unittest.mock import MagicMock, call, patch
+except ImportError:
+    from mock import MagicMock, call, patch
 
 sys.path.insert(
     0,

--- a/susemanager/src/test/test_authenticator.py
+++ b/susemanager/src/test/test_authenticator.py
@@ -19,7 +19,11 @@ try:
 except ImportError:
     import unittest
 
-import xmlrpclib
+try:
+    import xmlrpc.client as xmlrpc_client
+except ImportError:
+    import xmlrpclib as xmlrpc_client
+
 import os.path
 import sys
 
@@ -100,7 +104,7 @@ class AuthenticatorTest(unittest.TestCase):
             ["interactive_username", "interactive_password"]
         ]
         expected_token = "test token"
-        exception = xmlrpclib.Fault(
+        exception = xmlrpc_client.Fault(
             2950,
             "Either the password or username is incorrect")
         login_mocked_return_values = [
@@ -138,7 +142,7 @@ class AuthenticatorTest(unittest.TestCase):
         ]
         cached_credentials = ["cached_username", "cached_password"]
         expected_token = "test token"
-        exception = xmlrpclib.Fault(
+        exception = xmlrpc_client.Fault(
             2950,
             "Either the password or username is incorrect")
         login_mocked_return_values = [
@@ -177,7 +181,7 @@ class AuthenticatorTest(unittest.TestCase):
             ["interactive_username3", "interactive_password3"]
         ]
         expected_token = "test token"
-        exception = xmlrpclib.Fault(
+        exception = xmlrpc_client.Fault(
             2950,
             "Either the password or username is incorrect")
         login_mocked_return_values = [
@@ -216,7 +220,7 @@ class AuthenticatorTest(unittest.TestCase):
             ["interactive_username3", "interactive_password3"]
         ]
         cached_credentials = ["cached_username", "cached_password"]
-        exception = xmlrpclib.Fault(
+        exception = xmlrpc_client.Fault(
             2950,
             "Either the password or username is incorrect")
         login_mocked_return_values = [

--- a/susemanager/src/test/test_helpers.py
+++ b/susemanager/src/test/test_helpers.py
@@ -20,7 +20,11 @@ try:
 except ImportError:
     import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
 import os
 import re
 import sys
@@ -29,10 +33,6 @@ from spacewalk.susemanager.helpers import cli_ask
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from .helper import FakeStdin
-
-def fake_user_input(*args):
-    for ret_value in args:
-        yield ret_value
 
 
 class HelpersTest(unittest.TestCase):
@@ -43,9 +43,8 @@ class HelpersTest(unittest.TestCase):
 
         with FakeStdin(None, response) as mocked_input:
             value = cli_ask(message)
-
-        self.assertEqual(response, value)
-        self.assertEqual(2, mocked_input.call_count)
+            self.assertEqual(response, value)
+            self.assertEqual(2, mocked_input.call_count)
 
     def test_cli_ask_with_tuple_validator(self):
         message = "how are you?"
@@ -54,9 +53,8 @@ class HelpersTest(unittest.TestCase):
 
         with FakeStdin("angry", response) as mocked_input:
             value = cli_ask(message, validator=validator)
-
-        self.assertEqual(response, value)
-        self.assertEqual(2, mocked_input.call_count)
+            self.assertEqual(response, value)
+            self.assertEqual(2, mocked_input.call_count)
 
     def test_cli_ask_with_list_validator(self):
         message = "how are you?"
@@ -65,9 +63,8 @@ class HelpersTest(unittest.TestCase):
 
         with FakeStdin("angry", response) as mocked_input:
             value = cli_ask(message, validator=validator)
-
-        self.assertEqual(response, value)
-        self.assertEqual(2, mocked_input.call_count)
+            self.assertEqual(response, value)
+            self.assertEqual(2, mocked_input.call_count)
 
     def test_cli_ask_with_regexp_validator(self):
         message = "how old are you?"
@@ -76,9 +73,8 @@ class HelpersTest(unittest.TestCase):
 
         with FakeStdin("young", response) as mocked_input:
             value = cli_ask(message, validator=validator)
-
-        self.assertEqual(response, value)
-        self.assertEqual(2, mocked_input.call_count)
+            self.assertEqual(response, value)
+            self.assertEqual(2, mocked_input.call_count)
 
     def test_cli_ask_with_custom_validator(self):
         message = "how old are you?"
@@ -87,7 +83,6 @@ class HelpersTest(unittest.TestCase):
 
         with FakeStdin("young", "0", "40", "10") as mocked_input:
             value = cli_ask(message, validator=validator)
-
-        self.assertEqual(response, value)
-        self.assertEqual(4, mocked_input.call_count)
+            self.assertEqual(response, value)
+            self.assertEqual(4, mocked_input.call_count)
 

--- a/susemanager/src/test/test_helpers.py
+++ b/susemanager/src/test/test_helpers.py
@@ -28,7 +28,7 @@ import sys
 from spacewalk.susemanager.helpers import cli_ask
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-from helper import FakeStdin
+from .helper import FakeStdin
 
 def fake_user_input(*args):
     for ret_value in args:

--- a/susemanager/src/test/test_mgr_sync/test_channel.py
+++ b/susemanager/src/test/test_mgr_sync/test_channel.py
@@ -58,7 +58,7 @@ class ChannelTest(unittest.TestCase):
 
         self.assertEqual(sorted(channels.keys()),
                          sorted(expected_hierarchy.keys()))
-        for label, bc in channels.items():
+        for label, bc in list(channels.items()):
             self.assertEqual(label, bc.label)
             self.assertEqual(
                 bc.status,

--- a/susemanager/src/test/test_mgr_sync/test_channel.py
+++ b/susemanager/src/test/test_mgr_sync/test_channel.py
@@ -23,7 +23,10 @@ try:
 except ImportError:
     import unittest
 
-from mock import MagicMock
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
 
 from spacewalk.susemanager.mgr_sync.channel import parse_channels, \
     find_channel_by_label, Channel

--- a/susemanager/src/test/test_mgr_sync/test_channel_operations.py
+++ b/susemanager/src/test/test_mgr_sync/test_channel_operations.py
@@ -70,7 +70,7 @@ class ChannelOperationsTest(unittest.TestCase):
         self.mgr_sync._execute_xmlrpc_method = stubbed_xmlrpm_call
         with ConsoleRecorder() as recorder:
             self.mgr_sync.run(options)
-             self.assertEqual(recorder.stdout, ["No channels found."])
+            self.assertEqual(recorder.stdout, ["No channels found."])
 
             stubbed_xmlrpm_call.assert_called_once_with(
                 self.mgr_sync.conn.sync.content,

--- a/susemanager/src/test/test_mgr_sync/test_channel_operations.py
+++ b/susemanager/src/test/test_mgr_sync/test_channel_operations.py
@@ -70,12 +70,12 @@ class ChannelOperationsTest(unittest.TestCase):
         self.mgr_sync._execute_xmlrpc_method = stubbed_xmlrpm_call
         with ConsoleRecorder() as recorder:
             self.mgr_sync.run(options)
-        self.assertEqual(recorder.stdout, ["No channels found."])
+             self.assertEqual(recorder.stdout, ["No channels found."])
 
-        stubbed_xmlrpm_call.assert_called_once_with(
-            self.mgr_sync.conn.sync.content,
-            "listChannels",
-            self.fake_auth_token)
+            stubbed_xmlrpm_call.assert_called_once_with(
+                self.mgr_sync.conn.sync.content,
+                "listChannels",
+                self.fake_auth_token)
 
     def test_list_channels(self):
         """ Testing list channel output """
@@ -86,7 +86,7 @@ class ChannelOperationsTest(unittest.TestCase):
         self.mgr_sync._execute_xmlrpc_method = stubbed_xmlrpm_call
         with ConsoleRecorder() as recorder:
             self.mgr_sync.run(options)
-        expected_output = """Available Channels:
+            expected_output = """Available Channels:
 
 
 Status:
@@ -100,12 +100,12 @@ Status:
     [ ] SLE10-SDK-SP4-Pool for x86_64 SUSE Linux Enterprise Software Development Kit 10 SP4 Software Development Kit [sle10-sdk-sp4-pool-x86_64]
     [I] SLE10-SDK-SP4-Updates for x86_64 SUSE Linux Enterprise Software Development Kit 10 SP4 Software Development Kit [sle10-sdk-sp4-updates-x86_64]"""
 
-        self.assertEqual(expected_output.split("\n"), recorder.stdout)
+            self.assertEqual(expected_output.split("\n"), recorder.stdout)
 
-        stubbed_xmlrpm_call.assert_called_once_with(
-            self.mgr_sync.conn.sync.content,
-            "listChannels",
-            self.fake_auth_token)
+            stubbed_xmlrpm_call.assert_called_once_with(
+                self.mgr_sync.conn.sync.content,
+                "listChannels",
+                self.fake_auth_token)
 
     def test_list_channels_compact_mode_enabled(self):
         """ Testing list channel output """
@@ -116,7 +116,7 @@ Status:
         self.mgr_sync._execute_xmlrpc_method = stubbed_xmlrpm_call
         with ConsoleRecorder() as recorder:
             self.mgr_sync.run(options)
-        expected_output = """Available Channels:
+            expected_output = """Available Channels:
 
 
 Status:
@@ -130,12 +130,12 @@ Status:
     [ ] sle10-sdk-sp4-pool-x86_64
     [I] sle10-sdk-sp4-updates-x86_64"""
 
-        self.assertEqual(expected_output.split("\n"), recorder.stdout)
+            self.assertEqual(expected_output.split("\n"), recorder.stdout)
 
-        stubbed_xmlrpm_call.assert_called_once_with(
-            self.mgr_sync.conn.sync.content,
-            "listChannels",
-            self.fake_auth_token)
+            stubbed_xmlrpm_call.assert_called_once_with(
+                self.mgr_sync.conn.sync.content,
+                "listChannels",
+                self.fake_auth_token)
 
     def test_list_channels_expand_enabled(self):
         """ Testing list channel output when expand option is toggled """
@@ -146,7 +146,7 @@ Status:
         self.mgr_sync._execute_xmlrpc_method = stubbed_xmlrpm_call
         with ConsoleRecorder() as recorder:
             self.mgr_sync.run(options)
-        expected_output = """Available Channels (full):
+            expected_output = """Available Channels (full):
 
 
 Status:
@@ -163,12 +163,12 @@ Status:
     [ ] SLE10-SDK-SP4-Pool for x86_64 SUSE Linux Enterprise Software Development Kit 10 SP4 Software Development Kit [sle10-sdk-sp4-pool-x86_64]
     [I] SLE10-SDK-SP4-Updates for x86_64 SUSE Linux Enterprise Software Development Kit 10 SP4 Software Development Kit [sle10-sdk-sp4-updates-x86_64]"""
 
-        self.assertEqual(expected_output.split("\n"), recorder.stdout)
+            self.assertEqual(expected_output.split("\n"), recorder.stdout)
 
-        stubbed_xmlrpm_call.assert_called_once_with(
-            self.mgr_sync.conn.sync.content,
-            "listChannels",
-            self.fake_auth_token)
+            stubbed_xmlrpm_call.assert_called_once_with(
+                self.mgr_sync.conn.sync.content,
+                "listChannels",
+                self.fake_auth_token)
 
     def test_list_channels_filter_set(self):
         """ Testing list channel output when a filter is set """
@@ -179,7 +179,7 @@ Status:
         self.mgr_sync._execute_xmlrpc_method = stubbed_xmlrpm_call
         with ConsoleRecorder() as recorder:
             self.mgr_sync.run(options)
-        expected_output = """Available Channels:
+            expected_output = """Available Channels:
 
 
 Status:
@@ -190,12 +190,12 @@ Status:
 [ ] RHEL i386 AS 4 RES 4 [rhel-i386-as-4]
 [ ] RHEL x86_64 AS 4 RES 4 [rhel-x86_64-as-4]"""
 
-        self.assertEqual(expected_output.split("\n"), recorder.stdout)
+            self.assertEqual(expected_output.split("\n"), recorder.stdout)
 
-        stubbed_xmlrpm_call.assert_called_once_with(
-            self.mgr_sync.conn.sync.content,
-            "listChannels",
-            self.fake_auth_token)
+            stubbed_xmlrpm_call.assert_called_once_with(
+                self.mgr_sync.conn.sync.content,
+                "listChannels",
+                self.fake_auth_token)
 
     def test_list_channels_filter_show_parent_when_child_matches(self):
         """ Testing list channel output when a filter is set.  Should show the
@@ -210,7 +210,7 @@ Status:
         self.mgr_sync._execute_xmlrpc_method = stubbed_xmlrpm_call
         with ConsoleRecorder() as recorder:
             self.mgr_sync.run(options)
-        expected_output = """Available Channels:
+            expected_output = """Available Channels:
 
 
 Status:
@@ -221,12 +221,12 @@ Status:
 [I] SLES10-SP4-Pool for x86_64 SUSE Linux Enterprise Server 10 SP4 x86_64 [sles10-sp4-pool-x86_64]
     [I] SLE10-SDK-SP4-Updates for x86_64 SUSE Linux Enterprise Software Development Kit 10 SP4 Software Development Kit [sle10-sdk-sp4-updates-x86_64]"""
 
-        self.assertEqual(expected_output.split("\n"), recorder.stdout)
+            self.assertEqual(expected_output.split("\n"), recorder.stdout)
 
-        stubbed_xmlrpm_call.assert_called_once_with(
-            self.mgr_sync.conn.sync.content,
-            "listChannels",
-            self.fake_auth_token)
+            stubbed_xmlrpm_call.assert_called_once_with(
+                self.mgr_sync.conn.sync.content,
+                "listChannels",
+                self.fake_auth_token)
 
     def test_list_channels_interactive(self):
         """ Test listing channels when interactive more is set """
@@ -241,7 +241,7 @@ Status:
                 filter=None,
                 no_optionals=True,
                 show_interactive_numbers=True)
-        expected_output = """Available Channels:
+            expected_output = """Available Channels:
 
 
 Status:
@@ -255,15 +255,15 @@ Status:
     03) [ ] SLE10-SDK-SP4-Pool for x86_64 SUSE Linux Enterprise Software Development Kit 10 SP4 Software Development Kit [sle10-sdk-sp4-pool-x86_64]
         [I] SLE10-SDK-SP4-Updates for x86_64 SUSE Linux Enterprise Software Development Kit 10 SP4 Software Development Kit [sle10-sdk-sp4-updates-x86_64]"""
 
-        self.assertEqual(expected_output.split("\n"), recorder.stdout)
+            self.assertEqual(expected_output.split("\n"), recorder.stdout)
 
-        stubbed_xmlrpm_call.assert_called_once_with(
-            self.mgr_sync.conn.sync.content,
-            "listChannels",
-            self.fake_auth_token)
+            stubbed_xmlrpm_call.assert_called_once_with(
+                self.mgr_sync.conn.sync.content,
+                "listChannels",
+                self.fake_auth_token)
 
-        self.assertEqual(['rhel-i386-as-4', 'rhel-x86_64-as-4', 'sle10-sdk-sp4-pool-x86_64'],
-                         available_channels)
+            self.assertEqual(['rhel-i386-as-4', 'rhel-x86_64-as-4', 'sle10-sdk-sp4-pool-x86_64'],
+                             available_channels)
 
     def test_add_available_base_channel_with_mirror(self):
         """ Test adding an available base channel"""
@@ -282,24 +282,24 @@ Status:
         with ConsoleRecorder() as recorder:
             self.assertEqual(0, self.mgr_sync.run(options))
 
-        expected_xmlrpc_calls = [
-            call._execute_xmlrpc_method(self.mgr_sync.conn.sync.content,
-                                        "addChannels",
-                                        self.fake_auth_token,
-                                        channel,
-                                        mirror_url),
-            self._mock_iterator(),
-            call._execute_xmlrpc_method(self.mgr_sync.conn.channel.software,
-                                        "syncRepo",
-                                        self.fake_auth_token,
-                                        [channel])
-        ]
-        stubbed_xmlrpm_call.assert_has_calls(expected_xmlrpc_calls)
+            expected_xmlrpc_calls = [
+                call._execute_xmlrpc_method(self.mgr_sync.conn.sync.content,
+                                            "addChannels",
+                                            self.fake_auth_token,
+                                            channel,
+                                            mirror_url),
+                self._mock_iterator(),
+                call._execute_xmlrpc_method(self.mgr_sync.conn.channel.software,
+                                            "syncRepo",
+                                            self.fake_auth_token,
+                                            [channel])
+            ]
+            stubbed_xmlrpm_call.assert_has_calls(expected_xmlrpc_calls)
 
-        expected_output = [
-            "Adding '{0}' channel".format(channel),
-            "Scheduling reposync for '{0}' channel".format(channel)
-        ]
+            expected_output = [
+                "Adding '{0}' channel".format(channel),
+                "Scheduling reposync for '{0}' channel".format(channel)
+            ]
 
     def test_add_available_base_channel(self):
         """ Test adding an available base channel"""
@@ -311,30 +311,30 @@ Status:
         self.mgr_sync._fetch_remote_channels = MagicMock(
         return_value=parse_channels(
             read_data_from_fixture("list_channels.data"), self.mgr_sync.log))
-	stubbed_xmlrpm_call = MagicMock()
-	stubbed_xmlrpm_call.side_effect = xmlrpc_sideeffect
-	self.mgr_sync._execute_xmlrpc_method = stubbed_xmlrpm_call
-	with ConsoleRecorder() as recorder:
-	    self.assertEqual(0, self.mgr_sync.run(options))
-	expected_xmlrpc_calls = [
-	    call._execute_xmlrpc_method(self.mgr_sync.conn.sync.content,
-		                        "addChannels",
-		                        self.fake_auth_token,
-		                        channel,
-		                        ''),
-            call._execute_xmlrpc_method(self.mgr_sync.conn.channel.software,
-                                        "syncRepo",
+        stubbed_xmlrpm_call = MagicMock()
+        stubbed_xmlrpm_call.side_effect = xmlrpc_sideeffect
+        self.mgr_sync._execute_xmlrpc_method = stubbed_xmlrpm_call
+        with ConsoleRecorder() as recorder:
+            self.assertEqual(0, self.mgr_sync.run(options))
+            expected_xmlrpc_calls = [
+                call._execute_xmlrpc_method(self.mgr_sync.conn.sync.content,
+                                        "addChannels",
                                         self.fake_auth_token,
-                                        [channel])
-        ]
-        stubbed_xmlrpm_call.assert_has_calls(expected_xmlrpc_calls)
+                                        channel,
+                                        ''),
+                call._execute_xmlrpc_method(self.mgr_sync.conn.channel.software,
+                                                "syncRepo",
+                                                self.fake_auth_token,
+                                                [channel])
+            ]
+            stubbed_xmlrpm_call.assert_has_calls(expected_xmlrpc_calls)
 
-        expected_output = [
-            "Added '{0}' channel".format(channel),
-            "Scheduling reposync for following channels:",
-            "- {0}".format(channel)
-        ]
-        self.assertEqual(expected_output, recorder.stdout)
+            expected_output = [
+                "Added '{0}' channel".format(channel),
+                "Scheduling reposync for following channels:",
+                "- {0}".format(channel)
+            ]
+            self.assertEqual(expected_output, recorder.stdout)
 
     def test_add_available_channel_with_available_base_channel(self):
         """ Test adding an available channel whose parent is available.
@@ -356,30 +356,29 @@ Status:
 
         with ConsoleRecorder() as recorder:
             self.assertEqual(0, self.mgr_sync.run(options))
+            expected_xmlrpc_calls = [
+                call._execute_xmlrpc_method(self.mgr_sync.conn.sync.content,
+                                            "addChannels",
+                                            self.fake_auth_token,
+                                            base_channel,
+                                            ''),
+                call._execute_xmlrpc_method(self.mgr_sync.conn.channel.software,
+                                            "syncRepo",
+                                            self.fake_auth_token,
+                                            [base_channel]),
+                call._execute_xmlrpc_method(self.mgr_sync.conn.sync.content,
+                                            "addChannels",
+                                            self.fake_auth_token,
+                                            channel,
+                                            ''),
+                call._execute_xmlrpc_method(self.mgr_sync.conn.channel.software,
+                                            "syncRepo",
+                                            self.fake_auth_token,
+                                            [channel])
+            ]
+            stubbed_xmlrpm_call.assert_has_calls(expected_xmlrpc_calls)
 
-        expected_xmlrpc_calls = [
-            call._execute_xmlrpc_method(self.mgr_sync.conn.sync.content,
-                                        "addChannels",
-                                        self.fake_auth_token,
-                                        base_channel,
-                                        ''),
-            call._execute_xmlrpc_method(self.mgr_sync.conn.channel.software,
-                                        "syncRepo",
-                                        self.fake_auth_token,
-                                        [base_channel]),
-            call._execute_xmlrpc_method(self.mgr_sync.conn.sync.content,
-                                        "addChannels",
-                                        self.fake_auth_token,
-                                        channel,
-                                        ''),
-            call._execute_xmlrpc_method(self.mgr_sync.conn.channel.software,
-                                        "syncRepo",
-                                        self.fake_auth_token,
-                                        [channel])
-        ]
-        stubbed_xmlrpm_call.assert_has_calls(expected_xmlrpc_calls)
-
-        expected_output = """'res4-es-i386' depends on channel 'rhel-i386-es-4' which has not been added yet
+            expected_output = """'res4-es-i386' depends on channel 'rhel-i386-es-4' which has not been added yet
 Going to add 'rhel-i386-es-4'
 Added 'rhel-i386-es-4' channel
 Scheduling reposync for following channels:
@@ -387,7 +386,7 @@ Scheduling reposync for following channels:
 Added 'res4-es-i386' channel
 Scheduling reposync for following channels:
 - res4-es-i386"""
-        self.assertEqual(expected_output.split("\n"), recorder.stdout)
+            self.assertEqual(expected_output.split("\n"), recorder.stdout)
 
     def test_add_already_installed_channel(self):
         """Test adding an already added channel.
@@ -408,20 +407,20 @@ Scheduling reposync for following channels:
         with ConsoleRecorder() as recorder:
             self.assertEqual(0, self.mgr_sync.run(options))
 
-        expected_xmlrpc_calls = [
-            call._execute_xmlrpc_method(self.mgr_sync.conn.channel.software,
-                                        "syncRepo",
-                                        self.fake_auth_token,
-                                        [channel])
-        ]
-        stubbed_xmlrpm_call.assert_has_calls(expected_xmlrpc_calls)
+            expected_xmlrpc_calls = [
+                call._execute_xmlrpc_method(self.mgr_sync.conn.channel.software,
+                                            "syncRepo",
+                                            self.fake_auth_token,
+                                            [channel])
+            ]
+            stubbed_xmlrpm_call.assert_has_calls(expected_xmlrpc_calls)
 
-        expected_output = [
-            "Channel '{0}' has already been added".format(channel),
-            "Scheduling reposync for following channels:",
-            "- {0}".format(channel)
-        ]
-        self.assertEqual(expected_output, recorder.stdout)
+            expected_output = [
+                "Channel '{0}' has already been added".format(channel),
+                "Scheduling reposync for following channels:",
+                "- {0}".format(channel)
+            ]
+            self.assertEqual(expected_output, recorder.stdout)
 
     def test_add_unavailable_base_channel(self):
         """Test adding an unavailable base channel
@@ -437,10 +436,9 @@ Scheduling reposync for following channels:
 
         with ConsoleRecorder() as recorder:
             self.assertEqual(1, self.mgr_sync.run(options))
-
-        self.assertEqual(
-            ["Channel 'sles11-sp3-vmware-pool-i586' is not available, skipping"],
-            recorder.stdout)
+            self.assertEqual(
+                ["Channel 'sles11-sp3-vmware-pool-i586' is not available, skipping"],
+                recorder.stdout)
 
     def test_add_unavailable_child_channel(self):
         """Test adding an unavailable child channel
@@ -456,10 +454,9 @@ Scheduling reposync for following channels:
 
         with ConsoleRecorder() as recorder:
             self.assertEqual(1, self.mgr_sync.run(options))
-
-        self.assertEqual(
-            ["Channel 'sle10-sdk-sp4-pool-x86_64' is not available, skipping"],
-            recorder.stdout)
+            self.assertEqual(
+                ["Channel 'sle10-sdk-sp4-pool-x86_64' is not available, skipping"],
+                recorder.stdout)
 
     def test_add_available_child_channel_with_unavailable_parent(self):
         """Test adding an available child channel which has an unavailable parent.
@@ -482,13 +479,12 @@ Scheduling reposync for following channels:
 
         with ConsoleRecorder() as recorder:
             self.assertEqual(1, self.mgr_sync.run(options))
+            expected_output = """Error, 'res4-es-i386' depends on channel 'rhel-i386-es-4' which is not available
+    'res4-es-i386' has not been added"""
 
-        expected_output = """Error, 'res4-es-i386' depends on channel 'rhel-i386-es-4' which is not available
-'res4-es-i386' has not been added"""
-
-        self.assertFalse(recorder.stdout)
-        self.assertEqual(expected_output.split("\n"),
-                         recorder.stderr)
+            self.assertFalse(recorder.stdout)
+            self.assertEqual(expected_output.split("\n"),
+                             recorder.stderr)
 
 
     def test_add_channels_interactive(self):
@@ -506,31 +502,30 @@ Scheduling reposync for following channels:
                 available_channels.index(chosen_channel) + 1)
             with ConsoleRecorder() as recorder:
                 self.mgr_sync.run(options)
+                expected_output = [
+                    "Added '{0}' channel".format(chosen_channel),
+                    "Scheduling reposync for following channels:",
+                    "- {0}".format(chosen_channel)
+                ]
+                self.assertEqual(expected_output, recorder.stdout)
 
-        expected_output = [
-            "Added '{0}' channel".format(chosen_channel),
-            "Scheduling reposync for following channels:",
-            "- {0}".format(chosen_channel)
-        ]
-        self.assertEqual(expected_output, recorder.stdout)
+            self.mgr_sync._list_channels.assert_called_once_with(
+                expand=False, filter=None, no_optionals=False,
+                show_interactive_numbers=True, compact=False)
 
-        self.mgr_sync._list_channels.assert_called_once_with(
-            expand=False, filter=None, no_optionals=False,
-            show_interactive_numbers=True, compact=False)
+            expected_xmlrpc_calls = [
+                call._execute_xmlrpc_method(self.mgr_sync.conn.sync.content,
+                                            "addChannels",
+                                            self.fake_auth_token,
+                                            chosen_channel,
+                                            ''),
+                call._execute_xmlrpc_method(self.mgr_sync.conn.channel.software,
+                                            "syncRepo",
+                                            self.fake_auth_token,
+                                            [chosen_channel])
+            ]
 
-        expected_xmlrpc_calls = [
-            call._execute_xmlrpc_method(self.mgr_sync.conn.sync.content,
-                                        "addChannels",
-                                        self.fake_auth_token,
-                                        chosen_channel,
-                                        ''),
-            call._execute_xmlrpc_method(self.mgr_sync.conn.channel.software,
-                                        "syncRepo",
-                                        self.fake_auth_token,
-                                        [chosen_channel])
-        ]
-
-        stubbed_xmlrpm_call.assert_has_calls(expected_xmlrpc_calls)
+            stubbed_xmlrpm_call.assert_has_calls(expected_xmlrpc_calls)
 
     def test_add_channels_interactive_no_optional(self):
         options = get_options("add channel --no-optional".split())
@@ -548,30 +543,30 @@ Scheduling reposync for following channels:
             with ConsoleRecorder() as recorder:
                 self.mgr_sync.run(options)
 
-        expected_output = [
-            "Added '{0}' channel".format(chosen_channel),
-            "Scheduling reposync for following channels:",
-            "- {0}".format(chosen_channel)
-        ]
-        self.assertEqual(expected_output, recorder.stdout)
+            expected_output = [
+                "Added '{0}' channel".format(chosen_channel),
+                "Scheduling reposync for following channels:",
+                "- {0}".format(chosen_channel)
+            ]
+            self.assertEqual(expected_output, recorder.stdout)
 
-        self.mgr_sync._list_channels.assert_called_once_with(
-            expand=False, filter=None, no_optionals=True,
-            show_interactive_numbers=True, compact=False)
+            self.mgr_sync._list_channels.assert_called_once_with(
+                expand=False, filter=None, no_optionals=True,
+                show_interactive_numbers=True, compact=False)
 
-        expected_xmlrpc_calls = [
-            call._execute_xmlrpc_method(self.mgr_sync.conn.sync.content,
-                                        "addChannels",
-                                        self.fake_auth_token,
-                                        chosen_channel,
-                                        ''),
-            call._execute_xmlrpc_method(self.mgr_sync.conn.channel.software,
-                                        "syncRepo",
-                                        self.fake_auth_token,
-                                        [chosen_channel])
-        ]
+            expected_xmlrpc_calls = [
+                call._execute_xmlrpc_method(self.mgr_sync.conn.sync.content,
+                                            "addChannels",
+                                            self.fake_auth_token,
+                                            chosen_channel,
+                                            ''),
+                call._execute_xmlrpc_method(self.mgr_sync.conn.channel.software,
+                                            "syncRepo",
+                                            self.fake_auth_token,
+                                            [chosen_channel])
+            ]
 
-        stubbed_xmlrpm_call.assert_has_calls(expected_xmlrpc_calls)
+            stubbed_xmlrpm_call.assert_has_calls(expected_xmlrpc_calls)
 
 def xmlrpc_sideeffect(*args, **kwargs):
     if args[1] == "addChannels":

--- a/susemanager/src/test/test_mgr_sync/test_channel_operations.py
+++ b/susemanager/src/test/test_mgr_sync/test_channel_operations.py
@@ -70,12 +70,12 @@ class ChannelOperationsTest(unittest.TestCase):
         self.mgr_sync._execute_xmlrpc_method = stubbed_xmlrpm_call
         with ConsoleRecorder() as recorder:
             self.mgr_sync.run(options)
-            self.assertEqual(recorder.stdout, ["No channels found."])
+        self.assertEqual(recorder.stdout, ["No channels found."])
 
-            stubbed_xmlrpm_call.assert_called_once_with(
-                self.mgr_sync.conn.sync.content,
-                "listChannels",
-                self.fake_auth_token)
+        stubbed_xmlrpm_call.assert_called_once_with(
+            self.mgr_sync.conn.sync.content,
+            "listChannels",
+            self.fake_auth_token)
 
     def test_list_channels(self):
         """ Testing list channel output """
@@ -86,7 +86,7 @@ class ChannelOperationsTest(unittest.TestCase):
         self.mgr_sync._execute_xmlrpc_method = stubbed_xmlrpm_call
         with ConsoleRecorder() as recorder:
             self.mgr_sync.run(options)
-            expected_output = """Available Channels:
+        expected_output = """Available Channels:
 
 
 Status:
@@ -100,12 +100,12 @@ Status:
     [ ] SLE10-SDK-SP4-Pool for x86_64 SUSE Linux Enterprise Software Development Kit 10 SP4 Software Development Kit [sle10-sdk-sp4-pool-x86_64]
     [I] SLE10-SDK-SP4-Updates for x86_64 SUSE Linux Enterprise Software Development Kit 10 SP4 Software Development Kit [sle10-sdk-sp4-updates-x86_64]"""
 
-            self.assertEqual(expected_output.split("\n"), recorder.stdout)
+        self.assertEqual(expected_output.split("\n"), recorder.stdout)
 
-            stubbed_xmlrpm_call.assert_called_once_with(
-                self.mgr_sync.conn.sync.content,
-                "listChannels",
-                self.fake_auth_token)
+        stubbed_xmlrpm_call.assert_called_once_with(
+            self.mgr_sync.conn.sync.content,
+            "listChannels",
+            self.fake_auth_token)
 
     def test_list_channels_compact_mode_enabled(self):
         """ Testing list channel output """
@@ -116,7 +116,7 @@ Status:
         self.mgr_sync._execute_xmlrpc_method = stubbed_xmlrpm_call
         with ConsoleRecorder() as recorder:
             self.mgr_sync.run(options)
-            expected_output = """Available Channels:
+        expected_output = """Available Channels:
 
 
 Status:
@@ -130,12 +130,12 @@ Status:
     [ ] sle10-sdk-sp4-pool-x86_64
     [I] sle10-sdk-sp4-updates-x86_64"""
 
-            self.assertEqual(expected_output.split("\n"), recorder.stdout)
+        self.assertEqual(expected_output.split("\n"), recorder.stdout)
 
-            stubbed_xmlrpm_call.assert_called_once_with(
-                self.mgr_sync.conn.sync.content,
-                "listChannels",
-                self.fake_auth_token)
+        stubbed_xmlrpm_call.assert_called_once_with(
+            self.mgr_sync.conn.sync.content,
+            "listChannels",
+            self.fake_auth_token)
 
     def test_list_channels_expand_enabled(self):
         """ Testing list channel output when expand option is toggled """
@@ -146,7 +146,7 @@ Status:
         self.mgr_sync._execute_xmlrpc_method = stubbed_xmlrpm_call
         with ConsoleRecorder() as recorder:
             self.mgr_sync.run(options)
-            expected_output = """Available Channels (full):
+        expected_output = """Available Channels (full):
 
 
 Status:
@@ -163,12 +163,12 @@ Status:
     [ ] SLE10-SDK-SP4-Pool for x86_64 SUSE Linux Enterprise Software Development Kit 10 SP4 Software Development Kit [sle10-sdk-sp4-pool-x86_64]
     [I] SLE10-SDK-SP4-Updates for x86_64 SUSE Linux Enterprise Software Development Kit 10 SP4 Software Development Kit [sle10-sdk-sp4-updates-x86_64]"""
 
-            self.assertEqual(expected_output.split("\n"), recorder.stdout)
+        self.assertEqual(expected_output.split("\n"), recorder.stdout)
 
-            stubbed_xmlrpm_call.assert_called_once_with(
-                self.mgr_sync.conn.sync.content,
-                "listChannels",
-                self.fake_auth_token)
+        stubbed_xmlrpm_call.assert_called_once_with(
+            self.mgr_sync.conn.sync.content,
+            "listChannels",
+            self.fake_auth_token)
 
     def test_list_channels_filter_set(self):
         """ Testing list channel output when a filter is set """
@@ -179,7 +179,7 @@ Status:
         self.mgr_sync._execute_xmlrpc_method = stubbed_xmlrpm_call
         with ConsoleRecorder() as recorder:
             self.mgr_sync.run(options)
-            expected_output = """Available Channels:
+        expected_output = """Available Channels:
 
 
 Status:
@@ -190,12 +190,12 @@ Status:
 [ ] RHEL i386 AS 4 RES 4 [rhel-i386-as-4]
 [ ] RHEL x86_64 AS 4 RES 4 [rhel-x86_64-as-4]"""
 
-            self.assertEqual(expected_output.split("\n"), recorder.stdout)
+        self.assertEqual(expected_output.split("\n"), recorder.stdout)
 
-            stubbed_xmlrpm_call.assert_called_once_with(
-                self.mgr_sync.conn.sync.content,
-                "listChannels",
-                self.fake_auth_token)
+        stubbed_xmlrpm_call.assert_called_once_with(
+            self.mgr_sync.conn.sync.content,
+            "listChannels",
+            self.fake_auth_token)
 
     def test_list_channels_filter_show_parent_when_child_matches(self):
         """ Testing list channel output when a filter is set.  Should show the
@@ -210,7 +210,7 @@ Status:
         self.mgr_sync._execute_xmlrpc_method = stubbed_xmlrpm_call
         with ConsoleRecorder() as recorder:
             self.mgr_sync.run(options)
-            expected_output = """Available Channels:
+        expected_output = """Available Channels:
 
 
 Status:
@@ -221,12 +221,12 @@ Status:
 [I] SLES10-SP4-Pool for x86_64 SUSE Linux Enterprise Server 10 SP4 x86_64 [sles10-sp4-pool-x86_64]
     [I] SLE10-SDK-SP4-Updates for x86_64 SUSE Linux Enterprise Software Development Kit 10 SP4 Software Development Kit [sle10-sdk-sp4-updates-x86_64]"""
 
-            self.assertEqual(expected_output.split("\n"), recorder.stdout)
+        self.assertEqual(expected_output.split("\n"), recorder.stdout)
 
-            stubbed_xmlrpm_call.assert_called_once_with(
-                self.mgr_sync.conn.sync.content,
-                "listChannels",
-                self.fake_auth_token)
+        stubbed_xmlrpm_call.assert_called_once_with(
+            self.mgr_sync.conn.sync.content,
+            "listChannels",
+            self.fake_auth_token)
 
     def test_list_channels_interactive(self):
         """ Test listing channels when interactive more is set """
@@ -241,7 +241,7 @@ Status:
                 filter=None,
                 no_optionals=True,
                 show_interactive_numbers=True)
-            expected_output = """Available Channels:
+        expected_output = """Available Channels:
 
 
 Status:
@@ -255,15 +255,15 @@ Status:
     03) [ ] SLE10-SDK-SP4-Pool for x86_64 SUSE Linux Enterprise Software Development Kit 10 SP4 Software Development Kit [sle10-sdk-sp4-pool-x86_64]
         [I] SLE10-SDK-SP4-Updates for x86_64 SUSE Linux Enterprise Software Development Kit 10 SP4 Software Development Kit [sle10-sdk-sp4-updates-x86_64]"""
 
-            self.assertEqual(expected_output.split("\n"), recorder.stdout)
+        self.assertEqual(expected_output.split("\n"), recorder.stdout)
 
-            stubbed_xmlrpm_call.assert_called_once_with(
-                self.mgr_sync.conn.sync.content,
-                "listChannels",
-                self.fake_auth_token)
+        stubbed_xmlrpm_call.assert_called_once_with(
+            self.mgr_sync.conn.sync.content,
+            "listChannels",
+            self.fake_auth_token)
 
-            self.assertEqual(['rhel-i386-as-4', 'rhel-x86_64-as-4', 'sle10-sdk-sp4-pool-x86_64'],
-                             available_channels)
+        self.assertEqual(['rhel-i386-as-4', 'rhel-x86_64-as-4', 'sle10-sdk-sp4-pool-x86_64'],
+                         available_channels)
 
     def test_add_available_base_channel_with_mirror(self):
         """ Test adding an available base channel"""
@@ -282,24 +282,24 @@ Status:
         with ConsoleRecorder() as recorder:
             self.assertEqual(0, self.mgr_sync.run(options))
 
-            expected_xmlrpc_calls = [
-                call._execute_xmlrpc_method(self.mgr_sync.conn.sync.content,
-                                            "addChannels",
-                                            self.fake_auth_token,
-                                            channel,
-                                            mirror_url),
-                self._mock_iterator(),
-                call._execute_xmlrpc_method(self.mgr_sync.conn.channel.software,
-                                            "syncRepo",
-                                            self.fake_auth_token,
-                                            [channel])
-            ]
-            stubbed_xmlrpm_call.assert_has_calls(expected_xmlrpc_calls)
+        expected_xmlrpc_calls = [
+            call._execute_xmlrpc_method(self.mgr_sync.conn.sync.content,
+                                        "addChannels",
+                                        self.fake_auth_token,
+                                        channel,
+                                        mirror_url),
+            self._mock_iterator(),
+            call._execute_xmlrpc_method(self.mgr_sync.conn.channel.software,
+                                        "syncRepo",
+                                        self.fake_auth_token,
+                                        [channel])
+        ]
+        stubbed_xmlrpm_call.assert_has_calls(expected_xmlrpc_calls)
 
-            expected_output = [
-                "Adding '{0}' channel".format(channel),
-                "Scheduling reposync for '{0}' channel".format(channel)
-            ]
+        expected_output = [
+            "Adding '{0}' channel".format(channel),
+            "Scheduling reposync for '{0}' channel".format(channel)
+        ]
 
     def test_add_available_base_channel(self):
         """ Test adding an available base channel"""
@@ -316,25 +316,26 @@ Status:
         self.mgr_sync._execute_xmlrpc_method = stubbed_xmlrpm_call
         with ConsoleRecorder() as recorder:
             self.assertEqual(0, self.mgr_sync.run(options))
-            expected_xmlrpc_calls = [
-                call._execute_xmlrpc_method(self.mgr_sync.conn.sync.content,
-                                        "addChannels",
-                                        self.fake_auth_token,
-                                        channel,
-                                        ''),
-                call._execute_xmlrpc_method(self.mgr_sync.conn.channel.software,
-                                                "syncRepo",
-                                                self.fake_auth_token,
-                                                [channel])
-            ]
-            stubbed_xmlrpm_call.assert_has_calls(expected_xmlrpc_calls)
 
-            expected_output = [
-                "Added '{0}' channel".format(channel),
-                "Scheduling reposync for following channels:",
-                "- {0}".format(channel)
-            ]
-            self.assertEqual(expected_output, recorder.stdout)
+        expected_xmlrpc_calls = [
+            call._execute_xmlrpc_method(self.mgr_sync.conn.sync.content,
+                                    "addChannels",
+                                    self.fake_auth_token,
+                                    channel,
+                                    ''),
+            call._execute_xmlrpc_method(self.mgr_sync.conn.channel.software,
+                                            "syncRepo",
+                                            self.fake_auth_token,
+                                            [channel])
+        ]
+        stubbed_xmlrpm_call.assert_has_calls(expected_xmlrpc_calls)
+
+        expected_output = [
+            "Added '{0}' channel".format(channel),
+            "Scheduling reposync for following channels:",
+            "- {0}".format(channel)
+        ]
+        self.assertEqual(expected_output, recorder.stdout)
 
     def test_add_available_channel_with_available_base_channel(self):
         """ Test adding an available channel whose parent is available.
@@ -356,29 +357,29 @@ Status:
 
         with ConsoleRecorder() as recorder:
             self.assertEqual(0, self.mgr_sync.run(options))
-            expected_xmlrpc_calls = [
-                call._execute_xmlrpc_method(self.mgr_sync.conn.sync.content,
-                                            "addChannels",
-                                            self.fake_auth_token,
-                                            base_channel,
-                                            ''),
-                call._execute_xmlrpc_method(self.mgr_sync.conn.channel.software,
-                                            "syncRepo",
-                                            self.fake_auth_token,
-                                            [base_channel]),
-                call._execute_xmlrpc_method(self.mgr_sync.conn.sync.content,
-                                            "addChannels",
-                                            self.fake_auth_token,
-                                            channel,
-                                            ''),
-                call._execute_xmlrpc_method(self.mgr_sync.conn.channel.software,
-                                            "syncRepo",
-                                            self.fake_auth_token,
-                                            [channel])
-            ]
-            stubbed_xmlrpm_call.assert_has_calls(expected_xmlrpc_calls)
+        expected_xmlrpc_calls = [
+            call._execute_xmlrpc_method(self.mgr_sync.conn.sync.content,
+                                        "addChannels",
+                                        self.fake_auth_token,
+                                        base_channel,
+                                        ''),
+            call._execute_xmlrpc_method(self.mgr_sync.conn.channel.software,
+                                        "syncRepo",
+                                        self.fake_auth_token,
+                                        [base_channel]),
+            call._execute_xmlrpc_method(self.mgr_sync.conn.sync.content,
+                                        "addChannels",
+                                        self.fake_auth_token,
+                                        channel,
+                                        ''),
+            call._execute_xmlrpc_method(self.mgr_sync.conn.channel.software,
+                                        "syncRepo",
+                                        self.fake_auth_token,
+                                        [channel])
+        ]
+        stubbed_xmlrpm_call.assert_has_calls(expected_xmlrpc_calls)
 
-            expected_output = """'res4-es-i386' depends on channel 'rhel-i386-es-4' which has not been added yet
+        expected_output = """'res4-es-i386' depends on channel 'rhel-i386-es-4' which has not been added yet
 Going to add 'rhel-i386-es-4'
 Added 'rhel-i386-es-4' channel
 Scheduling reposync for following channels:
@@ -386,7 +387,7 @@ Scheduling reposync for following channels:
 Added 'res4-es-i386' channel
 Scheduling reposync for following channels:
 - res4-es-i386"""
-            self.assertEqual(expected_output.split("\n"), recorder.stdout)
+        self.assertEqual(expected_output.split("\n"), recorder.stdout)
 
     def test_add_already_installed_channel(self):
         """Test adding an already added channel.
@@ -407,20 +408,20 @@ Scheduling reposync for following channels:
         with ConsoleRecorder() as recorder:
             self.assertEqual(0, self.mgr_sync.run(options))
 
-            expected_xmlrpc_calls = [
-                call._execute_xmlrpc_method(self.mgr_sync.conn.channel.software,
-                                            "syncRepo",
-                                            self.fake_auth_token,
-                                            [channel])
-            ]
-            stubbed_xmlrpm_call.assert_has_calls(expected_xmlrpc_calls)
+        expected_xmlrpc_calls = [
+            call._execute_xmlrpc_method(self.mgr_sync.conn.channel.software,
+                                        "syncRepo",
+                                        self.fake_auth_token,
+                                        [channel])
+        ]
+        stubbed_xmlrpm_call.assert_has_calls(expected_xmlrpc_calls)
 
-            expected_output = [
-                "Channel '{0}' has already been added".format(channel),
-                "Scheduling reposync for following channels:",
-                "- {0}".format(channel)
-            ]
-            self.assertEqual(expected_output, recorder.stdout)
+        expected_output = [
+            "Channel '{0}' has already been added".format(channel),
+            "Scheduling reposync for following channels:",
+            "- {0}".format(channel)
+        ]
+        self.assertEqual(expected_output, recorder.stdout)
 
     def test_add_unavailable_base_channel(self):
         """Test adding an unavailable base channel
@@ -436,9 +437,10 @@ Scheduling reposync for following channels:
 
         with ConsoleRecorder() as recorder:
             self.assertEqual(1, self.mgr_sync.run(options))
-            self.assertEqual(
-                ["Channel 'sles11-sp3-vmware-pool-i586' is not available, skipping"],
-                recorder.stdout)
+
+        self.assertEqual(
+            ["Channel 'sles11-sp3-vmware-pool-i586' is not available, skipping"],
+            recorder.stdout)
 
     def test_add_unavailable_child_channel(self):
         """Test adding an unavailable child channel
@@ -454,9 +456,10 @@ Scheduling reposync for following channels:
 
         with ConsoleRecorder() as recorder:
             self.assertEqual(1, self.mgr_sync.run(options))
-            self.assertEqual(
-                ["Channel 'sle10-sdk-sp4-pool-x86_64' is not available, skipping"],
-                recorder.stdout)
+
+        self.assertEqual(
+            ["Channel 'sle10-sdk-sp4-pool-x86_64' is not available, skipping"],
+            recorder.stdout)
 
     def test_add_available_child_channel_with_unavailable_parent(self):
         """Test adding an available child channel which has an unavailable parent.
@@ -479,12 +482,12 @@ Scheduling reposync for following channels:
 
         with ConsoleRecorder() as recorder:
             self.assertEqual(1, self.mgr_sync.run(options))
-            expected_output = """Error, 'res4-es-i386' depends on channel 'rhel-i386-es-4' which is not available
-    'res4-es-i386' has not been added"""
+        expected_output = """Error, 'res4-es-i386' depends on channel 'rhel-i386-es-4' which is not available
+'res4-es-i386' has not been added"""
 
-            self.assertFalse(recorder.stdout)
-            self.assertEqual(expected_output.split("\n"),
-                             recorder.stderr)
+        self.assertFalse(recorder.stdout)
+        self.assertEqual(expected_output.split("\n"),
+                         recorder.stderr)
 
 
     def test_add_channels_interactive(self):
@@ -502,12 +505,13 @@ Scheduling reposync for following channels:
                 available_channels.index(chosen_channel) + 1)
             with ConsoleRecorder() as recorder:
                 self.mgr_sync.run(options)
-                expected_output = [
-                    "Added '{0}' channel".format(chosen_channel),
-                    "Scheduling reposync for following channels:",
-                    "- {0}".format(chosen_channel)
-                ]
-                self.assertEqual(expected_output, recorder.stdout)
+
+            expected_output = [
+                "Added '{0}' channel".format(chosen_channel),
+                "Scheduling reposync for following channels:",
+                "- {0}".format(chosen_channel)
+            ]
+            self.assertEqual(expected_output, recorder.stdout)
 
             self.mgr_sync._list_channels.assert_called_once_with(
                 expand=False, filter=None, no_optionals=False,

--- a/susemanager/src/test/test_mgr_sync/test_channel_operations.py
+++ b/susemanager/src/test/test_mgr_sync/test_channel_operations.py
@@ -22,7 +22,10 @@ except ImportError:
 import os.path
 import sys
 
-from mock import MagicMock, call, patch
+try:
+    from unittest.mock import MagicMock, call, patch
+except ImportError:
+    from mock import MagicMock, call, patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from helper import ConsoleRecorder, read_data_from_fixture

--- a/susemanager/src/test/test_mgr_sync/test_config.py
+++ b/susemanager/src/test/test_mgr_sync/test_config.py
@@ -54,8 +54,8 @@ class ConfigTest(unittest.TestCase):
         # only rhn config is in place
         config = Config()
 
-        self.assertEquals(rhn_user, config.user)
-        self.assertEquals(rhn_token, config.token)
+        self.assertEqual(rhn_user, config.user)
+        self.assertEqual(rhn_token, config.token)
 
         # add user config, should get higher priority at parsing time
 
@@ -66,9 +66,9 @@ class ConfigTest(unittest.TestCase):
 
         config = Config()
 
-        self.assertEquals(local_user, config.user)
-        self.assertEquals(local_password, config.password)
-        self.assertEquals(rhn_token, config.token)
+        self.assertEqual(local_user, config.user)
+        self.assertEqual(local_password, config.password)
+        self.assertEqual(rhn_token, config.token)
 
     def _create_fake_config_file(self, filename, user=None, password=None,
                                  host=None, port=None, uri=None, token=None):

--- a/susemanager/src/test/test_mgr_sync/test_credential_operations.py
+++ b/susemanager/src/test/test_mgr_sync/test_credential_operations.py
@@ -22,7 +22,10 @@ except ImportError:
 import os.path
 import sys
 
-from mock import MagicMock, call, patch
+try:
+    from unittest.mock import MagicMock, call, patch
+except ImportError:
+    from mock import MagicMock, call, patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from helper import ConsoleRecorder, read_data_from_fixture

--- a/susemanager/src/test/test_mgr_sync/test_mgr_sync.py
+++ b/susemanager/src/test/test_mgr_sync/test_mgr_sync.py
@@ -22,7 +22,10 @@ except ImportError:
 import os.path
 import sys
 
-from mock import MagicMock, call, patch
+try:
+    from unittest.mock import MagicMock, call, patch
+except ImportError:
+    from mock import MagicMock, call, patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from helper import ConsoleRecorder, read_data_from_fixture

--- a/susemanager/src/test/test_mgr_sync/test_product.py
+++ b/susemanager/src/test/test_mgr_sync/test_product.py
@@ -22,7 +22,10 @@ try:
 except ImportError:
     import unittest
 
-from mock import MagicMock
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
 
 from spacewalk.susemanager.mgr_sync.product import parse_products, Product
 from spacewalk.susemanager.mgr_sync.mgr_sync import MgrSync

--- a/susemanager/src/test/test_mgr_sync/test_product_operations.py
+++ b/susemanager/src/test/test_mgr_sync/test_product_operations.py
@@ -739,7 +739,7 @@ All the available products have already been installed, nothing to do"""
             with ConsoleRecorder() as recorder:
                 try:
                     self.mgr_sync.run(options)
-                except SystemExit, ex:
+                except SystemExit as ex:
                     self.assertEqual(0, ex.code)
 
         expected_output = """Available Products:

--- a/susemanager/src/test/test_mgr_sync/test_product_operations.py
+++ b/susemanager/src/test/test_mgr_sync/test_product_operations.py
@@ -22,7 +22,10 @@ except ImportError:
 import os.path
 import sys
 
-from mock import MagicMock, call, patch
+try:
+    from unittest.mock import MagicMock, call, patch
+except ImportError:
+    from mock import MagicMock, call, patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from helper import ConsoleRecorder, read_data_from_fixture

--- a/susemanager/src/test/test_mgr_sync/test_refresh_operations.py
+++ b/susemanager/src/test/test_mgr_sync/test_refresh_operations.py
@@ -22,7 +22,10 @@ except ImportError:
 import os.path
 import sys
 
-from mock import MagicMock, call, patch
+try:
+    from unittest.mock import MagicMock, call, patch
+except ImportError:
+    from mock import MagicMock, call, patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from helper import ConsoleRecorder, read_data_from_fixture

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- add support for Python 3
 - do not fail if postgresql user has no interactive login shell
 - add new dependency python-setuptools to bootstrap packages (bsc#1106026)
 - fix broken stderr redirection in mgr-setup


### PR DESCRIPTION
## What does this PR change?

This PR adapts the code under `susemanager/` directory to be Python 2/3 compatible. Most of the Python code here is deployed by the `susemanager-tools` package which provides the `mgr-sync`, `mgr-create-bootstrap-repo`, `mgr-delete-patch`, `mgr-delete-old-patches` and `mgr-register` scripts.

## Test coverage
- No tests: *No feature added, only porting code**
- Unit tests were added
- Cucumber tests were added

- [X] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/5518

- [X] **DONE**
