### PR TITLE
Port to Python3: Fix suseRegisterInfo package to be Python 2/3 compatible

### DIFF
--- a/suseRegisterInfo/Makefile.defs
+++ b/suseRegisterInfo/Makefile.defs
@@ -8,7 +8,7 @@ TOP		?= .
 ROOT		?= /usr/share/rhn
 export ROOT
 
-SPACEWALK_ROOT	?= $(shell python -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")/spacewalk
+SPACEWALK_ROOT	?= $(shell $(PYTHON_BIN) -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")/spacewalk
 export SPACEWALK_ROOT
 
 PREFIX		?=

--- a/suseRegisterInfo/suseRegisterInfo.changes
+++ b/suseRegisterInfo/suseRegisterInfo.changes
@@ -1,3 +1,5 @@
+- Make suseRegisterInfo compatible with Python 2 and 3
+
 -------------------------------------------------------------------
 Fri Aug 10 15:41:44 CEST 2018 - jgonzalez@suse.com
 

--- a/suseRegisterInfo/suseRegisterInfo.spec
+++ b/suseRegisterInfo/suseRegisterInfo.spec
@@ -77,10 +77,10 @@ Python 2 specific files for %{name}.
 %install
 mkdir -p %{buildroot}/usr/lib/suseRegister/bin/
 install -m 0755 suseRegister/parse_release_info %{buildroot}/usr/lib/suseRegister/bin/parse_release_info
-make -C suseRegister install PREFIX=$RPM_BUILD_ROOT PYTHONPATH=%{python_sitelib}
+make -C suseRegister install PREFIX=$RPM_BUILD_ROOT PYTHONPATH=%{python_sitelib} PYTHON_BIN=%{pythonX}
 
 %if 0%{?build_py3}
-make -C suseRegister install PREFIX=$RPM_BUILD_ROOT PYTHONPATH=%{python3_sitelib}
+make -C suseRegister install PREFIX=$RPM_BUILD_ROOT PYTHONPATH=%{python3_sitelib} PYTHON_BIN=%{pythonX}
 %endif
 
 %if 0%{?suse_version}


### PR DESCRIPTION
## What does this PR change?
This PR makes some fixes on the `suseRegisterInfo` package spec file to keep consistency while doing it ready for Python 3.