### PR TITLE
Testsuite: Fix incorrect type use in new implemented step

### DIFF
--- a/testsuite/docs/cucumber-steps.md
+++ b/testsuite/docs/cucumber-steps.md
@@ -225,7 +225,7 @@ For a test with a regular expression, there is ```I should see a text like "..."
 
 ```cucumber
   Then I wait until I see "Successfully bootstrapped host! " text
-  Then I wait at most "360" seconds until I see "Product Description" text
+  Then I wait at most 360 seconds until I see "Product Description" text
 ```
 
 * Same, but re-issue HTTP requests to refresh the page

--- a/testsuite/features/core_srv_setup_wizard.feature
+++ b/testsuite/features/core_srv_setup_wizard.feature
@@ -26,7 +26,7 @@ Feature: The Setup Wizard
     # Order matters here, refresh first
     When I refresh SCC
     And I follow "SUSE Products" in the content area
-    And I wait at most "360" seconds until I see "Product Description" text
+    And I wait at most 360 seconds until I see "Product Description" text
     And I should see a "Arch" text
     And I should see a "Channels" text
     And I should not see a "WebYaST 1.3" text
@@ -46,7 +46,7 @@ Feature: The Setup Wizard
   Scenario: Select product with recommended enabled
     Given I am on the Admin page
     When I follow "SUSE Products" in the content area
-    And I wait at most "360" seconds until I see "Product Description" text
+    And I wait at most 360 seconds until I see "Product Description" text
     And I enter "SUSE Linux Enterprise Server 15" in the css "input[name='product-description-filter']"
     And I select "x86_64" in the dropdown list of the architecture filter
     And I open the sub-list of the product "SUSE Linux Enterprise Server 15"
@@ -61,7 +61,7 @@ Feature: The Setup Wizard
   Scenario: View the channels list in the products page
     Given I am on the Admin page
     When I follow "SUSE Products" in the content area
-    And I wait at most "360" seconds until I see "Product Description" text
+    And I wait at most 360 seconds until I see "Product Description" text
     And I enter "SUSE Linux Enterprise Server for SAP All-in-One 11 SP2" in the css "input[name='product-description-filter']"
     And I select "x86_64" in the dropdown list of the architecture filter
     And I click the channel list of product "SUSE Linux Enterprise Server for SAP All-in-One 11 SP2"

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -39,9 +39,9 @@ When(/^I wait until I see "([^"]*)" text$/) do |text|
   end
 end
 
-When(/^I wait at most "([^"]*)" seconds until I see "([^"]*)" text$/) do |seconds, text|
+When(/^I wait at most (\d+) seconds until I see "([^"]*)" text$/) do |seconds, text|
   begin
-    Timeout.timeout(seconds) do
+    Timeout.timeout(seconds.to_i) do
       loop do
         break if page.has_content?(text)
         sleep 3


### PR DESCRIPTION
## What does this PR change?
This PR fixes a testsuite error caused by the new step `I wait at most X seconds until I see Y text` which is not handling the types properly:

```
undefined method `zero?' for "360":String (NoMethodError)
```