### PR TITLE
Port to Python3: Fix typo on dependency for python2-python-dateutil

### DIFF
--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -431,7 +431,7 @@ Requires:       python3-python-dateutil
 Requires:       python3-gzipstream
 Requires:       python3-rhn-client-tools
 %else
-Requires:       python2-python-ateutil
+Requires:       python2-python-dateutil
 Requires:       python2-gzipstream
 Requires:       python2-rhn-client-tools
 %endif


### PR DESCRIPTION
## What does this PR change?
Fix typo on `python2-python-dateutil` package dependency name.