### PR TITLE
Port to Python3: Fix use of custom has_key method implementation

### DIFF
--- a/backend/satellite_tools/contentRemove.py
+++ b/backend/satellite_tools/contentRemove.py
@@ -62,7 +62,7 @@ class RemoteApi:
     def list_channel_labels(self):
         self.auth_check()
         key = "chan_labels"
-        if key in self.cache:
+        if self.cache.has_key(key):
             return self.cache[key]
 
         chan_list = self.client.channel.listAllChannels(self.auth_token)

--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -766,7 +766,7 @@ class ContentSource(object):
             thiskey = {}
             for info in ('keyid', 'timestamp', 'userid',
                          'fingerprint', 'raw_key'):
-                if info not in keyinfo:
+                if not keyinfo.has_key(info):
                     raise ChannelException('GPG key parsing failed: key does not have value %s' % info)
                 thiskey[info] = keyinfo[info]
             thiskey['keyid'] = str("%016x" % (thiskey['keyid'] & 0xffffffffffffffff)).upper()

--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -1888,11 +1888,11 @@ class RepoSync(object):
             """)
             query.execute(**product)
             row = query.fetchone_dict()
-            if not row or 'id' not in row:
+            if not row or not row.has_key('id'):
                 get_id_q = rhnSQL.prepare("""SELECT sequence_nextval('suse_prod_file_id_seq') as id FROM dual""")
                 get_id_q.execute()
                 row = get_id_q.fetchone_dict() or {}
-                if not row or 'id' not in row:
+                if not row or not row.has_key('id'):
                     print("no id for sequence suse_prod_file_id_seq")
                     continue
 
@@ -1929,7 +1929,7 @@ class RepoSync(object):
 
             query.execute(**params)
             packrow = query.fetchone_dict()
-            if not packrow or 'id' not in packrow:
+            if not packrow or not packrow.has_key('id'):
                 # package not in DB
                 continue
 
@@ -1964,7 +1964,7 @@ class RepoSync(object):
                           arch=package['arch'], pkgid=package['pkgid'],
                           channel_id=int(self.channel['id']))
             row = query.fetchone_dict() or None
-            if not row or 'id' not in row:
+            if not row or not row.has_key('id'):
                 # package not found in DB
                 continue
             pkgid = int(row['id'])
@@ -2002,7 +2002,7 @@ class RepoSync(object):
                     kadd.execute(package_id=pkgid, channel_id=int(self.channel['id']), keyword_id=kwcache[keyword])
                     self.regen = True
 
-            if 'eula' in package:
+            if package.has_key('eula'):
                 eula_id = suseEula.find_or_create_eula(package['eula'])
                 rhnPackage.add_eula_to_package(
                   package_id=pkgid,

--- a/backend/satellite_tools/satsync.py
+++ b/backend/satellite_tools/satsync.py
@@ -689,9 +689,9 @@ class Syncer:
             for label in requested_channels:
                 timestamp = self._channel_collection.get_channel_timestamp(label)
                 ch = self._channel_collection.get_channel(label, timestamp)
-                if 'comps_last_modified' in ch and ch['comps_last_modified'] is not None:
+                if ch.has_key('comps_last_modified') and ch['comps_last_modified'] is not None:
                     self._process_comps(importer.backend, label, sync_handlers._to_timestamp(ch['comps_last_modified']))
-                if 'modules_last_modified' in ch and ch['modules_last_modified'] is not None:
+                if ch.has_key('modules_last_modified') and ch['modules_last_modified'] is not None:
                     self._process_modules(importer.backend, label, \
                         sync_handlers._to_timestamp(ch['modules_last_modified']))
 

--- a/backend/satellite_tools/sync_handlers.py
+++ b/backend/satellite_tools/sync_handlers.py
@@ -238,14 +238,14 @@ def import_channels(channels, orgid=None, master=None):
                 c_obj['org_id'] = org_map[c_obj['org_id']]
             else:
                 c_obj['org_id'] = orgid
-                if 'trust_list' in c_obj:
+                if c_obj.has_key('trust_list'):
                     del(c_obj['trust_list'])
             for family in c_obj['families']:
                 family['label'] = 'private-channel-family-' + \
                     str(c_obj['org_id'])
         # If there's a trust list on the channel, transform the org ids to
         # the local ones
-        if 'trust_list' in c_obj and c_obj['trust_list']:
+        if c_obj.has_key('trust_list') and c_obj['trust_list']:
             trusts = []
             for trust in c_obj['trust_list']:
                 if trust['org_trust_id'] in org_map:

--- a/backend/server/action/packages.py
+++ b/backend/server/action/packages.py
@@ -146,7 +146,7 @@ def setLocks(serverId, actionId, dry_run=0):
     client_caps = rhnCapability.get_client_capabilities()
     log_debug(3,"Client Capabilities", client_caps)
     multiarch = 0
-    if not client_caps or 'packages.setLocks' not in client_caps:
+    if not client_caps or not client_caps.has_key('packages.setLocks'):
         raise InvalidAction("Client is not capable of locking packages.")
 
     h = rhnSQL.prepare(_query_action_setLocks)

--- a/backend/server/handlers/xmlrpc/registration.py
+++ b/backend/server/handlers/xmlrpc/registration.py
@@ -331,7 +331,7 @@ class Registration(rhnHandler):
                 newserv.dispose_packages()
                 # The new server may have a different base channel
                 suse_products = None
-                if 'suse_products' in data:
+                if data.has_key('suse_products'):
                     suse_products = data['suse_products']
                 newserv.change_base_channel(release, suse_products=suse_products)
 

--- a/backend/server/importlib/backend.py
+++ b/backend/server/importlib/backend.py
@@ -104,7 +104,7 @@ class Backend:
             capabilityHash[(name, version)] = row['id']
 
     def processChangeLog(self, changelogHash):
-        if 'package_import_skip_changelog' in CFG and CFG.package_import_skip_changelog:
+        if CFG.has_key('package_import_skip_changelog') and CFG.package_import_skip_changelog:
             return
         sql = "select id from rhnPackageChangeLogData where name = :name and time = :time and text = :text"
         h = self.dbmodule.prepare(sql)
@@ -556,12 +556,12 @@ class Backend:
 
         h = self.dbmodule.prepare(sql)
 
-        if 'security_impact' in erratum and erratum['security_impact']:
+        if erratum.has_key('security_impact') and erratum['security_impact']:
             #concatenate the severity to reflect the db
             #bz-204374: rhnErrataSeverity tbl has lower case severity values,
             #so we convert severity in errata hash to lower case to lookup.
             severity_label = 'errata.sev.label.' + erratum['security_impact'].lower()
-        elif 'severity' in erratum and erratum['severity']:
+        elif erratum.has_key('severity') and erratum['severity']:
             severity_label = erratum['severity']
         else:
             return None
@@ -830,7 +830,7 @@ class Backend:
             'susePackageEula':         'package_id',
         }
 
-        if 'package_import_skip_changelog' in CFG and CFG.package_import_skip_changelog:
+        if CFG.has_key('package_import_skip_changelog') and CFG.package_import_skip_changelog:
             del childTables['rhnPackageChangeLogRec']
 
         for package in packages:

--- a/backend/server/rhnAction.py
+++ b/backend/server/rhnAction.py
@@ -23,7 +23,7 @@ def schedule_action(action_type, action_name=None, delta_time=0,
     action_id = next(rhnSQL.Sequence('rhn_event_id_seq'))
 
     at = rhnSQL.Table('rhnActionType', 'label')
-    if action_type not in at:
+    if not at.has_key(action_type):
         raise ValueError("Unknown action type %s" % action_type)
 
     params = {

--- a/backend/server/rhnSQL/driver_cx_Oracle.py
+++ b/backend/server/rhnSQL/driver_cx_Oracle.py
@@ -157,7 +157,7 @@ class Cursor(sql_base.Cursor):
         # Check that all required parameters were provided:
         # NOTE: bindnames() is Oracle specific:
         for k in self._real_cursor.bindnames():
-            if k not in _p:
+            if not _p.has_key(k):
                 # Raise the fault ourselves
                 raise sql_base.SQLError(1008, 'Not all variables bound', k)
             params[k] = to_string(_p[k])
@@ -549,7 +549,7 @@ class Database(sql_base.Database):
             value = None
             # Do we have a config object?
             if rhnConfig.CFG.is_initialized():
-                if "nls_lang" in rhnConfig.CFG:
+                if rhnConfig.CFG.has_key("nls_lang"):
                     # Get the value from the configuration object
                     value = rhnConfig.CFG.nls_lang
             if not value:

--- a/backend/server/rhnSQL/sql_table.py
+++ b/backend/server/rhnSQL/sql_table.py
@@ -181,7 +181,7 @@ class Table:
         if items == []:  # quick check for noop
             return
         sql = None
-        if key in self:
+        if self.has_key(key):
             sql, pdict = sql_lib.build_sql_update(self.__table, self.__hashid, items)
         else:
             sql, pdict = sql_lib.build_sql_insert(self.__table, self.__hashid, items)
@@ -260,5 +260,5 @@ class Table:
         return self.__db.rollback()
 
     def printcache(self):
-        print((self.__cache))
+        print(self.__cache)
         return

--- a/backend/server/rhnServer/server_class.py
+++ b/backend/server/rhnServer/server_class.py
@@ -167,7 +167,7 @@ class Server(ServerWrapper):
 
     # return the id of this system
     def getid(self):
-        if "id" not in self.server:
+        if not self.server.has_key("id"):
             sysid = rhnSQL.Sequence("rhn_server_id_seq")()
             self.server["digital_server_id"] = "ID-%09d" % sysid
             # we can't reset the id column, so we need to poke into
@@ -535,7 +535,7 @@ class Server(ServerWrapper):
 
             # some more default values
             self.server["auto_update"] = "N"
-            if self.user and "creator_id" not in self.server:
+            if self.user and not self.server.has_key("creator_id"):
                 # save the link to the user that created it if we have
                 # that information
                 self.server["creator_id"] = self.user.getid()
@@ -729,7 +729,7 @@ class Server(ServerWrapper):
 
     # Is this server entitled?
     def check_entitlement(self):
-        if "id" not in self.server:
+        if not self.server.has_key("id"):
             return None
         log_debug(3, self.server["id"])
 
@@ -737,19 +737,19 @@ class Server(ServerWrapper):
 
     def checkin(self, commit=1):
         """ convenient wrapper for these thing until we clean the code up """
-        if "id" not in self.server:
+        if not self.server.has_key("id"):
             return 0  # meaningless if rhnFault not raised
         return server_lib.checkin(self.server["id"], commit)
 
     def throttle(self):
         """ convenient wrapper for these thing until we clean the code up """
-        if "id" not in self.server:
+        if not self.server.has_key("id"):
             return 1  # meaningless if rhnFault not raised
         return server_lib.throttle(self.server)
 
     def set_qos(self):
         """ convenient wrapper for these thing until we clean the code up """
-        if "id" not in self.server:
+        if not self.server.has_key("id"):
             return 1  # meaningless if rhnFault not raised
         return server_lib.set_qos(self.server["id"])
 

--- a/backend/server/rhnServer/server_hardware.py
+++ b/backend/server/rhnServer/server_hardware.py
@@ -240,7 +240,7 @@ class GenericDevice:
         # clean up fields we don't want
         if self.data:
             for k in ["created", "modified"]:
-                if k in self.data:
+                if self.data.has_key(k):
                     del self.data[k]
         self.id = devid
         self.status = 0
@@ -295,10 +295,10 @@ class Device(GenericDevice):
         for k in list(dict.keys()):
             if dict[k] == '':
                 dict[k] = None
-            if k in self.data:
+            if self.data.has_key(k):
                 self.data[k] = dict[k]
                 continue
-            if k in mapping:
+            if mapping.has_key(k):
                 # the mapping dict might tell us to lose some fields
                 if mapping[k] is not None:
                     self.data[mapping[k]] = dict[k]
@@ -379,18 +379,18 @@ class CPUDevice(Device):
         if self.data.get("cpu_arch_id") is not None:
             return  # all fine, we have the arch
         # if we don't have an architecture, guess it
-        if "architecture" not in self.data:
+        if not self.data.has_key("architecture"):
             log_error("hash does not have a platform member: %s" % dict)
             raise AttributeError("Expected a hash value for member `platform'")
         # now extract the arch field, which has to come out of rhnCpuArch
         arch = self.data["architecture"]
         row = rhnSQL.Table("rhnCpuArch", "label")[arch]
-        if row is None or "id" not in row:
+        if row is None or not row.has_key("id"):
             log_error("Can not find arch %s in rhnCpuArch" % arch)
             raise AttributeError("Invalid architecture for CPU: `%s'" % arch)
         self.data["cpu_arch_id"] = row["id"]
         del self.data["architecture"]
-        if "nrcpu" in self.data:  # make sure this is a number
+        if self.data.has_key("nrcpu"):  # make sure this is a number
             try:
                 self.data["nrcpu"] = int(self.data["nrcpu"])
             except:
@@ -836,7 +836,7 @@ class MemoryInformation(Device):
             return
         # Sometimes we get sent a NNNNL number and we need to strip the L
         for k in fields:
-            if k not in self.data:
+            if not self.data.has_key(k):
                 continue
             if self.data[k] in [None, "None", ""]:
                 self.data[k] = -1

--- a/backend/server/rhnUser.py
+++ b/backend/server/rhnUser.py
@@ -131,7 +131,7 @@ class User:
         self.customer.load(int(org_id))
 
     def getid(self):
-        if "id" not in self.contact:
+        if not self.contact.has_key("id"):
             userid = rhnSQL.Sequence("web_contact_id_seq")()
             self.contact.data["id"] = userid  # kind of illegal, but hey!
         else:
@@ -202,7 +202,7 @@ class User:
             valids["Sig."] = "Sr."
             valids["Sir"] = "Mr."
             # Now check it out
-            if value in valids:
+            if valids.has_key(value):
                 self.info["prefix"] = valids[value]
                 changed = 1
             else:

--- a/backend/server/test/attic/rhnActivationKey.py
+++ b/backend/server/test/attic/rhnActivationKey.py
@@ -193,7 +193,7 @@ class ActivationKey:
         s = hashlib.new('sha1')
         s.update(str(os.getpid()))
         for field in ['org_id', 'user_id', 'server_id']:
-            if field in self._row_reg_token:
+            if self._row_reg_token.has_key(field):
                 val = self._row_reg_token[field]
             s.update(str(val))
         s.update("%.8f" % time.time())
@@ -213,7 +213,7 @@ class ActivationKey:
     def _save(self):
         h = self._row_reg_token
         k = 'entitlement_level'
-        if k in h:
+        if h.has_key(k):
             entitlements = h[k]
             del h.data[k]
         else:

--- a/backend/test/johntest.py
+++ b/backend/test/johntest.py
@@ -175,52 +175,52 @@ class ChannelList:
         return self._num_channels
 
     def get_last_modified(self, ch_index):
-        if self._last_modified in self.channel_list[ch_index]:
+        if self.channel_list[ch_index].has_key(self._last_modified):
             return self.channel_list[ch_index][self._last_modified]
         return None
 
     def get_description(self, ch_index):
-        if self._description in self.channel_list[ch_index]:
+        if self.channel_list[ch_index].has_key(self._description):
             return self.channel_list[ch_index][self._description]
         return None
 
     def get_name(self, ch_index):
-        if self._name in self.channel_list[ch_index]:
+        if self.channel_list[ch_index].has_key(self._name):
             return self.channel_list[ch_index][self._name]
         return None
 
     def get_local_channel(self, ch_index):
-        if self._local_channel in self.channel_list[ch_index]:
+        if self.channel_list[ch_index].has_key(self._local_channel):
             return self.channel_list[ch_index][self._local_channel]
         return None
 
     def get_arch(self, ch_index):
-        if self._arch in self.channel_list[ch_index]:
+        if self.channel_list[ch_index].has_key(self._arch):
             return self.channel_list[ch_index][self._arch]
         return None
 
     def get_parent_channel(self, ch_index):
-        if self._parent_channel in self.channel_list[ch_index]:
+        if self.channel_list[ch_index].has_key(self._parent_channel):
             return self.channel_list[ch_index][self._parent_channel]
         return None
 
     def get_summary(self, ch_index):
-        if self._summary in self.channel_list[ch_index]:
+        if self.channel_list[ch_index].has_key(self._summary):
             return self.channel_list[ch_index][self._summary]
         return None
 
     def get_org_id(self, ch_index):
-        if self._org_id in self.channel_list[ch_index]:
+        if self.channel_list[ch_index].has_key(self._org_id):
             return self.channel_list[ch_index][self._org_id]
         return None
 
     def get_id(self, ch_index):
-        if self._id in self.channel_list[ch_index]:
+        if self.channel_list[ch_index].has_key(self._id):
             return self.channel_list[ch_index][self._id]
         return None
 
     def get_label(self, ch_index):
-        if self._label in self.channel_list[ch_index]:
+        if self.channel_list[ch_index].has_key(self._label):
             return self.channel_list[ch_index][self._label]
         return None
 
@@ -244,65 +244,65 @@ class LoginInfo:
         self.login_dict = login_dict
 
     def get_server_id(self):
-        if self._server_key in self.login_dict:
+        if self.login_dict.has_key(self._server_key):
             return str(self.login_dict[self._server_key])
         return None
 
     def get_user_id(self):
-        if self._user_key in self.login_dict:
+        if self.login_dict.has_key(self._user_key):
             return self.login_dict[self._user_key]
         return None
 
     def get_signature(self):
-        if self._sig_key in self.login_dict:
+        if self.login_dict.has_key(self._sig_key):
             return self.login_dict[self._sig_key]
         return None
 
     def get_server_time(self):
-        if self._time_key in self.login_dict:
+        if self.login_dict.has_key(self._time_key):
             return self.login_dict[self._time_key]
         return None
 
     def get_expire_offset(self):
-        if self._expire_key in self.login_dict:
+        if self.login_dict.has_key(self._expire_key):
             return self.login_dict[self._expire_key]
         return None
 
     def get_auth_channels(self):
-        if self._channel_key in self.login_dict:
+        if self.login_dict.has_key(self._channel_key):
             return self.login_dict.has_key[self._channel_key]
         return None
 
 if __name__ == "__main__":
     t = Test()
     lg = t.login()
-    print(("Server ID: " + lg.get_server_id()))
-    print(("User ID: " + lg.get_user_id()))
-    print(("Server Time: " + lg.get_server_time()))
-    print(("Auth: " + lg.get_signature()))
-    print(("Expire Offset: " + lg.get_expire_offset()))
+    print("Server ID: " + lg.get_server_id())
+    print("User ID: " + lg.get_user_id())
+    print("Server Time: " + lg.get_server_time())
+    print("Auth: " + lg.get_signature())
+    print("Expire Offset: " + lg.get_expire_offset())
 
     list = t.list_channels()
     print("\n")
     for i in range(list.get_num_channels()):
-        print(("Channel Name: " + list.get_name(i)))
-        print(("Channel Last Modified: " + list.get_last_modified(i)))
-        print(("Channel Description: " + list.get_description(i)))
-        print(("Channel Local Channel: " + list.get_local_channel(i)))
-        print(("Channel Arch: " + list.get_arch(i)))
-        print(("Channel Parent Channel: " + list.get_parent_channel(i)))
-        print(("Channel Summary: " + list.get_summary(i)))
-        print(("Channel org_id: " + list.get_org_id(i)))
-        print(("Channel id: " + list.get_id(i)))
-        print(("Channel label: " + list.get_label(i)))
+        print("Channel Name: " + list.get_name(i))
+        print("Channel Last Modified: " + list.get_last_modified(i))
+        print("Channel Description: " + list.get_description(i))
+        print("Channel Local Channel: " + list.get_local_channel(i))
+        print("Channel Arch: " + list.get_arch(i))
+        print("Channel Parent Channel: " + list.get_parent_channel(i))
+        print("Channel Summary: " + list.get_summary(i))
+        print("Channel org_id: " + list.get_org_id(i))
+        print("Channel id: " + list.get_id(i))
+        print("Channel label: " + list.get_label(i))
 
     print("")
     plist = t.list_packages()
     for j in range(plist.get_num_packages()):
-        print(("Package Name: " + plist.get_name(j)))
-        print(("Package Version: " + plist.get_version(j)))
-        print(("Package Release: " + plist.get_release(j)))
-        print(("Package Epoch: " + plist.get_epoch(j)))
+        print("Package Name: " + plist.get_name(j))
+        print("Package Version: " + plist.get_version(j))
+        print("Package Release: " + plist.get_release(j))
+        print("Package Epoch: " + plist.get_epoch(j))
         print("")
 
     #package = t.package([plist.get_name(0), plist.get_version(0), plist.get_release(0), plist.get_epoch(j)])
@@ -315,5 +315,5 @@ if __name__ == "__main__":
     org_id = raw_input("ord_id:")
     org_password = raw_input("org_password:")
 
-    print((t.reserve_user(uname, password)))
-    print((t.new_user(uname, password, email, org_id, org_password)))
+    print(t.reserve_user(uname, password))
+    print(t.new_user(uname, password, email, org_id, org_password))

--- a/backend/upload_server/handlers/package_push/package_push.py
+++ b/backend/upload_server/handlers/package_push/package_push.py
@@ -75,7 +75,7 @@ class PackagePush(basePackageUpload.BasePackageUpload):
         # Init the database connection
         rhnSQL.initDB()
         use_session = 0
-        if 'Auth-Session' in self.field_data:
+        if self.field_data.has_key('Auth-Session'):
             session_token = self.field_data['Auth-Session']
             use_session = 1
         else:

--- a/backend/wsgi/wsgiRequest.py
+++ b/backend/wsgi/wsgiRequest.py
@@ -81,7 +81,7 @@ class WsgiRequest:
         if len(self.content_type) > 0:
             self.headers_out['Content-Type'] = self.content_type
         # default to text/xml
-        if 'Content-Type' not in self.headers_out:
+        if not self.headers_out.has_key('Content-Type'):
             self.headers_out['Content-Type'] = 'text/xml'
 
         self.start_response(self.status, list(self.headers_out.items()))


### PR DESCRIPTION
## What does this PR change?
This PR brings back the use of custom `has_key` method implementation on several RHN classes after being wrongly transformed by `2to3` execution.

Also a minor cleanup of unneeded parens.