### PR TITLE
Enable automatic patch updates for Salt clients

### DIFF
--- a/java/code/webapp/WEB-INF/pages/ssm/systems/misc/index.jsp
+++ b/java/code/webapp/WEB-INF/pages/ssm/systems/misc/index.jsp
@@ -60,13 +60,14 @@
                 <td align="center"><input type="radio" name="summary" value="no_change" checked="1" /></td>
             </tr>
 
-            <tr class="list-row-odd">
-                <td><bean:message key="ssm.misc.index.syspref.update"/></td>
-                <td align="center"><input type="radio" name="update" value="yes" /></td>
-                <td align="center"><input type="radio" name="update" value="no" /></td>
-                <td align="center"><input type="radio" name="update" value="no_change" checked="1" /></td>
-            </tr>
-
+            <rhn:require acl="all_systems_in_set_have_feature(ftr_auto_errata_updates)">
+                <tr class="list-row-odd">
+                    <td><bean:message key="ssm.misc.index.syspref.update"/></td>
+                    <td align="center"><input type="radio" name="update" value="yes" /></td>
+                    <td align="center"><input type="radio" name="update" value="no" /></td>
+                    <td align="center"><input type="radio" name="update" value="no_change" checked="1" /></td>
+                </tr>
+            </rhn:require>
         </table>
 
         <div class="text-right">

--- a/java/code/webapp/WEB-INF/pages/systems/sdc/details.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/sdc/details.jsp
@@ -82,7 +82,7 @@
                         </div>
                     </div>
 
-                    <rhn:require acl="system_has_management_entitlement() or system_has_salt_entitlement()">
+                    <rhn:require acl="system_feature(ftr_system_preferences)">
                         <div class="form-group">
                             <label class="col-lg-3 control-label">
                                 <bean:message key="sdc.details.edit.notifications"/>
@@ -112,7 +112,9 @@
                                 </c:choose>
                             </div>
                         </div>
+                    </rhn:require>
 
+                    <rhn:require acl="system_has_management_entitlement()">
                         <div class="form-group">
                             <label class="col-lg-3 control-label" for="contact-method">
                                 <bean:message key="server.contact-method.label"/>
@@ -130,7 +132,9 @@
                                 </c:choose>
                             </div>
                         </div>
+                    </rhn:require>
 
+                    <rhn:require acl="system_feature(ftr_auto_errata_updates)">
                         <div class="form-group">
                             <label class="col-lg-3 control-label" for="autoerrataupdate">
                                 <bean:message key="sdc.details.edit.autoerrataupdate"/>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix ACLs for system details settings
 - Method to Unsubscribe channel from system(bsc#1104120)
 - Fix 'Compare Config Files' task hanging (bsc#1103218)
 - Fix: delete old custom OS images pillar before generation (bsc#1105107)

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Enable auto patch updates for salt clients
 - Fix ACLs for system details settings
 - Method to Unsubscribe channel from system(bsc#1104120)
 - Fix 'Compare Config Files' task hanging (bsc#1103218)

--- a/schema/spacewalk/common/data/rhnServerGroupTypeFeature.sql
+++ b/schema/spacewalk/common/data/rhnServerGroupTypeFeature.sql
@@ -201,6 +201,11 @@ values (lookup_sg_type('salt_entitled'), lookup_feature_type('ftr_errata_updates
 
 insert into rhnServerGroupTypeFeature (server_group_type_id, feature_id,
                                        created, modified)
+values (lookup_sg_type('salt_entitled'), lookup_feature_type('ftr_auto_errata_updates'),
+        current_timestamp,current_timestamp);
+
+insert into rhnServerGroupTypeFeature (server_group_type_id, feature_id,
+                                       created, modified)
 values (lookup_sg_type('salt_entitled'), lookup_feature_type('ftr_daily_summary'),
         current_timestamp,current_timestamp);
 

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,5 @@
+- Enable auto patch updates for Salt minions
+
 -------------------------------------------------------------------
 Fri Aug 10 15:45:07 CEST 2018 - jgonzalez@suse.com
 

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.12-to-susemanager-schema-3.2.13/900-ftr-auto-errata-updates-salt.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.12-to-susemanager-schema-3.2.13/900-ftr-auto-errata-updates-salt.sql
@@ -1,0 +1,4 @@
+INSERT INTO rhnServerGroupTypeFeature (server_group_type_id, feature_id, created, modified)
+SELECT lookup_sg_type('salt_entitled'), lookup_feature_type('ftr_auto_errata_updates'),  current_timestamp, current_timestamp FROM dual
+WHERE NOT EXISTS (SELECT 1 FROM rhnServerGroupTypeFeature WHERE server_group_type_id = lookup_sg_type('salt_entitled') AND feature_id = lookup_feature_type('ftr_auto_errata_updates'));
+


### PR DESCRIPTION
## What does this PR change?

This patch enables the "automatic patch updates" feature for Salt clients. This is a forward-port of a [downstream PR](https://github.com/SUSE/spacewalk/pull/5511), therefore no additional review should be needed.

## GUI diff

Relevant checkboxes will be visible in the system settings not only for traditional but also for Salt based clients.

After:
![auto-patch-update](https://user-images.githubusercontent.com/729454/44040632-1240586e-9f1c-11e8-88b8-c3dbd085e5bd.png)

## Documentation

- Documentation should be fine according to this (downstream) doc issue: https://github.com/SUSE/spacewalk/issues/5417

## Test coverage

- No new unit tests for the same reason as in #62.

## Links

Tracks #https://github.com/SUSE/spacewalk/pull/5511
