### PR TITLE
Make EULA test skippable for Uyuni

### DIFF
--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -13,10 +13,7 @@ Apart from Cucumber, the testsuite relies on a number of [software components](d
 
 You can run the SUSE Manager testsuite [with sumaform](https://github.com/moio/sumaform/blob/master/README_ADVANCED.md#cucumber-testsuite).
 
-If you want to run the testsuite for [Uyuni](https://www.uyuni-project.org), you need to export the variable PRODUCT with value Uyuni:
-```bash
-export PRODUCT=Uyuni
-```
+If you want to run the testsuite for [Uyuni](https://www.uyuni-project.org), nothing special needs to be done. The testuite will autodetect it.
 
 ## Core features, idempotency and tests order
 

--- a/testsuite/docs/optional.md
+++ b/testsuite/docs/optional.md
@@ -103,6 +103,18 @@ Inside of the testsuite, the scenarios that are tagged with
 ```
 are executed only if the minion is a SLE 15 system.
 
+### Testing Uyuni
+
+The test suite will determine automatically whether your server
+is running Uyuni or SUSE Manager
+
+Inside the testsuite, the scenarios that are tagged with
+
+```
+@susemanager
+```
+are executed only if the server has SUSE Manager installed and will
+not run if Uyuni is detected.
 
 ### Testing with a mirror
 

--- a/testsuite/features/srv_mainpage.feature
+++ b/testsuite/features/srv_mainpage.feature
@@ -20,12 +20,13 @@ Feature: Main landing page options and preferences
     And I follow "Copyright Notice"
     Then I should see a "Copyright (c) 2011 - 2018 SUSE LLC." text
 
+  @susemanager
   Scenario: Access the EULA
     Given I am not authorized
     When I go to the home page
     And I follow "Copyright Notice"
     And I follow "SUSE MANAGER LICENSE AGREEMENT"
-    Then I should see a "$PRODUCT License Agreement" text
+    Then I should see a "SUSE Manager License Agreement" text
 
   Scenario: Log into SUSE Manager
     Given I am not authorized

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -55,7 +55,7 @@ When(/^I wait until I see "([^"]*)" text or "([^"]*)" text$/) do |text1, text2|
 end
 
 When(/^I wait until I see "([^"]*)" text, refreshing the page$/) do |text|
-  text.gsub! '$PRODUCT', product
+  text.gsub! '$PRODUCT', $product
   begin
     Timeout.timeout(DEFAULT_TIMEOUT) do
       loop do
@@ -419,7 +419,7 @@ end
 # Test for a text in the whole page
 #
 Then(/^I should see a "([^"]*)" text$/) do |text|
-  text.gsub! '$PRODUCT', product
+  text.gsub! '$PRODUCT', $product
   unless page.has_content?(text)
     sleep 2
     raise unless page.has_content?(text)

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -33,12 +33,10 @@ def count_table_items
   items_label.split('of ')[1]
 end
 
-# Define the product name, depending on the environment variable
-# PRODUCT
 def product
-  if ENV['PRODUCT'] == 'Uyuni' || ENV['PRODUCT'] == 'SUSE Manager'
-    ENV['PRODUCT']
-  else
-    'SUSE Manager'
-  end
+  _product_raw, code = $server.run('rpm -q patterns-uyuni_server')
+  return 'Uyuni' if code.zero?
+  _product_raw, code = $server.run('rpm -q patterns-suma_server')
+  return 'SUSE Manager' if code.zero?
+  raise 'Could not determine product'
 end

--- a/testsuite/features/support/setup_browser.rb
+++ b/testsuite/features/support/setup_browser.rb
@@ -84,6 +84,11 @@ Before('@no_mirror') do |scenario|
   scenario.skip_invoke! if $mirror
 end
 
+# do some tests only if the server is using SUSE Manager
+Before('@susemanager') do |scenario|
+  scenario.skip_invoke! unless $product == 'SUSE Manager'
+end
+
 # have more infos about the errors
 def debug_server_on_realtime_failure
   puts

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -96,3 +96,4 @@ $sle15_minion = minion_is_sle15
 $private_net = !ENV['PRIVATENET'].nil?
 $mirror = ENV['MIRROR']
 $git_profiles = ENV['GITPROFILES']
+$product = product


### PR DESCRIPTION
## What does this PR change?

This adds a tag, so we can use --tags not @susemanager when running cucumber for Uyuni.

Since we now can skip this test, it reverts the ugly `$PRODUCT` hack for this test.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Internal testsuite change

- [x] **DONE**

## Test coverage
- Cucumber tests were modified

- [x] **DONE**

## Links

Part of https://github.com/SUSE/spacewalk/issues/5701

- [x] **DONE**
