### PR TITLE
Show groups tabs for bootstrap minions

### DIFF
--- a/java/code/src/com/redhat/rhn/common/security/acl/Access.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/Access.java
@@ -247,6 +247,26 @@ public class Access extends BaseHandler {
     }
 
     /**
+     * Check if a system is a {@link com.redhat.rhn.domain.server.MinionServer} which has a bootstrap entitlement
+     * @param ctx Context map to pass in.
+     * @param params Parameters to use to fetch from context.
+     * @return True if system is a MinionServer with bootstrap entitlement, false otherwise.
+     */
+    public boolean aclSystemIsBootstrapMinionServer(Object ctx, String[] params) {
+        Map<String, Object> map = (Map<String, Object>) ctx;
+        Long sid = getAsLong(map.get("sid"));
+        boolean ret = false;
+        if (sid != null) {
+            User user = (User) map.get("user");
+            Server server = SystemManager.lookupByIdAndUser(sid, user);
+            if (server != null) {
+                ret = server.asMinionServer().isPresent();
+            }
+        }
+        return ret && aclSystemHasBootstrapEntitlement(ctx, params);
+    }
+
+    /**
      * Check if any system has a Salt entitlement.
      * Check single system if used in an action for a single system or
      * SSM in case of an SSM action.

--- a/java/code/webapp/WEB-INF/nav/system_detail.xml
+++ b/java/code/webapp/WEB-INF/nav/system_detail.xml
@@ -179,7 +179,7 @@
   </rhn-tab>
 <!-- ENDFIX -->
 
-  <rhn-tab name="Groups" acl="system_feature(ftr_system_grouping); user_role(org_admin) or user_role(system_group_admin);system_has_management_entitlement() or system_has_salt_entitlement() or system_has_bootstrap_entitlement()" url="/rhn/systems/details/groups/ListRemove.do">
+  <rhn-tab name="Groups" acl="system_feature(ftr_system_grouping); user_role(org_admin) or user_role(system_group_admin);system_has_management_entitlement() or system_has_salt_entitlement() or system_is_bootstrap_minion_server()" url="/rhn/systems/details/groups/ListRemove.do">
 
     <rhn-tab name="List / Leave" url="/rhn/systems/details/groups/ListRemove.do"/>
     <rhn-tab name="Join" url="/rhn/systems/details/groups/Add.do"/>
@@ -218,7 +218,7 @@
      </rhn-tab>
   </rhn-tab>
 
-  <rhn-tab name="Formulas" acl="system_has_salt_entitlement() or system_has_bootstrap_entitlement(); salt_formulas_installed()">
+  <rhn-tab name="Formulas" acl="system_has_salt_entitlement() or system_is_bootstrap_minion_server(); salt_formulas_installed()">
     <rhn-tab-url>/rhn/manager/systems/details/formulas</rhn-tab-url>
   </rhn-tab>
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Modify acls: hide 'System details -> Groups and Formulas' tab for non-minions with bootstrap entitlement
 - fix typo in messages (bsc#1111249)
 - Cleanup formula data and assignment when migrating formulas or when removing system
 - Remove restrictions on SUSE Manager Channel subscriptions (bsc#1105724)


### PR DESCRIPTION
Depends on https://github.com/uyuni-project/uyuni/pull/76

The problem was that https://github.com/uyuni-project/uyuni/pull/76 allowed displaying that tab for all bootstrap-entitled systems. I suggest making this more strict and display this only for minions with a bootstrap entitlement so that we don't affect existing behavior.

## GUI diff

No difference.

Before:
![](https://user-images.githubusercontent.com/1412268/45562724-7cc2cf80-b84b-11e8-9be1-a1b2f40f0828.png)

After:
![](https://user-images.githubusercontent.com/1412268/45562730-80eeed00-b84b-11e8-8e50-1cf5e24541c2.png)

Update: on the second screenshot, the "Formulas" tab is also hidden.

- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Downstream PR: https://github.com/SUSE/spacewalk/pull/5822

**DONE**
