### PR TITLE
Add last boot to systems

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
@@ -459,7 +459,8 @@ SELECT ES.id, S.name, 1 as selectable
 select * from (
   SELECT  DISTINCT S.id AS ID,
           S.name AS NAME,
-          INFO.checkin AS LAST_CHECKIN
+          INFO.checkin AS LAST_CHECKIN,
+          S.last_boot AS LAST_BOOT
     FROM  rhnServer S, rhnUserServerPerms USP, rhnServerInfo INFO
    WHERE  USP.user_id = :user_id
      AND  S.id = USP.server_id
@@ -474,7 +475,8 @@ ORDER BY  UPPER(COALESCE(X.name, '(none)')), X.id
 select * from (
   SELECT  DISTINCT S.id AS ID,
           S.name AS NAME,
-          INFO.checkin AS LAST_CHECKIN
+          INFO.checkin AS LAST_CHECKIN,
+          S.last_boot AS LAST_BOOT
     FROM  rhnServer S, rhnUserServerPerms USP, rhnServerInfo INFO
    WHERE  USP.user_id = :user_id
      AND  S.id = USP.server_id
@@ -490,7 +492,8 @@ ORDER BY  UPPER(COALESCE(X.name, '(none)')), X.id
 select * from (
   SELECT  DISTINCT S.id AS ID,
           S.name AS NAME,
-          INFO.checkin AS LAST_CHECKIN
+          INFO.checkin AS LAST_CHECKIN,
+          S.last_boot AS LAST_BOOT
     FROM  rhnServer S, rhnUserServerPerms USP, rhnServerInfo INFO
    WHERE  USP.user_id = :user_id
      AND  S.id = USP.server_id

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
@@ -601,7 +601,7 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
         s.setRelease("9");
         s.setSecret("12345678901234567890123456789012");
         s.setAutoUpdate("N");
-        s.setLastBoot(new Long(System.currentTimeMillis()));
+        s.setLastBoot(System.currentTimeMillis() / 1000);
         s.setServerArch(ServerFactory.lookupServerArchByLabel("i386-redhat-linux"));
         s.setCreated(new Date());
         s.setModified(new Date());

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -946,6 +946,18 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         assertEquals(1, results.size());
     }
 
+    public void testListSystems() throws Exception {
+        Server server = ServerFactoryTest.createTestServer(admin);
+        Object[] results = handler.listSystems(admin);
+        assertEquals(1, results.length);
+
+        List<Object> r = Arrays.asList(results);
+
+        for (Object o : r) {
+            SystemOverview so = (SystemOverview) o;
+            assertNotNull(so.getLastBootAsDate());
+        }
+    }
 
     public void testSetProfileName() throws Exception {
         Server server = ServerFactoryTest.createTestServer(admin);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- add last_boot to listSystems() API call
 - Changed localization strings for file summaries (bsc#1090676)
 - Added menu item entries for creating/deleting file preservation lists (bsc#1034030)
 - Fix displayed number of systems requiring reboot in Tasks pane (bsc#1106875)


### PR DESCRIPTION
## What does this PR change?

system.listSystems() defines parameter last_boot, but it is not available.
The reason is, that the mode query does not return the value.

## Documentation
- No documentation needed: **allign to existing doc**

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/5852

- [x] **DONE**
