### PR TITLE
Pg version check

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/General_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/General_queries.xml
@@ -349,5 +349,16 @@ ORDER BY UPPER(name)
   </query>
 </mode>
 
-</datasource_modes>
+<mode name="pg_version_num">
+  <query>
+    show server_version_num
+  </query>
+</mode>
 
+<mode name="pg_version">
+  <query>
+    show server_version
+  </query>
+</mode>
+
+</datasource_modes>

--- a/java/code/src/com/redhat/rhn/frontend/action/LoginHelper.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/LoginHelper.java
@@ -362,7 +362,7 @@ public class LoginHelper {
             if (serverVersion < MIN_PG_DB_VERSION) {
                 validationErrors.add(ls.getMessage("error.unsupported_db", pgVersion, MIN_PG_DB_VERSION_STRING));
             }
-            else if (serverVersion < 100001 && osVersion >= 12.4) {
+            else if (!ConfigDefaults.get().isUyuni() && serverVersion < 100001 && osVersion >= 12.4) {
                 validationErrors.add(ls.getMessage("error.unsupported_db_on_os", pgVersion, osName, "10"));
             }
         }

--- a/java/code/src/com/redhat/rhn/frontend/action/LoginSetupAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/LoginSetupAction.java
@@ -47,6 +47,7 @@ public class LoginSetupAction extends RhnAction {
         request.setAttribute("isUyuni", ConfigDefaults.get().isUyuni());
         request.setAttribute("schemaUpgradeRequired",
                 LoginHelper.isSchemaUpgradeRequired().toString());
+        request.setAttribute("validationErrors", LoginHelper.validateDBVersion());
 
         if (!UserManager.satelliteHasUsers()) {
             return mapping.findForward("needuser");

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -1203,7 +1203,7 @@
          <source>Running postgresql {0} is not supported. Minimal require version is {1}.</source>
       </trans-unit>
       <trans-unit id="error.unsupported_db_on_os">
-        <source>Running postgresql {0} on {1} is unsupported. Please migrate to postgresql {2}.</source>
+        <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
       </trans-unit>
       <trans-unit id="error.invalid_login">
         <source>Either the password or username is incorrect.</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -1199,6 +1199,12 @@
           <context context-type="sourcefile">/rhn/users/CreateUser</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="error.unsupported_db">
+         <source>Running postgresql {0} is not supported. Minimal require version is {1}.</source>
+      </trans-unit>
+      <trans-unit id="error.unsupported_db_on_os">
+        <source>Running postgresql {0} on {1} is unsupported. Please migrate to postgresql {2}.</source>
+      </trans-unit>
       <trans-unit id="error.invalid_login">
         <source>Either the password or username is incorrect.</source>
         <context-group name="ctx">

--- a/java/code/webapp/WEB-INF/pages/common/login.jsp
+++ b/java/code/webapp/WEB-INF/pages/common/login.jsp
@@ -13,6 +13,13 @@
       <bean:message key="login.jsp.schemaupgraderequired" />
     </div>
   </c:if>
+  <c:if test="${not empty validationErrors}">
+    <div class="alert alert-danger">
+      <c:forEach items="${validationErrors}" var="err" varStatus="loop">
+        ${err}<br/>
+      </c:forEach>
+    </div>
+  </c:if>
   <div class="col-sm-6">
       <c:choose>
           <c:when test="${isUyuni}">

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- check valid postgresql database version
 - Change Saltboot grain trigger from "initrd" to "saltboot_initrd"
 - add last_boot to listSystems() API call
 - Changed localization strings for file summaries (bsc#1090676)

--- a/schema/spacewalk/spacewalk-schema-upgrade
+++ b/schema/spacewalk/spacewalk-schema-upgrade
@@ -51,6 +51,7 @@ else {
     my $pg_version = "";
     my $os_version = 0.0;
     my $os_name = "";
+    my $isUyuni = 0;
     $server_version = run_query("show server_version_num;");
     $pg_version = run_query("show server_version;");
 
@@ -66,13 +67,16 @@ else {
         elsif ($k eq "PRETTY_NAME") {
             $os_name = $v;
         }
+        elsif ($k eq "ID" && $v =~ m/opensuse/) {
+            $isUyuni = 1;
+        }
     }
     close $fh;
     if ($server_version < $MIN_PG_DB_VERSION) {
         print "\nRunning postgresql $pg_version is not supported. Minimal require version is $MIN_PG_DB_VERSION_STRING.\n\n";
         exit 1;
     }
-    elsif($server_version < 100001 && $os_version >= 12.4) {
+    elsif(!$isUyuni && $server_version < 100001 && $os_version >= 12.4) {
         print "\nRunning postgresql $pg_version on $os_name is unsupported. Please migrate to postgresql 10.\n\n";
         exit 1;
     }

--- a/schema/spacewalk/spacewalk-schema-upgrade
+++ b/schema/spacewalk/spacewalk-schema-upgrade
@@ -7,6 +7,8 @@ use Spacewalk::Setup ();
 use IPC::Open3 ();
 use File::Basename;
 
+my $MIN_PG_DB_VERSION = 90600;
+my $MIN_PG_DB_VERSION_STRING = "9.6";
 my $SCHEMA_UPGRADE_DIR = '/etc/sysconfig/rhn/schema-upgrade';
 my $SCHEMA_UPGRADE_LOGDIR = '/var/log/spacewalk/schema-upgrade';
 
@@ -42,6 +44,37 @@ if ($options{db_backend} eq 'oracle') {
 EOF
     if (not defined $default_tablespace) {
         die "Failed to retrieve default_tablespace from database.\n";
+    }
+}
+else {
+    my $server_version = 0;
+    my $pg_version = "";
+    my $os_version = 0.0;
+    my $os_name = "";
+    $server_version = run_query("show server_version_num;");
+    $pg_version = run_query("show server_version;");
+
+    open(my $fh, '<:encoding(UTF-8)', "/etc/os-release") or die "Could not open file '/etc/os-release' $!";
+    while (my $row = <$fh>) {
+        chomp $row;
+        my ($k,$v) = split(/=/, $row, 2);
+        if ($k eq "VERSION_ID") {
+            if ($v =~ /(\d+\.\d+)/) {
+                $os_version = $1;
+            }
+        }
+        elsif ($k eq "PRETTY_NAME") {
+            $os_name = $v;
+        }
+    }
+    close $fh;
+    if ($server_version < $MIN_PG_DB_VERSION) {
+        print "\nRunning postgresql $pg_version is not supported. Minimal require version is $MIN_PG_DB_VERSION_STRING.\n\n";
+        exit 1;
+    }
+    elsif($server_version < 100001 && $os_version >= 12.4) {
+        print "\nRunning postgresql $pg_version on $os_name is unsupported. Please migrate to postgresql 10.\n\n";
+        exit 1;
     }
 }
 

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- check valid postgresql database version
 - Enable auto patch updates for Salt minions
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Check for valid postgres DB version and show error on Login page.
We have two checks:

- a absolute minimal DB version because we use statements which are only supported with this
version.
- a special DB version available on a specific OS version/SP. (e.g. on 12.4 we will have only v10)

## Documentation

- https://github.com/SUSE/spacewalk/issues/5820

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/5821

- [x] **DONE**
