### PR TITLE
Testsuite: fix XPath expression and group tests

### DIFF
--- a/testsuite/features/srv_group_union_intersection.feature
+++ b/testsuite/features/srv_group_union_intersection.feature
@@ -93,12 +93,14 @@ Feature: Work with Union and Intersection buttons in the group list
 
 @centosminion
   Scenario: Cleanup: remove the centos group
+    Given I am on the groups page
     When I follow "centos" in the content area
     And I follow "Delete Group" in the content area
     And I click on "Confirm Deletion"
     Then I should see a "deleted" text
 
   Scenario: Cleanup: remove the traditional group
+    Given I am on the groups page
     When I follow "traditional" in the content area
     And I follow "Delete Group" in the content area
     And I click on "Confirm Deletion"

--- a/testsuite/features/step_definitions/docker_steps.rb
+++ b/testsuite/features/step_definitions/docker_steps.rb
@@ -78,8 +78,8 @@ end
 
 When(/^I check the first image$/) do
   within(:xpath, '//section') do
-    row = first(:xpath, '//div[@class=\"table-responsive\"]/table/tbody/tr[.//td]')
-    row.first(:xpath, './/input[@type="checkbox"]').set(true)
+    row = first(:xpath, "//div[@class='table-responsive']/table/tbody/tr[.//td]")
+    row.first(:xpath, ".//input[@type='checkbox']").set(true)
   end
 end
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes two errors I introduced:
* incorrect XPath in OS image cleanup
* missing prerequisite step in groups union/intersection
