### PR TITLE
Rename initrd grain for saltboot_initrd

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -200,10 +200,10 @@ public class RegisterMinionEventMessageAction implements MessageAction {
             // This way we don't need to call grains for each register minion event.
             if (isRetailMinion(registeredMinion)) {
                 ValueMap grains = new ValueMap(SALT_SERVICE.getGrains(minionId).orElseGet(HashMap::new));
-                grains.getOptionalAsBoolean("initrd").ifPresent(initrd -> {
-                    // if we have the "initrd" grain we want to re-deploy an image via saltboot,
+                grains.getOptionalAsBoolean("saltboot_initrd").ifPresent(initrd -> {
+                    // if we have the "saltboot_initrd" grain we want to re-deploy an image via saltboot,
                     // otherwise the image has been already fully deployed and we want to finalize the registration
-                    LOG.info("\"initrd\" present for minion " + minionId);
+                    LOG.info("\"saltboot_initrd\" present for minion " + minionId);
 
                     if (initrd) {
                         LOG.info("Applying saltboot for minion " + minionId);
@@ -364,8 +364,8 @@ public class RegisterMinionEventMessageAction implements MessageAction {
             });
 
             // Saltboot treatment - prepare and apply saltboot
-            if (isNewMinion && grains.getOptionalAsBoolean("initrd").orElse(false)) {
-                LOG.info("\"initrd\" grain set to true: Preparing & applying saltboot for minion " + minionId);
+            if (isNewMinion && grains.getOptionalAsBoolean("saltboot_initrd").orElse(false)) {
+                LOG.info("\"saltboot_initrd\" grain set to true: Preparing & applying saltboot for minion " + minionId);
                 prepareRetailMinionForSaltboot(minionServer, org, grains);
                 applySaltboot(minionServer);
                 return;

--- a/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
@@ -954,7 +954,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                     allowing(saltServiceMock).getGrains(MINION_ID);
                     will(returnValue(getGrains(MINION_ID, null, "non-existent-key")
                             .map(map -> {
-                                map.put("initrd", true);
+                                map.put("saltboot_initrd", true);
                                 map.put("manufacturer", "QEMU");
                                 map.put("productname", "CashDesk01");
                                 map.put("minion_id_prefix", "Branch001");
@@ -996,7 +996,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                         allowing(saltServiceMock).getGrains(MINION_ID);
                         will(returnValue(getGrains(MINION_ID, null, "non-existent-key")
                                 .map(map -> {
-                                    map.put("initrd", true);
+                                    map.put("saltboot_initrd", true);
                                     map.put("manufacturer", "QEMU");
                                     map.put("productname", "CashDesk01");
                                     map.put("minion_id_prefix", "Branch001");
@@ -1039,7 +1039,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                         allowing(saltServiceMock).getGrains(MINION_ID);
                         will(returnValue(getGrains(MINION_ID, null, "non-existent-key")
                                 .map(map -> {
-                                    map.put("initrd", true);
+                                    map.put("saltboot_initrd", true);
                                     map.put("manufacturer", "QEMU");
                                     map.put("productname", "CashDesk01");
                                     map.put("minion_id_prefix", "Branch001");
@@ -1080,7 +1080,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                     allowing(saltServiceMock).getGrains(MINION_ID);
                     will(returnValue(getGrains(MINION_ID, null, "non-existent-key")
                             .map(map -> {
-                                map.put("initrd", true);
+                                map.put("saltboot_initrd", true);
                                 map.put("manufacturer", "QEMU");
                                 map.put("productname", "CashDesk01");
                                 map.put("minion_id_prefix", "Branch001");
@@ -1126,7 +1126,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                         allowing(saltServiceMock).getGrains(MINION_ID);
                         will(returnValue(getGrains(MINION_ID, null, "non-existent-key")
                                 .map(map -> {
-                                    map.put("initrd", true);
+                                    map.put("saltboot_initrd", true);
                                     map.put("manufacturer", "QEMU");
                                     map.put("productname", "CashDesk01");
                                     map.put("minion_id_prefix", "Branch001");
@@ -1205,7 +1205,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                     allowing(saltServiceMock).getGrains(MINION_ID);
                     will(returnValue(getGrains(MINION_ID, null, "non-existent-key")
                             .map(map -> {
-                                map.put("initrd", false);
+                                map.put("saltboot_initrd", false);
                                 map.put("manufacturer", "QEMU");
                                 map.put("productname", "CashDesk02");
                                 map.put("minion_id_prefix", "Branch001");

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Change Saltboot grain trigger from "initrd" to "saltboot_initrd"
 - add last_boot to listSystems() API call
 - Changed localization strings for file summaries (bsc#1090676)
 - Added menu item entries for creating/deleting file preservation lists (bsc#1034030)


### PR DESCRIPTION
To prevend accidental saltboot deployment, this commit renames
generic "initrd" grain to "saltboot_initrd"

Port of https://github.com/SUSE/spacewalk/pull/5843
