### PR TITLE
Fix tests after adding rhel8

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartInstallType.java
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartInstallType.java
@@ -32,6 +32,7 @@ public class KickstartInstallType extends BaseDomainHelper {
     public static final String RHEL_5 = "rhel_5";
     public static final String RHEL_6 = "rhel_6";
     public static final String RHEL_7 = "rhel_7";
+    public static final String RHEL_8 = "rhel_8";
     public static final String GENERIC_RPM = "generic_rpm";
 
     // Spacewalk's install type prefixes for some multi-version
@@ -72,6 +73,13 @@ public class KickstartInstallType extends BaseDomainHelper {
         // we need to reverse logic here
         return (!isRhel2() && !isRhel3() && !isRhel4() && !isFedora() && !isGeneric() &&
                 !isSUSE());
+    }
+
+    /**
+     * @return true if the installer type is rhel 8
+     */
+    public boolean isRhel8() {
+        return RHEL_8.equals(getLabel());
     }
 
     /**
@@ -120,7 +128,7 @@ public class KickstartInstallType extends BaseDomainHelper {
      * @return true if the installer type is rhel
      */
     public boolean isRhel() {
-        return isRhel2() || isRhel3() || isRhel4() || isRhel5() || isRhel6() || isRhel7();
+        return isRhel2() || isRhel3() || isRhel4() || isRhel5() || isRhel6() || isRhel7() || isRhel8();
     }
 
     /**

--- a/schema/spacewalk/common/data/rhnKSInstallType.sql
+++ b/schema/spacewalk/common/data/rhnKSInstallType.sql
@@ -14,11 +14,6 @@
 --
 insert into rhnKSInstallType (id, label, name)
         values (sequence_nextval('rhn_ksinstalltype_id_seq'),
-                'rhel_8','Red Hat Enterprise Linux 8'
-        );
-
-insert into rhnKSInstallType (id, label, name)
-        values (sequence_nextval('rhn_ksinstalltype_id_seq'),
                 'rhel_7','Red Hat Enterprise Linux 7'
         );
 
@@ -80,4 +75,10 @@ insert into rhnKSInstallType (id, label, name)
         values (sequence_nextval('rhn_ksinstalltype_id_seq'),
                 'sles15generic','SUSE Linux Enterprise 15'
         );
+
+insert into rhnKSInstallType (id, label, name)
+        values (sequence_nextval('rhn_ksinstalltype_id_seq'),
+                'rhel_8','Red Hat Enterprise Linux 8'
+        );
+
 commit;


### PR DESCRIPTION
## What does this PR change?

Upstream implemented RHEL8 only half way. Add missing steps and fix unit tests by
inserting rhel8 kickstart install type at the end when setting up new DB.

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- tests were fixed

- [x] **DONE**

