### PR TITLE
Do not reuse TaskomaticApi mock when running ErrataManagerTest

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/errata/test/ErrataManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/test/ErrataManagerTest.java
@@ -653,6 +653,13 @@ public class ErrataManagerTest extends JMockBaseTestCaseWithUser {
         serverIds.add(server1.getId());
         serverIds.add(server2.getId());
 
+        TaskomaticApi taskomaticMock = mock(TaskomaticApi.class);
+        ErrataManager.setTaskomaticApi(taskomaticMock);
+
+        context().checking(new Expectations() { {
+            allowing(taskomaticMock).scheduleActionExecution(with(any(Action.class)));
+        } });
+
         ErrataManager.applyErrata(user, errataIds, new Date(), serverIds);
 
         // we want to check that no matter how many actions were scheduled for
@@ -856,6 +863,13 @@ public class ErrataManagerTest extends JMockBaseTestCaseWithUser {
         List<Long> serverIds = new ArrayList<Long>();
         serverIds.add(server1.getId());
         serverIds.add(server2.getId());
+
+        TaskomaticApi taskomaticMock = mock(TaskomaticApi.class);
+        ErrataManager.setTaskomaticApi(taskomaticMock);
+
+        context().checking(new Expectations() { {
+            allowing(taskomaticMock).scheduleActionExecution(with(any(Action.class)));
+        } });
 
         ErrataManager.applyErrata(user, errataIds, new Date(), serverIds);
 


### PR DESCRIPTION
## What does this PR change?
This PR should fix some spurious jUnit tests failures caused by reusing the `TaskomaticApi` mock across multiple tests. It seems this might cause expectation inconsistencies in some cases:

```
Error Message

unexpected invocation: taskomaticApi.scheduleActionExecution(<1380 : Patch Update: JAVA Test r9I2TMlBHHt17 - Test synopsis>)
expectations:
  expected once, already invoked 1 time: taskomaticApi.scheduleActionExecution(an instance of com.redhat.rhn.domain.action.Action)
      parameter 0 matched: an instance of com.redhat.rhn.domain.action.Action
  expected never, never invoked: taskomaticApi.scheduleStagingJob(an instance of java.lang.Long, <1000010844L>, an instance of java.util.Date)
what happened before this:
  taskomaticApi.scheduleActionExecution(<1246 : Combined Patch Update: JAVA Test DnW2KMsICT05P - Test synopsis (and 0 more patches)>)

Stacktrace

junit.framework.AssertionFailedError: unexpected invocation: taskomaticApi.scheduleActionExecution(<1380 : Patch Update: JAVA Test r9I2TMlBHHt17 - Test synopsis>)
expectations:
  expected once, already invoked 1 time: taskomaticApi.scheduleActionExecution(an instance of com.redhat.rhn.domain.action.Action)
      parameter 0 matched: an instance of com.redhat.rhn.domain.action.Action
  expected never, never invoked: taskomaticApi.scheduleStagingJob(an instance of java.lang.Long, <1000010844L>, an instance of java.util.Date)
what happened before this:

	at org.jmock.api.ExpectationError.unexpected(ExpectationError.java:23)
	at org.jmock.internal.InvocationDispatcher.dispatch(InvocationDispatcher.java:85)
	at org.jmock.Mockery.dispatch(Mockery.java:231)
	at org.jmock.Mockery.access$100(Mockery.java:29)
	at org.jmock.Mockery$MockObject.invoke(Mockery.java:271)
	at org.jmock.internal.InvocationDiverter.invoke(InvocationDiverter.java:27)
	at org.jmock.internal.FakeObjectMethods.invoke(FakeObjectMethods.java:38)
	at org.jmock.internal.SingleThreadedPolicy$1.invoke(SingleThreadedPolicy.java:21)
	at org.jmock.lib.legacy.ClassImposteriser$4.invoke(ClassImposteriser.java:129)
	at com.redhat.rhn.taskomatic.TaskomaticApi$$EnhancerByCGLIB$$5aa79708.scheduleActionExecution(<generated>)
	at com.redhat.rhn.manager.errata.ErrataManager.applyErrata(ErrataManager.java:1910)
	at com.redhat.rhn.manager.errata.ErrataManager.applyErrata(ErrataManager.java:1744)
	at com.redhat.rhn.manager.errata.ErrataManager.applyErrata(ErrataManager.java:1724)
	at com.redhat.rhn.manager.errata.test.ErrataManagerTest.testApplyErrataOnManagementStack(ErrataManagerTest.java:656)
	at org.jmock.integration.junit3.VerifyingTestCase.runBare(VerifyingTestCase.java:38)
```

I've run jUnit test locally for few runs and it seems I don't get failures on `testApplyErrataOnManagementStack` nor `testApplyErrataOnManagementStackZypp` so far.