### PR TITLE
Removed curl dependency at bootstrap (bsc#1095220)

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -33,6 +33,7 @@ disable_repo_{{ alias }}:
 {% set bootstrap_repo_url = 'https://' ~ salt['pillar.get']('mgr_server') ~ '/pub/repositories/res/' ~ grains['osmajorrelease'] ~ '/bootstrap/' %}
 {%- endif %}
 
+{%- set bootstrap_repo_exists = (0 < salt['http.query'](bootstrap_repo_url + 'repodata/repomd.xml', status=True)['status'] < 300) %}
 
 bootstrap_repo:
   file.managed:
@@ -53,7 +54,7 @@ bootstrap_repo:
       - module: disable_repo_*
 {%- endif %}
     - onlyif:
-      - curl --output /dev/null --silent --head --fail {{ bootstrap_repo_url }}repodata/repomd.xml
+      - ([ {{ bootstrap_repo_exists }} = "True" ])
 
 
 {%- if grains['os_family'] == 'RedHat' %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Removed the need for curl to be present at bootstrap phase (bsc#1095220)
 - Migrate Python code to be Python 2/3 compatible 
 - Fix merging of image pillars
 - Fix: delete old custom OS images pillar before generation (bsc#1105107)


### PR DESCRIPTION
This patch replaces a check which tested the presence
of a repomd.xml while bootstrapping a minion.
Originally curl was used for this, but since it is not
guaranteed to be already installed, it got replaced with a
salt module.

Technical details:

The Http-status-code that is returned by the http.query
module is checked if it is between 0 and 300 (exclusively).
The check to see if the http-code is higher than 0 is
important, because when the http.query module fails
it sometimes returns the value 0

Cherrypick from https://github.com/SUSE/spacewalk/pull/5858