### PR TITLE
Change ivy repo from cokerunner to ramrod

### DIFF
--- a/java/buildconf/ivy/ivyconf.xml
+++ b/java/buildconf/ivy/ivyconf.xml
@@ -2,7 +2,7 @@
   <settings defaultResolver="default" />
   <resolvers>
     <url name="default">
-      <artifact pattern="http://cokerunner.mgr.suse.de/ivy/[artifact]-[revision].[ext]" />
+      <artifact pattern="http://ramrod.mgr.suse.de/ivy/[artifact]-[revision].[ext]" />
     </url>
   </resolvers>
 </ivysettings>

--- a/search-server/spacewalk-search/buildconf/ivyconf.xml
+++ b/search-server/spacewalk-search/buildconf/ivyconf.xml
@@ -2,7 +2,7 @@
   <settings defaultResolver="default" />
   <resolvers>
     <url name="default">
-      <artifact pattern="http://cokerunner.mgr.suse.de/ivy/[artifact]-[revision].[ext]" />
+      <artifact pattern="http://ramrod.mgr.suse.de/ivy/[artifact]-[revision].[ext]" />
     </url>
   </resolvers>
 </ivysettings>


### PR DESCRIPTION
## What does this PR change?

The ivy repository, used for local development builds, was copied to ramrod to allow freeing cokerunner to be used in our public CI. This PR is about changing ivy configuration on java projects to use the ivy repo on ramrod.

## GUI diff

No difference.

## Documentation

N/A

## Test coverage
- No tests: Change affects build scripts only

## Links

Fixes https://github.com/SUSE/spacewalk/issues/5597
