### PR TITLE
Allow either atftpd service (SLE12) or socket (openSUSE Leap 42.3) cucumber testsuite

### DIFF
--- a/testsuite/features/core_first_settings.feature
+++ b/testsuite/features/core_first_settings.feature
@@ -57,8 +57,8 @@ Feature: Very first settings
     When I wait until mgr-sync refresh is finished
 
   Scenario: Check services which should run
-    Then service "atftpd" is enabled on "server"
-    And service "atftpd" is running on "server"
+    Then service or socket "atftpd" is enabled on "server"
+    And service or socket "atftpd" is active on "server"
     And service "auditlog-keeper" is enabled on "server"
     And service "auditlog-keeper" is running on "server"
     And service "cobblerd" is enabled on "server"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -292,6 +292,24 @@ Then(/^service "([^"]*)" is running on "([^"]*)"$/) do |service, host|
   raise if output != 'active'
 end
 
+Then(/^service or socket "([^"]*)" is enabled on "([^"]*)"$/) do |name, host|
+  node = get_target(host)
+  output_service, _code_service = node.run("systemctl is-enabled '#{name}'", false)
+  output_service = output_service.split(/\n+/)[-1]
+  output_socket, _code_socket = node.run(" systemctl is-enabled '#{name}.socket'", false)
+  output_socket = output_socket.split(/\n+/)[-1]
+  raise if output.service != 'enabled' and output.socket != 'enabled'
+end
+
+Then(/^service or socket "([^"]*)" is active on "([^"]*)"$/) do |name, host|
+  node = get_target(host)
+  output_service, _code_service = node.run("systemctl is-active '#{name}'", false)
+  output_service = output_service.split(/\n+/)[-1]
+  output_socket, _code_socket = node.run(" systemctl is-active '#{name}.socket'", false)
+  output_socket = output_socket.split(/\n+/)[-1]
+  raise if output.service != 'active' and output.socket != 'active'
+end
+
 When(/^I run "([^"]*)" on "([^"]*)"$/) do |cmd, host|
   node = get_target(host)
   node.run(cmd)


### PR DESCRIPTION
## What does this PR change?

Allows "Scenario: Check services which should run" to pass by allowing either atftpd service or socket to be enabled.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Testsuite test change

- [x] **DONE**

## Test coverage
- Cucumber tests were modified

- [x] **DONE**

## Links

Part of https://github.com/SUSE/spacewalk/issues/5701

- [x] **DONE**
