### PR TITLE
Fix 'Compare Config Files' task hanging (bsc#1103218)

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/CompareConfigFilesTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/CompareConfigFilesTask.java
@@ -25,8 +25,6 @@ import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.frontend.dto.ConfigFileNameDto;
 import com.redhat.rhn.manager.configuration.ConfigurationManager;
-import com.redhat.rhn.taskomatic.TaskomaticApi;
-import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
@@ -41,7 +39,6 @@ import java.util.Set;
  */
 public class CompareConfigFilesTask extends RhnJavaJob {
 
-    private static final TaskomaticApi TASKOMATIC_API = new TaskomaticApi();
     private Queue<Action> actionsToSchedule = new LinkedList<>();
 
     /**
@@ -100,13 +97,6 @@ public class CompareConfigFilesTask extends RhnJavaJob {
 
     @Override
     protected void finishJob() {
-        actionsToSchedule.forEach(a -> {
-            try {
-                TASKOMATIC_API.scheduleActionExecution(a);
-            }
-            catch (TaskomaticApiException e) {
-                log.error("Could not schedule config files diff action: " + e.getMessage(), e);
-            }
-        });
+        actionsToSchedule.forEach(a -> TaskHelper.scheduleActionExecution(a));
     }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/RhnJavaJob.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/RhnJavaJob.java
@@ -90,7 +90,15 @@ public abstract class RhnJavaJob implements RhnJob {
         run.finished();
         HibernateFactory.commitTransaction();
         HibernateFactory.closeSession();
+        finishJob();
+        HibernateFactory.commitTransaction();
+        HibernateFactory.closeSession();
     }
+
+    /**
+     * Finish the job after the main DB transaction has been committed.
+     */
+    protected void finishJob() { }
 
     protected void executeExtCmd(String[] args)
         throws JobExecutionException {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix 'Compare Config Files' task hanging (bsc#1103218)
 - Fix: delete old custom OS images pillar before generation (bsc#1105107)
 - Fix an error in the system software channels UI due to SUSE product channels missing a
   corresponding synced channel (bsc#1105886


### PR DESCRIPTION
## What does this PR change?

This is a forward-port of a downstream PR (https://github.com/SUSE/spacewalk/pull/5584) to fix [bsc#1103218](https://bugzilla.suse.com/show_bug.cgi?id=1103218). No further review should be needed.

## Documentation

- No documentation needed: implements the expected behavior.

## Test coverage

- No tests: new unit tests would be great, at least for TaskHelper.scheduleActionExecution(). Unfortunately the code internally is committing to the database twice so we would need to refactor this code first in order to avoid those DB commits in case we are running a test.

## Links

Fixes https://github.com/SUSE/spacewalk/issues/5341
Tracks https://github.com/SUSE/spacewalk/pull/5584
