### PR TITLE
Testsuite: Make sure the cache is cleaned before applying config channels

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -629,6 +629,7 @@ end
 
 When(/^I schedule apply configchannels for "([^"]*)"$/) do |host|
   node = get_target(host)
+  $server.run('spacecmd -u admin -p admin clear_caches')
   command = "spacecmd -y -u admin -p admin -- system_scheduleapplyconfigchannels  #{node.full_hostname}"
   $server.run(command)
 end


### PR DESCRIPTION
## What does this PR change?

`spacecmd` keeps cache of systems (and packages (non-relevant here)) which is a bit volatile and can cause incorrect system name -> system id translation. The cache is designed this way (it doesn't have automatic invalidation, it relies on either timeouts or on an explicit invalidation (e.g. using `clear_caches` call).

This PR fixes a testsuite problem by explicit cache invalidation.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: testsuite

- [x] **DONE**

## Test coverage
- No tests: testsuite

- [x] **DONE**

## Links

Relevant branches (GitHub automatic links expected below):
 - Downstream 3.2: https://github.com/SUSE/spacewalk/pull/6015

- [x] **DONE**
