### PR TITLE
Increases Apache "ProxyTimeout" to 10 minutes

### DIFF
--- a/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-www.conf
+++ b/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-www.conf
@@ -44,7 +44,7 @@ RewriteRule ^/index\.html$ /rhn/Login.do
 RewriteRule ^/WEBRPC /rhn/rpc/api
 
 # increase timeout on proxy requests
-ProxyTimeout 360
+ProxyTimeout 600
 
 <IfModule proxy_ajp_module>
 <Proxy ajp://localhost:8009>

--- a/spacewalk/config/spacewalk-config.changes
+++ b/spacewalk/config/spacewalk-config.changes
@@ -1,4 +1,4 @@
-- Increase the Apache proxy timeout to 6 minutes
+- Increase the Apache proxy timeout to 10 minutes
 - fix /etc/sudoers.d/spacewalk file (related to bsc#1099517)
   NOTE: In case there have been custom modifications to this file,
         it will be saved in /root/sudoers-spacewalk.save as sudo


### PR DESCRIPTION
## What does this PR change?
This PR increases the Apache "ProxyTimeout" to 10 minutes in order to be on the safe side and to prevent timeouts when CPU is heavily used: syncing packages + products page, or multiple requested products pages, etc.

Along with these changes, we've also increased the number of CPUs for the uyuni server on the testsuite which is running with less CPU resources than for SUSE Manager.

I'm still investigating if there is some kind of process or DB lock that might be also affecting here, but I was able to reproduce the timeouts locally (with 2 vcpu) when opening multiple instances of the "Admin -> Products" page at the same time, then CPU starts burning (100%) and requests time starts taking longer until they reach the timeouts, so not sure if there is actually a lock here.

/cc @moio @mcalmer 

