### PR TITLE
Guest properties refactoring

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/system/VirtualizationActionCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/system/VirtualizationActionCommand.java
@@ -37,7 +37,7 @@ import java.util.Map;
 public class VirtualizationActionCommand {
 
     private static Logger log = Logger.getLogger(VirtualizationActionCommand.class);
-    private static final TaskomaticApi TASKOMATIC_API = new TaskomaticApi();
+    private static TaskomaticApi taskomaticApi = new TaskomaticApi();
 
     private User user;
     private Date scheduleDate;
@@ -109,7 +109,7 @@ public class VirtualizationActionCommand {
 
         log.debug("saving virtAction.");
         ActionFactory.save(virtAction);
-        TASKOMATIC_API.scheduleActionExecution(virtAction);
+        taskomaticApi.scheduleActionExecution(virtAction);
         action = virtAction;
         return null;
     }
@@ -242,5 +242,12 @@ public class VirtualizationActionCommand {
         this.uuid = argUuid;
     }
 
+    /**
+     * Set the {@link TaskomaticApi} instance to use. Only needed for unit tests.
+     * @param taskomaticApiIn the {@link TaskomaticApi}
+     */
+    public static void setTaskomaticApi(TaskomaticApi taskomaticApiIn) {
+        taskomaticApi = taskomaticApiIn;
+    }
 }
 

--- a/java/code/src/com/redhat/rhn/manager/system/VirtualizationActionCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/system/VirtualizationActionCommand.java
@@ -100,7 +100,7 @@ public class VirtualizationActionCommand {
 
         ServerAction serverAction = new ServerAction();
         serverAction.setStatus(ActionFactory.STATUS_QUEUED);
-        serverAction.setRemainingTries(new Long(5));
+        serverAction.setRemainingTries(Long.valueOf(5));
         serverAction.setServer(this.getTargetSystem());
         virtAction.extractParameters(getContext());
 

--- a/java/code/src/com/redhat/rhn/manager/system/VirtualizationActionCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/system/VirtualizationActionCommand.java
@@ -36,7 +36,8 @@ import java.util.Map;
  */
 public class VirtualizationActionCommand {
 
-    private static Logger log = Logger.getLogger(VirtualizationActionCommand.class);
+    private static final Logger LOG = Logger.getLogger(VirtualizationActionCommand.class);
+
     private static TaskomaticApi taskomaticApi = new TaskomaticApi();
 
     private User user;
@@ -82,9 +83,9 @@ public class VirtualizationActionCommand {
                                                     "VirtualizationActionCommand");
         }
 
-        log.debug("store() called.");
+        LOG.debug("store() called.");
 
-        log.debug("creating virtAction");
+        LOG.debug("creating virtAction");
         BaseVirtualizationAction virtAction =
             (BaseVirtualizationAction) ActionFactory.createAction(this.getActionType());
         virtAction.setName(this.getActionType().getName());
@@ -93,8 +94,8 @@ public class VirtualizationActionCommand {
         virtAction.setEarliestAction(this.getScheduleDate());
         virtAction.setUuid(this.getUuid());
 
-        if (log.isDebugEnabled()) {
-            log.debug("virtAction.name: " + virtAction.getName() + " uuid: " +
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("virtAction.name: " + virtAction.getName() + " uuid: " +
                     virtAction.getUuid());
         }
 
@@ -107,7 +108,7 @@ public class VirtualizationActionCommand {
         virtAction.addServerAction(serverAction);
         serverAction.setParentAction(virtAction);
 
-        log.debug("saving virtAction.");
+        LOG.debug("saving virtAction.");
         ActionFactory.save(virtAction);
         taskomaticApi.scheduleActionExecution(virtAction);
         action = virtAction;

--- a/java/code/src/com/suse/manager/webui/Router.java
+++ b/java/code/src/com/suse/manager/webui/Router.java
@@ -339,6 +339,8 @@ public class Router implements SparkApplication {
                 withUser(VirtualGuestsController::data));
         post("/manager/api/systems/details/virtualization/guests/:sid/:action",
                 withUser(VirtualGuestsController::action));
+        get("/manager/api/systems/details/virtualization/guests/:sid/guest/:uuid",
+                withUser(VirtualGuestsController::getGuest));
     }
 
     private void initContentManagementRoutes(JadeTemplateEngine jade) {

--- a/java/code/src/com/suse/manager/webui/controllers/VirtualGuestsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/VirtualGuestsController.java
@@ -298,11 +298,11 @@ public class VirtualGuestsController {
                                                    VirtualGuestsUpdateActionJson data) {
         List<String> results = new ArrayList<>();
         // Comparing against the DB data may not be accurate, but that will change with virt.running state soon
-        if (data.getVcpu() != guest.getVcpus()) {
+        if (data.getVcpu().longValue() != guest.getVcpus().longValue()) {
             results.add(triggerGuestSetterAction(host, guest, "setVcpu", ActionFactory.TYPE_VIRTUALIZATION_SET_VCPUS,
                                                  user, data.getVcpu()));
         }
-        if (data.getMemory() != guest.getMemory()) {
+        if (data.getMemory().longValue() != guest.getMemory().longValue()) {
             results.add(triggerGuestSetterAction(host, guest, "setMemory",
                                                  ActionFactory.TYPE_VIRTUALIZATION_SET_MEMORY,
                                                  user, data.getMemory()));

--- a/java/code/src/com/suse/manager/webui/controllers/VirtualGuestsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/VirtualGuestsController.java
@@ -287,7 +287,7 @@ public class VirtualGuestsController {
         data.put("inSSM", RhnSetDecl.SYSTEMS.get(user).contains(hostId));
 
         /* For the rest of the template */
-        data.put("guest", GSON.toJson(guest.get()));
+        data.put("guestUuid", guestUuid);
         data.put("isSalt", host.hasEntitlement(EntitlementManager.SALT));
         return new ModelAndView(data, "virtualization/guests/edit.jade");
     }

--- a/java/code/src/com/suse/manager/webui/templates/virtualization/guests/edit.jade
+++ b/java/code/src/com/suse/manager/webui/templates/virtualization/guests/edit.jade
@@ -19,6 +19,6 @@ script(type='text/javascript').
                     "count": #{server.cpu.nrCPU}
                 }
             },
-            guest: JSON.parse('!{guest}')
+            guestUuid: "#{guestUuid}"
         }
     );

--- a/java/code/src/com/suse/manager/webui/templates/virtualization/guests/edit.jade
+++ b/java/code/src/com/suse/manager/webui/templates/virtualization/guests/edit.jade
@@ -17,7 +17,8 @@ script(type='text/javascript').
                 "id": "#{server.id}",
                 "cpu": {
                     "count": #{server.cpu.nrCPU}
-                }
+                },
+                saltEntitled: #{isSalt},
             },
             guestUuid: "#{guestUuid}"
         }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add REST API to retrieve VM definition
 - Nav and section scroll independently
 - Listen to salt libvirt events to update VMs state
 - avoid a NullPointerException error in Taskomatic (bsc#1119271)

--- a/web/html/src/manager/virtualization/guests/edit/guests-edit.js
+++ b/web/html/src/manager/virtualization/guests/edit/guests-edit.js
@@ -4,61 +4,76 @@
 const { hot } = require('react-hot-loader');
 const React = require('react');
 const { TopPanel } = require('components/panels/TopPanel');
+const MessagesUtils = require('components/messages').Utils;
+const { Loading } = require('components/loading/loading');
 const { GuestProperties } = require('../guest-properties');
 const { VirtualizationGuestActionApi } = require('../virtualization-guest-action-api');
+const { VirtualizationGuestDefinitionApi } = require('../virtualization-guest-definition-api');
 
 declare function t(msg: string): string;
 
 type Props = {
   host: Object,
-  guest: Object,
+  guestUuid: string,
 };
 
 class GuestsEdit extends React.Component<Props> {
-  initialGuestMemory = 1024;
-
-  initialGuestCpu = 1;
-
-  constructor(props: Props) {
-    super(props);
-    this.initialGuestMemory = props.guest.memory / 1024;
-    this.initialGuestCpu = props.guest.vcpus;
+  static getModelFromDefinition(definition: Object) : Object {
+    return {
+      memory: definition.maxMemory / 1024,
+      vcpu: definition.vcpu.max,
+    };
   }
-
-  getInitialModel = () => ({
-    memory: this.initialGuestMemory,
-    vcpu: this.initialGuestCpu,
-  })
 
   render() {
     return (
-      <VirtualizationGuestActionApi
+      <VirtualizationGuestDefinitionApi
         hostid={this.props.host.id}
-        bounce={`/rhn/manager/systems/details/virtualization/guests/${this.props.host.id}`}
+        guestUuid={this.props.guestUuid}
       >
         {
           ({
-            onAction,
-            messages,
-          }) => {
-            const onSubmit = (properties) => {
-              const newProperties = Object.assign(properties, { memory: properties.memory * 1024 });
-              return onAction('update', [this.props.guest.uuid], newProperties);
-            };
-            return (
-              <TopPanel title={this.props.guest.name} icon="fa spacewalk-icon-virtual-guest">
-                <GuestProperties
-                  host={this.props.host}
-                  submitText={t('Update')}
-                  submit={onSubmit}
-                  messages={messages}
-                  getInitialModel={this.getInitialModel}
-                />
-              </TopPanel>
-            );
-          }
+            definition,
+            messages: definitionMessages,
+          }) => (
+            <VirtualizationGuestActionApi
+              hostid={this.props.host.id}
+              bounce={`/rhn/manager/systems/details/virtualization/guests/${this.props.host.id}`}
+            >
+              {
+                ({
+                  onAction,
+                  messages: actionMessages,
+                }) => {
+                  if (definition == null) {
+                    return <Loading text={t('Loading...')} withBorders={false} />;
+                  }
+
+                  const initialModel = GuestsEdit.getModelFromDefinition(definition);
+                  const onSubmit = (properties) => {
+                    const newProperties = Object.assign(properties, { memory: properties.memory * 1024 });
+                    return onAction('update', [this.props.guestUuid], newProperties);
+                  };
+                  const messages = [].concat(definitionMessages, actionMessages)
+                    .filter(item => item)
+                    .map(item => MessagesUtils.error(item));
+                  const guestName = definition !== null ? definition.name : '';
+                  return (
+                    <TopPanel title={guestName} icon="fa spacewalk-icon-virtual-guest">
+                      <GuestProperties
+                        host={this.props.host}
+                        submitText={t('Update')}
+                        submit={onSubmit}
+                        messages={messages}
+                        initialModel={initialModel}
+                      />
+                    </TopPanel>
+                  );
+                }
+              }
+            </VirtualizationGuestActionApi>)
         }
-      </VirtualizationGuestActionApi>);
+      </VirtualizationGuestDefinitionApi>);
   }
 }
 

--- a/web/html/src/manager/virtualization/guests/edit/guests-edit.renderer.js
+++ b/web/html/src/manager/virtualization/guests/edit/guests-edit.renderer.js
@@ -5,11 +5,11 @@ const { GuestsEdit } = require('./guests-edit');
 window.pageRenderers = window.pageRenderers || {};
 window.pageRenderers.guests = window.pageRenderers.guests || {};
 window.pageRenderers.guests.edit = window.pageRenderers.guests.edit || {};
-window.pageRenderers.guests.edit.guestsEditRenderer = (id, { host, guest }) => {
+window.pageRenderers.guests.edit.guestsEditRenderer = (id, { host, guestUuid }) => {
   ReactDOM.render(
     <GuestsEdit
       host={host}
-      guest={guest}
+      guestUuid={guestUuid}
     />,
     document.getElementById(id),
   );

--- a/web/html/src/manager/virtualization/guests/guest-properties.js
+++ b/web/html/src/manager/virtualization/guests/guest-properties.js
@@ -15,7 +15,7 @@ type Props = {
   host: Object,
   submitText: string,
   submit: Function,
-  getInitialModel: Function,
+  initialModel: Object,
   messages: Array<String>,
 };
 
@@ -33,15 +33,23 @@ class GuestProperties extends React.Component<Props, State> {
     super(props);
 
     this.state = {
-      model: props.getInitialModel(),
+      model: Object.assign({}, props.initialModel),
       isInvalid: false,
       messages: [],
     };
   }
 
+  componentWillReceiveProps(nextProps: Props) {
+    if (this.props.initialModel !== nextProps.initialModel) {
+      this.setState({
+        model: Object.assign({}, nextProps.initialModel),
+      });
+    }
+  }
+
   clearFields = () => {
     this.setState({
-      model: this.props.getInitialModel(),
+      model: Object.assign({}, this.props.initialModel),
     });
   }
 

--- a/web/html/src/manager/virtualization/guests/properties/guest-properties-form.js
+++ b/web/html/src/manager/virtualization/guests/properties/guest-properties-form.js
@@ -1,0 +1,100 @@
+// @flow
+
+const React = require('react');
+const { Form } = require('components/input/Form');
+const { SubmitButton, Button } = require('components/buttons');
+const { Messages } = require('components/messages');
+
+declare function t(msg: string, ...args: Array<any>): string;
+
+type Props = {
+  submitText: string,
+  submit: Function,
+  initialModel: Object,
+  validationChecks: Array<{ check: (model: Object) => boolean, message: Object }>,
+  messages: Array<String>,
+  children: Function,
+};
+
+type State = {
+  model: Object,
+  isInvalid: boolean,
+  messages: Array<Object>,
+};
+
+/*
+ * Component editing a virtual machine properties
+ */
+class GuestPropertiesForm extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      model: Object.assign({}, props.initialModel),
+      isInvalid: false,
+      messages: [],
+    };
+  }
+
+  clearFields = () => {
+    this.setState({
+      model: Object.assign({}, this.props.initialModel),
+    });
+  }
+
+  onValidate = (isValid: boolean) => {
+    this.setState(prevState => ({
+      isInvalid: !isValid,
+      messages: this.props.validationChecks
+        .filter(item => item.check(prevState.model))
+        .map(item => item.message),
+    }));
+  }
+
+  onChange = (model: Object) => {
+    this.setState({
+      model,
+    });
+  }
+
+  onSubmit = () => {
+    const model = Object.assign({}, this.state.model);
+    this.props.submit(model);
+  }
+
+  render() {
+    return (
+      <div>
+        <Form
+          className="form-horizontal"
+          model={this.state.model}
+          onValidate={this.onValidate}
+          onChange={this.onChange}
+          onSubmit={this.onSubmit}
+        >
+          <Messages items={[].concat(this.state.messages, this.props.messages)} />
+          {this.props.children({ model: this.state.model })}
+          <div className="col-md-offset-3 col-md-6">
+            <SubmitButton
+              id="submit-btn"
+              className="btn-success"
+              text={this.props.submitText}
+              disabled={this.state.isInvalid}
+            />
+            <Button
+              id="clear-btn"
+              className="btn-default pull-right"
+              icon="fa-eraser"
+              text={t('Clear Fields')}
+              handler={this.clearFields}
+            />
+          </div>
+        </Form>
+      </div>
+    );
+  }
+}
+
+module.exports = {
+  GuestPropertiesForm,
+};

--- a/web/html/src/manager/virtualization/guests/properties/guest-properties-form.js
+++ b/web/html/src/manager/virtualization/guests/properties/guest-properties-form.js
@@ -62,6 +62,12 @@ class GuestPropertiesForm extends React.Component<Props, State> {
     this.props.submit(model);
   }
 
+  changeModel = (model: Object) => {
+    this.setState({
+      model,
+    });
+  }
+
   render() {
     return (
       <div>
@@ -73,7 +79,12 @@ class GuestPropertiesForm extends React.Component<Props, State> {
           onSubmit={this.onSubmit}
         >
           <Messages items={[].concat(this.state.messages, this.props.messages)} />
-          {this.props.children({ model: this.state.model })}
+          {
+            this.props.children({
+              model: this.state.model,
+              changeModel: this.changeModel,
+            })
+          }
           <div className="col-md-offset-3 col-md-6">
             <SubmitButton
               id="submit-btn"

--- a/web/html/src/manager/virtualization/guests/properties/guest-properties-traditional.js
+++ b/web/html/src/manager/virtualization/guests/properties/guest-properties-traditional.js
@@ -5,8 +5,7 @@ const { Panel } = require('components/panels/Panel');
 const { Text } = require('components/input/Text');
 const Validation = require('components/validation');
 const MessagesUtils = require('components/messages').Utils;
-const { GuestPropertiesForm } = require('./properties/guest-properties-form');
-const { GuestPropertiesTraditional } = require('./properties/guest-properties-traditional');
+const { GuestPropertiesForm } = require('./guest-properties-form');
 
 declare function t(msg: string, ...args: Array<any>): string;
 
@@ -18,10 +17,16 @@ type Props = {
   messages: Array<String>,
 };
 
+type State = {
+  model: Object,
+  isInvalid: boolean,
+  messages: Array<String>,
+};
+
 /*
  * Component editing a virtual machine properties
  */
-class GuestProperties extends React.Component<Props> {
+class GuestPropertiesTraditional extends React.Component<Props, State> {
   validationChecks = [{
     check: (model: Object) => !Number.isNaN(Number.parseInt(model.vcpu, 10))
       && (model.vcpu > this.props.host.cpu.count),
@@ -29,18 +34,6 @@ class GuestProperties extends React.Component<Props> {
   }]
 
   render() {
-    if (!this.props.host.saltEntitled) {
-      return (
-        <GuestPropertiesTraditional
-          host={this.props.host}
-          submitText={this.props.submitText}
-          submit={this.props.submit}
-          initialModel={this.props.initialModel}
-          messages={this.props.messages}
-        />
-      );
-    }
-
     return (
       <GuestPropertiesForm
         submitText={this.props.submitText}
@@ -50,8 +43,8 @@ class GuestProperties extends React.Component<Props> {
         messages={this.props.messages}
       >
         {
-          () => [
-            <Panel key="general" title={t('General')} headingLevel="h2">
+          () => (
+            <Panel title={t('General')} headingLevel="h2">
               <Text
                 name="memory"
                 label={t('Maximum Memory (MiB)')}
@@ -70,8 +63,8 @@ class GuestProperties extends React.Component<Props> {
                 divClass="col-md-6"
                 validators={[Validation.isInt({ gt: 0 })]}
               />
-            </Panel>,
-          ]
+            </Panel>
+          )
         }
       </GuestPropertiesForm>
     );
@@ -79,5 +72,5 @@ class GuestProperties extends React.Component<Props> {
 }
 
 module.exports = {
-  GuestProperties,
+  GuestPropertiesTraditional,
 };

--- a/web/html/src/manager/virtualization/guests/virtualization-guest-definition-api.js
+++ b/web/html/src/manager/virtualization/guests/virtualization-guest-definition-api.js
@@ -1,0 +1,55 @@
+// @flow
+const React = require('react');
+const Network = require('utils/network');
+const MessagesUtils = require('components/messages').Utils;
+
+declare function t(msg: string, ...args: Array<any>): string;
+
+type Props = {
+  hostid: string,
+  guestUuid: string,
+  children: Function,
+};
+
+type State = {
+  messages: Array<Object>,
+  definition: ?Object,
+};
+
+class VirtualizationGuestDefinitionApi extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      messages: [],
+      definition: null,
+    };
+  }
+
+  componentDidMount() {
+    Network.get(`/rhn/manager/api/systems/details/virtualization/guests/${this.props.hostid}/guest/${this.props.guestUuid}`,
+      'application/json').promise
+      .then((response) => {
+        this.setState({ definition: response });
+      }, (xhr) => {
+        const errMessages = xhr.status === 0
+          ? [MessagesUtils.error(
+            t('Request interrupted or invalid response received from the server. Please try again.'),
+          )]
+          : [MessagesUtils.error(Network.errorMessageByStatus(xhr.status))];
+        this.setState({
+          messages: errMessages,
+        });
+      });
+  }
+
+  render() {
+    return this.props.children({
+      definition: this.state.definition,
+      messages: this.state.messages,
+    });
+  }
+}
+
+module.exports = {
+  VirtualizationGuestDefinitionApi,
+};


### PR DESCRIPTION
## What does this PR change?

This PR adds a REST API to fetch the definition of a Virtual Machine. This is thus used in the GuestEdit ReactJS component to get the guest data and get rid of the ugly structure passed from the jade template.

This also has the advantage to be more flexible and will help adding new properties to the edit dialog in the future.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only an implementation difference so far, real UI changes will come in a follow up PR.

- [X] **DONE**

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

Based on PR #155 since some data structures are reused from there.

- [X] **DONE**
