### PR TITLE
Manager postgresql10

### DIFF
--- a/spacewalk/package/spacewalk.changes
+++ b/spacewalk/package/spacewalk.changes
@@ -1,5 +1,6 @@
 - require postgresql 9.6 as we only support this version for
   migration to version 10. Take into account new versioning scheme
+  (FATE#325659)
 - Change dependencies from osa-dispatcher to mgr-osa-dispatcher and
   from rhnpush to mgr-push (bsc#1104034)
 

--- a/spacewalk/package/spacewalk.changes
+++ b/spacewalk/package/spacewalk.changes
@@ -1,3 +1,5 @@
+- require postgresql 9.6 as we only support this version for
+  migration to version 10. Take into account new versioning scheme
 - Change dependencies from osa-dispatcher to mgr-osa-dispatcher and
   from rhnpush to mgr-push (bsc#1104034)
 

--- a/spacewalk/package/spacewalk.spec
+++ b/spacewalk/package/spacewalk.spec
@@ -162,7 +162,7 @@ Requires:       postgresql84-contrib
 Requires:       postgresql-contrib >= 8.4
 %endif
 Requires:       postgresql >= 9.6
-# we do not support postgresql versions > 9.6 yet
+# we do not support postgresql versions > 10.x yet
 Conflicts:      postgresql >= 11.0
 Conflicts:      postgresql-contrib >= 11.0
 

--- a/spacewalk/package/spacewalk.spec
+++ b/spacewalk/package/spacewalk.spec
@@ -161,10 +161,10 @@ Requires:       postgresql84-contrib
 %else
 Requires:       postgresql-contrib >= 8.4
 %endif
-Requires:       postgresql >= 8.4
+Requires:       postgresql >= 9.6
 # we do not support postgresql versions > 9.6 yet
-Conflicts:      postgresql >= 9.7
-Conflicts:      postgresql-contrib >= 9.7
+Conflicts:      postgresql >= 11.0
+Conflicts:      postgresql-contrib >= 11.0
 
 %description postgresql
 Spacewalk is a systems management application that will 

--- a/spacewalk/package/spacewalk.spec
+++ b/spacewalk/package/spacewalk.spec
@@ -163,8 +163,8 @@ Requires:       postgresql-contrib >= 8.4
 %endif
 Requires:       postgresql >= 9.6
 # we do not support postgresql versions > 10.x yet
-Conflicts:      postgresql >= 11.0
-Conflicts:      postgresql-contrib >= 11.0
+Conflicts:      postgresql >= 11
+Conflicts:      postgresql-contrib >= 11
 
 %description postgresql
 Spacewalk is a systems management application that will 

--- a/susemanager/bin/pg-migrate.sh
+++ b/susemanager/bin/pg-migrate.sh
@@ -57,56 +57,56 @@ spacewalk-service stop
 systemctl stop postgresql
 
 echo "`date +"%H:%M:%S"`   Checking postgresql version..."
-rpm -q postgresql96-server > /dev/null 2>&1
+rpm -q postgresql10-server > /dev/null 2>&1
 if [ $? -eq 0 ]; then
-    echo "`date +"%H:%M:%S"`   postgresql 9.6 is already installed. Good."
+    echo "`date +"%H:%M:%S"`   postgresql 10 is already installed. Good."
 else
-    echo "`date +"%H:%M:%S"`   Installing postgresql 9.6..."
-    zypper --non-interactive in postgresql96 postgresql96-contrib postgresql96-server
+    echo "`date +"%H:%M:%S"`   Installing postgresql 10..."
+    zypper --non-interactive in postgresql10 postgresql10-contrib postgresql10-server
 
     if [ ! $? -eq 0 ]; then
-        echo "`date +"%H:%M:%S"`   Installation of postgresql 9.6 failed!"
+        echo "`date +"%H:%M:%S"`   Installation of postgresql 10 failed!"
         exit 1
     fi
 fi
 
-echo "`date +"%H:%M:%S"`   Ensure postgresql 9.6 is being used as default..."
-/usr/sbin/update-alternatives --set postgresql /usr/lib/postgresql96
+echo "`date +"%H:%M:%S"`   Ensure postgresql 10 is being used as default..."
+/usr/sbin/update-alternatives --set postgresql /usr/lib/postgresql10
 if [ $? -eq 0 ]; then
-    echo "`date +"%H:%M:%S"`   Successfully switched to new postgresql version 9.6."
+    echo "`date +"%H:%M:%S"`   Successfully switched to new postgresql version 10."
 else
-    echo "`date +"%H:%M:%S"`   Could not switch to new postgresql version 9.6!"
+    echo "`date +"%H:%M:%S"`   Could not switch to new postgresql version 10!"
     exit 1
 fi
 
 echo "`date +"%H:%M:%S"`   Create new database directory..."
-mv /var/lib/pgsql/data /var/lib/pgsql/data-pg94
+mv /var/lib/pgsql/data /var/lib/pgsql/data-pg96
 mkdir /var/lib/pgsql/data
 chown postgres:postgres /var/lib/pgsql/data
 
-echo "`date +"%H:%M:%S"`   Initialize new postgresql 9.6 database..."
+echo "`date +"%H:%M:%S"`   Initialize new postgresql 10 database..."
 su -s /bin/bash - postgres -c "initdb -D /var/lib/pgsql/data"
 if [ $? -eq 0 ]; then
-    echo "`date +"%H:%M:%S"`   Successfully initialized new postgresql 9.6 database."
+    echo "`date +"%H:%M:%S"`   Successfully initialized new postgresql 10 database."
 else
-    echo "`date +"%H:%M:%S"`   Initialization of new postgresql 9.6 database failed!"
+    echo "`date +"%H:%M:%S"`   Initialization of new postgresql 10 database failed!"
     echo "`date +"%H:%M:%S"`   Trying to restore previous state..."
     mv /var/lib/pgsql/data /var/lib/pgsql/data-new-failed
-    mv /var/lib/pgsql/data-pg94 /var/lib/pgsql/data
-    /usr/sbin/update-alternatives --set postgresql /usr/lib/postgresql94
+    mv /var/lib/pgsql/data-pg96 /var/lib/pgsql/data
+    /usr/sbin/update-alternatives --set postgresql /usr/lib/postgresql96
     exit 1
 fi
 
-echo "`date +"%H:%M:%S"`   Upgrade database to new version postgresql 9.6..."
-su -s /bin/bash - postgres -c "pg_upgrade --old-bindir=/usr/lib/postgresql94/bin --new-bindir=/usr/lib/postgresql96/bin --old-datadir=/var/lib/pgsql/data-pg94 --new-datadir=/var/lib/pgsql/data --retain $FAST_UPGRADE"
+echo "`date +"%H:%M:%S"`   Upgrade database to new version postgresql 10..."
+su -s /bin/bash - postgres -c "pg_upgrade --old-bindir=/usr/lib/postgresql96/bin --new-bindir=/usr/lib/postgresql10/bin --old-datadir=/var/lib/pgsql/data-pg96 --new-datadir=/var/lib/pgsql/data $FAST_UPGRADE"
 if [ $? -eq 0 ]; then
-    echo "`date +"%H:%M:%S"`   Successfully upgraded database to postgresql 9.6."
+    echo "`date +"%H:%M:%S"`   Successfully upgraded database to postgresql 10."
 else
-    echo "`date +"%H:%M:%S"`   Upgrading database to version 9.6 failed!"
+    echo "`date +"%H:%M:%S"`   Upgrading database to version 10 failed!"
     echo "`date +"%H:%M:%S"`   Trying to restore previous state..."
     mv /var/lib/pgsql/data /var/lib/pgsql/data-new-failed
-    mv /var/lib/pgsql/data-pg94 /var/lib/pgsql/data
-    /usr/sbin/update-alternatives --set postgresql /usr/lib/postgresql94
+    mv /var/lib/pgsql/data-pg96 /var/lib/pgsql/data
+    /usr/sbin/update-alternatives --set postgresql /usr/lib/postgresql96
     exit 1
 fi
 
@@ -119,7 +119,7 @@ else
     exit 1
 fi
 
-cp /var/lib/pgsql/data-pg94/pg_hba.conf /var/lib/pgsql/data
+cp /var/lib/pgsql/data-pg96/pg_hba.conf /var/lib/pgsql/data
 chown postgres:postgres /var/lib/pgsql/data/*
 
 echo "`date +"%H:%M:%S"`   Starting spacewalk services..."
@@ -128,7 +128,7 @@ spacewalk-service start
 
 if [ $BACKUP_CONFIGURED -eq 1 ]; then
     echo
-    echo "It seems database backups via smdba had been configured for postgresql 9.4."
+    echo "It seems database backups via smdba had been configured for postgresql 9.6."
     echo "Please re-configure backup for new database version!"
     echo
 fi

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- support postgresql migration from 9.6 to 10.x
 - add support for Python 3
 - do not fail if postgresql user has no interactive login shell
 - add new dependency python-setuptools to bootstrap packages (bsc#1106026)


### PR DESCRIPTION
## What does this PR change?

Soon we will need to support migrations to postgresql10. The migration script will only support migrations from version 9.6, not for older versions (older versions do not work anymore since one of the latest schema upgrades anyway). Also take into account new postgresql versioning scheme: In the past, "9.6" was considered as major version number. This has changed. Major versions now are only one number as with most other packages. So former "9.6" is equivalent to new "11" in this regard.

Still wonder if this should already go into 3.2 branch right now. This would force people that still are not migrated to really do the migration now. OTOH they will already have an outdated system by now.