### PR TITLE
Clean up scripts only if /scripts directory exists

### DIFF
--- a/java/code/src/com/suse/manager/webui/utils/MinionActionUtils.java
+++ b/java/code/src/com/suse/manager/webui/utils/MinionActionUtils.java
@@ -21,6 +21,7 @@ import static java.util.stream.Collectors.toMap;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonSyntaxException;
@@ -317,16 +318,19 @@ public class MinionActionUtils {
      * @throws IOException in case of problems listing the scripts
      */
     public static void cleanupScriptActions() throws IOException {
-        Pattern p = Pattern.compile("script_(\\d*).sh");
-        Files.list(SaltUtils.INSTANCE.getScriptsDir()).forEach(file -> {
-            Matcher m = p.matcher(file.getFileName().toString());
-            if (m.find()) {
-                long actionId = Long.parseLong(m.group(1));
-                if (ActionFactory.lookupById(actionId).allServersFinished()) {
-                    LOG.info("Deleting script file: " + file);
-                    FileUtils.deleteFile(file);
+        Path scriptsDir = SaltUtils.INSTANCE.getScriptsDir();
+        if (Files.isDirectory(scriptsDir)) {
+            Pattern p = Pattern.compile("script_(\\d*).sh");
+            Files.list(scriptsDir).forEach(file -> {
+                Matcher m = p.matcher(file.getFileName().toString());
+                if (m.find()) {
+                    long actionId = Long.parseLong(m.group(1));
+                    if (ActionFactory.lookupById(actionId).allServersFinished()) {
+                        LOG.info("Deleting script file: " + file);
+                        FileUtils.deleteFile(file);
+                    }
                 }
-            }
-        });
+            });
+        }
     }
 }


### PR DESCRIPTION
## What does this PR change?

This patch is a port of https://github.com/SUSE/spacewalk/pull/6173.

It is supposed to fix the following exception that is happening on the cleanup of script actions in case a script action was never executed before, i.e. the corresponding `scripts` folder does not exist on the SUSE Manager server:

```
INFO   | jvm 1    | 2018/10/23 16:59:12 | 2018-10-23 16:59:12,301 [DefaultQuartzScheduler_Worker-16] ERROR com.redhat.rhn.taskomatic.task.MinionActionCleanup - Could not cleanup script files: /srv/susemanager/salt/scripts
INFO   | jvm 1    | 2018/10/23 16:59:12 | java.nio.file.NoSuchFileException: /srv/susemanager/salt/scripts
INFO   | jvm 1    | 2018/10/23 16:59:12 |       at sun.nio.fs.UnixException.translateToIOException(UnixException.java:98)
INFO   | jvm 1    | 2018/10/23 16:59:12 |       at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:114)
INFO   | jvm 1    | 2018/10/23 16:59:12 |       at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:119)
INFO   | jvm 1    | 2018/10/23 16:59:12 |       at sun.nio.fs.UnixFileSystemProvider.newDirectoryStream(UnixFileSystemProvider.java:439)
INFO   | jvm 1    | 2018/10/23 16:59:12 |       at java.nio.file.Files.newDirectoryStream(Files.java:468)
INFO   | jvm 1    | 2018/10/23 16:59:12 |       at java.nio.file.Files.list(Files.java:3462)
INFO   | jvm 1    | 2018/10/23 16:59:12 |       at com.suse.manager.webui.utils.MinionActionUtils.cleanupScriptActions(MinionActionUtils.java:321)
INFO   | jvm 1    | 2018/10/23 16:59:12 |       at com.redhat.rhn.taskomatic.task.MinionActionCleanup.execute(MinionActionCleanup.java:46)
INFO   | jvm 1    | 2018/10/23 16:59:12 |       at com.redhat.rhn.taskomatic.task.RhnJavaJob.execute(RhnJavaJob.java:88)
INFO   | jvm 1    | 2018/10/23 16:59:12 |       at com.redhat.rhn.taskomatic.TaskoJob.execute(TaskoJob.java:199)
INFO   | jvm 1    | 2018/10/23 16:59:12 |       at org.quartz.core.JobRunShell.run(JobRunShell.java:202)
INFO   | jvm 1    | 2018/10/23 16:59:12 |       at org.quartz.simpl.SimpleThreadPool$WorkerThread.run(SimpleThreadPool.java:573)
```

## Documentation

- No documentation needed: this is just a bugfix.

## Test coverage

- No tests: no additional tests needed.

## Links

Relevant branches (GitHub automatic links expected below):
 - Manager-3.2: https://github.com/SUSE/spacewalk/pull/6173
 - Uyuni: this PR

- [x] **DONE**
