### PR TITLE
Require openJDK in all cases, as IBM JDK will not be available at SLE15

### DIFF
--- a/java/conf/default/rhn_taskomatic_daemon.conf
+++ b/java/conf/default/rhn_taskomatic_daemon.conf
@@ -30,15 +30,6 @@ wrapper.java.classpath.5=/usr/share/spacewalk/taskomatic/*.jar
 # Java Additional Parameters
 wrapper.java.additional.1=-Dibm.dst.compatibility=true
 wrapper.java.additional.2=-Dfile.encoding=UTF-8
-### NOTE: Only uncomment these lines if you are running IBM Java ###
-wrapper.java.additional.3=-Xdump:heap:file=/var/crash/heapdump.%Y%m%d.%H%M%S.%pid.%seq.phd
-wrapper.java.additional.4=-Xdump:java:file=/var/crash/javacore.%Y%m%d.%H%M%S.%pid.%seq.txt
-wrapper.java.additional.5=-Xdump:snap:file=/var/crash/Snap.%Y%m%d.%H%M%S.%pid.%seq.trc
-wrapper.java.additional.6=-Xdump:system:file=/var/crash/core.%Y%m%d.%H%M%S.%pid.%seq.dmp
-#wrapper.java.additional.7=-Xdebug
-#wrapper.java.additional.8=-Xrunjdwp:transport=dt_socket,address=8001,server=y,suspend=n
-## or disable dumps completely
-#wrapper.java.additional.3=-Xdump:none
 
 # Initial Java Heap Size (in MB)
 wrapper.java.initmemory=256

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Require openJDK in all cases, as IBM JDK will not be available at SLE15
 - Add missing jar dependency 'xalan-j2-serializer'
 - Modify acls: hide 'System details -> Groups and Formulas' tab for non-minions with bootstrap entitlement
 - fix typo in messages (bsc#1111249)

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -68,15 +68,7 @@ Requires:       concurrent
 Requires:       google-gson >= 2.2.4
 Requires:       httpcomponents-client
 Requires:       jakarta-commons-digester
-%if !0%{?is_opensuse}
-%if %{suse_version} < 1500
-Requires:       java-ibm >= 1.8.0
-%else
 Requires:       java >= 1.8.0
-%endif
-%else
-Requires:       java >= 1.8.0
-%endif
 Requires:       classmate
 Requires:       ehcache >= 2.10.1
 Requires:       gnu-jaf
@@ -624,12 +616,6 @@ find . -type f -name '*.xml' | xargs perl -CSAD -lne '
               }
           }
           END { exit $exit }'
-%endif
-
-# Crash dumps are disabled by default for openJDK, disable them
-# (only SUSE < 15 ships IBM Java with crash dumps enabled)
-%if 0%{?suse_version} >= 1500 || 0%{?is_opensuse}
-sed -i '/^wrapper\.java\.additional\.[0-9]=-Xdump:.\+/s/^/#/g' conf/default/rhn_taskomatic_daemon.conf
 %endif
 
 echo "Building apidoc docbook sources"


### PR DESCRIPTION
## What does this PR change?

Require openJDK in all cases, as IBM JDK will not be available at SLE15.

For openSUSE we were not using it already.

As a benefit, we'll try to see this way if using openJDK the performance is worse than we IBM JDK as we suspect, and we'll be able to start working on that problem.

So far we suspect junit pgsql and failing because of the switch from IBM to openJDK, as they started to be unstable just as soon as we switched containers from SLE to openSUSE.

And according to @cbbayburt his impression is that the testsuite for Uyuni on his laptop is working slower when testing SUMA Head (with SLE12 and IBM JDK).

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: I can't find any reference to the JDK that should be used at the documentation.

- [x] **DONE**

## Test coverage
- No tests: Test already exist.

- [x] **DONE**

## Links

None, but this if this provokes now the testsuite working slower on SLE12, we will need to create a performance issue.

- [x] **DONE**
