### PR TITLE
fix testsuite for postgresql10

### DIFF
--- a/testsuite/features/srv_smdba.feature
+++ b/testsuite/features/srv_smdba.feature
@@ -44,7 +44,8 @@ Feature: SMBDA database helper tool
   Scenario: Check database utilities
     Given a postgresql database is running
     When I issue command "smdba space-overview"
-    Then I find tablespaces "susemanager" and "template0"
+    Then I find tablespaces "susemanager" and "template"
+    And I find tablespaces "susemanager" and "postgres"
     When I issue command "smdba space-reclaim"
     Then I find core examination is "finished", database analysis is "done" and space reclamation is "done"
     When I issue command "smdba space-tables"
@@ -80,6 +81,7 @@ Feature: SMBDA database helper tool
     And when I issue command "smdba backup-hot"
     And when in the database I create dummy table "dummy" with column "test" and value "bogus data"
     And I destroy "/var/lib/pgsql/data/pg_xlog" directory on server
+    And I destroy "/var/lib/pgsql/data/pg_wal" directory on server
     And when I restore database from the backup
     And when I issue command "smdba db-status"
     Given a postgresql database is running


### PR DESCRIPTION
## What does this PR change?

1.) Internal tablespace of the database is not always named "template0", but can also be "template1" (especially after the database has been migrated), so make check more generic. Add test for internal tablespace "postgres" to compensate for this.

2.) With postgresql10 the directory for the transaction logs has been renamed. As the DESTROY step is using "rm -rf", we can just try to delete both directories; it will also be successful for a non-existing one. So with these changes the testsuite can run on both postgresql9.x and postgresql10.