### PR TITLE
Fix software channels cucumber timeouts

### DIFF
--- a/testsuite/features/allcli_software_channels.feature
+++ b/testsuite/features/allcli_software_channels.feature
@@ -23,7 +23,7 @@ Feature: Chanel subscription via SSM
     And I click on "Next"
     Then I should see a "Channel Changes Overview" text
     And I should see a "2 system(s) to subscribe" text
-    When I schedule action to 1 minutes from now
+    When I schedule action to 2 minutes from now
     And I click on "Confirm"
     And I remember when I scheduled an action
     Then I should see a "Channel Changes Actions" text
@@ -60,12 +60,12 @@ Feature: Chanel subscription via SSM
   Scenario: Check channel change has completed for the SLES minion
     Given I am on the Systems overview page of this "sle-minion"
     When I wait until event "Subscribe channels scheduled by admin" is completed
-    Then I should see "The client completed this action on" at least 1 minutes after I scheduled an action
+    Then I should see "The client completed this action on" at least 2 minutes after I scheduled an action
 
   Scenario: Check channel change has completed for the SLES client
     Given I am on the Systems overview page of this "sle-client"
     When I wait until event "Subscribe channels scheduled by admin" is completed
-    Then I should see "The client completed this action on" at least 1 minutes after I scheduled an action
+    Then I should see "The client completed this action on" at least 2 minutes after I scheduled an action
 
   Scenario: Check the SLES minion is subscribed to the new channels
     Given I am on the Systems overview page of this "sle-minion"


### PR DESCRIPTION
## What does this PR change?

There were some tests relying on this postponed event, so they could check the state before and after it has been applied. As some timeouts for these tests were increased, the span of 1 minute isn't enough anymore.