### PR TITLE
Adapt "spacewalk-certs-tools" code to be Python 2/3 compatible

### DIFF
--- a/spacewalk/certs-tools/rhn_bootstrap.py
+++ b/spacewalk/certs-tools/rhn_bootstrap.py
@@ -563,7 +563,7 @@ def writeClientConfigOverrides(options):
 #       unchanged.
 
 """)
-        keys = d.keys()
+        keys = list(d.keys())
         keys.sort()
         for key in keys:
             if d[key] is not None:
@@ -574,7 +574,7 @@ def writeClientConfigOverrides(options):
   '%s'\n""" % _overrides)
         if options.verbose>=0:
             print("Values written:")
-            for k, v in d.items():
+            for k, v in list(d.items()):
                 print(k + ' '*(25-len(k)) + repr(v))
 
 

--- a/spacewalk/certs-tools/rhn_bootstrap.py
+++ b/spacewalk/certs-tools/rhn_bootstrap.py
@@ -27,8 +27,12 @@ import sys
 import glob
 import socket
 import shutil
-import urlparse
 import operator
+
+try:
+    import urllib.parse as urlparse
+except ImportError:
+    import urlparse
 
 from optparse import Option, OptionParser, SUPPRESS_HELP
 

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,5 @@
+- Add support for Python 3 (bsc#1102528)
+
 -------------------------------------------------------------------
 Fri Aug 10 15:14:30 CEST 2018 - jgonzalez@suse.com
 

--- a/spacewalk/certs-tools/spacewalk-certs-tools.spec
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.spec
@@ -31,7 +31,7 @@
 %endif
 %global rhnroot %{_datadir}/rhn
 
-%if 0%{?fedora}
+%if 0%{?fedora} || 0%{?suse_version} > 1320
 %global build_py3   1
 %global default_py3 1
 %endif
@@ -63,6 +63,11 @@ BuildRequires:  filesystem
 Requires:       susemanager-build-keys-web
 %endif
 BuildRequires:  python
+%if 0%{?build_py3}
+Requires(post):  python3-spacewalk-backend-libs
+Requires(post):  python3-rhnlib
+Requires(post):  python3-rpm
+%endif
 Requires(post): spacewalk-backend-libs
 Requires(post): rhnlib
 Requires(post): rpm-python

--- a/spacewalk/certs-tools/sslToolConfig.py
+++ b/spacewalk/certs-tools/sslToolConfig.py
@@ -292,7 +292,7 @@ def figureDEFS_distinguishing(options):
               }
 
     # map config file settings to DEFS (see mapping dict above)
-    for key in conf.keys():
+    for key in list(conf.keys()):
         #print 'XXX KEY', key, repr(mapping[key])
         for v in mapping[key]:
             DEFS[v] = conf[key]
@@ -704,7 +704,7 @@ serial                  = $dir/serial
                   }
 
         rdn = {}
-        for k in d.keys():
+        for k in list(d.keys()):
             if k in mapping:
                 rdn[mapping[k]] = d[k].strip()
 


### PR DESCRIPTION
## What does this PR change?
This PR migrates `spacewalk-certs-tools` code to be Python 2/3 compatible.

## Test coverage
- No tests: **no tests are implemented**

- [x] **DONE**

## Links

Fixes: https://github.com/SUSE/salt-board/issues/29
Tracks https://github.com/SUSE/salt-board/issues/59

- [x] **DONE**
