### PR TITLE
Port to Python3: Remove space from pythonX on suseRegisterInfo spec

### DIFF
--- a/suseRegisterInfo/suseRegisterInfo.spec
+++ b/suseRegisterInfo/suseRegisterInfo.spec
@@ -22,7 +22,7 @@
 %global default_py3 1
 %endif
 
-%define pythonX %{?default_py3: python3}%{!?default_py3: python2}
+%define pythonX %{?default_py3:python3}%{!?default_py3:python2}
 
 Name:           suseRegisterInfo
 Version:        4.0.1


### PR DESCRIPTION
## What does this PR change?
This PR fixes the broken `suseRegisterInfo` package due a whitespace contained on the `pythonX` variable of the spec file:

```
[   46s] + make -C suseRegister install PREFIX=/home/abuild/rpmbuild/BUILDROOT/suseRegisterInfo-4.0.1-400.3.1.develHead.x86_64 PYTHONPATH=/usr/lib/python2.7/site-packages PYTHON_BIN= python2
[   46s] make: Entering directory '/home/abuild/rpmbuild/BUILD/suseRegisterInfo-git-0.09a26a7/suseRegister'
[   46s] /bin/sh: - : invalid option
```