### PR TITLE
Feat: enable Kiwi OS image building by default

### DIFF
--- a/java/conf/rhn_java.conf
+++ b/java/conf/rhn_java.conf
@@ -170,4 +170,4 @@ java.salt_api_host = localhost
 java.salt_api_port = 9080
 
 # If true, Kiwi OS Image building feature preview will be enabled
-java.kiwi_os_image_building_enabled = false
+java.kiwi_os_image_building_enabled = true

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Make Kiwi OS Image building enabled by default
 - check valid postgresql database version
 - Change Saltboot grain trigger from "initrd" to "saltboot_initrd"
 - add last_boot to listSystems() API call


### PR DESCRIPTION
## What does this PR change?

Make Kiwi OS Image building enabled by default

## GUI diff

No difference.

- [X] **DONE**

## Documentation

- https://github.com/SUSE/doc-susemanager/pull/198

- [X] **DONE**

## Test coverage
- No tests: tests were already added

- [X] **DONE**

