### PR TITLE
Adjust timeouts softwarechannels cucumber

### DIFF
--- a/testsuite/features/allcli_software_channels.feature
+++ b/testsuite/features/allcli_software_channels.feature
@@ -23,10 +23,10 @@ Feature: Chanel subscription via SSM
     And I click on "Next"
     Then I should see a "Channel Changes Overview" text
     And I should see a "2 system(s) to subscribe" text
-    When I schedule action to 2 minutes from now
+    When I schedule action to 3 minutes from now
     And I click on "Confirm"
     And I remember when I scheduled an action
-    Then I should see a "Channel Changes Actions" text
+    Then I wait until I see "Channel Changes Actions" text
     And I should see a "Items 1 - 2 of 2" text
     And a table line should contain system "sle-minion", "Scheduled"
     And a table line should contain system "sle-client", "Scheduled"
@@ -60,12 +60,12 @@ Feature: Chanel subscription via SSM
   Scenario: Check channel change has completed for the SLES minion
     Given I am on the Systems overview page of this "sle-minion"
     When I wait until event "Subscribe channels scheduled by admin" is completed
-    Then I should see "The client completed this action on" at least 2 minutes after I scheduled an action
+    Then I should see "The client completed this action on" at least 3 minutes after I scheduled an action
 
   Scenario: Check channel change has completed for the SLES client
     Given I am on the Systems overview page of this "sle-client"
     When I wait until event "Subscribe channels scheduled by admin" is completed
-    Then I should see "The client completed this action on" at least 2 minutes after I scheduled an action
+    Then I should see "The client completed this action on" at least 3 minutes after I scheduled an action
 
   Scenario: Check the SLES minion is subscribed to the new channels
     Given I am on the Systems overview page of this "sle-minion"


### PR DESCRIPTION
## What does this PR change?

Adjust timeouts of the software channels cucumber.

There are 2 changes here and the rational behind them is:

**[1º](https://ci.suse.de/view/Manager/view/Manager-Head/job/Uyuni-Master-cucumber/186/testReport/(root)/Chanel%20subscription%20via%20SSM/Change_child_channels_for_two_systems_subscribed_to_a_base_channel/)**

[test failure](https://ci.suse.de/view/Manager/view/Manager-Head/job/Uyuni-Master-cucumber/186/testReport/(root)/Chanel%20subscription%20via%20SSM/Change_child_channels_for_two_systems_subscribed_to_a_base_channel/)

This test for some reason started failing for the first time... there were no changes that can justify this failure. The only reason I can see is that some previous test affected it. After some tests locally this test only could be broken while running the whole testsuite together, if it's only the software channels one it passes. Therefore there isn't anything wrong with the test, just some sort of long request when confirming. We can be sure the confirming is working otherwise all the tests would have failed as well.

Hopefully this change will be enough: https://github.com/uyuni-project/uyuni/pull/223/files#diff-80c5296d7c55e4c68b194b9590fe5f64R29

**[2º](https://github.com/uyuni-project/uyuni/pull/223/commits/64ecf5b5f9af3f2cf99bb5aed64dbb588765d43f#diff-80c5296d7c55e4c68b194b9590fe5f64R26)**

I raised the action postpone for 3 minute as 2 minutes seemed to be really tight due to the next next tests running really slow.

Example:

https://ci.suse.de/view/Manager/view/Manager-Head/job/Uyuni-Master-cucumber/185/testReport/ (failed)
https://ci.suse.de/view/Manager/view/Manager-Head/job/Uyuni-Master-cucumber/186/testReport/ (success)

No changes were done between both and we can see that the tests that needed to run in a span of 2 minutes one the first run had a slightly higher duration.