### PR TITLE
Do not reuse handler mock on SystemHandlerTest

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -952,7 +952,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
 
     public void testListSystems() throws Exception {
         Server server = ServerFactoryTest.createTestServer(admin);
-        Object[] results = handler.listSystems(admin);
+        Object[] results = getMockedHandler().listSystems(admin);
         assertEquals(1, results.length);
 
         List<Object> r = Arrays.asList(results);


### PR DESCRIPTION
## What does this PR change?
This PR follows up https://github.com/uyuni-project/uyuni/pull/238 by fixing a spurious jUnit tests failure on `SystemHandlerTest` which is caused because of reusing the `TaskomaticApi` mock across multiple tests. It seems this might cause expectation inconsistencies in some cases:

```
Error Message

expected:<1> but was:<3>

Stacktrace

junit.framework.AssertionFailedError: expected:<1> but was:<3>
	at com.redhat.rhn.frontend.xmlrpc.system.test.SystemHandlerTest.testListSystems(SystemHandlerTest.java:956)

Standard Output

{Start: 1 End: 1 Total: 1[com.redhat.rhn.frontend.dto.SystemOverview@692aa149[id=1000010694,serverName=<null>]]}
```

After this PR I haven't seen any failure testing `SystemHandlerTest` on my local environment.