### PR TITLE
Remove the failed cleanup try when deleting empty system profiles

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/SystemsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/SystemsController.java
@@ -102,9 +102,10 @@ public class SystemsController {
             return json(response, HttpStatus.SC_BAD_REQUEST, ResultJson.success());
         }
         Server server = SystemManager.lookupByIdAndUser(sid, user);
+        boolean isEmptyProfile = server.hasEntitlement(EntitlementManager.BOOTSTRAP);
 
         if (server.asMinionServer().isPresent()) {
-            if (!Boolean.parseBoolean(noclean)) {
+            if (!Boolean.parseBoolean(noclean) && !isEmptyProfile) {
                 Optional<List<String>> cleanupErr =
                         SaltService.INSTANCE.
                                 cleanupMinion(server.asMinionServer().get(), 300);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Do not try cleanup when deleting empty system profiles (bsc#1111247)
 - ActivationKey base and child channel in a reactjs component
 
 -------------------------------------------------------------------

--- a/web/html/src/manager/delete-system.js
+++ b/web/html/src/manager/delete-system.js
@@ -36,7 +36,7 @@ class DeleteSystem extends React.Component {
           this.props.onDeleteSuccess();
         } else {
           this.setState({
-            messages: MessagesUtils.error(data.messages)
+            messages: MessagesUtils.error(data.messages.map(m => msgMap[m]))
           });
           this.showErrorDialog();
         }

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Show human-readable system cleanup error messages
 - ActivationKey base and child channel in a reactjs component
 
 -------------------------------------------------------------------


### PR DESCRIPTION
This PR removes the failed cleanup try when deleting empty system profiles. It also fixes error messages to be human-readable.

## Documentation
- No documentation needed: Bugfix

## Test coverage
- No tests: Feature not yet tested
