### PR TITLE
Wait for new package highstate to be applied

### DIFF
--- a/testsuite/features/min_salt_software_states.feature
+++ b/testsuite/features/min_salt_software_states.feature
@@ -44,7 +44,7 @@ Feature: Salt package states
     Then I should see a "1 Changes" text
     And I click save
     And I click apply
-    And I wait for "milkyway-dummy" to be uninstalled on "sle-minion"
+    And I wait at most 360 seconds for "milkyway-dummy" to be uninstalled on "sle-minion"
 
   Scenario: Install a package through the UI
     Given I am on the Systems overview page of this "sle-minion"

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -484,6 +484,25 @@ Then(/^I wait for "([^"]*)" to be uninstalled on "([^"]*)"$/) do |package, host|
   raise "Package removal failed (Code #{$CHILD_STATUS}): #{$ERROR_INFO}: #{output}" unless uninstalled
 end
 
+Then(/^I wait at most (\d+) seconds for "([^"]*)" to be uninstalled on "([^"]*)"$/) do |seconds, package, host|
+  node = get_target(host)
+  uninstalled = false
+  output = ''
+  begin
+    Timeout.timeout(seconds.to_i) do
+      loop do
+        output, code = node.run("rpm -q #{package}", false)
+        if code.nonzero?
+          uninstalled = true
+          break
+        end
+        sleep 1
+      end
+    end
+  end
+  raise "Package removal failed (Code #{$CHILD_STATUS}): #{$ERROR_INFO}: #{output}" unless uninstalled
+end
+
 Then(/^I wait for "([^"]*)" to be installed on this "([^"]*)"$/) do |package, host|
   node = get_target(host)
   node.run_until_ok("rpm -q #{package}")


### PR DESCRIPTION
## What does this PR change?

One more... :sweat_smile: this probably fix the [test](https://ci.suse.de/view/Manager/view/Manager-Head/job/Uyuni-Master-cucumber/186/testReport/(root)/Salt%20package%20states/Remove_a_package_through_the_UI/), but I wonder If we aren't hiding some more serious problems.. :thinking: 

https://ci.suse.de/view/Manager/view/Manager-Head/job/Uyuni-Master-cucumber/188/testReport/(root)/Salt%20package%20states/Remove_a_package_through_the_UI/

I wasn't able to reproduce the failure running the testsuite "min_salt_software_states.feature" isolated or manually through the interface, I would say it's a timeout problem again.. 

Maybe caused by some recent hardware changed being used by the testsuite?

