### PR TITLE
Port to Python3: Fix dependency for python-psycopg2 on spec file

### DIFF
--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -200,7 +200,7 @@ Group:          Applications/Internet
 Requires:       python3-psycopg2 >= 2.0.14-2
 Requires:       python3-spacewalk-usix
 %else
-Requires:       python3-psycopg2 >= 2.0.14-2
+Requires:       python-psycopg2 >= 2.0.14-2
 Requires:       python2-spacewalk-usix
 %endif
 Provides:       %{name}-sql-virtual = %{version}-%{release}


### PR DESCRIPTION
## What does this PR change?
This PR fixes a wrong dependency name for `python-psycopg2` package on non-python3 builds.

This should fix the issue we have currently to deploy our "Head" testsuite environment.