### PR TITLE
Adapt "spacewalk-backend" code to be Python 2/3 compatible

### DIFF
--- a/backend/Makefile.backend
+++ b/backend/Makefile.backend
@@ -34,8 +34,8 @@ install :: install-code install-conf
 clean :: clean-code clean-conf
 
 test    ::
-	$(MAKE) -C common/test/unit-test
-	$(MAKE) -C server/test/unit-test
+	$(MAKE) -C common/test/unit-test PYTHON_BIN=$(PYTHON_BIN)
+	$(MAKE) -C server/test/unit-test PYTHON_BIN=$(PYTHON_BIN)
 
 unittest ::
 	if test -x /usr/bin/unit2 ; then \

--- a/backend/cdn_tools/activation.py
+++ b/backend/cdn_tools/activation.py
@@ -105,7 +105,7 @@ class Activation(object):
             try:
                 family = self.families[label]
                 family_object = ChannelFamily()
-                for k in family.keys():
+                for k in list(family.keys()):
                     family_object[k] = family[k]
                 family_object['label'] = label
                 batch.append(family_object)
@@ -179,7 +179,7 @@ class Activation(object):
                     elif content_source_ssl not in content_sources_batch[repository]['ssl-sets']:
                         content_sources_batch[repository]['ssl-sets'].append(content_source_ssl)
 
-        importer = ContentSourcesImport(content_sources_batch.values(), backend)
+        importer = ContentSourcesImport(list(content_sources_batch.values()), backend)
         importer.run()
 
     def activate(self):

--- a/backend/cdn_tools/cdnsync.py
+++ b/backend/cdn_tools/cdnsync.py
@@ -19,7 +19,7 @@ import sys
 import fnmatch
 from datetime import datetime, timedelta
 
-import constants
+from . import constants
 from spacewalk.common.rhnConfig import CFG, initCFG, PRODUCT_NAME
 from spacewalk.common import rhnLog
 from spacewalk.server import rhnSQL
@@ -37,8 +37,8 @@ from spacewalk.satellite_tools.satCerts import get_certificate_info, verify_cert
 from spacewalk.satellite_tools.syncLib import log, log2disk, log2, initEMAIL_LOG, log2email, log2background
 from spacewalk.satellite_tools.repo_plugins import yum_src
 
-from common import CustomChannelSyncError, CountingPackagesError, verify_mappings, human_readable_size
-from repository import CdnRepositoryManager, CdnRepositoryNotFoundError
+from .common import CustomChannelSyncError, CountingPackagesError, verify_mappings, human_readable_size
+from .repository import CdnRepositoryManager, CdnRepositoryNotFoundError
 
 
 class CdnSync(object):
@@ -291,7 +291,7 @@ class CdnSync(object):
         for label in channels:
             channel = self.channel_metadata[label]
             channel_object = Channel()
-            for k in channel.keys():
+            for k in list(channel.keys()):
                 channel_object[k] = channel[k]
 
             family_object = ChannelFamily()
@@ -741,7 +741,7 @@ class CdnSync(object):
         available_base_channels = [x for x in sorted(channel_tree) if x not in not_available_channels]
         custom_cdn_channels = [ch for ch in self.synced_channels if self.synced_channels[ch]]
         longest_label = len(max(available_base_channels + custom_cdn_channels +
-                                [i for l in channel_tree.values() for i in l] + [""], key=len))
+                                [i for l in list(channel_tree.values()) for i in l] + [""], key=len))
 
         log(0, "p = previously imported/synced channel")
         log(0, ". = channel not yet imported/synced")

--- a/backend/cdn_tools/cdnsync.py
+++ b/backend/cdn_tools/cdnsync.py
@@ -19,7 +19,7 @@ import sys
 import fnmatch
 from datetime import datetime, timedelta
 
-from . import constants
+import constants
 from spacewalk.common.rhnConfig import CFG, initCFG, PRODUCT_NAME
 from spacewalk.common import rhnLog
 from spacewalk.server import rhnSQL

--- a/backend/cdn_tools/common.py
+++ b/backend/cdn_tools/common.py
@@ -13,7 +13,7 @@
 #
 
 from spacewalk.common import fileutils
-import constants
+from . import constants
 
 
 def verify_mappings():

--- a/backend/cdn_tools/common.py
+++ b/backend/cdn_tools/common.py
@@ -13,7 +13,7 @@
 #
 
 from spacewalk.common import fileutils
-from . import constants
+import constants
 
 
 def verify_mappings():

--- a/backend/cdn_tools/manifest.py
+++ b/backend/cdn_tools/manifest.py
@@ -14,7 +14,11 @@
 
 import sys
 
-import cStringIO
+try:
+    import io as cStringIO
+except ImportError:
+    import cStringIO
+
 import json
 import zipfile
 import os
@@ -23,7 +27,7 @@ from M2Crypto import X509
 from spacewalk.satellite_tools.syncLib import log2
 from spacewalk.server.rhnServer.satellite_cert import SatelliteCert
 
-import constants
+from . import constants
 
 
 class Manifest(object):

--- a/backend/cdn_tools/manifest.py
+++ b/backend/cdn_tools/manifest.py
@@ -27,7 +27,7 @@ from M2Crypto import X509
 from spacewalk.satellite_tools.syncLib import log2
 from spacewalk.server.rhnServer.satellite_cert import SatelliteCert
 
-from . import constants
+import constants
 
 
 class Manifest(object):

--- a/backend/cdn_tools/repository.py
+++ b/backend/cdn_tools/repository.py
@@ -23,7 +23,7 @@ from spacewalk.satellite_tools.satCerts import verify_certificate_dates
 from spacewalk.satellite_tools.syncLib import log, log2
 from spacewalk.server.importlib.importLib import ContentSource, ContentSourceSsl
 
-import constants
+from . import constants
 
 
 class CdnRepositoryManager(object):
@@ -115,7 +115,7 @@ class CdnRepositoryManager(object):
             cdn_repository.add_ssl_set(ssl_set)
 
         # Add populated repository to tree
-        for cdn_repository in cdn_repositories.values():
+        for cdn_repository in list(cdn_repositories.values()):
             self.repository_tree.add_repository(cdn_repository)
 
     def get_content_sources_regular(self, channel_label, source=False):
@@ -372,7 +372,7 @@ class CdnRepositoryTree(object):
         elif (is_leaf and keys) or (not is_leaf and not keys):
             raise CdnRepositoryNotFoundError()
         step = keys[0]
-        to_check = [x for x in node.keys() if x in self.VARIABLES or x == step]
+        to_check = [x for x in list(node.keys()) if x in self.VARIABLES or x == step]
         # Remove first step in path, create new list
         next_keys = keys[1:]
 

--- a/backend/cdn_tools/repository.py
+++ b/backend/cdn_tools/repository.py
@@ -23,7 +23,7 @@ from spacewalk.satellite_tools.satCerts import verify_certificate_dates
 from spacewalk.satellite_tools.syncLib import log, log2
 from spacewalk.server.importlib.importLib import ContentSource, ContentSourceSsl
 
-from . import constants
+import constants
 
 
 class CdnRepositoryManager(object):

--- a/backend/common/rhnApache.py
+++ b/backend/common/rhnApache.py
@@ -248,7 +248,7 @@ class rhnApache:
             # This has to be here, or else we blow-up.
             return None
         prefix = "x-rhn-auth"
-        tokenKeys = [x for x in headers.keys() if x[:len(prefix)].lower() == prefix]
+        tokenKeys = [x for x in list(headers.keys()) if x[:len(prefix)].lower() == prefix]
         for k in tokenKeys:
             token[k] = headers[k]
 

--- a/backend/common/rhnCache.py
+++ b/backend/common/rhnCache.py
@@ -211,7 +211,7 @@ class ReadLockedFile(LockedFile):
     def get_fd(self, name, _user, _group, _mode):
         if not os.access(self.fname, os.R_OK):
             raise KeyError(name)
-        fd = open(self.fname, "r")
+        fd = open(self.fname, "rb")
 
         fcntl.lockf(fd.fileno(), fcntl.LOCK_SH)
 
@@ -237,7 +237,7 @@ class WriteLockedFile(LockedFile):
 
         # now we have the fd open, lock it
         fcntl.lockf(fd, fcntl.LOCK_EX)
-        return os.fdopen(fd, 'w')
+        return os.fdopen(fd, 'wb')
 
     def close_fd(self):
         # Set the file's mtime if necessary
@@ -358,7 +358,7 @@ class CompressedCache:
                  mode=int('0755', 8)):
         io = self.cache.set_file(name, modified, user, group, mode)
 
-        f = ClosingZipFile('w', io)
+        f = ClosingZipFile('wb', io)
         return f
 
 

--- a/backend/common/rhnCache.py
+++ b/backend/common/rhnCache.py
@@ -377,13 +377,18 @@ class ObjectCache:
         pickled = self.cache.get(name, modified)
 
         try:
+            if sys.version_info[0] >= 3 and isinstance(pickled, str):
+                 pickled = pickled.encode('latin-1')
             return cPickle.loads(pickled)
         except cPickle.UnpicklingError:
             raise_with_tb(KeyError(name), sys.exc_info()[2])
 
     def set(self, name, value, modified=None, user='root', group='root',
             mode=int('0755', 8)):
-        pickled = cPickle.dumps(value, -1)
+        if sys.version_info[0] >= 3:
+            pickled = cPickle.dumps(value, -1).decode('latin-1')
+        else:
+            pickled = cPickle.dumps(value, -1)
         self.cache.set(name, pickled, modified, user, group, mode)
 
     def has_key(self, name, modified=None):

--- a/backend/common/rhnCache.py
+++ b/backend/common/rhnCache.py
@@ -257,12 +257,18 @@ class Cache:
         s = fd.read()
         fd.close()
 
+        if sys.version_info[0] >= 3 and isinstance(s, bytes):
+            s = s.decode('latin-1')
+
         return s
 
     def set(self, name, value, modified=None, user='root', group='root',
             mode=int('0755', 8)):
         fd = self.set_file(name, modified, user, group, mode)
 
+        if sys.version_info[0] >= 3:
+            if isinstance(value, str):
+                value = value.encode('latin-1')
         fd.write(value)
         fd.close()
 

--- a/backend/common/rhnConfig.py
+++ b/backend/common/rhnConfig.py
@@ -176,7 +176,7 @@ class RHNOptions:
             # is going to be () and we need to override it with
             # whatever we're parsing now in the self.__defaults table
             def_dict = {}
-            for k in _dict[()].keys():
+            for k in list(_dict[()].keys()):
                 # we extract just the values and dump the line number
                 # from the (values,linno) tuples which is the hash
                 # value for _dict[()][k]
@@ -212,7 +212,7 @@ class RHNOptions:
         for k, v in vals:
             if v is None:
                 v = ""
-            print("%-20s = %s" % (k, v))
+            print(("%-20s = %s" % (k, v)))
 
     # polymorphic methods
 
@@ -275,7 +275,7 @@ class RHNOptions:
             if comp not in self.__parsedConfig:
                 # No such entry in the config file
                 continue
-            for key, (values, _lineno_) in self.__parsedConfig[comp].items():
+            for key, (values, _lineno_) in list(self.__parsedConfig[comp].items()):
                 # we don't really want to force every item in the
                 # config file to have a default value first. If we do,
                 # uncomment this section
@@ -506,7 +506,7 @@ def getAllComponents(defaultDir=None, compsTree=None):
     if compsTree is None:
         compsTree = getAllComponents_tree(defaultDir)
     l = []
-    for k, v in compsTree.items():
+    for k, v in list(compsTree.items()):
         l.extend(getAllComponents(None, v))
         l.append(k)
     return l
@@ -563,10 +563,10 @@ def runTest():
     print("=============== an erronous lookup example =======================")
     print("testing __getattr__")
     try:
-        print(test_cfg.lkasjdfxxxxxxxxxxxxxx)
+        print((test_cfg.lkasjdfxxxxxxxxxxxxxx))
     except AttributeError:
         e = sys.exc_info()[1]
-        print('Testing: "AttributeError: %s"' % e)
+        print(('Testing: "AttributeError: %s"' % e))
     print("")
     print("=============== the object's merged settings ======================")
     test_cfg.show()
@@ -602,4 +602,4 @@ if __name__ == "__main__":
     if do_list:
         cfg.show()
     else:
-        print(cfg.get(key_arg))
+        print((cfg.get(key_arg)))

--- a/backend/common/rhnException.py
+++ b/backend/common/rhnException.py
@@ -347,7 +347,7 @@ class rhnFault(Exception):
 
         # update the templateValues in the module
         if templateOverrides:
-            for label in templateOverrides.keys():
+            for label in list(templateOverrides.keys()):
                 # only care about values we've defined defaults for...
                 if label in templateValues:
                     templateValues[label] = templateOverrides[label]

--- a/backend/common/rhnLib.py
+++ b/backend/common/rhnLib.py
@@ -64,9 +64,10 @@ def rfc822time(arg):
            be translated to GMT in the return value.
     """
 
+
     if isinstance(arg, (usix.ListType, usix.TupleType)):
         # Convert to float.
-        arg = time.mktime(arg)
+        arg = time.mktime(tuple(arg))
 
     # Now, the arg must be a float.
 
@@ -96,7 +97,7 @@ def timestamp(s):
     timeval = list(time.strptime(s, format_string))
     # No daylight information available
     timeval[8] = -1
-    return time.mktime(timeval)
+    return time.mktime(tuple(timeval))
 
 
 def checkValue(val, *args):

--- a/backend/common/rhnMail.py
+++ b/backend/common/rhnMail.py
@@ -54,9 +54,9 @@ def send(headers, body, sender=None):
     (headers, toaddrs) = __check_headers(headers)
     if sender is None:
         sender = headers["From"]
-    joined_headers = u''
-    for h in headers.keys():
-        joined_headers += u"%s: %s\n" % (h, headers[h])
+    joined_headers = ''
+    for h in list(headers.keys()):
+        joined_headers += "%s: %s\n" % (h, headers[h])
 
     server = smtplib.SMTP('localhost')
     msg = "%s\n%s\n" % (to_string(joined_headers), to_string(body))

--- a/backend/common/rhnRepository.py
+++ b/backend/common/rhnRepository.py
@@ -264,7 +264,7 @@ class Repository(RPC_Base):
                 last_modified = rfc822time(last_modified)
             transport['Last-Modified'] = last_modified
         if extra_headers:
-            for k, v in extra_headers.items():
+            for k, v in list(extra_headers.items()):
                 transport[str(k)] = str(v)
         return transport
 

--- a/backend/common/rhnTB.py
+++ b/backend/common/rhnTB.py
@@ -76,7 +76,7 @@ def print_locals(fd=sys.stderr, tb=None):
         fd.write("Frame %s in %s at line %s\n" % (frame.f_code.co_name,
                                                   frame.f_code.co_filename,
                                                   frame.f_lineno))
-        for key, value in frame.f_locals.items():
+        for key, value in list(frame.f_locals.items()):
             fd.write("\t%20s = " % to_string(key))
             # We have to be careful not to cause a new error in our error
             # printer! Calling str() on an unknown object could cause an

--- a/backend/common/rhnTranslate.py
+++ b/backend/common/rhnTranslate.py
@@ -71,7 +71,7 @@ class i18n:
         return self.cat.getlangs()
 
     def setlangs(self, langs):
-        if isinstance(langs, StringType):
+        if isinstance(langs, StringType) or type(langs) == str:
             langs = [langs]
         # Filter "C" - we will add it ourselves later anyway
         langs = [l for l in langs if l != 'C']

--- a/backend/common/rhn_deb.py
+++ b/backend/common/rhn_deb.py
@@ -73,7 +73,7 @@ class deb_Header:
                                  ('payload_size', 'Installed-Size')]:
                 if deb_k in debcontrol:
                     self.hdr[hdr_k] = debcontrol.get_as_string(deb_k)
-            for k in debcontrol.keys():
+            for k in list(debcontrol.keys()):
                 if k not in self.hdr:
                     self.hdr[k] = debcontrol.get_as_string(k)
 

--- a/backend/common/rhn_mpm.py
+++ b/backend/common/rhn_mpm.py
@@ -304,7 +304,7 @@ def _replace_null(obj):
         return tuple(_replace_null(list(obj)))
     if hasattr(obj, 'items'):
         obj_dict = {}
-        for k, v in obj.items():
+        for k, v in list(obj.items()):
             obj_dict[_replace_null(k)] = _replace_null(v)
         return obj_dict
     return obj

--- a/backend/common/rhn_rpm.py
+++ b/backend/common/rhn_rpm.py
@@ -103,7 +103,7 @@ class RPM_Header:
     def __len__(self):
         return len(self.hdr)
 
-    def __bool__(self):
+    def __nonzero__(self):
         return bool(self.hdr)
 
     __bool__ = __nonzero__

--- a/backend/common/rhn_rpm.py
+++ b/backend/common/rhn_rpm.py
@@ -39,7 +39,7 @@ if not hasattr(tempfile, 'SpooledTemporaryFile'):
 error = rpm.error
 
 sym, val = None, None
-for sym, val in rpm.__dict__.items():
+for sym, val in list(rpm.__dict__.items()):
     if sym[:3] == 'RPM':
         # A constant, probably - import it into our namespace
         globals()[sym] = val
@@ -103,7 +103,7 @@ class RPM_Header:
     def __len__(self):
         return len(self.hdr)
 
-    def __nonzero__(self):
+    def __bool__(self):
         return bool(self.hdr)
 
     __bool__ = __nonzero__
@@ -387,7 +387,7 @@ class MatchIterator:
     def pattern(self, tag_name, mode, pattern):
         self.mi.pattern(tag_name, mode, pattern)
 
-    def next(self):
+    def __next__(self):
         try:
             hdr = usix_next(self.mi)
         except StopIteration:
@@ -462,7 +462,7 @@ def getInstalledHeader(rpmName):
 
     matchiter = MatchIterator("name")
     matchiter.pattern("name", rpm.RPMMIRE_STRCMP, rpmName)
-    return matchiter.next()
+    return next(matchiter)
 
 
 if __name__ == '__main__':

--- a/backend/common/rhn_rpm.py
+++ b/backend/common/rhn_rpm.py
@@ -387,7 +387,7 @@ class MatchIterator:
     def pattern(self, tag_name, mode, pattern):
         self.mi.pattern(tag_name, mode, pattern)
 
-    def __next__(self):
+    def next(self):
         try:
             hdr = usix_next(self.mi)
         except StopIteration:
@@ -462,7 +462,7 @@ def getInstalledHeader(rpmName):
 
     matchiter = MatchIterator("name")
     matchiter.pattern("name", rpm.RPMMIRE_STRCMP, rpmName)
-    return next(matchiter)
+    return matchiter.next()
 
 
 if __name__ == '__main__':

--- a/backend/common/test/unit-test/Makefile
+++ b/backend/common/test/unit-test/Makefile
@@ -7,4 +7,4 @@ all:	$(addprefix test-,$(TESTS))
 
 test-%:
 	@echo Running $*
-	@PYTHONPATH=$(PYTHONPATH):../../.. python $*
+	@PYTHONPATH=$(PYTHONPATH):../../.. $(PYTHON_BIN) $*

--- a/backend/common/test/unit-test/test_gettext.py
+++ b/backend/common/test/unit-test/test_gettext.py
@@ -52,14 +52,14 @@ class Tests(unittest.TestCase):
         lang = "en"
         self._setup(lang)
         langs = rhnTranslate.cat.getlangs()
-        self.failUnless(langs[0] == lang)
+        self.assertTrue(langs[0] == lang)
 
     def test_setlangs_ro(self):
         "Tests setting the language to ro"
         lang = "ro"
         self._setup(lang)
         langs = rhnTranslate.cat.getlangs()
-        self.failUnless(langs[0] == lang)
+        self.assertTrue(langs[0] == lang)
 
     def test_setlangs_go(self):
         """Tests setting the language to go (does not exist)"""
@@ -69,9 +69,9 @@ class Tests(unittest.TestCase):
         if hasattr(sys, "version_info"):
             # On python 1.5.2 we don't really get an idea what the language
             # is, so it's ok to check for the first component
-            self.failIf(langs[0] == lang, "Language is %s" % langs[0])
+            self.assertFalse(langs[0] == lang, "Language is %s" % langs[0])
         else:
-            self.failUnless(langs[0] == lang, "Language is %s" % langs[0])
+            self.assertTrue(langs[0] == lang, "Language is %s" % langs[0])
 
     def test_en_1(self):
         "Tests plain English messages"

--- a/backend/common/test/unit-test/test_rhnCache.py
+++ b/backend/common/test/unit-test/test_rhnCache.py
@@ -52,12 +52,12 @@ class Tests(unittest.TestCase):
         rhnCache.CACHEDIR = '/tmp/rhn'
         self._cleanup(key)
         rhnCache.set(key, content, **modifiers)
-        self.assertTrue(key in rhnCache)
+        self.assertTrue(rhnCache.has_key(key))
         content2 = rhnCache.get(key, **modifiers)
         self.assertEqual(content, content2)
 
         self._cleanup(key)
-        self.assertFalse(key in rhnCache)
+        self.assertFalse(rhnCache.has_key(key))
         return (key, content)
 
     def test_cache_5(self):
@@ -67,7 +67,7 @@ class Tests(unittest.TestCase):
         self._cleanup(self.key)
         rhnCache.set(self.key, content, modified=timestamp)
 
-        self.assertTrue(self.key in rhnCache)
+        self.assertTrue(rhnCache.has_key(self.key))
         self.assertTrue(rhnCache.has_key(self.key, modified=timestamp))
         self.assertFalse(rhnCache.has_key(self.key, modified='20001122112233'))
         self._cleanup(self.key)
@@ -98,10 +98,10 @@ class Tests(unittest.TestCase):
       self._cleanup(self.key)
 
     def _cleanup(self, key):
-        if key in rhnCache:
+        if rhnCache.has_key(key):
             rhnCache.delete(key)
 
-        self.assertFalse(key in rhnCache)
+        self.assertFalse(rhnCache.has_key(key))
 
 if __name__ == '__main__':
     sys.exit(unittest.main() or 0)

--- a/backend/common/test/unit-test/test_rhnCache.py
+++ b/backend/common/test/unit-test/test_rhnCache.py
@@ -52,12 +52,12 @@ class Tests(unittest.TestCase):
         rhnCache.CACHEDIR = '/tmp/rhn'
         self._cleanup(key)
         rhnCache.set(key, content, **modifiers)
-        self.failUnless(rhnCache.has_key(key))
+        self.assertTrue(key in rhnCache)
         content2 = rhnCache.get(key, **modifiers)
         self.assertEqual(content, content2)
 
         self._cleanup(key)
-        self.failIf(rhnCache.has_key(key))
+        self.assertFalse(key in rhnCache)
         return (key, content)
 
     def test_cache_5(self):
@@ -67,9 +67,9 @@ class Tests(unittest.TestCase):
         self._cleanup(self.key)
         rhnCache.set(self.key, content, modified=timestamp)
 
-        self.failUnless(rhnCache.has_key(self.key))
-        self.failUnless(rhnCache.has_key(self.key, modified=timestamp))
-        self.failIf(rhnCache.has_key(self.key, modified='20001122112233'))
+        self.assertTrue(self.key in rhnCache)
+        self.assertTrue(rhnCache.has_key(self.key, modified=timestamp))
+        self.assertFalse(rhnCache.has_key(self.key, modified='20001122112233'))
         self._cleanup(self.key)
 
     def test_missing_1(self):
@@ -98,10 +98,10 @@ class Tests(unittest.TestCase):
       self._cleanup(self.key)
 
     def _cleanup(self, key):
-        if rhnCache.has_key(key):
+        if key in rhnCache:
             rhnCache.delete(key)
 
-        self.failIf(rhnCache.has_key(key))
+        self.assertFalse(key in rhnCache)
 
 if __name__ == '__main__':
     sys.exit(unittest.main() or 0)

--- a/backend/common/test/unit-test/test_rhnLib.py
+++ b/backend/common/test/unit-test/test_rhnLib.py
@@ -63,17 +63,17 @@ class Tests(unittest.TestCase):
         self.assertEqual(result, target, result + " != " + target)
 
     def testParseUrl(self):
-        self.assertEquals(('', '', '', '', '', ''),
+        self.assertEqual(('', '', '', '', '', ''),
                           rhnLib.parseUrl(''))
-        self.assertEquals(('', 'somehostname', '', '', '', ''),
+        self.assertEqual(('', 'somehostname', '', '', '', ''),
                           rhnLib.parseUrl('somehostname'))
-        self.assertEquals(('http', 'somehostname', '', '', '', ''),
+        self.assertEqual(('http', 'somehostname', '', '', '', ''),
                           rhnLib.parseUrl('http://somehostname'))
-        self.assertEquals(('https', 'somehostname', '', '', '', ''),
+        self.assertEqual(('https', 'somehostname', '', '', '', ''),
                           rhnLib.parseUrl('https://somehostname'))
-        self.assertEquals(('https', 'somehostname:123', '', '', '', ''),
+        self.assertEqual(('https', 'somehostname:123', '', '', '', ''),
                           rhnLib.parseUrl('https://somehostname:123'))
-        self.assertEquals(('https', 'somehostname:123', '/ABCDE', '', '', ''),
+        self.assertEqual(('https', 'somehostname:123', '/ABCDE', '', '', ''),
                           rhnLib.parseUrl('https://somehostname:123/ABCDE'))
 
 if __name__ == '__main__':

--- a/backend/common/test/unit-test/test_rhnLib.py
+++ b/backend/common/test/unit-test/test_rhnLib.py
@@ -33,14 +33,14 @@ class Tests(unittest.TestCase):
 
     def test_rfc822time_normal_tuple(self):
         "rfc822time: Simple call using a valid tuple argument."
-        test_arg = (2006, 1, 27, (14 - TIMEZONE_SHIFT), 12, 5, 4, 27, -1)
+        test_arg = (2006, 1, 27, int(14 - TIMEZONE_SHIFT), 12, 5, 4, 27, -1)
         target = "Fri, 27 Jan 2006 14:12:05 GMT"
         result = rhnLib.rfc822time(test_arg)
         self.assertEqual(result, target, result + " != " + target)
 
     def test_rfc822time_normal_list(self):
         "rfc822time: Simple call using a valid list argument."
-        test_arg = [2006, 1, 27, (14 - TIMEZONE_SHIFT), 12, 5, 4, 27, -1]
+        test_arg = [2006, 1, 27, int(14 - TIMEZONE_SHIFT), 12, 5, 4, 27, -1]
         target = "Fri, 27 Jan 2006 14:12:05 GMT"
         result = rhnLib.rfc822time(test_arg)
         self.assertEqual(result, target, result + " != " + target)

--- a/backend/common/timezone_utils.py
+++ b/backend/common/timezone_utils.py
@@ -33,4 +33,4 @@ def get_utc_offset():
 
 
 if __name__ == "__main__":
-    print "UTC offset (allowing for DST if in effect): %s" % get_utc_offset()
+    print("UTC offset (allowing for DST if in effect): %s" % get_utc_offset())

--- a/backend/db-checker.py
+++ b/backend/db-checker.py
@@ -38,14 +38,14 @@ def main():
     g = globals()
 
     for module_name in args:
-        print("Checking module %s" % module_name)
+        print(("Checking module %s" % module_name))
         pmn = proper_module_name(module_name)
         try:
             m = __import__(pmn)
             g[module_name] = m
         except ImportError:
             e = sys.exc_info()[1]
-            print("Unable to import module %s: %s" % (module_name, e))
+            print(("Unable to import module %s: %s" % (module_name, e)))
             continue
 
         comps = pmn.split('.')
@@ -57,7 +57,7 @@ def main():
                 rhnSQL.prepare(statement)
             except rhnSQL.SQLStatementPrepareError:
                 e = sys.exc_info()[1]
-                print("Error: %s.%s: %s" % (mod.__name__, name, e))
+                print(("Error: %s.%s: %s" % (mod.__name__, name, e)))
 
 
 def proper_module_name(module_name):
@@ -78,7 +78,7 @@ def get_class_instances(obj, class_obj):
         return []
     _objs_seen[id_obj] = None
     result = []
-    for k, v in obj.__dict__.items():
+    for k, v in list(obj.__dict__.items()):
         if isinstance(v, class_obj):
             result.append((obj, k, v))
         elif isinstance(v, usix.ClassType):

--- a/backend/satellite_exporter/handlers/non_auth_dumper.py
+++ b/backend/satellite_exporter/handlers/non_auth_dumper.py
@@ -132,7 +132,7 @@ class NonAuthenticatedDumper(rhnHandler, dumper.XML_Dumper):
             # No compression
             self.compress_level = 0
             self._raw_stream.content_type = 'text/xml'
-        for h, v in self.headers_out.items():
+        for h, v in list(self.headers_out.items()):
             self._raw_stream.headers_out[h] = str(v)
         self._raw_stream.send_http_header()
         # If need be, start gzipping
@@ -571,7 +571,7 @@ class NonAuthenticatedDumper(rhnHandler, dumper.XML_Dumper):
 
         self.headers_out['Content-Length'] = len(s)
         self._raw_stream.content_type = 'text/xml'
-        for h, v in self.headers_out.items():
+        for h, v in list(self.headers_out.items()):
             self._raw_stream.headers_out[h] = str(v)
         self._raw_stream.send_http_header()
         self._raw_stream.write(s)

--- a/backend/satellite_tools/diskImportLib.py
+++ b/backend/satellite_tools/diskImportLib.py
@@ -18,7 +18,7 @@
 
 import os
 
-import xmlSource
+from . import xmlSource
 from spacewalk.common.rhnLib import hash_object_id
 from spacewalk.server.importlib.backendOracle import SQLBackend
 from spacewalk.server.importlib.channelImport import ChannelImport, ChannelFamilyImport

--- a/backend/satellite_tools/diskImportLib.py
+++ b/backend/satellite_tools/diskImportLib.py
@@ -18,7 +18,7 @@
 
 import os
 
-from . import xmlSource
+import xmlSource
 from spacewalk.common.rhnLib import hash_object_id
 from spacewalk.server.importlib.backendOracle import SQLBackend
 from spacewalk.server.importlib.channelImport import ChannelImport, ChannelFamilyImport

--- a/backend/satellite_tools/disk_dumper/dumper.py
+++ b/backend/satellite_tools/disk_dumper/dumper.py
@@ -32,7 +32,7 @@ from spacewalk.common.rhnException import rhnFault
 from spacewalk.server import rhnSQL
 from spacewalk.satellite_tools import constants
 from spacewalk.satellite_tools.exporter import exportLib, xmlWriter
-from string_buffer import StringBuffer
+from .string_buffer import StringBuffer
 
 
 class XML_Dumper:

--- a/backend/satellite_tools/disk_dumper/iss.py
+++ b/backend/satellite_tools/disk_dumper/iss.py
@@ -26,7 +26,7 @@ try:
 except ImportError:
     #  python3
     import io as cStringIO
-import dumper
+from . import dumper
 from spacewalk.common.usix import raise_with_tb
 from spacewalk.common import rhnMail
 from spacewalk.common.rhnConfig import CFG, initCFG
@@ -37,9 +37,9 @@ from spacewalk.server.rhnSQL import SQLError, SQLSchemaError, SQLConnectError
 from spacewalk.satellite_tools.exporter import xmlWriter
 from spacewalk.satellite_tools import xmlDiskSource, diskImportLib, progress_bar
 from spacewalk.satellite_tools.syncLib import initEMAIL_LOG, dumpEMAIL_LOG, log2email, log2stderr, log2stdout
-from iss_ui import UI
-from iss_actions import ActionDeps
-import iss_isos
+from .iss_ui import UI
+from .iss_actions import ActionDeps
+from . import iss_isos
 
 t = gettext.translation('spacewalk-backend-server', fallback=True)
 _ = t.ugettext
@@ -302,7 +302,7 @@ class Dumper(dumper.XML_Dumper):
             # "incremental" dumps. So we will gather list of channel ids for channels already
             # in dump.
             channel_labels_for_families = self.fm.filemap['channels'].list()
-            print("Appending channels %s" % (channel_labels_for_families))
+            print(("Appending channels %s" % (channel_labels_for_families)))
             for ids in channel_labels_for_families:
                 ch_data.execute(label=ids)
                 ch_info = ch_data.fetchall_dict()
@@ -1269,8 +1269,8 @@ class ExporterMain:
                 self.end_date = self.options.end_date.ljust(14, '0')
 
             self.start_date = self.options.start_date.ljust(14, '0')
-            print("start date limit: %s" % self.start_date)
-            print("end date limit: %s" % self.end_date)
+            print(("start date limit: %s" % self.start_date))
+            print(("end date limit: %s" % self.end_date))
         else:
             self.start_date = None
             self.end_date = None
@@ -1390,10 +1390,10 @@ class ExporterMain:
             child_template = "C\t%s"
 
             # Print channel information.
-            for pc in channel_dict.keys():
-                print(base_template % (pc,))
+            for pc in list(channel_dict.keys()):
+                print((base_template % (pc,)))
                 for cc in channel_dict[pc]:
-                    print(child_template % (cc,))
+                    print((child_template % (cc,)))
                 print(" ")
         else:
             print("No Channels available for listing.")
@@ -1416,7 +1416,7 @@ class ExporterMain:
         if orgs:
             print("Orgs available for export:")
             for org in orgs:
-                print("Id: %s, Name: \'%s\'" % (org['id'], org['name']))
+                print(("Id: %s, Name: \'%s\'" % (org['id'], org['name'])))
         else:
             print("No Orgs available for listing.")
 

--- a/backend/satellite_tools/disk_dumper/iss.py
+++ b/backend/satellite_tools/disk_dumper/iss.py
@@ -26,7 +26,7 @@ try:
 except ImportError:
     #  python3
     import io as cStringIO
-from . import dumper
+import dumper
 from spacewalk.common.usix import raise_with_tb
 from spacewalk.common import rhnMail
 from spacewalk.common.rhnConfig import CFG, initCFG
@@ -39,7 +39,7 @@ from spacewalk.satellite_tools import xmlDiskSource, diskImportLib, progress_bar
 from spacewalk.satellite_tools.syncLib import initEMAIL_LOG, dumpEMAIL_LOG, log2email, log2stderr, log2stdout
 from .iss_ui import UI
 from .iss_actions import ActionDeps
-from . import iss_isos
+import iss_isos
 
 t = gettext.translation('spacewalk-backend-server', fallback=True)
 _ = t.ugettext

--- a/backend/satellite_tools/disk_dumper/iss_actions.py
+++ b/backend/satellite_tools/disk_dumper/iss_actions.py
@@ -15,7 +15,7 @@
 
 import sys
 
-from . import iss_ui
+import iss_ui
 
 
 class ActionDeps:

--- a/backend/satellite_tools/disk_dumper/iss_actions.py
+++ b/backend/satellite_tools/disk_dumper/iss_actions.py
@@ -15,7 +15,7 @@
 
 import sys
 
-import iss_ui
+from . import iss_ui
 
 
 class ActionDeps:
@@ -148,4 +148,4 @@ class ActionDeps:
 if __name__ == "__main__":
     a = iss_ui.UI()
     b = ActionDeps(a)
-    print(b.get_actions())
+    print((b.get_actions()))

--- a/backend/satellite_tools/disk_dumper/iss_ui.py
+++ b/backend/satellite_tools/disk_dumper/iss_ui.py
@@ -88,11 +88,11 @@ class UI:
         if self.options.verbose and not self.options.debug_level:
             self.options.debug_level = 3
 
-        for i in self.options.__dict__.keys():
+        for i in list(self.options.__dict__.keys()):
             if i not in self.__dict__:
                 self.__dict__[i] = self.options.__dict__[i]
 
 if __name__ == "__main__":
     # pylint: disable=E1101
     a = UI()
-    print(str(a.no_errata))
+    print((str(a.no_errata)))

--- a/backend/satellite_tools/download.py
+++ b/backend/satellite_tools/download.py
@@ -17,15 +17,17 @@ import os
 import sys
 import re
 import time
-from Queue import Queue, Empty
 from threading import Thread, Lock
 try:
     #  python 2
     import urlparse
+    from Queue import Queue, Empty
+    from urllib import quote
 except ImportError:
     #  python3
     import urllib.parse as urlparse # pylint: disable=F0401,E0611
-from urllib import quote
+    from queue import Queue, Empty
+    from urllib.parse import quote
 import pycurl
 from urlgrabber.grabber import URLGrabberOptions, PyCurlFileObject, URLGrabError
 from spacewalk.common.checksum import getFileChecksum
@@ -309,7 +311,7 @@ class ThreadedDownloader:
 
     def run(self):
         size = 0
-        for queue in self.queues.values():
+        for queue in list(self.queues.values()):
             size += queue.qsize()
         if size <= 0:
             return

--- a/backend/satellite_tools/exporter/xmlWriter.py
+++ b/backend/satellite_tools/exporter/xmlWriter.py
@@ -62,7 +62,7 @@ class XMLWriter:
         self.data(name)
         # Dump the attributes, if any
         if attributes:
-            for k, v in attributes.items():
+            for k, v in list(attributes.items()):
                 self.stream.write(" ")
                 self.data(k)
                 self.stream.write('="')

--- a/backend/satellite_tools/geniso.py
+++ b/backend/satellite_tools/geniso.py
@@ -52,8 +52,8 @@ def main(arglist):
 
     # Check to see if mkisofs is installed
     if not os.path.exists('/usr/bin/mkisofs'):
-        print("ERROR:: mkisofs is not Installed. Cannot Proceed iso build. " \
-              + "Please install mkisofs and rerun this command.")
+        print(("ERROR:: mkisofs is not Installed. Cannot Proceed iso build. " \
+              + "Please install mkisofs and rerun this command."))
         return
 
     mountPoint = options.mountpoint or MOUNT_POINT
@@ -64,7 +64,7 @@ def main(arglist):
         sizeStr = options.size or IMAGE_SIZE
     imageSize = sizeStrToInt(sizeStr)
     if imageSize == 0:
-        print("Unknown size %s" % sizeStr)
+        print(("Unknown size %s" % sizeStr))
         return
 
     if options.version is None:
@@ -116,7 +116,7 @@ def main(arglist):
     mkisofsTemplate = "mkisofs -r -J -D -file-mode 0444 -new-dir-mode 0555 -dir-mode 0555 " \
         + "-graft-points %s -o %s /DISK_%s_OF_%s=%s"
     for i in range(cdcount):
-        print("---------- %s/%s" % (i + 1, cdcount))
+        print(("---------- %s/%s" % (i + 1, cdcount)))
 
         # if options.type is None:
         filename = "%s/%s-%s.%s-%02d.iso" % (options.output, file_prefix,
@@ -158,19 +158,19 @@ def main(arglist):
             os.write(pathfiles_fd, "\n")
         os.close(pathfiles_fd)
 
-        print("Creating %s" % filename)
+        print(("Creating %s" % filename))
         # And run it
         fd = os.popen(cmd, "r")
-        print(fd.read())
+        print((fd.read()))
 
         if options.copy_iso_dir is not None:
             copy_iso_path = os.path.join(options.copy_iso_dir, os.path.basename(os.path.dirname(filename)))
             if not os.path.exists(copy_iso_path):
                 os.mkdir(copy_iso_path)
             fd = os.popen("mv %s %s" % (filename, copy_iso_path), "r")
-            print(fd.read())
+            print((fd.read()))
             fd = os.popen("rm %s" % filename)
-            print(fd.read())
+            print((fd.read()))
 
         # Remove the temp file
         os.unlink(pathfiles)

--- a/backend/satellite_tools/repo_plugins/__init__.py
+++ b/backend/satellite_tools/repo_plugins/__init__.py
@@ -12,6 +12,7 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
+from __future__ import unicode_literals
 
 import re
 import rpm

--- a/backend/satellite_tools/repo_plugins/deb_src.py
+++ b/backend/satellite_tools/repo_plugins/deb_src.py
@@ -12,6 +12,7 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
+from __future__ import unicode_literals
 
 import sys
 import os.path

--- a/backend/satellite_tools/repo_plugins/deb_src.py
+++ b/backend/satellite_tools/repo_plugins/deb_src.py
@@ -96,7 +96,7 @@ class DebRepo(object):
                         fd.close()
                 return filename
             except requests.exceptions.RequestException:
-                print "ERROR: requests.exceptions.RequestException occured"
+                print("ERROR: requests.exceptions.RequestException occured")
                 time.sleep(RETRY_DELAY)
 
         return ''

--- a/backend/satellite_tools/repo_plugins/uln_src.py
+++ b/backend/satellite_tools/repo_plugins/uln_src.py
@@ -56,9 +56,9 @@ class ContentSource(yum_ContentSource):
         self.uln_user = self.yumbase.conf.username
         self.uln_pass = self.yumbase.conf.password
         self.url = self.uln_url + "/XMLRPC/GET-REQ/" + label
-        print("The download URL is: " + self.url)
+        print(("The download URL is: " + self.url))
         if self.proxy_addr:
-            print("Trying proxy " + self.proxy_addr)
+            print(("Trying proxy " + self.proxy_addr))
         slist = ServerList([self.uln_url+"/rpc/api",])
         s = RetryServer(slist.server(),
                         refreshCallback=None,

--- a/backend/satellite_tools/repo_plugins/uln_src.py
+++ b/backend/satellite_tools/repo_plugins/uln_src.py
@@ -18,6 +18,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 
 ULN plugin for spacewalk-repo-sync.
 """
+from __future__ import unicode_literals
+
 # pylint: disable=E0012, C0413
 import sys
 sys.path.append('/usr/share/rhn')

--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -13,6 +13,7 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
+from __future__ import unicode_literals
 
 import subprocess
 import sys

--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -22,7 +22,10 @@ import time
 import traceback
 import base64
 from datetime import datetime
-from HTMLParser import HTMLParser
+try:
+    from html.parser import HTMLParser
+except ImportError:
+    from HTMLParser import HTMLParser
 from dateutil.parser import parse as parse_date
 from xml.dom import minidom
 import gzip
@@ -52,7 +55,7 @@ from spacewalk.satellite_tools.repo_plugins import CACHE_DIR
 from spacewalk.server import taskomatic, rhnPackageUpload
 from spacewalk.satellite_tools.satCerts import verify_certificate_dates
 
-from syncLib import log, log2, log2disk, dumpEMAIL_LOG, log2background
+from .syncLib import log, log2, log2disk, dumpEMAIL_LOG, log2background
 
 translation = gettext.translation('spacewalk-backend-server', fallback=True)
 _ = translation.ugettext
@@ -101,7 +104,7 @@ def send_mail(sync_type="Repo"):
     """ Send email summary """
     body = dumpEMAIL_LOG()
     if body:
-        print(_("+++ sending log as an email +++"))
+        print((_("+++ sending log as an email +++")))
         host_label = idn_puny_to_unicode(os.uname()[1])
         headers = {
             'Subject': _("%s sync. report from %s") % (sync_type, host_label),
@@ -111,7 +114,7 @@ def send_mail(sync_type="Repo"):
             sndr = CFG.default_mail_from
         rhnMail.send(headers, body, sender=sndr)
     else:
-        print(_("+++ email requested, but there is nothing to send +++"))
+        print((_("+++ email requested, but there is nothing to send +++")))
 
 
 class KSDirParser:
@@ -577,26 +580,26 @@ class RepoSync(object):
                         self.import_products(plugin)
                         self.import_susedata(plugin)
 
-                except rhnSQL.SQLError, e:
+                except rhnSQL.SQLError as e:
                     log(0, "SQLError: %s" % e)
                     raise
-                except ChannelTimeoutException, e:
+                except ChannelTimeoutException as e:
                     log(0, e)
                     self.sendErrorMail(str(e))
                     sync_error = -1
-                except ChannelException, e:
+                except ChannelException as e:
                     log(0, "ChannelException: %s" % e)
                     self.sendErrorMail("ChannelException: %s" % str(e))
                     sync_error = -1
-                except Errors.YumGPGCheckError, e:
+                except Errors.YumGPGCheckError as e:
                     log(0, "YumGPGCheckError: %s" % e)
                     self.sendErrorMail("YumGPGCheckError: %s" % e)
                     sync_error = -1
-                except Errors.RepoError, e:
+                except Errors.RepoError as e:
                     log(0, "RepoError: %s" % e)
                     self.sendErrorMail("RepoError: %s" % e)
                     sync_error = -1
-                except Errors.RepoMDError, e:
+                except Errors.RepoMDError as e:
                     if "primary not available" in str(e):
                         taskomatic.add_to_repodata_queue_for_channel_package_subscription(
                             [self.channel_label], [], "server.app.yumreposync")
@@ -1303,7 +1306,7 @@ class RepoSync(object):
             ret = parse_date(date)
             try:
                 ret = ret.astimezone(tzutc())
-            except ValueError, e:
+            except ValueError as e:
                 log(2, e)
         return ret.isoformat(' ')[:19]  # return 1st 19 letters of date, therefore preventing ORA-01830 caused by fractions of seconds
 
@@ -1884,12 +1887,12 @@ class RepoSync(object):
             """)
             query.execute(**product)
             row = query.fetchone_dict()
-            if not row or not row.has_key('id'):
+            if not row or 'id' not in row:
                 get_id_q = rhnSQL.prepare("""SELECT sequence_nextval('suse_prod_file_id_seq') as id FROM dual""")
                 get_id_q.execute()
                 row = get_id_q.fetchone_dict() or {}
-                if not row or not row.has_key('id'):
-                    print "no id for sequence suse_prod_file_id_seq"
+                if not row or 'id' not in row:
+                    print("no id for sequence suse_prod_file_id_seq")
                     continue
 
                 h = rhnSQL.prepare("""
@@ -1925,7 +1928,7 @@ class RepoSync(object):
 
             query.execute(**params)
             packrow = query.fetchone_dict()
-            if not packrow or not packrow.has_key('id'):
+            if not packrow or 'id' not in packrow:
                 # package not in DB
                 continue
 
@@ -1960,7 +1963,7 @@ class RepoSync(object):
                           arch=package['arch'], pkgid=package['pkgid'],
                           channel_id=int(self.channel['id']))
             row = query.fetchone_dict() or None
-            if not row or not row.has_key('id'):
+            if not row or 'id' not in row:
                 # package not found in DB
                 continue
             pkgid = int(row['id'])
@@ -1998,7 +2001,7 @@ class RepoSync(object):
                     kadd.execute(package_id=pkgid, channel_id=int(self.channel['id']), keyword_id=kwcache[keyword])
                     self.regen = True
 
-            if package.has_key('eula'):
+            if 'eula' in package:
                 eula_id = suseEula.find_or_create_eula(package['eula'])
                 rhnPackage.add_eula_to_package(
                   package_id=pkgid,
@@ -2214,7 +2217,7 @@ class RepoSync(object):
                                   'summary': bz['title'] or ("Bug %s" % bz['id']),
                                   'href': bz['href']})
                     bugs[bz['id']] = bug
-        return bugs.values()
+        return list(bugs.values())
 
     @staticmethod
     def _update_cve(notice):
@@ -2292,7 +2295,7 @@ class RepoSync(object):
              WHERE errata_id = :errata_id
         """)
         h.execute(errata_id=errata_id)
-        channels = map(lambda x: x['channel_id'], h.fetchall_dict() or [])
+        channels = [x['channel_id'] for x in h.fetchall_dict() or []]
 
         # delete channel from errata
         h = rhnSQL.prepare("""

--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -13,6 +13,8 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
+from __future__ import unicode_literals
+
 import os
 import re
 import shutil

--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -13,7 +13,6 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-from __future__ import unicode_literals
 
 import os
 import re

--- a/backend/satellite_tools/req_channels.py
+++ b/backend/satellite_tools/req_channels.py
@@ -100,7 +100,7 @@ class RequestedChannels:
 
     def _print_values(self):
         for name in self.__lists:
-            print("Contents of %s: %s" % (name, getattr(self, name)))
+            print(("Contents of %s: %s" % (name, getattr(self, name))))
         return self
 
     def compute(self):
@@ -125,7 +125,7 @@ class RequestedChannels:
             # Typo
             self._typos.append(c)
 
-        for c in available.keys():
+        for c in list(available.keys()):
             if c in imported:
                 # Available, already imported
                 del imported[c]
@@ -170,14 +170,14 @@ class Method:
 
 
 def _verify_expectations(c, expectations):
-    for k, expected in expectations.items():
+    for k, expected in list(expectations.items()):
         method_name = 'get' + k
         val = getattr(c, method_name)()
         if val == expected:
-            print("ok: %s = %s" % (method_name, expected))
+            print(("ok: %s = %s" % (method_name, expected)))
         else:
-            print("FAILED: %s: expected %s, got %s" % (method_name, expected,
-                                                       val))
+            print(("FAILED: %s: expected %s, got %s" % (method_name, expected,
+                                                       val)))
 
 
 def test1(requested, available, imported, expectations):

--- a/backend/satellite_tools/rhn_satellite_activate.py
+++ b/backend/satellite_tools/rhn_satellite_activate.py
@@ -92,12 +92,12 @@ def getCertChecksumString(sat_cert):
     for field in sat_cert.fields_scalar:
         tree[field] = getattr(sat_cert, field)
     # List attributes of sat_cert
-    for name, value in sat_cert.fields_list.items():
+    for name, value in list(sat_cert.fields_list.items()):
         field = value.attribute_name
         tree[name] = []
         for item in getattr(sat_cert, field):
             attributes = {}
-            for k, v in item.attributes.items():
+            for k, v in list(item.attributes.items()):
                 attr = getattr(item, v)
                 if attr != "":
                     attributes[k] = attr
@@ -106,7 +106,7 @@ def getCertChecksumString(sat_cert):
     # Create string from tree
     for key in sorted(tree):
         if isinstance(tree[key], list):
-            for item in sorted(tree[key], key=lambda item: "".join(sorted(item.keys() + item.values()))):
+            for item in sorted(tree[key], key=lambda item: "".join(sorted(list(item.keys()) + list(item.values())))):
                 line = "%s" % key
                 for attribute in sorted(item):
                     line += "-%s-%s" % (attribute, item[attribute])
@@ -193,14 +193,14 @@ def storeRhsmManifest(options):
     if options.manifest and options.manifest != DEFAULT_RHSM_MANIFEST_LOCATION:
         try:
             manifest = open(os.path.abspath(os.path.expanduser(options.manifest)), 'rb').read()
-        except (IOError, OSError), e:
+        except (IOError, OSError) as e:
             msg = _('"%s" (specified in commandline)\n'
                     'could not be opened and read:\n%s') % (options.manifest, str(e))
             writeError(msg)
             raise
         try:
             writeRhsmManifest(options, manifest)
-        except (IOError, OSError), e:
+        except (IOError, OSError) as e:
             msg = _('"%s" could not be opened\nand/or written to:\n%s') % (
                 DEFAULT_RHSM_MANIFEST_LOCATION, str(e))
             writeError(msg)
@@ -425,20 +425,20 @@ def main():
     # Handle RHSM manifest
     try:
         cdn_activate = cdn_activation.Activation(options.manifest)
-    except CdnMappingsLoadError, e:
+    except CdnMappingsLoadError as e:
         writeError(e)
         return 15
-    except MissingSatelliteCertificateError, e:
+    except MissingSatelliteCertificateError as e:
         writeError(e)
         return 13
-    except IncorrectEntitlementsFileFormatError, e:
+    except IncorrectEntitlementsFileFormatError as e:
         writeError(e)
         return 18
 
     # general sanity/GPG check
     try:
         validateSatCert(cdn_activate.manifest.get_satellite_certificate())
-    except RHNCertGeneralSanityException, e:
+    except RHNCertGeneralSanityException as e:
         writeError(e)
         return 10
 

--- a/backend/satellite_tools/rhn_ssl_dbstore.py
+++ b/backend/satellite_tools/rhn_ssl_dbstore.py
@@ -20,7 +20,7 @@ from optparse import Option, OptionParser
 from spacewalk.common import rhnTB
 from spacewalk.server import rhnSQL
 
-import satCerts
+from . import satCerts
 
 DEFAULT_TRUSTED_CERT = 'RHN-ORG-TRUSTED-SSL-CERT'
 
@@ -61,7 +61,7 @@ ERROR: there was a problem trying to initialize the database:
         sys.exit(11)
 
     if values.verbose:
-        print('Public CA SSL certificate:  %s' % values.ca_cert)
+        print(('Public CA SSL certificate:  %s' % values.ca_cert))
 
     return values
 

--- a/backend/satellite_tools/rhn_ssl_dbstore.py
+++ b/backend/satellite_tools/rhn_ssl_dbstore.py
@@ -20,7 +20,7 @@ from optparse import Option, OptionParser
 from spacewalk.common import rhnTB
 from spacewalk.server import rhnSQL
 
-from . import satCerts
+import satCerts
 
 DEFAULT_TRUSTED_CERT = 'RHN-ORG-TRUSTED-SSL-CERT'
 

--- a/backend/satellite_tools/satCerts.py
+++ b/backend/satellite_tools/satCerts.py
@@ -133,7 +133,7 @@ def _insertPrep_rhnCryptoKey(rhn_cryptokey_id, description, org_id):
     #       do so if the row does not exist.
     #       bugzilla: 120297 - and no I don't like it.
     rhn_cryptokey_id_seq = rhnSQL.Sequence('rhn_cryptokey_id_seq')
-    rhn_cryptokey_id = rhn_cryptokey_id_seq.next()
+    rhn_cryptokey_id = next(rhn_cryptokey_id_seq)
     # print 'no cert found, new one with id:', rhn_cryptokey_id
     h = rhnSQL.prepare(_queryInsertCryptoCertInfo)
     # ...insert

--- a/backend/satellite_tools/satComputePkgHeaders.py
+++ b/backend/satellite_tools/satComputePkgHeaders.py
@@ -107,7 +107,7 @@ class Runner:
         package_ids = {}
 
         h = rhnSQL.prepare(self._query_get_packages)
-        for channel_id in self._channels_hash.values():
+        for channel_id in list(self._channels_hash.values()):
             h.execute(channel_id=channel_id)
             while 1:
                 row = h.fetchone_dict()
@@ -140,7 +140,7 @@ class Runner:
             print("Bailing out because of packages shared with other channels")
             for package_id in orphaned_packages:
                 channels = self._channel_packages[package_id]
-                print(package_id, channels)
+                print((package_id, channels))
             return None
 
         return package_ids
@@ -190,18 +190,18 @@ class Runner:
         if not package_ids:
             return
         h = rhnSQL.prepare(self._query_add_package_header_values)
-        for package_id, (path, header_start, header_end) in package_ids.items():
+        for package_id, (path, header_start, header_end) in list(package_ids.items()):
             try:
                 p_file = file(self.options.prefix + "/" + path, 'r')
             except IOError:
-                print("Error opening file %s" % path)
+                print(("Error opening file %s" % path))
                 continue
 
             try:
                 (header_start, header_end) = rhn_rpm.get_header_byte_range(p_file)
             except InvalidPackageError:
                 e = sys.exc_info()[1]
-                print("Error reading header size from file %s: %s" % (path, e))
+                print(("Error reading header size from file %s: %s" % (path, e)))
 
             try:
                 h.execute(package_id=package_id, header_start=header_start, header_end=header_end)
@@ -216,7 +216,7 @@ class Runner:
             return
 
         template = "update rhnPackage set header_start=%s and header_end=%s where id = %s;\n"
-        for package_id, (_path, header_start, header_end) in package_ids.items():
+        for package_id, (_path, header_start, header_end) in list(package_ids.items()):
             s = template % (header_start, header_end, package_id)
             f.write(s)
         f.write("commit;\n")

--- a/backend/satellite_tools/satsync.py
+++ b/backend/satellite_tools/satsync.py
@@ -52,8 +52,8 @@ from spacewalk.server.rhnLib import get_package_path
 from spacewalk.common import fileutils
 
 # __rhn sync/import imports__
-from . import xmlWireSource
-from . import xmlDiskSource
+import xmlWireSource
+import xmlDiskSource
 from .progress_bar import ProgressBar
 from .xmlSource import FatalParseException, ParseException
 from .diskImportLib import rpmsPath
@@ -70,11 +70,11 @@ from spacewalk.server.importlib.importLib import InvalidChannelFamilyError
 from spacewalk.server.importlib.importLib import MissingParentChannelError
 from spacewalk.server.importlib.importLib import get_nevra, get_nevra_dict
 
-from . import satCerts
-from . import req_channels
-from . import messages
-from . import sync_handlers
-from . import constants
+import satCerts
+import req_channels
+import messages
+import sync_handlers
+import constants
 
 translation = gettext.translation('spacewalk-backend-server', fallback=True)
 _ = translation.ugettext

--- a/backend/satellite_tools/syncCache.py
+++ b/backend/satellite_tools/syncCache.py
@@ -104,4 +104,4 @@ if __name__ == '__main__':
     c = PackageCache()
     pid = 'package-12345'
     c.cache_set(pid, {'a': 1, 'b': 2})
-    print(c.cache_get(pid))
+    print((c.cache_get(pid)))

--- a/backend/satellite_tools/syncLib.py
+++ b/backend/satellite_tools/syncLib.py
@@ -32,7 +32,7 @@ from spacewalk.common.rhnConfig import CFG
 from spacewalk.common.rhnLog import log_time, log_clean
 from spacewalk.common.fileutils import createPath, setPermsPath
 
-import messages
+from . import messages
 
 EMAIL_LOG = None
 

--- a/backend/satellite_tools/syncLib.py
+++ b/backend/satellite_tools/syncLib.py
@@ -32,7 +32,7 @@ from spacewalk.common.rhnConfig import CFG
 from spacewalk.common.rhnLog import log_time, log_clean
 from spacewalk.common.fileutils import createPath, setPermsPath
 
-from . import messages
+import messages
 
 EMAIL_LOG = None
 

--- a/backend/satellite_tools/syncLib.py
+++ b/backend/satellite_tools/syncLib.py
@@ -12,6 +12,7 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
+from __future__ import unicode_literals
 
 # system imports:
 import os

--- a/backend/satellite_tools/sync_handlers.py
+++ b/backend/satellite_tools/sync_handlers.py
@@ -20,10 +20,10 @@ from spacewalk.common import usix
 from spacewalk.server.importlib import channelImport, packageImport, errataImport, \
     kickstartImport
 from spacewalk.common.usix import raise_with_tb
-import diskImportLib
-import xmlSource
-import syncCache
-import syncLib
+from . import diskImportLib
+from . import xmlSource
+from . import syncCache
+from . import syncLib
 
 DEFAULT_ORG = 1
 
@@ -238,14 +238,14 @@ def import_channels(channels, orgid=None, master=None):
                 c_obj['org_id'] = org_map[c_obj['org_id']]
             else:
                 c_obj['org_id'] = orgid
-                if c_obj.has_key('trust_list'):
+                if 'trust_list' in c_obj:
                     del(c_obj['trust_list'])
             for family in c_obj['families']:
                 family['label'] = 'private-channel-family-' + \
                     str(c_obj['org_id'])
         # If there's a trust list on the channel, transform the org ids to
         # the local ones
-        if c_obj.has_key('trust_list') and c_obj['trust_list']:
+        if 'trust_list' in c_obj and c_obj['trust_list']:
             trusts = []
             for trust in c_obj['trust_list']:
                 if trust['org_trust_id'] in org_map:

--- a/backend/satellite_tools/sync_handlers.py
+++ b/backend/satellite_tools/sync_handlers.py
@@ -20,10 +20,10 @@ from spacewalk.common import usix
 from spacewalk.server.importlib import channelImport, packageImport, errataImport, \
     kickstartImport
 from spacewalk.common.usix import raise_with_tb
-from . import diskImportLib
-from . import xmlSource
-from . import syncCache
-from . import syncLib
+import diskImportLib
+import xmlSource
+import syncCache
+import syncLib
 
 DEFAULT_ORG = 1
 

--- a/backend/satellite_tools/test/unit/test_reposync.py
+++ b/backend/satellite_tools/test/unit/test_reposync.py
@@ -18,7 +18,10 @@ import imp
 import sys
 import unittest
 import json
-from StringIO import StringIO
+try:
+    from io import StringIO
+except ImportError:
+    from StringIO import StringIO
 from datetime import datetime, timedelta
 
 from mock import Mock, patch, call
@@ -69,7 +72,7 @@ class RepoSyncTest(unittest.TestCase):
         self.stderr.close()
         sys.stderr = self.saved_stderr
 
-        reload(spacewalk.satellite_tools.reposync)
+        imp.reload(spacewalk.satellite_tools.reposync)
 
     def test_init_succeeds_with_correct_attributes(self):
         rs = self._init_reposync('Label', RTYPE)
@@ -243,9 +246,9 @@ class RepoSyncTest(unittest.TestCase):
 
         self.assertEqual(len(bugs), 3)
         for bug in bugs:
-            self.assertEqual(bug.keys(), ['bug_id', 'href', 'summary'])
+            self.assertEqual(list(bug.keys()), ['bug_id', 'href', 'summary'])
             assert set(bug.values()) in bug_values, (
-                "Bug set(%s) not in %s" % (bug.values(), bug_values))
+                "Bug set(%s) not in %s" % (list(bug.values()), bug_values))
 
     def test_update_cves(self):
         notice = {'references': [{'type': 'cve',

--- a/backend/satellite_tools/test/unit/test_reposync.py
+++ b/backend/satellite_tools/test/unit/test_reposync.py
@@ -13,7 +13,6 @@
 # Red Hat trademarks are not licensed under GPLv2. No permission is
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
-from __future__ import unicode_literals
 
 import imp
 import sys
@@ -866,20 +865,20 @@ class RunScriptTest(unittest.TestCase):
             os=Mock(**{'getuid.return_value': 0}),
             open=Mock(
                 return_value=StringIO(
-                    json.dumps(
-                        {
-                            "no_errata": False,
-                            "sync_kickstart": False,
-                            "fail": True,
-                            "channel": {
-                                "chann_1": [
-                                    "http://example.com/repo1",
-                                    "http://example.com/repo2"
-                                ],
-                                "chann_2": []
-                            }
-                        }
-                    )
+					json.dumps(
+						{
+							"no_errata": False,
+							"sync_kickstart": False,
+							"fail": True,
+							"channel": {
+								"chann_1": [
+									"http://example.com/repo1",
+									"http://example.com/repo2"
+								],
+								"chann_2": []
+							}
+						}
+					).decode()
                 )
             ),
             rhnLockfile=Mock(),
@@ -925,7 +924,7 @@ class RunScriptTest(unittest.TestCase):
                     "fail": True,
                     "channel": {"chann_1": "http://example.com/repo1"}
                 }
-            )
+            ).decode()
         )
         self.assertRaises(SystemExit, self.repo_sync.main)
         self.repo_sync.systemExit.assert_called_once_with(

--- a/backend/satellite_tools/test/unit/test_reposync.py
+++ b/backend/satellite_tools/test/unit/test_reposync.py
@@ -13,6 +13,7 @@
 # Red Hat trademarks are not licensed under GPLv2. No permission is
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
+from __future__ import unicode_literals
 
 import imp
 import sys

--- a/backend/satellite_tools/test/unit/test_yum_src.py
+++ b/backend/satellite_tools/test/unit/test_yum_src.py
@@ -16,7 +16,10 @@
 
 import os
 import unittest
-from StringIO import StringIO
+try:
+    from io import StringIO
+except ImportError:
+    from StringIO import StringIO
 from collections import namedtuple
 
 import mock

--- a/backend/satellite_tools/test/unit/test_yum_src.py
+++ b/backend/satellite_tools/test/unit/test_yum_src.py
@@ -114,7 +114,7 @@ class YumSrcTest(unittest.TestCase):
     def test_get_updates_suse_patches(self):
         cs = self._make_dummy_cs()
 
-        patches_xml = StringIO("""<?xml version="1.0" encoding="UTF-8"?>
+        patches_xml = StringIO(u"""<?xml version="1.0" encoding="UTF-8"?>
                 <patches xmlns="http://novell.com/package/metadata/suse/patches">
                   <patch id="smcl3-cobbler-7778">
                     <checksum type="sha">ec34048ebda707a83190056d832d43c9fbb55ca6</checksum>
@@ -135,7 +135,7 @@ class YumSrcTest(unittest.TestCase):
         # returned object and then subsequent reads to the StringIO
         # object will return nothing, because the file pointer is at the
         # end of the file
-        os.path.join = Mock(side_effect=lambda *args: StringIO("<xml></xml>"))
+        os.path.join = Mock(side_effect=lambda *args: StringIO(u"<xml></xml>"))
 
         patches = cs.get_updates()
         self.assertEqual(patches[0], 'patches')

--- a/backend/satellite_tools/updatePackages.py
+++ b/backend/satellite_tools/updatePackages.py
@@ -141,7 +141,7 @@ def process_package_data():
         # Nothing to change
         return
     if verbose:
-        print("Processing %s packages" % len(paths))
+        print(("Processing %s packages" % len(paths)))
     pb = ProgressBar(prompt='standby: ', endTag=' - Complete!',
                      finalSize=len(paths), finalBarLength=40, stream=sys.stdout)
     pb.printAll(1)
@@ -237,9 +237,9 @@ def process_package_data():
     rhnSQL.commit()
     sys.stderr.write("Transaction Committed! \n")
     if verbose:
-        print(" Skipping %s packages, paths not found" % len(skip_list))
+        print((" Skipping %s packages, paths not found" % len(skip_list)))
     if new_ok_list and verbose:
-        print(" There were %s packages found in the correct location" % len(new_ok_list))
+        print((" There were %s packages found in the correct location" % len(new_ok_list)))
     return
 
 
@@ -318,7 +318,7 @@ def process_sha256_packages():
         return
 
     if verbose:
-        print("Processing %s SHA256 capable packages" % len(packages))
+        print(("Processing %s SHA256 capable packages" % len(packages)))
 
     pb = ProgressBar(prompt='standby: ', endTag=' - Complete!',
                      finalSize=len(packages), finalBarLength=40, stream=sys.stdout)
@@ -631,7 +631,7 @@ def process_changelog():
         return
 
     if verbose:
-        print("Processing %s non-ASCII changelog entries" % nrows)
+        print(("Processing %s non-ASCII changelog entries" % nrows))
 
     pb = ProgressBar(prompt='standby: ', endTag=' - Complete!',
                      finalSize=nrows, finalBarLength=40, stream=sys.stdout)

--- a/backend/satellite_tools/xmlDiskSource.py
+++ b/backend/satellite_tools/xmlDiskSource.py
@@ -406,6 +406,6 @@ class ClonedChannelsDiskSource(DiskSource):
 if __name__ == '__main__':
     # TEST CODE
     s = ChannelDiskSource("/tmp")
-    print(s.list())
+    print((s.list()))
     s.setChannel("redhat-linux-i386-7.2")
-    print(s.load())
+    print((s.load()))

--- a/backend/satellite_tools/xmlSource.py
+++ b/backend/satellite_tools/xmlSource.py
@@ -126,7 +126,7 @@ class BaseDispatchHandler(ContentHandler, ErrorHandler):
         self.__container = None
         # Reset all the containers, to make sure previous runs don't leave
         # garbage data
-        for container in self.container_dispatch.values():
+        for container in list(self.container_dispatch.values()):
             container.reset()
 
     def restoreParser(self):
@@ -319,7 +319,7 @@ class BaseItem:
 
     def populateFromAttributes(self, obj, sourceDict):
         # Populates dict with items from sourceDict
-        for key, value in sourceDict.items():
+        for key, value in list(sourceDict.items()):
             if key not in self.tagMap:
                 if key not in obj:
                     # Unsupported key
@@ -378,7 +378,7 @@ def _stringify(data):
 def _dict_to_utf8(d):
     # Convert the dictionary to have non-unocide key-value pairs
     ret = {}
-    for k, v in d.items():
+    for k, v in list(d.items()):
         if isinstance(k, usix.UnicodeType):
             k = k.encode('UTF8')
         if isinstance(v, usix.UnicodeType):

--- a/backend/satellite_tools/xmlWireSource.py
+++ b/backend/satellite_tools/xmlWireSource.py
@@ -30,12 +30,12 @@ from spacewalk.common import rhnLib
 from spacewalk.common.rhnConfig import CFG
 
 # local imports
-from syncLib import log, log2, RhnSyncException
+from .syncLib import log, log2, RhnSyncException
 
 from rhn import rpclib
 
 from spacewalk.common.suseLib import get_proxy
-import connection
+from . import connection
 
 class BaseWireSource:
 

--- a/backend/satellite_tools/xmlWireSource.py
+++ b/backend/satellite_tools/xmlWireSource.py
@@ -35,7 +35,7 @@ from .syncLib import log, log2, RhnSyncException
 from rhn import rpclib
 
 from spacewalk.common.suseLib import get_proxy
-from . import connection
+import connection
 
 class BaseWireSource:
 

--- a/backend/server/action/distupgrade.py
+++ b/backend/server/action/distupgrade.py
@@ -102,25 +102,25 @@ def upgrade(serverId, actionId, dry_run=0):
             "dry_run"             : (row['dry_run'] == 'Y') }
         return (params)
 
-    to_subscribe = filter(lambda x: x['task'] == 'S', channel_changes)
-    to_unsubscribe = filter(lambda x: x['task'] == 'U', channel_changes)
+    to_subscribe = [x for x in channel_changes if x['task'] == 'S']
+    to_unsubscribe = [x for x in channel_changes if x['task'] == 'U']
 
     try:
         unsubscribe_channels(serverId, to_unsubscribe)
         subscribe_channels(serverId, to_subscribe)
-    except rhnFault, f:
+    except rhnFault as f:
         if f.code == 38:
             # channel is already subscribed, ignore it
             pass
         else:
-            raise InvalidAction(str(f)), None, sys.exc_info()[2]
-    except Exception, e:
-        raise InvalidAction(str(e)), None, sys.exc_info()[2]
+            raise InvalidAction(str(f)).with_traceback(sys.exc_info()[2])
+    except Exception as e:
+        raise InvalidAction(str(e)).with_traceback(sys.exc_info()[2])
 
     rhnSQL.commit()
 
     params = {
-        "dup_channel_names"   : map(lambda x: x['label'], to_subscribe),
+        "dup_channel_names"   : [x['label'] for x in to_subscribe],
         "full_update"         : (row['full_update'] == 'Y'),
         "change_product"      : do_change,
         "products"            : sle10_products,

--- a/backend/server/action/packages.py
+++ b/backend/server/action/packages.py
@@ -146,7 +146,7 @@ def setLocks(serverId, actionId, dry_run=0):
     client_caps = rhnCapability.get_client_capabilities()
     log_debug(3,"Client Capabilities", client_caps)
     multiarch = 0
-    if not client_caps or not client_caps.has_key('packages.setLocks'):
+    if not client_caps or 'packages.setLocks' not in client_caps:
         raise InvalidAction("Client is not capable of locking packages.")
 
     h = rhnSQL.prepare(_query_action_setLocks)

--- a/backend/server/action_extra_data/configfiles.py
+++ b/backend/server/action_extra_data/configfiles.py
@@ -62,7 +62,7 @@ def upload(server_id, action_id, data={}):
                   'quota_failed': 'insufficient_quota',
                   }
 
-    for reason in reason_map.keys():
+    for reason in list(reason_map.keys()):
         log_debug(6, 'reason', reason)
         failed_files = data.get(reason)
         log_debug(6, 'failed_files', failed_files)
@@ -235,7 +235,7 @@ def _mark_missing_diff_files(server_id, action_id, missing_files):
 
 def _process_diffs(server_id, action_id, diffs):
     _disable_old_diffs(server_id)
-    for file_path, diff in diffs.items():
+    for file_path, diff in list(diffs.items()):
         action_config_revision_id = _lookup_action_revision_id(server_id,
                                                                action_id, file_path)
         if action_config_revision_id is None:

--- a/backend/server/action_extra_data/distupgrade.py
+++ b/backend/server/action_extra_data/distupgrade.py
@@ -59,13 +59,13 @@ def _restore_channels(serverId, action_dup_id):
     # we need to rollback the changes from action
     # therefore unsubscribe task 'S' and
     # subscribe task 'U'
-    to_unsubscribe = filter(lambda x: x['task'] == 'S', channel_changes)
-    to_subscribe = filter(lambda x: x['task'] == 'U', channel_changes)
+    to_unsubscribe = [x for x in channel_changes if x['task'] == 'S']
+    to_subscribe = [x for x in channel_changes if x['task'] == 'U']
 
     try:
         unsubscribe_channels(serverId, to_unsubscribe)
         subscribe_channels(serverId, to_subscribe)
-    except Exception, e:
+    except Exception as e:
         log_error(str(e), sys.exc_info()[2])
 
     return

--- a/backend/server/action_extra_data/packages.py
+++ b/backend/server/action_extra_data/packages.py
@@ -152,7 +152,7 @@ def verify(server_id, action_id, data={}):
             hash[dict['filename']] = dict
 
         # Add the rest of the variables to the dictionaries
-        for filename, dict in hash.items():
+        for filename, dict in list(hash.items()):
             dict['server_id'] = server_id
             dict['action_id'] = action_id
 
@@ -291,7 +291,7 @@ def _parse_response_line(response, tests):
 
 def _hash_append(dst, src):
     # Append the values of src to dst
-    for k, list in dst.items():
+    for k, list in list(dst.items()):
         list.append(src[k])
 
 

--- a/backend/server/apacheAuth.py
+++ b/backend/server/apacheAuth.py
@@ -24,7 +24,7 @@ from spacewalk.common.rhnConfig import CFG
 from spacewalk.common.rhnException import rhnFault
 from spacewalk.common.rhnTranslate import _
 
-from rhnLib import computeSignature
+from .rhnLib import computeSignature
 
 
 def splitProxyAuthToken(token):
@@ -149,7 +149,7 @@ def auth_client():
         log_debug(4, "declined client authentication for GET requests")
         return 0
 
-    token = dict((k.lower(),v) for k,v in rhnFlags.get("AUTH_SESSION_TOKEN").items())
+    token = dict((k.lower(),v) for k,v in list(rhnFlags.get("AUTH_SESSION_TOKEN").items()))
     # Check to see if everything we need to compute the signature is there
     for k in ('x-rhn-server-id',
               'x-rhn-auth-user-id',

--- a/backend/server/apacheHandler.py
+++ b/backend/server/apacheHandler.py
@@ -24,10 +24,10 @@ from spacewalk.common.rhnConfig import CFG, initCFG
 from spacewalk.common.rhnLog import log_debug, log_error, initLOG, log_setreq
 
 # local module imports
-from . import rhnSQL
+import rhnSQL
 
 from .apacheRequest import apacheGET, apachePOST, HandlerNotFoundError
-from . import rhnCapability
+import rhnCapability
 
 # a lame timer function for pretty logs
 

--- a/backend/server/apacheHandler.py
+++ b/backend/server/apacheHandler.py
@@ -24,10 +24,10 @@ from spacewalk.common.rhnConfig import CFG, initCFG
 from spacewalk.common.rhnLog import log_debug, log_error, initLOG, log_setreq
 
 # local module imports
-import rhnSQL
+from . import rhnSQL
 
-from apacheRequest import apacheGET, apachePOST, HandlerNotFoundError
-import rhnCapability
+from .apacheRequest import apacheGET, apachePOST, HandlerNotFoundError
+from . import rhnCapability
 
 # a lame timer function for pretty logs
 

--- a/backend/server/apacheRequest.py
+++ b/backend/server/apacheRequest.py
@@ -43,11 +43,11 @@ from spacewalk.common.rhnTB import Traceback
 from spacewalk.server.auditlog import auditlog_xmlrpc, AuditLogException
 
 # local modules
-from . import rhnRepository
-from . import rhnImport
-from . import rhnSQL
-from . import rhnCapability
-from . import apacheAuth
+import rhnRepository
+import rhnImport
+import rhnSQL
+import rhnCapability
+import apacheAuth
 
 # Exceptions
 

--- a/backend/server/apacheRequest.py
+++ b/backend/server/apacheRequest.py
@@ -43,11 +43,11 @@ from spacewalk.common.rhnTB import Traceback
 from spacewalk.server.auditlog import auditlog_xmlrpc, AuditLogException
 
 # local modules
-import rhnRepository
-import rhnImport
-import rhnSQL
-import rhnCapability
-import apacheAuth
+from . import rhnRepository
+from . import rhnImport
+from . import rhnSQL
+from . import rhnCapability
+from . import apacheAuth
 
 # Exceptions
 
@@ -143,7 +143,7 @@ class apacheRequest:
             if sys.version_info[0] == 3:
                 exctype = sys.exc_info()[0]
             else:
-                exctype = sys.exc_type
+                exctype = sys.exc_info()[0]
 
             if exctype == UnknownXML:
                 fault = -1
@@ -208,7 +208,7 @@ class apacheRequest:
         # it will cause AuditLogException below.
         try:
             auditlog_xmlrpc(func, method, params, self.req)
-        except AuditLogException, e:
+        except AuditLogException as e:
             # if logging didn't succeed, cancel the whole action
             rhnSQL.rollback()
             Traceback(method, self.req,
@@ -405,7 +405,7 @@ class apacheRequest:
         # we're about done here, patch up the headers
         output.process(response)
         # Copy the rest of the fields
-        for k, v in output.headers.items():
+        for k, v in list(output.headers.items()):
             if string.lower(k) == 'content-type':
                 # Content-type
                 self.req.content_type = v
@@ -656,14 +656,14 @@ class GetHandler(apacheRequest):
                 self.req.headers_out.add("X-RHN-Fault-String",
                                              string.strip(line))
             # And then send all the other things
-            for k, v in rhnFlags.get('outputTransportOptions').items():
+            for k, v in list(rhnFlags.get('outputTransportOptions').items()):
                 setHeaderValue(self.req.headers_out, k, v)
             return retcode
         # Otherwise we're pretty much fine with the standard response
         # handler
 
         # Copy the fields from the transport options, if necessary
-        for k, v in rhnFlags.get('outputTransportOptions').items():
+        for k, v in list(rhnFlags.get('outputTransportOptions').items()):
             setHeaderValue(self.req.headers_out, k, v)
         # and jump into the base handler
         return apacheRequest.response(self, response)

--- a/backend/server/apacheServer.py
+++ b/backend/server/apacheServer.py
@@ -21,7 +21,7 @@ from spacewalk.common.rhnConfig import CFG, initCFG
 from spacewalk.common.rhnTB import Traceback
 from spacewalk.common.rhnLog import initLOG, log_setreq
 
-from apacheHandler import apacheHandler
+from .apacheHandler import apacheHandler
 apache_server = apacheHandler()
 HeaderParserHandler = apache_server.headerParserHandler
 Handler = apache_server.handler

--- a/backend/server/apacheUploadServer.py
+++ b/backend/server/apacheUploadServer.py
@@ -18,7 +18,7 @@ import string
 import sys
 from spacewalk.common import apache
 
-import rhnSession
+from . import rhnSession
 
 from spacewalk.common import rhnFlags
 from spacewalk.common.rhnLog import log_debug, log_error, log_setreq, initLOG

--- a/backend/server/apacheUploadServer.py
+++ b/backend/server/apacheUploadServer.py
@@ -18,7 +18,7 @@ import string
 import sys
 from spacewalk.common import apache
 
-from . import rhnSession
+import rhnSession
 
 from spacewalk.common import rhnFlags
 from spacewalk.common.rhnLog import log_debug, log_error, log_setreq, initLOG

--- a/backend/server/auditlog.py
+++ b/backend/server/auditlog.py
@@ -15,7 +15,10 @@ import inspect
 import os
 import pwd
 from socket import error
-from xmlrpclib import ServerProxy, Error
+try:
+    from xmlrpc.client import ServerProxy, Error
+except:
+    from xmlrpclib import ServerProxy, Error
 
 from spacewalk.common.rhnConfig import initCFG, CFG
 from spacewalk.common.rhnLog import log_error, log_debug
@@ -55,7 +58,7 @@ def auditlog_xmlrpc(method, method_name, args, request):
 
     try:
         server = ServerProxy(server_url)
-    except IOError, e:
+    except IOError as e:
         raise AuditLogException("Could not establish a connection to the "
                                 "AuditLog server. IOError: %s. "
                                 "Is this server url correct? %s"
@@ -88,7 +91,7 @@ def auditlog_xmlrpc(method, method_name, args, request):
                     "REQ.ORIGINAL_ADDR": headers.get("HTTP_X_RHN_IP_PATH", "")})
         try:
             server.audit.log(uid, message, hostname, extmap)
-        except (Error, error), e:
+        except (Error, error) as e:
             raise AuditLogException("Got an error while talking to the "
                                     "AuditLogging server at %s. Error was: %s"
                                     % (server_url, e))

--- a/backend/server/configFilesHandler.py
+++ b/backend/server/configFilesHandler.py
@@ -40,7 +40,7 @@ from spacewalk.server.rhnHandler import rhnHandler
 from spacewalk.server.config_common.templated_document import ServerTemplatedDocument, var_interp_prep
 
 
-from . import rhnSession
+import rhnSession
 
 # Exceptions
 

--- a/backend/server/configFilesHandler.py
+++ b/backend/server/configFilesHandler.py
@@ -40,7 +40,7 @@ from spacewalk.server.rhnHandler import rhnHandler
 from spacewalk.server.config_common.templated_document import ServerTemplatedDocument, var_interp_prep
 
 
-import rhnSession
+from . import rhnSession
 
 # Exceptions
 
@@ -357,7 +357,7 @@ class ConfigFilesHandler(rhnHandler):
 
         # We have to insert a new file now
         content_seq = rhnSQL.Sequence('rhn_confcontent_id_seq')
-        config_content_id = content_seq.next()
+        config_content_id = next(content_seq)
         file['config_content_id'] = config_content_id
         file['contents'] = file_contents
 
@@ -511,7 +511,7 @@ class ConfigFilesHandler(rhnHandler):
         return CFG.maximum_config_file_size
 
     def new_config_channel_id(self):
-        return rhnSQL.Sequence('rhn_confchan_id_seq').next()
+        return next(rhnSQL.Sequence('rhn_confchan_id_seq'))
 
 
 def format_file_results(row, server=None):

--- a/backend/server/config_common/templated_document.py
+++ b/backend/server/config_common/templated_document.py
@@ -15,7 +15,7 @@
 #
 #
 
-from base_templated_document import TemplatedDocument
+from .base_templated_document import TemplatedDocument
 
 from spacewalk.common.rhnLog import log_debug
 

--- a/backend/server/handlers/app/__init__.py
+++ b/backend/server/handlers/app/__init__.py
@@ -17,7 +17,7 @@
 
 __all__ = []
 
-import packages
+from . import packages
 
 rpcClasses = {
     "packages": packages.Packages,

--- a/backend/server/handlers/app/__init__.py
+++ b/backend/server/handlers/app/__init__.py
@@ -17,7 +17,7 @@
 
 __all__ = []
 
-from . import packages
+import packages
 
 rpcClasses = {
     "packages": packages.Packages,

--- a/backend/server/handlers/app/packages.py
+++ b/backend/server/handlers/app/packages.py
@@ -470,7 +470,7 @@ class Packages(RPC_Base):
         log_debug(3)
         row_list = {}
         checksum_exists = 0
-        for pkg in pkg_infos.keys():
+        for pkg in list(pkg_infos.keys()):
 
             pkg_info = pkg_infos[pkg]
             pkg_epoch = pkg_info['epoch']
@@ -529,7 +529,7 @@ class Packages(RPC_Base):
     def _MD5sum2Checksum_info(self, info):
         log_debug(5)
         pkg_infos = info.get('packages')
-        for pkg in pkg_infos.keys():
+        for pkg in list(pkg_infos.keys()):
             if 'md5sum' in pkg_infos[pkg]:
                 pkg_infos[pkg]['checksum_type'] = 'md5'
                 pkg_infos[pkg]['checksum'] = pkg_infos[pkg]['md5sum']
@@ -538,7 +538,7 @@ class Packages(RPC_Base):
     def _Checksum2MD5sum_list(self, checksum_list):
         log_debug(5)
         row_list = {}
-        for k in checksum_list.keys():
+        for k in list(checksum_list.keys()):
             if checksum_list[k] == '' or checksum_list[k] == 'on-disk':
                 row_list[k] = checksum_list[k]
             elif type(checksum_list[k]) == TupleType and checksum_list[k][0] == 'md5':
@@ -591,7 +591,7 @@ class Packages(RPC_Base):
              """
         h = rhnSQL.prepare(statement)
         row_list = {}
-        for pkg in pkg_infos.keys():
+        for pkg in list(pkg_infos.keys()):
             row_list[pkg] = self._get_package_checksum(h,
                                                        {'name': pkg, 'orgid': org_id})
         return row_list

--- a/backend/server/handlers/applet/__init__.py
+++ b/backend/server/handlers/applet/__init__.py
@@ -18,7 +18,7 @@
 
 __all__ = []
 
-import applet
+from . import applet
 
 rpcClasses = {
     "applet": applet.Applet,

--- a/backend/server/handlers/applet/__init__.py
+++ b/backend/server/handlers/applet/__init__.py
@@ -18,7 +18,7 @@
 
 __all__ = []
 
-from . import applet
+import applet
 
 rpcClasses = {
     "applet": applet.Applet,

--- a/backend/server/handlers/applet/applet.py
+++ b/backend/server/handlers/applet/applet.py
@@ -245,7 +245,7 @@ class Applet(rhnHandler):
         contents = {}
 
         for p in plist:
-            for k in p.keys():
+            for k in list(p.keys()):
                 if p[k] is None:
                     p[k] = ""
             p["nevr"] = "%s-%s-%s:%s" % (

--- a/backend/server/handlers/config/__init__.py
+++ b/backend/server/handlers/config/__init__.py
@@ -17,7 +17,7 @@
 
 __all__ = []
 
-import rhn_config_management
+from . import rhn_config_management
 
 rpcClasses = {
     'config': rhn_config_management.ConfigManagement,

--- a/backend/server/handlers/config/__init__.py
+++ b/backend/server/handlers/config/__init__.py
@@ -17,7 +17,7 @@
 
 __all__ = []
 
-from . import rhn_config_management
+import rhn_config_management
 
 rpcClasses = {
     'config': rhn_config_management.ConfigManagement,

--- a/backend/server/handlers/config/test/test_template1.py
+++ b/backend/server/handlers/config/test/test_template1.py
@@ -31,7 +31,7 @@ t = ServerTemplatedDocument(server, start_delim='@@', end_delim='@@')
 data = open("test/template1.tmpl").read()
 
 try:
-    print("interpolated:  ", t.interpolate(data))
+    print(("interpolated:  ", t.interpolate(data)))
 except Exception:
     e = sys.exc_info()[1]
     print(e)
@@ -49,11 +49,11 @@ except Exception:
         f = f.f_back
 
     for frame in stack:
-        print("Frame %s in %s at line %s\n" % (frame.f_code.co_name,
+        print(("Frame %s in %s at line %s\n" % (frame.f_code.co_name,
                                                frame.f_code.co_filename,
-                                               frame.f_lineno))
+                                               frame.f_lineno)))
 
-        for key, value in frame.f_locals.items():
+        for key, value in list(frame.f_locals.items()):
             message = "\t%20s = " % key
             try:
                 s = str(value)
@@ -61,4 +61,4 @@ except Exception:
                 s = "<ERROR WHILE PRINTING VALUE>"
             if len(s) > 100 * 1024:
                 s = "<ERROR WHILE PRINTING VALUE: string representation too large>"
-            print(message + s)
+            print((message + s))

--- a/backend/server/handlers/config_mgmt/__init__.py
+++ b/backend/server/handlers/config_mgmt/__init__.py
@@ -17,7 +17,7 @@
 
 __all__ = []
 
-import rhn_config_management
+from . import rhn_config_management
 
 rpcClasses = {
     'config': rhn_config_management.ConfigManagement,

--- a/backend/server/handlers/config_mgmt/__init__.py
+++ b/backend/server/handlers/config_mgmt/__init__.py
@@ -17,7 +17,7 @@
 
 __all__ = []
 
-from . import rhn_config_management
+import rhn_config_management
 
 rpcClasses = {
     'config': rhn_config_management.ConfigManagement,

--- a/backend/server/handlers/sat/__init__.py
+++ b/backend/server/handlers/sat/__init__.py
@@ -16,8 +16,8 @@
 
 __all__ = []
 
-import auth
-import cert
+from . import auth
+from . import cert
 
 rpcClasses = {
     'authentication':   auth.Authentication,

--- a/backend/server/handlers/sat/__init__.py
+++ b/backend/server/handlers/sat/__init__.py
@@ -16,8 +16,8 @@
 
 __all__ = []
 
-from . import auth
-from . import cert
+import auth
+import cert
 
 rpcClasses = {
     'authentication':   auth.Authentication,

--- a/backend/server/handlers/sat/cert.py
+++ b/backend/server/handlers/sat/cert.py
@@ -20,7 +20,7 @@ from spacewalk.common.rhnException import rhnException
 
 # server imports
 from spacewalk.server import rhnSQL
-from auth import Authentication
+from .auth import Authentication
 
 
 class Certificate(Authentication):

--- a/backend/server/handlers/xmlrpc/__init__.py
+++ b/backend/server/handlers/xmlrpc/__init__.py
@@ -18,14 +18,14 @@
 
 __all__ = []
 
-import registration
-import up2date
-import queue
-import errata
-import proxy
-import get_handler
-import abrt
-import scap
+from . import registration
+from . import up2date
+from . import queue
+from . import errata
+from . import proxy
+from . import get_handler
+from . import abrt
+from . import scap
 
 rpcClasses = {
     "registration": registration.Registration,

--- a/backend/server/handlers/xmlrpc/__init__.py
+++ b/backend/server/handlers/xmlrpc/__init__.py
@@ -18,14 +18,14 @@
 
 __all__ = []
 
-from . import registration
-from . import up2date
-from . import queue
-from . import errata
-from . import proxy
-from . import get_handler
-from . import abrt
-from . import scap
+import registration
+import up2date
+import queue
+import errata
+import proxy
+import get_handler
+import abrt
+import scap
 
 rpcClasses = {
     "registration": registration.Registration,

--- a/backend/server/handlers/xmlrpc/errata.py
+++ b/backend/server/handlers/xmlrpc/errata.py
@@ -169,7 +169,7 @@ class Errata(rhnHandler):
             row = h.fetchone_dict()
             if row is None:
                 break
-            for k in row.keys():
+            for k in list(row.keys()):
                 if row[k] is None:
                     row[k] = "N/A"
             ret.append(row)

--- a/backend/server/handlers/xmlrpc/getMethod.py
+++ b/backend/server/handlers/xmlrpc/getMethod.py
@@ -139,13 +139,13 @@ if __name__ == '__main__':
     ]
 
     for m in methods:
-        print("----Running method %s: " % m)
+        print(("----Running method %s: " % m))
         try:
             method = getMethod(m, 'Actions')
         except GetMethodException:
             e = sys.exc_info()[1]
-            print("Error getting the method %s: %s" % (m,
-                                                       string.join(map(str, e.args))))
+            print(("Error getting the method %s: %s" % (m,
+                                                       string.join(map(str, e.args)))))
         else:
             method()
 #-----------------------------------------------------------------------------

--- a/backend/server/handlers/xmlrpc/queue.py
+++ b/backend/server/handlers/xmlrpc/queue.py
@@ -38,7 +38,7 @@ from spacewalk.server import rhnSQL, rhnCapability, rhnAction
 from spacewalk.server.rhnLib import InvalidAction, EmptyAction, ShadowAction
 from spacewalk.server.rhnServer import server_kickstart
 
-from . import getMethod
+import getMethod
 
 
 class Queue(rhnHandler):

--- a/backend/server/handlers/xmlrpc/queue.py
+++ b/backend/server/handlers/xmlrpc/queue.py
@@ -38,7 +38,7 @@ from spacewalk.server import rhnSQL, rhnCapability, rhnAction
 from spacewalk.server.rhnLib import InvalidAction, EmptyAction, ShadowAction
 from spacewalk.server.rhnServer import server_kickstart
 
-import getMethod
+from . import getMethod
 
 
 class Queue(rhnHandler):
@@ -488,7 +488,7 @@ class Queue(rhnHandler):
                 rmsg = result["faultString"] + str(data)
         if type(rcode) in [type({}), type(()), type([])] \
                 or type(rcode) is not IntType:
-            rmsg = u"%s [%s]" % (UnicodeType(message), UnicodeType(rcode))
+            rmsg = "%s [%s]" % (UnicodeType(message), UnicodeType(rcode))
             rcode = -1
         # map to db codes.
         status = self.status_for_action_type_code(action_type, rcode)

--- a/backend/server/handlers/xmlrpc/registration.py
+++ b/backend/server/handlers/xmlrpc/registration.py
@@ -331,7 +331,7 @@ class Registration(rhnHandler):
                 newserv.dispose_packages()
                 # The new server may have a different base channel
                 suse_products = None
-                if data.has_key('suse_products'):
+                if 'suse_products' in data:
                     suse_products = data['suse_products']
                 newserv.change_base_channel(release, suse_products=suse_products)
 
@@ -432,9 +432,9 @@ class Registration(rhnHandler):
             try:
                 # don't commit
                 newserv.save(0, channel)
-            except (rhnChannel.NoBaseChannelError), channel_error:
+            except (rhnChannel.NoBaseChannelError) as channel_error:
                 raise_with_tb(rhnFault(70), sys.exc_info()[2])
-            except rhnChannel.BaseChannelDeniedError, channel_error:
+            except rhnChannel.BaseChannelDeniedError as channel_error:
                 raise_with_tb(rhnFault(71), sys.exc_info()[2])
             except server_lib.rhnSystemEntitlementException:
                 e = sys.exc_info()[1]
@@ -469,9 +469,9 @@ class Registration(rhnHandler):
         #   +--rhnNoSystemEntitlementsException
         try:
             newserv.save(1, channel)
-        except (rhnChannel.NoBaseChannelError), channel_error:
+        except (rhnChannel.NoBaseChannelError) as channel_error:
             raise_with_tb(rhnFault(70), sys.exc_info()[2])
-        except rhnChannel.BaseChannelDeniedError, channel_error:
+        except rhnChannel.BaseChannelDeniedError as channel_error:
             raise_with_tb(rhnFault(71), sys.exc_info()[2])
         except server_lib.rhnSystemEntitlementException:
             e = sys.exc_info()[1]
@@ -1020,13 +1020,13 @@ class Registration(rhnHandler):
         return packagesV2
 
     def extract_and_save_netinfos(self, server, hardware):
-        if 'hostname' in hardware.keys():
+        if 'hostname' in list(hardware.keys()):
             server.server["hostname"] = hardware["hostname"]
             del hardware["hostname"]
-        if 'ipaddr' in hardware.keys():
+        if 'ipaddr' in list(hardware.keys()):
             server.addr["ipaddr"] = hardware["ipaddr"]
             del hardware["ipaddr"]
-        if 'ip6addr' in hardware.keys():
+        if 'ip6addr' in list(hardware.keys()):
             server.addr["ip6addr"] = hardware["ip6addr"]
             del hardware["ip6addr"]
 

--- a/backend/server/handlers/xmlrpc/up2date.py
+++ b/backend/server/handlers/xmlrpc/up2date.py
@@ -109,7 +109,7 @@ class Up2date(rhnHandler):
         # Duplicate these values in the headers so that the proxy can
         # intercept and cache them without parseing the xmlrpc.
         transport = rhnFlags.get('outputTransportOptions')
-        for k, v in loginDict.items():
+        for k, v in list(loginDict.items()):
             # Special case for channels
             if string.lower(k) == string.lower('X-RHN-Auth-Channels'):
                 # Concatenate the channel information column-separated

--- a/backend/server/importlib/archImport.py
+++ b/backend/server/importlib/archImport.py
@@ -16,7 +16,7 @@
 # Arch import process
 #
 
-from importLib import Import
+from .importLib import Import
 
 
 class ArchImport(Import):

--- a/backend/server/importlib/backendLib.py
+++ b/backend/server/importlib/backendLib.py
@@ -82,7 +82,7 @@ class Table:
 
     def __init__(self, name, **kwargs):
         self.name = name
-        for k in kwargs.keys():
+        for k in list(kwargs.keys()):
             if k not in self.keywords:
                 raise TypeError("Unknown keyword attribute '%s'" % k)
         # Initialize stuff
@@ -102,7 +102,7 @@ class Table:
         # Sequence column - a column that is populated off a sequence
         self.sequenceColumn = None
 
-        for k, v in kwargs.items():
+        for k, v in list(kwargs.items()):
             datatype = self.keywords[k]
             if not isinstance(v, datatype):
                 raise TypeError("%s expected to be %s; got %s" % (
@@ -149,7 +149,7 @@ class Table:
         return attribute
 
     def getSeverityHash(self):
-        for field in self.fields.keys():
+        for field in list(self.fields.keys()):
             if field not in self.severityHash:
                 self.severityHash[field] = self.defaultSeverity
         return self.severityHash
@@ -297,7 +297,7 @@ class TableUpdate(BaseTableLookup):
         # should only have one element if the primary key has no nullable
         # fields
         blobValuesHash = {}
-        for key in self.whereclauses.keys():
+        for key in list(self.whereclauses.keys()):
             hash = {}
             for i in range(len(key)):
                 pk = self.pks[i]
@@ -339,7 +339,7 @@ class TableUpdate(BaseTableLookup):
         valuesHash, blobValuesHash = self._split_blob_values(values, blob_only=0)
         # And now do the actual update for non-blobs
         if self.otherfields:
-            for key, val in valuesHash.items():
+            for key, val in list(valuesHash.items()):
                 if not val[self.firstkey]:
                     # Nothing to do
                     continue
@@ -355,7 +355,7 @@ class TableUpdate(BaseTableLookup):
         # Now update BLOB fields
         template = "select %s from %s where %s for update"
         blob_fields_string = string.join(self.blob_fields, ", ")
-        for key, val in blobValuesHash.items():
+        for key, val in list(blobValuesHash.items()):
             statement = template % (blob_fields_string, self.table.name,
                                     self.whereclauses[key])
             h = self.dbmodule.prepare(statement)
@@ -366,7 +366,7 @@ class TableUpdate(BaseTableLookup):
                 if not row:
                     # XXX This should normally not happen
                     raise ValueError("BLOB query did not retrieve a value")
-                for k, v in blob_hash.items():
+                for k, v in list(blob_hash.items()):
                     blob = row[k]
                     len_v = len(v)
                     # If new value is shorter than old value, we have to trim
@@ -395,7 +395,7 @@ class TableDelete(TableLookup):
     def query(self, values):
         # Build the values hash
         valuesHash = {}
-        for key in self.whereclauses.keys():
+        for key in list(self.whereclauses.keys()):
             hash = {}
             for i in range(len(key)):
                 pk = self.pks[i]
@@ -415,8 +415,8 @@ class TableDelete(TableLookup):
             addHash(valuesHash[key], val)
 
         # And now do the actual delete
-        for key, val in valuesHash.items():
-            firstkey = val.keys()[0]
+        for key, val in list(valuesHash.items()):
+            firstkey = list(val.keys())[0]
             if not val[firstkey]:
                 # Nothing to do
                 continue
@@ -463,7 +463,7 @@ def executeStatement(statement, valuesHash, chunksize):
     count = 0
     while 1:
         tempdict = {}
-        for k, vals in valuesHash.items():
+        for k, vals in list(valuesHash.items()):
             if not vals:
                 # Empty
                 break
@@ -522,6 +522,6 @@ def sanitizeValue(value, datatype):
 def addHash(hasharray, hash):
     # hasharray is a hash of arrays
     # add hash's values to hasharray
-    for k, v in hash.items():
+    for k, v in list(hash.items()):
         if k in hasharray:
             hasharray[k].append(v)

--- a/backend/server/importlib/backendOracle.py
+++ b/backend/server/importlib/backendOracle.py
@@ -19,8 +19,8 @@
 #
 
 import sys
-from backend import Backend
-from backendLib import DBint, DBstring, DBdateTime, Table, \
+from .backend import Backend
+from .backendLib import DBint, DBstring, DBdateTime, Table, \
     TableCollection, DBblob
 from spacewalk.server import rhnSQL
 from spacewalk.server.rhnSQL.const import ORACLE, POSTGRESQL
@@ -688,7 +688,7 @@ class PostgresqlBackend(OracleBackend):
         try:
             self.dbmodule.execute_secondary(lock_sql)
             h = self.dbmodule.prepare_secondary(sql)
-            for name, version in capabilityHash.keys():
+            for name, version in list(capabilityHash.keys()):
                 ver = version
                 if version == '':
                     ver = None
@@ -712,7 +712,7 @@ class PostgresqlBackend(OracleBackend):
         try:
             self.dbmodule.execute_secondary(lock_sql)
             h = self.dbmodule.prepare_secondary(sql)
-            for k in checksumHash.keys():
+            for k in list(checksumHash.keys()):
                 ctype, csum = k
                 if csum != '':
                     h.execute(ctype=ctype, csum=csum)

--- a/backend/server/importlib/backend_checker.py
+++ b/backend/server/importlib/backend_checker.py
@@ -15,17 +15,17 @@ q = rhnSQL.prepare("""select data_length
 
 backend = backendOracle.PostgresqlBackend()
 
-for tn, tc in backend.tables.items():
-    for cn, cv in tc.getFields().items():
+for tn, tc in list(backend.tables.items()):
+    for cn, cv in list(tc.getFields().items()):
         if isinstance(cv, DBstring):
             q.execute(tname=tn, cname=cn)
             row = q.fetchone_dict()
             if not row or row['data_length'] != cv.limit:
-                print(("ERROR: database column %s.%s is %s chars long "
+                print((("ERROR: database column %s.%s is %s chars long "
                        + "but defined as %s chars in backendOracle.py") % (
-                    tn, cn, row['data_length'], cv.limit))
+                    tn, cn, row['data_length'], cv.limit)))
                 exitval = 1
             else:
-                print("%s.%s = %d" % (tn, cn, row['data_length']))
+                print(("%s.%s = %d" % (tn, cn, row['data_length'])))
 
 sys.exit(exitval)

--- a/backend/server/importlib/channelImport.py
+++ b/backend/server/importlib/channelImport.py
@@ -15,7 +15,7 @@
 # Channel import process
 #
 
-from importLib import Import, InvalidArchError, \
+from .importLib import Import, InvalidArchError, \
     InvalidChannelError, InvalidChannelFamilyError, MissingParentChannelError
 from spacewalk.satellite_tools.syncLib import log
 
@@ -169,7 +169,7 @@ class ChannelImport(Import):
 
         # Build an extra hash for the channels with unknown ids
         unknownChannels = {}
-        for k, v in parentChannels.items():
+        for k, v in list(parentChannels.items()):
             if v is None:
                 unknownChannels[k] = None
 
@@ -178,7 +178,7 @@ class ChannelImport(Import):
 
         # Copy the ids back into parentChannels, to make life easier
         missingParents = []
-        for k, v in unknownChannels.items():
+        for k, v in list(unknownChannels.items()):
             if v is None:
                 missingParents.append(k)
             else:
@@ -314,8 +314,8 @@ class DistChannelMapImport(Import):
 if __name__ == '__main__':
     import sys
     from spacewalk.server import rhnSQL
-    from backendOracle import OracleBackend
-    from importLib import Collection, ChannelFamily, DistChannelMap
+    from .backendOracle import OracleBackend
+    from .importLib import Collection, ChannelFamily, DistChannelMap
     backend = OracleBackend()
     if 1:
         batch = Collection()

--- a/backend/server/importlib/contentSourcesImport.py
+++ b/backend/server/importlib/contentSourcesImport.py
@@ -14,7 +14,7 @@
 #
 #
 
-from importLib import Import, Channel
+from .importLib import Import, Channel
 from spacewalk.server.rhnChannel import channel_info
 
 
@@ -43,7 +43,7 @@ class ContentSourcesImport(Import):
     def submit(self):
         try:
             self.backend.processContentSources(self.batch)
-            for channel in self.channels_to_link.values():
+            for channel in list(self.channels_to_link.values()):
                 self.backend.processChannelContentSources(channel)
         except:
             self.backend.rollback()

--- a/backend/server/importlib/debPackage.py
+++ b/backend/server/importlib/debPackage.py
@@ -16,7 +16,7 @@
 # Converts headers to the intermediate format
 #
 
-from . import headerSource
+import headerSource
 import time
 from .importLib import Channel
 from .backendLib import gmtime, localtime

--- a/backend/server/importlib/debPackage.py
+++ b/backend/server/importlib/debPackage.py
@@ -16,10 +16,10 @@
 # Converts headers to the intermediate format
 #
 
-import headerSource
+from . import headerSource
 import time
-from importLib import Channel
-from backendLib import gmtime, localtime
+from .importLib import Channel
+from .backendLib import gmtime, localtime
 from spacewalk.common.usix import IntType, UnicodeType
 from spacewalk.common.stringutils import to_string
 
@@ -45,7 +45,7 @@ class debBinaryPackage(headerSource.rpmBinaryPackage):
 
         # XXX is seems to me that this is the place that 'source_rpm' is getting
         # set
-        for f in self.keys():
+        for f in list(self.keys()):
             field = f
             if f in self.tagMap:
                 field = self.tagMap[f]
@@ -126,7 +126,7 @@ class debBinaryPackage(headerSource.rpmBinaryPackage):
             'breaks': headerSource.rpmBreaks,
             'predepends': headerSource.rpmPredepends,
         }
-        for k, dclass in mapping.items():
+        for k, dclass in list(mapping.items()):
             l = []
             values = header[k]
             if values is not None:

--- a/backend/server/importlib/errataImport.py
+++ b/backend/server/importlib/errataImport.py
@@ -17,7 +17,7 @@
 #
 
 from spacewalk.common.rhnException import rhnFault
-from importLib import GenericPackageImport
+from .importLib import GenericPackageImport
 from spacewalk.satellite_tools.syncLib import log
 
 
@@ -45,7 +45,7 @@ class ErrataImport(GenericPackageImport):
             release = errata['advisory_rel']
             errata_hash["%s%s" % (advisory, release)] = errata
             if advisory in advisories:
-                if long(release) < long(advisories[advisory]):
+                if int(release) < int(advisories[advisory]):
                     # Seen a newer one already
                     errata.ignored = 1
                     continue
@@ -146,10 +146,10 @@ class ErrataImport(GenericPackageImport):
             self._fix_erratum_file_channels(erratum)
 
         # remove erratas that have been ignored
-        ignored_erratas = list(filter(lambda x: x.ignored, self.batch))
+        ignored_erratas = list([x for x in self.batch if x.ignored])
         if len(ignored_erratas) > 0:
             log(0, "Ignoring %d old, superseded erratas" % len(ignored_erratas))
-            self.batch = list(filter(lambda x: not x.ignored, self.batch))
+            self.batch = list([x for x in self.batch if not x.ignored])
 
     def _fixCVE(self):
         # Look up and insert the missing CVE's
@@ -235,7 +235,7 @@ class ErrataImport(GenericPackageImport):
 
             channels[channel['id']] = None
 
-        erratum['channels'] = [{'channel_id': x} for x in channels.keys()]
+        erratum['channels'] = [{'channel_id': x} for x in list(channels.keys())]
 
     def _fix_erratum_packages_lookup(self, erratum):
         # To make the packages unique
@@ -279,7 +279,7 @@ class ErrataImport(GenericPackageImport):
         # 'package in erratum['packages'].values()' here. But for (to me) unknown
         # reason it sometimes has package.id == None which makes whole import fail.
         # And self.packages[nevrao].id contains always right value.
-        for nevrao in erratum['packages'].keys():
+        for nevrao in list(erratum['packages'].keys()):
             package = self.packages[nevrao]
             if package.ignored:
                 # Ignore this package

--- a/backend/server/importlib/headerSource.py
+++ b/backend/server/importlib/headerSource.py
@@ -18,9 +18,9 @@
 
 import time
 import string
-from importLib import File, Dependency, ChangeLog, Channel, \
+from .importLib import File, Dependency, ChangeLog, Channel, \
     IncompletePackage, Package, SourcePackage
-from backendLib import gmtime, localtime
+from .backendLib import gmtime, localtime
 from spacewalk.common.usix import ListType, TupleType, IntType, LongType, StringType, UnicodeType
 from spacewalk.common.rhnLog import log_debug
 from spacewalk.common.stringutils import to_string
@@ -45,7 +45,7 @@ class rpmPackage(IncompletePackage):
 
         # XXX is seems to me that this is the place that 'source_rpm' is getting
         # set
-        for f in self.keys():
+        for f in list(self.keys()):
             field = f
             if f in self.tagMap:
                 field = self.tagMap[f]
@@ -194,11 +194,11 @@ class rpmBinaryPackage(Package, rpmPackage):
             'recommends': rpmRecommends,
         }
 
-        for k, v in mapping.items():
+        for k, v in list(mapping.items()):
             self._populateTag(header, k, v)
-        for k, v in old_weak_deps_mapping.items():
+        for k, v in list(old_weak_deps_mapping.items()):
             self._populateTag(header, k, v)
-        for k, v in new_weak_deps_mapping.items():
+        for k, v in list(new_weak_deps_mapping.items()):
             self._populateTag(header, k, v)
 
     def _populateChangeLog(self, header):
@@ -223,7 +223,7 @@ class rpmBinaryPackage(Package, rpmPackage):
         fix = {}
         itemcount = 0
 
-        for f, rf in Class.tagMap.items():
+        for f, rf in list(Class.tagMap.items()):
             v = sanitizeList(header[rf])
             ic = len(v)
             if not itemcount or ic < itemcount:
@@ -237,7 +237,7 @@ class rpmBinaryPackage(Package, rpmPackage):
         unique_deps = []
         for i in range(itemcount):
             hash = {}
-            for k, v in fix.items():
+            for k, v in list(fix.items()):
                 # bugzilla 426963: fix for rpm v3 obsoletes header with
                 # empty version and flags values
                 if not len(v) and k == 'version':

--- a/backend/server/importlib/headerSource.py
+++ b/backend/server/importlib/headerSource.py
@@ -232,7 +232,7 @@ class rpmBinaryPackage(Package, rpmPackage):
 
         # Now create the array of objects
         if self[tag] is None:
-	  self[tag] = []
+            self[tag] = []
 
         unique_deps = []
         for i in range(itemcount):
@@ -249,7 +249,7 @@ class rpmBinaryPackage(Package, rpmPackage):
 
             # for the old weak dependency tags
             # RPMSENSE_STRONG(1<<27) indicate recommends; if not set it is suggests only
-	    if Class in [rpmOldRecommends, rpmOldSupplements, rpmOldSuggests, rpmOldEnhances]:
+            if Class in [rpmOldRecommends, rpmOldSupplements, rpmOldSuggests, rpmOldEnhances]:
                 if tag in ['recommends', 'supplements'] and not(hash['flags'] & (1 << 27)):
                     continue
                 if tag in ['suggests', 'enhances'] and (hash['flags'] & (1 << 27)):

--- a/backend/server/importlib/importLib.py
+++ b/backend/server/importlib/importLib.py
@@ -69,7 +69,7 @@ class BaseInformation(Item):
     def __init__(self, dict=None):
         Item.__init__(self, dict)
         # Initialize attributes
-        for k in dict.keys():
+        for k in list(dict.keys()):
             self[k] = None
         # Each information object has an id (which is set by the database)
         self.id = None
@@ -499,7 +499,7 @@ class Package(IncompletePackage):
         # Inherit from IncompletePackage
         IncompletePackage.__init__(self)
         # And initialize the specific ones
-        for k in self.attributeTypes.keys():
+        for k in list(self.attributeTypes.keys()):
             self[k] = None
 
 
@@ -528,7 +528,7 @@ class SourcePackage(IncompletePackage):
         IncompletePackage.__init__(self)
         # And initialize the specific ones
         self.source_rpm = None
-        for k in self.attributeTypes.keys():
+        for k in list(self.attributeTypes.keys()):
             self[k] = None
 
     def short_str(self):
@@ -783,7 +783,7 @@ class GenericPackageImport(Import):
         if package.arch not in self.package_arches:
             self.package_arches[package.arch] = None
 
-        for type, chksum in package['checksums'].items():
+        for type, chksum in list(package['checksums'].items()):
             checksumTuple = (type, chksum)
             if not checksumTuple in self.checksums:
                 self.checksums[checksumTuple] = None

--- a/backend/server/importlib/kickstartImport.py
+++ b/backend/server/importlib/kickstartImport.py
@@ -16,7 +16,7 @@
 # Package import process
 #
 
-from importLib import KickstartableTree, Import
+from .importLib import KickstartableTree, Import
 
 
 class KickstartableTreeImport(Import):

--- a/backend/server/importlib/mpmSource.py
+++ b/backend/server/importlib/mpmSource.py
@@ -16,8 +16,8 @@
 # Converts headers to the intermediate format
 #
 
-from . import headerSource
-from . import debPackage
+import headerSource
+import debPackage
 
 
 class mpmBinaryPackage(headerSource.rpmBinaryPackage):

--- a/backend/server/importlib/mpmSource.py
+++ b/backend/server/importlib/mpmSource.py
@@ -16,8 +16,8 @@
 # Converts headers to the intermediate format
 #
 
-import headerSource
-import debPackage
+from . import headerSource
+from . import debPackage
 
 
 class mpmBinaryPackage(headerSource.rpmBinaryPackage):
@@ -70,7 +70,7 @@ class mpmBinaryPackage(headerSource.rpmBinaryPackage):
             'suggests': headerSource.rpmSuggests,
         }
 
-        for k, dclass in mapping.items():
+        for k, dclass in list(mapping.items()):
             unique_deps = []
             l = []
             for dinfo in header.get(k, []):

--- a/backend/server/importlib/orgImport.py
+++ b/backend/server/importlib/orgImport.py
@@ -16,7 +16,7 @@
 # Org import process
 #
 
-from importLib import Import
+from .importLib import Import
 
 # Thanks for this class goes to Alex Martelli:
 # http://stackoverflow.com/questions/1151658/python-hashable-dicts

--- a/backend/server/importlib/packageImport.py
+++ b/backend/server/importlib/packageImport.py
@@ -19,10 +19,10 @@
 import rpm
 import sys
 import os.path
-from importLib import GenericPackageImport, IncompletePackage, \
+from .importLib import GenericPackageImport, IncompletePackage, \
     Import, InvalidArchError, InvalidChannelError, \
     IncompatibleArchError
-from mpmSource import mpmBinaryPackage
+from .mpmSource import mpmBinaryPackage
 from spacewalk.common import rhn_pkg
 from spacewalk.common.rhnConfig import CFG
 from spacewalk.server import taskomatic
@@ -66,7 +66,7 @@ class ChannelPackageSubscription(GenericPackageImport):
         self.backend.lookupChannels(self.channels)
         # Initialize self.channel_package_arch_compat
         self.channel_package_arch_compat = {}
-        for channel, channel_row in self.channels.items():
+        for channel, channel_row in list(self.channels.items()):
             if not channel_row:
                 # Unsupported channel
                 continue

--- a/backend/server/importlib/packageUpload.py
+++ b/backend/server/importlib/packageUpload.py
@@ -149,7 +149,7 @@ def _dump(object):
     from spacewalk.common.usix import DictType
     if isinstance(object, DictType):
         dict = {}
-        for h, v in object.items():
+        for h, v in list(object.items()):
             dict[_dump(h)] = _dump(v)
         return dict
     return str(object)

--- a/backend/server/importlib/productNamesImport.py
+++ b/backend/server/importlib/productNamesImport.py
@@ -15,7 +15,7 @@
 #
 # Product Names Import
 
-from importLib import Import
+from .importLib import Import
 
 
 class ProductNamesImport(Import):

--- a/backend/server/importlib/supportInformationImport.py
+++ b/backend/server/importlib/supportInformationImport.py
@@ -10,7 +10,7 @@
 #
 # Support Information Import
 
-from importLib import GenericPackageImport
+from .importLib import GenericPackageImport
 from spacewalk.satellite_tools import syncCache
 
 class SupportInformationImport(GenericPackageImport):
@@ -23,10 +23,10 @@ class SupportInformationImport(GenericPackageImport):
         channelLabels = {}
         keywords = {}
         for item in self.batch:
-            if not channelLabels.has_key(item['channel']):
+            if item['channel'] not in channelLabels:
                 channelLabels[item['channel']] = None
                 self.backend.lookupChannels(channelLabels)
-            if not keywords.has_key(item['keyword']):
+            if item['keyword'] not in keywords:
                 keywords[item['keyword']] = self.backend.lookupKeyword(item['keyword'])
             pkg = self._cache.cache_get(item['pkgid'])
             if not pkg:

--- a/backend/server/importlib/suseProductsImport.py
+++ b/backend/server/importlib/suseProductsImport.py
@@ -10,7 +10,7 @@
 #
 # SUSE Products Import
 
-from importLib import GenericPackageImport
+from .importLib import GenericPackageImport
 from spacewalk.satellite_tools import syncCache
 
 class SuseProductsImport(GenericPackageImport):

--- a/backend/server/importlib/test/test_backendOracle.py
+++ b/backend/server/importlib/test/test_backendOracle.py
@@ -10,7 +10,7 @@ tabs = OracleBackend.tables
 utabs = {}
 
 # convert table names to uppercase
-for k, v in tabs.items():
+for k, v in list(tabs.items()):
     utabs[k.upper()] = v
 
 
@@ -30,20 +30,20 @@ ora2py = {
 }
 
 for i in rows:
-    if utabs.has_key(i['table_name']):
+    if i['table_name'] in utabs:
         # table exists in backendOracle
         cols = utabs[i['table_name']]
-        if cols.fields.has_key(i['column_name'].lower()):
+        if i['column_name'].lower() in cols.fields:
             # column defined in backendOracle
             t = cols.fields[i['column_name'].lower()]
 
             # check column type
             if not isinstance(t, eval(ora2py[i['data_type']])):
-                print("%s.%s:  %s vs. %s" % (i['table_name'],
-                                             i['column_name'], i['data_type'], t.__class__))
+                print(("%s.%s:  %s vs. %s" % (i['table_name'],
+                                             i['column_name'], i['data_type'], t.__class__)))
             elif isinstance(t, DBstring) and t.limit != i['data_length']:
                 # for VARCHAR2/DBstring check also size
-                print("%s.%s: DBstring(%d) vs. VARCHAR2(%s)" % (
-                    i['table_name'], i['column_name'], t.limit, i['data_length']))
+                print(("%s.%s: DBstring(%d) vs. VARCHAR2(%s)" % (
+                    i['table_name'], i['column_name'], t.limit, i['data_length'])))
             else:
-                print("%s.%s: OK" % (i['table_name'], i['column_name']))
+                print(("%s.%s: OK" % (i['table_name'], i['column_name'])))

--- a/backend/server/importlib/test/test_strict_channel_package_subscription.py
+++ b/backend/server/importlib/test/test_strict_channel_package_subscription.py
@@ -65,7 +65,7 @@ def main():
     cps = packageImport.ChannelPackageSubscription(batch, backend,
                                                    caller="misa.testing", strict=1)
     cps.run()
-    print(cps.affected_channel_packages)
+    print((cps.affected_channel_packages))
 
 if __name__ == '__main__':
     sys.exit(main() or 0)

--- a/backend/server/repomd/mapper.py
+++ b/backend/server/repomd/mapper.py
@@ -25,7 +25,7 @@ from spacewalk.common.rhnConfig import CFG
 from spacewalk.common.usix import UnicodeType
 from spacewalk.server import rhnSQL
 
-import domain
+from . import domain
 
 
 CACHE_PREFIX = "/var/cache/rhn/"

--- a/backend/server/repomd/mapper.py
+++ b/backend/server/repomd/mapper.py
@@ -25,7 +25,7 @@ from spacewalk.common.rhnConfig import CFG
 from spacewalk.common.usix import UnicodeType
 from spacewalk.server import rhnSQL
 
-from . import domain
+import domain
 
 
 CACHE_PREFIX = "/var/cache/rhn/"

--- a/backend/server/repomd/repository.py
+++ b/backend/server/repomd/repository.py
@@ -35,8 +35,8 @@ from spacewalk.common import rhnCache
 from spacewalk.common.rhnLog import log_debug
 from spacewalk.common.rhnConfig import CFG
 
-from . import mapper
-from . import view
+import mapper
+import view
 from .domain import RepoMD
 from spacewalk.server import rhnChannel
 

--- a/backend/server/repomd/repository.py
+++ b/backend/server/repomd/repository.py
@@ -35,9 +35,9 @@ from spacewalk.common import rhnCache
 from spacewalk.common.rhnLog import log_debug
 from spacewalk.common.rhnConfig import CFG
 
-import mapper
-import view
-from domain import RepoMD
+from . import mapper
+from . import view
+from .domain import RepoMD
 from spacewalk.server import rhnChannel
 
 # One meg
@@ -52,7 +52,7 @@ comps_mapping = {
     'rhel-x86_64-server-cluster-5': 'rhn/kickstart/ks-rhel-x86_64-server-5/Cluster/repodata/comps-rhel5-cluster.xml',
     'rhel-x86_64-server-cluster-storage-5': 'rhn/kickstart/ks-rhel-x86_64-server-5/ClusterStorage/repodata/comps-rhel5-cluster-st.xml',
 }
-for k in comps_mapping.keys():
+for k in list(comps_mapping.keys()):
     for arch in ('i386', 'ia64', 's390x', 'ppc'):
         comps_mapping[k.replace('x86_64', arch)] = comps_mapping[k].replace('x86_64', arch)
 

--- a/backend/server/rhnAction.py
+++ b/backend/server/rhnAction.py
@@ -20,10 +20,10 @@ from spacewalk.server import rhnSQL
 
 def schedule_action(action_type, action_name=None, delta_time=0,
                     scheduler=None, org_id=None, prerequisite=None):
-    action_id = rhnSQL.Sequence('rhn_event_id_seq').next()
+    action_id = next(rhnSQL.Sequence('rhn_event_id_seq'))
 
     at = rhnSQL.Table('rhnActionType', 'label')
-    if not at.has_key(action_type):
+    if action_type not in at:
         raise ValueError("Unknown action type %s" % action_type)
 
     params = {

--- a/backend/server/rhnCapability.py
+++ b/backend/server/rhnCapability.py
@@ -23,7 +23,7 @@ from spacewalk.common import rhnFlags
 from spacewalk.common.rhnLog import log_debug
 
 # local module
-from . import rhnSQL
+import rhnSQL
 
 # Globally store the parsed capabilities in rhnFlags
 

--- a/backend/server/rhnCapability.py
+++ b/backend/server/rhnCapability.py
@@ -23,7 +23,7 @@ from spacewalk.common import rhnFlags
 from spacewalk.common.rhnLog import log_debug
 
 # local module
-import rhnSQL
+from . import rhnSQL
 
 # Globally store the parsed capabilities in rhnFlags
 
@@ -105,7 +105,7 @@ def update_client_capabilities(server_id):
         deletes['capability_name_id'].append(capability_name_id)
 
     # Everything else has to be inserted
-    for name, hash in caps.items():
+    for name, hash in list(caps.items()):
         inserts['server_id'].append(server_id)
         inserts['capability'].append(name)
         inserts['version'].append(hash['version'])
@@ -184,7 +184,7 @@ def _set_server_capabilities():
         'machine_info': {'version': 1, 'value': 1},
     }
     l = []
-    for name, hashval in capabilities.items():
+    for name, hashval in list(capabilities.items()):
         l.append("%s(%s)=%s" % (name, hashval['version'], hashval['value']))
 
     log_debug(4, "Setting capabilities", l)

--- a/backend/server/rhnChannel.py
+++ b/backend/server/rhnChannel.py
@@ -37,9 +37,9 @@ from spacewalk.common.rhnException import rhnFault, rhnException
 from spacewalk.common.rhnTranslate import _
 
 # local module
-from . import rhnUser
-from . import rhnSQL
-from . import rhnLib
+import rhnUser
+import rhnSQL
+import rhnLib
 
 
 class NoBaseChannelError(Exception):

--- a/backend/server/rhnChannel.py
+++ b/backend/server/rhnChannel.py
@@ -37,9 +37,9 @@ from spacewalk.common.rhnException import rhnFault, rhnException
 from spacewalk.common.rhnTranslate import _
 
 # local module
-import rhnUser
-import rhnSQL
-import rhnLib
+from . import rhnUser
+from . import rhnSQL
+from . import rhnLib
 
 
 class NoBaseChannelError(Exception):
@@ -201,7 +201,7 @@ class BaseChannelObject(BaseDatabaseObject):
     def _new_row(self):
         if self._row is None:
             self._row = rhnSQL.Row(self._table_name, 'id')
-            channel_id = rhnSQL.Sequence(self._sequence_name).next()
+            channel_id = next(rhnSQL.Sequence(self._sequence_name))
             self._row.create(channel_id)
 
     def as_dict(self):
@@ -382,7 +382,7 @@ class Channel(BaseChannelObject):
 
     def get_dists(self):
         ret = []
-        for release, os in self._dists.items():
+        for release, os in list(self._dists.items()):
             ret.append({'release': release, 'os': os})
         return ret
 
@@ -585,7 +585,7 @@ def __stringify(object):
         return tuple(map(__stringify, object))
     if type(object) == type({}):
         ret = {}
-        for k, v in object.items():
+        for k, v in list(object.items()):
             ret[__stringify(k)] = __stringify(v)
         return ret
     # by default, we just str() it
@@ -1940,7 +1940,7 @@ def guess_suse_channels_for_server(server, org_id=None, user_id=None, raise_exce
                 childchannels[cc['id']] = cc
 
     channels = [bc]
-    for chan in childchannels.itervalues():
+    for chan in list(childchannels.values()):
         channels.append(chan)
 
     return __stringify(channels)
@@ -2206,7 +2206,7 @@ def system_reg_message(server):
                 (server.server["release"], server.archname))
 
     # System does have a base channel; check entitlements
-    from rhnServer import server_lib  # having this on top, cause TB due circular imports
+    from .rhnServer import server_lib  # having this on top, cause TB due circular imports
     entitlements = server_lib.check_entitlement(server_id)
     if not entitlements:
         # No entitlement

--- a/backend/server/rhnDependency.py
+++ b/backend/server/rhnDependency.py
@@ -16,8 +16,8 @@
 
 from spacewalk.common.rhnLog import log_debug, log_error
 from spacewalk.common.rhnException import rhnFault
-from . import rhnSQL
-from . import rhnLib
+import rhnSQL
+import rhnLib
 import rpm
 
 # QUERY PACKAGES

--- a/backend/server/rhnDependency.py
+++ b/backend/server/rhnDependency.py
@@ -16,8 +16,8 @@
 
 from spacewalk.common.rhnLog import log_debug, log_error
 from spacewalk.common.rhnException import rhnFault
-import rhnSQL
-import rhnLib
+from . import rhnSQL
+from . import rhnLib
 import rpm
 
 # QUERY PACKAGES
@@ -362,7 +362,7 @@ def solve_dependencies_with_limits(server_id, deps, version, all=0, limit_operat
                 packages_all[record['name']] = [record]
 
         # sort all the package lists so the most recent version is first
-        for pl in packages_all.keys():
+        for pl in list(packages_all.keys()):
 
             packages_all[pl].sort(cmp_evr)
             package_list = package_list + packages_all[pl]

--- a/backend/server/rhnLib.py
+++ b/backend/server/rhnLib.py
@@ -24,7 +24,7 @@ from spacewalk.common.rhnLog import log_debug
 from spacewalk.common.rhnException import rhnFault
 
 # architecture work
-from rhnMapping import check_package_arch
+from .rhnMapping import check_package_arch
 
 
 def computeSignature(*fields):
@@ -217,7 +217,7 @@ def make_evr(nvre, source=False):
     if len(nvr_parts) != 3:
         raise rhnFault(err_code=21, err_text="NVRE is missing name, version, or release.")
 
-    result = dict(zip(["name", "version", "release"], nvr_parts))
+    result = dict(list(zip(["name", "version", "release"], nvr_parts)))
     result["epoch"] = epoch
 
     if source and result["release"].endswith(".src"):

--- a/backend/server/rhnMapping.py
+++ b/backend/server/rhnMapping.py
@@ -33,4 +33,4 @@ if __name__ == '__main__':
     """Test code.
     """
     rhnSQL.initDB()
-    print(check_package_arch('i386'))
+    print((check_package_arch('i386')))

--- a/backend/server/rhnPackage.py
+++ b/backend/server/rhnPackage.py
@@ -24,7 +24,7 @@ from spacewalk.common.rhnConfig import CFG
 from spacewalk.common.rhnException import rhnFault
 from spacewalk.common.rhnTranslate import _
 from spacewalk.server import rhnSQL
-from rhnLib import parseRPMFilename
+from .rhnLib import parseRPMFilename
 
 
 #
@@ -284,5 +284,5 @@ if __name__ == '__main__':
     rhnSQL.initDB()
     print("")
     # new client
-    print(get_package_path(1000463284, 'kernel-2.4.2-2.i686.rpm', 'redhat-linux-i386-7.1'))
-    print(get_source_package_path(1000463284, 'kernel-2.4.2-2.i686.rpm', 'redhat-linux-i386-7.1'))
+    print((get_package_path(1000463284, 'kernel-2.4.2-2.i686.rpm', 'redhat-linux-i386-7.1')))
+    print((get_source_package_path(1000463284, 'kernel-2.4.2-2.i686.rpm', 'redhat-linux-i386-7.1')))

--- a/backend/server/rhnRepository.py
+++ b/backend/server/rhnRepository.py
@@ -31,8 +31,8 @@ from spacewalk.common.rhnLib import rfc822time, timestamp
 
 # local modules imports
 from spacewalk.server import rhnChannel, rhnPackage, taskomatic, rhnSQL
-from rhnServer import server_lib
-from repomd import repository
+from .rhnServer import server_lib
+from .repomd import repository
 
 
 class Repository(rhnRepository.Repository):

--- a/backend/server/rhnSQL/__init__.py
+++ b/backend/server/rhnSQL/__init__.py
@@ -24,17 +24,17 @@ from spacewalk.common.rhnException import rhnException
 from spacewalk.common.rhnTB import add_to_seclist
 
 # SQL objects
-import sql_table
-import sql_row
-import sql_sequence
-import dbi
-import sql_types
+from . import sql_table
+from . import sql_row
+from . import sql_sequence
+from . import dbi
+from . import sql_types
 types = sql_types
 
-from const import ORACLE, POSTGRESQL, SUPPORTED_BACKENDS
+from .const import ORACLE, POSTGRESQL, SUPPORTED_BACKENDS
 
 # expose exceptions
-from sql_base import SQLError, SQLSchemaError, SQLConnectError, \
+from .sql_base import SQLError, SQLSchemaError, SQLConnectError, \
     SQLStatementPrepareError, Statement, ModifiedRowError
 
 # ths module works with a private global __DB object that is

--- a/backend/server/rhnSQL/__init__.py
+++ b/backend/server/rhnSQL/__init__.py
@@ -24,11 +24,11 @@ from spacewalk.common.rhnException import rhnException
 from spacewalk.common.rhnTB import add_to_seclist
 
 # SQL objects
-from . import sql_table
-from . import sql_row
-from . import sql_sequence
-from . import dbi
-from . import sql_types
+import sql_table
+import sql_row
+import sql_sequence
+import dbi
+import sql_types
 types = sql_types
 
 from .const import ORACLE, POSTGRESQL, SUPPORTED_BACKENDS

--- a/backend/server/rhnSQL/dbi.py
+++ b/backend/server/rhnSQL/dbi.py
@@ -14,7 +14,7 @@
 #
 #
 
-from const import ORACLE, POSTGRESQL
+from .const import ORACLE, POSTGRESQL
 
 # Map supported backend constants to a specific Python driver:
 BACKEND_DRIVERS = {

--- a/backend/server/rhnSQL/driver_cx_Oracle.py
+++ b/backend/server/rhnSQL/driver_cx_Oracle.py
@@ -20,8 +20,8 @@
 # specific exceptions and return generic ones. (or to deal with other Oracle
 # one-offs)
 
-import sql_base
-import sql_types
+from . import sql_base
+from . import sql_types
 import cx_Oracle
 import sys
 import string
@@ -36,7 +36,7 @@ from spacewalk.common import rhnConfig
 from spacewalk.common.rhnLog import log_debug, log_error
 from spacewalk.common.rhnException import rhnException
 from spacewalk.common.stringutils import to_string
-from const import ORACLE
+from .const import ORACLE
 
 ORACLE_TYPE_MAPPING = [
     (sql_types.NUMBER, cx_Oracle.NUMBER),
@@ -138,7 +138,7 @@ class Cursor(sql_base.Cursor):
             self.reparsed = 0  # reset the reparsed counter
 
         if self.blob_map:
-            for blob_var, content in blob_content.items():
+            for blob_var, content in list(blob_content.items()):
                 kw[blob_var].getvalue().write(content)
         # Munge back the values
         self._unmunge_args(kw, modified_params)
@@ -157,7 +157,7 @@ class Cursor(sql_base.Cursor):
         # Check that all required parameters were provided:
         # NOTE: bindnames() is Oracle specific:
         for k in self._real_cursor.bindnames():
-            if not _p.has_key(k):
+            if k not in _p:
                 # Raise the fault ourselves
                 raise sql_base.SQLError(1008, 'Not all variables bound', k)
             params[k] = to_string(_p[k])
@@ -187,7 +187,7 @@ class Cursor(sql_base.Cursor):
 
         chunk_size = min(max_array_size, array_size)
         pdict = {}
-        for k in kwargs.iterkeys():
+        for k in list(kwargs.keys()):
             pdict[k] = None
         arr = []
         for i in range(chunk_size):
@@ -204,7 +204,7 @@ class Cursor(sql_base.Cursor):
 
             for i in range(item_count):
                 pdict = arr[i]
-                for k, v in kwargs.items():
+                for k, v in list(kwargs.items()):
                     pdict[k] = to_string(v[start + i])
 
             # We clear self->bindVariables so that list of all nulls
@@ -266,7 +266,7 @@ class Cursor(sql_base.Cursor):
     # TODO: Don't think this is doing anything for PostgreSQL, maybe move to Oracle?
     def _munge_args(self, kw_dict):
         modified = []
-        for k, v in kw_dict.items():
+        for k, v in list(kw_dict.items()):
             if not isinstance(v, sql_types.DatabaseDataType):
                 continue
             vv = self._munge_arg(v)
@@ -457,7 +457,7 @@ class Database(sql_base.Database):
         _cursor_cache = self._cursor_class._cursor_cache
         if dbh_id in _cursor_cache:
             _cache = _cursor_cache[dbh_id]
-            for sql, cursor in _cache.items():
+            for sql, cursor in list(_cache.items()):
                 # Close cursors
                 try:
                     cursor.close()
@@ -478,7 +478,7 @@ class Database(sql_base.Database):
         if blob_map:
             col_list = []
             bind_list = []
-            for bind_var, column in blob_map.items():
+            for bind_var, column in list(blob_map.items()):
                 r = re.compile(":%s" % bind_var)
                 sql = re.sub(r, 'empty_blob()', sql)
                 col_list.append(column)
@@ -549,7 +549,7 @@ class Database(sql_base.Database):
             value = None
             # Do we have a config object?
             if rhnConfig.CFG.is_initialized():
-                if rhnConfig.CFG.has_key("nls_lang"):
+                if "nls_lang" in rhnConfig.CFG:
                     # Get the value from the configuration object
                     value = rhnConfig.CFG.nls_lang
             if not value:

--- a/backend/server/rhnSQL/driver_cx_Oracle.py
+++ b/backend/server/rhnSQL/driver_cx_Oracle.py
@@ -20,8 +20,8 @@
 # specific exceptions and return generic ones. (or to deal with other Oracle
 # one-offs)
 
-from . import sql_base
-from . import sql_types
+import sql_base
+import sql_types
 import cx_Oracle
 import sys
 import string

--- a/backend/server/rhnSQL/driver_postgresql.py
+++ b/backend/server/rhnSQL/driver_postgresql.py
@@ -27,14 +27,14 @@ import psycopg2
 if not hasattr(psycopg2, 'extensions'):
     import psycopg2.extensions
 
-import sql_base
+from . import sql_base
 from rhn.UserDictCase import UserDictCase
 from spacewalk.server import rhnSQL
 
 from spacewalk.common.usix import BufferType, raise_with_tb
 from spacewalk.common.rhnLog import log_debug, log_error
 from spacewalk.common.rhnException import rhnException
-from const import POSTGRESQL
+from .const import POSTGRESQL
 
 
 def convert_named_query_params(query):
@@ -181,7 +181,7 @@ class Database(sql_base.Database):
             if self.sslmode is not None and self.sslrootcert is None:
                 raise AttributeError("Attribute sslrootcert needs to be set if sslmode is set.")
 
-            self.dbh = psycopg2.connect(" ".join("%s=%s" % (k, re.escape(str(v))) for k, v in dsndata.items()))
+            self.dbh = psycopg2.connect(" ".join("%s=%s" % (k, re.escape(str(v))) for k, v in list(dsndata.items())))
 
             # convert all DECIMAL types to float (let Python to choose one)
             DEC2INTFLOAT = psycopg2.extensions.new_type(psycopg2._psycopg.DECIMAL.values,
@@ -332,7 +332,7 @@ class Cursor(sql_base.Cursor):
         # First break all the incoming keyword arg lists into individual
         # hashes:
         all_kwargs = []
-        for key in params.keys():
+        for key in list(params.keys()):
             if len(all_kwargs) < len(params[key]):
                 for i in range(len(params[key])):
                     all_kwargs.append({})

--- a/backend/server/rhnSQL/driver_postgresql.py
+++ b/backend/server/rhnSQL/driver_postgresql.py
@@ -27,7 +27,7 @@ import psycopg2
 if not hasattr(psycopg2, 'extensions'):
     import psycopg2.extensions
 
-from . import sql_base
+import sql_base
 from rhn.UserDictCase import UserDictCase
 from spacewalk.server import rhnSQL
 

--- a/backend/server/rhnSQL/sql_base.py
+++ b/backend/server/rhnSQL/sql_base.py
@@ -25,7 +25,7 @@
 
 import string
 import sys
-import sql_types
+from . import sql_types
 from spacewalk.common import usix
 
 
@@ -176,7 +176,7 @@ class Cursor:
         start_chunk = 0
         while 1:
             subdict = {}
-            for k, arr in dict.items():
+            for k, arr in list(dict.items()):
                 subarr = arr[start_chunk:start_chunk + chunk_size]
                 if not subarr:
                     # Nothing more to do here - we exhausted the array(s)

--- a/backend/server/rhnSQL/sql_base.py
+++ b/backend/server/rhnSQL/sql_base.py
@@ -25,7 +25,7 @@
 
 import string
 import sys
-from . import sql_types
+import sql_types
 from spacewalk.common import usix
 
 

--- a/backend/server/rhnSQL/sql_row.py
+++ b/backend/server/rhnSQL/sql_row.py
@@ -20,8 +20,8 @@ import string
 from rhn.UserDictCase import UserDictCase
 from spacewalk.common.rhnException import rhnException
 
-import sql_base
-import sql_lib
+from . import sql_base
+from . import sql_lib
 
 
 class Row(UserDictCase):
@@ -82,7 +82,7 @@ class Row(UserDictCase):
 
     def reset(self, val=0):
         """ reset the changed status for these entries """
-        for k, v in self.data.items():
+        for k, v in list(self.data.items()):
             # tuples do not support item assignement
             self.data[k] = (v[0], val)
 
@@ -105,7 +105,7 @@ class Row(UserDictCase):
         if not ret:
             self.real = 0
             return 0
-        for k, v in ret.items():
+        for k, v in list(ret.items()):
             self.data[k] = (v, 0)
         self.real = 1
         return 1

--- a/backend/server/rhnSQL/sql_row.py
+++ b/backend/server/rhnSQL/sql_row.py
@@ -20,8 +20,8 @@ import string
 from rhn.UserDictCase import UserDictCase
 from spacewalk.common.rhnException import rhnException
 
-from . import sql_base
-from . import sql_lib
+import sql_base
+import sql_lib
 
 
 class Row(UserDictCase):

--- a/backend/server/rhnSQL/sql_sequence.py
+++ b/backend/server/rhnSQL/sql_sequence.py
@@ -32,7 +32,7 @@ class Sequence:
             raise rhnException("Argument db is not a database instance", db)
         self.__db = db
 
-    def __next__(self):
+    def next(self):
         sql = "select sequence_nextval('%s') as ID from dual" % self.__seq
         cursor = self.__db.prepare(sql)
         cursor.execute()
@@ -42,7 +42,7 @@ class Sequence:
         return int(ret['id'])
 
     def __call__(self):
-        return next(self)
+        return self.next()
 
     def __del__(self):
         self.__seq = self.__db = None

--- a/backend/server/rhnSQL/sql_sequence.py
+++ b/backend/server/rhnSQL/sql_sequence.py
@@ -17,7 +17,7 @@
 
 from spacewalk.common.rhnException import rhnException
 
-from . import sql_base
+import sql_base
 
 
 # A class to handle sequences

--- a/backend/server/rhnSQL/sql_sequence.py
+++ b/backend/server/rhnSQL/sql_sequence.py
@@ -17,7 +17,7 @@
 
 from spacewalk.common.rhnException import rhnException
 
-import sql_base
+from . import sql_base
 
 
 # A class to handle sequences
@@ -32,7 +32,7 @@ class Sequence:
             raise rhnException("Argument db is not a database instance", db)
         self.__db = db
 
-    def next(self):
+    def __next__(self):
         sql = "select sequence_nextval('%s') as ID from dual" % self.__seq
         cursor = self.__db.prepare(sql)
         cursor.execute()
@@ -42,7 +42,7 @@ class Sequence:
         return int(ret['id'])
 
     def __call__(self):
-        return self.next()
+        return next(self)
 
     def __del__(self):
         self.__seq = self.__db = None

--- a/backend/server/rhnSQL/sql_table.py
+++ b/backend/server/rhnSQL/sql_table.py
@@ -21,8 +21,8 @@ import string
 from rhn.UserDictCase import UserDictCase
 from spacewalk.common.rhnException import rhnException
 
-from . import sql_base
-from . import sql_lib
+import sql_base
+import sql_lib
 
 
 # A class to handle row updates transparently

--- a/backend/server/rhnSQL/sql_table.py
+++ b/backend/server/rhnSQL/sql_table.py
@@ -21,8 +21,8 @@ import string
 from rhn.UserDictCase import UserDictCase
 from spacewalk.common.rhnException import rhnException
 
-import sql_base
-import sql_lib
+from . import sql_base
+from . import sql_lib
 
 
 # A class to handle row updates transparently
@@ -181,7 +181,7 @@ class Table:
         if items == []:  # quick check for noop
             return
         sql = None
-        if self.has_key(key):
+        if key in self:
             sql, pdict = sql_lib.build_sql_update(self.__table, self.__hashid, items)
         else:
             sql, pdict = sql_lib.build_sql_insert(self.__table, self.__hashid, items)
@@ -260,5 +260,5 @@ class Table:
         return self.__db.rollback()
 
     def printcache(self):
-        print(self.__cache)
+        print((self.__cache))
         return

--- a/backend/server/rhnServer/__init__.py
+++ b/backend/server/rhnServer/__init__.py
@@ -23,9 +23,9 @@ from spacewalk.common.rhnLog import log_debug, log_error
 from spacewalk.server import rhnUser
 
 # Local imports
-from server_class import Server
-from server_certificate import Certificate
-from server_token import fetch_token, fetch_org_token
+from .server_class import Server
+from .server_certificate import Certificate
+from .server_token import fetch_token, fetch_org_token
 
 
 def get(system_id, load_user=1):

--- a/backend/server/rhnServer/__init__.py
+++ b/backend/server/rhnServer/__init__.py
@@ -17,10 +17,10 @@
 
 
 # these are pretty much the only entry points
-from spacewalk.common.usix import StringType, UnicodeType
-from spacewalk.common.rhnException import rhnFault
-from spacewalk.common.rhnLog import log_debug, log_error
-from spacewalk.server import rhnUser
+#from spacewalk.common.usix import StringType, UnicodeType
+#from spacewalk.common.rhnException import rhnFault
+#from spacewalk.common.rhnLog import log_debug, log_error
+#from spacewalk.server import rhnUser
 
 # Local imports
 from .server_class import Server

--- a/backend/server/rhnServer/satellite_cert.py
+++ b/backend/server/rhnServer/satellite_cert.py
@@ -41,7 +41,7 @@ class Item:
     def __init__(self, node=None):
         if not node:
             return
-        for attr_name, storage_name in self.attributes.items():
+        for attr_name, storage_name in list(self.attributes.items()):
             attr = node.getAttribute(attr_name)
             # Make sure we stringify the attribute - it may get out as unicode
             setattr(self, storage_name, attr)
@@ -49,7 +49,7 @@ class Item:
     def __repr__(self):
         return "<%s; %s>" % (self.pretty_name,
                              string.join(
-                                 ['%s="%s"' % (x, getattr(self, x)) for x in self.attributes.values()],
+                                 ['%s="%s"' % (x, getattr(self, x)) for x in list(self.attributes.values())],
                                  ', '
                              ))
 
@@ -134,7 +134,7 @@ class SatelliteCert:
     def __init__(self):
         for f in self.fields_scalar:
             setattr(self, f, None)
-        for f in self.fields_list.values():
+        for f in list(self.fields_list.values()):
             setattr(self, f.attribute_name, [])
         self.signature = None
         self._slots = {}
@@ -147,7 +147,7 @@ class SatelliteCert:
             raise ParseException(None, sys.exc_info()[2])
         # Now represent the slots in a more meaningful way
         self._slots.clear()
-        for slot_name, (slot_attr, factory) in self._slot_maps.items():
+        for slot_name, (slot_attr, factory) in list(self._slot_maps.items()):
             quantity = getattr(self, slot_attr)
             self._slots[slot_name] = factory(quantity)
 
@@ -203,11 +203,11 @@ class SatelliteCert:
         return self._slots[slot_type]
 
     def get_slot_types(self):
-        return self._slot_maps.keys()
+        return list(self._slot_maps.keys())
 
     def lookup_slot_by_db_label(self, db_label):
         # Given a string like 'sw_mgr_entitled', returns a string 'management'
-        for label, (_, slot_class) in self._slot_maps.items():
+        for label, (_, slot_class) in list(self._slot_maps.items()):
             if slot_class._db_label == db_label:
                 return label
         return None

--- a/backend/server/rhnServer/search_notify.py
+++ b/backend/server/rhnServer/search_notify.py
@@ -45,4 +45,4 @@ class SearchNotify:
 if __name__ == "__main__":
     search = SearchNotify()
     result = search.notify()
-    print("search.notify() = %s" % (result))
+    print(("search.notify() = %s" % (result)))

--- a/backend/server/rhnServer/server_certificate.py
+++ b/backend/server/rhnServer/server_certificate.py
@@ -33,8 +33,8 @@ except ImportError:
 from spacewalk.common.rhnLog import log_debug, log_error
 from spacewalk.common.rhnException import rhnFault
 from spacewalk.common.stringutils import to_string
-from server_lib import getServerSecret
-from server_lib import check_entitlement_by_machine_id
+from .server_lib import getServerSecret
+from .server_lib import check_entitlement_by_machine_id
 
 def gen_secret():
     """ Generate a secret """
@@ -166,7 +166,7 @@ class Certificate:
         else:
             s = sysid[0]
             del junk
-        if "system_id" not in s or not s.has_key("fields"):
+        if "system_id" not in s or "fields" not in s:
             log_error("Got certificate with missing entries: %s" % s)
             return -1
         # check the certificate some more
@@ -181,7 +181,7 @@ class Certificate:
 
         # at this point we know the certificate is sane enough for the
         # following processing
-        for k in s.keys():
+        for k in list(s.keys()):
             if k == "fields":
                 self.__fields = s[k]
                 continue

--- a/backend/server/rhnServer/server_class.py
+++ b/backend/server/rhnServer/server_class.py
@@ -30,9 +30,9 @@ from spacewalk.server import rhnChannel, rhnUser, rhnSQL, rhnLib, rhnAction, \
 from .search_notify import SearchNotify
 
 # Local Modules
-from . import server_kickstart
-from . import server_lib
-from . import server_token
+import server_kickstart
+import server_lib
+import server_token
 from .server_certificate import Certificate, gen_secret
 from .server_wrapper import ServerWrapper
 

--- a/backend/server/rhnServer/server_class.py
+++ b/backend/server/rhnServer/server_class.py
@@ -27,14 +27,14 @@ from spacewalk.common.rhnException import rhnFault, rhnException
 from spacewalk.common.rhnTranslate import _
 from spacewalk.server import rhnChannel, rhnUser, rhnSQL, rhnLib, rhnAction, \
     rhnVirtualization
-from search_notify import SearchNotify
+from .search_notify import SearchNotify
 
 # Local Modules
-import server_kickstart
-import server_lib
-import server_token
-from server_certificate import Certificate, gen_secret
-from server_wrapper import ServerWrapper
+from . import server_kickstart
+from . import server_lib
+from . import server_token
+from .server_certificate import Certificate, gen_secret
+from .server_wrapper import ServerWrapper
 
 
 class Server(ServerWrapper):
@@ -167,7 +167,7 @@ class Server(ServerWrapper):
 
     # return the id of this system
     def getid(self):
-        if not self.server.has_key("id"):
+        if "id" not in self.server:
             sysid = rhnSQL.Sequence("rhn_server_id_seq")()
             self.server["digital_server_id"] = "ID-%09d" % sysid
             # we can't reset the id column, so we need to poke into
@@ -221,8 +221,7 @@ class Server(ServerWrapper):
         # Let get_server_channels deal with the errors and raise rhnFault
         target_channels = rhnChannel.guess_channels_for_server(s, none_ok=True)
         if target_channels:
-            target_base = filter(lambda x: not x['parent_channel'],
-                                 target_channels)[0]
+            target_base = [x for x in target_channels if not x['parent_channel']][0]
         else:
             target_base = None
 
@@ -536,7 +535,7 @@ class Server(ServerWrapper):
 
             # some more default values
             self.server["auto_update"] = "N"
-            if self.user and not self.server.has_key("creator_id"):
+            if self.user and "creator_id" not in self.server:
                 # save the link to the user that created it if we have
                 # that information
                 self.server["creator_id"] = self.user.getid()
@@ -730,7 +729,7 @@ class Server(ServerWrapper):
 
     # Is this server entitled?
     def check_entitlement(self):
-        if not self.server.has_key("id"):
+        if "id" not in self.server:
             return None
         log_debug(3, self.server["id"])
 
@@ -738,19 +737,19 @@ class Server(ServerWrapper):
 
     def checkin(self, commit=1):
         """ convenient wrapper for these thing until we clean the code up """
-        if not self.server.has_key("id"):
+        if "id" not in self.server:
             return 0  # meaningless if rhnFault not raised
         return server_lib.checkin(self.server["id"], commit)
 
     def throttle(self):
         """ convenient wrapper for these thing until we clean the code up """
-        if not self.server.has_key("id"):
+        if "id" not in self.server:
             return 1  # meaningless if rhnFault not raised
         return server_lib.throttle(self.server)
 
     def set_qos(self):
         """ convenient wrapper for these thing until we clean the code up """
-        if not self.server.has_key("id"):
+        if "id" not in self.server:
             return 1  # meaningless if rhnFault not raised
         return server_lib.set_qos(self.server["id"])
 

--- a/backend/server/rhnServer/server_hardware.py
+++ b/backend/server/rhnServer/server_hardware.py
@@ -34,7 +34,7 @@ from spacewalk.common import rhnFlags
 from spacewalk.server import rhnSQL, rhnVirtualization, rhnUser
 
 # Local imports
-from . import server_class
+import server_class
 
 def kudzu_mapping(dict=None):
     """ this is a class we use to get the mapping for a kudzu entry """

--- a/backend/server/rhnServer/server_kickstart.py
+++ b/backend/server/rhnServer/server_kickstart.py
@@ -191,7 +191,7 @@ def schedule_kickstart_delta(server_id, kickstart_session_id,
         delta_time=0, scheduler=scheduler, org_id=org_id,
     )
 
-    package_delta_id = rhnSQL.Sequence('rhn_packagedelta_id_seq').next()
+    package_delta_id = next(rhnSQL.Sequence('rhn_packagedelta_id_seq'))
 
     h = rhnSQL.prepare(_query_insert_package_delta)
     h.execute(package_delta_id=package_delta_id)
@@ -588,7 +588,7 @@ def __execute_many(cursor, array, col_names, **kwargs):
         return
     # Transpose the array into a hash with col_names as keys
     params = rhnLib.transpose_to_hash(array, col_names)
-    for k, v in kwargs.items():
+    for k, v in list(kwargs.items()):
         params[k] = [v] * linecount
 
     cursor.executemany(**params)

--- a/backend/server/rhnServer/server_lib.py
+++ b/backend/server/rhnServer/server_lib.py
@@ -366,4 +366,4 @@ def generate_random_string(length=20):
 
 if __name__ == '__main__':
     rhnSQL.initDB()
-    print(update_push_client_registration(1000102174))
+    print((update_push_client_registration(1000102174)))

--- a/backend/server/rhnServer/server_packages.py
+++ b/backend/server/rhnServer/server_packages.py
@@ -27,7 +27,7 @@ from spacewalk.common import rhn_rpm
 from spacewalk.common.rhnLog import log_debug
 from spacewalk.common.rhnException import rhnFault
 from spacewalk.server import rhnSQL, rhnAction
-from server_lib import snapshot_server, check_entitlement
+from .server_lib import snapshot_server, check_entitlement
 
 UNCHANGED = 0
 ADDED = 1
@@ -392,13 +392,13 @@ class Packages:
         if not package_names:
             return None
 
-        package_arch_ids = package_names.keys()
+        package_arch_ids = list(package_names.keys())
 
         action_id = rhnAction.schedule_server_packages_update_by_arch(self.server['id'],
                                                                       package_arch_ids,
                                                                       org_id=self.server['org_id'],
                                                                       action_name="Product Package Auto-Install")
-        for p in package_names.values():
+        for p in list(package_names.values()):
             log_debug(1, "Scheduled for install:  '%s'" % p)
 
         rhnSQL.commit()

--- a/backend/server/rhnServer/server_suse.py
+++ b/backend/server/rhnServer/server_suse.py
@@ -67,7 +67,7 @@ class SuseData:
       log_debug(1, suse_products)
       if not isinstance(suse_products, dict):
 	  log_error("argument type is not  hash: %s" % suse_products)
-	  raise TypeError, "This function requires a hash as an argument"
+	  raise TypeError("This function requires a hash as an argument")
       self.suse_products = suse_products
 
   def save_suse_products_byid(self, sysid):
@@ -168,7 +168,7 @@ class SuseData:
                  ostarget_id = (select id from suseOSTarget where os = :ostarget)
            WHERE rhn_server_id = :rhn_server_id
         """)
-        apply(h.execute, (), data)
+        h.execute(*(), **data)
     # check products
     h = rhnSQL.prepare("""
       SELECT
@@ -177,7 +177,7 @@ class SuseData:
        WHERE rhn_server_id = :sysid
     """)
     h.execute(sysid=sysid)
-    existing_products = map(lambda x: x['id'], h.fetchall_dict() or [])
+    existing_products = [x['id'] for x in h.fetchall_dict() or []]
 
     for product in products:
       sipid = self.get_installed_product_id(product)
@@ -237,7 +237,7 @@ class SuseData:
          AND %s
          AND sip.is_baseproduct = :baseproduct
     """ % (version_query, release_query))
-    apply(h.execute, (), product)
+    h.execute(*(), **product)
     d = h.fetchone_dict()
     if not d:
       # not available yet, so let's create one
@@ -248,8 +248,8 @@ class SuseData:
                (SELECT id FROM rhnPackageArch WHERE label = :arch),
                :release, :baseproduct)
       """)
-      apply(n.execute, (), product)
-      apply(h.execute, (), product)
+      n.execute(*(), **product)
+      h.execute(*(), **product)
       d = h.fetchone_dict()
       if not d:
         # should never happen

--- a/backend/server/rhnServer/server_suse.py
+++ b/backend/server/rhnServer/server_suse.py
@@ -66,19 +66,19 @@ class SuseData:
   def add_suse_products(self, suse_products):
       log_debug(1, suse_products)
       if not isinstance(suse_products, dict):
-	  log_error("argument type is not  hash: %s" % suse_products)
-	  raise TypeError("This function requires a hash as an argument")
+          log_error("argument type is not  hash: %s" % suse_products)
+          raise TypeError("This function requires a hash as an argument")
       self.suse_products = suse_products
 
   def save_suse_products_byid(self, sysid):
       log_debug(1, sysid, self.suse_products )
       if len(self.suse_products) == 0: # nothing loaded
-	return 0
+          return 0
       self.create_update_suse_products(self.server["id"],
-				       self.suse_products["guid"],
-				       self.suse_products["secret"],
-				       self.suse_products["ostarget"],
-				       self.suse_products["products"])
+                                       self.suse_products["guid"],
+                                       self.suse_products["secret"],
+                                       self.suse_products["ostarget"],
+                                       self.suse_products["products"])
       return 0
 
   def create_update_suse_products(self, sysid, guid, secret, ostarget, products):

--- a/backend/server/rhnServer/server_token.py
+++ b/backend/server/rhnServer/server_token.py
@@ -526,7 +526,7 @@ class ActivationTokens:
         self.entitlements = entitlements
         self.contact_method_id = contact_method_id
 
-    def __bool__(self):
+    def __nonzero__(self):
         return (len(self.tokens) > 0)
 
     __bool__ = __nonzero__

--- a/backend/server/rhnServer/server_token.py
+++ b/backend/server/rhnServer/server_token.py
@@ -24,7 +24,7 @@ from spacewalk.common.rhnException import rhnFault, rhnException
 from spacewalk.common.rhnTranslate import _
 from spacewalk.server import rhnSQL, rhnChannel, rhnAction
 
-from server_lib import join_server_group, check_entitlement
+from .server_lib import join_server_group, check_entitlement
 
 VIRT_ENT_LABEL = 'virtualization_host'
 
@@ -123,7 +123,7 @@ def token_channels(server, server_arch, tokens_obj):
     # channel family ids used in the loop below.
     channel_family_ids = set()
 
-    for c in [a for a in chash.values() if a["parent_channel"]]:
+    for c in [a for a in list(chash.values()) if a["parent_channel"]]:
         # make sure this channel has the right parent
         if str(c["parent_channel"]) != str(sbc["id"]):
             ret.append("NOT subscribed to channel '%s' "
@@ -178,7 +178,7 @@ def token_server_groups(server_id, tokens_obj):
 
     # Now try to subscribe server to group
     ret = []
-    for server_group_id, sg in server_groups.items():
+    for server_group_id, sg in list(server_groups.items()):
         log_debug(4, "token server group", sg)
 
         try:
@@ -240,7 +240,7 @@ def token_packages(server_id, tokens_obj):
     # This action becomes the latest now
     rhnFlags.set('token_last_action_id', action_id)
 
-    for p in package_names.values():
+    for p in list(package_names.values()):
         ret.append("Scheduled for install:  '%s'" % p)
 
     rhnSQL.commit()
@@ -320,7 +320,7 @@ def deploy_configs_if_needed(server):
 
     h = rhnSQL.prepare(_query_add_revision_to_action)
     # XXX should use executemany() or execute_bulk
-    for revision_id in revisions.values():
+    for revision_id in list(revisions.values()):
         log_debug(5, action_id, revision_id)
         h.execute(server_id=server_id,
                   action_id=action_id,
@@ -526,7 +526,7 @@ class ActivationTokens:
         self.entitlements = entitlements
         self.contact_method_id = contact_method_id
 
-    def __nonzero__(self):
+    def __bool__(self):
         return (len(self.tokens) > 0)
 
     __bool__ = __nonzero__
@@ -712,7 +712,7 @@ def _categorize_token_entitlements(token_entitlements, entitlements_base,
     """ Given a hash token_entitlements, splits the base ones and puts them in
         the entitlements_base hash, and the extras in entitlements_extra
     """
-    for tup in token_entitlements.keys():
+    for tup in list(token_entitlements.keys()):
         is_base = tup[2]
         ent = (tup[0], tup[1])
         if is_base == 'Y':
@@ -817,7 +817,7 @@ def fetch_token(token_string):
             num_of_rereg += 1
 
             # Store the re-reg ents:
-            for tup in token_entitlements.keys():
+            for tup in list(token_entitlements.keys()):
                 rereg_ents.append(tup[0])
 
         # Check user_id

--- a/backend/server/rhnServer/server_wrapper.py
+++ b/backend/server/rhnServer/server_wrapper.py
@@ -20,10 +20,10 @@
 # the server.Server class inherits this ServerWrapper class
 #
 
-from server_hardware import Hardware
-from server_packages import Packages
-from server_history import History
-from server_suse import SuseData
+from .server_hardware import Hardware
+from .server_packages import Packages
+from .server_history import History
+from .server_suse import SuseData
 
 from rhn.UserDictCase import UserDictCase
 from spacewalk.server import rhnSQL

--- a/backend/server/rhnServer/server_wrapper.py
+++ b/backend/server/rhnServer/server_wrapper.py
@@ -111,16 +111,16 @@ class ServerWrapper(Packages, Hardware, History, SuseData):
     ### SUSE PRODUCT DATA
     ###
     def save_suse_products(self):
-	ret = self.save_suse_products_byid(self.server["id"])
+        ret = self.save_suse_products_byid(self.server["id"])
         rhnSQL.commit()
         return ret
 
     def update_suse_products(self, guid, secret, target, products):
         suse_products = {
-	  "guid" 	: guid,
-	  "secret"	: secret,
-	  "ostarget"	: target,
-	  "products"	: products
-	}
+            "guid"     : guid,
+            "secret"    : secret,
+            "ostarget"    : target,
+            "products"    : products
+        }
         self.add_suse_products(suse_products)
         return self.save_suse_products()

--- a/backend/server/rhnSession.py
+++ b/backend/server/rhnSession.py
@@ -25,7 +25,7 @@ import sys
 from spacewalk.common.rhnConfig import CFG
 from spacewalk.common.usix import raise_with_tb
 
-import rhnSQL
+from . import rhnSQL
 
 
 class InvalidSessionError(Exception):
@@ -46,7 +46,7 @@ class Session:
 
     def generate(self, duration=None, web_user_id=None):
         # Grabs a session ID
-        self.session_id = rhnSQL.Sequence('pxt_id_seq').next()
+        self.session_id = next(rhnSQL.Sequence('pxt_id_seq'))
         self.duration = int(duration or CFG.SESSION_LIFETIME)
         self.web_user_id(web_user_id)
         return self
@@ -54,7 +54,7 @@ class Session:
     def _get_secrets(self):
         # Reads the four secrets from the config file
         return list(map(lambda x, cfg=CFG: getattr(cfg, 'session_secret_%s' % x),
-                    range(1, 5)))
+                    list(range(1, 5))))
 
     def get_secrets(self):
         # Validates the secrets from the config file

--- a/backend/server/rhnSession.py
+++ b/backend/server/rhnSession.py
@@ -25,7 +25,7 @@ import sys
 from spacewalk.common.rhnConfig import CFG
 from spacewalk.common.usix import raise_with_tb
 
-from . import rhnSQL
+import rhnSQL
 
 
 class InvalidSessionError(Exception):

--- a/backend/server/rhnUser.py
+++ b/backend/server/rhnUser.py
@@ -26,8 +26,8 @@ from spacewalk.common.rhnConfig import CFG
 from spacewalk.common.rhnException import rhnFault, rhnException
 from spacewalk.common.rhnTranslate import _
 
-from . import rhnSQL
-from . import rhnSession
+import rhnSQL
+import rhnSession
 
 
 class User:
@@ -111,7 +111,7 @@ class User:
                                    self.contact["login"])
             if data['use_pam_authentication'] == 'Y':
                 # use PAM
-                from . import rhnAuthPAM
+                import rhnAuthPAM
                 return rhnAuthPAM.check_password(self.contact["login"],
                                                  password, CFG.pam_auth_service)
         # If the entry in rhnUserInfo is 'N', perform regular authentication
@@ -387,7 +387,7 @@ def __reserve_user_db(user, password):
         # contact exists, check password
         if data['use_pam_authentication'] == 'Y' and CFG.pam_auth_service:
             # We use PAM for authentication
-            from . import rhnAuthPAM
+            import rhnAuthPAM
             if rhnAuthPAM.check_password(user, password, CFG.pam_auth_service) > 0:
                 return 1
             return -1
@@ -478,7 +478,7 @@ def __new_user_db(username, password, email, org_id, org_password):
     # Note that if the user is only reserved we don't do PAM authentication
     if data.get('use_pam_authentication') == 'Y' and CFG.pam_auth_service:
         # Check the password with PAM
-        from . import rhnAuthPAM
+        import rhnAuthPAM
         if rhnAuthPAM.check_password(username, password, CFG.pam_auth_service) <= 0:
             # Bad password
             raise rhnFault(2)

--- a/backend/server/rhnUser.py
+++ b/backend/server/rhnUser.py
@@ -26,8 +26,8 @@ from spacewalk.common.rhnConfig import CFG
 from spacewalk.common.rhnException import rhnFault, rhnException
 from spacewalk.common.rhnTranslate import _
 
-import rhnSQL
-import rhnSession
+from . import rhnSQL
+from . import rhnSession
 
 
 class User:
@@ -111,7 +111,7 @@ class User:
                                    self.contact["login"])
             if data['use_pam_authentication'] == 'Y':
                 # use PAM
-                import rhnAuthPAM
+                from . import rhnAuthPAM
                 return rhnAuthPAM.check_password(self.contact["login"],
                                                  password, CFG.pam_auth_service)
         # If the entry in rhnUserInfo is 'N', perform regular authentication
@@ -131,7 +131,7 @@ class User:
         self.customer.load(int(org_id))
 
     def getid(self):
-        if not self.contact.has_key("id"):
+        if "id" not in self.contact:
             userid = rhnSQL.Sequence("web_contact_id_seq")()
             self.contact.data["id"] = userid  # kind of illegal, but hey!
         else:
@@ -202,7 +202,7 @@ class User:
             valids["Sig."] = "Sr."
             valids["Sir"] = "Mr."
             # Now check it out
-            if valids.has_key(value):
+            if value in valids:
                 self.info["prefix"] = valids[value]
                 changed = 1
             else:
@@ -387,7 +387,7 @@ def __reserve_user_db(user, password):
         # contact exists, check password
         if data['use_pam_authentication'] == 'Y' and CFG.pam_auth_service:
             # We use PAM for authentication
-            import rhnAuthPAM
+            from . import rhnAuthPAM
             if rhnAuthPAM.check_password(user, password, CFG.pam_auth_service) > 0:
                 return 1
             return -1
@@ -478,7 +478,7 @@ def __new_user_db(username, password, email, org_id, org_password):
     # Note that if the user is only reserved we don't do PAM authentication
     if data.get('use_pam_authentication') == 'Y' and CFG.pam_auth_service:
         # Check the password with PAM
-        import rhnAuthPAM
+        from . import rhnAuthPAM
         if rhnAuthPAM.check_password(username, password, CFG.pam_auth_service) <= 0:
             # Bad password
             raise rhnFault(2)

--- a/backend/server/taskomatic.py
+++ b/backend/server/taskomatic.py
@@ -3,7 +3,10 @@
 Module for taskomatic related functions (inserting into queues, etc)
 """
 
-import xmlrpclib
+try:
+    import xmlrpc.client as xmlrpclib
+except ImportError:
+    import xmlrpclib
 from spacewalk.server import rhnSQL
 
 # see TaskoXmlRpcHandler.java for available methods

--- a/backend/server/test/TestRhnpush.py
+++ b/backend/server/test/TestRhnpush.py
@@ -37,9 +37,9 @@ class TestRhnpush(TestServer.TestServer):
 if __name__ == "__main__":
     server = TestRhnpush()
     app = server.getApp()
-    print(app.test_login(server.getUsername(), server.getPassword()))
-    print(app.listChannel(['wregglej-test'], "wregglej", "bm8gv5z2"))
-    print(app.listChannelSource(['wregglej-test'], "wregglej", "bm8gv5z2"))
+    print((app.test_login(server.getUsername(), server.getPassword())))
+    print((app.listChannel(['wregglej-test'], "wregglej", "bm8gv5z2")))
+    print((app.listChannelSource(['wregglej-test'], "wregglej", "bm8gv5z2")))
     server = SimpleXMLRPCServer.SimpleXMLRPCServer(addr=('', 16000))
     for func in app.functions:
         print(func)

--- a/backend/server/test/TestServer.py
+++ b/backend/server/test/TestServer.py
@@ -36,7 +36,7 @@ class TestServer:
             self.filesuploaded = False
 
             self.options = rhnConfig.initCFG('server')
-            print(self.options)
+            print((self.options))
 
             mytime = time.time()
             self.test_username = username or ("test_username_%.3f" % mytime)
@@ -201,12 +201,12 @@ if __name__ == "__main__":
         myserver.getServerId(), "packages.update", action_name="Testing", delta_time=9999, org_id=myserver.org_id)
     fake_token = rhnServer.search_token(fake_key._token)
 
-    print(look_at_actions(myserver.getServerId()))
+    print((look_at_actions(myserver.getServerId())))
 
     rhnFlags.set("registration_token", fake_token)
     myserver.testserver.use_token()
 
-    print(look_at_actions(myserver.getServerId()))
+    print((look_at_actions(myserver.getServerId())))
 
     rhnAction.invalidate_action(myserver.getServerId(), fake_action)
     rhnSQL.rollback()

--- a/backend/server/test/attic/rhnActivationKey.py
+++ b/backend/server/test/attic/rhnActivationKey.py
@@ -105,7 +105,7 @@ class ActivationKey:
 
     def set_entitlement_level(self, val):
         entitlements = {}
-        for k, v in val.items():
+        for k, v in list(val.items()):
             entitlement_level_id = self._lookup_entitlement_level(k)
             entitlements[entitlement_level_id] = k
 
@@ -139,7 +139,7 @@ class ActivationKey:
     def _set(self, name, val):
         if self._row_reg_token is None:
             self._row_reg_token = rhnSQL.Row('rhnRegToken', 'id')
-            token_id = rhnSQL.Sequence('rhn_reg_token_seq').next()
+            token_id = next(rhnSQL.Sequence('rhn_reg_token_seq'))
             self._row_reg_token.create(token_id)
             self._row_reg_token['usage_limit'] = None
 
@@ -193,7 +193,7 @@ class ActivationKey:
         s = hashlib.new('sha1')
         s.update(str(os.getpid()))
         for field in ['org_id', 'user_id', 'server_id']:
-            if self._row_reg_token.has_key(field):
+            if field in self._row_reg_token:
                 val = self._row_reg_token[field]
             s.update(str(val))
         s.update("%.8f" % time.time())
@@ -213,7 +213,7 @@ class ActivationKey:
     def _save(self):
         h = self._row_reg_token
         k = 'entitlement_level'
-        if h.has_key(k):
+        if k in h:
             entitlements = h[k]
             del h.data[k]
         else:
@@ -314,8 +314,8 @@ class ActivationKey:
         "diffs src and dst; returns a list of (inserts, deletes)"
         inserts = []
         h1 = h1.copy()
-        for k in h2.keys():
-            if not h1.has_key(k):
+        for k in list(h2.keys()):
+            if k not in h1:
                 inserts.append(k)
                 continue
             del h1[k]

--- a/backend/server/test/attic/rhnServerGroup.py
+++ b/backend/server/test/attic/rhnServerGroup.py
@@ -63,7 +63,7 @@ class ServerGroup:
     def _set(self, name, val):
         if self._row_server_group is None:
             self._row_server_group = rhnSQL.Row('rhnServerGroup', 'id')
-            server_group_id = rhnSQL.Sequence('rhn_server_group_id_seq').next()
+            server_group_id = next(rhnSQL.Sequence('rhn_server_group_id_seq'))
             self._row_server_group.create(server_group_id)
 
         self._row_server_group[name] = val

--- a/backend/server/test/byterangetests.py
+++ b/backend/server/test/byterangetests.py
@@ -70,18 +70,18 @@ class ByteRangeTests(unittest.TestCase):
 
     def testGoodRange(self):
         start, end = server.byterange.parse_byteranges("bytes=0-4")
-        self.assertEquals(0, start)
-        self.assertEquals(5, end)
+        self.assertEqual(0, start)
+        self.assertEqual(5, end)
 
     def testStartByteToEnd(self):
         start, end = server.byterange.parse_byteranges("bytes=12-")
-        self.assertEquals(12, start)
-        self.assertEquals(None, end)
+        self.assertEqual(12, start)
+        self.assertEqual(None, end)
 
     def testSuffixRange(self):
         start, end = server.byterange.parse_byteranges("bytes=-30")
-        self.assertEquals(-30, start)
-        self.assertEquals(None, end)
+        self.assertEqual(-30, start)
+        self.assertEqual(None, end)
 
     def testMultipleRanges(self):
         try:
@@ -92,13 +92,13 @@ class ByteRangeTests(unittest.TestCase):
 
     def testStartWithFileSize(self):
         start, end = server.byterange.parse_byteranges("bytes=23-", 50)
-        self.assertEquals(23, start)
-        self.assertEquals(50, end)
+        self.assertEqual(23, start)
+        self.assertEqual(50, end)
 
     def testSuffixWithFileSize(self):
         start, end = server.byterange.parse_byteranges("bytes=-40", 50)
-        self.assertEquals(10, start)
-        self.assertEquals(50, end)
+        self.assertEqual(10, start)
+        self.assertEqual(50, end)
 
     def testStartPastFileSize(self):
         try:

--- a/backend/server/test/misc_functions.py
+++ b/backend/server/test/misc_functions.py
@@ -179,10 +179,10 @@ class InvalidRoleError(Exception):
 def listdir(directory):
     directory = os.path.abspath(os.path.normpath(directory))
     if not os.access(directory, os.R_OK | os.X_OK):
-        print("Can't access %s." % (directory))
+        print(("Can't access %s." % (directory)))
         sys.exit(1)
     if not os.path.isdir(directory):
-        print("%s not valid." % (directory))
+        print(("%s not valid." % (directory)))
         sys.exit(1)
     packageList = []
     for f in os.listdir(directory):
@@ -202,7 +202,7 @@ def new_channel_dict(**kwargs):
 
     release = kwargs.get('release') or 'release-' + label
     os = kwargs.get('os') or 'Unittest Distro'
-    if kwargs.has_key('org_id'):
+    if 'org_id' in kwargs:
         org_id = kwargs['org_id']
     else:
         org_id = 'rhn-noc'
@@ -284,7 +284,7 @@ def build_sys_params_with_username(**kwargs):
         'password': 'no such password',
     }
     params.update(kwargs)
-    if params.has_key('token'):
+    if 'token' in params:
         del params['token']
     return params
 

--- a/backend/server/test/test-cx_Oracle-memleak.py
+++ b/backend/server/test/test-cx_Oracle-memleak.py
@@ -18,7 +18,7 @@ import string
 import cx_Oracle
 
 if len(sys.argv) == 1:
-    print("Usage: %s <connection_string>" % sys.argv[0])
+    print(("Usage: %s <connection_string>" % sys.argv[0]))
     sys.exit(0)
 
 
@@ -41,4 +41,4 @@ h.execute('select 1 from dual')
 for i in range(10000):
     d = h.description
     if not (i % 100):
-        print(mem_usage())
+        print((mem_usage()))

--- a/backend/server/test/test_CFG.py
+++ b/backend/server/test/test_CFG.py
@@ -16,4 +16,4 @@ from spacewalk.common.rhnConfig import initCFG, CFG
 
 initCFG('server.config-management-tool')
 
-print(CFG.config_delim_start)
+print((CFG.config_delim_start))

--- a/backend/server/test/test_action_rpm_verify_extra_data.py
+++ b/backend/server/test/test_action_rpm_verify_extra_data.py
@@ -15,7 +15,7 @@
 import sys
 
 if len(sys.argv) != 3:
-    print("Usage: %s server_id action_id" % sys.argv[0])
+    print(("Usage: %s server_id action_id" % sys.argv[0]))
     sys.exit(1)
 
 system_id = sys.argv[1]

--- a/backend/server/test/test_applet.py
+++ b/backend/server/test/test_applet.py
@@ -20,5 +20,5 @@ server = "coyote.devel.redhat.com"
 s = rpclib.Server("http://%s/APPLET" % server)
 
 # print s.applet.poll_status()
-print(s.applet.poll_packages('2.1AS', 'i386'))
-print(s.applet.poll_packages('8.0', 'i386'))
+print((s.applet.poll_packages('2.1AS', 'i386')))
+print((s.applet.poll_packages('8.0', 'i386')))

--- a/backend/server/test/test_applet_as.py
+++ b/backend/server/test/test_applet_as.py
@@ -21,5 +21,5 @@ s = rpclib.Server("http://%s/APPLET" % server)
 
 dict = s.applet.poll_packages('2.1AS', 'i386')
 pkg_count = len(dict['contents'])
-print("Available packages: %d" % pkg_count)
+print(("Available packages: %d" % pkg_count))
 assert pkg_count > 0, "No packages available for 2.1AS"

--- a/backend/server/test/test_capabilities.py
+++ b/backend/server/test/test_capabilities.py
@@ -87,7 +87,7 @@ def main():
 
     sobj = rhnServer.get(systemid)
     server_id = sobj.getid()
-    print("Registered server", server_id)
+    print(("Registered server", server_id))
 
     return 0
 

--- a/backend/server/test/test_caps_display.py
+++ b/backend/server/test/test_caps_display.py
@@ -16,4 +16,4 @@ from rhn import rpclib
 
 s = rpclib.Server("http://coyote.devel.redhat.com/REDHAT-XMLRPC")
 
-print(s.actions.system_capabilities(1003485542))
+print((s.actions.system_capabilities(1003485542)))

--- a/backend/server/test/test_delta_computation.py
+++ b/backend/server/test/test_delta_computation.py
@@ -55,8 +55,8 @@ list2 = [
 ]
 
 i, r = server_packages.package_delta(list1, list2)
-print("Install set:  ", i)
-print("Remove set:   ", r)
+print(("Install set:  ", i))
+print(("Remove set:   ", r))
 
 assert i == [aalib1, kernel3, unzip1, unzip2], "Invalid install set %s" % i
 assert r == [aalib2, abiword1, abiword2, kernel1, kernel2, quota], "Invalid remove set %s" % r

--- a/backend/server/test/test_leak.py
+++ b/backend/server/test/test_leak.py
@@ -18,7 +18,7 @@ import sys
 import time
 from spacewalk.server import rhnSQL
 
-print(os.getpid())
+print((os.getpid()))
 rhnSQL.initDB('rhnuser/rhnuser@webdev')
 
 h = rhnSQL.prepare("select 1 from dual")

--- a/backend/server/test/test_leak2.py
+++ b/backend/server/test/test_leak2.py
@@ -18,7 +18,7 @@ import sys
 import time
 from DCOracle import Connect
 
-print(os.getpid())
+print((os.getpid()))
 dbh = Connect('rhnuser/rhnuser@webdev')
 
 h = dbh.prepare("select 1 from dual")

--- a/backend/server/test/test_leak3.py
+++ b/backend/server/test/test_leak3.py
@@ -17,7 +17,7 @@ import os
 import time
 from DCOracle2 import connect
 
-print(os.getpid())
+print((os.getpid()))
 dbh = connect('rhnuser/rhnuser@webdev')
 
 h = dbh.prepare("select 1 from dual")
@@ -27,8 +27,8 @@ i = 0
 while 1:
     h.execute()
     if 0:
-        print(h.fetchone_dict())
+        print((h.fetchone_dict()))
     else:
-        print(i, "%.3f" % (time.time() - start))
+        print((i, "%.3f" % (time.time() - start)))
     i = i + 1
     time.sleep(.01)

--- a/backend/server/test/test_leak4.py
+++ b/backend/server/test/test_leak4.py
@@ -17,7 +17,7 @@ import sys
 import time
 from DCOracle2 import connect
 
-print('PID', os.getpid())
+print(('PID', os.getpid()))
 db = connect('rhnuser/rhnuser@webdev')
 
 #c = db.prepare("select 1, 'z', 2, 3, 4, 't' from dual")

--- a/backend/server/test/test_malformed_xml.py
+++ b/backend/server/test/test_malformed_xml.py
@@ -53,6 +53,6 @@ h.endheaders()
 h.send(data)
 
 r = h.getresponse()
-print(r.msg.headers)
+print((r.msg.headers))
 
-print(r.read())
+print((r.read()))

--- a/backend/server/test/test_message.py
+++ b/backend/server/test/test_message.py
@@ -19,6 +19,6 @@ from spacewalk.server import rhnSQL, rhnServer
 initCFG("server.xmlrpc")
 rhnSQL.initDB("rhnuser/rhnuser@webdev")
 
-print(rhnServer.search(1003485567).fetch_registration_message())
-print(rhnServer.search(1003485558).fetch_registration_message())
-print(rhnServer.search(1003485584).fetch_registration_message())
+print((rhnServer.search(1003485567).fetch_registration_message()))
+print((rhnServer.search(1003485558).fetch_registration_message()))
+print((rhnServer.search(1003485584).fetch_registration_message()))

--- a/backend/server/test/test_procedures.py
+++ b/backend/server/test/test_procedures.py
@@ -23,7 +23,7 @@ while 1:
     #p = rhnSQL.Procedure('rhn_entitlements.get_server_entitlement')
     p = rhnSQL.Procedure('rhn_entitlements.upgrade_server')
     ret = p(1000102174)
-    print(counter, ret)
+    print((counter, ret))
     counter = counter + 1
     # if counter > 700:
     #    time.sleep(.5)

--- a/backend/server/test/test_queue_get.py
+++ b/backend/server/test/test_queue_get.py
@@ -24,7 +24,7 @@ rhnSQL.initDB('rhnuser/rhnuser@webdev')
 q = queue.Queue()
 if 1:
     systemid = open("../../test/backend/checks/systemid-farm06").read()
-    print(q.get(systemid, version=2))
+    print((q.get(systemid, version=2)))
 else:
     q.server_id = 1003485791
 

--- a/backend/server/test/test_rhnChannel.py
+++ b/backend/server/test/test_rhnChannel.py
@@ -31,7 +31,7 @@ def test_server_search(use_key=0):
     if use_key:
         rhnFlags.set("registration_token", 'a02487cf77e72f86338f44212d23140d')
     s.save()
-    print(s.server["id"])
+    print((s.server["id"]))
 
 
 if __name__ == "__main__":
@@ -42,31 +42,31 @@ if __name__ == "__main__":
         test_server_search(use_key=1)
         sys.exit(1)
 
-    print(rhnChannel.get_server_channel_mappings(1000102174, release='2.1AS'))
-    print(rhnChannel.get_server_channel_mappings(1000102174, release='2.1AS',
-                                                 user_id=2825619, none_ok=1))
+    print((rhnChannel.get_server_channel_mappings(1000102174, release='2.1AS')))
+    print((rhnChannel.get_server_channel_mappings(1000102174, release='2.1AS',
+                                                 user_id=2825619, none_ok=1)))
 
-    print(rhnChannel.channels_for_release_arch('2.1AS', 'athlon-redhat-linux'))
-    print(rhnChannel.channels_for_release_arch('2.1AS', 'athlon-redhat-linux', user_id=575937))
-    print(rhnChannel.channels_for_release_arch('2.1AS', 'XXXX-redhat-linux', user_id=575937))
+    print((rhnChannel.channels_for_release_arch('2.1AS', 'athlon-redhat-linux')))
+    print((rhnChannel.channels_for_release_arch('2.1AS', 'athlon-redhat-linux', user_id=575937)))
+    print((rhnChannel.channels_for_release_arch('2.1AS', 'XXXX-redhat-linux', user_id=575937)))
     # mibanescu-2
 #    print rhnChannel.channels_for_release_arch('9', 'i386-redhat-linux', user_id=2012148)
     # mibanescu-plain
-    print(rhnChannel.channels_for_release_arch('2.1AS', 'athlon-redhat-linux', user_id=2825619))
+    print((rhnChannel.channels_for_release_arch('2.1AS', 'athlon-redhat-linux', user_id=2825619)))
     sys.exit(1)
 
     channel = "redhat-linux-i386-7.1"
 
     start = time.time()
     ret = rhnChannel.list_packages(channel)
-    print("Took %.2f seconds to list %d packages in %s" % (
-        time.time() - start, len(ret), channel))
+    print(("Took %.2f seconds to list %d packages in %s" % (
+        time.time() - start, len(ret), channel)))
     # pprint.pprint(ret)
 
     start = time.time()
     ret = rhnChannel.list_obsoletes(channel)
-    print("Took %.2f seconds to list %d obsoletes in %s" % (
-        time.time() - start, len(ret), channel))
+    print(("Took %.2f seconds to list %d obsoletes in %s" % (
+        time.time() - start, len(ret), channel)))
     # pprint.pprint(ret)
 
     server_id = 1002156837

--- a/backend/server/test/test_rhnSession.py
+++ b/backend/server/test/test_rhnSession.py
@@ -24,8 +24,8 @@ session = u.create_session()
 
 s = session.get_session()
 
-print("Checking with session", s)
+print(("Checking with session", s))
 
 u = rhnUser.session_reload(s)
 print(u)
-print(u.username)
+print((u.username))

--- a/backend/server/test/test_upload_imports.py
+++ b/backend/server/test/test_upload_imports.py
@@ -17,5 +17,5 @@ from spacewalk.server import rhnImport
 
 root_dir = "/var/www/rhns"
 
-print(rhnImport.load("upload_server/handlers",
-                     interface_signature='upload_class'))
+print((rhnImport.load("upload_server/handlers",
+                     interface_signature='upload_class')))

--- a/backend/server/test/unit-test/rhnSQL/rhnsql-tests.py
+++ b/backend/server/test/unit-test/rhnSQL/rhnsql-tests.py
@@ -34,13 +34,13 @@ class RhnSQLTests(unittest.TestCase):
             "INSERT INTO people(id, name, phone) VALUES(%(id)s, %(name)s, %(phone)s)"
 
         new_query = convert_named_query_params(query)
-        self.assertEquals(expected_query, new_query)
+        self.assertEqual(expected_query, new_query)
 
     def test_convert_named_params_none_required(self):
         query = "SELECT * FROM people"
 
         new_query = convert_named_query_params(query)
-        self.assertEquals(query, new_query)
+        self.assertEqual(query, new_query)
 
     def test_convert_named_params_multiple_uses(self):
         query = "INSERT INTO people(a, b, c, d) VALUES(:a, :b, :a, :b)"
@@ -48,10 +48,10 @@ class RhnSQLTests(unittest.TestCase):
             "INSERT INTO people(a, b, c, d) VALUES(%(a)s, %(b)s, %(a)s, %(b)s)"
 
         new_query = convert_named_query_params(query)
-        self.assertEquals(expected_query, new_query)
+        self.assertEqual(expected_query, new_query)
 
     def test_date_format_conversion_issue(self):
         query = "SELECT TO_CHAR(issued, 'YYYY-MM-DD HH24:MI:SS') issued FROM rhnSatelliteCert WHERE id=:id, name=:name"
         expected_query = "SELECT TO_CHAR(issued, 'YYYY-MM-DD HH24:MI:SS') issued FROM rhnSatelliteCert WHERE id=%(id)s, name=%(name)s"
         new_query = convert_named_query_params(query)
-        self.assertEquals(expected_query, new_query)
+        self.assertEqual(expected_query, new_query)

--- a/backend/server/test/unit-test/rhnSQL/test_1.py
+++ b/backend/server/test/unit-test/rhnSQL/test_1.py
@@ -60,7 +60,7 @@ class Tests1(unittest.TestCase):
         self.assertEqual(len(args), len(ret))
         self.assertEqual(args[0], ret[0])
         self.assertEqual(args[1], ret[1])
-        self.failUnless(isinstance(ret[2], usix.FloatType))
+        self.assertTrue(isinstance(ret[2], usix.FloatType))
 
     def test_procedure_2(self):
         """Run the same stored procedure twice. This should excerise the
@@ -81,7 +81,7 @@ class Tests1(unittest.TestCase):
         table_name = self.table_name + "_1"
         rhnSQL.execute("create table %s (id int)" % table_name)
         tables = self._list_tables()
-        self.failUnless(string.upper(table_name) in tables,
+        self.assertTrue(string.upper(table_name) in tables,
                         "Table %s not created" % table_name)
         rhnSQL.execute("drop table %s" % table_name)
 

--- a/backend/server/test/unit-test/rhnSQL/test_lob.py
+++ b/backend/server/test/unit-test/rhnSQL/test_lob.py
@@ -48,7 +48,7 @@ class ExceptionsTest(unittest.TestCase):
         rhnSQL.commit()
 
     def test_lobs(self):
-        new_id = rhnSQL.Sequence('misatestlob_id_seq').next()
+        new_id = next(rhnSQL.Sequence('misatestlob_id_seq'))
         h = rhnSQL.prepare("""
             insert into misatestlob (id, val) values (:id, empty_blob())
         """)

--- a/backend/server/test/unit-test/rhnSQL/test_rhnChannel.py
+++ b/backend/server/test/unit-test/rhnSQL/test_rhnChannel.py
@@ -51,7 +51,7 @@ class Tests(unittest.TestCase):
         vdict = self._new_channel_dict(label=label, channel_family=label)
 
         c = rhnChannel.Channel()
-        for k, v in vdict.items():
+        for k, v in list(vdict.items()):
             method = getattr(c, "set_" + k)
             method(v)
         c.save()
@@ -59,7 +59,7 @@ class Tests(unittest.TestCase):
 
         c = rhnChannel.Channel()
         c.load_by_label(label)
-        for k, v in vdict.items():
+        for k, v in list(vdict.items()):
             method = getattr(c, "get_" + k)
             dbv = method()
             self.assertEqual(v, dbv)
@@ -82,7 +82,7 @@ class Tests(unittest.TestCase):
 
         c = rhnChannel.Channel()
         c.load_by_label(label)
-        for k, v in vdict.items():
+        for k, v in list(vdict.items()):
             method = getattr(c, "get_" + k)
             dbv = method()
             self.assertEqual(v, dbv)
@@ -95,7 +95,7 @@ class Tests(unittest.TestCase):
         label = vdict['label']
 
         c = rhnChannel.ChannelFamily()
-        for k, v in vdict.items():
+        for k, v in list(vdict.items()):
             method = getattr(c, "set_" + k)
             method(v)
         c.save()
@@ -103,7 +103,7 @@ class Tests(unittest.TestCase):
 
         c = rhnChannel.ChannelFamily()
         c.load_by_label(label)
-        for k, v in vdict.items():
+        for k, v in list(vdict.items()):
             method = getattr(c, "get_" + k)
             dbv = method()
             self.assertEqual(v, dbv)
@@ -122,7 +122,7 @@ class Tests(unittest.TestCase):
 
         c = rhnChannel.ChannelFamily()
         c.load_by_label(label)
-        for k, v in vdict.items():
+        for k, v in list(vdict.items()):
             method = getattr(c, "get_" + k)
             dbv = method()
             self.assertEqual(v, dbv)
@@ -132,7 +132,7 @@ class Tests(unittest.TestCase):
     def test_list_channel_families_1(self):
         """Tests rhnChannel.list_channel_families"""
         channel_families = rhnChannel.list_channel_families()
-        self.failUnless(len(channel_families) > 0)
+        self.assertTrue(len(channel_families) > 0)
 
     def test_list_channels_1(self):
         """Tests rhnChannel.list_channels"""
@@ -146,13 +146,13 @@ class Tests(unittest.TestCase):
         vdict = self._new_channel_dict(label=label, channel_family=label)
 
         c = rhnChannel.Channel()
-        for k, v in vdict.items():
+        for k, v in list(vdict.items()):
             method = getattr(c, "set_" + k)
             method(v)
         c.save()
 
         channels = rhnChannel.list_channels(pattern="rhn-unittest-%")
-        self.failUnless(len(channels) > 0)
+        self.assertTrue(len(channels) > 0)
 
     def _new_channel_dict(self, **kwargs):
         if not hasattr(self, '_counter'):
@@ -165,7 +165,7 @@ class Tests(unittest.TestCase):
 
         release = kwargs.get('release') or 'release-' + label
         os = kwargs.get('os') or 'Unittest Distro'
-        if kwargs.has_key('org_id'):
+        if 'org_id' in kwargs:
             org_id = kwargs['org_id']
         else:
             org_id = misc_functions.create_new_org()

--- a/backend/server/test/unit-test/rhnSQL/test_server_registration.py
+++ b/backend/server/test/unit-test/rhnSQL/test_server_registration.py
@@ -268,7 +268,7 @@ def build_new_system_params_with_username(**kwargs):
         'password': 'no such password',
     }
     params.update(kwargs)
-    if params.has_key('token'):
+    if 'token' in params:
         del params['token']
     return params
 

--- a/backend/server/test/unit-test/test_rhnLib_timestamp.py
+++ b/backend/server/test/unit-test/test_rhnLib_timestamp.py
@@ -34,7 +34,7 @@ class Tests(unittest.TestCase):
             is_eq, t1, tstr, t2 = self._test(t)
             #self.assertEqual(t, t2, "%s %s %s %s" % (t, t2, ttuple, tstr))
             if not is_eq:
-                print("%s %s %s" % (t1, t2, tstr))
+                print(("%s %s %s" % (t1, t2, tstr)))
             t = t + increment
 
     def _str(self, t):
@@ -62,13 +62,13 @@ class Tests(unittest.TestCase):
 
             is_eq, t1, tstr, t2 = self._test(t)
             if not is_eq:
-                print("%s %s %s" % (t, t2, tstr))
+                print(("%s %s %s" % (t, t2, tstr)))
 
     def test_timestamp_3(self):
         t = 57739297
         dstshift = (time.localtime(t)[8] - time.daylight) * 3600
         is_eq, t1, tstr, t2 = self._test(t, dstshift)
-        self.failUnless(is_eq, "Failed: %s, %s" % (t1, t2))
+        self.assertTrue(is_eq, "Failed: %s, %s" % (t1, t2))
 
     def _test_timestamp_4(self):
         return self.test_timestamp_3()

--- a/backend/server/test/unittest/test_auditlog.py
+++ b/backend/server/test/unittest/test_auditlog.py
@@ -15,9 +15,13 @@
 # in this software or its documentation
 
 import unittest
-from StringIO import StringIO
+try:
+    from io import StringIO
+    from xmlrpc.client import Error
+except ImportError:
+    from StringIO import StringIO
+    from xmlrpclib import Error
 from collections import defaultdict
-from xmlrpclib import Error
 
 from mock import Mock, patch
 

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Make spacewalk-backend code compatible with Python 3
 - Channels to be actually un-subscribed from the assigned systems when being removed
   using spacewalk-remove-channel tool(bsc#1104120)
 - Prepare spacewalk-backend packages to build on Python 3

--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -592,9 +592,6 @@ rm -f $RPM_BUILD_ROOT%{python2rhnroot}/common/__init__.py*
 # Copy spacewalk-usix python files to allow unit tests to run
 cp %{pythonrhnroot}/common/usix* $RPM_BUILD_ROOT%{pythonrhnroot}/common/
 make -f Makefile.backend PYTHONPATH=$RPM_BUILD_ROOT%{python_sitelib} PYTHON_BIN=%{pythonX} test
-#%if 0%{?build_py3}
-#make -f Makefile.backend PYTHONPATH=$RPM_BUILD_ROOT%{python2_sitelib} PYTHON_BIN=python2 test
-#%endif
 
 %if 0%{?pylint_check}
 # check coding style

--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -620,6 +620,9 @@ rm -f $RPM_BUILD_ROOT%{pythonrhnroot}/common/__init__.py*
 
 # Remove spacewalk-usix python files used for running unit-tests
 rm -f $RPM_BUILD_ROOT%{pythonrhnroot}/common/usix.py*
+%if 0%{?build_py3}
+rm -f $RPM_BUILD_ROOT%{pythonrhnroot}/common/__pycache__/usix*
+%endif
 
 %if !0%{?build_py3}
 if [ -x %py_libdir/py_compile.py ]; then

--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -28,6 +28,7 @@
 
 %if 0%{?fedora} >= 23 || 0%{?suse_version} > 1320 || 0%{?rhel} >= 8
 %{!?python3_sitelib: %global python3_sitelib %(%{__python3} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
+%global python_sitelib %{python3_sitelib}
 %global python3rhnroot %{python3_sitelib}/spacewalk
 %global pythonrhnroot %{python3_sitelib}/spacewalk
 %global build_py3 1
@@ -103,9 +104,10 @@ Requires:       pyliblzma
 %endif # %if 0%{?rhel} > 5 || 0%{?suse_version} >= 1315
 %endif # 0%{?suse_version} > 1320
 %if 0%{?pylint_check}
-BuildRequires:  spacewalk-python2-pylint
 %if 0%{?build_py3}
 BuildRequires:  spacewalk-python3-pylint
+%else
+BuildRequires:  spacewalk-python2-pylint
 %endif
 %endif
 BuildRequires:  /usr/bin/docbook2man
@@ -194,10 +196,11 @@ modules.
 %package sql-postgresql
 Summary:        Postgresql backend for Spacewalk
 Group:          Applications/Internet
-Requires:       python-psycopg2 >= 2.0.14-2
 %if 0%{?build_py3}
+Requires:       python3-psycopg2 >= 2.0.14-2
 Requires:       python3-spacewalk-usix
 %else
+Requires:       python3-psycopg2 >= 2.0.14-2
 Requires:       python2-spacewalk-usix
 %endif
 Provides:       %{name}-sql-virtual = %{version}-%{release}
@@ -211,11 +214,12 @@ Summary:        Basic code that provides Spacewalk Server functionality
 Group:          Applications/Internet
 Requires(pre): %{name}-sql = %{version}-%{release}
 Requires:       %{name}-sql = %{version}-%{release}
-Requires:       python-python-pam
 %if 0%{?build_py3}
 Requires:       python3-spacewalk-usix
+Requires:       python3-python-pam
 %else
 Requires:       python2-spacewalk-usix
+Requires:       python-python-pam
 %endif
 Requires:       spacewalk-config
 Obsoletes:      rhns-server < 5.3.0
@@ -422,9 +426,15 @@ Group:          Applications/Internet
 Requires:       %{name}
 Requires:       %{name}-app = %{version}-%{release}
 Requires:       %{name}-xmlrpc = %{version}-%{release}
-Requires:       python-dateutil
+%if 0%{?build_py3}
+Requires:       python3-python-dateutil
+Requires:       python3-gzipstream
+Requires:       python3-rhn-client-tools
+%else
+Requires:       python2-python-ateutil
 Requires:       python2-gzipstream
 Requires:       python2-rhn-client-tools
+%endif
 Requires:       spacewalk-admin >= 0.1.1-0
 Requires:       spacewalk-certs-tools
 %if 0%{?suse_version}
@@ -486,10 +496,11 @@ Summary:        CDN tools
 Group:          Applications/Internet
 Requires:       %{m2crypto}
 Requires:       %{name}-server = %{version}-%{release}
-Requires:       python-argparse
 %if 0%{?build_py3}
+Requires:       python3-argparse
 Requires:       python3-spacewalk-usix
 %else
+Requires:       python2-argparse
 Requires:       python2-spacewalk-usix
 %endif
 Requires:       subscription-manager
@@ -514,7 +525,9 @@ done
 %install
 install -d $RPM_BUILD_ROOT%{rhnroot}
 install -d $RPM_BUILD_ROOT%{pythonrhnroot}
+install -d $RPM_BUILD_ROOT%{pythonrhnroot}/common
 install -d $RPM_BUILD_ROOT%{rhnconf}
+
 make -f Makefile.backend install PREFIX=$RPM_BUILD_ROOT \
     MANDIR=%{_mandir} APACHECONFDIR=%{apacheconfd} PYTHON_BIN=%{pythonX}
 %if !0%{?with_oracle}
@@ -522,6 +535,7 @@ rm -f $RPM_BUILD_ROOT%{pythonrhnroot}/server/rhnSQL/driver_cx_Oracle.py*
 %endif
 
 %if 0%{?build_py3}
+install -d $RPM_BUILD_ROOT%{pythonrhnroot}/common
 install -d $RPM_BUILD_ROOT%{python2rhnroot}/common
 cp $RPM_BUILD_ROOT%{pythonrhnroot}/__init__.py \
     $RPM_BUILD_ROOT%{python2rhnroot}/
@@ -572,17 +586,15 @@ popd
 rm -f $RPM_BUILD_ROOT%{python2rhnroot}/__init__.py*
 rm -f $RPM_BUILD_ROOT%{python2rhnroot}/common/__init__.py*
 %endif
-
-# prevent file conflict with spacewalk-usix
-rm -f $RPM_BUILD_ROOT%{pythonrhnroot}/__init__.py*
-rm -f $RPM_BUILD_ROOT%{pythonrhnroot}/common/__init__.py*
 %endif
 
 %check
-make -f Makefile.backend PYTHONPATH=$RPM_BUILD_ROOT%{python_sitelib} PYTHON_BIN=%{pythonX} test || :
-%if 0%{?build_py3}
-make -f Makefile.backend PYTHONPATH=$RPM_BUILD_ROOT%{python2_sitelib} PYTHON_BIN=python2 test || :
-%endif
+# Copy spacewalk-usix python files to allow unit tests to run
+cp %{pythonrhnroot}/common/usix* $RPM_BUILD_ROOT%{pythonrhnroot}/common/
+make -f Makefile.backend PYTHONPATH=$RPM_BUILD_ROOT%{python_sitelib} PYTHON_BIN=%{pythonX} test
+#%if 0%{?build_py3}
+#make -f Makefile.backend PYTHONPATH=$RPM_BUILD_ROOT%{python2_sitelib} PYTHON_BIN=python2 test
+#%endif
 
 %if 0%{?pylint_check}
 # check coding style
@@ -605,6 +617,11 @@ spacewalk-python2 $RPM_BUILD_ROOT%{python2rhnroot}/common \
 %endif
 %endif
 
+# prevent file conflict with spacewalk-usix
+rm -f $RPM_BUILD_ROOT%{pythonrhnroot}/__init__.py*
+rm -f $RPM_BUILD_ROOT%{pythonrhnroot}/common/__init__.py*
+
+# Remove spacewalk-usix python files used for running unit-tests
 rm -f $RPM_BUILD_ROOT%{pythonrhnroot}/common/usix.py*
 
 %if !0%{?build_py3}

--- a/backend/test/johntest.py
+++ b/backend/test/johntest.py
@@ -175,52 +175,52 @@ class ChannelList:
         return self._num_channels
 
     def get_last_modified(self, ch_index):
-        if self.channel_list[ch_index].has_key(self._last_modified):
+        if self._last_modified in self.channel_list[ch_index]:
             return self.channel_list[ch_index][self._last_modified]
         return None
 
     def get_description(self, ch_index):
-        if self.channel_list[ch_index].has_key(self._description):
+        if self._description in self.channel_list[ch_index]:
             return self.channel_list[ch_index][self._description]
         return None
 
     def get_name(self, ch_index):
-        if self.channel_list[ch_index].has_key(self._name):
+        if self._name in self.channel_list[ch_index]:
             return self.channel_list[ch_index][self._name]
         return None
 
     def get_local_channel(self, ch_index):
-        if self.channel_list[ch_index].has_key(self._local_channel):
+        if self._local_channel in self.channel_list[ch_index]:
             return self.channel_list[ch_index][self._local_channel]
         return None
 
     def get_arch(self, ch_index):
-        if self.channel_list[ch_index].has_key(self._arch):
+        if self._arch in self.channel_list[ch_index]:
             return self.channel_list[ch_index][self._arch]
         return None
 
     def get_parent_channel(self, ch_index):
-        if self.channel_list[ch_index].has_key(self._parent_channel):
+        if self._parent_channel in self.channel_list[ch_index]:
             return self.channel_list[ch_index][self._parent_channel]
         return None
 
     def get_summary(self, ch_index):
-        if self.channel_list[ch_index].has_key(self._summary):
+        if self._summary in self.channel_list[ch_index]:
             return self.channel_list[ch_index][self._summary]
         return None
 
     def get_org_id(self, ch_index):
-        if self.channel_list[ch_index].has_key(self._org_id):
+        if self._org_id in self.channel_list[ch_index]:
             return self.channel_list[ch_index][self._org_id]
         return None
 
     def get_id(self, ch_index):
-        if self.channel_list[ch_index].has_key(self._id):
+        if self._id in self.channel_list[ch_index]:
             return self.channel_list[ch_index][self._id]
         return None
 
     def get_label(self, ch_index):
-        if self.channel_list[ch_index].has_key(self._label):
+        if self._label in self.channel_list[ch_index]:
             return self.channel_list[ch_index][self._label]
         return None
 
@@ -244,65 +244,65 @@ class LoginInfo:
         self.login_dict = login_dict
 
     def get_server_id(self):
-        if self.login_dict.has_key(self._server_key):
+        if self._server_key in self.login_dict:
             return str(self.login_dict[self._server_key])
         return None
 
     def get_user_id(self):
-        if self.login_dict.has_key(self._user_key):
+        if self._user_key in self.login_dict:
             return self.login_dict[self._user_key]
         return None
 
     def get_signature(self):
-        if self.login_dict.has_key(self._sig_key):
+        if self._sig_key in self.login_dict:
             return self.login_dict[self._sig_key]
         return None
 
     def get_server_time(self):
-        if self.login_dict.has_key(self._time_key):
+        if self._time_key in self.login_dict:
             return self.login_dict[self._time_key]
         return None
 
     def get_expire_offset(self):
-        if self.login_dict.has_key(self._expire_key):
+        if self._expire_key in self.login_dict:
             return self.login_dict[self._expire_key]
         return None
 
     def get_auth_channels(self):
-        if self.login_dict.has_key(self._channel_key):
+        if self._channel_key in self.login_dict:
             return self.login_dict.has_key[self._channel_key]
         return None
 
 if __name__ == "__main__":
     t = Test()
     lg = t.login()
-    print("Server ID: " + lg.get_server_id())
-    print("User ID: " + lg.get_user_id())
-    print("Server Time: " + lg.get_server_time())
-    print("Auth: " + lg.get_signature())
-    print("Expire Offset: " + lg.get_expire_offset())
+    print(("Server ID: " + lg.get_server_id()))
+    print(("User ID: " + lg.get_user_id()))
+    print(("Server Time: " + lg.get_server_time()))
+    print(("Auth: " + lg.get_signature()))
+    print(("Expire Offset: " + lg.get_expire_offset()))
 
     list = t.list_channels()
     print("\n")
     for i in range(list.get_num_channels()):
-        print("Channel Name: " + list.get_name(i))
-        print("Channel Last Modified: " + list.get_last_modified(i))
-        print("Channel Description: " + list.get_description(i))
-        print("Channel Local Channel: " + list.get_local_channel(i))
-        print("Channel Arch: " + list.get_arch(i))
-        print("Channel Parent Channel: " + list.get_parent_channel(i))
-        print("Channel Summary: " + list.get_summary(i))
-        print("Channel org_id: " + list.get_org_id(i))
-        print("Channel id: " + list.get_id(i))
-        print("Channel label: " + list.get_label(i))
+        print(("Channel Name: " + list.get_name(i)))
+        print(("Channel Last Modified: " + list.get_last_modified(i)))
+        print(("Channel Description: " + list.get_description(i)))
+        print(("Channel Local Channel: " + list.get_local_channel(i)))
+        print(("Channel Arch: " + list.get_arch(i)))
+        print(("Channel Parent Channel: " + list.get_parent_channel(i)))
+        print(("Channel Summary: " + list.get_summary(i)))
+        print(("Channel org_id: " + list.get_org_id(i)))
+        print(("Channel id: " + list.get_id(i)))
+        print(("Channel label: " + list.get_label(i)))
 
     print("")
     plist = t.list_packages()
     for j in range(plist.get_num_packages()):
-        print("Package Name: " + plist.get_name(j))
-        print("Package Version: " + plist.get_version(j))
-        print("Package Release: " + plist.get_release(j))
-        print("Package Epoch: " + plist.get_epoch(j))
+        print(("Package Name: " + plist.get_name(j)))
+        print(("Package Version: " + plist.get_version(j)))
+        print(("Package Release: " + plist.get_release(j)))
+        print(("Package Epoch: " + plist.get_epoch(j)))
         print("")
 
     #package = t.package([plist.get_name(0), plist.get_version(0), plist.get_release(0), plist.get_epoch(j)])
@@ -315,5 +315,5 @@ if __name__ == "__main__":
     org_id = raw_input("ord_id:")
     org_password = raw_input("org_password:")
 
-    print(t.reserve_user(uname, password))
-    print(t.new_user(uname, password, email, org_id, org_password))
+    print((t.reserve_user(uname, password)))
+    print((t.new_user(uname, password, email, org_id, org_password)))

--- a/backend/test/non-unit/server/rhnSQL/dbtests.py
+++ b/backend/test/non-unit/server/rhnSQL/dbtests.py
@@ -85,8 +85,8 @@ class RhnSQLDatabaseTests(unittest.TestCase):
         cursor = rhnSQL.prepare(query)
         cursor.execute(id=TEST_IDS[0], name="Sam")  # name should be ignored
         results = cursor.fetchone()
-        self.assertEquals(TEST_IDS[0], results[0])
-        self.assertEquals(TEST_NAMES[0], results[1])
+        self.assertEqual(TEST_IDS[0], results[0])
+        self.assertEqual(TEST_NAMES[0], results[1])
 
     def test_executemany(self):
         query = "INSERT INTO %s(id, name) VALUES(:id, :name)" \
@@ -101,12 +101,12 @@ class RhnSQLDatabaseTests(unittest.TestCase):
                                % self.temp_table)
         query.execute()
         rows = query.fetchall()
-        self.assertEquals(2, len(rows))
+        self.assertEqual(2, len(rows))
 
-        self.assertEquals(1000, rows[0][0])
-        self.assertEquals(1001, rows[1][0])
-        self.assertEquals("Somebody", rows[0][1])
-        self.assertEquals("Else", rows[1][1])
+        self.assertEqual(1000, rows[0][0])
+        self.assertEqual(1001, rows[1][0])
+        self.assertEqual("Somebody", rows[0][1])
+        self.assertEqual("Else", rows[1][1])
 
     def test_executemany2(self):
         query = "SELECT * FROM %s" \
@@ -133,12 +133,12 @@ class RhnSQLDatabaseTests(unittest.TestCase):
                                % self.temp_table)
         query.execute()
         rows = query.fetchall()
-        self.assertEquals(2, len(rows))
+        self.assertEqual(2, len(rows))
 
-        self.assertEquals(1000, rows[0][0])
-        self.assertEquals(1001, rows[1][0])
-        self.assertEquals("Somebody", rows[0][1])
-        self.assertEquals("Else", rows[1][1])
+        self.assertEqual(1000, rows[0][0])
+        self.assertEqual(1001, rows[1][0])
+        self.assertEqual("Somebody", rows[0][1])
+        self.assertEqual("Else", rows[1][1])
 
     def test_numeric_columns(self):
         h = rhnSQL.prepare("SELECT num FROM %s WHERE id = %s" %
@@ -152,29 +152,29 @@ class RhnSQLDatabaseTests(unittest.TestCase):
         cursor = rhnSQL.prepare(query)
         cursor.execute()
         results = cursor.fetchone()
-        self.assertEquals(TEST_IDS[0], results[0])
-        self.assertEquals(TEST_NAMES[0], results[1])
+        self.assertEqual(TEST_IDS[0], results[0])
+        self.assertEqual(TEST_NAMES[0], results[1])
 
     def test_fetchone_dict(self):
         query = "SELECT * FROM %s WHERE id = 1 ORDER BY id" % self.temp_table
         cursor = rhnSQL.prepare(query)
         cursor.execute()
         results = cursor.fetchone_dict()
-        self.assertEquals(TEST_IDS[0], results['id'])
-        self.assertEquals(TEST_NAMES[0], results['name'])
-        self.assertEquals(TEST_NUMS[0], results['num'])
+        self.assertEqual(TEST_IDS[0], results['id'])
+        self.assertEqual(TEST_NAMES[0], results['name'])
+        self.assertEqual(TEST_NUMS[0], results['num'])
 
     def test_fetchall(self):
         query = rhnSQL.prepare("SELECT * FROM %s ORDER BY id" %
                                self.temp_table)
         query.execute()
         rows = query.fetchall()
-        self.assertEquals(len(TEST_IDS), len(rows))
+        self.assertEqual(len(TEST_IDS), len(rows))
 
         i = 0
         while i < len(TEST_IDS):
-            self.assertEquals(TEST_IDS[i], rows[i][0])
-            self.assertEquals(TEST_NAMES[i], rows[i][1])
+            self.assertEqual(TEST_IDS[i], rows[i][0])
+            self.assertEqual(TEST_NAMES[i], rows[i][1])
             i = i + 1
 
     def test_fetchall_dict(self):
@@ -182,18 +182,18 @@ class RhnSQLDatabaseTests(unittest.TestCase):
                                self.temp_table)
         query.execute()
         rows = query.fetchall_dict()
-        self.assertEquals(len(TEST_IDS), len(rows))
+        self.assertEqual(len(TEST_IDS), len(rows))
 
         i = 0
         while i < len(TEST_IDS):
-            self.assertEquals(TEST_IDS[i], rows[i]['id'])
-            self.assertEquals(TEST_NAMES[i], rows[i]['name'])
+            self.assertEqual(TEST_IDS[i], rows[i]['id'])
+            self.assertEqual(TEST_NAMES[i], rows[i]['name'])
             i = i + 1
 
     def test_unicode_string_argument(self):
         query = rhnSQL.prepare("SELECT * FROM %s WHERE name=:name" %
                                self.temp_table)
-        query.execute(name=u'blah')
+        query.execute(name='blah')
 
 #    def test_procedure(self):
 #        sp = rhnSQL.Procedure("return_int")

--- a/backend/upload_server/handlers/package_push/__init__.py
+++ b/backend/upload_server/handlers/package_push/__init__.py
@@ -18,6 +18,6 @@
 
 __all__ = []
 
-import package_push
+from . import package_push
 
 upload_class = package_push.PackagePush

--- a/backend/upload_server/handlers/package_push/__init__.py
+++ b/backend/upload_server/handlers/package_push/__init__.py
@@ -18,6 +18,6 @@
 
 __all__ = []
 
-from . import package_push
+import package_push
 
 upload_class = package_push.PackagePush

--- a/backend/upload_server/handlers/package_push/package_push.py
+++ b/backend/upload_server/handlers/package_push/package_push.py
@@ -75,7 +75,7 @@ class PackagePush(basePackageUpload.BasePackageUpload):
         # Init the database connection
         rhnSQL.initDB()
         use_session = 0
-        if self.field_data.has_key('Auth-Session'):
+        if 'Auth-Session' in self.field_data:
             session_token = self.field_data['Auth-Session']
             use_session = 1
         else:

--- a/backend/wsgi/wsgiHandler.py
+++ b/backend/wsgi/wsgiHandler.py
@@ -21,10 +21,10 @@ def handle(environ, start_response, server, component_type, servertype="spacewal
     # wsgi seems to capitalize incoming headers and add HTTP- to the front :/
     # so we strip out the first 5 letters, and transform it into what we want.
     replacements = {'_': '-', 'Rhn': 'RHN', 'Md5Sum': 'MD5sum', 'Xml': 'XML', 'Actualuri': 'ActualURI'}
-    for key in environ.keys():
+    for key in list(environ.keys()):
         if key[:5] == "HTTP_":
             new_key = key[5:].title()
-            for k, v in replacements.items():
+            for k, v in list(replacements.items()):
                 new_key = new_key.replace(k, v)
             environ[new_key] = environ[key]
 

--- a/backend/wsgi/wsgiRequest.py
+++ b/backend/wsgi/wsgiRequest.py
@@ -68,7 +68,7 @@ class WsgiRequest:
         if len(self.status) == 0 or self.status is None:
             self.status = "200"
         elif self.status.startswith("500"):
-            for i in self.err_headers_out.items():
+            for i in list(self.err_headers_out.items()):
                 self.headers_out.add(i[0], i[1])
 
         if hasattr(httplib, "responses"):
@@ -81,7 +81,7 @@ class WsgiRequest:
         if len(self.content_type) > 0:
             self.headers_out['Content-Type'] = self.content_type
         # default to text/xml
-        if not self.headers_out.has_key('Content-Type'):
+        if 'Content-Type' not in self.headers_out:
             self.headers_out['Content-Type'] = 'text/xml'
 
         self.start_response(self.status, list(self.headers_out.items()))
@@ -153,7 +153,7 @@ class WsgiMPtable:
 
     def items(self):
         ilist = []
-        for k, v in self.dict.items():
+        for k, v in list(self.dict.items()):
             for vi in v:
                 ilist.append((k, vi))
         return ilist
@@ -165,4 +165,4 @@ class WsgiMPtable:
         return list(self.dict.keys())
 
     def __str__(self):
-        return str(self.items())
+        return str(list(self.items()))


### PR DESCRIPTION
## What does this PR change?

This PR migrates "spacewalk-backend" code to be Python 2/3 compatible.

Some notes:
- General fixes addressed by `2to3`.
- Fix issues with `spacewalk-usix` dependency to allow unit test to run.
- Require succeeded unit tests during package building.
- Fix unit tests after migration.

## Test coverage
- Unit tests were enabled

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/salt-board/issues/64

- [x] **DONE**
