### PR TITLE
Fix websocket endpoint log error on connection closed

### DIFF
--- a/java/code/src/com/suse/manager/webui/websocket/RemoteMinionCommands.java
+++ b/java/code/src/com/suse/manager/webui/websocket/RemoteMinionCommands.java
@@ -371,12 +371,12 @@ public class RemoteMinionCommands {
      */
     @OnError
     public void onError(Session session, Throwable err) {
-        if (err instanceof EOFException) {
+        Boolean didClientAbortedConnection = err instanceof EOFException ||
+                !session.isOpen() ||
+                err.getMessage().startsWith("Unexpected error [32]");
+
+        if (didClientAbortedConnection) {
             LOG.debug("The client aborted the connection.", err);
-        }
-        else if (err.getMessage().startsWith("Unexpected error [32]")) {
-            // [32] "Broken pipe" is caught when the client side breaks the connection.
-            LOG.debug("The client broke the connection.", err);
         }
         else {
             LOG.error("Websocket endpoint error", err);

--- a/java/code/src/com/suse/manager/webui/websocket/VirtNotifications.java
+++ b/java/code/src/com/suse/manager/webui/websocket/VirtNotifications.java
@@ -103,12 +103,12 @@ public class VirtNotifications {
      */
     @OnError
     public void onError(Session session, Throwable err) {
-        if (err instanceof EOFException) {
+        Boolean didClientAbortedConnection = err instanceof EOFException ||
+                !session.isOpen() ||
+                err.getMessage().startsWith("Unexpected error [32]");
+
+        if (didClientAbortedConnection) {
             LOG.debug("The client aborted the connection.", err);
-        }
-        else if (err.getMessage().startsWith("Unexpected error [32]")) {
-            // [32] "Broken pipe" is caught when the client side breaks the connection.
-            LOG.debug("The client broke the connection.", err);
         }
         else {
             LOG.error("Websocket endpoint error", err);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -22,7 +22,7 @@
 - Added menu item entries for creating/deleting file preservation lists (bsc#1034030)
 - Fix displayed number of systems requiring reboot in Tasks pane (bsc#1106875)
 - Added link from virtualization tab to Scheduled > Pending Actions (bsc#1037389)
-- Double check if the websocket connection is still open on sendText failure (bsc#1080474)
+- Better error handling when a websocket connection is aborted (bsc#1080474)
 - Enable auto patch updates for salt clients
 - Fix ACLs for system details settings
 - Method to Unsubscribe channel from system(bsc#1104120)


### PR DESCRIPTION
## What does this PR change?

Stop logging an error if the websocket connection is already closed when trying to send a new notification

## GUI diff

No difference.


## Documentation
- No documentation needed:

- [x] **DONE**

## Test coverage
- No tests. 

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/4311

- [x] **DONE**
