### PR TITLE
Testsuite: have virtio_blk inside the initrd

### DIFF
--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS6/config.xml
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS6/config.xml
@@ -26,6 +26,9 @@
     <users group="root">
       <user home="/root" name="root" password="linux" pwdformat="plain" shell="/bin/bash"/>
     </users>
+    <drivers>
+      <file name="drivers/block/virtio_blk.ko" />
+    </drivers>
     <repository type="rpm-md" >
         <source path="http://euklid.nue.suse.com/mirror/SuSE/build.suse.de/SUSE/Products/SLE-SERVER/12-SP3/x86_64/product/"/>
     </repository>


### PR DESCRIPTION
## What does this PR change?

It adds `virtio_blk`driver to the OS images used by the testsuite, so we can use virtio disks.
