### PR TITLE
Add support for Optional installedProductSet on spmigration jsp files

### DIFF
--- a/java/code/webapp/WEB-INF/pages/systems/spmigration/spmigration-setup.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/spmigration/spmigration-setup.jsp
@@ -37,10 +37,10 @@
                 <div class="col-sm-10">
                     <ul class="form-control-static products-list">
                         <li>
-                            <strong><c:out value="${system.installedProductSet.baseProduct.friendlyName}" /></strong>
+                            <strong><c:out value="${system.installedProductSet.get().baseProduct.friendlyName}" /></strong>
                             <ul>
                                 <c:forEach
-                                    items="${system.installedProductSet.addonProducts}"
+                                    items="${system.installedProductSet.get().addonProducts}"
                                     var="addonProduct">
                                     <li class="addon-product">
                                         <c:out value="${addonProduct.friendlyName}" />

--- a/java/code/webapp/WEB-INF/pages/systems/spmigration/spmigration-target.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/spmigration/spmigration-target.jsp
@@ -69,10 +69,10 @@
                         <div class="col-sm-10">
                             <ul class="form-control-static products-list">
                                 <li>
-                                    <strong><c:out value="${system.installedProductSet.baseProduct.friendlyName}" /></strong>
+                                    <strong><c:out value="${system.installedProductSet.get().baseProduct.friendlyName}" /></strong>
                                     <ul>
                                         <c:forEach
-                                            items="${system.installedProductSet.addonProducts}"
+                                            items="${system.installedProductSet.get().addonProducts}"
                                             var="addonProduct">
                                             <li class="addon-product">
                                                 <c:out value="${addonProduct.friendlyName}" />


### PR DESCRIPTION
## What does this PR change?

getInstalledProductSet() return now Optional .
We need to handle this value in JSP pages and tests correctly.

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **should makes existing tests work again**

- [x] **DONE**