### PR TITLE
add postgresql-jdbc 9.4 to ivy repo

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -68,7 +68,7 @@
         <dependency org="suse" name="ojdbc7" rev="1.0" />
         <dependency org="suse" name="oro" rev="2.0.8" />
         <dependency org="suse" name="oscache" rev="2.2" />
-        <dependency org="suse" name="postgresql-jdbc" rev="9.3" />
+        <dependency org="suse" name="postgresql-jdbc" rev="9.4" />
         <dependency org="suse" name="quartz" rev="2.3.0" />
         <dependency org="suse" name="redstone-xmlrpc" rev="1.1_20071120" />
         <dependency org="suse" name="redstone-xmlrpc-client" rev="1.1_20071120" />


### PR DESCRIPTION
## What does this PR change?

We use since a longer time now v9.4 which should also go into your ivy repo.

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **internal**

- [x] **DONE**

## Links

Tracks # **add downstream PR, if any**

- [x] **DONE**
