### PR TITLE
Testsuite: add root user to jeos images

### DIFF
--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS6/config.xml
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS6/config.xml
@@ -18,10 +18,14 @@
         <hwclock>utc</hwclock>
 
         <rpm-excludedocs>true</rpm-excludedocs>
-        <type boot="saltboot/suse-SLES12" bootloader="grub2" checkprebuilt="true" compressed="false" filesystem="ext3" fsmountoptions="acl" fsnocheck="true" image="pxe" kernelcmdline="quiet"></type>
-        <type boot="isoboot/suse-SLES12" image="iso"></type>
-        <type boot="oemboot/suse-SLES12" filesystem="ext3" image="oem" installiso="true"></type>
+
+        <type boot="saltboot/suse-SLES12" bootloader="grub2" checkprebuilt="true" compressed="false" filesystem="ext3" fsmountoptions="acl" fsnocheck="true" image="pxe" kernelcmdline="quiet"/>
+        <type boot="isoboot/suse-SLES12" image="iso"/>
+        <type boot="oemboot/suse-SLES12" filesystem="ext3" image="oem" installiso="true"/>
     </preferences>
+    <users group="root">
+      <user home="/root" name="root" password="lQxldvDc9mR/o" shell="/bin/bash"/>
+    </users>
     <repository type="rpm-md" >
         <source path="http://euklid.nue.suse.com/mirror/SuSE/build.suse.de/SUSE/Products/SLE-SERVER/12-SP3/x86_64/product/"/>
     </repository>


### PR DESCRIPTION
## What does this PR change?

It adds a root user to JeOS images used by the testsuite so the PXE-booted systems are usable :yum: .

## Links

uyuni only as this is where the kiwi profiles are.