### PR TITLE
Apply activation key on saltbooted minion

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -138,7 +138,7 @@ public class RegisterMinionEventMessageAction implements MessageAction {
     @Override
     public void execute(EventMessage msg) {
         registerMinion(((RegisterMinionEventMessage) msg).getMinionId(), false,
-                Optional.empty(), Optional.empty());
+                empty(), empty());
     }
 
     /**
@@ -298,7 +298,7 @@ public class RegisterMinionEventMessageAction implements MessageAction {
             LOG.error("The existing server organization (" + minion.getOrg() + ") does not match the " +
                     "organization selected for registration (" + org + "). Keeping the " +
                     "existing server organization. " + ignoreAKMessage);
-            activationKey = Optional.empty();
+            activationKey = empty();
             org = minion.getOrg();
             addHistoryEvent(minion, "Invalid Server Organization",
                     "The existing server organization (" + minion.getOrg() + ") does not match the " +
@@ -894,7 +894,7 @@ public class RegisterMinionEventMessageAction implements MessageAction {
         });
         if (!baseChannel.isPresent()) {
             LOG.warn("Product Base channel not found - refresh SCC sync?");
-            return Optional.empty();
+            return empty();
         }
         return baseChannel;
     }
@@ -905,13 +905,13 @@ public class RegisterMinionEventMessageAction implements MessageAction {
 
     private Optional<String> rpmErrQueryRHELProvidesRelease(String minionId) {
         LOG.error("No package providing 'redhat-release' found on RHEL minion " + minionId);
-        return Optional.empty();
+        return empty();
     }
 
     private Optional<String> rpmErrQueryRHELRelease(SaltError err, String minionId) {
         LOG.error("Error querying 'redhat-release' package on RHEL minion " +
                 minionId + ": " + err);
-        return Optional.empty();
+        return empty();
     }
 
     private String unknownRHELVersion(String minionId) {
@@ -996,7 +996,7 @@ public class RegisterMinionEventMessageAction implements MessageAction {
                     .stream()
                     .findFirst()
                     .map(e -> of(e.getValue()))
-                    .orElse(Optional.empty());
+                    .orElse(empty());
 
             osRelease = whatprovidesRes.flatMap(res -> res.fold(
                     err -> err.fold(err1 -> rpmErrQueryRHELProvidesRelease(minionId),
@@ -1054,7 +1054,7 @@ public class RegisterMinionEventMessageAction implements MessageAction {
                             Optional<String> version = Optional
                                     .ofNullable(pkgtags.get("VERSION"))
                                     .map(v -> v.stream().findFirst())
-                                    .orElse(Optional.empty());
+                                    .orElse(empty());
                             List<String> provideName = pkgtags.get("PROVIDENAME");
                             List<String> provideVersion = pkgtags.get("PROVIDEVERSION");
                             int idxReleasever = provideName
@@ -1062,11 +1062,11 @@ public class RegisterMinionEventMessageAction implements MessageAction {
                             if (idxReleasever > -1) {
                                 version = provideVersion.size() > idxReleasever ?
                                         of(provideVersion.get(idxReleasever)) :
-                                        Optional.empty();
+                                        empty();
                             }
                             return version;
                         })
-                        .orElse(Optional.empty())
+                        .orElse(empty())
             )
             .orElseGet(() -> unknownRHELVersion(minionId));
         }

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -245,7 +245,8 @@ public class RegisterMinionEventMessageAction implements MessageAction {
                         // call the 'finishRegistration' on every minion start
                         // BEWARE: this also means the activation key is applied on each retail minion start for now
                         LOG.info("Finishing registration for minion " + minionId);
-                        subscribeMinionToChannels(minionId, registeredMinion, grains, activationKey, activationKeyLabel);
+                        subscribeMinionToChannels(minionId, registeredMinion, grains, activationKey,
+                                activationKeyLabel);
                         activationKey.ifPresent(ak -> applyActivationKeyProperties(registeredMinion, ak, grains));
                         finishRegistration(registeredMinion, activationKey, creator, !isSaltSSH);
                     }

--- a/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
@@ -1150,6 +1150,79 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         }
     }
 
+    /**
+     * When a retail terminal that already has a system profile in SUMA boots, an activation key
+     * should be applied to it.
+     *
+     * @throws Exception - if anything goes wrong
+     */
+    public void testApplyActivationKeyToRetailTerminal() throws Exception {
+        ManagedServerGroup hwGroup = ServerGroupFactory.create("HWTYPE:QEMU-CashDesk02", "HW group",
+                OrgFactory.getSatelliteOrg());
+        ManagedServerGroup terminalsGroup = ServerGroupFactory.create("TERMINALS", "All terminals group",
+                OrgFactory.getSatelliteOrg());
+        ManagedServerGroup branchGroup = ServerGroupFactory.create("Branch001", "Branch group",
+                OrgFactory.getSatelliteOrg());
+        MinionServer server = MinionServerFactoryTest.createTestMinionServer(user);
+        server.setMinionId(MINION_ID);
+        server.setMachineId(MACHINE_ID);
+        server.setOrg(OrgFactory.getSatelliteOrg());
+        SystemManager.addServerToServerGroup(server, hwGroup);
+        SystemManager.addServerToServerGroup(server, terminalsGroup);
+        SystemManager.addServerToServerGroup(server, branchGroup);
+
+        ChannelFamily channelFamily = createTestChannelFamily();
+        SUSEProduct product = SUSEProductTestUtils.createTestSUSEProduct(channelFamily);
+        Channel baseChannelX8664 = setupBaseAndRequiredChannels(channelFamily, product);
+
+        executeTest(
+                (saltServiceMock, key) -> new Expectations() {{
+                    allowing(saltServiceMock).getMasterHostname(MINION_ID);
+                    will(returnValue(Optional.of(MINION_ID)));
+                    allowing(saltServiceMock).getMachineId(MINION_ID);
+                    will(returnValue(Optional.of(MACHINE_ID)));
+                    allowing(saltServiceMock).syncGrains(with(any(MinionList.class)));
+                    allowing(saltServiceMock).syncModules(with(any(MinionList.class)));
+                    allowing(saltServiceMock).getGrains(MINION_ID);
+                    will(returnValue(getGrains(MINION_ID, null, key)
+                            .map(map -> {
+                                map.put("saltboot_initrd", false);
+                                map.put("manufacturer", "QEMU");
+                                map.put("productname", "CashDesk02");
+                                map.put("minion_id_prefix", "Branch001");
+                                return map;
+                            })));
+
+                    allowing(saltServiceMock).callSync(
+                            with(any(LocalCall.class)),
+                            with(any(String.class)));
+                    will(returnValue(Optional.empty()));
+                }},
+                (contactMethod) -> {
+                    ActivationKey key = ActivationKeyTest.createTestActivationKey(user);
+                    key.setBaseChannel(baseChannelX8664);
+                    baseChannelX8664.getAccessibleChildrenFor(user)
+                            .forEach(channel -> key.addChannel(channel));
+                    key.setOrg(user.getOrg());
+
+                    ActivationKeyFactory.save(key);
+                    return key.getKey();
+                },
+                (optMinion, machineId, key) -> {
+                    assertTrue(optMinion.isPresent());
+                    MinionServer minion = optMinion.get();
+
+                    assertContains(ActivationKeyFactory.lookupByKey(key).getToken().getActivatedServers(), minion);
+
+                    Set<Channel> channels = new HashSet<>();
+                    channels.add(baseChannelX8664);
+                    baseChannelX8664.getAccessibleChildrenFor(user)
+                            .forEach(channel -> channels.add(channel));
+                    assertEquals(channels, minion.getChannels());
+                },
+                null,
+                DEFAULT_CONTACT_METHOD);
+    }
 
     /**
      * Tests that grains aren't queried for an existing non-retail minion.

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Subscribe saltbooted minion to software channels, respect activation key in final registration steps
 - Fix script is deleted too early (bsc#1105807)
 - Remove special characters from HW type string
 - Optimize execution of actions in minions (bsc#1099857)


### PR DESCRIPTION
This should be merged first: https://github.com/uyuni-project/uyuni/pull/59

## What does this PR change?
Previously, an AK wasn't considered for a saltbooted minion. This PR fixes it.

**WARNING**: Until the event for image redeployment detection is implemented, the AK application happens on each saltbooted minion restart (since we can't determine if the minion has been re-deployed). Corresponding PR: https://github.com/SUSE/spacewalk/pull/5672

This is a port of private PR https://github.com/SUSE/spacewalk/pull/5673

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- https://github.com/SUSE/doc-susemanager/issues/169

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**


