### PR TITLE
Increase the Apache proxy timeout to 6 minutes

### DIFF
--- a/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-www.conf
+++ b/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-www.conf
@@ -44,7 +44,7 @@ RewriteRule ^/index\.html$ /rhn/Login.do
 RewriteRule ^/WEBRPC /rhn/rpc/api
 
 # increase timeout on proxy requests
-ProxyTimeout 300
+ProxyTimeout 360
 
 <IfModule proxy_ajp_module>
 <Proxy ajp://localhost:8009>

--- a/spacewalk/config/spacewalk-config.changes
+++ b/spacewalk/config/spacewalk-config.changes
@@ -1,3 +1,4 @@
+- Increase the Apache proxy timeout to 6 minutes
 - fix /etc/sudoers.d/spacewalk file (related to bsc#1099517)
   NOTE: In case there have been custom modifications to this file,
         it will be saved in /root/sudoers-spacewalk.save as sudo


### PR DESCRIPTION
## What does this PR change?
This PR increases to 6 minutes (+1 minute) the `ProxyTimeout` value from the Apache configuration in order to prevent "timeouts" errors on the testsuite when dealing with SCC:



```
08:20:54       Refreshing Channel families                    [DONE]
08:20:54       Refreshing SUSE products                       [FAIL]
08:20:54       	Error: <ProtocolError for uyuni-master-srv.mgr.suse.de:80/rpc/api: 500 Internal Server Error>
```

Then at "/var/log/apache/error_log":
```
[proxy_ajp:error] [pid 30091] (70007)The timeout specified has expired: AH01030: ajp_ilink_receive() can't receive header                                                   
[proxy_ajp:error] [pid 30091] [client 10.162.210.46:33648] AH00992: ajp_read_header: ajp_ilink_receive failed, referer: https://uyuni-master-srv.mgr.suse.de/rhn/admin/setup/MirrorCredentials.do
[proxy_ajp:error] [pid 30091] (70007)The timeout specified has expired: [client 10.162.210.46:33648] AH00893: dialog to [::1]:8009 (localhost) failed, referer: https://uyuni-master-srv.mgr.suse.de/rhn/admin/setup/MirrorCredentials.do
[proxy_ajp:error] [pid 30091] [client 10.162.210.46:33648] AH00877: read zero bytes, expecting 303 bytes, referer: https://uyuni-master-srv.mgr.suse.de/rhn/admin/setup/MirrorCredentials.do
[proxy_ajp:error] [pid 32630] (70007)The timeout specified has expired: AH01030: ajp_ilink_receive() can't receive header
[proxy_ajp:error] [pid 32630] [client 10.162.210.46:33600] AH00992: ajp_read_header: ajp_ilink_receive failed, referer: https://uyuni-master-srv.mgr.suse.de/rhn/admin/setup/MirrorCredentials.do
[proxy_ajp:error] [pid 32630] (70007)The timeout specified has expired: [client 10.162.210.46:33600] AH00893: dialog to [::1]:8009 (localhost) failed, referer: https://uyuni-master-srv.mgr.suse.de/rhn/admin/setup/MirrorCredentials.do
[proxy_ajp:error] [pid 32630] [client 10.162.210.46:33600] AH00877: read zero bytes, expecting 279 bytes, referer: https://uyuni-master-srv.mgr.suse.de/rhn/admin/setup/MirrorCredentials.do
```

## Links

Tracks https://github.com/SUSE/spacewalk/issues/5701

