### PR TITLE
Set timeout to 10 minutes when dealing with "Products" page

### DIFF
--- a/testsuite/features/core_srv_setup_wizard.feature
+++ b/testsuite/features/core_srv_setup_wizard.feature
@@ -26,7 +26,7 @@ Feature: The Setup Wizard
     # Order matters here, refresh first
     When I refresh SCC
     And I follow "SUSE Products" in the content area
-    And I wait at most 360 seconds until I see "Product Description" text
+    And I wait at most 600 seconds until I see "Product Description" text
     And I should see a "Arch" text
     And I should see a "Channels" text
     And I should not see a "WebYaST 1.3" text
@@ -46,7 +46,7 @@ Feature: The Setup Wizard
   Scenario: Select product with recommended enabled
     Given I am on the Admin page
     When I follow "SUSE Products" in the content area
-    And I wait at most 360 seconds until I see "Product Description" text
+    And I wait at most 600 seconds until I see "Product Description" text
     And I enter "SUSE Linux Enterprise Server 15" in the css "input[name='product-description-filter']"
     And I select "x86_64" in the dropdown list of the architecture filter
     And I open the sub-list of the product "SUSE Linux Enterprise Server 15"
@@ -61,7 +61,7 @@ Feature: The Setup Wizard
   Scenario: View the channels list in the products page
     Given I am on the Admin page
     When I follow "SUSE Products" in the content area
-    And I wait at most 420 seconds until I see "Product Description" text
+    And I wait at most 600 seconds until I see "Product Description" text
     And I enter "SUSE Linux Enterprise Server for SAP All-in-One 11 SP2" in the css "input[name='product-description-filter']"
     And I select "x86_64" in the dropdown list of the architecture filter
     And I click the channel list of product "SUSE Linux Enterprise Server for SAP All-in-One 11 SP2"


### PR DESCRIPTION
## What does this PR change?
Since we've increased the "ProxyTimeout" to avoid the failures on the "Admin / Products" page, this PR just set the timeout to 10 minutes also in the testsuite when testing those scenarios.