### PR TITLE
Testsuite: fixing a bug that has been here for ages

### DIFF
--- a/testsuite/features/core_centos_tradclient.feature
+++ b/testsuite/features/core_centos_tradclient.feature
@@ -13,7 +13,7 @@ Feature: Be able to register a CentOS 7 traditional client and do some basic ope
 @centos_minion
   Scenario: Prepare a CentOS 7 traditional client
      Given I am authorized
-     When I enable repository "Devel_Galaxy_Manager_HEAD_RES-Manager-Tools-7-x86_64" on this "ceos-traditional-client"
+     When I enable repository "Devel_Galaxy_Manager_Head_RES-Manager-Tools-7-x86_64" on this "ceos-traditional-client"
      And  I enable repository "SLE-Manager-Tools-RES-7-x86_64" on this "ceos-traditional-client"
      And  I enable repository "CentOS-Base" on this "ceos-traditional-client"
      And  I install package "hwdata m2crypto wget" on this "ceos-traditional-client"


### PR DESCRIPTION
## What does this PR change?

uyuni branch only: name of CentOS repo has been wrong for ages, it contains `Head`and not `HEAD`.

We never detected this capitalization problem before because:
* we were using `without error control`
* this repo was not needed for real until we had the new CentOS 7 images

:smiley:
