### PR TITLE
Increase timeout when dealing with Admin -> Products page

### DIFF
--- a/testsuite/docs/cucumber-steps.md
+++ b/testsuite/docs/cucumber-steps.md
@@ -225,6 +225,7 @@ For a test with a regular expression, there is ```I should see a text like "..."
 
 ```cucumber
   Then I wait until I see "Successfully bootstrapped host! " text
+  Then I wait at most "360" seconds until I see "Product Description" text
 ```
 
 * Same, but re-issue HTTP requests to refresh the page

--- a/testsuite/features/core_srv_setup_wizard.feature
+++ b/testsuite/features/core_srv_setup_wizard.feature
@@ -26,7 +26,7 @@ Feature: The Setup Wizard
     # Order matters here, refresh first
     When I refresh SCC
     And I follow "SUSE Products" in the content area
-    And I wait until I see "Product Description" text
+    And I wait at most "360" seconds until I see "Product Description" text
     And I should see a "Arch" text
     And I should see a "Channels" text
     And I should not see a "WebYaST 1.3" text
@@ -46,7 +46,7 @@ Feature: The Setup Wizard
   Scenario: Select product with recommended enabled
     Given I am on the Admin page
     When I follow "SUSE Products" in the content area
-    And I wait until I see "Product Description" text
+    And I wait at most "360" seconds until I see "Product Description" text
     And I enter "SUSE Linux Enterprise Server 15" in the css "input[name='product-description-filter']"
     And I select "x86_64" in the dropdown list of the architecture filter
     And I open the sub-list of the product "SUSE Linux Enterprise Server 15"
@@ -61,7 +61,7 @@ Feature: The Setup Wizard
   Scenario: View the channels list in the products page
     Given I am on the Admin page
     When I follow "SUSE Products" in the content area
-    And I wait until I see "Product Description" text
+    And I wait at most "360" seconds until I see "Product Description" text
     And I enter "SUSE Linux Enterprise Server for SAP All-in-One 11 SP2" in the css "input[name='product-description-filter']"
     And I select "x86_64" in the dropdown list of the architecture filter
     And I click the channel list of product "SUSE Linux Enterprise Server for SAP All-in-One 11 SP2"

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -39,6 +39,19 @@ When(/^I wait until I see "([^"]*)" text$/) do |text|
   end
 end
 
+When(/^I wait at most "([^"]*)" seconds until I see "([^"]*)" text$/) do |seconds, text|
+  begin
+    Timeout.timeout(seconds) do
+      loop do
+        break if page.has_content?(text)
+        sleep 3
+      end
+    end
+  rescue Timeout::Error
+    raise "Couldn't find the #{text} in webpage"
+  end
+end
+
 When(/^I wait until I see "([^"]*)" text or "([^"]*)" text$/) do |text1, text2|
   begin
     Timeout.timeout(DEFAULT_TIMEOUT) do


### PR DESCRIPTION
## What does this PR change?
This PR increases the timeout for dealing with the "Admin -> Products" page. According to latest cucumber results for uyuni, it might be that we need to wait a bit more that the DEFAULT_TIMEOUT.