### PR TITLE
Fix script is deleted too early (bsc#1105807)

### DIFF
--- a/java/code/src/com/redhat/rhn/common/util/FileUtils.java
+++ b/java/code/src/com/redhat/rhn/common/util/FileUtils.java
@@ -30,6 +30,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 
 /**
@@ -196,5 +198,18 @@ public class FileUtils {
             sb.append(System.getProperty("line.separator"));
         }
         return sb.toString();
+    }
+
+    /**
+     * Delete file with a given path.
+     * @param path path of the file to be deleted
+     */
+    public static void deleteFile(Path path) {
+        try {
+            Files.deleteIfExists(path);
+        }
+        catch (IOException e) {
+            log.warn("Could not delete file: " + path, e);
+        }
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/action/Action.java
+++ b/java/code/src/com/redhat/rhn/domain/action/Action.java
@@ -336,6 +336,17 @@ public class Action extends BaseDomainHelper implements Serializable {
     }
 
     /**
+     * @return true if all servers have finished the action as either COMPLETED or FAILED
+     */
+    public boolean allServersFinished() {
+        if (getServerActions() == null) {
+            return true;
+        }
+        return getServerActions().stream().allMatch(sa -> ActionFactory.STATUS_COMPLETED.equals(sa.getStatus()) ||
+                ActionFactory.STATUS_FAILED.equals(sa.getStatus()));
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override

--- a/java/code/src/com/redhat/rhn/domain/action/script/ScriptRunAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/script/ScriptRunAction.java
@@ -15,9 +15,11 @@
 package com.redhat.rhn.domain.action.script;
 
 import com.redhat.rhn.common.localization.LocalizationService;
+import com.redhat.rhn.common.util.FileUtils;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.download.DownloadManager;
+import com.suse.manager.utils.SaltUtils;
 
 import org.apache.commons.lang3.StringEscapeUtils;
 
@@ -76,4 +78,10 @@ public class ScriptRunAction extends ScriptAction {
         return retval.toString();
     }
 
+    @Override
+    public void onCancelAction() {
+        if (allServersFinished()) {
+            FileUtils.deleteFile(SaltUtils.INSTANCE.getScriptPath(getId()));
+        }
+    }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionCleanup.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionCleanup.java
@@ -16,6 +16,9 @@ package com.redhat.rhn.taskomatic.task;
 
 import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.utils.MinionActionUtils;
+
+import java.io.IOException;
+
 import org.quartz.JobExecutionContext;
 
 
@@ -37,6 +40,14 @@ public class MinionActionCleanup extends RhnJavaJob {
         // Measure time and calculate the total duration
         long start = System.currentTimeMillis();
         MinionActionUtils.cleanupMinionActions(SaltService.INSTANCE);
+
+        // Delete script files for script actions that have completed
+        try {
+            MinionActionUtils.cleanupScriptActions();
+        }
+        catch (IOException e) {
+            log.error("Could not cleanup script files: " + e.getMessage(), e);
+        }
 
         if (log.isDebugEnabled()) {
             long duration = System.currentTimeMillis() - start;

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -120,11 +120,9 @@ import org.apache.log4j.Logger;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -541,15 +539,6 @@ public class SaltUtils {
                         jid + "]");
             }
             scriptResult.setOutput(printStdMessages(result.getStderr(), result.getStdout()).getBytes());
-
-            Path scriptPath = getScriptPath(action.getId());
-            try {
-                Files.deleteIfExists(scriptPath);
-            }
-            catch (IOException e) {
-                LOG.warn("Could not delete script file " + scriptPath, e);
-            }
-
         }
         else if (action.getActionType().equals(ActionFactory.TYPE_IMAGE_BUILD)) {
             handleImageBuildData(serverAction, jsonResult);
@@ -1685,6 +1674,14 @@ public class SaltUtils {
      */
     public void setScriptsDir(Path scriptsDirIn) {
         scriptsDir = scriptsDirIn;
+    }
+
+    /**
+     * Return the scripts directory.
+     * @return scripts directory
+     */
+    public Path getScriptsDir() {
+        return scriptsDir;
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/utils/test/MinionActionUtilsTest.java
+++ b/java/code/src/com/suse/manager/webui/utils/test/MinionActionUtilsTest.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2018 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.webui.utils.test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import com.redhat.rhn.common.util.FileUtils;
+import com.redhat.rhn.domain.action.Action;
+import com.redhat.rhn.domain.action.ActionFactory;
+import com.redhat.rhn.domain.action.server.ServerAction;
+import com.redhat.rhn.domain.action.test.ActionFactoryTest;
+import com.redhat.rhn.domain.server.test.ServerFactoryTest;
+import com.redhat.rhn.testing.BaseTestCaseWithUser;
+import com.suse.manager.utils.SaltUtils;
+import com.suse.manager.webui.utils.MinionActionUtils;
+
+/**
+ * Tests for MinionActionUtils.
+ */
+public class MinionActionUtilsTest extends BaseTestCaseWithUser {
+
+    /**
+     * Verify script is deleted in case all servers are finished (COMPLETED or FAILED).
+     */
+    public void testCleanupScriptActions() throws Exception {
+        SaltUtils.INSTANCE.setScriptsDir(Files.createTempDirectory("scripts"));
+        Action action = ActionFactoryTest.createAction(user, ActionFactory.TYPE_SCRIPT_RUN);
+        ServerAction sa = ActionFactoryTest.createServerAction(ServerFactoryTest.createTestServer(user), action);
+        sa.setStatus(ActionFactory.STATUS_COMPLETED);
+        action.addServerAction(sa);
+        ServerAction sa2 = ActionFactoryTest.createServerAction(ServerFactoryTest.createTestServer(user), action);
+        sa2.setStatus(ActionFactory.STATUS_FAILED);
+        action.addServerAction(sa2);
+        Path scriptFile = Files.createFile(SaltUtils.INSTANCE.getScriptPath(action.getId()));
+
+        // Testing
+        MinionActionUtils.cleanupScriptActions();
+        assertFalse(Files.exists(scriptFile));
+
+        // Cleanup
+        Files.delete(SaltUtils.INSTANCE.getScriptsDir());
+    }
+
+    /**
+     * Verify script is not deleted as long as not all servers have finished (e.g. PICKED_UP).
+     */
+    public void testCleanupScriptActionsPickedUp() throws Exception {
+        SaltUtils.INSTANCE.setScriptsDir(Files.createTempDirectory("scripts"));
+        Action action = ActionFactoryTest.createAction(user, ActionFactory.TYPE_SCRIPT_RUN);
+        ServerAction sa = ActionFactoryTest.createServerAction(ServerFactoryTest.createTestServer(user), action);
+        sa.setStatus(ActionFactory.STATUS_PICKED_UP);
+        action.addServerAction(sa);
+        ServerAction sa2 = ActionFactoryTest.createServerAction(ServerFactoryTest.createTestServer(user), action);
+        sa2.setStatus(ActionFactory.STATUS_COMPLETED);
+        action.addServerAction(sa2);
+        Path scriptFile = Files.createFile(SaltUtils.INSTANCE.getScriptPath(action.getId()));
+
+        // Testing
+        MinionActionUtils.cleanupScriptActions();
+        assertTrue(Files.exists(scriptFile));
+
+        // Cleanup
+        FileUtils.deleteFile(scriptFile);
+        Files.delete(SaltUtils.INSTANCE.getScriptsDir());
+    }
+}

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix script is deleted too early (bsc#1105807)
 - Remove special characters from HW type string
 - Optimize execution of actions in minions (bsc#1099857)
 - Make Kiwi OS Image building enabled by default


### PR DESCRIPTION
## What does this PR change?

This patch is supposed to fix [bsc#1105807](https://bugzilla.suse.com/show_bug.cgi?id=1105807) by deleting a script corresponding to a `ScriptRunAction` not before the last server on the action has returned a result. Implementation is based on a regular (hourly) cleanup to remove scripts where the corresponding action has completed.

## Documentation

- No documentation needed, this is the expected behavior.

- [x] **DONE**

## Test coverage

- Unit tests were added

- [x] **DONE**

## Links

Fixes [downstream issue](https://github.com/SUSE/spacewalk/issues/5758) and tracks downstream PR: https://github.com/SUSE/spacewalk/pull/5575

- [x] **DONE**
