### PR TITLE
Add the missing xalan-j2-serializer jar dependency

### DIFF
--- a/java/buildconf/build-props.xml
+++ b/java/buildconf/build-props.xml
@@ -124,7 +124,7 @@
   <property name="run.jar.dependencies"
       value="antlr objectweb-asm/asm cglib c3p0 commons-discovery dom4j jaf jta ojdbc14 sitemesh
              taglibs-standard-impl taglibs-standard-jstlel taglibs-standard-spec
-             xalan-j2 xerces-j2 xml-commons-apis ${common.jar.dependencies}" />
+             xalan-j2 xalan-j2-serializer xerces-j2 xml-commons-apis ${common.jar.dependencies}" />
 
   <!-- =================== RPM build, use jpackage syntax ======================= -->
   <!-- property name="install.test.jar.dependencies"
@@ -146,7 +146,7 @@
   <property name="install.run.jar.dependencies"
       value="antlr objectweb-asm/asm cglib c3p0 commons-discovery dom4j dwr jaf jta sitemesh
              taglibs-standard-impl taglibs-standard-jstlel taglibs-standard-spec
-             xalan-j2 xerces-j2 xml-commons-apis ${install.common.jar.dependencies}" />
+             xalan-j2 xalan-j2-serializer xerces-j2 xml-commons-apis ${install.common.jar.dependencies}" />
 
   <property name="install.common.jar.dependencies"
       value="bcel cglib commons-beanutils commons-cli commons-codec
@@ -171,7 +171,7 @@
              taglibs-standard-impl taglibs-standard-jstlel taglibs-standard-spec
              tanukiwrapper postgresql-jdbc snakeyaml simple-xml
              ${suse-common-jars} ${suse-runtime-jars}
-	     xalan-j2 xerces-j2 xml-commons-apis simple-core ${ehcache}" />
+	     xalan-j2 xalan-j2-serializer xerces-j2 xml-commons-apis simple-core ${ehcache}" />
 
   <property name="taskomatic.jar.dependencies"
       value="${dist.jar.dependencies} commons-pool jsch" />

--- a/java/manager-build.xml
+++ b/java/manager-build.xml
@@ -158,7 +158,6 @@
         <exclude name="**/websocket-api*" />
         <exclude name="**/checkstyle*" />
         <exclude name="**/jacocoant*" />
-        <exclude name="**/xalan-j2-serializer*" />
       </fileset>
     </copy>
   </target>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add missing jar dependency 'xalan-j2-serializer'
 - Modify acls: hide 'System details -> Groups and Formulas' tab for non-minions with bootstrap entitlement
 - fix typo in messages (bsc#1111249)
 - Cleanup formula data and assignment when migrating formulas or when removing system

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -974,6 +974,7 @@ fi
 %{jardir}/tanukiwrapper.jar
 # %{jardir}/velocity-*.jar
 %{jardir}/xalan-j2.jar
+%{jardir}/xalan-j2-serializer.jar
 %{jardir}/xerces-j2.jar
 %{jardir}/xml-commons-apis.jar
 


### PR DESCRIPTION
## What does this PR change?

This PR adds the missing `xalan-j2-serializer` jar dependency to Java app. The missing jar causes an error when getting OpenSCAP results.

## Documentation
- No documentation needed: Bugfix

- [x] **DONE**

## Test coverage
- No tests: Already tested in Cucumber

- [x] **DONE**
