### PR TITLE
Testsuite: rename @notwithfromdir tag

### DIFF
--- a/testsuite/docs/optional.md
+++ b/testsuite/docs/optional.md
@@ -94,10 +94,36 @@ are executed only if the CentOS minion is available.
 
 ### Testing with a SLE 15 system
 
-The test suite will determine whether your minion is a SLE15 or not.
+The test suite will determine automatically whether your minion
+is a SLE15 system or not.
 
 Inside of the testsuite, the scenarios that are tagged with
 ```
 @sle15minion
 ```
-are executed only if the minion is a SLE 15 minion.
+are executed only if the minion is a SLE 15 system.
+
+
+### Testing with a mirror
+
+Using a mirror with the testsuite is not mandatory.
+
+If you do not want a mirror, do not define `MIRROR` environment
+variable before you run the testsuite. That's all.
+If you want a mirror, let this variable be equal to
+`yes` or `true`:
+```bash
+export MIRROR=yes
+```
+and then run the testsuite.
+
+Sumaform can prepare a mirror and declare the `$MIRROR`
+variable on the controller (in `/root/.bashrc`).
+To declare a mirror in your `main.tf` file, follow the
+instructions in sumaform documentation.
+
+Inside of the testsuite, the scenarios that are tagged with
+```
+@nomirror
+```
+are executed only if you don't use a mirror.

--- a/testsuite/features/core_srv_setup_wizard.feature
+++ b/testsuite/features/core_srv_setup_wizard.feature
@@ -1,13 +1,11 @@
-# Copyright 2017 SUSE LLC
+# Copyright 2017-2018 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: The Setup Wizard
 
-  Background:
+@nomirror
+  Scenario: Set up some credentials
     Given I am on the Admin page
-
-@notwithfromdir
-  Scenario: Set up the credentials
     When I follow "Organization Credentials" in the content area
     And I want to add a new credential
     And I enter "asdf" as "edit-user"
@@ -24,8 +22,9 @@ Feature: The Setup Wizard
     Then I should not see a "asdf" text
 
   Scenario: Play with the products page
-    When I refresh SCC
-    And I follow "SUSE Products" in the content area
+    Given I am on the Admin page
+    When I follow "SUSE Products" in the content area
+    And I refresh SCC
     And I wait until I see "Product Description" text
     And I should see a "Arch" text
     And I should see a "Channels" text
@@ -44,7 +43,8 @@ Feature: The Setup Wizard
     Then the products should be added
 
   Scenario: Select product with recommended enabled
-    And I follow "SUSE Products" in the content area
+    Given I am on the Admin page
+    When I follow "SUSE Products" in the content area
     And I wait until I see "Product Description" text
     And I enter "SUSE Linux Enterprise Server 15" in the css "input[name='product-description-filter']"
     And I select "x86_64" in the dropdown list of the architecture filter
@@ -58,6 +58,7 @@ Feature: The Setup Wizard
     Then the products should be added
 
   Scenario: View the channels list in the products page
+    Given I am on the Admin page
     When I follow "SUSE Products" in the content area
     And I wait until I see "Product Description" text
     And I enter "SUSE Linux Enterprise Server for SAP All-in-One 11 SP2" in the css "input[name='product-description-filter']"

--- a/testsuite/features/step_definitions/docker_steps.rb
+++ b/testsuite/features/step_definitions/docker_steps.rb
@@ -77,10 +77,10 @@ Then(/^all "([^"]*)" container images are built correctly in the GUI$/) do |coun
 end
 
 When(/^I check the first image$/) do
-   within(:xpath, '//section') do
-     row = first(:xpath, '//div[@class=\"table-responsive\"]/table/tbody/tr[.//td]')
-     row.first(:xpath, './/input[@type="checkbox"]').set(true)
-   end
+  within(:xpath, '//section') do
+    row = first(:xpath, '//div[@class=\"table-responsive\"]/table/tbody/tr[.//td]')
+    row.first(:xpath, './/input[@type="checkbox"]').set(true)
+  end
 end
 
 When(/^I schedule the build of image "([^"]*)" via XML-RPC calls$/) do |image|

--- a/testsuite/features/support/setup_browser.rb
+++ b/testsuite/features/support/setup_browser.rb
@@ -74,9 +74,9 @@ Before('@sle15minion') do |scenario|
   scenario.skip_invoke! unless $sle15_minion
 end
 
-# skip tests if we run with fromdir option
-Before('@notwithfromdir') do |scenario|
-  scenario.skip_invoke! if ENV['NOTWITHFROMDIR']
+# do some tests only if we don't use a mirror
+Before('@nomirror') do |scenario|
+  scenario.skip_invoke! if $mirror
 end
 
 # have more infos about the errors

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -93,3 +93,4 @@ end
 
 # Other global variables
 $sle15_minion = minion_is_sle15
+$mirror = ENV['MIRROR']


### PR DESCRIPTION
## What does this PR change?

This PR changes @notwithfromdir cucumber tag into @nomirror and $NOTWITHFROMDIR environment variable into $MIRROR. It also documents the tag and the variable.

Port of SUSE/spacewalk#5691
