### PR TITLE
HibernateFactory: refactor unproxy() in own method

### DIFF
--- a/java/code/src/com/redhat/rhn/common/hibernate/HibernateFactory.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/HibernateFactory.java
@@ -30,6 +30,7 @@ import org.hibernate.Query;
 import org.hibernate.Session;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.metadata.ClassMetadata;
+import org.hibernate.proxy.HibernateProxy;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -741,5 +742,25 @@ public abstract class HibernateFactory {
     protected static void executeCallableMode(String name, String mode, Map params) {
         CallableMode m = ModeFactory.getCallableMode(name, mode);
         m.execute(params, new HashMap());
+    }
+
+    /**
+     * Makes sure the specified entity, presumably loaded via Hibernate's {@link Session#get(Class, Serializable)},
+     * is not a proxy.
+     *
+     * Impelmentation is copied from Hibernate 5.2.10 and this method should be removed after that release.
+     *
+     * @param entity an entity
+     * @param <T> type of entity
+     * @return the entity and not a proxy
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T unproxy(T entity) {
+        Hibernate.initialize(entity);
+        if (entity instanceof HibernateProxy) {
+            entity = (T) ((HibernateProxy) entity).getHibernateLazyInitializer()
+                    .getImplementation();
+        }
+        return entity;
     }
 }

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -117,8 +117,6 @@ import com.google.gson.reflect.TypeToken;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
-import org.hibernate.Hibernate;
-import org.hibernate.proxy.HibernateProxy;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -469,7 +467,7 @@ public class SaltUtils {
             serverAction.setStatus(ActionFactory.STATUS_COMPLETED);
         }
 
-        Action action = unproxy(serverAction.getParentAction());
+        Action action = HibernateFactory.unproxy(serverAction.getParentAction());
 
         if (action.getActionType().equals(ActionFactory.TYPE_APPLY_STATES)) {
             ApplyStatesAction applyStatesAction = (ApplyStatesAction) action;
@@ -655,15 +653,6 @@ public class SaltUtils {
      */
     public Path getScriptPath(Long scriptActionId) {
         return scriptsDir.resolve("script_" + scriptActionId + ".sh");
-    }
-
-    private Action unproxy(Action entity) {
-        Hibernate.initialize(entity);
-        if (entity instanceof HibernateProxy) {
-            entity = (Action) ((HibernateProxy) entity).getHibernateLazyInitializer()
-                    .getImplementation();
-        }
-        return entity;
     }
 
     /**


### PR DESCRIPTION
## What does this PR change?

It refactors the `unproxy` method to be reusable.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal refactoring**

- [x] **DONE**

## Test coverage
- No tests: **already covered**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/5726

- [x] **DONE**
