### PR TITLE
More optional fixes

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/test/InstalledProductTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/InstalledProductTest.java
@@ -51,7 +51,7 @@ public class InstalledProductTest extends RhnBaseTestCase {
         server.setInstalledProducts(products);
         TestUtils.saveAndReload(server);
 
-        assertNotNull(server.getInstalledProductSet());
+        assertNotNull(server.getInstalledProductSet().orElse(null));
 
         Set<InstalledProduct> readProducts = server.getInstalledProducts();
         assertNotNull(readProducts);

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemOverviewAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemOverviewAction.java
@@ -137,7 +137,7 @@ public class SystemOverviewAction extends RhnAction {
         request.setAttribute("baseChannel", baseChannel);
         request.setAttribute("childChannels", childChannels);
         request.setAttribute("description", description);
-        request.setAttribute("installedProducts", s.getInstalledProductSet());
+        request.setAttribute("installedProducts", s.getInstalledProductSet().orElse(null));
         request.setAttribute("prefs", findUserServerPreferences(user, s));
         request.setAttribute("system", s);
         request.setAttribute("hasLocation",

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -2376,7 +2376,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         server.setInstalledProducts(products);
         TestUtils.saveAndReload(server);
 
-        assertNotNull(server.getInstalledProductSet());
+        assertNotNull(server.getInstalledProductSet().orElse(null));
 
         server.getInstalledProductSet().get().getBaseProduct().getUpgrades();
 
@@ -2416,7 +2416,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         server.setInstalledProducts(products);
         TestUtils.saveAndReload(server);
 
-        assertNotNull(server.getInstalledProductSet());
+        assertNotNull(server.getInstalledProductSet().orElse(null));
 
         server.getInstalledProductSet().get().getBaseProduct().getUpgrades();
 
@@ -2465,7 +2465,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         server.setInstalledProducts(products);
         TestUtils.saveAndReload(server);
 
-        assertNotNull(server.getInstalledProductSet());
+        assertNotNull(server.getInstalledProductSet().orElse(null));
 
         server.getInstalledProductSet().get().getBaseProduct().getUpgrades();
 

--- a/java/code/webapp/WEB-INF/pages/systems/sdc/overview.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/sdc/overview.jsp
@@ -169,7 +169,7 @@
                 </c:when>
                 <c:otherwise>
                   <ul class="list-group">
-                    <li class="list-group-item">${installedProducts.get().baseProduct.friendlyName}</li>
+                    <li class="list-group-item">${installedProducts.baseProduct.friendlyName}</li>
                     <c:forEach items="${installedProducts.addonProducts}" var="current" varStatus="loop">
                       <li class="list-group-item">${current.friendlyName}</li>
                     </c:forEach>


### PR DESCRIPTION
## What does this PR change?

getInstalledProductSet() return now Optional<SUSEProductSet> . 
We need to handle this value in JSP pages and tests correctly.

## Documentation
- No documentation needed: **internal**

- [ ] **DONE**

## Test coverage
- No tests: **should makes existing tests work again**

- [ ] **DONE**
