### PR TITLE
virtualization: completely revert the use of ES6 imports.

### DIFF
--- a/web/html/src/manager/virtualization/guests/edit/guests-edit.js
+++ b/web/html/src/manager/virtualization/guests/edit/guests-edit.js
@@ -1,11 +1,12 @@
 /* eslint-disable */
 // @flow
+
 const React = require("react");
 const PropTypes = React.PropTypes;
 const {Panel} = require("components/panel");
 const MessagesUtils = require("components/messages").Utils;
-const GuestProperties = require('../guest-properties');
-const VirtualizationGuestActionApi = require('../virtualization-guest-action-api');
+const {GuestProperties} = require('../guest-properties');
+const {VirtualizationGuestActionApi} = require('../virtualization-guest-action-api');
 
 
 class GuestsEdit extends React.Component {
@@ -58,4 +59,6 @@ GuestsEdit.propTypes = {
     guest: PropTypes.object.isRequired,
 };
 
-export default GuestsEdit;
+module.exports = {
+  GuestsEdit,
+};

--- a/web/html/src/manager/virtualization/guests/edit/guests-edit.renderer.js
+++ b/web/html/src/manager/virtualization/guests/edit/guests-edit.renderer.js
@@ -1,6 +1,8 @@
 /* eslint-disable */
 // @flow
-const GuestsEdit = require("./guests-edit");
+"use strict";
+
+const {GuestsEdit} = require("./guests-edit");
 const React = require("react");
 const ReactDOM = require("react-dom");
 

--- a/web/html/src/manager/virtualization/guests/guest-properties.js
+++ b/web/html/src/manager/virtualization/guests/guest-properties.js
@@ -1,5 +1,6 @@
 /* eslint-disable */
 // @flow
+
 const React = require("react");
 const ReactDOM = require("react-dom");
 const {SmallPanel} = require("components/panel");
@@ -113,4 +114,6 @@ GuestProperties.propTypes = {
     messages: PropTypes.array,
 };
 
-export default GuestProperties;
+module.exports = {
+  GuestProperties,
+};

--- a/web/html/src/manager/virtualization/guests/list/guests-list.js
+++ b/web/html/src/manager/virtualization/guests/list/guests-list.js
@@ -1,5 +1,6 @@
 /* eslint-disable */
 // @flow
+
 const React = require("react");
 const PropTypes = React.PropTypes;
 const MessageContainer = require("components/messages").Messages;
@@ -12,8 +13,8 @@ const {DeleteDialog} = require("components/dialog/DeleteDialog");
 const {DangerDialog} = require("components/dialog/DangerDialog");
 const {ModalButton} = require("components/dialog/ModalButton");
 const Systems = require("components/systems");
-const VirtualizationGuestActionApi = require('../virtualization-guest-action-api');
-const VirtualizationGuestsListRefreshApi = require('../virtualization-guests-list-refresh-api');
+const {VirtualizationGuestActionApi} = require('../virtualization-guest-action-api');
+const {VirtualizationGuestsListRefreshApi} = require('../virtualization-guests-list-refresh-api');
 
 class GuestsList extends React.Component {
 
@@ -400,4 +401,6 @@ GuestsList.propTypes = {
     is_admin: PropTypes.bool.isRequired,
 };
 
-export default GuestsList;
+module.exports = {
+  GuestsList,
+};

--- a/web/html/src/manager/virtualization/guests/list/guests-list.renderer.js
+++ b/web/html/src/manager/virtualization/guests/list/guests-list.renderer.js
@@ -1,6 +1,8 @@
 /* eslint-disable */
 // @flow
-const GuestsList = require("./guests-list");
+"use strict";
+
+const {GuestsList} = require("./guests-list");
 const ReactDOM = require("react-dom");
 const React = require("react");
 window.pageRenderers = window.pageRenderers || {};

--- a/web/html/src/manager/virtualization/guests/virtualization-guest-action-api.js
+++ b/web/html/src/manager/virtualization/guests/virtualization-guest-action-api.js
@@ -1,5 +1,6 @@
 /* eslint-disable */
 // @flow
+
 const React = require("react");
 const Network = require("utils/network");
 const MessagesUtils = require("components/messages").Utils;
@@ -55,4 +56,7 @@ VirtualizationGuestActionApi.propTypes = {
   bounce: React.PropTypes.string,
   callback: React.PropTypes.func,
 };
-export default VirtualizationGuestActionApi;
+
+module.exports = {
+  VirtualizationGuestActionApi,
+};

--- a/web/html/src/manager/virtualization/guests/virtualization-guests-list-refresh-api.js
+++ b/web/html/src/manager/virtualization/guests/virtualization-guests-list-refresh-api.js
@@ -1,5 +1,6 @@
 /* eslint-disable */
 // @flow
+
 const React = require("react");
 const PropTypes = React.PropTypes;
 const Network = require("utils/network");
@@ -55,4 +56,6 @@ VirtualizationGuestsListRefreshApi.propTypes = {
     refreshInterval: PropTypes.number.isRequired,
 };
 
-export default VirtualizationGuestsListRefreshApi;
+module.exports = {
+  VirtualizationGuestsListRefreshApi,
+};


### PR DESCRIPTION
## What does this PR change?

If using the requires, we need to get rid of the exports in components. Fixes PR #115

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: implementation detail

- [X] **DONE**

## Test coverage
- No tests: already the test suite covering this

- [X] **DONE**

## Links

- [X] **DONE**
