### PR TITLE
Spacecmd show gid

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,5 @@
+- show group id on group_details (bsc#1111542)
+
 -------------------------------------------------------------------
 Fri Oct 26 10:03:04 CEST 2018 - jgonzalez@suse.com
 

--- a/spacecmd/src/lib/group.py
+++ b/spacecmd/src/lib/group.py
@@ -445,7 +445,7 @@ def do_group_details(self, args, short=False):
         add_separator = True
 
         print('ID:                %i' % details.get('id'))
-        print('Name               %s' % details.get('name'))
+        print('Name:              %s' % details.get('name'))
         print('Description:       %s' % details.get('description'))
         print('Number of Systems: %i' % details.get('system_count'))
 

--- a/spacecmd/src/lib/group.py
+++ b/spacecmd/src/lib/group.py
@@ -444,6 +444,7 @@ def do_group_details(self, args, short=False):
             print(self.SEPARATOR)
         add_separator = True
 
+        print('ID:                %i' % details.get('id'))
         print('Name               %s' % details.get('name'))
         print('Description:       %s' % details.get('description'))
         print('Number of Systems: %i' % details.get('system_count'))


### PR DESCRIPTION
## What does this PR change?

Show group id when calling spacecmd group_details

## Documentation
- No documentation needed: **it is documented that it is show. We adapt code to docs**

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/6085
Tracks https://github.com/SUSE/spacewalk/pull/6124

- [x] **DONE**
