### PR TITLE
Added link to 'Pending Actions' menu (bsc#1037389)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -6902,13 +6902,13 @@ Follow this url to see the full list of inactive systems:
         </context-group>
       </trans-unit>
       <trans-unit id="systems.details.virt.one.actions.scheduled">
-        <source>Scheduled one action.</source>
+        <source>Scheduled one action, see &lt;a href="/rhn/schedule/PendingActions.do"&gt;&lt;strong&gt;pending actions&lt;/strong&gt;&lt;/a&gt;.</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/system/details/virtualization/VirtualGuestsConfirm.do</context>
         </context-group>
       </trans-unit>
       <trans-unit id="systems.details.virt.actions.scheduled">
-        <source>Scheduled {0} actions.</source>
+        <source>Scheduled {0} actions, see &lt;a href="/rhn/schedule/PendingActions.do"&gt;&lt;strong&gt;pending actions&lt;/strong&gt;&lt;/a&gt;.</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/system/details/virtualization/VirtualGuestsConfirm.do</context>
         </context-group>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Added link from virtualization tab to Scheduled > Pending Actions (bsc#1037389)
 - Enable auto patch updates for salt clients
 - Fix ACLs for system details settings
 - Method to Unsubscribe channel from system(bsc#1104120)


### PR DESCRIPTION
When applying actions to one or more guests of a virtual
host, the message on the top will now show a link to the
'Schedule > Pending Actions' menu.

Cherrypick from Manager-3.1, see https://github.com/SUSE/spacewalk/pull/5756