### PR TITLE
Remove special characters from HW type string

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -459,12 +459,13 @@ public class RegisterMinionEventMessageAction implements MessageAction {
                     "on retail minion registration! Aborting registration.");
         }
 
-        String hwType = "HWTYPE:" + manufacturer.get() + "-" + productName.get();
+        String hwType = manufacturer.get() + "-" + productName.get();
+        String hwTypeGroup = "HWTYPE:" + hwType.replaceAll("[^A-Za-z0-9_-]", "");
 
         String branchIdGroupName = branchId.get();
         ManagedServerGroup terminalsGroup = ServerGroupFactory.lookupByNameAndOrg(TERMINALS_GROUP_NAME, org);
         ManagedServerGroup branchIdGroup = ServerGroupFactory.lookupByNameAndOrg(branchIdGroupName, org);
-        ManagedServerGroup hwGroup = ServerGroupFactory.lookupByNameAndOrg(hwType, org);
+        ManagedServerGroup hwGroup = ServerGroupFactory.lookupByNameAndOrg(hwTypeGroup, org);
 
         if (terminalsGroup == null || branchIdGroup == null) {
             throw new IllegalStateException("Missing required server groups (\"" + TERMINALS_GROUP_NAME + "\" or \"" +

--- a/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
@@ -952,11 +952,12 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                     allowing(saltServiceMock).syncGrains(with(any(MinionList.class)));
                     allowing(saltServiceMock).syncModules(with(any(MinionList.class)));
                     allowing(saltServiceMock).getGrains(MINION_ID);
+                    // Notice product name has spaces in the string. It is intentional to test hw string preprocessing
                     will(returnValue(getGrains(MINION_ID, null, "non-existent-key")
                             .map(map -> {
                                 map.put("saltboot_initrd", true);
                                 map.put("manufacturer", "QEMU");
-                                map.put("productname", "CashDesk01");
+                                map.put("productname", "Cash Desk 01");
                                 map.put("minion_id_prefix", "Branch001");
                                 return map;
                             })));

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Remove special characters from HW type string
 - Optimize execution of actions in minions (bsc#1099857)
 - Make Kiwi OS Image building enabled by default
 - Increase Java API version


### PR DESCRIPTION
## What does this PR change?
Saltboot initrd part does a preprocessing of HW type string to remove special characters. This preprocessing must be done in Java handler as well.

## Documentation
- No documentation needed: internal functionality

## Test coverage
- [X] Unit tests included

## Links

Fixes https://github.com/SUSE/spacewalk/issues/5901

Relevant branches (GitHub automatic links expected below):
- [X] https://github.com/SUSE/spacewalk/pull/5919
