### PR TITLE
Fix testsuite product detection

### DIFF
--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -34,9 +34,9 @@ def count_table_items
 end
 
 def product
-  _product_raw, code = $server.run('rpm -q patterns-uyuni_server')
+  _product_raw, code = $server.run('rpm -q patterns-uyuni_server', false)
   return 'Uyuni' if code.zero?
-  _product_raw, code = $server.run('rpm -q patterns-suma_server')
+  _product_raw, code = $server.run('rpm -q patterns-suma_server', false)
   return 'SUSE Manager' if code.zero?
   raise 'Could not determine product'
 end


### PR DESCRIPTION
## What does this PR change?

Fix testsuite product detection. When using `$run.cmd` we need to specify `fatal = false` so we don't get an exception.

See https://github.com/uyuni-project/uyuni/blob/master/testsuite/features/support/lavanda.rb#L38 for reference.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Internal testsuite fix.

- [x] **DONE**

## Test coverage
- Cucumber tests were fixed

- [x] **DONE**

## Links

Related: https://github.com/SUSE/spacewalk/issues/5701
- [x] **DONE**
