### PR TITLE
Testsuite: Wait for the dynamic table to load on the "Images" page

### DIFF
--- a/testsuite/features/min_osimage_build_image.feature
+++ b/testsuite/features/min_osimage_build_image.feature
@@ -28,7 +28,7 @@ Feature: Build OS images
   Scenario: Cleanup: remove the image from SUSE Manager server
     Given I am authorized as "admin" with password "admin"
     When I navigate to images webpage
-    Then I wait until I do not see "There are no entries to show." text
+    And I wait until I do not see "There are no entries to show." text
     And I check the first image
     And I click on "Delete"
     And I click on "Delete" in "Delete Selected Image(s)" modal

--- a/testsuite/features/min_osimage_build_image.feature
+++ b/testsuite/features/min_osimage_build_image.feature
@@ -28,6 +28,7 @@ Feature: Build OS images
   Scenario: Cleanup: remove the image from SUSE Manager server
     Given I am authorized as "admin" with password "admin"
     When I navigate to images webpage
+    Then I wait until I do not see "There are no entries to show." text
     And I check the first image
     And I click on "Delete"
     And I click on "Delete" in "Delete Selected Image(s)" modal

--- a/testsuite/features/step_definitions/docker_steps.rb
+++ b/testsuite/features/step_definitions/docker_steps.rb
@@ -65,6 +65,7 @@ Then(/^all "([^"]*)" container images are built correctly in the GUI$/) do |coun
     build_timeout = 320
     Timeout.timeout(build_timeout) do
       step %(I navigate to images webpage)
+      step %(I wait until I do not see "There are no entries to show." text)
       raise 'error detected while building images' if has_xpath?("//*[contains(@title, 'Failed')]")
       break if has_xpath?("//*[contains(@title, 'Built')]", count: count)
       sleep 5


### PR DESCRIPTION
## What does this PR change?
This PR should fix a spurious failure we have when testing the "Images" page.

This page contains a table which is initially loaded as empty and then dynamically filled with data, but the testsuite is not actually waiting for the table to be loaded so that makes scenario to fail in case the the testsuite is running slow and the data is not yet there:

```cucumber
Stacktrace

    Scenario: Cleanup: remove the image from SUSE Manager server

Given I am authorized as "admin" with password "admin"
When I navigate to images webpage
And I check the first image
And I click on "Delete"
And I click on "Delete" in "Delete Selected Image(s)" modal
And I wait until I see "Deleted successfully." text

Message:

    undefined method `first' for nil:NilClass (NoMethodError)
./features/step_definitions/docker_steps.rb:82:in `block (2 levels) in <top (required)>'
./features/step_definitions/docker_steps.rb:80:in `/^I check the first image$/'
features/min_osimage_build_image.feature:31:in `And I check the first image'
```
