### PR TITLE
Adapt "susemanager-tftpsync" and "susemanager-tftpsync-recv" to be Python 2/3 compatible

### DIFF
--- a/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.changes
+++ b/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.changes
@@ -1,3 +1,5 @@
+- Build package for Python 3 on SLE15
+
 -------------------------------------------------------------------
 Fri Aug 10 15:49:13 CEST 2018 - jgonzalez@suse.com
 

--- a/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.spec
+++ b/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.spec
@@ -15,6 +15,10 @@
 # Please submit bugfixes or comments via http://bugs.opensuse.org/
 #
 
+%if 0%{?suse_version} > 1320
+# SLE15 builds on Python 3
+%global build_py3   1   
+%endif
 
 Name:           susemanager-tftpsync-recv
 Version:        4.0.1
@@ -29,7 +33,11 @@ BuildArch:      noarch
 Requires(pre):  apache2
 Requires:       apache2-mod_wsgi
 Requires(pre):  tftp(server)
+%if 0%{?build_py3}
+Requires:       python3
+%else
 Requires:       python
+%endif
 Requires:       spacewalk-backend
 Requires:       spacewalk-proxy-common
 Requires(pre):  coreutils

--- a/tftpsync/susemanager-tftpsync/MultipartPostHandler.py
+++ b/tftpsync/susemanager-tftpsync/MultipartPostHandler.py
@@ -38,8 +38,13 @@ Further Example:
   then uploads it to the W3C validator.
 """
 
-import urllib
-import urllib2
+try:
+    from urllib.parse import urlencode
+    from urllib.request import build_opener, HTTPHandler, BaseHandler
+except ImportError:
+    from urllib import urlencode
+    from urllib2 import build_opener, HTTPHandler, BaseHandler
+
 import mimetools, mimetypes
 import os, stat
 
@@ -51,8 +56,8 @@ class Callable:
 #  assigning a sequence.
 doseq = 1
 
-class MultipartPostHandler(urllib2.BaseHandler):
-    handler_order = urllib2.HTTPHandler.handler_order - 10 # needs to run first
+class MultipartPostHandler(BaseHandler):
+    handler_order = HTTPHandler.handler_order - 10 # needs to run first
 
     def http_request(self, request):
         data = request.get_data()
@@ -70,7 +75,7 @@ class MultipartPostHandler(urllib2.BaseHandler):
                 raise TypeError, "not a valid non-string sequence or mapping object", traceback
 
             if len(v_files) == 0:
-                data = urllib.urlencode(v_vars, doseq)
+                data = urlencode(v_vars, doseq)
             else:
                 boundary, data = self.multipart_encode(v_vars, v_files)
                 contenttype = 'multipart/form-data; boundary=%s' % boundary
@@ -111,7 +116,7 @@ def main():
     import tempfile, sys
 
     validatorURL = "http://validator.w3.org/check"
-    opener = urllib2.build_opener(MultipartPostHandler)
+    opener = build_opener(MultipartPostHandler)
 
     def validateFile(url):
         temp = tempfile.mkstemp(suffix=".html")

--- a/tftpsync/susemanager-tftpsync/MultipartPostHandler.py
+++ b/tftpsync/susemanager-tftpsync/MultipartPostHandler.py
@@ -65,14 +65,14 @@ class MultipartPostHandler(BaseHandler):
             v_files = []
             v_vars = []
             try:
-                 for(key, value) in data.items():
+                 for(key, value) in list(data.items()):
                      if type(value) == file:
                          v_files.append((key, value))
                      else:
                          v_vars.append((key, value))
             except TypeError:
                 systype, value, traceback = sys.exc_info()
-                raise TypeError, "not a valid non-string sequence or mapping object", traceback
+                raise TypeError("not a valid non-string sequence or mapping object").with_traceback(traceback)
 
             if len(v_files) == 0:
                 data = urlencode(v_vars, doseq)
@@ -81,7 +81,7 @@ class MultipartPostHandler(BaseHandler):
                 contenttype = 'multipart/form-data; boundary=%s' % boundary
                 if(request.has_header('Content-Type')
                    and request.get_header('Content-Type').find('multipart/form-data') != 0):
-                    print "Replacing %s with %s" % (request.get_header('content-type'), 'multipart/form-data')
+                    print("Replacing %s with %s" % (request.get_header('content-type'), 'multipart/form-data'))
                 request.add_unredirected_header('Content-Type', contenttype)
 
             request.add_data(data)
@@ -124,7 +124,7 @@ def main():
         params = { "ss" : "0",            # show source
                    "doctype" : "Inline",
                    "uploaded_file" : open(temp[1], "rb") }
-        print opener.open(validatorURL, params).read()
+        print(opener.open(validatorURL, params).read())
         os.remove(temp[1])
 
     if len(sys.argv[1:]) > 0:

--- a/tftpsync/susemanager-tftpsync/susemanager-tftpsync.changes
+++ b/tftpsync/susemanager-tftpsync/susemanager-tftpsync.changes
@@ -1,3 +1,5 @@
+- Migrate Python code to be Python 2/3 compatible
+
 -------------------------------------------------------------------
 Fri Aug 10 15:48:12 CEST 2018 - jgonzalez@suse.com
 

--- a/tftpsync/susemanager-tftpsync/susemanager-tftpsync.spec
+++ b/tftpsync/susemanager-tftpsync/susemanager-tftpsync.spec
@@ -33,7 +33,13 @@ Source0:        %{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 
 Requires(pre):  cobbler
+%if 0%{?build_py3}
+Requires:       python3
+BuildRequires:  python3-devel
+%else
 Requires:       python
+BuildRequires:  python-devel
+%endif
 
 %description
 Add a cobbler trigger module which sync the cobbler created tftp enviroment
@@ -81,5 +87,9 @@ fi
 %{python_sitelib}/cobbler/modules/sync_post_tftpd_proxies.py*
 %{python_sitelib}/cobbler/MultipartPostHandler.py*
 %{_sbindir}/configure-tftpsync.sh
+%if 0%{?build_py3}
+%{python_sitelib}/cobbler/__pycache__/*
+%{python_sitelib}/cobbler/modules/__pycache__/*
+%endif
 
 %changelog

--- a/tftpsync/susemanager-tftpsync/sync_post_tftpd_proxies.py
+++ b/tftpsync/susemanager-tftpsync/sync_post_tftpd_proxies.py
@@ -175,7 +175,7 @@ def check_push(fn, tftpbootdir, settings, lcache='/var/lib/cobbler', logger=None
     needpush = True
     if _DEBUG:
         logger.debug("check_push(%s)" % fn)
-    if db.has_key(fn):
+    if fn in db:
         if db[fn][0] < mtime:
             if _DEBUG:
                 logger.debug("mtime differ - old: %s new: %s" % (db[fn][0], mtime))
@@ -245,7 +245,7 @@ class ProxySync(threading.Thread):
             params = { "file_name" : os.path.basename(self.filename), "file" : open(self.filename, "rb"), "file_type" : self.format, "directory": path }
             try:
                 response = opener.open("http://%s/tftpsync/add/" % self.proxy, params, self.timeout)
-            except Exception, e:
+            except Exception as e:
                 ret = False
                 if self.logger:
                     self.logger.error("uploading to proxy %s failed: %s" % (self.proxy, e))

--- a/tftpsync/susemanager-tftpsync/sync_post_tftpd_proxies.py
+++ b/tftpsync/susemanager-tftpsync/sync_post_tftpd_proxies.py
@@ -22,10 +22,17 @@ import os
 import traceback
 import cobbler.utils as utils
 import time
-import MultipartPostHandler, urllib2, urllib
+import MultipartPostHandler
 import simplejson
 import clogger
 import threading
+
+try:
+    from urllib.parse import urlencode
+    from urllib.request import urlopen, build_opener
+except ImportError:
+    from urllib import urlencode
+    from urllib2 import urlopen, build_opener
 
 _DEBUG = False
 
@@ -228,7 +235,7 @@ class ProxySync(threading.Thread):
 
         if self.logger:
             self.logger.info("uploading %s to proxy %s as %s" % (self.filename, self.proxy, os.path.basename(self.filename)))
-        opener = urllib2.build_opener(MultipartPostHandler.MultipartPostHandler)
+        opener = build_opener(MultipartPostHandler.MultipartPostHandler)
         path = os.path.dirname(self.filename)
         if not path.startswith(self.tftpbootdir):
             self.logger.error("Invalid path: %s" % path)
@@ -276,12 +283,12 @@ class ProxyDelete(threading.Thread):
         elif "grub" in self.path:
             p["file_type"] = 'grub'
 
-        parameters = urllib.urlencode(p)
+        parameters = urlencode(p)
 
         try:
             url = "https://%s/tftpsync/delete/?%s" % (self.proxy, parameters)
-            data = urllib2.urlopen(url, None, self.timeout)
-        except Exception, e:
+            data = urlopen(url, None, self.timeout)
+        except Exception as e:
             ret = False
             if self.logger:
                 self.logger.info("delete from proxy %s failed: %s" % (self.proxy, e))


### PR DESCRIPTION
## What does this PR change?
This PR migrates the code contained on "susemanager-tftpsync" and "susemanager-tftpsync-recv" to make them Python 2/3 compatible.

Also makes necessary fixes on the spec files to build packages with Python 3 on SLE 15.

**NOTE:**
The SLE15 package fails because the "cobbler" package needs to be built for Python 3 in order to make `/usr/lib/python3.X/site-packages/cobbler/` path to be owned by "cobbler". That way we should prevent the failure we currently have for SLE15: https://build.suse.de/package/show/home:PSuarezHernandez:branches:Devel:Galaxy:Manager:Head/susemanager-tftpsync

## Links

Tracks:

- https://github.com/SUSE/salt-board/issues/56
- https://github.com/SUSE/salt-board/issues/57

- [x] **DONE**
