### PR TITLE
Testsuite: Wait until no 'pending' minions to avoid failures on Remote Commands

### DIFF
--- a/testsuite/features/core_min_bootstrap.feature
+++ b/testsuite/features/core_min_bootstrap.feature
@@ -106,8 +106,9 @@ Feature: Be able to bootstrap a Salt minion via the GUI
     When I enter command "file /tmp"
     And I click on preview
     Then I should see "sle-minion" hostname
+    And I wait until I do not see "pending" text
     When I click on run
-    And I wait for "3" seconds
+    And I wait until I do not see "pending" text
     And I expand the results for "sle-minion"
     Then I should see "/tmp: sticky, directory" in the command output for "sle-minion"
 


### PR DESCRIPTION
## What does this PR change?
This PR fixes a testsuite scenario that sometimes fails because the testsuite is not explicitly waiting until there are no pending minions and the "run" button is shown:

```
10:19:06   Scenario: Run a remote command on normal SLES minion                                 # features/core_min_bootstrap.feature:101
10:19:06       This scenario ran at: 2018-10-16 12:19:04 +0200
10:19:06     Given I am authorized as "testing" with password "testing"                         # features/step_definitions/navigation_steps.rb:381
10:19:06     When I follow "Salt"                                                               # features/step_definitions/navigation_steps.rb:203
10:19:08     And I follow "Remote Commands"                                                     # features/step_definitions/navigation_steps.rb:203
10:19:08     Then I should see a "Remote Commands" text                                         # features/step_definitions/navigation_steps.rb:467
10:19:08     When I enter command "file /tmp"                                                   # features/step_definitions/salt_steps.rb:206
10:19:08     And I click on preview                                                             # features/step_definitions/salt_steps.rb:170
10:19:09     Then I should see "sle-minion" hostname                                            # features/step_definitions/salt_steps.rb:191
10:23:19     When I click on run                                                                # features/step_definitions/salt_steps.rb:174
10:23:19       Run button not found (RuntimeError)
10:23:19       ./features/step_definitions/salt_steps.rb:187:in `rescue in block in <top (required)>'
10:23:19       ./features/step_definitions/salt_steps.rb:175:in `/^I click on run$/'
10:23:19       features/core_min_bootstrap.feature:109:in `When I click on run'
10:23:19     And I wait for "3" seconds                                                         # features/step_definitions/common_steps.rb:12
10:23:19     And I expand the results for "sle-minion"                                          # features/step_definitions/salt_steps.rb:201
10:23:19     Then I should see "/tmp: sticky, directory" in the command output for "sle-minion" # features/step_definitions/salt_steps.rb:214
```
