### PR TITLE
MessageAction transaction handling refactoring

### DIFF
--- a/java/code/src/com/redhat/rhn/common/messaging/ActionExecutor.java
+++ b/java/code/src/com/redhat/rhn/common/messaging/ActionExecutor.java
@@ -60,12 +60,8 @@ class ActionExecutor implements Runnable {
                         Thread.sleep(10);
                     }
                     LOG.debug("Transaction finished.  Executing");
-                    action.execute(msg);
                 }
-                else {
-                    action.execute(msg);
-                }
-
+                action.execute(msg);
             }
             catch (Throwable t) {
                 LOG.error(t);

--- a/java/code/src/com/redhat/rhn/common/messaging/ActionExecutor.java
+++ b/java/code/src/com/redhat/rhn/common/messaging/ActionExecutor.java
@@ -14,6 +14,8 @@
  */
 package com.redhat.rhn.common.messaging;
 
+import com.redhat.rhn.frontend.events.TransactionHelper;
+
 import org.apache.log4j.Logger;
 
 import java.util.ArrayList;
@@ -61,7 +63,12 @@ class ActionExecutor implements Runnable {
                     }
                     LOG.debug("Transaction finished.  Executing");
                 }
-                action.execute(msg);
+                if (action.needsTransactionHandling()) {
+                    TransactionHelper.handlingTransaction(() -> action.execute(msg), action.getExceptionHandler());
+                }
+                else {
+                    action.execute(msg);
+                }
             }
             catch (Throwable t) {
                 LOG.error(t);

--- a/java/code/src/com/redhat/rhn/common/messaging/MessageAction.java
+++ b/java/code/src/com/redhat/rhn/common/messaging/MessageAction.java
@@ -15,6 +15,8 @@
 
 package com.redhat.rhn.common.messaging;
 
+import java.util.function.Consumer;
+
 /**
  * A interface representing a class that can act on a EventMessage
  *
@@ -48,6 +50,15 @@ public interface MessageAction {
      */
     default boolean needsTransactionHandling() {
         return true;
+    }
+
+    /**
+     * Returns code to be executed after a rollback in case of unexpected errors.
+     *
+     * @return a consumer
+     */
+    default Consumer<Exception> getExceptionHandler() {
+        return e -> { };
     }
 }
 

--- a/java/code/src/com/redhat/rhn/common/messaging/MessageAction.java
+++ b/java/code/src/com/redhat/rhn/common/messaging/MessageAction.java
@@ -40,6 +40,15 @@ public interface MessageAction {
     default boolean canRunConcurrently() {
         return false;
     }
+
+    /**
+     * Return true in case this action needs Hibernate session and transaction handling.
+     *
+     * @return true if this action operates on the database
+     */
+    default boolean needsTransactionHandling() {
+        return true;
+    }
 }
 
 

--- a/java/code/src/com/redhat/rhn/common/messaging/MessageAction.java
+++ b/java/code/src/com/redhat/rhn/common/messaging/MessageAction.java
@@ -19,8 +19,6 @@ import java.util.function.Consumer;
 
 /**
  * A interface representing a class that can act on a EventMessage
- *
- * @version $Rev$
  */
 public interface MessageAction {
 

--- a/java/code/src/com/redhat/rhn/common/messaging/test/TestAction.java
+++ b/java/code/src/com/redhat/rhn/common/messaging/test/TestAction.java
@@ -38,6 +38,14 @@ public class TestAction implements MessageAction {
         TestEventMessage tm = (TestEventMessage) msg;
         tm.setMessageReceived(true);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean needsTransactionHandling() {
+        return false;
+    }
 }
 
 

--- a/java/code/src/com/redhat/rhn/common/messaging/test/TestDBAction.java
+++ b/java/code/src/com/redhat/rhn/common/messaging/test/TestDBAction.java
@@ -61,6 +61,13 @@ public class TestDBAction implements MessageAction {
 
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean needsTransactionHandling() {
+        return false;
+    }
 }
 
 

--- a/java/code/src/com/redhat/rhn/common/messaging/test/TestExceptionAction.java
+++ b/java/code/src/com/redhat/rhn/common/messaging/test/TestExceptionAction.java
@@ -20,7 +20,6 @@ import com.redhat.rhn.common.messaging.MessageQueue;
 
 /**
  * TestExceptionAction
- * @version $Rev$
  */
 public class TestExceptionAction implements MessageAction  {
     private static MessageAction registered;

--- a/java/code/src/com/redhat/rhn/common/messaging/test/TestExceptionAction.java
+++ b/java/code/src/com/redhat/rhn/common/messaging/test/TestExceptionAction.java
@@ -43,4 +43,12 @@ public class TestExceptionAction implements MessageAction  {
         tm.setMessageReceived(true);
         throw new RuntimeException("TEST: Try and kill the thread");
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean needsTransactionHandling() {
+        return false;
+    }
 }

--- a/java/code/src/com/redhat/rhn/frontend/action/BaseSearchAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/BaseSearchAction.java
@@ -180,12 +180,12 @@ public abstract class BaseSearchAction extends RhnAction {
     }
 
     /**
-     * This method invokes insureFormDefaults(), followed by doExecute().  Child classes
+     * This method invokes insureFormDefaults(), followed by execute().  Child classes
      * are expected to do "reasonable" things in those methods.
      * @param request http request
      * @param mapping action mapping
      * @param form associated form
-     * @return expected destination from doExecute
+     * @return expected destination from execute
      * @throws MalformedURLException malformed URL exception
      * @throws XmlRpcFault XMLrpc fault
      */

--- a/java/code/src/com/redhat/rhn/frontend/events/CloneErrataAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/CloneErrataAction.java
@@ -36,7 +36,6 @@ import java.util.Set;
 
 /**
  * CloneErrataAction
- * @version $Rev$
  */
 public class CloneErrataAction implements MessageAction {
 

--- a/java/code/src/com/redhat/rhn/frontend/events/CloneErrataAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/CloneErrataAction.java
@@ -15,6 +15,7 @@
 package com.redhat.rhn.frontend.events;
 
 import com.redhat.rhn.common.messaging.EventMessage;
+import com.redhat.rhn.common.messaging.MessageAction;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.ChannelFactory;
 import com.redhat.rhn.domain.errata.Errata;
@@ -37,15 +38,14 @@ import java.util.Set;
  * CloneErrataAction
  * @version $Rev$
  */
-public class CloneErrataAction
-        extends AbstractDatabaseAction {
+public class CloneErrataAction implements MessageAction {
 
     private static Logger log = Logger.getLogger(CloneErrataAction.class);
 
     /**
      * {@inheritDoc}
      */
-    public void doExecute(EventMessage msgIn) {
+    public void execute(EventMessage msgIn) {
 
 
         CloneErrataEvent msg = (CloneErrataEvent) msgIn;

--- a/java/code/src/com/redhat/rhn/frontend/events/NewCloneErrataAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/NewCloneErrataAction.java
@@ -15,6 +15,7 @@
 package com.redhat.rhn.frontend.events;
 
 import com.redhat.rhn.common.messaging.EventMessage;
+import com.redhat.rhn.common.messaging.MessageAction;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.errata.Errata;
 import com.redhat.rhn.domain.errata.ErrataFactory;
@@ -27,14 +28,13 @@ import java.util.List;
  * NewCloneErrataAction
  * @version $Rev$
  */
-public class NewCloneErrataAction
-extends AbstractDatabaseAction {
+public class NewCloneErrataAction implements MessageAction {
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public void doExecute(EventMessage msgIn) {
+    public void execute(EventMessage msgIn) {
         NewCloneErrataEvent msg = (NewCloneErrataEvent) msgIn;
         Long eid = msg.getErrata();
         List<Errata> errata = new ArrayList<Errata>();

--- a/java/code/src/com/redhat/rhn/frontend/events/NewCloneErrataAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/NewCloneErrataAction.java
@@ -26,7 +26,6 @@ import java.util.List;
 
 /**
  * NewCloneErrataAction
- * @version $Rev$
  */
 public class NewCloneErrataAction implements MessageAction {
 

--- a/java/code/src/com/redhat/rhn/frontend/events/NewUserAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/NewUserAction.java
@@ -130,4 +130,11 @@ public class NewUserAction extends BaseMailAction implements MessageAction {
         return retval;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean needsTransactionHandling() {
+        return false;
+    }
 }

--- a/java/code/src/com/redhat/rhn/frontend/events/NewUserAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/NewUserAction.java
@@ -32,8 +32,6 @@ import java.util.Map;
 
 /**
  * Implement Action for TraceBackEvents
- *
- * @version $Rev: 59372 $
  */
 public class NewUserAction extends BaseMailAction implements MessageAction {
 

--- a/java/code/src/com/redhat/rhn/frontend/events/RestartSatelliteAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/RestartSatelliteAction.java
@@ -57,4 +57,11 @@ public class RestartSatelliteAction implements MessageAction {
         return new RestartCommand(currentUser);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean needsTransactionHandling() {
+        return false;
+    }
 }

--- a/java/code/src/com/redhat/rhn/frontend/events/ScheduleRepoSyncAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/ScheduleRepoSyncAction.java
@@ -74,4 +74,12 @@ public class ScheduleRepoSyncAction implements MessageAction {
             }
         }
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean needsTransactionHandling() {
+        return false;
+    }
 }

--- a/java/code/src/com/redhat/rhn/frontend/events/SsmChangeBaseChannelSubscriptionsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/SsmChangeBaseChannelSubscriptionsAction.java
@@ -33,7 +33,6 @@ import java.util.Collection;
  * Handles performing subscription changes for servers in the SSM.
  *
  * @see com.redhat.rhn.frontend.events.SsmChangeChannelSubscriptionsEvent
- * @version $Revision$
  */
 public class SsmChangeBaseChannelSubscriptionsAction implements MessageAction {
     /** Logger instance. */

--- a/java/code/src/com/redhat/rhn/frontend/events/SsmChangeBaseChannelSubscriptionsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/SsmChangeBaseChannelSubscriptionsAction.java
@@ -16,6 +16,7 @@ package com.redhat.rhn.frontend.events;
 
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.messaging.EventMessage;
+import com.redhat.rhn.common.messaging.MessageAction;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.user.User;
@@ -34,13 +35,13 @@ import java.util.Collection;
  * @see com.redhat.rhn.frontend.events.SsmChangeChannelSubscriptionsEvent
  * @version $Revision$
  */
-public class SsmChangeBaseChannelSubscriptionsAction extends AbstractDatabaseAction {
+public class SsmChangeBaseChannelSubscriptionsAction implements MessageAction {
     /** Logger instance. */
     private static Log log = LogFactory.getLog(
             SsmChangeBaseChannelSubscriptionsAction.class);
 
     /** {@inheritDoc} */
-    protected void doExecute(EventMessage msg) {
+    public void execute(EventMessage msg) {
         SsmChangeChannelSubscriptionsEvent event = (SsmChangeChannelSubscriptionsEvent) msg;
 
         User user = event.getUser();

--- a/java/code/src/com/redhat/rhn/frontend/events/SsmChangeChannelSubscriptionsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/SsmChangeChannelSubscriptionsAction.java
@@ -30,7 +30,6 @@ import java.util.Collection;
  * Handles performing subscription changes for servers in the SSM.
  *
  * @see com.redhat.rhn.frontend.events.SsmChangeChannelSubscriptionsEvent
- * @version $Revision$
  */
 public class SsmChangeChannelSubscriptionsAction implements MessageAction {
     /** Logger instance. */

--- a/java/code/src/com/redhat/rhn/frontend/events/SsmChangeChannelSubscriptionsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/SsmChangeChannelSubscriptionsAction.java
@@ -15,6 +15,7 @@
 package com.redhat.rhn.frontend.events;
 
 import com.redhat.rhn.common.messaging.EventMessage;
+import com.redhat.rhn.common.messaging.MessageAction;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.action.channel.ssm.ChannelActionDAO;
 import com.redhat.rhn.manager.ssm.SsmManager;
@@ -31,12 +32,12 @@ import java.util.Collection;
  * @see com.redhat.rhn.frontend.events.SsmChangeChannelSubscriptionsEvent
  * @version $Revision$
  */
-public class SsmChangeChannelSubscriptionsAction extends AbstractDatabaseAction {
+public class SsmChangeChannelSubscriptionsAction implements MessageAction {
     /** Logger instance. */
     private static Log log = LogFactory.getLog(SsmChangeChannelSubscriptionsAction.class);
 
     /** {@inheritDoc} */
-    protected void doExecute(EventMessage msg) {
+    public void execute(EventMessage msg) {
         SsmChangeChannelSubscriptionsEvent event = (SsmChangeChannelSubscriptionsEvent) msg;
 
         User user = event.getUser();

--- a/java/code/src/com/redhat/rhn/frontend/events/SsmConfigFilesAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/SsmConfigFilesAction.java
@@ -14,25 +14,26 @@
  */
 package com.redhat.rhn.frontend.events;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 import com.redhat.rhn.common.messaging.EventMessage;
+import com.redhat.rhn.common.messaging.MessageAction;
 import com.redhat.rhn.domain.action.ActionChain;
 import com.redhat.rhn.domain.action.ActionChainFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.domain.user.UserFactory;
 import com.redhat.rhn.manager.action.ActionChainManager;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 /**
  * Schedules config files actions for systems.
  */
-public class SsmConfigFilesAction extends AbstractDatabaseAction {
+public class SsmConfigFilesAction implements MessageAction {
 
     private final Log log = LogFactory.getLog(this.getClass());
 
     /** {@inheritDoc} */
-    protected void doExecute(EventMessage msg) {
+    public void execute(EventMessage msg) {
         SsmConfigFilesEvent event = (SsmConfigFilesEvent) msg;
 
         User user = UserFactory.lookupById(event.getUserId());

--- a/java/code/src/com/redhat/rhn/frontend/events/SsmDeleteServersAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/SsmDeleteServersAction.java
@@ -16,6 +16,7 @@ package com.redhat.rhn.frontend.events;
 
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.messaging.EventMessage;
+import com.redhat.rhn.common.messaging.MessageAction;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.domain.user.UserFactory;
 import com.redhat.rhn.manager.ssm.SsmOperationManager;
@@ -31,14 +32,14 @@ import java.util.List;
  *
  * @see com.redhat.rhn.frontend.events.SsmDeleteServersEvent
  */
-public class SsmDeleteServersAction extends AbstractDatabaseAction {
+public class SsmDeleteServersAction implements MessageAction {
     public static final String OPERATION_NAME = "ssm.server.delete.operationname";
 
     /** Logger instance. */
     private static Log log = LogFactory.getLog(SsmDeleteServersAction.class);
 
     /** {@inheritDoc} */
-    protected void doExecute(EventMessage msg) {
+    public void execute(EventMessage msg) {
         SsmDeleteServersEvent event = (SsmDeleteServersEvent) msg;
         User user = UserFactory.lookupById(event.getUserId());
         List<Long> sids = event.getSids();

--- a/java/code/src/com/redhat/rhn/frontend/events/SsmErrataAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/SsmErrataAction.java
@@ -18,6 +18,7 @@
 package com.redhat.rhn.frontend.events;
 
 import com.redhat.rhn.common.messaging.EventMessage;
+import com.redhat.rhn.common.messaging.MessageAction;
 import com.redhat.rhn.domain.action.ActionChain;
 import com.redhat.rhn.domain.action.ActionChainFactory;
 import com.redhat.rhn.domain.user.User;
@@ -33,12 +34,12 @@ import org.apache.log4j.Logger;
  *
  * @author Bo Maryniuk
  */
-public class SsmErrataAction extends AbstractDatabaseAction {
+public class SsmErrataAction implements MessageAction {
     private static Logger log = Logger.getLogger(SsmErrataAction.class);
 
     /** {@inheritDoc} */
     @Override
-    protected void doExecute(EventMessage msg) {
+    public void execute(EventMessage msg) {
         SsmErrataAction.log.debug("Scheduling errata in SSM.");
 
         SsmErrataEvent event = (SsmErrataEvent) msg;

--- a/java/code/src/com/redhat/rhn/frontend/events/SsmPackagesAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/SsmPackagesAction.java
@@ -14,13 +14,8 @@
  */
 package com.redhat.rhn.frontend.events;
 
-import java.util.Date;
-import java.util.List;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 import com.redhat.rhn.common.messaging.EventMessage;
+import com.redhat.rhn.common.messaging.MessageAction;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionChain;
 import com.redhat.rhn.domain.action.ActionChainFactory;
@@ -30,6 +25,12 @@ import com.redhat.rhn.manager.rhnset.RhnSetDecl;
 import com.redhat.rhn.manager.ssm.SsmOperationManager;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.util.Date;
+import java.util.List;
+
 /**
  * Base functionality for responding to SSM package install/update/remove.
  * Handles ordering if a remote-cmd has been specified.  Subclasses are responsible
@@ -38,11 +39,14 @@ import com.redhat.rhn.taskomatic.TaskomaticApiException;
  * @author ggainey
  *
  */
-public abstract class SsmPackagesAction extends AbstractDatabaseAction {
+public abstract class SsmPackagesAction implements MessageAction {
 
     private final Log log = LogFactory.getLog(this.getClass());
 
-    protected void doExecute(EventMessage msg) {
+    /**
+     * {@inheritDoc}
+     */
+    public void execute(EventMessage msg) {
         SsmPackageEvent event = (SsmPackageEvent) msg;
 
         User user = UserFactory.lookupById(event.getUserId());

--- a/java/code/src/com/redhat/rhn/frontend/events/SsmPowerManagementAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/SsmPowerManagementAction.java
@@ -15,6 +15,7 @@
 package com.redhat.rhn.frontend.events;
 
 import com.redhat.rhn.common.messaging.EventMessage;
+import com.redhat.rhn.common.messaging.MessageAction;
 import com.redhat.rhn.common.validator.ValidatorError;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
@@ -34,7 +35,7 @@ import java.util.List;
 /**
  * @author Silvio Moioli {@literal <smoioli@suse.de>}
  */
-public class SsmPowerManagementAction extends AbstractDatabaseAction {
+public class SsmPowerManagementAction implements MessageAction {
 
     /** Logger instance */
     private static Logger log = Logger.getLogger(SsmPowerManagementAction.class);
@@ -43,7 +44,7 @@ public class SsmPowerManagementAction extends AbstractDatabaseAction {
      * {@inheritDoc}
      */
     @Override
-    protected void doExecute(EventMessage msgIn) {
+    public void execute(EventMessage msgIn) {
         SsmPowerManagementEvent event = (SsmPowerManagementEvent) msgIn;
         Long userId = event.getUserId();
         User user = UserFactory.lookupById(userId);

--- a/java/code/src/com/redhat/rhn/frontend/events/SsmSystemRebootAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/SsmSystemRebootAction.java
@@ -19,6 +19,7 @@
 package com.redhat.rhn.frontend.events;
 
 import com.redhat.rhn.common.messaging.EventMessage;
+import com.redhat.rhn.common.messaging.MessageAction;
 import com.redhat.rhn.domain.action.ActionChain;
 import com.redhat.rhn.domain.action.ActionChainFactory;
 import com.redhat.rhn.domain.user.User;
@@ -34,11 +35,11 @@ import org.apache.log4j.Logger;
  * System Reboot action in the SSM/Miscellaneous.
  * @author Bo Maryniuk {@literal <bo@suse.de>}
  */
-public class SsmSystemRebootAction extends AbstractDatabaseAction {
+public class SsmSystemRebootAction implements MessageAction {
     private static Logger log = Logger.getLogger(SsmSystemRebootAction.class);
 
     @Override
-    protected void doExecute(EventMessage msg) {
+    public void execute(EventMessage msg) {
         SsmSystemRebootAction.log.debug("Scheduling systems reboot in SSM.");
         SsmSystemRebootEvent event = (SsmSystemRebootEvent) msg;
         User user = UserFactory.lookupById(event.getUserId());

--- a/java/code/src/com/redhat/rhn/frontend/events/SsmVerifyPackagesAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/SsmVerifyPackagesAction.java
@@ -16,6 +16,7 @@ package com.redhat.rhn.frontend.events;
 
 import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.common.messaging.EventMessage;
+import com.redhat.rhn.common.messaging.MessageAction;
 import com.redhat.rhn.domain.action.ActionChain;
 import com.redhat.rhn.domain.action.ActionChainFactory;
 import com.redhat.rhn.domain.server.Server;
@@ -40,12 +41,12 @@ import java.util.Map;
 /**
  * Schedules package verifications on systems in the SSM.
  */
-public class SsmVerifyPackagesAction extends AbstractDatabaseAction {
+public class SsmVerifyPackagesAction implements MessageAction {
 
     private final Log log = LogFactory.getLog(this.getClass());
 
     /** {@inheritDoc} */
-    protected void doExecute(EventMessage msg) {
+    public void execute(EventMessage msg) {
         SsmVerifyPackagesEvent event = (SsmVerifyPackagesEvent) msg;
 
         User user = UserFactory.lookupById(event.getUserId());

--- a/java/code/src/com/redhat/rhn/frontend/events/TraceBackAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/TraceBackAction.java
@@ -28,8 +28,6 @@ import java.util.Date;
 
 /**
  * Implement Action for TraceBackEvents
- *
- * @version $Rev$
  */
 public class TraceBackAction extends BaseMailAction implements MessageAction {
 

--- a/java/code/src/com/redhat/rhn/frontend/events/TraceBackAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/TraceBackAction.java
@@ -71,4 +71,11 @@ public class TraceBackAction extends BaseMailAction implements MessageAction {
         return retval;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean needsTransactionHandling() {
+        return false;
+    }
 }

--- a/java/code/src/com/redhat/rhn/frontend/events/TransactionHelper.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/TransactionHelper.java
@@ -14,55 +14,54 @@
  */
 package com.redhat.rhn.frontend.events;
 
+
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+
 import com.redhat.rhn.common.hibernate.HibernateFactory;
-import com.redhat.rhn.common.messaging.EventMessage;
-import com.redhat.rhn.common.messaging.MessageAction;
 
 import org.apache.log4j.Logger;
 import org.hibernate.HibernateException;
 
-/**
- * Base action for any action that communicates with the database. This class will
- * take care of committing the transaction and any cleanup that is necessary.
- */
-public abstract class AbstractDatabaseAction implements MessageAction {
+import java.util.Optional;
+import java.util.function.Consumer;
 
-    private static Logger log = Logger.getLogger(AbstractDatabaseAction.class);
-    private static final String ROLLBACK_MSG = "Error during transaction. Rolling back.";
+/**
+ * Offers utility methods to handle database transactions.
+ */
+public abstract class TransactionHelper {
+
+    private static Logger log = Logger.getLogger(TransactionHelper.class);
 
     /**
-     * Performs the business logic of the action. This method should be implemented
-     * instead of overriding {@link #execute(EventMessage)}.
+     * Runs the runnable and handles the closing of the transaction and Hibernate session upon completion,
+     * rolling back in case of unexpected Exceptions.
      *
-     * @param msg event being executed; will not be <code>null</code>
+     * @param runnable code to wrap
+     * @param errorHandler called in case of unexpected Exceptions
      */
-    protected abstract void doExecute(EventMessage msg);
-
-    /** {@inheritDoc} */
-    public void execute(EventMessage msg) {
-        boolean commit = true;
+    public static void handlingTransaction(Runnable runnable, Consumer<Exception> errorHandler) {
+        Optional<Exception> exception = empty();
         try {
-            doExecute(msg);
+            runnable.run();
         }
         catch (Exception e) {
-            commit = false;
-            log.error("Error executing action " + getClass().getName(), e);
+            log.error("Unexpected error executing action", e);
+            exception = of(e);
         }
         finally {
-            handleTransactions(commit);
+            handleTransactions(!exception.isPresent());
         }
+
+        exception.ifPresent(e -> {
+            handlingTransaction(
+                    () -> errorHandler.accept(e),
+                    f -> log.error("Additional Exception during handling", f)
+            );
+        });
     }
 
-
-    /**
-     * Commits the current thread transaction, as well as close the Hibernate session.
-     * <p>
-     * Note that this call <em>MUST</em> take place for any database operations done in
-     * a message queue action for the transaction to be committed.
-     * @param commit true if transaction should be committed.  if false, it will be
-     * rolled back.  It will also be rolled back if attempt to commit fails.
-     */
-    protected void handleTransactions(boolean commit) {
+    private static void handleTransactions(boolean commit) {
         boolean committed = false;
 
         try {
@@ -76,7 +75,7 @@ public abstract class AbstractDatabaseAction implements MessageAction {
             }
         }
         catch (HibernateException e) {
-            log.error(ROLLBACK_MSG, e);
+            log.error("Error during transaction. Rolling back.", e);
         }
         finally {
             try {
@@ -95,9 +94,8 @@ public abstract class AbstractDatabaseAction implements MessageAction {
             }
             finally {
                 // cleanup the session
-                    HibernateFactory.closeSession();
+                HibernateFactory.closeSession();
             }
         }
     }
-
 }

--- a/java/code/src/com/redhat/rhn/frontend/events/UpdateErrataCacheAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/UpdateErrataCacheAction.java
@@ -22,7 +22,6 @@ import org.apache.log4j.Logger;
 
 /**
  * UpdateErrataCacheAction
- * @version $Rev$
  */
 public class UpdateErrataCacheAction implements MessageAction {
 

--- a/java/code/src/com/redhat/rhn/frontend/events/UpdateErrataCacheAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/UpdateErrataCacheAction.java
@@ -15,6 +15,7 @@
 package com.redhat.rhn.frontend.events;
 
 import com.redhat.rhn.common.messaging.EventMessage;
+import com.redhat.rhn.common.messaging.MessageAction;
 import com.redhat.rhn.manager.errata.cache.UpdateErrataCacheCommand;
 
 import org.apache.log4j.Logger;
@@ -23,12 +24,12 @@ import org.apache.log4j.Logger;
  * UpdateErrataCacheAction
  * @version $Rev$
  */
-public class UpdateErrataCacheAction extends AbstractDatabaseAction {
+public class UpdateErrataCacheAction implements MessageAction {
 
     private static Logger log = Logger.getLogger(UpdateErrataCacheAction.class);
 
     /** {@inheritDoc} */
-    protected void doExecute(EventMessage msg) {
+    public void execute(EventMessage msg) {
         UpdateErrataCacheEvent evt = (UpdateErrataCacheEvent) msg;
         if (log.isDebugEnabled()) {
             log.debug("Updating errata cache, with type: " + evt.getUpdateType());

--- a/java/code/src/com/redhat/rhn/frontend/events/test/CloneErrataActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/test/CloneErrataActionTest.java
@@ -54,7 +54,7 @@ public class CloneErrataActionTest extends BaseTestCaseWithUser {
     }
 
     /**
-     * Tests doExecute().
+     * Tests execute().
      * @throws Exception if something bad happens
      */
     public void testDoExecute() throws Exception {
@@ -83,7 +83,7 @@ public class CloneErrataActionTest extends BaseTestCaseWithUser {
         // run CloneErrataAction
         Collection<Long> errataIds = new LinkedList<Long>() { { add(errata.getId()); } };
         CloneErrataEvent event = new CloneErrataEvent(cloned, errataIds, user);
-        new CloneErrataAction().doExecute(event);
+        new CloneErrataAction().execute(event);
 
         // new errata should be in cloned channel, new repository metadata
         // generation scheduled

--- a/java/code/src/com/suse/manager/reactor/messaging/ApplyStatesEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/ApplyStatesEventMessageAction.java
@@ -15,19 +15,18 @@
 package com.suse.manager.reactor.messaging;
 
 import com.redhat.rhn.common.messaging.EventMessage;
+import com.redhat.rhn.common.messaging.MessageAction;
 import com.redhat.rhn.domain.action.salt.ApplyStatesAction;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.domain.user.UserFactory;
-import com.redhat.rhn.frontend.events.AbstractDatabaseAction;
 import com.redhat.rhn.manager.action.ActionManager;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
 import com.suse.manager.utils.MinionServerUtils;
-
 import org.apache.log4j.Logger;
 
 import java.util.Arrays;
@@ -36,7 +35,7 @@ import java.util.Date;
 /**
  * Applies states to a server
  */
-public class ApplyStatesEventMessageAction extends AbstractDatabaseAction {
+public class ApplyStatesEventMessageAction implements MessageAction {
 
     private static final TaskomaticApi TASKOMATIC_API = new TaskomaticApi();
     private static final Logger LOG = Logger.getLogger(ApplyStatesEventMessageAction.class);
@@ -48,7 +47,7 @@ public class ApplyStatesEventMessageAction extends AbstractDatabaseAction {
     }
 
     @Override
-    public void doExecute(EventMessage event) {
+    public void execute(EventMessage event) {
         ApplyStatesEventMessage applyStatesEvent = (ApplyStatesEventMessage) event;
         Server server = ServerFactory.lookupById(applyStatesEvent.getServerId());
 

--- a/java/code/src/com/suse/manager/reactor/messaging/ChannelsChangedEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/ChannelsChangedEventMessageAction.java
@@ -15,6 +15,7 @@
 package com.suse.manager.reactor.messaging;
 
 import com.redhat.rhn.common.messaging.EventMessage;
+import com.redhat.rhn.common.messaging.MessageAction;
 import com.redhat.rhn.domain.action.salt.ApplyStatesAction;
 import com.redhat.rhn.domain.channel.AccessTokenFactory;
 import com.redhat.rhn.domain.rhnpackage.Package;
@@ -25,14 +26,12 @@ import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.state.StateFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.domain.user.UserFactory;
-import com.redhat.rhn.frontend.events.AbstractDatabaseAction;
 import com.redhat.rhn.manager.action.ActionManager;
 import com.redhat.rhn.manager.errata.ErrataManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
 import com.suse.manager.webui.services.SaltStateGeneratorService;
-
 import org.apache.log4j.Logger;
 
 import java.util.Collections;
@@ -45,14 +44,14 @@ import java.util.stream.Collectors;
  * Handle changes of channel assignments on minions: trigger a refresh of the errata cache,
  * regenerate pillar data and propagate the changes to the minion via state application.
  */
-public class ChannelsChangedEventMessageAction extends AbstractDatabaseAction {
+public class ChannelsChangedEventMessageAction implements MessageAction {
 
     private static Logger log = Logger.getLogger(ChannelsChangedEventMessageAction.class);
 
     private static final TaskomaticApi TASKOMATIC_API = new TaskomaticApi();
 
     @Override
-    protected void doExecute(EventMessage event) {
+    public void execute(EventMessage event) {
         ChannelsChangedEventMessage msg = (ChannelsChangedEventMessage) event;
         long serverId = msg.getServerId();
 

--- a/java/code/src/com/suse/manager/reactor/messaging/JobReturnEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/JobReturnEventMessageAction.java
@@ -14,30 +14,27 @@
  */
 package com.suse.manager.reactor.messaging;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonParseException;
-import com.google.gson.JsonSyntaxException;
-
-import com.google.gson.reflect.TypeToken;
 import com.redhat.rhn.common.messaging.EventMessage;
+import com.redhat.rhn.common.messaging.MessageAction;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.server.ServerAction;
+import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.MinionServerFactory;
 import com.redhat.rhn.domain.server.VirtualInstance;
-import com.redhat.rhn.frontend.events.AbstractDatabaseAction;
-import com.redhat.rhn.domain.server.MinionServer;
-
 import com.redhat.rhn.manager.action.ActionManager;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.reflect.TypeToken;
 import com.suse.manager.reactor.hardware.CpuArchUtil;
 import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.utils.SaltUtils.PackageChangeOutcome;
-import com.suse.manager.webui.utils.salt.custom.ScheduleMetadata;
 import com.suse.manager.webui.services.SaltActionChainGeneratorService;
+import com.suse.manager.webui.utils.salt.custom.ScheduleMetadata;
 import com.suse.salt.netapi.event.JobReturnEvent;
-
 import com.suse.salt.netapi.results.Ret;
 import com.suse.salt.netapi.results.StateApplyResult;
 import com.suse.utils.Json;
@@ -57,7 +54,7 @@ import java.util.stream.Collectors;
 /**
  * Handler class for {@link JobReturnEventMessage}.
  */
-public class JobReturnEventMessageAction extends AbstractDatabaseAction {
+public class JobReturnEventMessageAction implements MessageAction {
 
     /**
      * Converts an event to json
@@ -81,7 +78,7 @@ public class JobReturnEventMessageAction extends AbstractDatabaseAction {
     private static final Logger LOG = Logger.getLogger(JobReturnEventMessageAction.class);
 
     @Override
-    public void doExecute(EventMessage msg) {
+    public void execute(EventMessage msg) {
         JobReturnEventMessage jobReturnEventMessage = (JobReturnEventMessage) msg;
         JobReturnEvent jobReturnEvent = jobReturnEventMessage.getJobReturnEvent();
 

--- a/java/code/src/com/suse/manager/reactor/messaging/MinionStartEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/MinionStartEventMessageAction.java
@@ -15,19 +15,19 @@
 package com.suse.manager.reactor.messaging;
 
 import com.redhat.rhn.common.messaging.EventMessage;
+import com.redhat.rhn.common.messaging.MessageAction;
 import com.redhat.rhn.domain.server.MinionServerFactory;
-import com.redhat.rhn.frontend.events.AbstractDatabaseAction;
+
+import com.suse.manager.utils.MinionServerUtils;
 import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.webui.services.impl.SaltService;
-import com.suse.manager.utils.MinionServerUtils;
 import com.suse.salt.netapi.datatypes.target.MinionList;
-
 import org.apache.log4j.Logger;
 
 /**
  * Event message handler for {@link MinionStartEventMessage}.
  */
-public class MinionStartEventMessageAction extends AbstractDatabaseAction {
+public class MinionStartEventMessageAction implements MessageAction {
 
     /* Logger for this class */
     private static final Logger LOG = Logger.getLogger(MinionStartEventMessageAction.class);
@@ -52,7 +52,7 @@ public class MinionStartEventMessageAction extends AbstractDatabaseAction {
     }
 
     @Override
-    protected void doExecute(EventMessage msg) {
+    public void execute(EventMessage msg) {
         String minionId = ((MinionStartEventMessage) msg).getMinionId();
         MinionServerFactory.findByMinionId(minionId)
                 .ifPresent(minion -> {

--- a/java/code/src/com/suse/manager/reactor/messaging/RefreshGeneratedSaltFilesEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RefreshGeneratedSaltFilesEventMessageAction.java
@@ -14,7 +14,13 @@
  */
 package com.suse.manager.reactor.messaging;
 
+import static com.suse.manager.webui.services.SaltConstants.SALT_CONFIG_STATES_DIR;
+import static com.suse.manager.webui.services.SaltConstants.SALT_FILE_GENERATION_TEMP_PATH;
+import static com.suse.manager.webui.services.SaltConstants.SALT_SERVER_STATE_FILE_PREFIX;
+import static com.suse.manager.webui.services.SaltConstants.SUMA_STATE_FILES_ROOT_PATH;
+
 import com.redhat.rhn.common.messaging.EventMessage;
+import com.redhat.rhn.common.messaging.MessageAction;
 import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.server.ManagedServerGroup;
@@ -22,7 +28,7 @@ import com.redhat.rhn.domain.server.ServerGroupFactory;
 import com.redhat.rhn.domain.state.OrgStateRevision;
 import com.redhat.rhn.domain.state.ServerGroupStateRevision;
 import com.redhat.rhn.domain.state.StateFactory;
-import com.redhat.rhn.frontend.events.AbstractDatabaseAction;
+
 import com.suse.manager.webui.services.SaltStateGeneratorService;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
@@ -34,15 +40,10 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.List;
 
-import static com.suse.manager.webui.services.SaltConstants.SUMA_STATE_FILES_ROOT_PATH;
-import static com.suse.manager.webui.services.SaltConstants.SALT_CONFIG_STATES_DIR;
-import static com.suse.manager.webui.services.SaltConstants.SALT_SERVER_STATE_FILE_PREFIX;
-import static com.suse.manager.webui.services.SaltConstants.SALT_FILE_GENERATION_TEMP_PATH;
-
 /**
  * Regenerate all state assignment .sls files for orgs and groups.
  */
-public class RefreshGeneratedSaltFilesEventMessageAction extends AbstractDatabaseAction {
+public class RefreshGeneratedSaltFilesEventMessageAction implements MessageAction {
 
     private static Logger log = Logger
             .getLogger(RefreshGeneratedSaltFilesEventMessageAction.class);
@@ -70,7 +71,7 @@ public class RefreshGeneratedSaltFilesEventMessageAction extends AbstractDatabas
     }
 
     @Override
-    protected void doExecute(EventMessage msg) {
+    public void execute(EventMessage msg) {
         try {
             refreshFiles();
         }

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -1057,7 +1057,10 @@ public class RegisterMinionEventMessageAction implements MessageAction {
         };
     }
 
-    private class RegisterMinionException extends RuntimeException {
+    /**
+     * Represents an Exception during the registration process.
+     */
+    public class RegisterMinionException extends RuntimeException {
         private String minionId;
         private Org org;
         RegisterMinionException(String minionIdIn, Org orgIn) {

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -19,6 +19,7 @@ import static java.util.Optional.empty;
 import static java.util.Optional.ofNullable;
 
 import com.redhat.rhn.common.messaging.EventMessage;
+import com.redhat.rhn.common.messaging.MessageAction;
 import com.redhat.rhn.common.messaging.MessageQueue;
 import com.redhat.rhn.common.util.RpmVersionComparator;
 import com.redhat.rhn.common.validator.ValidatorResult;
@@ -53,7 +54,6 @@ import com.redhat.rhn.domain.token.ActivationKey;
 import com.redhat.rhn.domain.token.ActivationKeyFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.dto.EssentialChannelDto;
-import com.redhat.rhn.frontend.events.AbstractDatabaseAction;
 import com.redhat.rhn.manager.action.ActionManager;
 import com.redhat.rhn.manager.distupgrade.DistUpgradeManager;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
@@ -98,7 +98,7 @@ import java.util.stream.Stream;
 /**
  * Event handler to create system records for salt minions.
  */
-public class RegisterMinionEventMessageAction extends AbstractDatabaseAction {
+public class RegisterMinionEventMessageAction implements MessageAction {
 
     // Logger for this class
     private static final Logger LOG = Logger.getLogger(
@@ -134,7 +134,7 @@ public class RegisterMinionEventMessageAction extends AbstractDatabaseAction {
      * {@inheritDoc}
      */
     @Override
-    public void doExecute(EventMessage msg) {
+    public void execute(EventMessage msg) {
         registerMinion(((RegisterMinionEventMessage) msg).getMinionId(), false,
                 Optional.empty(), Optional.empty());
     }

--- a/java/code/src/com/suse/manager/reactor/messaging/RunnableEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RunnableEventMessageAction.java
@@ -16,20 +16,21 @@
 package com.suse.manager.reactor.messaging;
 
 import com.redhat.rhn.common.messaging.EventMessage;
-import com.redhat.rhn.frontend.events.AbstractDatabaseAction;
+import com.redhat.rhn.common.messaging.MessageAction;
+
 import org.apache.log4j.Logger;
 
 /**
  * Action for executing RunnableEventMessageAction
  */
-public class RunnableEventMessageAction extends AbstractDatabaseAction {
+public class RunnableEventMessageAction implements MessageAction {
 
     /* Logger for this class */
     private static final Logger LOG = Logger
             .getLogger(RunnableEventMessageAction.class);
 
     @Override
-    protected void doExecute(EventMessage msg) {
+    public void execute(EventMessage msg) {
        if (msg instanceof RunnableEventMessage) {
             RunnableEventMessage event = (RunnableEventMessage) msg;
             event.getAction().run();

--- a/java/code/src/com/suse/manager/reactor/messaging/VirtpollerBeaconEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/VirtpollerBeaconEventMessageAction.java
@@ -15,21 +15,21 @@
 package com.suse.manager.reactor.messaging;
 
 import com.redhat.rhn.common.messaging.EventMessage;
+import com.redhat.rhn.common.messaging.MessageAction;
 import com.redhat.rhn.domain.server.MinionServerFactory;
 import com.redhat.rhn.domain.server.VirtualInstanceFactory;
-import com.redhat.rhn.frontend.events.AbstractDatabaseAction;
 import com.redhat.rhn.manager.system.VirtualInstanceManager;
 
 /**
  * Virtpoller Beacon Event Action Handler
  */
-public class VirtpollerBeaconEventMessageAction extends AbstractDatabaseAction {
+public class VirtpollerBeaconEventMessageAction implements MessageAction {
 
     /**
      * {@inheritDoc}
      */
     @Override
-    protected void doExecute(EventMessage msg) {
+    public void execute(EventMessage msg) {
         VirtpollerBeaconEventMessage vMsg = (VirtpollerBeaconEventMessage) msg;
 
         MinionServerFactory.findByMinionId(vMsg.getMinionId()).ifPresent(minion -> {

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -149,7 +149,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
-        messageAction.doExecute(message);
+        messageAction.execute(message);
 
         // Verify the results
         for (InstalledPackage pkg : minion.getPackages()) {
@@ -274,7 +274,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 .parse(getJobReturnEvent("packages.profileupdate.allversions.json", action.getId()))
                 .get());
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
-        messageAction.doExecute(message);
+        messageAction.execute(message);
 
         // Verify names and versions
         for (InstalledPackage pkg : minion.getPackages()) {
@@ -340,7 +340,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 .parse(getJobReturnEvent("packages.profileupdate.json", action.getId()))
                 .get());
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
-        messageAction.doExecute(message);
+        messageAction.execute(message);
 
         // Verify names and versions
         for (InstalledPackage pkg : minion.getPackages()) {
@@ -371,7 +371,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         message = new JobReturnEventMessage(JobReturnEvent.parse(
                 getJobReturnEvent("packages.profileupdate.updated.json", action.getId()))
                 .get());
-        messageAction.doExecute(message);
+        messageAction.execute(message);
 
         // Verify names and versions
         for (InstalledPackage pkg : minion.getPackages()) {
@@ -415,7 +415,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
-        messageAction.doExecute(message);
+        messageAction.execute(message);
 
         // Verify no live patching version is returned
         assertNull(minion.getKernelLiveVersion());
@@ -425,7 +425,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 .parse(getJobReturnEvent("packages.profileupdate.livepatching.json",
                         action.getId()))
                 .get());
-        messageAction.doExecute(message);
+        messageAction.execute(message);
 
         // Verify live patching version
         assertEquals("kgraft_patch_2_2_1", minion.getKernelLiveVersion());
@@ -435,7 +435,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 .parse(getJobReturnEvent("packages.profileupdate.json",
                         action.getId()))
                 .get());
-        messageAction.doExecute(message);
+        messageAction.execute(message);
 
         // Verify no live patching version is returned again
         assertNull(minion.getKernelLiveVersion());
@@ -465,7 +465,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
-        messageAction.doExecute(message);
+        messageAction.execute(message);
 
         // Verify the results
         for (InstalledPackage pkg : minion.getPackages()) {
@@ -769,7 +769,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
-        messageAction.doExecute(message);
+        messageAction.execute(message);
 
         HibernateFactory.getSession().flush();
     }
@@ -815,7 +815,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
-        messageAction.doExecute(message);
+        messageAction.execute(message);
     }
 
     public void testHardwareProfileUpdatePrimaryIPsEmptySSH()  throws Exception {
@@ -937,7 +937,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
-        messageAction.doExecute(message);
+        messageAction.execute(message);
 
         assertions.accept(server);
         return server;
@@ -1034,7 +1034,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
-        messageAction.doExecute(message);
+        messageAction.execute(message);
 
         assertEquals(
             Arrays.asList(sa),
@@ -1099,7 +1099,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
         SaltUtils.INSTANCE.setXccdfResumeXsl(resumeXsl);
         SaltUtils.INSTANCE.setSaltService(saltServiceMock);
-        messageAction.doExecute(message);
+        messageAction.execute(message);
 
         assertEquals(ActionFactory.STATUS_COMPLETED, sa.getStatus());
     }
@@ -1283,7 +1283,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
-        messageAction.doExecute(message);
+        messageAction.execute(message);
 
         // assertions after inspect
         assertions.accept(imgInfo);
@@ -1305,7 +1305,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
-        messageAction.doExecute(message);
+        messageAction.execute(message);
 
         // assert we have the same initial ImageInfo even after processing the event
         assertTrue(ImageInfoFactory.lookupById(imgInfoBuild.get().getId()).isPresent());
@@ -1411,7 +1411,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
-        messageAction.doExecute(message);
+        messageAction.execute(message);
 
         // assert we have the same initial ImageInfo even after processing the event
         assertTrue(ImageInfoFactory.lookupById(imgInfoBuild.get().getId()).isPresent());
@@ -1447,7 +1447,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
-        messageAction.doExecute(message);
+        messageAction.execute(message);
 
         assertTrue(ImageInfoFactory.lookupById(imgInfoBuild.get().getId()).isPresent());
         ImageInfo imgInfo = TestUtils.reload(imgInfoBuild.get());
@@ -1480,7 +1480,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
-        messageAction.doExecute(message);
+        messageAction.execute(message);
 
         assertEquals(initialMessageCount, MessageQueue.getMessageCount());
     }
@@ -1530,7 +1530,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
-        messageAction.doExecute(message);
+        messageAction.execute(message);
 
         assertEquals(ActionFactory.STATUS_COMPLETED, sa.getStatus());
         assertEquals(0L, (long)sa.getResultCode());
@@ -1593,7 +1593,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
-        messageAction.doExecute(message);
+        messageAction.execute(message);
 
         // check that tokens are really gone
         assertEquals(0, minion.getAccessTokens().size());
@@ -1688,7 +1688,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
-        messageAction.doExecute(message);
+        messageAction.execute(message);
 
         applyHighstate = (ApplyStatesAction)ActionFactory.lookupById(applyHighstate.getId());
         saHighstate = applyHighstate.getServerActions().stream().findFirst().get();

--- a/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
@@ -284,7 +284,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         }
 
         RegisterMinionEventMessageAction action = new RegisterMinionEventMessageAction(saltServiceMock);
-        action.doExecute(new RegisterMinionEventMessage(MINION_ID));
+        action.execute(new RegisterMinionEventMessage(MINION_ID));
 
         // Verify the resulting system entry
         String machineId = saltServiceMock.getMachineId(MINION_ID).get();
@@ -984,31 +984,36 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         ServerGroupFactory.create("HWTYPE:QEMU-CashDesk01", "HW group", OrgFactory.getSatelliteOrg());
         ServerGroupFactory.create("Branch001", "Branch group", OrgFactory.getSatelliteOrg());
 
-        executeTest(
-                (saltServiceMock, key) -> new Expectations() {{
-                    allowing(saltServiceMock).getMasterHostname(MINION_ID);
-                    will(returnValue(Optional.of(MINION_ID)));
-                    allowing(saltServiceMock).getMachineId(MINION_ID);
-                    will(returnValue(Optional.of(MACHINE_ID)));
-                    allowing(saltServiceMock).syncGrains(with(any(MinionList.class)));
-                    allowing(saltServiceMock).syncModules(with(any(MinionList.class)));
-                    allowing(saltServiceMock).getGrains(MINION_ID);
-                    will(returnValue(getGrains(MINION_ID, null, "non-existent-key")
-                            .map(map -> {
-                                map.put("initrd", true);
-                                map.put("manufacturer", "QEMU");
-                                map.put("productname", "CashDesk01");
-                                map.put("minion_id_prefix", "Branch001");
-                                return map;
-                            })));
-                    allowing(saltServiceMock).callSync(
-                            with(any(LocalCall.class)),
-                            with(any(String.class)));
-                }},
-                (contactMethod) -> null, // no AK
-                (optMinion, machineId, key) -> {
-                    assertFalse(optMinion.isPresent());
-                }, DEFAULT_CONTACT_METHOD);
+        try {
+            executeTest(
+                    (saltServiceMock, key) -> new Expectations() {{
+                        allowing(saltServiceMock).getMasterHostname(MINION_ID);
+                        will(returnValue(Optional.of(MINION_ID)));
+                        allowing(saltServiceMock).getMachineId(MINION_ID);
+                        will(returnValue(Optional.of(MACHINE_ID)));
+                        allowing(saltServiceMock).syncGrains(with(any(MinionList.class)));
+                        allowing(saltServiceMock).syncModules(with(any(MinionList.class)));
+                        allowing(saltServiceMock).getGrains(MINION_ID);
+                        will(returnValue(getGrains(MINION_ID, null, "non-existent-key")
+                                .map(map -> {
+                                    map.put("initrd", true);
+                                    map.put("manufacturer", "QEMU");
+                                    map.put("productname", "CashDesk01");
+                                    map.put("minion_id_prefix", "Branch001");
+                                    return map;
+                                })));
+                        allowing(saltServiceMock).callSync(
+                                with(any(LocalCall.class)),
+                                with(any(String.class)));
+                    }},
+                    (contactMethod) -> null, // no AK
+                    (optMinion, machineId, key) -> {
+                        assertFalse(optMinion.isPresent());
+                    }, DEFAULT_CONTACT_METHOD);
+        } catch (RegisterMinionEventMessageAction.RegisterMinionException e) {
+            return;
+        }
+        fail("Expected Exception not thrown");
     }
 
 
@@ -1022,31 +1027,36 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         ServerGroupFactory.create("HWTYPE:QEMU-CashDesk01", "HW group", OrgFactory.getSatelliteOrg());
         ServerGroupFactory.create("TERMINALS", "All terminals group", OrgFactory.getSatelliteOrg());
 
-        executeTest(
-                (saltServiceMock, key) -> new Expectations() {{
-                    allowing(saltServiceMock).getMasterHostname(MINION_ID);
-                    will(returnValue(Optional.of(MINION_ID)));
-                    allowing(saltServiceMock).getMachineId(MINION_ID);
-                    will(returnValue(Optional.of(MACHINE_ID)));
-                    allowing(saltServiceMock).syncGrains(with(any(MinionList.class)));
-                    allowing(saltServiceMock).syncModules(with(any(MinionList.class)));
-                    allowing(saltServiceMock).getGrains(MINION_ID);
-                    will(returnValue(getGrains(MINION_ID, null, "non-existent-key")
-                            .map(map -> {
-                                map.put("initrd", true);
-                                map.put("manufacturer", "QEMU");
-                                map.put("productname", "CashDesk01");
-                                map.put("minion_id_prefix", "Branch001");
-                                return map;
-                            })));
-                    allowing(saltServiceMock).callSync(
-                            with(any(LocalCall.class)),
-                            with(any(String.class)));
-                }},
-                (contactMethod) -> null, // no AK
-                (optMinion, machineId, key) -> {
-                    assertFalse(optMinion.isPresent());
-                }, DEFAULT_CONTACT_METHOD);
+        try {
+            executeTest(
+                    (saltServiceMock, key) -> new Expectations() {{
+                        allowing(saltServiceMock).getMasterHostname(MINION_ID);
+                        will(returnValue(Optional.of(MINION_ID)));
+                        allowing(saltServiceMock).getMachineId(MINION_ID);
+                        will(returnValue(Optional.of(MACHINE_ID)));
+                        allowing(saltServiceMock).syncGrains(with(any(MinionList.class)));
+                        allowing(saltServiceMock).syncModules(with(any(MinionList.class)));
+                        allowing(saltServiceMock).getGrains(MINION_ID);
+                        will(returnValue(getGrains(MINION_ID, null, "non-existent-key")
+                                .map(map -> {
+                                    map.put("initrd", true);
+                                    map.put("manufacturer", "QEMU");
+                                    map.put("productname", "CashDesk01");
+                                    map.put("minion_id_prefix", "Branch001");
+                                    return map;
+                                })));
+                        allowing(saltServiceMock).callSync(
+                                with(any(LocalCall.class)),
+                                with(any(String.class)));
+                    }},
+                    (contactMethod) -> null, // no AK
+                    (optMinion, machineId, key) -> {
+                        assertFalse(optMinion.isPresent());
+                    }, DEFAULT_CONTACT_METHOD);
+        } catch (RegisterMinionEventMessageAction.RegisterMinionException e) {
+            return;
+        }
+        fail("Expected Exception not thrown");
     }
 
     /**
@@ -1274,7 +1284,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
 
         RegisterMinionEventMessageAction action =
                 new RegisterMinionEventMessageAction(saltService);
-        action.doExecute(new RegisterMinionEventMessage(MINION_ID));
+        action.execute(new RegisterMinionEventMessage(MINION_ID));
         return saltService;
     }
 

--- a/java/code/src/com/suse/manager/webui/controllers/NotificationMessageController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/NotificationMessageController.java
@@ -183,7 +183,7 @@ public class NotificationMessageController {
         String resultMessage = "Onboarding restarted of the minioniId '%s'";
 
         RegisterMinionEventMessageAction action = new RegisterMinionEventMessageAction(SaltService.INSTANCE);
-        action.doExecute(new RegisterMinionEventMessage(minionId));
+        action.execute(new RegisterMinionEventMessage(minionId));
 
         Map<String, String> data = new HashMap<>();
         data.put("severity", severity);


### PR DESCRIPTION
## What does this PR change?

It moves transaction-handling code out of `AbstractDatabaseAction` and into a separate utility class that can be reused elsewhere.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **refactoring**

- [x] **DONE**

## Test coverage
- No tests: **abundantly covered by unit and integration tests already**

- [x] **DONE**

## Links

Follows https://github.com/SUSE/spacewalk/pull/5599

- [x] **DONE**
