### PR TITLE
Testsuite: introducing function get_name()

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -38,9 +38,9 @@ When(/^I apply highstate on "(.*?)"$/) do |minion|
   $server.run_until_ok("#{cmd} #{node.full_hostname} state.highstate #{extra_cmd}")
 end
 
-Then(/^I wait until "([^"]*)" service is active on "([^"]*)"$/) do |service, target|
+Then(/^I wait until "([^"]*)" service is active on "([^"]*)"$/) do |service, host|
+  node = get_target(host)
   cmd = "systemctl is-active #{service}"
-  node = get_target(target)
   node.run_until_ok(cmd)
 end
 
@@ -100,8 +100,8 @@ When(/^I execute mgr\-bootstrap "([^"]*)"$/) do |arg1|
   $command_output = sshcmd("mgr-bootstrap --activation-keys=1-SUSE-PKG-#{arch} #{arg1}")[:stdout]
 end
 
-When(/^I fetch "([^"]*)" to "([^"]*)"$/) do |file, target|
-  node = get_target(target)
+When(/^I fetch "([^"]*)" to "([^"]*)"$/) do |file, host|
+  node = get_target(host)
   node.run("wget http://#{$server.ip}/#{file}")
 end
 
@@ -148,8 +148,8 @@ Then(/^I execute spacewalk-debug on the server$/) do
   end
 end
 
-When(/^I copy "([^"]*)" to "([^"]*)"$/) do |file, target|
-  node = get_target(target)
+When(/^I copy "([^"]*)" to "([^"]*)"$/) do |file, host|
+  node = get_target(host)
   return_code = file_inject(node, file, File.basename(file))
   raise 'File injection failed' unless return_code.zero?
 end
@@ -353,11 +353,11 @@ When(/^I wait until file "(.*)" exists on server$/) do |file|
   end
 end
 
-Then(/^I wait and check that "([^"]*)" has rebooted$/) do |target|
+Then(/^I wait and check that "([^"]*)" has rebooted$/) do |host|
   reboot_timeout = 800
-  node = get_target(target)
-  check_shutdown(node.full_hostname, reboot_timeout)
-  check_restart(node.full_hostname, get_target(target), reboot_timeout)
+  name = get_name(host)
+  check_shutdown(name, reboot_timeout)
+  check_restart(name, get_target(host), reboot_timeout)
 end
 
 When(/^I call spacewalk\-repo\-sync for channel "(.*?)" with a custom url "(.*?)"$/) do |arg1, arg2|
@@ -407,9 +407,9 @@ When(/^I wait for the openSCAP audit to finish$/) do
   end
 end
 
-And(/I check status "([^"]*)" with spacecmd on "([^"]*)"$/) do |status, target|
-  host = get_target(target)
-  cmd = "spacecmd -u admin -p admin system_listevents #{host.full_hostname} | head -n5"
+And(/I check status "([^"]*)" with spacecmd on "([^"]*)"$/) do |status, host|
+  name = get_name(host)
+  cmd = "spacecmd -u admin -p admin system_listevents #{name} | head -n5"
   $server.run("spacecmd -u admin -p admin clear_caches")
   out, _code = $server.run(cmd)
   raise "#{out} should contain #{status}" unless out.include? status
@@ -547,8 +547,8 @@ When(/^I wait until the package "(.*?)" has been cached on this "(.*?)"$/) do |p
   end
 end
 
-And(/^I create the "([^"]*)" bootstrap repository for "([^"]*)" on the server$/) do |arch, target|
-  node = get_target(target)
+And(/^I create the "([^"]*)" bootstrap repository for "([^"]*)" on the server$/) do |arch, host|
+  node = get_target(host)
   os_version = get_os_version(node)
   cmd = 'false'
   if (os_version.include? '12') || (os_version.include? '15')

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -27,8 +27,8 @@ When(/^I make the SSL certificate available to zypper$/) do
   $client.run('update-ca-certificates')
 end
 
-Then(/^I can see all system information for "([^"]*)"$/) do |target|
-  node = get_target(target)
+Then(/^I can see all system information for "([^"]*)"$/) do |host|
+  node = get_target(host)
   step %(I should see a "#{node.hostname}" text)
   kernel_version, _code = node.run('uname -r')
   puts 'i should see kernel version: ' + kernel_version
@@ -301,10 +301,10 @@ end
 
 Then(/^"([^"]*)" should exist in the metadata for "([^"]*)"$/) do |file, host|
   raise 'Invalid target.' unless host == 'sle-client'
-  target = $client
-  arch, _code = target.run('uname -m')
+  node = $client
+  arch, _code = node.run('uname -m')
   arch.chomp!
-  raise unless file_exists?(target, "#{client_raw_repodata_dir("test-channel-#{arch}")}/#{file}")
+  raise unless file_exists?(node, "#{client_raw_repodata_dir("test-channel-#{arch}")}/#{file}")
 end
 
 Then(/^I should have '([^']*)' in the patch metadata$/) do |text|
@@ -493,8 +493,8 @@ end
 
 # Repository steps
 
-When(/^I enable SUSE Manager tools repository on "([^"]*)"$/) do |target|
-  node = get_target(target)
+When(/^I enable SUSE Manager tools repository on "([^"]*)"$/) do |host|
+  node = get_target(host)
   out, _code = node.run('zypper lr | grep SLE-Manager-Tools | cut -d"|" -f2')
   # This enables tools development repository too if it exists
   node.run("zypper mr --enable #{out.gsub(/\s/, ' ')}")

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -6,8 +6,8 @@
 #
 
 When(/^I follow "(.*?)" link$/) do |host|
-  node = get_target(host)
-  step %(I follow "#{node.hostname}")
+  name = get_name(host)
+  step %(I follow "#{name}")
 end
 
 When(/^I should see a "(.*)" text in the content area$/) do |txt|
@@ -82,9 +82,9 @@ When(/^I wait at most (\d+) seconds until the event is completed, refreshing the
   end
 end
 
-When(/^I wait until I see the name of "([^"]*)", refreshing the page$/) do |target|
-  node = get_target(target)
-  step %(I wait until I see "#{node.full_hostname}" text, refreshing the page)
+When(/^I wait until I see the name of "([^"]*)", refreshing the page$/) do |host|
+  name = get_name(host)
+  step %(I wait until I see "#{name}" text, refreshing the page)
 end
 
 When(/^I wait until I do not see "([^"]*)" text, refreshing the page$/) do |text|
@@ -101,9 +101,9 @@ When(/^I wait until I do not see "([^"]*)" text, refreshing the page$/) do |text
   end
 end
 
-When(/^I wait until I do not see the name of "([^"]*)", refreshing the page$/) do |target|
-  node = get_target(target)
-  step %(I wait until I do not see "#{node.full_hostname}" text, refreshing the page)
+When(/^I wait until I do not see the name of "([^"]*)", refreshing the page$/) do |host|
+  name = get_name(host)
+  step %(I wait until I do not see "#{name}" text, refreshing the page)
 end
 
 #
@@ -236,8 +236,8 @@ When(/^I follow "([^"]*)" in class "([^"]*)"$/) do |arg1, arg2|
 end
 
 When(/^I follow "([^"]*)" on "(.*?)" row$/) do |text, host|
-  node = get_target(host)
-  xpath_query = "//tr[td[contains(.,'#{node.full_hostname}')]]//a[contains(., '#{text}')]"
+  name = get_name(host)
+  xpath_query = "//tr[td[contains(.,'#{name}')]]//a[contains(., '#{text}')]"
   raise unless find(:xpath, xpath_query).click
 end
 
@@ -283,34 +283,34 @@ When(/^I am on the Organizations page$/) do
 end
 
 # access the multi-clients/minions
-Given(/^I am on the Systems overview page of this "(.*?)"$/) do |target|
-  node = get_target(target)
+Given(/^I am on the Systems overview page of this "([^"]*)"$/) do |host|
+  name = get_name(host)
   steps %(
     Given I am on the Systems page
   )
-  step %(I follow "#{node.full_hostname}")
+  step %(I follow "#{name}")
 end
 
-Given(/^I am on the "([^"]*)" page of this "(.*?)"$/) do |page, target|
+Given(/^I am on the "([^"]*)" page of this "([^"]*)"$/) do |page, host|
   steps %(
-    Given I am on the Systems overview page of this "#{target}"
+    Given I am on the Systems overview page of this "#{host}"
     And I follow "#{page}" in the content area
   )
 end
 
-When(/^I follow this "(.*?)" link$/) do |target|
-  node = get_target(target)
-  step %(I follow "#{node.full_hostname}")
+When(/^I follow this "([^"]*)" link$/) do |host|
+  name = get_name(host)
+  step %(I follow "#{name}")
 end
 
-When(/^I check the "(.*?)" client$/) do |target|
-  node = get_target(target)
-  step %(I check "#{node.full_hostname}" in the list)
+When(/^I check the "([^"]*)" client$/) do |host|
+  name = get_name(host)
+  step %(I check "#{name}" in the list)
 end
 
-When(/^I uncheck the "(.*?)" client$/) do |host|
-  node = get_target(host)
-  step %(I uncheck "#{node.full_hostname}" in the list)
+When(/^I uncheck the "([^"]*)" client$/) do |host|
+  name = get_name(host)
+  step %(I uncheck "#{name}" in the list)
 end
 
 Given(/^I am on the groups page$/) do
@@ -655,8 +655,8 @@ Then(/^I check the row with the "([^"]*)" text$/) do |text|
 end
 
 Then(/^I check the row with the "([^"]*)" hostname$/) do |host|
-  node = get_target(host)
-  within(:xpath, "//tr[td[contains(., '#{node.full_hostname}')]]") do
+  name = get_name(host)
+  within(:xpath, "//tr[td[contains(., '#{name}')]]") do
     first('input[type=checkbox]').set(true)
   end
 end

--- a/testsuite/features/step_definitions/xmlrpc_common.rb
+++ b/testsuite/features/step_definitions/xmlrpc_common.rb
@@ -311,8 +311,8 @@ Given(/^I am logged in via XML\-RPC actionchain as user "(.*?)" and password "(.
   scdrpc.login(luser, password)
 end
 
-Given(/^I want to operate on this "(.*?)"$/) do |target|
-  hostname = get_target(target).full_hostname
+Given(/^I want to operate on this "([^"]*)"$/) do |host|
+  hostname = get_name(host)
   $client_id = syschaintest.search_by_name(hostname).first['id']
   refute_nil($client_id, "Could not find system with hostname #{hostname}")
 end

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -72,6 +72,13 @@ def get_target(host)
   node
 end
 
+# This function gets the hostname of the host
+def get_name(host)
+  node = get_target(host)
+  name = node.full_hostname
+  name
+end
+
 # This function tests whether a file exists on a node
 def file_exists?(node, file)
   _out, local, _remote, code = node.test_and_store_results_together("test -f #{file}", 'root', 500)


### PR DESCRIPTION
The reason for this preparation is that PXE-booted minion cannot be implemented as a twopence target, because the controller cannot even directly reach it through the network. Still, it has a name (made up of a complicated fingerprint).

This PR also normalizes the name of variables (`host`, `node`, and `name`).

## Links

Preparation for retail tests.

Relevant branches (GitHub automatic links expected below):
 - Manager-3.1  SUSE/spacewalk#6028
 - Manager-3.2  SUSE/spacewalk#6030
