### PR TITLE
Fix "SystemHandlerTest" when multiple systems are returned by "listSystems"

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -952,12 +952,11 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
 
     public void testListSystems() throws Exception {
         Server server = ServerFactoryTest.createTestServer(admin);
-        Object[] results = getMockedHandler().listSystems(admin);
-        assertEquals(1, results.length);
+        List<Object> results = Arrays.asList(handler.listSystems(admin));
+        assertTrue(results.size() >= 1);
+        assertTrue(results.contains(server));
 
-        List<Object> r = Arrays.asList(results);
-
-        for (Object o : r) {
+        for (Object o : results) {
             SystemOverview so = (SystemOverview) o;
             assertNotNull(so.getLastBootAsDate());
         }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -954,7 +954,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         Server server = ServerFactoryTest.createTestServer(admin);
         List<Object> results = Arrays.asList(handler.listSystems(admin));
         assertTrue(results.size() >= 1);
-        assertTrue(results.contains(server));
+        assertTrue(results.stream().anyMatch(so -> ((SystemOverview) so).getId().equals(server.getId())));
 
         for (Object o : results) {
             SystemOverview so = (SystemOverview) o;


### PR DESCRIPTION
## What does this PR change?
This PR follows up https://github.com/uyuni-project/uyuni/pull/239 (didn't fix the issue) and fixes the behavior of the test to prevent failures when multiple systems are returned by `SystemHandler.listSystems`. It seems sometimes, due testsuite timings, more than the just created test server is returned by this function making the test to fail. So this PR makes the test to handle this possible situation.

```
Error Message

expected:<1> but was:<3>

Stacktrace

junit.framework.AssertionFailedError: expected:<1> but was:<3>
	at com.redhat.rhn.frontend.xmlrpc.system.test.SystemHandlerTest.testListSystems(SystemHandlerTest.java:956)

Standard Output

{Start: 1 End: 1 Total: 1[com.redhat.rhn.frontend.dto.SystemOverview@692aa149[id=1000010694,serverName=<null>]]}
```