### PR TITLE
Don't assign a HW type group for empty profile if it already has some HW type group assigned

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -433,9 +433,15 @@ public class RegisterMinionEventMessageAction implements MessageAction {
 
         SystemManager.addServerToServerGroup(minion, terminalsGroup);
         SystemManager.addServerToServerGroup(minion, branchIdGroup);
-        if (hwGroup != null && minion.getManagedGroups().stream()
-                .noneMatch(g -> g.getName().startsWith(hwTypeGroupPrefix))) {
-            SystemManager.addServerToServerGroup(minion, hwGroup);
+        if (hwGroup != null) {
+            // if the system is already assigned to some HWTYPE group, skip assignment and log this only
+            if (minion.getManagedGroups().stream().anyMatch(g -> g.getName().startsWith(hwTypeGroupPrefix))) {
+                LOG.info("Skipping assignment of the minion " + minion + " to HW group " + hwGroup +
+                        ". The minion is already in a HW group.");
+            }
+            else {
+                SystemManager.addServerToServerGroup(minion, hwGroup);
+            }
         }
 
         minion.asMinionServer().ifPresent(SaltStateGeneratorService.INSTANCE::generatePillar);

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -417,8 +417,9 @@ public class RegisterMinionEventMessageAction implements MessageAction {
                     "on retail minion registration! Aborting registration.");
         }
 
+        String hwTypeGroupPrefix = "HWTYPE:";
         String hwType = manufacturer.get() + "-" + productName.get();
-        String hwTypeGroup = "HWTYPE:" + hwType.replaceAll("[^A-Za-z0-9_-]", "");
+        String hwTypeGroup = hwTypeGroupPrefix + hwType.replaceAll("[^A-Za-z0-9_-]", "");
 
         String branchIdGroupName = branchId.get();
         ManagedServerGroup terminalsGroup = ServerGroupFactory.lookupByNameAndOrg(TERMINALS_GROUP_NAME, org);
@@ -432,7 +433,8 @@ public class RegisterMinionEventMessageAction implements MessageAction {
 
         SystemManager.addServerToServerGroup(minion, terminalsGroup);
         SystemManager.addServerToServerGroup(minion, branchIdGroup);
-        if (hwGroup != null) {
+        if (hwGroup != null && minion.getManagedGroups().stream()
+                .noneMatch(g -> g.getName().startsWith(hwTypeGroupPrefix))) {
             SystemManager.addServerToServerGroup(minion, hwGroup);
         }
 


### PR DESCRIPTION
see ^. Previously the HW type group was assigned even if the empty profile had some other HW type group assigned. Apparently, this is not the wanted behavior.

## UI diff
No difference.

- [x] **DONE**

## Doc
- https://github.com/SUSE/doc-susemanager/issues/243

- [x] **DONE**

## Tests
- Unit tests were added

- [x] **DONE**

## Links
Fixes https://github.com/SUSE/spacewalk/issues/6062
Tracks https://github.com/SUSE/spacewalk/pull/6148

- [x] **DONE**