### PR TITLE
Install all available known kiwi boot descriptions

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/services/kiwi-image-server.sls
+++ b/susemanager-utils/susemanager-sls/salt/services/kiwi-image-server.sls
@@ -4,12 +4,18 @@
 
 {% if pillar['addon_group_types'] is defined and 'osimage_build_host' in pillar['addon_group_types'] %}
 {% set kiwi_dir = '/var/lib/Kiwi' %}
+{% set kiwi_boot_modules = ['kiwi-desc-netboot', 'kiwi-desc-saltboot', 'kiwi-desc-vmxboot', 'kiwi-desc-oemboot', 'kiwi-desc-isoboot'] %}
+{% set available_packages = salt['pkg.search']('kiwi*').keys() %}
 
 mgr_install_kiwi:
   pkg.installed:
     - pkgs:
       - kiwi
-    - order: first
+{% for km in kiwi_boot_modules %}
+    {% if km in available_packages %}
+      - {{ km }}
+    {% endif %}
+{% endfor %}
 
 mgr_kiwi_build_tools:
   pkg.installed:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- install all available known kiwi boot descriptions
 - Fix: Cleanup Kiwi cache in highstate (bsc#1109892)
 - removed the ssl certificate verification while checking bootstrap repo URL (bsc#1095220)
 - Removed the need for curl to be present at bootstrap phase (bsc#1095220)


### PR DESCRIPTION
This installs retail saltboot and vmxboot for virtual machines, but does not fail if package is not available.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: internal functionality

- [X] **DONE**

## Test coverage
- No tests: covered by existing tests

- [X] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/5961

- [X] **DONE**
