### PR TITLE
Manager bsc1106026

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -108,6 +108,7 @@ PKGLIST12 = [
                 "python",
                 "python-cffi",
                 "python-cryptography",
+                "python-setuptools",
                 "python-dmidecode",
                 "python-ethtool",
                 "python-gobject2",

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- add new dependency python-setuptools to bootstrap packages (bsc#1106026)
 - fix broken stderr redirection in mgr-setup
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Recently a new dependency of python-cryptography on python-setuptools has been introduced. So this package is now also needed in the bootstrap repo to allow installation of osad. Other distributions such as RES6, RES7 already have this package and SLES15 explicitly lists python3-setuptools