### PR TITLE
Port to Python3: Address some issues on broken "spacewalk-backend"

### DIFF
--- a/backend/cdn_tools/cdnsync.py
+++ b/backend/cdn_tools/cdnsync.py
@@ -37,8 +37,8 @@ from spacewalk.satellite_tools.satCerts import get_certificate_info, verify_cert
 from spacewalk.satellite_tools.syncLib import log, log2disk, log2, initEMAIL_LOG, log2email, log2background
 from spacewalk.satellite_tools.repo_plugins import yum_src
 
-from .common import CustomChannelSyncError, CountingPackagesError, verify_mappings, human_readable_size
-from .repository import CdnRepositoryManager, CdnRepositoryNotFoundError
+from common import CustomChannelSyncError, CountingPackagesError, verify_mappings, human_readable_size
+from repository import CdnRepositoryManager, CdnRepositoryNotFoundError
 
 
 class CdnSync(object):

--- a/backend/common/suseLib.py
+++ b/backend/common/suseLib.py
@@ -162,7 +162,7 @@ def send(url, sendData=None):
     connect_retries = 10
     try_counter = connect_retries
     timeout = 120
-    if CFG.is_initialized() and 'TIMEOUT' in CFG:
+    if CFG.is_initialized() and CFG.has_key('TIMEOUT'):
         timeout = CFG.TIMEOUT
     curl = pycurl.Curl()
 
@@ -177,7 +177,7 @@ def send(url, sendData=None):
     if sendData is not None:
         curl.setopt(pycurl.POSTFIELDS, sendData)
         if (CFG.is_initialized() and
-                'DISABLE_EXPECT' in CFG and
+                CFG.has_key('DISABLE_EXPECT') and
                 CFG.DISABLE_EXPECT):
             # disable Expect header
             curl.setopt(pycurl.HTTPHEADER, ['Expect:'])
@@ -243,7 +243,7 @@ def accessible(url):
 
     """
     timeout = 120
-    if CFG.is_initialized() and 'TIMEOUT' in CFG:
+    if CFG.is_initialized() and CFG.has_key('TIMEOUT'):
         timeout = CFG.TIMEOUT
     curl = pycurl.Curl()
 
@@ -592,7 +592,7 @@ def _get_proxy_from_rhn_conf():
 
     """
     comp = CFG.getComponent()
-    if "http_proxy" not in CFG:
+    if not CFG.has_key("http_proxy"):
         initCFG("server.satellite")
     result = None
     if CFG.http_proxy:
@@ -629,9 +629,9 @@ def _useProxyFor(url):
     if hostname in ["localhost", "127.0.0.1", "::1"]:
         return False
     comp = CFG.getComponent()
-    if "no_proxy" not in CFG:
+    if not CFG.has_key("no_proxy"):
         initCFG("server.satellite")
-    if 'no_proxy' not in CFG:
+    if not CFG.has_key('no_proxy'):
         initCFG(comp)
         return True
     noproxy = CFG.no_proxy

--- a/backend/satellite_tools/disk_dumper/dumper.py
+++ b/backend/satellite_tools/disk_dumper/dumper.py
@@ -32,7 +32,7 @@ from spacewalk.common.rhnException import rhnFault
 from spacewalk.server import rhnSQL
 from spacewalk.satellite_tools import constants
 from spacewalk.satellite_tools.exporter import exportLib, xmlWriter
-from .string_buffer import StringBuffer
+from string_buffer import StringBuffer
 
 
 class XML_Dumper:

--- a/backend/satellite_tools/disk_dumper/iss.py
+++ b/backend/satellite_tools/disk_dumper/iss.py
@@ -37,8 +37,8 @@ from spacewalk.server.rhnSQL import SQLError, SQLSchemaError, SQLConnectError
 from spacewalk.satellite_tools.exporter import xmlWriter
 from spacewalk.satellite_tools import xmlDiskSource, diskImportLib, progress_bar
 from spacewalk.satellite_tools.syncLib import initEMAIL_LOG, dumpEMAIL_LOG, log2email, log2stderr, log2stdout
-from .iss_ui import UI
-from .iss_actions import ActionDeps
+from iss_ui import UI
+from iss_actions import ActionDeps
 import iss_isos
 
 t = gettext.translation('spacewalk-backend-server', fallback=True)

--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -56,7 +56,7 @@ from spacewalk.satellite_tools.repo_plugins import CACHE_DIR
 from spacewalk.server import taskomatic, rhnPackageUpload
 from spacewalk.satellite_tools.satCerts import verify_certificate_dates
 
-from .syncLib import log, log2, log2disk, dumpEMAIL_LOG, log2background
+from syncLib import log, log2, log2disk, dumpEMAIL_LOG, log2background
 
 translation = gettext.translation('spacewalk-backend-server', fallback=True)
 _ = translation.ugettext

--- a/backend/satellite_tools/satsync.py
+++ b/backend/satellite_tools/satsync.py
@@ -54,16 +54,16 @@ from spacewalk.common import fileutils
 # __rhn sync/import imports__
 import xmlWireSource
 import xmlDiskSource
-from .progress_bar import ProgressBar
-from .xmlSource import FatalParseException, ParseException
-from .diskImportLib import rpmsPath
+from progress_bar import ProgressBar
+from xmlSource import FatalParseException, ParseException
+from diskImportLib import rpmsPath
 
-from .syncLib import log, log2, log2disk, log2stderr, log2email
-from .syncLib import RhnSyncException, RpmManip, ReprocessingNeeded
-from .syncLib import initEMAIL_LOG, dumpEMAIL_LOG
-from .syncLib import FileCreationError, FileManip
+from syncLib import log, log2, log2disk, log2stderr, log2email
+from syncLib import RhnSyncException, RpmManip, ReprocessingNeeded
+from syncLib import initEMAIL_LOG, dumpEMAIL_LOG
+from syncLib import FileCreationError, FileManip
 
-from .SequenceServer import SequenceServer
+from SequenceServer import SequenceServer
 from spacewalk.server.importlib.errataCache import schedule_errata_cache_update
 
 from spacewalk.server.importlib.importLib import InvalidChannelFamilyError

--- a/backend/satellite_tools/xmlWireSource.py
+++ b/backend/satellite_tools/xmlWireSource.py
@@ -30,7 +30,7 @@ from spacewalk.common import rhnLib
 from spacewalk.common.rhnConfig import CFG
 
 # local imports
-from .syncLib import log, log2, RhnSyncException
+from syncLib import log, log2, RhnSyncException
 
 from rhn import rpclib
 

--- a/backend/server/apacheAuth.py
+++ b/backend/server/apacheAuth.py
@@ -24,7 +24,7 @@ from spacewalk.common.rhnConfig import CFG
 from spacewalk.common.rhnException import rhnFault
 from spacewalk.common.rhnTranslate import _
 
-from .rhnLib import computeSignature
+from rhnLib import computeSignature
 
 
 def splitProxyAuthToken(token):

--- a/backend/server/apacheHandler.py
+++ b/backend/server/apacheHandler.py
@@ -26,7 +26,7 @@ from spacewalk.common.rhnLog import log_debug, log_error, initLOG, log_setreq
 # local module imports
 import rhnSQL
 
-from .apacheRequest import apacheGET, apachePOST, HandlerNotFoundError
+from apacheRequest import apacheGET, apachePOST, HandlerNotFoundError
 import rhnCapability
 
 # a lame timer function for pretty logs

--- a/backend/server/apacheServer.py
+++ b/backend/server/apacheServer.py
@@ -21,7 +21,7 @@ from spacewalk.common.rhnConfig import CFG, initCFG
 from spacewalk.common.rhnTB import Traceback
 from spacewalk.common.rhnLog import initLOG, log_setreq
 
-from .apacheHandler import apacheHandler
+from apacheHandler import apacheHandler
 apache_server = apacheHandler()
 HeaderParserHandler = apache_server.headerParserHandler
 Handler = apache_server.handler

--- a/backend/server/config_common/templated_document.py
+++ b/backend/server/config_common/templated_document.py
@@ -15,7 +15,7 @@
 #
 #
 
-from .base_templated_document import TemplatedDocument
+from base_templated_document import TemplatedDocument
 
 from spacewalk.common.rhnLog import log_debug
 

--- a/backend/server/handlers/sat/cert.py
+++ b/backend/server/handlers/sat/cert.py
@@ -20,7 +20,7 @@ from spacewalk.common.rhnException import rhnException
 
 # server imports
 from spacewalk.server import rhnSQL
-from .auth import Authentication
+from auth import Authentication
 
 
 class Certificate(Authentication):

--- a/backend/server/importlib/archImport.py
+++ b/backend/server/importlib/archImport.py
@@ -16,7 +16,7 @@
 # Arch import process
 #
 
-from .importLib import Import
+from importLib import Import
 
 
 class ArchImport(Import):

--- a/backend/server/importlib/backend.py
+++ b/backend/server/importlib/backend.py
@@ -27,10 +27,10 @@ from spacewalk.common.rhnException import rhnFault
 from spacewalk.common.rhnLog import log_debug
 from spacewalk.common.stringutils import to_string
 from spacewalk.server import rhnSQL, rhnChannel, taskomatic
-from .importLib import Diff, Package, IncompletePackage, Erratum, \
+from importLib import Diff, Package, IncompletePackage, Erratum, \
     AlreadyUploadedError, InvalidPackageError, TransactionError, \
     SourcePackage
-from .backendLib import TableCollection, sanitizeValue, TableDelete, \
+from backendLib import TableCollection, sanitizeValue, TableDelete, \
     TableUpdate, TableLookup, addHash, TableInsert
 
 sequences = {

--- a/backend/server/importlib/backendOracle.py
+++ b/backend/server/importlib/backendOracle.py
@@ -19,8 +19,8 @@
 #
 
 import sys
-from .backend import Backend
-from .backendLib import DBint, DBstring, DBdateTime, Table, \
+from backend import Backend
+from backendLib import DBint, DBstring, DBdateTime, Table, \
     TableCollection, DBblob
 from spacewalk.server import rhnSQL
 from spacewalk.server.rhnSQL.const import ORACLE, POSTGRESQL

--- a/backend/server/importlib/channelImport.py
+++ b/backend/server/importlib/channelImport.py
@@ -15,7 +15,7 @@
 # Channel import process
 #
 
-from .importLib import Import, InvalidArchError, \
+from importLib import Import, InvalidArchError, \
     InvalidChannelError, InvalidChannelFamilyError, MissingParentChannelError
 from spacewalk.satellite_tools.syncLib import log
 
@@ -314,8 +314,8 @@ class DistChannelMapImport(Import):
 if __name__ == '__main__':
     import sys
     from spacewalk.server import rhnSQL
-    from .backendOracle import OracleBackend
-    from .importLib import Collection, ChannelFamily, DistChannelMap
+    from backendOracle import OracleBackend
+    from importLib import Collection, ChannelFamily, DistChannelMap
     backend = OracleBackend()
     if 1:
         batch = Collection()

--- a/backend/server/importlib/contentSourcesImport.py
+++ b/backend/server/importlib/contentSourcesImport.py
@@ -14,7 +14,7 @@
 #
 #
 
-from .importLib import Import, Channel
+from importLib import Import, Channel
 from spacewalk.server.rhnChannel import channel_info
 
 

--- a/backend/server/importlib/debPackage.py
+++ b/backend/server/importlib/debPackage.py
@@ -18,8 +18,8 @@
 
 import headerSource
 import time
-from .importLib import Channel
-from .backendLib import gmtime, localtime
+from importLib import Channel
+from backendLib import gmtime, localtime
 from spacewalk.common.usix import IntType, UnicodeType
 from spacewalk.common.stringutils import to_string
 

--- a/backend/server/importlib/errataImport.py
+++ b/backend/server/importlib/errataImport.py
@@ -17,7 +17,7 @@
 #
 
 from spacewalk.common.rhnException import rhnFault
-from .importLib import GenericPackageImport
+from importLib import GenericPackageImport
 from spacewalk.satellite_tools.syncLib import log
 
 

--- a/backend/server/importlib/headerSource.py
+++ b/backend/server/importlib/headerSource.py
@@ -18,9 +18,9 @@
 
 import time
 import string
-from .importLib import File, Dependency, ChangeLog, Channel, \
+from importLib import File, Dependency, ChangeLog, Channel, \
     IncompletePackage, Package, SourcePackage
-from .backendLib import gmtime, localtime
+from backendLib import gmtime, localtime
 from spacewalk.common.usix import ListType, TupleType, IntType, LongType, StringType, UnicodeType
 from spacewalk.common.rhnLog import log_debug
 from spacewalk.common.stringutils import to_string

--- a/backend/server/importlib/kickstartImport.py
+++ b/backend/server/importlib/kickstartImport.py
@@ -16,7 +16,7 @@
 # Package import process
 #
 
-from .importLib import KickstartableTree, Import
+from importLib import KickstartableTree, Import
 
 
 class KickstartableTreeImport(Import):

--- a/backend/server/importlib/orgImport.py
+++ b/backend/server/importlib/orgImport.py
@@ -16,7 +16,7 @@
 # Org import process
 #
 
-from .importLib import Import
+from importLib import Import
 
 # Thanks for this class goes to Alex Martelli:
 # http://stackoverflow.com/questions/1151658/python-hashable-dicts

--- a/backend/server/importlib/packageImport.py
+++ b/backend/server/importlib/packageImport.py
@@ -19,10 +19,10 @@
 import rpm
 import sys
 import os.path
-from .importLib import GenericPackageImport, IncompletePackage, \
+from importLib import GenericPackageImport, IncompletePackage, \
     Import, InvalidArchError, InvalidChannelError, \
     IncompatibleArchError
-from .mpmSource import mpmBinaryPackage
+from mpmSource import mpmBinaryPackage
 from spacewalk.common import rhn_pkg
 from spacewalk.common.rhnConfig import CFG
 from spacewalk.server import taskomatic

--- a/backend/server/importlib/productNamesImport.py
+++ b/backend/server/importlib/productNamesImport.py
@@ -15,7 +15,7 @@
 #
 # Product Names Import
 
-from .importLib import Import
+from importLib import Import
 
 
 class ProductNamesImport(Import):

--- a/backend/server/importlib/supportInformationImport.py
+++ b/backend/server/importlib/supportInformationImport.py
@@ -10,7 +10,7 @@
 #
 # Support Information Import
 
-from .importLib import GenericPackageImport
+from importLib import GenericPackageImport
 from spacewalk.satellite_tools import syncCache
 
 class SupportInformationImport(GenericPackageImport):

--- a/backend/server/importlib/suseProductsImport.py
+++ b/backend/server/importlib/suseProductsImport.py
@@ -10,7 +10,7 @@
 #
 # SUSE Products Import
 
-from .importLib import GenericPackageImport
+from importLib import GenericPackageImport
 from spacewalk.satellite_tools import syncCache
 
 class SuseProductsImport(GenericPackageImport):

--- a/backend/server/repomd/repository.py
+++ b/backend/server/repomd/repository.py
@@ -37,7 +37,7 @@ from spacewalk.common.rhnConfig import CFG
 
 import mapper
 import view
-from .domain import RepoMD
+from domain import RepoMD
 from spacewalk.server import rhnChannel
 
 # One meg

--- a/backend/server/rhnChannel.py
+++ b/backend/server/rhnChannel.py
@@ -2206,7 +2206,7 @@ def system_reg_message(server):
                 (server.server["release"], server.archname))
 
     # System does have a base channel; check entitlements
-    from .rhnServer import server_lib  # having this on top, cause TB due circular imports
+    from rhnServer import server_lib  # having this on top, cause TB due circular imports
     entitlements = server_lib.check_entitlement(server_id)
     if not entitlements:
         # No entitlement

--- a/backend/server/rhnLib.py
+++ b/backend/server/rhnLib.py
@@ -24,7 +24,7 @@ from spacewalk.common.rhnLog import log_debug
 from spacewalk.common.rhnException import rhnFault
 
 # architecture work
-from .rhnMapping import check_package_arch
+from rhnMapping import check_package_arch
 
 
 def computeSignature(*fields):

--- a/backend/server/rhnPackage.py
+++ b/backend/server/rhnPackage.py
@@ -24,7 +24,7 @@ from spacewalk.common.rhnConfig import CFG
 from spacewalk.common.rhnException import rhnFault
 from spacewalk.common.rhnTranslate import _
 from spacewalk.server import rhnSQL
-from .rhnLib import parseRPMFilename
+from rhnLib import parseRPMFilename
 
 
 #

--- a/backend/server/rhnRepository.py
+++ b/backend/server/rhnRepository.py
@@ -31,8 +31,8 @@ from spacewalk.common.rhnLib import rfc822time, timestamp
 
 # local modules imports
 from spacewalk.server import rhnChannel, rhnPackage, taskomatic, rhnSQL
-from .rhnServer import server_lib
-from .repomd import repository
+from rhnServer import server_lib
+from repomd import repository
 
 
 class Repository(rhnRepository.Repository):

--- a/backend/server/rhnSQL/__init__.py
+++ b/backend/server/rhnSQL/__init__.py
@@ -31,10 +31,10 @@ import dbi
 import sql_types
 types = sql_types
 
-from .const import ORACLE, POSTGRESQL, SUPPORTED_BACKENDS
+from const import ORACLE, POSTGRESQL, SUPPORTED_BACKENDS
 
 # expose exceptions
-from .sql_base import SQLError, SQLSchemaError, SQLConnectError, \
+from sql_base import SQLError, SQLSchemaError, SQLConnectError, \
     SQLStatementPrepareError, Statement, ModifiedRowError
 
 # ths module works with a private global __DB object that is

--- a/backend/server/rhnSQL/dbi.py
+++ b/backend/server/rhnSQL/dbi.py
@@ -14,7 +14,7 @@
 #
 #
 
-from .const import ORACLE, POSTGRESQL
+from const import ORACLE, POSTGRESQL
 
 # Map supported backend constants to a specific Python driver:
 BACKEND_DRIVERS = {

--- a/backend/server/rhnSQL/driver_cx_Oracle.py
+++ b/backend/server/rhnSQL/driver_cx_Oracle.py
@@ -36,7 +36,7 @@ from spacewalk.common import rhnConfig
 from spacewalk.common.rhnLog import log_debug, log_error
 from spacewalk.common.rhnException import rhnException
 from spacewalk.common.stringutils import to_string
-from .const import ORACLE
+from const import ORACLE
 
 ORACLE_TYPE_MAPPING = [
     (sql_types.NUMBER, cx_Oracle.NUMBER),

--- a/backend/server/rhnSQL/driver_postgresql.py
+++ b/backend/server/rhnSQL/driver_postgresql.py
@@ -34,7 +34,7 @@ from spacewalk.server import rhnSQL
 from spacewalk.common.usix import BufferType, raise_with_tb
 from spacewalk.common.rhnLog import log_debug, log_error
 from spacewalk.common.rhnException import rhnException
-from .const import POSTGRESQL
+from const import POSTGRESQL
 
 
 def convert_named_query_params(query):

--- a/backend/server/rhnServer/__init__.py
+++ b/backend/server/rhnServer/__init__.py
@@ -23,9 +23,9 @@ from spacewalk.common.rhnLog import log_debug, log_error
 from spacewalk.server import rhnUser
 
 # Local imports
-from .server_class import Server
-from .server_certificate import Certificate
-from .server_token import fetch_token, fetch_org_token
+from server_class import Server
+from server_certificate import Certificate
+from server_token import fetch_token, fetch_org_token
 
 
 def get(system_id, load_user=1):

--- a/backend/server/rhnServer/__init__.py
+++ b/backend/server/rhnServer/__init__.py
@@ -17,10 +17,10 @@
 
 
 # these are pretty much the only entry points
-#from spacewalk.common.usix import StringType, UnicodeType
-#from spacewalk.common.rhnException import rhnFault
-#from spacewalk.common.rhnLog import log_debug, log_error
-#from spacewalk.server import rhnUser
+from spacewalk.common.usix import StringType, UnicodeType
+from spacewalk.common.rhnException import rhnFault
+from spacewalk.common.rhnLog import log_debug, log_error
+from spacewalk.server import rhnUser
 
 # Local imports
 from .server_class import Server

--- a/backend/server/rhnServer/server_certificate.py
+++ b/backend/server/rhnServer/server_certificate.py
@@ -33,8 +33,8 @@ except ImportError:
 from spacewalk.common.rhnLog import log_debug, log_error
 from spacewalk.common.rhnException import rhnFault
 from spacewalk.common.stringutils import to_string
-from .server_lib import getServerSecret
-from .server_lib import check_entitlement_by_machine_id
+from server_lib import getServerSecret
+from server_lib import check_entitlement_by_machine_id
 
 def gen_secret():
     """ Generate a secret """

--- a/backend/server/rhnServer/server_class.py
+++ b/backend/server/rhnServer/server_class.py
@@ -27,14 +27,14 @@ from spacewalk.common.rhnException import rhnFault, rhnException
 from spacewalk.common.rhnTranslate import _
 from spacewalk.server import rhnChannel, rhnUser, rhnSQL, rhnLib, rhnAction, \
     rhnVirtualization
-from .search_notify import SearchNotify
+from search_notify import SearchNotify
 
 # Local Modules
 import server_kickstart
 import server_lib
 import server_token
-from .server_certificate import Certificate, gen_secret
-from .server_wrapper import ServerWrapper
+from server_certificate import Certificate, gen_secret
+from server_wrapper import ServerWrapper
 
 
 class Server(ServerWrapper):

--- a/backend/server/rhnServer/server_packages.py
+++ b/backend/server/rhnServer/server_packages.py
@@ -27,7 +27,7 @@ from spacewalk.common import rhn_rpm
 from spacewalk.common.rhnLog import log_debug
 from spacewalk.common.rhnException import rhnFault
 from spacewalk.server import rhnSQL, rhnAction
-from .server_lib import snapshot_server, check_entitlement
+from server_lib import snapshot_server, check_entitlement
 
 UNCHANGED = 0
 ADDED = 1

--- a/backend/server/rhnServer/server_token.py
+++ b/backend/server/rhnServer/server_token.py
@@ -24,7 +24,7 @@ from spacewalk.common.rhnException import rhnFault, rhnException
 from spacewalk.common.rhnTranslate import _
 from spacewalk.server import rhnSQL, rhnChannel, rhnAction
 
-from .server_lib import join_server_group, check_entitlement
+from server_lib import join_server_group, check_entitlement
 
 VIRT_ENT_LABEL = 'virtualization_host'
 

--- a/backend/server/rhnServer/server_wrapper.py
+++ b/backend/server/rhnServer/server_wrapper.py
@@ -20,10 +20,10 @@
 # the server.Server class inherits this ServerWrapper class
 #
 
-from .server_hardware import Hardware
-from .server_packages import Packages
-from .server_history import History
-from .server_suse import SuseData
+from server_hardware import Hardware
+from server_packages import Packages
+from server_history import History
+from server_suse import SuseData
 
 from rhn.UserDictCase import UserDictCase
 from spacewalk.server import rhnSQL


### PR DESCRIPTION
## What does this PR change?
This PR fixes some issues on the `spacewalk-backend` package after Python 3 porting:

- Wrong relative imports.
- Wrongly commented imports that causes missing code dependencies.

This would hopefully reduce the cucumber failures we currently have on "Head" and "Uyuni/master" so we can keep debugging and retriggering testsuite.

There are still some other remaining fixes for `spacewalk-backend` that I'll address also in the meanwhile.