### PR TITLE
Testsuite: OS image build host needs highstate too

### DIFF
--- a/testsuite/features/core_min_bootstrap.feature
+++ b/testsuite/features/core_min_bootstrap.feature
@@ -138,14 +138,6 @@ Feature: Be able to bootstrap a Salt minion via the GUI
     And I should see a "To apply the state, either use the states page or run state.highstate from the command line." text
     And I should see a "System properties changed" text
 
-  Scenario: Apply the highstate to container build host
-    Given I am on the Systems overview page of this "sle-minion"
-    When I wait until no Salt job is running on "sle-minion"
-    And I enable repositories before installing Docker
-    And I apply highstate on "sle-minion"
-    And I wait until "docker" service is up and running on "sle-minion"
-    And I disable repositories after installing Docker
-
   Scenario: Turn the SLES minion into a OS image build host
     Given I am on the Systems overview page of this "sle-minion"
     When I follow "Details" in the content area
@@ -156,6 +148,15 @@ Feature: Be able to bootstrap a Salt minion via the GUI
     And I should see a "Note: This action will not result in state application" text
     And I should see a "To apply the state, either use the states page or run state.highstate from the command line." text
     And I should see a "System properties changed" text
+
+  Scenario: Apply the highstate to build host
+    Given I am on the Systems overview page of this "sle-minion"
+    When I wait until no Salt job is running on "sle-minion"
+    And I enable repositories before installing Docker
+    And I apply highstate on "sle-minion"
+    And I wait until "docker" service is up and running on "sle-minion"
+    And I wait until file "/var/lib/Kiwi/repo/rhn-org-trusted-ssl-cert-osimage-1.0-1.noarch.rpm" exists on "sle-minion"
+    And I disable repositories after installing Docker
 
   Scenario: Check that the minion is now a build host
     Given I am on the Systems overview page of this "sle-minion"

--- a/testsuite/features/core_proxy_register_as_minion_with_gui.feature
+++ b/testsuite/features/core_proxy_register_as_minion_with_gui.feature
@@ -39,4 +39,4 @@ Feature: Setup SUSE Manager proxy
   Scenario: Check proxy system details
     When I am on the Systems overview page of this "proxy"
     Then I should see "proxy" hostname
-    And I wait until I see "$PRODUCT Proxy" text
+    And I wait until I see "$PRODUCT Proxy" text, refreshing the page

--- a/testsuite/features/core_proxy_register_as_minion_with_script.feature
+++ b/testsuite/features/core_proxy_register_as_minion_with_script.feature
@@ -40,7 +40,7 @@ Feature: Setup SUSE Manager proxy
   Scenario: Check proxy system details
     When I am on the Systems overview page of this "proxy"
     Then I should see "proxy" hostname
-    And I wait until I see "$PRODUCT Proxy" text
+    And I wait until I see "$PRODUCT Proxy" text, refreshing the page
 
 @proxy
   Scenario: Cleanup: remove proxy bootstrap scripts

--- a/testsuite/features/core_proxy_register_as_trad_with_script.feature
+++ b/testsuite/features/core_proxy_register_as_trad_with_script.feature
@@ -29,7 +29,7 @@ Feature: Setup SUSE Manager proxy
   Scenario: Check proxy system details
     When I am on the Systems overview page of this "proxy"
     Then I should see "proxy" hostname
-    And I wait until I see "$PRODUCT Proxy" text
+    And I wait until I see "$PRODUCT Proxy" text, refreshing the page
 
 @proxy
   Scenario: Cleanup: remove proxy bootstrap scripts

--- a/testsuite/features/min_activationkey.feature
+++ b/testsuite/features/min_activationkey.feature
@@ -137,14 +137,6 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
     And I check "container_build_host"
     And I click on "Update Properties"
 
-  Scenario: Cleanup: Apply the highstate to container build host after activation key tests
-    Given I am on the Systems overview page of this "sle-minion"
-    When I wait until no Salt job is running on "sle-minion"
-    And I enable repositories before installing Docker
-    And I apply highstate on "sle-minion"
-    And I wait until "docker" service is up and running on "sle-minion"
-    And I disable repositories after installing Docker
-
   Scenario: Cleanup: Turn the SLES minion into a OS image build host after activation key tests
     Given I am on the Systems overview page of this "sle-minion"
     When I follow "Details" in the content area
@@ -155,6 +147,15 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
     And I should see a "Note: This action will not result in state application" text
     And I should see a "To apply the state, either use the states page or run state.highstate from the command line." text
     And I should see a "System properties changed" text
+
+  Scenario: Cleanup: Apply the highstate to build host after activation key tests
+    Given I am on the Systems overview page of this "sle-minion"
+    When I wait until no Salt job is running on "sle-minion"
+    And I enable repositories before installing Docker
+    And I apply highstate on "sle-minion"
+    And I wait until "docker" service is up and running on "sle-minion"
+    And I wait until file "/var/lib/Kiwi/repo/rhn-org-trusted-ssl-cert-osimage-1.0-1.noarch.rpm" exists on "sle-minion"
+    And I disable repositories after installing Docker
 
   Scenario: Cleanup: Check that the minion is now a build host after activation key tests
     Given I am on the Systems overview page of this "sle-minion"

--- a/testsuite/features/min_bootstrap_xmlrpc.feature
+++ b/testsuite/features/min_bootstrap_xmlrpc.feature
@@ -68,14 +68,6 @@ Feature: Register a Salt minion via XML-RPC API
     And I check "container_build_host"
     And I click on "Update Properties"
 
-  Scenario: Cleanup: Apply the highstate to container build host after XML bootstrap
-    Given I am on the Systems overview page of this "sle-minion"
-    When I wait until no Salt job is running on "sle-minion"
-    And I enable repositories before installing Docker
-    And I apply highstate on "sle-minion"
-    And I wait until "docker" service is up and running on "sle-minion"
-    And I disable repositories after installing Docker
-
   Scenario: Cleanup: Turn the SLES minion into a OS image build host after XML bootstrap
     Given I am on the Systems overview page of this "sle-minion"
     When I follow "Details" in the content area
@@ -86,6 +78,15 @@ Feature: Register a Salt minion via XML-RPC API
     And I should see a "Note: This action will not result in state application" text
     And I should see a "To apply the state, either use the states page or run state.highstate from the command line." text
     And I should see a "System properties changed" text
+
+  Scenario: Cleanup: Apply the highstate to build host after XML bootstrap
+    Given I am on the Systems overview page of this "sle-minion"
+    When I wait until no Salt job is running on "sle-minion"
+    And I enable repositories before installing Docker
+    And I apply highstate on "sle-minion"
+    And I wait until "docker" service is up and running on "sle-minion"
+    And I wait until file "/var/lib/Kiwi/repo/rhn-org-trusted-ssl-cert-osimage-1.0-1.noarch.rpm" exists on "sle-minion"
+    And I disable repositories after installing Docker
 
   Scenario: Cleanup: Check that the minion is now a build host after XML bootstrap
     Given I am on the Systems overview page of this "sle-minion"

--- a/testsuite/features/min_salt_minions_page.feature
+++ b/testsuite/features/min_salt_minions_page.feature
@@ -99,14 +99,6 @@ Feature: Management of minion keys
     And I check "container_build_host"
     And I click on "Update Properties"
 
-  Scenario: Cleanup: Apply the highstate to container build host after new bootstrap
-    Given I am on the Systems overview page of this "sle-minion"
-    When I wait until no Salt job is running on "sle-minion"
-    And I enable repositories before installing Docker
-    And I apply highstate on "sle-minion"
-    And I wait until "docker" service is up and running on "sle-minion"
-    And I disable repositories after installing Docker
-
   Scenario: Cleanup: Turn the SLES minion into a OS image build host after new bootstrap
     Given I am on the Systems overview page of this "sle-minion"
     When I follow "Details" in the content area
@@ -117,6 +109,15 @@ Feature: Management of minion keys
     And I should see a "Note: This action will not result in state application" text
     And I should see a "To apply the state, either use the states page or run state.highstate from the command line." text
     And I should see a "System properties changed" text
+
+  Scenario: Cleanup: Apply the highstate to build host after new bootstrap
+    Given I am on the Systems overview page of this "sle-minion"
+    When I wait until no Salt job is running on "sle-minion"
+    And I enable repositories before installing Docker
+    And I apply highstate on "sle-minion"
+    And I wait until "docker" service is up and running on "sle-minion"
+    And I wait until file "/var/lib/Kiwi/repo/rhn-org-trusted-ssl-cert-osimage-1.0-1.noarch.rpm" exists on "sle-minion"
+    And I disable repositories after installing Docker
 
   Scenario: Cleanup: Check that the minion is now a build host after new bootstrap
     Given I am on the Systems overview page of this "sle-minion"


### PR DESCRIPTION
## What does this PR change?

It makes sure a highstate is always called after changing type to OS build host.

Port of SUSE/spacewalk#5623