### PR TITLE
Manager - improve performance apply errata bsc 1106430

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Errata_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Errata_queries.xml
@@ -1424,17 +1424,6 @@ ORDER BY UPPER(EK.keyword)
   </query>
 </mode>
 
-<mode name="available_to_org">
-  <query params="eid, org_id">
-SELECT  1
-  FROM  rhnChannelErrata CE
- WHERE  CE.errata_id = :eid
-   AND  CE.channel_id IN(SELECT channel_id
-                           FROM rhnAvailableChannels
-                          WHERE org_id = :org_id)
-  </query>
-</mode>
-
 <mode name="channel_errata_for_list" class="com.redhat.rhn.frontend.dto.ErrataOverview">
   <query params="cid">
  SELECT DISTINCT E.id,

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/ssm_operation_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/ssm_operation_queries.xml
@@ -136,9 +136,9 @@
                FROM rhnSet s
               WHERE label = :set_label
                 AND user_id = :user_id
-                AND s.element NOT IN
+                AND NOT EXISTS
                     (
-                    SELECT sos.server_id
+                    SELECT 1
                       FROM rhnSsmOperationServer sos
                      WHERE sos.operation_id = :op_id
                        AND sos.server_id = s.element

--- a/java/code/src/com/redhat/rhn/domain/errata/ErrataFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/errata/ErrataFactory.java
@@ -69,7 +69,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * ErrataFactory - the singleton class used to fetch and store

--- a/java/code/src/com/redhat/rhn/domain/errata/impl/PublishedErrata.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/errata/impl/PublishedErrata.hbm.xml
@@ -245,4 +245,23 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         <return-scalar column="restart_suggested" type="boolean" />
     </sql-query>
 
+    <sql-query name="PublishedErrata.listAvailableToOrgByIds">
+        <![CDATA[SELECT E.*, 0 as clazz_
+                 FROM rhnErrata as E
+                 WHERE E.id in (:eids)
+                     AND (E.org_id = :orgId
+                          OR EXISTS (SELECT 1
+                                     FROM WEB_CUSTOMER ORG
+                                     INNER JOIN rhnTrustedOrgs TORG ON ORG.id = TORG.org_id
+                                     WHERE ORG.id = :orgId
+                                         AND E.org_id = TORG.org_trust_id)
+                          OR EXISTS (SELECT 1
+                                     FROM rhnAvailableChannels AC,
+                                     rhnChannelErrata CE
+                                     WHERE CE.errata_id = E.id
+                                         AND CE.channel_id = AC.channel_id
+                                         AND AC.org_id = :orgId))
+                          ]]>
+        <return alias="E" class="com.redhat.rhn.domain.errata.impl.PublishedErrata" />
+    </sql-query>
 </hibernate-mapping>

--- a/java/code/src/com/redhat/rhn/domain/errata/impl/UnpublishedErrata.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/errata/impl/UnpublishedErrata.hbm.xml
@@ -91,4 +91,17 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                  where c.original = :original
                  and c.org = :org]]>
     </query>
+    <sql-query name="UnpublishedErrata.listAvailableToOrgByIds">
+        <![CDATA[SELECT E.*, 0 as clazz_
+                 FROM rhnErrataTmp as E
+                 WHERE E.id in (:eids)
+                     AND (E.org_id = :orgId
+                          OR EXISTS (SELECT 1
+                                     FROM WEB_CUSTOMER ORG
+                                     INNER JOIN rhnTrustedOrgs TORG ON ORG.id = TORG.org_id
+                                     WHERE ORG.id = :orgId
+                                         AND E.org_id = TORG.org_trust_id))
+                          ]]>
+        <return alias="E" class="com.redhat.rhn.domain.errata.impl.UnpublishedErrata" />
+    </sql-query>
 </hibernate-mapping>

--- a/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
@@ -57,6 +57,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
@@ -346,6 +347,26 @@ public class ServerFactory extends HibernateFactory {
         }
 
         return null;
+    }
+
+    /**
+     * Retrieves the ids of the unscheduled erratas for a given set of servers
+     * @param serverIds the ids of the servers
+     * @return the ids of the erratas grouped by server id
+     */
+    public static Map<Long, List<Long>> findUnscheduledErrataByServerIds(User user, List<Long> serverIds) {
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("user_id", user.getId());
+
+        List<Object[]> result = (singleton.listObjectsByNamedQuery("Server.findUnscheduledErrataByServerIds",
+                params, serverIds, "serverIds"));
+
+        return result.stream().collect(
+                Collectors.groupingBy(
+                        row -> Long.valueOf(row[0].toString()),
+                        Collectors.mapping(row -> Long.valueOf(row[1].toString()), Collectors.toList())
+                        )
+                );
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
@@ -57,7 +57,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;

--- a/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
@@ -349,6 +349,18 @@ public class ServerFactory extends HibernateFactory {
     }
 
     /**
+     * Lookup a list of servers by their ids
+     * @param serverIds the server ids to search for
+     * @param org the organization who owns the server
+     * @return the list of servers
+     */
+    public static List<Server> lookupByIdsAndOrg(Set<Long> serverIds, Org org) {
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("orgId", org.getId());
+        return singleton.listObjectsByNamedQuery("Server.findByIdsAndOrgId", params, serverIds, "serverIds");
+    }
+
+    /**
      * Lookup a Server by their id
      * @param id the id to search for
      * @param orgIn Org who owns the server

--- a/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
@@ -382,6 +382,17 @@ public class ServerFactory extends HibernateFactory {
     }
 
     /**
+     * Retrieves the ids of the non-zypper traditional clients given a set of server ids
+     * @param ids the server ids to search for
+     * @return the list of non-zypper server ids
+     */
+    public static List<Long> findNonZypperTradClientsIds(Set<Long> ids) {
+        Map<String, Object> params = new HashMap<String, Object>();
+        return singleton.listObjectsByNamedQuery("Server.findNonZypperTradClientsIds", params, ids,
+                "serverIds");
+    }
+
+    /**
      * Lookup a Server by their id
      * @param id the id to search for
      * @param orgIn Org who owns the server

--- a/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
@@ -351,6 +351,7 @@ public class ServerFactory extends HibernateFactory {
 
     /**
      * Retrieves the ids of the unscheduled erratas for a given set of servers
+     * @param user the ids of the servers
      * @param serverIds the ids of the servers
      * @return the ids of the erratas grouped by server id
      */

--- a/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
@@ -341,6 +341,27 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
     ]]>
     </query>
 
+    <sql-query name="Server.findUnscheduledErrataByServerIds">
+        <return-scalar column="serverId" type="long"/>
+        <return-scalar column="errataId" type="long"/>
+        <![CDATA[SELECT SNPC.server_id as serverId, E.id as errataId
+                 FROM rhnErrata E, rhnServerNeededErrataCache SNPC
+                 WHERE EXISTS (SELECT 1
+                               FROM rhnUserServerPerms USP
+                               WHERE USP.user_id = :user_id AND USP.server_id = SNPC.server_id)
+                     AND SNPC.server_id in (:serverIds)
+                     AND SNPC.errata_id = E.id
+                     AND NOT EXISTS (SELECT 1
+                                     FROM rhnActionErrataUpdate AEU, rhnServerAction SA, rhnActionStatus AST
+                                     WHERE SA.server_id = SNPC.server_id
+                                         AND SA.status = AST.id
+                                         AND AST.name IN('Queued', 'Picked Up')
+                                         AND AEU.action_id = SA.action_id
+                                         AND AEU.errata_id = E.id )
+                 ORDER BY E.id
+        ]]>
+    </sql-query>
+    
     <sql-query name="Server.serverIdVirtualHostManagerId">
         <return-scalar column="server_id" type="long"/>
         <return-scalar column="vhmserver_id" type="long"/>

--- a/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
@@ -341,6 +341,20 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
     ]]>
     </query>
 
+    <query name="Server.findNonZypperTradClientsIds">
+        <![CDATA[SELECT s.id
+                 FROM Server s
+                 WHERE s.class != com.redhat.rhn.domain.server.MinionServer
+                     AND s.id in (:serverIds)
+                     AND NOT EXISTS (SELECT 1
+                                     FROM com.redhat.rhn.domain.server.InstalledPackage as p
+                                     JOIN p.name as n 
+                                     JOIN p.server as s2
+                                     WHERE s.id = s2.id
+                                         AND n.name = 'zypper')
+        ]]>
+    </query>
+    
     <sql-query name="Server.findUnscheduledErrataByServerIds">
         <return-scalar column="serverId" type="long"/>
         <return-scalar column="errataId" type="long"/>

--- a/java/code/src/com/redhat/rhn/frontend/action/errata/ErrataConfirmAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/errata/ErrataConfirmAction.java
@@ -43,11 +43,12 @@ import org.apache.struts.action.ActionMessage;
 import org.apache.struts.action.ActionMessages;
 import org.apache.struts.action.DynaActionForm;
 
-import java.util.Collections;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import static java.util.Collections.singletonList;
 
 /**
  * ErrataConfirmAction
@@ -130,7 +131,7 @@ public class ErrataConfirmAction extends RhnListDispatchAction {
             ActionManager.storeAction(update);
             try {
                 TASKOMATIC_API.scheduleActionExecution(update);
-                MinionActionManager.scheduleStagingJobsForMinions(Collections.singletonList(update), user);
+                MinionActionManager.scheduleStagingJobsForMinions(singletonList(update), user);
             }
             catch (TaskomaticApiException e) {
                 log.error("Could not schedule errata application:");

--- a/java/code/src/com/redhat/rhn/frontend/action/errata/ErrataConfirmAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/errata/ErrataConfirmAction.java
@@ -43,6 +43,7 @@ import org.apache.struts.action.ActionMessage;
 import org.apache.struts.action.ActionMessages;
 import org.apache.struts.action.DynaActionForm;
 
+import java.util.Collections;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
@@ -129,7 +130,7 @@ public class ErrataConfirmAction extends RhnListDispatchAction {
             ActionManager.storeAction(update);
             try {
                 TASKOMATIC_API.scheduleActionExecution(update);
-                MinionActionManager.scheduleStagingJobsForMinions(update, user);
+                MinionActionManager.scheduleStagingJobsForMinions(Collections.singletonList(update), user);
             }
             catch (TaskomaticApiException e) {
                 log.error("Could not schedule errata application:");

--- a/java/code/src/com/redhat/rhn/manager/action/ActionChainManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionChainManager.java
@@ -622,7 +622,7 @@ public class ActionChainManager {
                 taskomaticApi.scheduleActionExecution(action);
             }
             if (ActionFactory.TYPE_PACKAGES_UPDATE.equals(type)) {
-                MinionActionManager.scheduleStagingJobsForMinions(action, user);
+                MinionActionManager.scheduleStagingJobsForMinions(Collections.singletonList(action), user);
             }
         }
         else {
@@ -636,7 +636,7 @@ public class ActionChainManager {
                     nextSortOrder);
                 result.add(action);
                 if (ActionFactory.TYPE_PACKAGES_UPDATE.equals(type)) {
-                    MinionActionManager.scheduleStagingJobsForMinions(action, user);
+                    MinionActionManager.scheduleStagingJobsForMinions(Collections.singletonList(action), user);
                 }
             }
         }

--- a/java/code/src/com/redhat/rhn/manager/action/ActionChainManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionChainManager.java
@@ -59,6 +59,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static java.util.Collections.singletonList;
+
 /**
  * An ActionManager companion to deal with Action Chains.
  *
@@ -622,7 +624,7 @@ public class ActionChainManager {
                 taskomaticApi.scheduleActionExecution(action);
             }
             if (ActionFactory.TYPE_PACKAGES_UPDATE.equals(type)) {
-                MinionActionManager.scheduleStagingJobsForMinions(Collections.singletonList(action), user);
+                MinionActionManager.scheduleStagingJobsForMinions(singletonList(action), user);
             }
         }
         else {
@@ -636,7 +638,7 @@ public class ActionChainManager {
                     nextSortOrder);
                 result.add(action);
                 if (ActionFactory.TYPE_PACKAGES_UPDATE.equals(type)) {
-                    MinionActionManager.scheduleStagingJobsForMinions(Collections.singletonList(action), user);
+                    MinionActionManager.scheduleStagingJobsForMinions(singletonList(action), user);
                 }
             }
         }

--- a/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
@@ -95,6 +95,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1872,7 +1873,7 @@ public class ActionManager extends BaseManager {
         addPackageActionDetails(Arrays.asList(action), pkgs);
         taskomaticApi.scheduleActionExecution(action);
         if (ActionFactory.TYPE_PACKAGES_UPDATE.equals(type)) {
-            MinionActionManager.scheduleStagingJobsForMinions(action, scheduler);
+            MinionActionManager.scheduleStagingJobsForMinions(Collections.singletonList(action), scheduler);
         }
 
         return action;

--- a/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
@@ -95,7 +95,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -107,6 +106,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.suse.manager.utils.MinionServerUtils.isMinionServer;
+import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
@@ -1873,7 +1873,7 @@ public class ActionManager extends BaseManager {
         addPackageActionDetails(Arrays.asList(action), pkgs);
         taskomaticApi.scheduleActionExecution(action);
         if (ActionFactory.TYPE_PACKAGES_UPDATE.equals(type)) {
-            MinionActionManager.scheduleStagingJobsForMinions(Collections.singletonList(action), scheduler);
+            MinionActionManager.scheduleStagingJobsForMinions(singletonList(action), scheduler);
         }
 
         return action;

--- a/java/code/src/com/redhat/rhn/manager/action/MinionActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/MinionActionManager.java
@@ -31,7 +31,9 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 
@@ -121,6 +123,7 @@ public class MinionActionManager {
                 if (!stagingWindowIsAlreadyEnded && stagingWindowStartIsBeforeAction &&
                         (stagingWindowEndTime.isBefore(earliestAction) ||
                                 stagingWindowEndTime.isEqual(earliestAction))) {
+                    Map<Long, Date> minionScheduleDate = new HashMap<>();
                     for (Long minionServerId : minionServerIds) {
                         ZonedDateTime stagingTime =
                                 stagingWindowStartTime.plus(
@@ -137,10 +140,13 @@ public class MinionActionManager {
                                     action.getId() + "): " +
                                     "scheduling staging job for minion server id: " +
                                     minionServerId + " at " + stagingTime);
-                            taskomaticApi.scheduleStagingJob(action.getId(), minionServerId,
-                                    Date.from(stagingTime.toInstant()));
+                            minionScheduleDate.put(minionServerId, Date.from(stagingTime.toInstant()));
                             ret.add(stagingTime);
                         }
+                    }
+
+                    if (!minionScheduleDate.isEmpty()) {
+                       taskomaticApi.scheduleStagingJobs(action.getId(), minionScheduleDate);
                     }
                 }
             }

--- a/java/code/src/com/redhat/rhn/manager/action/test/MinionActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/action/test/MinionActionManagerTest.java
@@ -45,6 +45,9 @@ import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 import com.redhat.rhn.testing.ServerTestUtils;
 
+import org.hamcrest.Matcher;
+import org.hamcrest.collection.IsMapContaining;
+import org.hamcrest.core.AllOf;
 import org.jmock.Expectations;
 import org.jmock.lib.legacy.ClassImposteriser;
 
@@ -56,6 +59,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -100,13 +104,14 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
         MinionActionManager.setTaskomaticApi(taskomaticMock);
 
         SystemHandler handler = new SystemHandler();
-
         context().checking(new Expectations() { {
+            Matcher<Map<Long, Date>> mapMatcher =
+                    AllOf.allOf(
+                            IsMapContaining.hasKey(minion1.getId())
+                    );
             exactly(1).of(taskomaticMock)
                     .scheduleActionExecution(with(any(Action.class)));
-            exactly(1).of(taskomaticMock).scheduleStagingJob(with(any(Long.class)),
-                    with(minion1.getId()),
-                    with(any(Date.class)));
+            exactly(1).of(taskomaticMock).scheduleStagingJobs(with(any(Long.class)), with(mapMatcher));
         } });
 
         DataResult dr = ActionManager.recentlyScheduledActions(user, null, 30);
@@ -149,11 +154,13 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
         SystemHandler handler = new SystemHandler();
 
         context().checking(new Expectations() { {
+            Matcher<Map<Long, Date>> mapMatcher =
+                    AllOf.allOf(
+                            IsMapContaining.hasKey(minion1.getId())
+                    );
             exactly(1).of(taskomaticMock)
                     .scheduleActionExecution(with(any(Action.class)));
-            exactly(1).of(taskomaticMock).scheduleStagingJob(with(any(Long.class)),
-                    with(minion1.getId()),
-                    with(any(Date.class)));
+            exactly(1).of(taskomaticMock).scheduleStagingJobs(with(any(Long.class)), with(mapMatcher));
         } });
 
         DataResult dr = ActionManager.recentlyScheduledActions(user, null, 30);
@@ -246,11 +253,13 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
         SystemHandler handler = new SystemHandler();
 
         context().checking(new Expectations() { {
+            Matcher<Map<Long, Date>> mapMatcher =
+                    AllOf.allOf(
+                            IsMapContaining.hasKey(minion1.getId())
+                    );
             exactly(1).of(taskomaticMock)
                     .scheduleActionExecution(with(any(Action.class)));
-            exactly(1).of(taskomaticMock).scheduleStagingJob(with(any(Long.class)),
-                    with(minion1.getId()),
-                    with(any(Date.class)));
+            exactly(1).of(taskomaticMock).scheduleStagingJobs(with(any(Long.class)), with(mapMatcher));
         } });
 
         DataResult dr = ActionManager.recentlyScheduledActions(user, null, 30);
@@ -344,14 +353,14 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
         MinionActionManager.setTaskomaticApi(taskomaticMock);
 
         context().checking(new Expectations() { {
+            Matcher<Map<Long, Date>> mapMatcher =
+                    AllOf.allOf(
+                            IsMapContaining.hasKey(minion1.getId()),
+                            IsMapContaining.hasKey(minion2.getId())
+                    );
             exactly(1).of(taskomaticMock)
                     .scheduleActionExecution(with(any(Action.class)));
-            exactly(1).of(taskomaticMock).scheduleStagingJob(with(any(Long.class)),
-                    with(minion1.getId()),
-                    with(any(Date.class)));
-            exactly(1).of(taskomaticMock).scheduleStagingJob(with(any(Long.class)),
-                    with(minion2.getId()),
-                    with(any(Date.class)));
+            exactly(1).of(taskomaticMock).scheduleStagingJobs(with(any(Long.class)),with(mapMatcher));
         } });
 
         ActionChainManager.schedulePackageInstalls(user,
@@ -405,11 +414,13 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
         MinionActionManager.setTaskomaticApi(taskomaticMock);
 
         context().checking(new Expectations() { {
+            Matcher<Map<Long, Date>> mapMatcher =
+                    AllOf.allOf(
+                            IsMapContaining.hasKey(server1.getId())
+                    );
             exactly(1).of(taskomaticMock)
-                    .scheduleActionExecution(with(any(Action.class)));
-            exactly(1).of(taskomaticMock).scheduleStagingJob(with(any(Long.class)),
-                    with(server1.getId()),
-                    with(any(Date.class)));
+                    .scheduleActionExecution(with(any(Action.class)),with(any(Boolean.class)),with(any(Boolean.class)));
+            exactly(1).of(taskomaticMock).scheduleStagingJobs(with(any(Long.class)), with(mapMatcher));
         } });
         HibernateFactory.getSession().flush();
         ErrataManager.applyErrata(user, errataIds,
@@ -461,11 +472,13 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
         MinionActionManager.setTaskomaticApi(taskomaticMock);
 
         context().checking(new Expectations() { {
+            Matcher<Map<Long, Date>> mapMatcher =
+                    AllOf.allOf(
+                            IsMapContaining.hasKey(server1.getId())
+                    );
             exactly(1).of(taskomaticMock)
-                    .scheduleActionExecution(with(any(Action.class)));
-            exactly(1).of(taskomaticMock).scheduleStagingJob(with(any(Long.class)),
-                    with(server1.getId()),
-                    with(any(Date.class)));
+                    .scheduleActionExecution(with(any(Action.class)),with(any(Boolean.class)),with(any(Boolean.class)));
+            exactly(1).of(taskomaticMock).scheduleStagingJobs(with(any(Long.class)), with(mapMatcher));
         } });
         HibernateFactory.getSession().flush();
         ErrataManager.applyErrata(user, errataIds,
@@ -521,11 +534,13 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
         MinionActionManager.setTaskomaticApi(taskomaticMock);
 
         context().checking(new Expectations() { {
+            Matcher<Map<Long, Date>> mapMatcher =
+                    AllOf.allOf(
+                            IsMapContaining.hasKey(server1.getId())
+                    );
             exactly(1).of(taskomaticMock)
-                    .scheduleActionExecution(with(any(Action.class)));
-            exactly(1).of(taskomaticMock).scheduleStagingJob(with(any(Long.class)),
-                    with(server1.getId()),
-                    with(any(Date.class)));
+                    .scheduleActionExecution(with(any(Action.class)),with(any(Boolean.class)),with(any(Boolean.class)));
+            exactly(1).of(taskomaticMock).scheduleStagingJobs(with(any(Long.class)), with(mapMatcher));
         } });
         HibernateFactory.getSession().flush();
         ErrataManager.applyErrata(user, errataIds,
@@ -586,11 +601,13 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
         MinionActionManager.setTaskomaticApi(taskomaticMock);
 
         context().checking(new Expectations() { {
+            Matcher<Map<Long, Date>> mapMatcher =
+                    AllOf.allOf(
+                            IsMapContaining.hasKey(server1.getId())
+                    );
             exactly(1).of(taskomaticMock)
-                    .scheduleActionExecution(with(any(Action.class)));
-            never(taskomaticMock).scheduleStagingJob(with(any(Long.class)),
-                    with(server1.getId()),
-                    with(any(Date.class)));
+                    .scheduleActionExecution(with(any(Action.class)),with(any(Boolean.class)),with(any(Boolean.class)));
+            never(taskomaticMock).scheduleStagingJobs(with(any(Long.class)), with(mapMatcher));
         } });
         HibernateFactory.getSession().flush();
         ErrataManager.applyErrata(user, errataIds,
@@ -642,7 +659,7 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
 
         context().checking(new Expectations() { {
             exactly(1).of(taskomaticMock)
-                    .scheduleActionExecution(with(any(Action.class)));
+                    .scheduleActionExecution(with(any(Action.class)), with(any(Boolean.class)), with(any(Boolean.class)));
             never(taskomaticMock).scheduleStagingJob(with(any(Long.class)),
                     with(server1.getId()),
                     with(any(Date.class)));
@@ -682,12 +699,12 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
         MinionActionManager.setTaskomaticApi(taskomaticMock);
 
         context().checking(new Expectations() { {
-            exactly(1).of(taskomaticMock).scheduleStagingJob(with(action.getId()),
-                    with(minion1.getId()),
-                    with(any(Date.class)));
-            exactly(1).of(taskomaticMock).scheduleStagingJob(with(action.getId()),
-                    with(minion2.getId()),
-                    with(any(Date.class)));
+            Matcher<Map<Long, Date>> mapMatcher =
+                    AllOf.allOf(
+                            IsMapContaining.hasKey(minion1.getId()),
+                            IsMapContaining.hasKey(minion2.getId())
+                    );
+            exactly(1).of(taskomaticMock).scheduleStagingJobs(with(any(Long.class)), with(mapMatcher));
         } });
 
         List<ZonedDateTime> scheduleTimes =

--- a/java/code/src/com/redhat/rhn/manager/action/test/MinionActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/action/test/MinionActionManagerTest.java
@@ -46,6 +46,7 @@ import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 import com.redhat.rhn.testing.ServerTestUtils;
 
 import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
 import org.hamcrest.collection.IsMapContaining;
 import org.hamcrest.core.AllOf;
 import org.jmock.Expectations;
@@ -55,12 +56,15 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
 
 /**
  * JUnit test case for the MinionActionManager
@@ -105,13 +109,13 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
 
         SystemHandler handler = new SystemHandler();
         context().checking(new Expectations() { {
-            Matcher<Map<Long, Date>> mapMatcher =
-                    AllOf.allOf(
-                            IsMapContaining.hasKey(minion1.getId())
-                    );
+            Matcher<Map<Long, ZonedDateTime>> minionMatcher =
+                    AllOf.allOf(IsMapContaining.hasKey(minion1.getId()));
+            Matcher<Map<Long, Map<Long, ZonedDateTime>>> actionsMatcher =
+                    AllOf.allOf(IsMapContaining.hasEntry(any(Long.class), minionMatcher));
             exactly(1).of(taskomaticMock)
                     .scheduleActionExecution(with(any(Action.class)));
-            exactly(1).of(taskomaticMock).scheduleStagingJobs(with(any(Long.class)), with(mapMatcher));
+            exactly(1).of(taskomaticMock).scheduleStagingJobs(with(actionsMatcher));
         } });
 
         DataResult dr = ActionManager.recentlyScheduledActions(user, null, 30);
@@ -154,13 +158,13 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
         SystemHandler handler = new SystemHandler();
 
         context().checking(new Expectations() { {
-            Matcher<Map<Long, Date>> mapMatcher =
-                    AllOf.allOf(
-                            IsMapContaining.hasKey(minion1.getId())
-                    );
+            Matcher<Map<Long, ZonedDateTime>> minionMatcher =
+                    AllOf.allOf(IsMapContaining.hasKey(minion1.getId()));
+            Matcher<Map<Long, Map<Long, ZonedDateTime>>> actionsMatcher =
+                    AllOf.allOf(IsMapContaining.hasEntry(any(Long.class), minionMatcher));
             exactly(1).of(taskomaticMock)
                     .scheduleActionExecution(with(any(Action.class)));
-            exactly(1).of(taskomaticMock).scheduleStagingJobs(with(any(Long.class)), with(mapMatcher));
+            exactly(1).of(taskomaticMock).scheduleStagingJobs(with(actionsMatcher));
         } });
 
         DataResult dr = ActionManager.recentlyScheduledActions(user, null, 30);
@@ -251,16 +255,15 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
         MinionActionManager.setTaskomaticApi(taskomaticMock);
 
         SystemHandler handler = new SystemHandler();
-
-        context().checking(new Expectations() { {
-            Matcher<Map<Long, Date>> mapMatcher =
-                    AllOf.allOf(
-                            IsMapContaining.hasKey(minion1.getId())
-                    );
+        context().checking(new Expectations() {{
+            Matcher<Map<Long, ZonedDateTime>> minionMatcher =
+                    AllOf.allOf(IsMapContaining.hasKey(minion1.getId()));
+            Matcher<Map<Long, Map<Long, ZonedDateTime>>> actionsMatcher =
+                    AllOf.allOf(IsMapContaining.hasEntry(any(Long.class), minionMatcher));
             exactly(1).of(taskomaticMock)
                     .scheduleActionExecution(with(any(Action.class)));
-            exactly(1).of(taskomaticMock).scheduleStagingJobs(with(any(Long.class)), with(mapMatcher));
-        } });
+            exactly(1).of(taskomaticMock).scheduleStagingJobs(with(actionsMatcher));
+        }});
 
         DataResult dr = ActionManager.recentlyScheduledActions(user, null, 30);
         int preScheduleSize = dr.size();
@@ -353,15 +356,14 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
         MinionActionManager.setTaskomaticApi(taskomaticMock);
 
         context().checking(new Expectations() { {
-            Matcher<Map<Long, Date>> mapMatcher =
-                    AllOf.allOf(
-                            IsMapContaining.hasKey(minion1.getId()),
-                            IsMapContaining.hasKey(minion2.getId())
-                    );
+            Matcher<Map<Long, ZonedDateTime>> minionMatcher =
+                    AllOf.allOf(IsMapContaining.hasKey(minion1.getId()), IsMapContaining.hasKey(minion2.getId()));
+            Matcher<Map<Long, Map<Long, ZonedDateTime>>> actionsMatcher =
+                    AllOf.allOf(IsMapContaining.hasEntry(any(Long.class), minionMatcher));
             exactly(1).of(taskomaticMock)
                     .scheduleActionExecution(with(any(Action.class)));
-            exactly(1).of(taskomaticMock).scheduleStagingJobs(with(any(Long.class)),with(mapMatcher));
-        } });
+            exactly(1).of(taskomaticMock).scheduleStagingJobs(with(actionsMatcher));
+       } });
 
         ActionChainManager.schedulePackageInstalls(user,
                 Arrays.asList(minion1.getId(), minion2.getId()), null,
@@ -412,15 +414,14 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
         TaskomaticApi taskomaticMock = mock(TaskomaticApi.class);
         ErrataManager.setTaskomaticApi(taskomaticMock);
         MinionActionManager.setTaskomaticApi(taskomaticMock);
-
         context().checking(new Expectations() { {
-            Matcher<Map<Long, Date>> mapMatcher =
-                    AllOf.allOf(
-                            IsMapContaining.hasKey(server1.getId())
-                    );
+            Matcher<Map<Long, ZonedDateTime>> minionMatcher =
+                    AllOf.allOf(IsMapContaining.hasKey(server1.getId()));
+            Matcher<Map<Long, Map<Long, ZonedDateTime>>> actionsMatcher =
+                    AllOf.allOf(IsMapContaining.hasEntry(any(Long.class), minionMatcher));
             exactly(1).of(taskomaticMock)
-                    .scheduleActionExecution(with(any(Action.class)),with(any(Boolean.class)),with(any(Boolean.class)));
-            exactly(1).of(taskomaticMock).scheduleStagingJobs(with(any(Long.class)), with(mapMatcher));
+                    .scheduleActionsExecution(with(any(List.class)),with(any(Boolean.class)),with(any(Boolean.class)));
+            exactly(1).of(taskomaticMock).scheduleStagingJobs(with(actionsMatcher));
         } });
         HibernateFactory.getSession().flush();
         ErrataManager.applyErrata(user, errataIds,
@@ -472,13 +473,13 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
         MinionActionManager.setTaskomaticApi(taskomaticMock);
 
         context().checking(new Expectations() { {
-            Matcher<Map<Long, Date>> mapMatcher =
-                    AllOf.allOf(
-                            IsMapContaining.hasKey(server1.getId())
-                    );
+            Matcher<Map<Long, ZonedDateTime>> minionMatcher =
+                    AllOf.allOf(IsMapContaining.hasKey(server1.getId()));
+            Matcher<Map<Long, Map<Long, ZonedDateTime>>> actionsMatcher =
+                    AllOf.allOf(IsMapContaining.hasEntry(any(Long.class), minionMatcher));
             exactly(1).of(taskomaticMock)
-                    .scheduleActionExecution(with(any(Action.class)),with(any(Boolean.class)),with(any(Boolean.class)));
-            exactly(1).of(taskomaticMock).scheduleStagingJobs(with(any(Long.class)), with(mapMatcher));
+                    .scheduleActionsExecution(with(any(List.class)),with(any(Boolean.class)),with(any(Boolean.class)));
+            exactly(1).of(taskomaticMock).scheduleStagingJobs(with(actionsMatcher));
         } });
         HibernateFactory.getSession().flush();
         ErrataManager.applyErrata(user, errataIds,
@@ -534,13 +535,13 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
         MinionActionManager.setTaskomaticApi(taskomaticMock);
 
         context().checking(new Expectations() { {
-            Matcher<Map<Long, Date>> mapMatcher =
-                    AllOf.allOf(
-                            IsMapContaining.hasKey(server1.getId())
-                    );
+            Matcher<Map<Long, ZonedDateTime>> minionMatcher =
+                    AllOf.allOf(IsMapContaining.hasKey(server1.getId()));
+            Matcher<Map<Long, Map<Long, ZonedDateTime>>> actionsMatcher =
+                    AllOf.allOf(IsMapContaining.hasEntry(any(Long.class), minionMatcher));
             exactly(1).of(taskomaticMock)
-                    .scheduleActionExecution(with(any(Action.class)),with(any(Boolean.class)),with(any(Boolean.class)));
-            exactly(1).of(taskomaticMock).scheduleStagingJobs(with(any(Long.class)), with(mapMatcher));
+                    .scheduleActionsExecution(with(any(List.class)),with(any(Boolean.class)),with(any(Boolean.class)));
+            exactly(1).of(taskomaticMock).scheduleStagingJobs(with(actionsMatcher));
         } });
         HibernateFactory.getSession().flush();
         ErrataManager.applyErrata(user, errataIds,
@@ -601,13 +602,13 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
         MinionActionManager.setTaskomaticApi(taskomaticMock);
 
         context().checking(new Expectations() { {
-            Matcher<Map<Long, Date>> mapMatcher =
-                    AllOf.allOf(
-                            IsMapContaining.hasKey(server1.getId())
-                    );
+            Matcher<Map<Long, ZonedDateTime>> minionMatcher =
+                    AllOf.allOf(IsMapContaining.hasKey(server1.getId()));
+            Matcher<Map<Long, Map<Long, ZonedDateTime>>> actionsMatcher =
+                    AllOf.allOf(IsMapContaining.hasEntry(any(Long.class), minionMatcher));
             exactly(1).of(taskomaticMock)
-                    .scheduleActionExecution(with(any(Action.class)),with(any(Boolean.class)),with(any(Boolean.class)));
-            never(taskomaticMock).scheduleStagingJobs(with(any(Long.class)), with(mapMatcher));
+                    .scheduleActionsExecution(with(any(List.class)),with(any(Boolean.class)),with(any(Boolean.class)));
+            never(taskomaticMock).scheduleStagingJobs(with(actionsMatcher));
         } });
         HibernateFactory.getSession().flush();
         ErrataManager.applyErrata(user, errataIds,
@@ -659,7 +660,7 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
 
         context().checking(new Expectations() { {
             exactly(1).of(taskomaticMock)
-                    .scheduleActionExecution(with(any(Action.class)), with(any(Boolean.class)), with(any(Boolean.class)));
+                    .scheduleActionsExecution(with(any(List.class)), with(any(Boolean.class)), with(any(Boolean.class)));
             never(taskomaticMock).scheduleStagingJob(with(any(Long.class)),
                     with(server1.getId()),
                     with(any(Date.class)));
@@ -699,16 +700,19 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
         MinionActionManager.setTaskomaticApi(taskomaticMock);
 
         context().checking(new Expectations() { {
-            Matcher<Map<Long, Date>> mapMatcher =
-                    AllOf.allOf(
-                            IsMapContaining.hasKey(minion1.getId()),
-                            IsMapContaining.hasKey(minion2.getId())
-                    );
-            exactly(1).of(taskomaticMock).scheduleStagingJobs(with(any(Long.class)), with(mapMatcher));
+            Matcher<Map<Long, ZonedDateTime>> minionMatcher =
+                    AllOf.allOf(IsMapContaining.hasKey(minion1.getId()),IsMapContaining.hasKey(minion2.getId()));
+            Matcher<Map<Long, Map<Long, ZonedDateTime>>> actionsMatcher =
+                    AllOf.allOf(IsMapContaining.hasEntry(any(Long.class), minionMatcher));
+            exactly(1).of(taskomaticMock).scheduleStagingJobs(with(actionsMatcher));
         } });
 
+        Map<Long, Map<Long, ZonedDateTime>> actionsDataMap =
+                MinionActionManager.scheduleStagingJobsForMinions(Collections.singletonList(action), user);
         List<ZonedDateTime> scheduleTimes =
-                MinionActionManager.scheduleStagingJobsForMinions(action, user);
+                actionsDataMap.values().stream().map(s -> new ArrayList<>(s.values()))
+                        .flatMap(List::stream).collect(Collectors.toList());
+
         assertEquals(2,
                 scheduleTimes.stream()
                     .filter(scheduleTime -> scheduleTime.isAfter(now))
@@ -755,9 +759,12 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
                     with(minion2.getId()),
                     with(any(Date.class)));
         } });
-
+        Map<Long, Map<Long, ZonedDateTime>> actionsDataMap =
+                MinionActionManager.scheduleStagingJobsForMinions(Collections.singletonList(action), user);
         List<ZonedDateTime> scheduleTimes =
-                MinionActionManager.scheduleStagingJobsForMinions(action, user);
+                actionsDataMap.values().stream().map(s -> new ArrayList<>(s.values()))
+                        .flatMap(List::stream).collect(Collectors.toList());
+
         assertEquals(0,
                 scheduleTimes.stream()
                     .filter(scheduleTime -> scheduleTime.isAfter(now))
@@ -804,9 +811,11 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
                     with(minion2.getId()),
                     with(any(Date.class)));
         } });
-
+        Map<Long, Map<Long, ZonedDateTime>> actionsDataMap =
+                MinionActionManager.scheduleStagingJobsForMinions(Collections.singletonList(action), user);
         List<ZonedDateTime> scheduleTimes =
-                MinionActionManager.scheduleStagingJobsForMinions(action, user);
+                actionsDataMap.values().stream().map(s -> new ArrayList<>(s.values()))
+                        .flatMap(List::stream).collect(Collectors.toList());
         assertEquals(0,
                 scheduleTimes.stream()
                     .filter(scheduleTime -> scheduleTime.isAfter(now))
@@ -855,8 +864,12 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
                     with(any(Date.class)));
         } });
 
+        Map<Long, Map<Long, ZonedDateTime>> actionsDataMap =
+                MinionActionManager.scheduleStagingJobsForMinions(Collections.singletonList(action), user);
         List<ZonedDateTime> scheduleTimes =
-                MinionActionManager.scheduleStagingJobsForMinions(action, user);
+                actionsDataMap.values().stream().map(s -> new ArrayList<>(s.values()))
+                        .flatMap(List::stream).collect(Collectors.toList());
+
         assertEquals(0,
                 scheduleTimes.stream()
                     .filter(scheduleTime -> scheduleTime.isAfter(now))
@@ -904,8 +917,11 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
                     with(any(Date.class)));
         } });
 
+        Map<Long, Map<Long, ZonedDateTime>> actionsDataMap =
+                MinionActionManager.scheduleStagingJobsForMinions(Collections.singletonList(action), user);
         List<ZonedDateTime> scheduleTimes =
-                MinionActionManager.scheduleStagingJobsForMinions(action, user);
+                actionsDataMap.values().stream().map(s -> new ArrayList<>(s.values()))
+                        .flatMap(List::stream).collect(Collectors.toList());
         assertEquals(0,
                 scheduleTimes.stream()
                     .filter(scheduleTime -> scheduleTime.isAfter(now))
@@ -953,8 +969,11 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
                     with(any(Date.class)));
         } });
 
+        Map<Long, Map<Long, ZonedDateTime>> actionsDataMap =
+                MinionActionManager.scheduleStagingJobsForMinions(Collections.singletonList(action), user);
         List<ZonedDateTime> scheduleTimes =
-                MinionActionManager.scheduleStagingJobsForMinions(action, user);
+                actionsDataMap.values().stream().map(s -> new ArrayList<>(s.values()))
+                        .flatMap(List::stream).collect(Collectors.toList());
         assertEquals(0,
                 scheduleTimes.stream()
                     .filter(scheduleTime -> scheduleTime.isAfter(now))
@@ -1001,9 +1020,11 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
                     with(s2.getId()),
                     with(any(Date.class)));
         } });
-
+        Map<Long, Map<Long, ZonedDateTime>> actionsDataMap =
+                MinionActionManager.scheduleStagingJobsForMinions(Collections.singletonList(action), user);
         List<ZonedDateTime> scheduleTimes =
-                MinionActionManager.scheduleStagingJobsForMinions(action, user);
+                actionsDataMap.values().stream().map(s -> new ArrayList<>(s.values()))
+                        .flatMap(List::stream).collect(Collectors.toList());
         assertEquals(0,
                 scheduleTimes.stream()
                     .filter(scheduleTime -> scheduleTime.isAfter(now))

--- a/java/code/src/com/redhat/rhn/manager/action/test/MinionActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/action/test/MinionActionManagerTest.java
@@ -46,7 +46,6 @@ import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 import com.redhat.rhn.testing.ServerTestUtils;
 
 import org.hamcrest.Matcher;
-import org.hamcrest.Matchers;
 import org.hamcrest.collection.IsMapContaining;
 import org.hamcrest.core.AllOf;
 import org.jmock.Expectations;
@@ -58,7 +57,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -420,7 +418,7 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
             Matcher<Map<Long, Map<Long, ZonedDateTime>>> actionsMatcher =
                     AllOf.allOf(IsMapContaining.hasEntry(any(Long.class), minionMatcher));
             exactly(1).of(taskomaticMock)
-                    .scheduleActionsExecution(with(any(List.class)),with(any(Boolean.class)),with(any(Boolean.class)));
+                    .scheduleMinionActionExecutions(with(any(List.class)),with(any(Boolean.class)));
             exactly(1).of(taskomaticMock).scheduleStagingJobs(with(actionsMatcher));
         } });
         HibernateFactory.getSession().flush();
@@ -478,7 +476,7 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
             Matcher<Map<Long, Map<Long, ZonedDateTime>>> actionsMatcher =
                     AllOf.allOf(IsMapContaining.hasEntry(any(Long.class), minionMatcher));
             exactly(1).of(taskomaticMock)
-                    .scheduleActionsExecution(with(any(List.class)),with(any(Boolean.class)),with(any(Boolean.class)));
+                    .scheduleMinionActionExecutions(with(any(List.class)),with(any(Boolean.class)));
             exactly(1).of(taskomaticMock).scheduleStagingJobs(with(actionsMatcher));
         } });
         HibernateFactory.getSession().flush();
@@ -540,7 +538,7 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
             Matcher<Map<Long, Map<Long, ZonedDateTime>>> actionsMatcher =
                     AllOf.allOf(IsMapContaining.hasEntry(any(Long.class), minionMatcher));
             exactly(1).of(taskomaticMock)
-                    .scheduleActionsExecution(with(any(List.class)),with(any(Boolean.class)),with(any(Boolean.class)));
+                    .scheduleMinionActionExecutions(with(any(List.class)),with(any(Boolean.class)));
             exactly(1).of(taskomaticMock).scheduleStagingJobs(with(actionsMatcher));
         } });
         HibernateFactory.getSession().flush();
@@ -607,7 +605,7 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
             Matcher<Map<Long, Map<Long, ZonedDateTime>>> actionsMatcher =
                     AllOf.allOf(IsMapContaining.hasEntry(any(Long.class), minionMatcher));
             exactly(1).of(taskomaticMock)
-                    .scheduleActionsExecution(with(any(List.class)),with(any(Boolean.class)),with(any(Boolean.class)));
+                    .scheduleMinionActionExecutions(with(any(List.class)),with(any(Boolean.class)));
             never(taskomaticMock).scheduleStagingJobs(with(actionsMatcher));
         } });
         HibernateFactory.getSession().flush();
@@ -660,7 +658,7 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
 
         context().checking(new Expectations() { {
             exactly(1).of(taskomaticMock)
-                    .scheduleActionsExecution(with(any(List.class)), with(any(Boolean.class)), with(any(Boolean.class)));
+                    .scheduleMinionActionExecutions(with(any(List.class)), with(any(Boolean.class)));
             never(taskomaticMock).scheduleStagingJob(with(any(Long.class)),
                     with(server1.getId()),
                     with(any(Date.class)));

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -1890,19 +1890,24 @@ public class ErrataManager extends BaseManager {
                 actionChain, errataMap, updateStackMap, serverMap, nonUpdateStackTargets);
         Stream<ErrataAction> minionActions = computeActions(user, earliest,
                 actionChain, errataMap, updateStackMap, serverMap, minionTargets);
-
         // store all actions and return ids
-        List<ErrataAction> errataActions =
+        List<ErrataAction> errataNonMinionActions =
             concat(traditionalYumClientActions,
             concat(updateStackActions,
-            concat(nonUpdateStackActions,
-                   minionActions)))
+            nonUpdateStackActions))
             .collect(toList());
-        List<Long> actionIds = new ArrayList<Long>();
-        for (ErrataAction errataAction : errataActions) {
-            Action action = ActionManager.storeAction(errataAction);
+        List<ErrataAction> errataMinionActions = minionActions.collect(toList());
 
-            taskomaticApi.scheduleActionExecution(action);
+        List<Long> actionIds = new ArrayList<Long>();
+
+        for (ErrataAction errataAction : errataNonMinionActions) {
+            Action action = ActionManager.storeAction(errataAction);
+            actionIds.add(action.getId());
+        }
+        //Taskomatic part is needed only for minionActions
+        for (ErrataAction errataAction : errataMinionActions) {
+            Action action = ActionManager.storeAction(errataAction);
+            taskomaticApi.scheduleActionExecution(action, false, false);
             MinionActionManager.scheduleStagingJobsForMinions(action, user);
             actionIds.add(action.getId());
         }

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -1775,9 +1775,11 @@ public class ErrataManager extends BaseManager {
         // if required, check that all specified errata ids are applicable
         // throw Exception if that's not the case
         if (!onlyRelevant) {
-            boolean allRelevant = errataIds.stream()
-                .allMatch(eid -> serverApplicableErrataMap.values().stream()
-                    .allMatch(eids -> eids.contains(eid)));
+            boolean allRelevant = errataIds.isEmpty() ||
+                    (errataIds.stream()
+                    .allMatch(eid -> serverApplicableErrataMap.values().stream()
+                    .allMatch(eids -> eids.contains(eid))) &&
+                    !serverApplicableErrataMap.isEmpty());
 
             if (!allRelevant) {
                 throw new InvalidErrataException();

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -1824,24 +1824,19 @@ public class ErrataManager extends BaseManager {
             .map(Server::getId)
             .collect(toSet());
 
-        Set<Long> traditionalYumClients = serverMap.entrySet().stream()
-            .filter(e -> !minions.contains(e.getKey()))
-            .filter(e ->
-                PackageFactory.lookupByNameAndServer("zypper", e.getValue()) == null)
-            .map(Map.Entry::getKey)
-            .collect(toSet());
+        List<Long> nonZypperTradClients = ServerFactory.findNonZypperTradClientsIds(serverMap.keySet());
 
         Set<Long> otherServers = serverMap.keySet().stream()
             .filter(sid -> !minions.contains(sid))
-            .filter(sid -> !traditionalYumClients.contains(sid))
+            .filter(sid -> !nonZypperTradClients.contains(sid))
             .collect(toSet());
 
         // 1- compute actions for traditional clients running yum
         // those get one Action per system, per errata (yum is known to have problems)
-        Stream<ErrataAction> traditionalYumClientActions = traditionalYumClients.stream()
+        Stream<ErrataAction> nonZypperTradClientActions = nonZypperTradClients.stream()
             .flatMap(sid -> serverErrataMap.get(sid).stream()
                 .sorted((a, b) -> updateStackMap.get(b).compareTo(updateStackMap.get(a)))
-                .map(eid -> createErrataActionForTraditionalYumClient(user,
+                .map(eid -> createErrataActionForNonZypperTradClient(user,
                     errataMap.get(eid), earliest, actionChain, serverMap.get(sid),
                     updateStackMap.get(eid))
                 )
@@ -1892,7 +1887,7 @@ public class ErrataManager extends BaseManager {
                 actionChain, errataMap, updateStackMap, serverMap, minionTargets);
         // store all actions and return ids
         List<ErrataAction> errataNonMinionActions =
-            concat(traditionalYumClientActions,
+            concat(nonZypperTradClientActions,
             concat(updateStackActions,
             nonUpdateStackActions))
             .collect(toList());
@@ -2062,7 +2057,7 @@ public class ErrataManager extends BaseManager {
     /**
      * Creates one errata action for a server and an errata.
      *
-     * Note that this is used exclusively on yum traditional clients (those are
+     * Note that this is used exclusively on non-zypper traditional clients (those are
      * known not to handle combined upgrades properly).
      *
      * @param user the user
@@ -2073,7 +2068,7 @@ public class ErrataManager extends BaseManager {
      * @param updateStack set to true if this is an update stack update
      * @return list of errata actions
      */
-    private static ErrataAction createErrataActionForTraditionalYumClient(User user,
+    private static ErrataAction createErrataActionForNonZypperTradClient(User user,
             Errata erratum, Date earliest, ActionChain actionChain, Server server,
             boolean updateStack) {
         ErrataAction errataUpdate = (ErrataAction) ActionManager.createErrataAction(

--- a/java/code/src/com/redhat/rhn/manager/errata/test/ErrataManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/test/ErrataManagerTest.java
@@ -512,7 +512,7 @@ public class ErrataManagerTest extends JMockBaseTestCaseWithUser {
         ErrataManager.setTaskomaticApi(taskomaticMock);
 
         context().checking(new Expectations() { {
-            allowing(taskomaticMock).scheduleActionsExecution(with(any(List.class)),with(any(Boolean.class)),with(any(Boolean.class)));
+            allowing(taskomaticMock).scheduleMinionActionExecutions(with(any(List.class)),with(any(Boolean.class)));
         } });
 
         ErrataManager.applyErrata(user, errataIds, new Date(), serverIds);
@@ -1159,7 +1159,7 @@ public class ErrataManagerTest extends JMockBaseTestCaseWithUser {
         ErrataManager.setTaskomaticApi(taskomaticMock);
 
         context().checking(new Expectations() { {
-            allowing(taskomaticMock).scheduleActionsExecution(with(any(List.class)),with(any(Boolean.class)),with(any(Boolean.class)));
+            allowing(taskomaticMock).scheduleMinionActionExecutions(with(any(List.class)),with(any(Boolean.class)));
         } });
 
         ErrataManager.applyErrata(user, errataIds, new Date(), serverIds);
@@ -1262,7 +1262,7 @@ public class ErrataManagerTest extends JMockBaseTestCaseWithUser {
         ErrataManager.setTaskomaticApi(taskomaticMock);
 
         context().checking(new Expectations() { {
-            allowing(taskomaticMock).scheduleActionsExecution(with(any(List.class)),with(any(Boolean.class)),with(any(Boolean.class)));
+            allowing(taskomaticMock).scheduleMinionActionExecutions(with(any(List.class)),with(any(Boolean.class)));
         } });
 
         ErrataManager.applyErrata(user, errataIds, new Date(), serverIds);

--- a/java/code/src/com/redhat/rhn/manager/errata/test/ErrataManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/test/ErrataManagerTest.java
@@ -512,7 +512,7 @@ public class ErrataManagerTest extends JMockBaseTestCaseWithUser {
         ErrataManager.setTaskomaticApi(taskomaticMock);
 
         context().checking(new Expectations() { {
-            allowing(taskomaticMock).scheduleActionExecution(with(any(Action.class)));
+            allowing(taskomaticMock).scheduleActionsExecution(with(any(List.class)),with(any(Boolean.class)),with(any(Boolean.class)));
         } });
 
         ErrataManager.applyErrata(user, errataIds, new Date(), serverIds);
@@ -1159,7 +1159,7 @@ public class ErrataManagerTest extends JMockBaseTestCaseWithUser {
         ErrataManager.setTaskomaticApi(taskomaticMock);
 
         context().checking(new Expectations() { {
-            allowing(taskomaticMock).scheduleActionExecution(with(any(Action.class)));
+            allowing(taskomaticMock).scheduleActionsExecution(with(any(List.class)),with(any(Boolean.class)),with(any(Boolean.class)));
         } });
 
         ErrataManager.applyErrata(user, errataIds, new Date(), serverIds);
@@ -1262,7 +1262,7 @@ public class ErrataManagerTest extends JMockBaseTestCaseWithUser {
         ErrataManager.setTaskomaticApi(taskomaticMock);
 
         context().checking(new Expectations() { {
-            allowing(taskomaticMock).scheduleActionExecution(with(any(Action.class)));
+            allowing(taskomaticMock).scheduleActionsExecution(with(any(List.class)),with(any(Boolean.class)),with(any(Boolean.class)));
         } });
 
         ErrataManager.applyErrata(user, errataIds, new Date(), serverIds);

--- a/java/code/src/com/redhat/rhn/taskomatic/TaskoXmlRpcHandler.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskoXmlRpcHandler.java
@@ -632,8 +632,8 @@ public class TaskoXmlRpcHandler {
     private void checkIfAlreadyScheduled(Integer orgId, String jobLabel)
             throws SchedulerException, InvalidParamException {
         if (!TaskoFactory.listActiveSchedulesByOrgAndLabel(orgId, jobLabel).isEmpty() ||
-                (SchedulerKernel.getScheduler().getTrigger(jobLabel,
-                        TaskoQuartzHelper.getGroupName(orgId)) != null)) {
+                (SchedulerKernel.getScheduler().getTrigger(triggerKey(jobLabel,
+                        TaskoQuartzHelper.getGroupName(orgId))) != null)) {
             throw new InvalidParamException("jobLabel already in use");
         }
     }

--- a/java/code/src/com/redhat/rhn/taskomatic/TaskomaticApi.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskomaticApi.java
@@ -545,6 +545,30 @@ public class TaskomaticApi {
     }
 
     /**
+     * Schedule a staging job for Salt minions.
+     *
+     * @param actionId ID of the action to be executed
+     * @param minionsData scheduling time of staging for each minion
+     * @throws TaskomaticApiException if there was an error
+     */
+    public void scheduleStagingJobs(Long actionId, Map<Long, Date> minionsData) throws TaskomaticApiException {
+
+        List<Map<String, String>> paramsList = new ArrayList<>();
+        minionsData.forEach((minionId, stagingDateTime) -> {
+            Map<String, String> params = new HashMap<String, String>();
+            params.put("action_id", Long.toString(actionId));
+            params.put("staging_job", "true");
+            params.put("staging_job_minion_server_id", Long.toString(minionId));
+            params.put("staging_date_time", stagingDateTime.toInstant().toString());
+            paramsList.add(params);
+
+        });
+        invoke("tasko.scheduleSingleSatBunchRunList", MINION_ACTION_BUNCH_LABEL,
+                MINION_ACTION_JOB_DOWNLOAD_PREFIX + actionId, paramsList);
+    }
+
+
+    /**
      * Schedule an Action execution for Salt minions, without forced
      * package refresh.
      *

--- a/java/code/src/com/redhat/rhn/taskomatic/TaskomaticApi.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskomaticApi.java
@@ -479,19 +479,22 @@ public class TaskomaticApi {
      *
      * @param action the action to be executed
      * @param forcePackageListRefresh is a package list is requested
+     * @param checkIfMinionInvolved check if action involves minions
      * @throws TaskomaticApiException if there was an error
      */
-    public void scheduleActionExecution(Action action, boolean forcePackageListRefresh)
+    public void scheduleActionExecution(Action action, boolean forcePackageListRefresh, boolean checkIfMinionInvolved)
         throws TaskomaticApiException {
-        boolean minionsInvolved = HibernateFactory.getSession()
-            .getNamedQuery("Action.findMinionIds")
-            .setParameter("id", action.getId())
-            .setMaxResults(1)
-            .stream()
-            .findAny()
-            .isPresent();
-        if (!minionsInvolved) {
-            return;
+        if (checkIfMinionInvolved) {
+            boolean minionsInvolved = HibernateFactory.getSession()
+                    .getNamedQuery("Action.findMinionIds")
+                    .setParameter("id", action.getId())
+                    .setMaxResults(1)
+                    .stream()
+                    .findAny()
+                    .isPresent();
+            if (!minionsInvolved) {
+                return;
+            }
         }
 
         Map<String, String> params = new HashMap<String, String>();
@@ -578,6 +581,18 @@ public class TaskomaticApi {
     public void scheduleActionExecution(Action action)
         throws TaskomaticApiException {
         scheduleActionExecution(action, false);
+    }
+
+    /**
+     * Schedule an Action execution for Salt minions.
+     *
+     * @param action the action to be executed
+     * @param forcePackageListRefresh is a package list is requested
+     * @throws TaskomaticApiException if there was an error
+     */
+    public void scheduleActionExecution(Action action, boolean forcePackageListRefresh)
+            throws TaskomaticApiException {
+        scheduleActionExecution(action, forcePackageListRefresh, true);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/taskomatic/TaskomaticApi.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskomaticApi.java
@@ -505,8 +505,11 @@ public class TaskomaticApi {
             params.put("earliest_action", action.getEarliestAction().toInstant().toString());
             paramsList.add(params);
         }
-        invoke("tasko.scheduleSatBunchRunList", MINION_ACTION_BUNCH_LABEL,
-                MINION_ACTION_JOB_PREFIX, paramsList);
+
+        if (!paramsList.isEmpty()) {
+            invoke("tasko.scheduleSatBunchRunList", MINION_ACTION_BUNCH_LABEL,
+                    MINION_ACTION_JOB_PREFIX, paramsList);
+        }
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Different methods have been refactored in tomcat/taskomatic for better performance(bsc#1106430)
 - Do not try cleanup when deleting empty system profiles (bsc#1111247)
 - ActivationKey base and child channel in a reactjs component
 


### PR DESCRIPTION
## What does this PR change?

Improves the performance when scheduling a patching action

The following tests were executed for performance analysis before and after applying the proposed changes:

All the tests were executed with the flag "enabled content staging" in TRUE, and all the tests were executed over a system set of 10.5k minions, which is the size of the systems set, NOT the size of the affected systems.

 Test                                                | Total time BEFORE changes     | Total time AFTER changes     |
|-----------------------------------------------------|----------|----------|
| Patching: 1 patch, ~1.5k affected minions, 1 scheduled action | ~109 minutes | ~1 minute |
| Patching: 500 patches, ~7k affected minions, 712 scheduled actions | ~117 minutes | ~5 minutes |
| Package upgrading: 1 package, ~1.5k affected minions, 1 scheduled actions | ~13 minutes | ~35 seconds |
| Package upgrading: 500 packages, ~3k affected minions, 58 scheduled actions  | ~16 minutes | ~1 minute 20 seconds |

## Documentation
- No documentation needed: Bug fix

- [x] **DONE**

## Test coverage
- No tests: unit test exists already

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/5640
Tracks https://github.com/SUSE/spacewalk/pull/5910 and https://github.com/SUSE/spacewalk/pull/6080

- [x] **DONE**
