### PR TITLE
Fix: Cleanup Kiwi cache in highstate (bsc#1109892)

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/services/kiwi-image-server.sls
+++ b/susemanager-utils/susemanager-sls/salt/services/kiwi-image-server.sls
@@ -36,6 +36,11 @@ mgr_osimage_cert_deployed:
     - name: {{ kiwi_dir }}/repo/rhn-org-trusted-ssl-cert-osimage-1.0-1.noarch.rpm
     - source: salt://images/rhn-org-trusted-ssl-cert-osimage-1.0-1.noarch.rpm
 
+mgr_kiwi_clear_cache:
+  file.directory:
+    - name: /var/cache/kiwi/zypper/
+    - clean: True
+
 mgr_sshd_installed_enabled:
   pkg.installed:
     - name: openssh

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Fix: Cleanup Kiwi cache in highstate (bsc#1109892)
 - removed the ssl certificate verification while checking bootstrap repo URL (bsc#1095220)
 - Removed the need for curl to be present at bootstrap phase (bsc#1095220)
 - Migrate Python code to be Python 2/3 compatible 


### PR DESCRIPTION
## What does this PR change?

Empty Kiwi cache on applying the highstate

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: internal mechanism

- [X] **DONE**

## Test coverage

- No tests: Salt state-related

- [X] **DONE**

## Links

Fix for:
  - https://bugzilla.suse.com/show_bug.cgi?id=1109892
  - Downstream PR: https://github.com/SUSE/spacewalk/pull/5941

- [X] **DONE**
