### PR TITLE
Remove flow-bin from package.json

### DIFF
--- a/susemanager-frontend/susemanager-nodejs-sdk-devel/package.json
+++ b/susemanager-frontend/susemanager-nodejs-sdk-devel/package.json
@@ -20,7 +20,6 @@
     "eslint-loader": "^2.1.0",
     "eslint-plugin-flowtype": "^2.50.0",
     "eslint-plugin-flowtype-errors": "^3.6.0",
-    "flow-bin": "^0.80.0",
     "copy-webpack-plugin": "^4.5.2",
     "event-stream": "^4.0.0",
     "eslint-plugin-import": "^2.14.0",

--- a/susemanager-frontend/yarn.lock
+++ b/susemanager-frontend/yarn.lock
@@ -2126,14 +2126,6 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.73.0:
-  version "0.73.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.73.0.tgz#da1b90a02b0ef9c439f068c2fc14968db83be425"
-
-flow-bin@^0.80.0:
-  version "0.80.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.80.0.tgz#04cc1ee626a6f50786f78170c92ebe1745235403"
-
 flush-write-stream@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.0.3.tgz#c5d586ef38af6097650b49bc41b55fabb19f35bd"

--- a/susemanager-utils/testing/docker/head/suma-head-nodejs/add_packages.sh
+++ b/susemanager-utils/testing/docker/head/suma-head-nodejs/add_packages.sh
@@ -5,4 +5,4 @@ set -e
 zypper --non-interactive in nodejs8 npm8
 
 # Install flow-bin globally
-npm_config_prefix=/usr npm install -g flow-bin@0.73
+npm_config_prefix=/usr npm install -g flow-bin@0.82.0

--- a/web/html/src/package.json
+++ b/web/html/src/package.json
@@ -4,7 +4,6 @@
   "description": "Suse Manager web javascript source code",
   "license": "UNLICENSED",
   "dependencies": {
-    "flow-bin": "^0.73.0",
     "susemanager-nodejs-sdk-devel": "1.0.0"
   },
   "scripts": {
@@ -14,5 +13,8 @@
     "dev": "webpack --config build/webpack.config.js --mode development && yarn run validate",
     "watch": "webpack --config build/webpack.config.js --mode development --watch",
     "clean": "rm -rf node_modules && rm -rf dist"
+  },
+  "devDependencies": {
+    "flow-bin": "^0.82.0"
   }
 }


### PR DESCRIPTION
## What does this PR change?

Remove `flow-bin` from dependencies because it ships binaries and this doesn't play well with OBS.

## GUI diff

No difference.

## Documentation
- Updated internal wiki 

## Test coverage
- No tests: not needed

## Links

