### PR TITLE
Fix: missing default type creating Configuration Channel

### DIFF
--- a/java/code/webapp/WEB-INF/pages/common/fragments/configuration/overview/links.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/configuration/overview/links.jspf
@@ -19,7 +19,7 @@
     </a>
   </li>
   <li class="list-group-item">
-    <a href="/rhn/configuration/ChannelCreate.do?editing=true">
+    <a href="/rhn/configuration/ChannelCreate.do?editing=true&type=normal">
       <bean:message key="configoverview.jsp.createchannel"/>
     </a>
   </li>


### PR DESCRIPTION
## What does this PR change?

Add the default missing and mandatory type in the link to create a `Configuration Channel`.
The `type` parameter is **mandatory** because unless the code fails during the [lookup](https://github.com/uyuni-project/uyuni/blob/master/java/code/src/com/redhat/rhn/frontend/action/configuration/channel/ChannelOverviewAction.java#L228)

## GUI diff

**Correct link**
![screenshot from 2018-10-22 16-17-56](https://user-images.githubusercontent.com/7080830/47297975-eb4b3800-d616-11e8-8e46-e0c866119da8.png)

**Incomplete link**
![screenshot from 2018-10-22 16-18-06](https://user-images.githubusercontent.com/7080830/47297974-eb4b3800-d616-11e8-9375-7b01dc79c7ab.png)


No difference.

- [x] **DONE**

## Documentation
- No documentation needed: link bugfix
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [x] **DONE**

## Test coverage
- No tests: nothing to test
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #
Tracks # https://github.com/SUSE/spacewalk/pull/6201 and https://github.com/SUSE/spacewalk/pull/6200

- [x] **DONE**
