### PR TITLE
Formula data cleanup

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
@@ -451,18 +451,14 @@ public class FormulaFactory {
         if (!dataFile.exists()) {
             dataFile.getParentFile().mkdirs();
             dataFile.createNewFile();
-            serverFormulas = new HashMap<String, List<String>>();
+            serverFormulas = new HashMap<>();
         }
         else {
-            serverFormulas =
-                    GSON.fromJson(new BufferedReader(new FileReader(dataFile)),
-                            Map.class);
+            serverFormulas = GSON.fromJson(new BufferedReader(new FileReader(dataFile)), Map.class);
         }
 
         // Remove formula data for unselected formulas
-        List<String> deletedFormulas =
-                new LinkedList<>(serverFormulas.getOrDefault(minionId,
-                        new LinkedList<>()));
+        List<String> deletedFormulas = new LinkedList<>(serverFormulas.getOrDefault(minionId, new LinkedList<>()));
         deletedFormulas.removeAll(selectedFormulas);
         for (String deletedFormula : deletedFormulas) {
             deleteServerFormulaData(minionId, deletedFormula);

--- a/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
@@ -469,7 +469,14 @@ public class FormulaFactory {
         }
 
         // Save selected Formulas
-        serverFormulas.put(minionId, orderFormulas(selectedFormulas));
+        List<String> orderedFormulas = orderFormulas(selectedFormulas);
+        if (orderedFormulas.isEmpty()) {
+            // when no formulas are assigned, we remove the entry completely for the minion
+            serverFormulas.remove(minionId);
+        }
+        else {
+            serverFormulas.put(minionId, orderedFormulas);
+        }
 
         // Write server_formulas file
         BufferedWriter writer = new BufferedWriter(new FileWriter(dataFile));

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Cleanup formula data and assignment when migrating formulas or when removing system
 - Remove restrictions on SUSE Manager Channel subscriptions (bsc#1105724)
 - Pair a new starting minion with empty profile based on its HW address (MAC)
 - Allow creating empty minion profiles via XMLRPC, allow assigning and editing formula for them


### PR DESCRIPTION
After a minion deletion or migration from `bootstap` entitled system, the formula data leftovers (formula data and the formula assignment) were left on the filesystem. This PR fixes it.


No difference.

- [x] **DONE**

- No documentation needed: bugfix

- [x] **DONE**

- Unit tests were added

- [x] **DONE**


Downstream issue: https://github.com/SUSE/spacewalk/issues/5789

- [x] **DONE**