### PR TITLE
TESTSUITE: Wait for child channels to be loaded on the "System -> Software Channels" page

### DIFF
--- a/testsuite/docs/cucumber-steps.md
+++ b/testsuite/docs/cucumber-steps.md
@@ -225,6 +225,7 @@ For a test with a regular expression, there is ```I should see a text like "..."
 
 ```cucumber
   Then I wait until I see "Successfully bootstrapped host! " text
+  Then I wait until I do not see "Loading..." text
   Then I wait at most 360 seconds until I see "Product Description" text
 ```
 

--- a/testsuite/features/allcli_software_channels.feature
+++ b/testsuite/features/allcli_software_channels.feature
@@ -36,6 +36,7 @@ Feature: Chanel subscription via SSM
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     Then radio button "Test-Channel-x86_64" is checked
+    And I wait until I do not see "Loading..." text
     And I should see "Test-Channel-x86_64 Child Channel" as unchecked
 
   Scenario: Check SLES client is still subscribed to old channels before channel change completes
@@ -43,6 +44,7 @@ Feature: Chanel subscription via SSM
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     Then radio button "Test-Channel-x86_64" is checked
+    And I wait until I do not see "Loading..." text
     And I should see "Test-Channel-x86_64 Child Channel" as unchecked
 
   Scenario: Check old channels are still enabled on SLES minion before channel change completes
@@ -70,6 +72,7 @@ Feature: Chanel subscription via SSM
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     Then radio button "Test Base Channel" is checked
+    And I wait until I do not see "Loading..." text
     And I should see "Test Child Channel" as checked
 
   Scenario: Check the SLES client is subscribed to the new channels
@@ -77,6 +80,7 @@ Feature: Chanel subscription via SSM
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     Then radio button "Test Base Channel" is checked
+    And I wait until I do not see "Loading..." text
     And I should see "Test Child Channel" as checked
 
   Scenario: Check the new channels are enabled on the SLES minion

--- a/testsuite/features/allcli_software_channels_dependencies.feature
+++ b/testsuite/features/allcli_software_channels_dependencies.feature
@@ -10,6 +10,7 @@ Feature: Chanel subscription with recommended/required dependencies
     And I follow "Software Channels" in the content area
     # check that the required channel by the base one is selected and disabled
     And I check radio button "SLE-Product-SLES15-Pool for x86_64"
+    And I wait until I do not see "Loading..." text
     Then I should see the child channel "SLE-Product-SLES15-Updates for x86_64" "selected" and "disabled"
     And I should see the toggler "disabled"
     And I should see a "SLE-Module-Basesystem15-Pool for x86_64" text

--- a/testsuite/features/core_centos_salt_ssh.feature
+++ b/testsuite/features/core_centos_salt_ssh.feature
@@ -59,6 +59,7 @@ Feature: Bootstrap a SSH-managed CentOS minion and do some basic operations on i
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I check radio button "Test Base Channel"
+    And I wait until I do not see "Loading..." text
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"

--- a/testsuite/features/core_min_bootstrap.feature
+++ b/testsuite/features/core_min_bootstrap.feature
@@ -84,6 +84,7 @@ Feature: Be able to bootstrap a Salt minion via the GUI
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I check radio button "Test-Channel-x86_64"
+    And I wait until I do not see "Loading..." text
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"

--- a/testsuite/features/core_min_salt_ssh.feature
+++ b/testsuite/features/core_min_salt_ssh.feature
@@ -40,6 +40,7 @@ Feature: Be able to bootstrap a Salt host managed via salt-ssh
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I check radio button "Test-Channel-x86_64"
+    And I wait until I do not see "Loading..." text
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"

--- a/testsuite/features/min_bootstrap_xmlrpc.feature
+++ b/testsuite/features/min_bootstrap_xmlrpc.feature
@@ -45,6 +45,7 @@ Feature: Register a Salt minion via XML-RPC API
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I check radio button "Test-Channel-x86_64"
+    And I wait until I do not see "Loading..." text
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"

--- a/testsuite/features/min_salt_minions_page.feature
+++ b/testsuite/features/min_salt_minions_page.feature
@@ -86,6 +86,7 @@ Feature: Management of minion keys
     When I follow "Software" in the content area
     Then I follow "Software Channels" in the content area
     And I check radio button "Test-Channel-x86_64"
+    And I wait until I do not see "Loading..." text
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"

--- a/testsuite/features/minssh_bootstrap_xmlrpc.feature
+++ b/testsuite/features/minssh_bootstrap_xmlrpc.feature
@@ -49,6 +49,7 @@ Feature: Register a salt-ssh system via XML-RPC
     When I follow "Software" in the content area
     Then I follow "Software Channels" in the content area
     And I check radio button "Test-Channel-x86_64"
+    And I wait until I do not see "Loading..." text
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -39,6 +39,19 @@ When(/^I wait until I see "([^"]*)" text$/) do |text|
   end
 end
 
+When(/^I wait until I do not see "([^"]*)" text$/) do |text|
+  begin
+    Timeout.timeout(DEFAULT_TIMEOUT) do
+      loop do
+        break unless page.has_content?(text)
+        sleep 3
+      end
+    end
+  rescue Timeout::Error
+    raise "The #{text} was always there in webpage"
+  end
+end
+
 When(/^I wait at most (\d+) seconds until I see "([^"]*)" text$/) do |seconds, text|
   begin
     Timeout.timeout(seconds.to_i) do

--- a/testsuite/features/trad_check_registration.feature
+++ b/testsuite/features/trad_check_registration.feature
@@ -181,6 +181,7 @@ Feature: Client display after registration
     And I follow "Software Channels" in the content area
     Then I should see a "Base Channel" text
     And I should see a "Child Channels" text
+    And I wait until I do not see "Loading..." text
     And I should see a "Next" button
 
   Scenario: Show Configuration => View/Modify Files page


### PR DESCRIPTION
## What does this PR change?
This PR fixes an issue on testsuite scenarios which are dealing with the "Systems -> Software Channels" page:

When selecting selecting a "Base Channel" we need to wait until the child channels are loaded and displayed on the page, and this takes some time. We need to wait until the "Loading..." text is not yet displayed to proceed doing the necessary checking on the child channels.

Also, the "Next" button is only available for clicking when the "Child Channels" has been loaded, so this is also fixed by this PR.

This PR will hopefully fix some of the failures we have in cucumber for Uyuni on latest runs.

/cc @juliogonzalez 