### PR TITLE
Missing square bracket

### DIFF
--- a/utils/spacewalk-manage-channel-lifecycle
+++ b/utils/spacewalk-manage-channel-lifecycle
@@ -391,7 +391,7 @@ option_list = [
     Option('', '--no-children', help="don't operate on child channels",
            action='store_true'),
     Option('-P', '--phases', default='',
-           help='comma-separated list of phases [default: dev,test,prod'),
+           help='comma-separated list of phases [default: dev,test,prod]'),
     Option('-u', '--username', help='Spacewalk username'),
     Option('-p', '--password', help='Spacewalk password'),
     Option('-s', '--server',


### PR DESCRIPTION
## What does this PR change?

It fixes the missing square bracket in the `spacewalk-manage-channel-lifecycle --help` command for the `--phases` option.


Relevant branches (GitHub automatic links expected below):
 - Manager-3.1: https://github.com/SUSE/spacewalk/pull/6041
 - Manager-3.2: https://github.com/SUSE/spacewalk/pull/6040
 - Manager: this PR

- [x] **DONE**
