### PR TITLE
Adapt "susemanager-sls" to be Python 2/3 compatible

### DIFF
--- a/susemanager-utils/susemanager-sls/modules/pillar/suma_minion.py
+++ b/susemanager-utils/susemanager-sls/modules/pillar/suma_minion.py
@@ -224,7 +224,7 @@ def adjust_empty_values(layout, data):
             if subtype is EditGroupSubtype.DICTIONARY_OF_DICTIONARIES:
                 value = {}
                 if isinstance(data.get(element_name), dict):
-                    for key, entry in data.get(element_name).items():
+                    for key, entry in list(data.get(element_name).items()):
                         proc_entry = adjust_empty_values(prototype, entry)
                         value[key] = proc_entry
             elif subtype is EditGroupSubtype.LIST_OF_DICTIONARIES:

--- a/susemanager-utils/susemanager-sls/modules/runners/mgrutil.py
+++ b/susemanager-utils/susemanager-sls/modules/runners/mgrutil.py
@@ -41,7 +41,7 @@ def chain_ssh_cmd(hosts=None, clientkey=None, proxykey=None, user="root", option
     cmd = []
     for idx, hostname in enumerate(hosts):
         key = clientkey if idx == 0 else proxykey
-        opts = " ".join(["-o {}={}".format(opt, val) for opt, val in options.items()])
+        opts = " ".join(["-o {}={}".format(opt, val) for opt, val in list(options.items())])
         ssh = "/usr/bin/ssh -i {} {} -o User={} {}"\
             .format(key, opts, user, hostname)
         cmd.extend(shlex.split(ssh))

--- a/susemanager-utils/susemanager-sls/src/beacons/virtpoller.py
+++ b/susemanager-utils/susemanager-sls/src/beacons/virtpoller.py
@@ -34,7 +34,11 @@ except ImportError:
     HAS_LIBVIRT = False
     libvirt = None
 
-import cPickle
+
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 import time
 import traceback
 import binascii
@@ -187,8 +191,8 @@ class PollerStateCache:
         state = {}
         if cache_file:
             try:
-                state = cPickle.load(cache_file)
-            except cPickle.PickleError, pe:
+                state = pickle.load(cache_file)
+            except pickle.PickleError as pe:
                 # Strange.  Possibly, the file is corrupt.  We'll load an empty
                 # state instead.
                 log.debug("Error occurred while loading state: {0}".format(str(pe)))
@@ -222,19 +226,19 @@ class PollerStateCache:
         # First, ensure that the proper parent directory is created.
         cache_dir_path = os.path.dirname(self.__cache_file)
         if not os.path.exists(cache_dir_path):
-            os.makedirs(cache_dir_path, 0700)
+            os.makedirs(cache_dir_path, 0o700)
 
         state = {}
         state['domain_data'] = self.__new_domain_data
         if self.__expire_time is None or self.is_expired():
-            state['expire_time'] = long(time.time()) + CACHE_EXPIRE_SECS
+            state['expire_time'] = int(time.time()) + CACHE_EXPIRE_SECS
         else:
             state['expire_time'] = self.__expire_time
 
         # Now attempt to open the file for writing.  We'll just overwrite
         # whatever's already there.  Also, let any exceptions bounce out.
         cache_file = open(self.__cache_file, "wb")
-        cPickle.dump(state, cache_file)
+        pickle.dump(state, cache_file)
         cache_file.close()
 
     def _compare_domain_data(self):

--- a/susemanager-utils/susemanager-sls/src/beacons/virtpoller.py
+++ b/susemanager-utils/susemanager-sls/src/beacons/virtpoller.py
@@ -143,7 +143,7 @@ class PollerStateCache:
         if self.__expire_time is None:
             return False
         else:
-            return long(time.time()) >= self.__expire_time
+            return int(time.time()) >= self.__expire_time
 
     def is_changed(self):
         return self.__added or self.__removed or self.__modified
@@ -181,7 +181,7 @@ class PollerStateCache:
         cache_file = None
         try:
             cache_file = open(self.__cache_file, 'r')
-        except IOError, ioe:
+        except IOError as ioe:
             # Couldn't open the cache file.  That's ok, there might not be one.
             # We'll only complain if debugging is enabled.
             log.debug("Could not open cache file '{0}': {1}".format(
@@ -205,7 +205,7 @@ class PollerStateCache:
         if state:
             log.debug("Loaded state: {0}".format(repr(state)))
 
-            self.__expire_time = long(state['expire_time'])
+            self.__expire_time = int(state['expire_time'])
 
             # If the cache is expired, set the old data to None so we force
             # a refresh.
@@ -254,9 +254,9 @@ class PollerStateCache:
 
         # First, figure out the modified and added uuids.
         if self.__new_domain_data:
-            for (uuid, new_properties) in self.__new_domain_data.items():
+            for (uuid, new_properties) in list(self.__new_domain_data.items()):
                 if not self.__old_domain_data or \
-                    not self.__old_domain_data.has_key(uuid):
+                    uuid not in self.__old_domain_data:
 
                     self.__added[uuid] = self.__new_domain_data[uuid]
                 else:
@@ -266,9 +266,9 @@ class PollerStateCache:
 
         # Now, figure out the removed uuids.
         if self.__old_domain_data:
-            for uuid in self.__old_domain_data.keys():
+            for uuid in list(self.__old_domain_data.keys()):
                 if not self.__new_domain_data or \
-                    not self.__new_domain_data.has_key(uuid):
+                    uuid not in self.__new_domain_data:
 
                     self.__removed[uuid] = self.__old_domain_data[uuid]
 
@@ -316,7 +316,7 @@ def beacon(config):
 
     try:
         conn = libvirt.openReadOnly(None)
-    except libvirt.libvirtError, lve:
+    except libvirt.libvirtError as lve:
         log.error("Warning: Could not retrieve virtualization information! libvirtd service needs to be running.")
         conn = None
 
@@ -371,21 +371,21 @@ def beacon(config):
                     'target_type': TargetType.DOMAIN }
             plan.append(item)
 
-        for (uuid, data) in added.items():
+        for (uuid, data) in list(added.items()):
             item = {'time': int(time.time()),
                     'event_type': EventType.EXISTS,
                     'target_type': TargetType.DOMAIN,
                     'guest_properties': data}
             plan.append(item)
 
-        for (uuid, data) in modified.items():
+        for (uuid, data) in list(modified.items()):
             item = {'time': int(time.time()),
                     'event_type': EventType.EXISTS,
                     'target_type': TargetType.DOMAIN,
                     'guest_properties': data}
             plan.append(item)
 
-        for (uuid, data) in removed.items():
+        for (uuid, data) in list(removed.items()):
             item = {'time': int(time.time()),
                     'event_type': EventType.REMOVED,
                     'target_type': TargetType.DOMAIN,

--- a/susemanager-utils/susemanager-sls/src/beacons/virtpoller.py
+++ b/susemanager-utils/susemanager-sls/src/beacons/virtpoller.py
@@ -180,7 +180,7 @@ class PollerStateCache:
         # Attempt to open up the cache file.
         cache_file = None
         try:
-            cache_file = open(self.__cache_file, 'r')
+            cache_file = open(self.__cache_file, 'rb')
         except IOError as ioe:
             # Couldn't open the cache file.  That's ok, there might not be one.
             # We'll only complain if debugging is enabled.

--- a/susemanager-utils/susemanager-sls/src/grains/cpuinfo.py
+++ b/susemanager-utils/susemanager-sls/src/grains/cpuinfo.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import logging
 import salt.modules.cmdmod
 import salt.utils

--- a/susemanager-utils/susemanager-sls/src/grains/cpuinfo.py
+++ b/susemanager-utils/susemanager-sls/src/grains/cpuinfo.py
@@ -48,7 +48,7 @@ def _parse_cpuinfo(feedback):
         try:
             log.debug("Trying /proc/cpuinfo to get CPU socket count")
             with open('/proc/cpuinfo') as handle:
-                for line in handle:
+                for line in handle.readlines():
                     if line.strip().startswith('physical id'):
                         comps = line.split(':')
                         if len(comps) < 2 or len(comps[1]) < 2:

--- a/susemanager-utils/susemanager-sls/src/modules/kiwi_info.py
+++ b/susemanager-utils/susemanager-sls/src/modules/kiwi_info.py
@@ -47,7 +47,7 @@ def parse_packages(path):
             if match:
                 # translate '(none)' values to ''
                 d = match.groupdict()
-                for k in d.keys():
+                for k in list(d.keys()):
                     if d[k] == '(none)':
                         d[k] = ''
 

--- a/susemanager-utils/susemanager-sls/src/modules/kiwi_source.py
+++ b/susemanager-utils/susemanager-sls/src/modules/kiwi_source.py
@@ -64,11 +64,11 @@ def _prepareHTTP(source, dest):
 
   filename = os.path.join(dest, source.split("/")[-1])
   res = __salt__['state.single']('file.managed', filename, source=source, makedirs=True, skip_verify=True)
-  for s, r in res.items():
+  for s, r in list(res.items()):
     if not r['result']:
       raise salt.exceptions.SaltException(r['comment'])
   res = __salt__['state.single']('archive.extracted', name=dest, source=filename, skip_verify=True, overwrite=True)
-  for s, r in res.items():
+  for s, r in list(res.items()):
     if not r['result']:
       raise salt.exceptions.SaltException(r['comment'])
   return dest

--- a/susemanager-utils/susemanager-sls/src/modules/sumautil.py
+++ b/susemanager-utils/susemanager-sls/src/modules/sumautil.py
@@ -68,7 +68,7 @@ def primary_ips():
     log.debug('Using master: {0}'.format(str(master)))
 
     ret = dict()
-    for sock_family, sock_descr in {socket.AF_INET: 'IPv4', socket.AF_INET6: 'IPv6'}.items():
+    for sock_family, sock_descr in list({socket.AF_INET: 'IPv4', socket.AF_INET6: 'IPv6'}.items()):
         try:
             ret['{0}'.format(sock_descr)] = __salt__['network.get_route'](get_master_ip(sock_family, master))
             log.debug("network.get_route({0}): ".format(ret['{0} source'.format(sock_descr)]))

--- a/susemanager-utils/susemanager-sls/src/modules/udevdb.py
+++ b/susemanager-utils/susemanager-sls/src/modules/udevdb.py
@@ -89,7 +89,7 @@ def normalize(dev):
     :param dev:
     :return:
     '''
-    for sect, val in dev.items():
+    for sect, val in list(dev.items()):
         if isinstance(val, list) and len(val) == 1:
             dev[sect] = val[0]
 

--- a/susemanager-utils/susemanager-sls/src/tests/mockery.py
+++ b/susemanager-utils/susemanager-sls/src/tests/mockery.py
@@ -1,6 +1,9 @@
 import sys
 import os
-from StringIO import StringIO
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
 from mock import MagicMock
 
 

--- a/susemanager-utils/susemanager-sls/src/tests/mockery.py
+++ b/susemanager-utils/susemanager-sls/src/tests/mockery.py
@@ -27,20 +27,3 @@ def get_test_data(filename):
     :return:
     '''
     return open(os.path.sep.join([os.path.abspath(''), 'data', filename]), 'r').read()
-
-
-def mock_open(data=None):
-    '''
-    Mock "open" function.
-
-    :param data:
-    :return:
-    '''
-    data = StringIO(data)
-    mock = MagicMock(spec=file)
-    handle = MagicMock(spec=file)
-    handle.write.return_value = None
-    handle.__enter__.return_value = data or handle
-    mock.return_value = handle
-
-    return mock

--- a/susemanager-utils/susemanager-sls/src/tests/test_beacon_virtpoller.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_beacon_virtpoller.py
@@ -92,7 +92,7 @@ def test_beacon_update():
                 ret = virtpoller.beacon({'cache_file': CACHE_FILE,
                                          'expire_time': 2})
     assert isinstance(ret, list)
-    print "%s" % ret
+    print("%s" % ret)
     assert len(ret) == 0
 
 def test_beacon_change():

--- a/susemanager-utils/susemanager-sls/src/tests/test_grains_cpuinfo.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_grains_cpuinfo.py
@@ -3,7 +3,7 @@ Author: bo@suse.de
 '''
 
 from mock import MagicMock, patch
-import mockery
+from . import mockery
 mockery.setup_environment()
 
 from ..grains import cpuinfo

--- a/susemanager-utils/susemanager-sls/src/tests/test_grains_cpuinfo.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_grains_cpuinfo.py
@@ -2,7 +2,7 @@
 Author: bo@suse.de
 '''
 
-from mock import MagicMock, patch
+from mock import MagicMock, patch, mock_open
 from . import mockery
 mockery.setup_environment()
 
@@ -54,11 +54,11 @@ def test_cpusockets_parse_cpuinfo():
     # cpuinfo parser is not applicable for non-Intel architectures, so should return nothing.
     for sample_name in ['cpuinfo.s390.sample', 'cpuinfo.ppc64le.sample']:
         with patch('os.access', MagicMock(return_value=True)):
-            with patch.object(cpuinfo, 'open', mockery.mock_open(mockery.get_test_data(sample_name)), create=True):
+            with patch.object(cpuinfo, 'open', mock_open(read_data=mockery.get_test_data(sample_name)), create=True):
                 assert cpuinfo._parse_cpuinfo([]) is None
 
     with patch('os.access', MagicMock(return_value=True)):
-        with patch.object(cpuinfo, 'open', mockery.mock_open(mockery.get_test_data('cpuinfo.sample')), create=True):
+        with patch.object(cpuinfo, 'open', mock_open(read_data=mockery.get_test_data('cpuinfo.sample')), create=True):
             out = cpuinfo._parse_cpuinfo([])
             assert type(out) == dict
             assert 'cpusockets' in out

--- a/susemanager-utils/susemanager-sls/src/tests/test_mgr_master_tops.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_mgr_master_tops.py
@@ -4,7 +4,7 @@
 '''
 
 from mock import MagicMock, patch
-import mockery
+from . import mockery
 mockery.setup_environment()
 
 import sys

--- a/susemanager-utils/susemanager-sls/src/tests/test_mgr_master_tops.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_mgr_master_tops.py
@@ -20,7 +20,10 @@ TEST_MANAGER_STATIC_TOP = {
         "custom",
         "custom_groups",
         "custom_org",
-        "formulas"
+        "formulas",
+        "services.salt-minion",
+        "services.docker",
+        "services.kiwi-image-server"
     ]
 }
 

--- a/susemanager-utils/susemanager-sls/src/tests/test_module_mainframesysinfo.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_module_mainframesysinfo.py
@@ -4,7 +4,7 @@ Author: Bo Maryniuk <bo@suse.de>
 
 import pytest
 from mock import MagicMock, patch
-import mockery
+from . import mockery
 mockery.setup_environment()
 
 from ..modules import mainframesysinfo

--- a/susemanager-utils/susemanager-sls/src/tests/test_module_sumautil.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_module_sumautil.py
@@ -3,7 +3,7 @@ Author: mc@suse.com
 '''
 
 from mock import MagicMock, patch
-import mockery
+from . import mockery
 mockery.setup_environment()
 
 from ..modules import sumautil

--- a/susemanager-utils/susemanager-sls/src/tests/test_module_udevdb.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_module_udevdb.py
@@ -90,11 +90,11 @@ def test_exportdb():
     with patch.dict(udevdb.__salt__, {'cmd.run_all': MagicMock(side_effect=[{'retcode': 0, 'stdout': udev_data},
                                                                             {'retcode': 0, 'stdout': '0'}])}):
         data = udevdb.exportdb()
-        assert data == filter(None, data)
+        assert data == [_f for _f in data if _f]
 
         for d_idx, d_section in enumerate(data):
             assert out[d_idx]['P'] == d_section['P']
             assert out[d_idx].get('N') == d_section.get('N')
             assert out[d_idx].get('X-Mgr') == d_section.get('X-Mgr')
-            for key, value in d_section['E'].items():
+            for key, value in list(d_section['E'].items()):
                 assert out[d_idx]['E'][key] == value

--- a/susemanager-utils/susemanager-sls/src/tests/test_module_udevdb.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_module_udevdb.py
@@ -3,7 +3,7 @@ Author: Bo Maryniuk <bo@suse.de>
 '''
 
 from mock import MagicMock, patch
-import mockery
+from . import mockery
 mockery.setup_environment()
 
 from ..modules import udevdb

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Migrate Python code to be Python 2/3 compatible 
 - Fix merging of image pillars
 - Fix: delete old custom OS images pillar before generation (bsc#1105107)
 - Generate OS image pillars via Java

--- a/susemanager-utils/susemanager-sls/susemanager-sls.spec
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.spec
@@ -15,6 +15,10 @@
 # Please submit bugfixes or comments via http://bugs.opensuse.org/
 #
 
+%if 0%{?suse_version} > 1320
+# SLE15 builds on Python 3
+%global build_py3   1
+%endif
 
 Name:           susemanager-sls
 Version:        4.0.1
@@ -25,6 +29,13 @@ Group:          Applications/Internet
 Source:         %{name}-%{version}.tar.gz
 Requires(pre):  coreutils
 Requires:       susemanager-build-keys-web >= 12.0.1
+%if 0%{?build_py3}
+BuildRequires:  python3-pytest
+BuildRequires:  python3-mock
+%else
+BuildRequires:  python-pytest
+BuildRequires:  python-mock
+%endif
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 
@@ -70,6 +81,10 @@ cp src/modules/udevdb.py %{buildroot}/usr/share/susemanager/salt/_modules
 cp src/modules/mgractionchains.py %{buildroot}/usr/share/susemanager/salt/_modules
 cp src/modules/kiwi_info.py %{buildroot}/usr/share/susemanager/salt/_modules
 cp src/modules/kiwi_source.py %{buildroot}/usr/share/susemanager/salt/_modules
+
+%check
+cd src/tests
+py.test
 
 %post
 # HACK! Create broken link when it will be replaces with the real file


### PR DESCRIPTION
## What does this PR change?

This PR migrates the Python code contained on "susemanager-sls" (Salt custom modules, grains and beacons) to be Python 2/3 compatible.

It also enables unit tests run as part of the package building.

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

Tracks https://github.com/SUSE/salt-board/issues/55

- [X] **DONE**
