### PR TITLE
Fix 'I wait until I see *** text, refreshing the page'

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -55,6 +55,7 @@ When(/^I wait until I see "([^"]*)" text or "([^"]*)" text$/) do |text1, text2|
 end
 
 When(/^I wait until I see "([^"]*)" text, refreshing the page$/) do |text|
+  text.gsub! '$PRODUCT', product
   begin
     Timeout.timeout(DEFAULT_TIMEOUT) do
       loop do


### PR DESCRIPTION
## What does this PR change?

Fix 'I wait until I see *** text, refreshing the page', so $PRODUCT can be replaced.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Internal testsuite change

- [x] **DONE**

## Test coverage
- No tests: Internal testsuite change

- [x] **DONE**