### PR TITLE
 Fix displayed number of systems requiring reboot in Tasks pane (bsc#1106875)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/renderers/TasksRenderer.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/renderers/TasksRenderer.java
@@ -41,7 +41,7 @@ public class TasksRenderer extends BaseFragmentRenderer {
         request.setAttribute("documentation", ConfigDefaults.get().isDocAvailable());
         request.setAttribute("amountOfMinions",
                 SaltService.INSTANCE.getKeys().getUnacceptedMinions().size());
-        request.setAttribute("requiringReboot", SystemManager.requiringRebootList(user, pc).size());
+        request.setAttribute("requiringReboot", SystemManager.requiringRebootList(user, null).size());
         RendererHelper.setTableStyle(request, null);
     }
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix displayed number of systems requiring reboot in Tasks pane (bsc#1106875)
 - Added link from virtualization tab to Scheduled > Pending Actions (bsc#1037389)
 - Double check if the websocket connection is still open on sendText failure (bsc#1080474)
 - Enable auto patch updates for salt clients


### PR DESCRIPTION
This PR fixes the displayed "number of systems requiring reboot" on the Tasks pane.

Previously, the number displayed here always topped up at 5, caused by a mistakenly applied pagination modifier.

[bsc#1106875](https://bugzilla.suse.com/1106875)

Port of https://github.com/SUSE/spacewalk/pull/5842 
