### PR TITLE
Testsuite: Wait longer for the notification message on "Admin -> Products" page

### DIFF
--- a/testsuite/features/core_srv_setup_wizard.feature
+++ b/testsuite/features/core_srv_setup_wizard.feature
@@ -40,7 +40,7 @@ Feature: The Setup Wizard
     Then I should see a "Legacy Module 12" text
     When I select the addon "Legacy Module 12"
     And I click the Add Product button
-    And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
+    And I wait at most 500 seconds until I see "Selected channels/products were scheduled successfully for syncing." text
     Then the products should be added
 
   Scenario: Select product with recommended enabled
@@ -55,7 +55,7 @@ Feature: The Setup Wizard
     When I select "SUSE Linux Enterprise Server 15" as a product
     Then I should see the "Basesystem Module 15" selected
     And I click the Add Product button
-    And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
+    And I wait at most 500 seconds until I see "Selected channels/products were scheduled successfully for syncing." text
     Then the products should be added
 
   Scenario: View the channels list in the products page


### PR DESCRIPTION
## What does this PR change?
This PR follows up previous testsuite fixes on the "Admin -> Products" page when dealing with overloaded scenarios. It seems sometimes we reach waiting timeouts while waiting for the notification message after adding products. 

This PR simply makes the testsuite to wait longer for those notifications messages.