### PR TITLE
Fix typo on common_steps to check services and sockets

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -298,7 +298,7 @@ Then(/^service or socket "([^"]*)" is enabled on "([^"]*)"$/) do |name, host|
   output_service = output_service.split(/\n+/)[-1]
   output_socket, _code_socket = node.run(" systemctl is-enabled '#{name}.socket'", false)
   output_socket = output_socket.split(/\n+/)[-1]
-  raise if output.service != 'enabled' and output.socket != 'enabled'
+  raise if output_service != 'enabled' and output_socket != 'enabled'
 end
 
 Then(/^service or socket "([^"]*)" is active on "([^"]*)"$/) do |name, host|
@@ -307,7 +307,7 @@ Then(/^service or socket "([^"]*)" is active on "([^"]*)"$/) do |name, host|
   output_service = output_service.split(/\n+/)[-1]
   output_socket, _code_socket = node.run(" systemctl is-active '#{name}.socket'", false)
   output_socket = output_socket.split(/\n+/)[-1]
-  raise if output.service != 'active' and output.socket != 'active'
+  raise if output_service != 'active' and output_socket != 'active'
 end
 
 When(/^I run "([^"]*)" on "([^"]*)"$/) do |cmd, host|


### PR DESCRIPTION
## What does this PR change?

Fix typo on common_steps to check services and sockets.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Internal fix for the testsuite

- [x] **DONE**

## Test coverage
- No tests: Fix is for the testsuite

- [x] **DONE**

## Links

Part of https://github.com/SUSE/spacewalk/issues/5701

- [x] **DONE**
