### PR TITLE
testsuite: wait for the modal to be fully visible before clicking

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -738,9 +738,15 @@ When(/^I click on "([^"]*)" in "([^"]*)" modal$/) do |btn, title|
   path = "//*[contains(@class, \"modal-title\") and text() = \"#{title}\"]" \
     '/ancestor::div[contains(@class, "modal-dialog")]'
 
-  # We accept invisible elements because the fade out
-  # animation might still be in progress
-  unless page.has_xpath?(path, visible: :all)
+  # We wait until the element becomes visible because
+  # the fade out animation might still be in progress
+  begin
+    Timeout.timeout(DEFAULT_TIMEOUT) do
+      loop do
+        break if page.has_xpath?(path, visible: true)
+      end
+    end
+  rescue Timeout::Error
     raise "Couldn't find the #{title} modal"
   end
 


### PR DESCRIPTION
## What does this PR change?

If the modal dialog is not fully visible when clicking we may have
random test failures. Waiting for the dialog to be visible will eat some
testing time but will make it more reliable.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: the change is just a test suite fix

- [X] **DONE**

## Test coverage
- Cucumber tests were fixed (no cucumber was harmed when making off this PR)

- [X] **DONE**

## Links

- [X] **DONE**
