### PR TITLE
do not test for internal stuff of postgresql

### DIFF
--- a/testsuite/features/srv_smdba.feature
+++ b/testsuite/features/srv_smdba.feature
@@ -45,7 +45,6 @@ Feature: SMBDA database helper tool
     Given a postgresql database is running
     When I issue command "smdba space-overview"
     Then I find tablespaces "susemanager" and "template"
-    And I find tablespaces "susemanager" and "postgres"
     When I issue command "smdba space-reclaim"
     Then I find core examination is "finished", database analysis is "done" and space reclamation is "done"
     When I issue command "smdba space-tables"


### PR DESCRIPTION
## What does this PR change?

We should not test for internal postgresql tablespaces. The only tablespace relevant for us is the one named "susemanager". Internal tablespaces depend on the actual postgresql version and also depend on whether it is a new installation or a migrated one.