### PR TITLE
Testsuite: do reboot tests very early

### DIFF
--- a/testsuite/features/allcli_reboot.feature
+++ b/testsuite/features/allcli_reboot.feature
@@ -1,5 +1,11 @@
 # Copyright (c) 2017-2018 SUSE LLC.
 # Licensed under the terms of the MIT license.
+#
+# Idempotency note:
+# * this feature is idempotent
+#   (the tests of this feature can be run several times with no change in the results)
+# * However, beware that firmware, kernel or library updates might be activated by the reboot
+#   (thus making changes in the behaviour of the system after the reboot)
 
 Feature: Reboot systems managed by SUSE Manager
 

--- a/testsuite/run_sets/testsuite.yml
+++ b/testsuite/run_sets/testsuite.yml
@@ -41,6 +41,8 @@
 ## Secondary features BEGIN ##
 
 # IDEMPOTENT
+
+- features/allcli_reboot.feature
 - features/trad_config_channel.feature
 - features/trad_lock_packages.feature
 - features/min_centos_salt_install_package_and_patch.feature
@@ -108,7 +110,6 @@
 - features/allcli_software_channels.feature
 - features/allcli_software_channels_dependencies.feature
 - features/srv_sync_products.feature
-- features/allcli_reboot.feature
 - features/srv_notifications.feature
 - features/minkvm_guests.feature
 - features/minxen_guests.feature


### PR DESCRIPTION
## What does this PR change?

It moves reboot tests to the very first idempotent tests.

When using released or unreleased updates options, this ensures
that kernel updates are effective in most of the testsuite.

Note: experimental PR - might be dropped based on outcome of SUSE/spacewalk#6158

## Links

Fixes: test suite timeouts in Provo (????)  - SUSE/spacewalk#6039

Relevant branches:
 - Manager-3.1 SUSE/spacewalk#6161
 - Manager-3.2 SUSE/spacewalk#6158
