### PR TITLE
Fix docker-javascript-lint.sh exit code

### DIFF
--- a/web/html/src/scripts/docker-javascript-lint.sh
+++ b/web/html/src/scripts/docker-javascript-lint.sh
@@ -9,4 +9,3 @@ ln -s /usr/lib/node_modules/ node_modules
 
 # execute eslint
 ./node_modules/eslint/bin/eslint.js -f codeframe .
-echo "Linting done."


### PR DESCRIPTION
## What does this PR change?

Remove echo that causes `docker-javascript-lint.sh` to report wrong exit code.

## GUI diff

No difference.

## Documentation
- No documentation needed: fix in jenkins scripts

## Test coverage
- No tests: fix in jenkins scripts


