### PR TITLE
Fix: OS Image building for Salt SSH

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -1133,7 +1133,7 @@ public class SaltService {
     public Optional<MgrUtilRunner.ExecResult> collectKiwiImage(MinionServer minion, String filepath,
             String imageStore) {
         RunnerCall<MgrUtilRunner.ExecResult> call =
-                MgrKiwiImageRunner.collectImage(minion.getName(), filepath, imageStore);
+                MgrKiwiImageRunner.collectImage(minion.getIpAddress(), filepath, imageStore);
         return callSync(call);
     }
 }

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -1133,7 +1133,7 @@ public class SaltService {
     public Optional<MgrUtilRunner.ExecResult> collectKiwiImage(MinionServer minion, String filepath,
             String imageStore) {
         RunnerCall<MgrUtilRunner.ExecResult> call =
-                MgrKiwiImageRunner.collectImage(minion.getIpAddress(), filepath, imageStore);
+                MgrKiwiImageRunner.collectImage(minion.getMinionId(), filepath, imageStore);
         return callSync(call);
     }
 }

--- a/java/code/src/com/suse/manager/webui/services/impl/runner/MgrKiwiImageRunner.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/runner/MgrKiwiImageRunner.java
@@ -33,15 +33,15 @@ public class MgrKiwiImageRunner {
     /**
      * Upload built Kiwi image to SUSE Manager
      *
-     * @param minionIPAddress the minion IP address
+     * @param minionId the minion ID (hostname)
      * @param filepath      the filepath
      * @param imageStoreDir the image store location
      * @return the execution result
      */
-    public static RunnerCall<MgrUtilRunner.ExecResult> collectImage(String minionIPAddress, String filepath,
+    public static RunnerCall<MgrUtilRunner.ExecResult> collectImage(String minionId, String filepath,
             String imageStoreDir) {
         Map<String, Object> args = new LinkedHashMap<>();
-        args.put("minion", minionIPAddress);
+        args.put("minion", minionId);
         args.put("filepath", filepath);
         args.put("image_store_dir", imageStoreDir);
 

--- a/java/code/src/com/suse/manager/webui/services/impl/runner/MgrKiwiImageRunner.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/runner/MgrKiwiImageRunner.java
@@ -15,8 +15,9 @@
 
 package com.suse.manager.webui.services.impl.runner;
 
-import com.google.gson.reflect.TypeToken;
 import com.suse.salt.netapi.calls.RunnerCall;
+
+import com.google.gson.reflect.TypeToken;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -32,15 +33,15 @@ public class MgrKiwiImageRunner {
     /**
      * Upload built Kiwi image to SUSE Manager
      *
-     * @param minion        the minion
+     * @param minionIPAddress the minion IP address
      * @param filepath      the filepath
      * @param imageStoreDir the image store location
      * @return the execution result
      */
-    public static RunnerCall<MgrUtilRunner.ExecResult> collectImage(String minion, String filepath,
+    public static RunnerCall<MgrUtilRunner.ExecResult> collectImage(String minionIPAddress, String filepath,
             String imageStoreDir) {
         Map<String, Object> args = new LinkedHashMap<>();
-        args.put("minion", minion);
+        args.put("minion", minionIPAddress);
         args.put("filepath", filepath);
         args.put("image_store_dir", imageStoreDir);
 

--- a/susemanager-utils/susemanager-sls/modules/runners/kiwi-image-collect.py
+++ b/susemanager-utils/susemanager-sls/modules/runners/kiwi-image-collect.py
@@ -9,8 +9,8 @@ import logging
 
 log = logging.getLogger(__name__)
 
-def upload_file_from_minion(addr4, filetoupload, targetdir):
-    src = 'root@' + addr4 + ':' + filetoupload
+def upload_file_from_minion(hostname, filetoupload, targetdir):
+    src = 'root@' + hostname + ':' + filetoupload
     return __salt__['salt.cmd'](
       'rsync.rsync',
       src, targetdir,

--- a/susemanager-utils/susemanager-sls/modules/runners/kiwi-image-collect.py
+++ b/susemanager-utils/susemanager-sls/modules/runners/kiwi-image-collect.py
@@ -9,20 +9,7 @@ import logging
 
 log = logging.getLogger(__name__)
 
-def upload_file_from_minion(minion, filetoupload, targetdir):
-    grains = list(__salt__['cache.grains'](tgt=minion).values())[0]
-    addr4 = None
-    for addr in grains.get('ipv4'):
-      if addr == '127.0.0.1':
-        continue
-      else:
-        if __salt__['salt.cmd']('network.ping', addr, return_boolean=True):
-          addr4 = addr
-          break
-
-    if not addr4:
-      raise salt.exceptions.SaltRunnerError('Could not find reachable IPv4 address for minion {}'.format(minion))
-
+def upload_file_from_minion(addr4, filetoupload, targetdir):
     src = 'root@' + addr4 + ':' + filetoupload
     return __salt__['salt.cmd'](
       'rsync.rsync',

--- a/susemanager-utils/susemanager-sls/src/modules/kiwi_source.py
+++ b/susemanager-utils/susemanager-sls/src/modules/kiwi_source.py
@@ -2,7 +2,10 @@ import salt.exceptions
 import logging
 import os
 from tempfile import mkdtemp
-from urlparse import urlparse
+try:
+    from urllib.parse import urlparse
+except ImportError:
+     from urlparse import urlparse
 
 log = logging.getLogger(__name__)
 
@@ -123,4 +126,3 @@ def prepare_source(source, root):
     return _prepareGit(source, dest, root)
   else:
     raise salt.exceptions.SaltException('Unknown source format "{}"'.format(source))
-


### PR DESCRIPTION
## What does this PR change?

1.  Fix: supply IP address of minion

To collect the image from the build host we used a Salt runner that
accessed the Salt grains in order to fetch the minion IP address.

This works perfectly with regular minions, but not for salt-ssh
minions.

This patch passes directly the IP address of the minion to the runner
so we do not need to access grains.

2. Fix for salt-ssh. If salt-ssh detects that Python 3 is installed
in the minion, it will use that for calling Salt and its modules.

In Python 3, urlparse has been renamed to urllib. This patch
makes sure to import the correct library name.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: internal

- [X] **DONE**

## Test coverage
- No tests: the situation was not caught by tests

- [X] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/5624

- [X] **DONE**
