### PR TITLE
Port to Python3: Fix wrong createrepo dependency on Python 3

### DIFF
--- a/susemanager/susemanager.spec
+++ b/susemanager/susemanager.spec
@@ -86,13 +86,14 @@ setup tasks, re-installation, upgrades and managing.
 %package tools
 Summary:        SUSE Manager Tools
 Group:          Productivity/Other
-Requires:       createrepo
 
 %if 0%{?build_py3}
+Requires:       createrepo_c
 Requires:       python3
 Requires:       python3-configobj
 BuildRequires:  python3-configobj
 %else
+Requires:       createrepo
 Requires:       python
 Requires:       python-argparse
 Requires:       python-configobj


### PR DESCRIPTION
## What does this PR change?

This fixes an issue with the "createrepo" CLI tools dependency on the "susemanager" package.

- On Python 2 builds, we keep using the old "createrepo" CLI tools based on python2.
- On Python 3 builds, we use "createrepo_c" package which provides the CLI tools binaries based on C implementation. (A "python3-createrepo_c" package with bindings is also available but not actually used by "susemanager")