### PR TITLE
Testsuite: clean up OS image via UI

### DIFF
--- a/testsuite/features/core_first_settings.feature
+++ b/testsuite/features/core_first_settings.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 SUSE LLC
+# Copyright (c) 2017-2018 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Very first settings

--- a/testsuite/features/min_osimage_build_image.feature
+++ b/testsuite/features/min_osimage_build_image.feature
@@ -26,4 +26,9 @@ Feature: Build OS images
     Then I should see a "POS_Image_JeOS6" text
 
   Scenario: Cleanup: remove the image from SUSE Manager server
-    When I run "rm /srv/www/os-images/1/*" on "server"
+    Given I am authorized as "admin" with password "admin"
+    When I navigate to images webpage
+    And I check the first image
+    And I click on "Delete"
+    And I click on "Delete" in "Delete Selected Image(s)" modal
+    And I wait until I see "Deleted successfully." text

--- a/testsuite/features/support/setup_browser.rb
+++ b/testsuite/features/support/setup_browser.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2017 SUSE-LINUX
+# Copyright (c) 2010-2018 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 require 'English'
@@ -74,8 +74,7 @@ Before('@sle15minion') do |scenario|
   scenario.skip_invoke! unless $sle15_minion
 end
 
-## this is for having more infos about the errors.
-
+# have more infos about the errors
 def debug_server_on_realtime_failure
   puts
   puts '#' * 55 + 'var/log/rhn_web_ui.log' + '#' * 55

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -1,3 +1,6 @@
+# Copyright (c) 2016-2018 SUSE-LINUX
+# Licensed under the terms of the MIT license.
+￼
 require 'twopence'
 
 # Initialize SSH targets from environment variables
@@ -88,4 +91,5 @@ def file_inject(node, local_file, remote_file)
   code
 end
 
+# Other global variables
 $sle15_minion = minion_is_sle15


### PR DESCRIPTION
## What does this PR change?

This PR uses the GUI to remove the previously built OS image, instead of simply removing the file.

It also updates a few comments.

Port of SUSE/spacewalk#5668