### PR TITLE
Fixd exception when refreshing channel bsc#1094992

### DIFF
--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix NullPointerException when refreshing deleted software channel (bsc#1094992)
 - Subscribe saltbooted minion to software channels, respect activation key in final registration steps
 - Fix script is deleted too early (bsc#1105807)
 - Remove special characters from HW type string


### PR DESCRIPTION
When a software channel failed to sync and the channel
got deleted afterwards, you are still able to retry
the repo sync via the Notification area.

Before this fix you would get a NullPointerException
everytime you pressed the refresh button.

Now there is no exception at all.

cherrypick from https://github.com/SUSE/spacewalk/pull/5909/
