### PR TITLE
MessageQueue: add thread names

### DIFF
--- a/java/code/src/com/redhat/rhn/common/messaging/MessageQueueThreadPool.java
+++ b/java/code/src/com/redhat/rhn/common/messaging/MessageQueueThreadPool.java
@@ -17,6 +17,7 @@ package com.redhat.rhn.common.messaging;
 import com.redhat.rhn.frontend.events.TraceBackAction;
 import com.redhat.rhn.frontend.events.TraceBackEvent;
 
+import org.apache.commons.lang3.concurrent.BasicThreadFactory;
 import org.apache.log4j.Logger;
 
 import java.util.concurrent.CancellationException;
@@ -44,6 +45,7 @@ public class MessageQueueThreadPool extends ThreadPoolExecutor {
      */
     public MessageQueueThreadPool(int size) {
         super(size, size, 0, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<Runnable>());
+        setThreadFactory(new BasicThreadFactory.Builder().namingPattern("message-queue-thread-%d").build());
         log.info("Started message queue thread pool (size: " + size + ")");
     }
 


### PR DESCRIPTION
## What does this PR change?

It sets readable names to threads used by the `MessageQueue`. Previously these threads would had automatically generated names like `pool-5-thread-2` that made it difficult to interpret thread dumps and profiler outputs. Now the name is readable, eg:

![visualvm-is-happier](https://user-images.githubusercontent.com/250541/46133964-11610080-c242-11e8-84a0-6d427949712b.png)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal implementation detail not visible to users**

- [x] **DONE**

## Test coverage
- No tests: **no effect expected**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/5942

- [x] **DONE**
