### PR TITLE
Removed SSL check when testing repoURL(bsc1095220)

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -33,7 +33,7 @@ disable_repo_{{ alias }}:
 {% set bootstrap_repo_url = 'https://' ~ salt['pillar.get']('mgr_server') ~ '/pub/repositories/res/' ~ grains['osmajorrelease'] ~ '/bootstrap/' %}
 {%- endif %}
 
-{%- set bootstrap_repo_exists = (0 < salt['http.query'](bootstrap_repo_url + 'repodata/repomd.xml', status=True)['status'] < 300) %}
+{%- set bootstrap_repo_exists = (0 < salt['http.query'](bootstrap_repo_url + 'repodata/repomd.xml', status=True, verify_ssl=False)['status'] < 300) %}
 
 bootstrap_repo:
   file.managed:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- removed the ssl certificate verification while checking bootstrap repo URL (bsc#1095220)
 - Removed the need for curl to be present at bootstrap phase (bsc#1095220)
 - Migrate Python code to be Python 2/3 compatible 
 - Fix merging of image pillars


### PR DESCRIPTION
This patch disables SSL check of the bootstrap repo
when bootstrapping a minion.

This prevents bootstraping from failing on systems
where SSL is not yet installed at this phase.

cherrypick from https://github.com/SUSE/spacewalk/pull/5934