### PR TITLE
Prevent NPE when sending email

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/TaskHelper.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/TaskHelper.java
@@ -78,7 +78,7 @@ public class TaskHelper {
     public static void sendTaskoEmail(Integer orgId, String messageBody) {
         Config c = Config.get();
         LocalizationService ls = LocalizationService.getInstance();
-        String[] recipients = null;
+        String[] recipients = MailHelper.getAdminRecipientsFromConfig();
         if (orgId != null) {
             List<String> emails = getActiveOrgAdminEmails(orgId);
             recipients = !emails.isEmpty() ?


### PR DESCRIPTION
## What does this PR change?

When an error happens on taskomatic startup it try to send an email with no recipients.
This result in a NullPointerException.

This code initialize the recipients list always with the value configured in the config file.

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **internal**

- [x] **DONE**

## Links

- none 

- [x] **DONE**
