### PR TITLE
Testsuite: use "get_system_name()" function

### DIFF
--- a/testsuite/features/min_osimage_build_image.feature
+++ b/testsuite/features/min_osimage_build_image.feature
@@ -20,8 +20,8 @@ Feature: Build OS images
 
   Scenario: Check the OS image built as Kiwi image administrator
     Given I am on the Systems overview page of this "sle-minion"
-    When I wait at most 2700 seconds until event "Image Build suse_os_image scheduled by kiwikiwi" is completed
-    And I wait at most 900 seconds until event "Image Inspect 1//suse_os_image:latest scheduled by kiwikiwi" is completed
+    When I wait at most 3300 seconds until event "Image Build suse_os_image scheduled by kiwikiwi" is completed
+    And I wait at most 300 seconds until event "Image Inspect 1//suse_os_image:latest scheduled by kiwikiwi" is completed
     And I navigate to "os-images/1/" page
     Then I should see a "POS_Image_JeOS6" text
 

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -23,19 +23,19 @@ When(/^I query latest Salt changes on "(.*?)"$/) do |host|
   end
 end
 
-When(/^I apply highstate on "(.*?)"$/) do |minion|
-  node = get_target(minion)
-  if minion == 'sle-minion'
+When(/^I apply highstate on "([^"]*)"$/) do |host|
+  system_name = get_system_name(host)
+  if host == 'sle-minion'
     cmd = 'salt'
     extra_cmd = ''
-  elsif minion == 'ssh-minion' or minion == 'ceos-minion'
+  elsif host == 'ssh-minion' or host == 'ceos-minion'
     cmd = 'salt-ssh'
     extra_cmd = '-i --roster-file=/tmp/roster_tests -w -W'
-    $server.run("printf '#{node.full_hostname}:\n  host: #{node.full_hostname}\n  user: root\n  passwd: linux\n' > /tmp/roster_tests")
+    $server.run("printf '#{system_name}:\n  host: #{system_name}\n  user: root\n  passwd: linux\n' > /tmp/roster_tests")
   else
     raise 'Invalid target'
   end
-  $server.run_until_ok("#{cmd} #{node.full_hostname} state.highstate #{extra_cmd}")
+  $server.run_until_ok("#{cmd} #{system_name} state.highstate #{extra_cmd}")
 end
 
 Then(/^I wait until "([^"]*)" service is active on "([^"]*)"$/) do |service, host|
@@ -179,7 +179,7 @@ When(/^the server stops mocking an IPMI host$/) do
 end
 
 When(/^I install a user-defined state for "([^"]*)" on the server$/) do |host|
-  node = get_target(host)
+  system_name = get_system_name(host)
   # copy state file to server
   file = 'user_defined_state.sls'
   source = File.dirname(__FILE__) + '/../upload_files/' + file
@@ -188,7 +188,7 @@ When(/^I install a user-defined state for "([^"]*)" on the server$/) do |host|
   raise 'File injection failed' unless return_code.zero?
   # generate top file and copy it to server
   script = "base:\n" \
-           "  '#{node.full_hostname}':\n" \
+           "  '#{system_name}':\n" \
            "    - user_defined_state\n"
   path = generate_temp_file('top.sls', script)
   return_code = file_inject($server, path, '/srv/salt/top.sls')
@@ -355,9 +355,9 @@ end
 
 Then(/^I wait and check that "([^"]*)" has rebooted$/) do |host|
   reboot_timeout = 800
-  name = get_name(host)
-  check_shutdown(name, reboot_timeout)
-  check_restart(name, get_target(host), reboot_timeout)
+  system_name = get_system_name(host)
+  check_shutdown(system_name, reboot_timeout)
+  check_restart(system_name, get_target(host), reboot_timeout)
 end
 
 When(/^I call spacewalk\-repo\-sync for channel "(.*?)" with a custom url "(.*?)"$/) do |arg1, arg2|
@@ -408,8 +408,8 @@ When(/^I wait for the openSCAP audit to finish$/) do
 end
 
 And(/I check status "([^"]*)" with spacecmd on "([^"]*)"$/) do |status, host|
-  name = get_name(host)
-  cmd = "spacecmd -u admin -p admin system_listevents #{name} | head -n5"
+  system_name = get_system_name(host)
+  cmd = "spacecmd -u admin -p admin system_listevents #{system_name} | head -n5"
   $server.run("spacecmd -u admin -p admin clear_caches")
   out, _code = $server.run(cmd)
   raise "#{out} should contain #{status}" unless out.include? status
@@ -628,9 +628,9 @@ When(/^I update init.sls from spacecmd with content "([^"]*)" for channel "([^"]
 end
 
 When(/^I schedule apply configchannels for "([^"]*)"$/) do |host|
-  node = get_target(host)
+  system_name = get_system_name(host)
   $server.run('spacecmd -u admin -p admin clear_caches')
-  command = "spacecmd -y -u admin -p admin -- system_scheduleapplyconfigchannels  #{node.full_hostname}"
+  command = "spacecmd -y -u admin -p admin -- system_scheduleapplyconfigchannels  #{system_name}"
   $server.run(command)
 end
 

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -143,14 +143,14 @@ end
 # nagios steps
 
 When(/^I perform a nagios check patches for "([^"]*)"$/) do |host|
-  node = get_target(host)
-  command = "/usr/lib/nagios/plugins/check_suma_patches #{node.full_hostname} > /tmp/nagios.out"
+  system_name = get_system_name(host)
+  command = "/usr/lib/nagios/plugins/check_suma_patches #{system_name} > /tmp/nagios.out"
   $server.run(command, false, 600, 'root')
 end
 
 When(/^I perform a nagios check last event for "([^"]*)"$/) do |host|
-  node = get_target(host)
-  command = "/usr/lib/nagios/plugins/check_suma_lastevent #{node.full_hostname} > /tmp/nagios.out"
+  system_name = get_system_name(host)
+  command = "/usr/lib/nagios/plugins/check_suma_lastevent #{system_name} > /tmp/nagios.out"
   $server.run(command, false, 600, 'root')
 end
 
@@ -440,8 +440,8 @@ Then(/^I should see a table line with "([^"]*)", "([^"]*)"$/) do |arg1, arg2|
 end
 
 Then(/^a table line should contain system "([^"]*)", "([^"]*)"$/) do |host, text|
-  node = get_target(host)
-  within(:xpath, "//div[@class=\"table-responsive\"]/table/tbody/tr[.//td[contains(.,'#{node.full_hostname}')]]") do
+  system_name = get_system_name(host)
+  within(:xpath, "//div[@class=\"table-responsive\"]/table/tbody/tr[.//td[contains(.,'#{system_name}')]]") do
     raise unless find_all(:xpath, "//td[contains(., '#{text}')]")
   end
 end
@@ -558,16 +558,16 @@ When(/^I register using "([^"]*)" key$/) do |key|
   $client.run(command, true, 500, 'root')
 end
 
-Then(/^I should see "(.*?)" in spacewalk$/) do |host|
+Then(/^I should see "([^"]*)" in spacewalk$/) do |host|
   steps %(
     Given I am on the Systems page
     Then I should see "#{host}" as link
     )
 end
 
-Then(/^I should see "(.*?)" as link$/) do |host|
-  node = get_target(host)
-  step %(I should see a "#{node.full_hostname}" link)
+Then(/^I should see "([^"]*)" as link$/) do |host|
+  system_name = get_system_name(host)
+  step %(I should see a "#{system_name}" link)
 end
 
 Then(/^config-actions are enabled$/) do

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -6,8 +6,8 @@
 #
 
 When(/^I follow "(.*?)" link$/) do |host|
-  name = get_name(host)
-  step %(I follow "#{name}")
+  system_name = get_system_name(host)
+  step %(I follow "#{system_name}")
 end
 
 When(/^I should see a "(.*)" text in the content area$/) do |txt|
@@ -83,8 +83,8 @@ When(/^I wait at most (\d+) seconds until the event is completed, refreshing the
 end
 
 When(/^I wait until I see the name of "([^"]*)", refreshing the page$/) do |host|
-  name = get_name(host)
-  step %(I wait until I see "#{name}" text, refreshing the page)
+  system_name = get_system_name(host)
+  step %(I wait until I see "#{system_name}" text, refreshing the page)
 end
 
 When(/^I wait until I do not see "([^"]*)" text, refreshing the page$/) do |text|
@@ -102,8 +102,8 @@ When(/^I wait until I do not see "([^"]*)" text, refreshing the page$/) do |text
 end
 
 When(/^I wait until I do not see the name of "([^"]*)", refreshing the page$/) do |host|
-  name = get_name(host)
-  step %(I wait until I do not see "#{name}" text, refreshing the page)
+  system_name = get_system_name(host)
+  step %(I wait until I do not see "#{system_name}" text, refreshing the page)
 end
 
 #
@@ -236,8 +236,8 @@ When(/^I follow "([^"]*)" in class "([^"]*)"$/) do |arg1, arg2|
 end
 
 When(/^I follow "([^"]*)" on "(.*?)" row$/) do |text, host|
-  name = get_name(host)
-  xpath_query = "//tr[td[contains(.,'#{name}')]]//a[contains(., '#{text}')]"
+  system_name = get_system_name(host)
+  xpath_query = "//tr[td[contains(.,'#{system_name}')]]//a[contains(., '#{text}')]"
   raise unless find(:xpath, xpath_query).click
 end
 
@@ -284,11 +284,11 @@ end
 
 # access the multi-clients/minions
 Given(/^I am on the Systems overview page of this "([^"]*)"$/) do |host|
-  name = get_name(host)
+  system_name = get_system_name(host)
   steps %(
     Given I am on the Systems page
   )
-  step %(I follow "#{name}")
+  step %(I follow "#{system_name}")
 end
 
 Given(/^I am on the "([^"]*)" page of this "([^"]*)"$/) do |page, host|
@@ -299,18 +299,18 @@ Given(/^I am on the "([^"]*)" page of this "([^"]*)"$/) do |page, host|
 end
 
 When(/^I follow this "([^"]*)" link$/) do |host|
-  name = get_name(host)
-  step %(I follow "#{name}")
+  system_name = get_system_name(host)
+  step %(I follow "#{system_name}")
 end
 
 When(/^I check the "([^"]*)" client$/) do |host|
-  name = get_name(host)
-  step %(I check "#{name}" in the list)
+  system_name = get_system_name(host)
+  step %(I check "#{system_name}" in the list)
 end
 
 When(/^I uncheck the "([^"]*)" client$/) do |host|
-  name = get_name(host)
-  step %(I uncheck "#{name}" in the list)
+  system_name = get_system_name(host)
+  step %(I uncheck "#{system_name}" in the list)
 end
 
 Given(/^I am on the groups page$/) do
@@ -655,8 +655,8 @@ Then(/^I check the row with the "([^"]*)" text$/) do |text|
 end
 
 Then(/^I check the row with the "([^"]*)" hostname$/) do |host|
-  name = get_name(host)
-  within(:xpath, "//tr[td[contains(., '#{name}')]]") do
+  system_name = get_system_name(host)
+  within(:xpath, "//tr[td[contains(., '#{system_name}')]]") do
     first('input[type=checkbox]').set(true)
   end
 end

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -4,7 +4,7 @@ require 'open-uri'
 require 'tempfile'
 
 Given(/^the Salt master can reach "(.*?)"$/) do |minion|
-  name = get_name(minion)
+  system_name = get_system_name(minion)
   begin
     start = Time.now
     # 300 is the default 1st keepalive interval for the minion
@@ -13,8 +13,8 @@ Given(/^the Salt master can reach "(.*?)"$/) do |minion|
     Timeout.timeout(keepalive_timeout) do
       # only try 3 times
       3.times do
-        out, _code = $server.run("salt #{name} test.ping")
-        if out.include?(name) && out.include?('True')
+        out, _code = $server.run("salt #{system_name} test.ping")
+        if out.include?(system_name) && out.include?('True')
           finished = Time.now
           puts "Took #{finished.to_i - start.to_i} seconds to contact the minion"
           break
@@ -58,19 +58,19 @@ When(/^I restart salt-minion on "(.*?)"$/) do |minion|
 end
 
 When(/^I wait at most (\d+) seconds until Salt master sees "([^"]*)" as "([^"]*)"$/) do |key_timeout, minion, key_type|
-  key_name = get_name(minion)
+  system_name = get_system_name(minion)
   cmd = "salt-key --list #{key_type}"
   output = ''
   begin
     Timeout.timeout(key_timeout.to_i) do
       loop do
         output, return_code = $server.run(cmd, false)
-        break if return_code.zero? && output.include?(key_name)
+        break if return_code.zero? && output.include?(system_name)
         sleep 1
       end
     end
   rescue Timeout::Error
-    raise "Minion #{key_name} is not listed among #{key_type} keys on Salt master after #{key_timeout} seconds"
+    raise "Minion #{system_name} is not listed among #{key_type} keys on Salt master after #{key_timeout} seconds"
   end
 end
 
@@ -98,28 +98,28 @@ When(/^I wait until onboarding is completed for "([^"]*)"$/) do |host|
   )
 end
 
-When(/^I delete "([^"]*)" key in the Salt master$/) do |minion|
-  key_name = get_name(minion)
-  $output, _code = $server.run("salt-key -y -d #{key_name}", false)
+When(/^I delete "([^"]*)" key in the Salt master$/) do |host|
+  system_name = get_system_name(host)
+  $output, _code = $server.run("salt-key -y -d #{system_name}", false)
 end
 
-When(/^I accept "([^"]*)" key in the Salt master$/) do |minion|
-  key_name = get_name(minion)
-  $server.run("salt-key -y --accept=#{key_name}")
+When(/^I accept "([^"]*)" key in the Salt master$/) do |host|
+  system_name = get_system_name(host)
+  $server.run("salt-key -y --accept=#{system_name}")
 end
 
-When(/^I reject "([^"]*)" key in the Salt master$/) do |minion|
-  key_name = get_name(minion)
-  $server.run("salt-key -y --reject=#{key_name}")
+When(/^I reject "([^"]*)" key in the Salt master$/) do |host|
+  system_name = get_system_name(host)
+  $server.run("salt-key -y --reject=#{system_name}")
 end
 
 When(/^I delete all keys in the Salt master$/) do
   $server.run('salt-key -y -D')
 end
 
-When(/^I get OS information of "([^"]*)" from the Master$/) do |minion|
-  key_name = get_name(minion)
-  $output, _code = $server.run("salt #{key_name} grains.get osfullname")
+When(/^I get OS information of "([^"]*)" from the Master$/) do |host|
+  system_name = get_system_name(host)
+  $output, _code = $server.run("salt #{system_name} grains.get osfullname")
 end
 
 Then(/^it should contain a "(.*?)" text$/) do |content|
@@ -141,17 +141,17 @@ Then(/^the system should have a base channel set$/) do
 end
 
 Then(/^"(.*?)" should not be registered$/) do |host|
-  name = get_name(host)
+  system_name = get_system_name(host)
   @rpc = XMLRPCSystemTest.new(ENV['SERVER'])
   @rpc.login('admin', 'admin')
-  refute_includes(@rpc.list_systems.map { |s| s['name'] }, name)
+  refute_includes(@rpc.list_systems.map { |s| s['name'] }, system_name)
 end
 
 Then(/^"(.*?)" should be registered$/) do |host|
-  name = get_name(host)
+  system_name = get_system_name(host)
   @rpc = XMLRPCSystemTest.new(ENV['SERVER'])
   @rpc.login('admin', 'admin')
-  assert_includes(@rpc.list_systems.map { |s| s['name'] }, name)
+  assert_includes(@rpc.list_systems.map { |s| s['name'] }, system_name)
 end
 
 # user salt steps
@@ -189,18 +189,18 @@ When(/^I click on run$/) do
 end
 
 Then(/^I should see "([^"]*)" hostname$/) do |host|
-  name = get_name(host)
-  raise unless page.has_content?(name)
+  system_name = get_system_name(host)
+  raise unless page.has_content?(system_name)
 end
 
 Then(/^I should not see "([^"]*)" hostname$/) do |host|
-  name = get_name(host)
-  raise if page.has_content?(name)
+  system_name = get_system_name(host)
+  raise if page.has_content?(system_name)
 end
 
 When(/^I expand the results for "([^"]*)"$/) do |host|
-  name = get_name(host)
-  find("div[id='#{name}']").click
+  system_name = get_system_name(host)
+  find("div[id='#{system_name}']").click
 end
 
 When(/^I enter command "([^"]*)"$/) do |cmd|
@@ -212,8 +212,8 @@ When(/^I enter target "([^"]*)"$/) do |minion|
 end
 
 Then(/^I should see "([^"]*)" in the command output for "([^"]*)"$/) do |text, host|
-  name = get_name(host)
-  within("pre[id='#{name}-results']") do
+  system_name = get_system_name(host)
+  within("pre[id='#{system_name}-results']") do
     raise unless page.has_content?(text)
   end
 end
@@ -339,18 +339,18 @@ When(/^I refresh the pillar data$/) do
 end
 
 Then(/^the pillar data for "([^"]*)" should (be|contain|not contain) "([^"]*)" on "([^"]*)"$/) do |key, verb, value, minion|
-  name = get_name(minion)
+  system_name = get_system_name(minion)
   if minion == 'sle-minion'
     cmd = 'salt'
     extra_cmd = ''
   elsif minion == 'ssh-minion' or minion == 'ceos-minion'
     cmd = 'salt-ssh'
     extra_cmd = '-i --roster-file=/tmp/roster_tests -w -W 2>/dev/null'
-    $server.run("printf '#{name}:\n  host: #{name}\n  user: root\n  passwd: linux\n' > /tmp/roster_tests")
+    $server.run("printf '#{system_name}:\n  host: #{system_name}\n  user: root\n  passwd: linux\n' > /tmp/roster_tests")
   else
     raise 'Invalid target'
   end
-  output, _code = $server.run("#{cmd} '#{name}' pillar.get '#{key}' #{extra_cmd}")
+  output, _code = $server.run("#{cmd} '#{system_name}' pillar.get '#{key}' #{extra_cmd}")
   if verb == 'be' && value == ''
     raise unless output.split("\n").length == 1
   elsif verb == 'be'
@@ -396,14 +396,14 @@ end
 
 # Perform actions
 When(/^I reject "([^"]*)" from the Pending section$/) do |host|
-  name = get_name(host)
-  xpath_query = "//tr[td[contains(.,'#{name}')]]//button[@title = 'Reject']"
+  system_name = get_system_name(host)
+  xpath_query = "//tr[td[contains(.,'#{system_name}')]]//button[@title = 'Reject']"
   raise unless find(:xpath, xpath_query).click
 end
 
 When(/^I delete "([^"]*)" from the Rejected section$/) do |host|
-  name = get_name(host)
-  xpath_query = "//tr[td[contains(.,'#{name}')]]//button[@title = 'Delete']"
+  system_name = get_system_name(host)
+  xpath_query = "//tr[td[contains(.,'#{system_name}')]]//button[@title = 'Delete']"
   raise unless find(:xpath, xpath_query).click
 end
 
@@ -415,8 +415,8 @@ When(/^I see "([^"]*)" fingerprint$/) do |host|
 end
 
 When(/^I accept "([^"]*)" key$/) do |host|
-  name = get_name(host)
-  xpath_query = "//tr[td[contains(.,'#{name}')]]//button[@title = 'Accept']"
+  system_name = get_system_name(host)
+  xpath_query = "//tr[td[contains(.,'#{system_name}')]]//button[@title = 'Accept']"
   raise unless find(:xpath, xpath_query).click
 end
 
@@ -513,8 +513,8 @@ end
 
 # minion bootstrap steps
 When(/^I enter the hostname of "([^"]*)" as "([^"]*)"$/) do |host, hostname|
-  name = get_name(host)
-  step %(I enter "#{name}" as "#{hostname}")
+  system_name = get_system_name(host)
+  step %(I enter "#{system_name}" as "#{hostname}")
 end
 
 When(/^I select the hostname of the proxy from "([^"]*)"$/) do |proxy|
@@ -523,9 +523,9 @@ When(/^I select the hostname of the proxy from "([^"]*)"$/) do |proxy|
 end
 
 Then(/^I run spacecmd listevents for "([^"]*)"$/) do |host|
-  name = get_name(host)
+  system_name = get_system_name(host)
   $server.run('spacecmd -u admin -p admin clear_caches')
-  $server.run("spacecmd -u admin -p admin system_listevents #{name}")
+  $server.run("spacecmd -u admin -p admin system_listevents #{system_name}")
 end
 
 When(/^I enter "([^"]*)" password$/) do |host|

--- a/testsuite/features/step_definitions/xmlrpc_common.rb
+++ b/testsuite/features/step_definitions/xmlrpc_common.rb
@@ -21,9 +21,9 @@ When(/^I call system\.list_systems\(\), I should get a list of them$/) do
 end
 
 When(/^I call system\.bootstrap\(\) on host "([^"]*)" and salt\-ssh "([^"]*)"$/) do |host, salt_ssh_enabled|
+  system_name = get_system_name(host)
   salt_ssh = (salt_ssh_enabled == 'enabled')
-  node = get_target(host)
-  result = systest.bootstrap_system(node.full_hostname, '', salt_ssh)
+  result = systest.bootstrap_system(system_name, '', salt_ssh)
   assert(result == 1, 'Bootstrap return code not equal to 1.')
 end
 
@@ -51,18 +51,18 @@ but with activation key with Default contact method, I should get an XML-RPC fau
 end
 
 When(/^I schedule a highstate for "([^"]*)" via XML\-RPC$/) do |host|
-  node = get_target(host)
-  node_id = retrieve_server_id(node.full_hostname)
+  system_name = get_system_name(host)
+  node_id = retrieve_server_id(system_name)
   now = DateTime.now
   date_high = XMLRPC::DateTime.new(now.year, now.month, now.day, now.hour, now.min, now.sec)
   systest.schedule_apply_highstate(node_id, date_high, false)
 end
 
 When(/^I unsubscribe "([^"]*)" and "([^"]*)" from configuration channel "([^"]*)"$/) do |host1, host2, channel|
-  node1 = get_target(host1)
-  node_id1 = retrieve_server_id(node1.full_hostname)
-  node2 = get_target(host2)
-  node_id2 = retrieve_server_id(node2.full_hostname)
+  system_name1 = get_system_name(host1)
+  node_id1 = retrieve_server_id(system_name1)
+  system_name2 = get_system_name(host2)
+  node_id2 = retrieve_server_id(system_name2)
   systest.remove_channels([ node_id1, node_id2 ], [ channel ])
 end
 
@@ -312,9 +312,9 @@ Given(/^I am logged in via XML\-RPC actionchain as user "(.*?)" and password "(.
 end
 
 Given(/^I want to operate on this "([^"]*)"$/) do |host|
-  hostname = get_name(host)
-  $client_id = syschaintest.search_by_name(hostname).first['id']
-  refute_nil($client_id, "Could not find system with hostname #{hostname}")
+  system_name = get_system_name(host)
+  $client_id = syschaintest.search_by_name(system_name).first['id']
+  refute_nil($client_id, "Could not find system with hostname #{system_name}")
 end
 
 # Listing chains
@@ -570,15 +570,15 @@ Then(/^channel "([^"]*)" should contain file "([^"]*)"$/) do |channel, file|
 end
 
 Then(/^"([^"]*)" should be subscribed to channel "([^"]*)"$/) do |host, channel|
-  node = get_target(host)
+  system_name = get_system_name(host)
   result = cfgtest.list_subscribed_systems(channel)
-  assert_equal(1, result.count { |item| item['name'] == node.full_hostname })
+  assert_equal(1, result.count { |item| item['name'] == system_name })
 end
 
 Then(/^"([^"]*)" should not be subscribed to channel "([^"]*)"$/) do |host, channel|
-  node = get_target(host)
+  system_name = get_system_name(host)
   result = cfgtest.list_subscribed_systems(channel)
-  assert_equal(0, result.count { |item| item['name'] == node.full_hostname })
+  assert_equal(0, result.count { |item| item['name'] == system_name })
 end
 
 When(/^I add file "([^"]*)" containing "([^"]*)" to channel "([^"]*)"$/) do |file, contents, channel|

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -72,11 +72,11 @@ def get_target(host)
   node
 end
 
-# This function gets the hostname of the host
-def get_name(host)
+# This function gets the system name, as displayed in systems list
+def get_system_name(host)
   node = get_target(host)
-  name = node.full_hostname
-  name
+  system_name = node.full_hostname
+  system_name
 end
 
 # This function tests whether a file exists on a node


### PR DESCRIPTION
## What does this PR change?

In the test suite:
- it gives a longer delay for building OS images on slow machines
- it uses `get_system_name()` function as discussed with @MalloZup

## Links

3.1: SUSE/spacewalk#6036
3.2: SUSE/spacewalk#6047