### PR TITLE
Manager pgmigrate

### DIFF
--- a/susemanager/bin/pg-migrate.sh
+++ b/susemanager/bin/pg-migrate.sh
@@ -85,7 +85,7 @@ mkdir /var/lib/pgsql/data
 chown postgres:postgres /var/lib/pgsql/data
 
 echo "`date +"%H:%M:%S"`   Initialize new postgresql 9.6 database..."
-su - postgres -c "initdb -D /var/lib/pgsql/data"
+su -s /bin/bash - postgres -c "initdb -D /var/lib/pgsql/data"
 if [ $? -eq 0 ]; then
     echo "`date +"%H:%M:%S"`   Successfully initialized new postgresql 9.6 database."
 else
@@ -98,7 +98,7 @@ else
 fi
 
 echo "`date +"%H:%M:%S"`   Upgrade database to new version postgresql 9.6..."
-su - postgres -c "pg_upgrade --old-bindir=/usr/lib/postgresql94/bin --new-bindir=/usr/lib/postgresql96/bin --old-datadir=/var/lib/pgsql/data-pg94 --new-datadir=/var/lib/pgsql/data --retain $FAST_UPGRADE"
+su -s /bin/bash - postgres -c "pg_upgrade --old-bindir=/usr/lib/postgresql94/bin --new-bindir=/usr/lib/postgresql96/bin --old-datadir=/var/lib/pgsql/data-pg94 --new-datadir=/var/lib/pgsql/data --retain $FAST_UPGRADE"
 if [ $? -eq 0 ]; then
     echo "`date +"%H:%M:%S"`   Successfully upgraded database to postgresql 9.6."
 else

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- do not fail if postgresql user has no interactive login shell
 - add new dependency python-setuptools to bootstrap packages (bsc#1106026)
 - fix broken stderr redirection in mgr-setup
 


### PR DESCRIPTION
## What does this PR change?

Some customers have a security policy that requires users like postgresql not having an interactive login shell. Trying to run commands via "su -" will fail in such a case. Explicitly use a working shell in such special cases.