### PR TITLE
Fix mismatching testsuite tag definition

### DIFF
--- a/testsuite/features/support/setup_browser.rb
+++ b/testsuite/features/support/setup_browser.rb
@@ -68,10 +68,10 @@ end
 Before('@ssh_minion') do |scenario|
   scenario.skip_invoke! unless $ssh_minion
 end
-Before('@virtualization_kvm') do |scenario|
+Before('@virthost_kvm') do |scenario|
   scenario.skip_invoke! unless $kvm_server
 end
-Before('@virtualization_xen') do |scenario|
+Before('@virthost_xen') do |scenario|
   scenario.skip_invoke! unless $xen_server
 end
 


### PR DESCRIPTION
## What does this PR change?

Tag definition remained the primitive @virtualization_(kvm|xen) while
it should now be @virthost_(kvm|xen). With this fix the virtualization
tests will actually be skipped if the VIRTHOST_* env variables are not
set.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: fixing testsuite

- [X] **DONE**

## Test coverage
- No tests: tests covering the tests would be chicken and egg problem
- Unit tests were added
- Cucumber tests were added

- [X] **DONE**

## Links

- [X] **DONE**
