### PR TITLE
Missing sleep and no SCC proxy test

### DIFF
--- a/testsuite/features/core_proxy_register_as_minion_with_gui.feature
+++ b/testsuite/features/core_proxy_register_as_minion_with_gui.feature
@@ -39,4 +39,5 @@ Feature: Setup SUSE Manager proxy
   Scenario: Check proxy system details
     When I am on the Systems overview page of this "proxy"
     Then I should see "proxy" hostname
-    And I wait until I see "$PRODUCT Proxy" text, refreshing the page
+    # TODO: uncomment when SCC product becomes available
+    # And I wait until I see "$PRODUCT Proxy" text, refreshing the page

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -738,12 +738,13 @@ When(/^I click on "([^"]*)" in "([^"]*)" modal$/) do |btn, title|
   path = "//*[contains(@class, \"modal-title\") and text() = \"#{title}\"]" \
     '/ancestor::div[contains(@class, "modal-dialog")]'
 
-  # We wait until the element becomes visible because
+  # We wait until the element becomes visible, because
   # the fade out animation might still be in progress
   begin
     Timeout.timeout(DEFAULT_TIMEOUT) do
       loop do
         break if page.has_xpath?(path, visible: true)
+        sleep 1
       end
     end
   rescue Timeout::Error


### PR DESCRIPTION
## What does this PR change?

* added "sleep 1" in loop to avoid CPU burning
* commented out proxy product test until SCC is updated
