### PR TITLE
Fix merging of image pillars

### DIFF
--- a/susemanager-utils/susemanager-sls/modules/pillar/suma_minion.py
+++ b/susemanager-utils/susemanager-sls/modules/pillar/suma_minion.py
@@ -266,7 +266,7 @@ def image_pillars(minion_id):
         if os.path.isfile(pillar_path) and pillar.endswith('.sls'):
             try:
                 with open(pillar_path) as p:
-                    ret.update(yaml.load(p.read()))
+                    ret = salt.utils.dictupdate.merge(ret, yaml.load(p.read()), strategy='recurse')
             except Exception as error:
                 log.error('Error loading data for image "{image}": {message}'.format(image=pillar.path(), message=str(error)))
 

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Fix merging of image pillars
 - Fix: delete old custom OS images pillar before generation (bsc#1105107)
 - Generate OS image pillars via Java
 - Store activation key in the Kiwi built image


### PR DESCRIPTION
## What does this PR change?

Use recursive merging for image pillar data. Without this patch the last image overwrites the previous ones.

## GUI diff

No difference.

## Documentation
- No documentation needed

## Test coverage
- Covered by retail OpenQA tests


Relevant branches (GitHub automatic links expected below):
 - Manager-3.2
 - Uyuni

