### PR TITLE
Fix create bootstrap repo with custom channels

### DIFF
--- a/susemanager/src/mgr-create-bootstrap-repo
+++ b/susemanager/src/mgr-create-bootstrap-repo
@@ -41,70 +41,54 @@ SELECT distinct
         full_list.arch_label AS arch,
         pkg.path
   FROM  (
-         SELECT  p.name_id name_id,
-                 max(pe.evr) evr,
-                 pa.id as arch_id,
-                 pa.label as arch_label
-           FROM  rhnPackageArch PA, rhnPackageEVR PE, rhnPackage P,
-                 rhnChannelNewestPackage CNP, suseProductChannel PC,
-                 suseProducts sp
-          WHERE  sp.product_id in ( %s )
-            AND  sp.id = pc.product_id
-            AND  pc.channel_id = cnp.channel_id
-            AND  cnp.package_id = p.id
-            AND  p.evr_id = pe.id
-            AND  p.package_arch_id = pa.id
-       GROUP BY  p.name_id, pa.label, pa.id
-       ) full_list,
-       rhnPackage pkg
-       join rhnPackageName pn on pkg.name_id = pn.id
-       join rhnPackageEVR pevr on pkg.evr_id = pevr.id
-       join rhnChannelPackage CP on CP.package_id = pkg.id
-       join suseProductChannel PC on PC.channel_id = CP.channel_id
-       join suseProducts SP on SP.id = PC.product_id
- WHERE full_list.name_id = pkg.name_id
-   AND full_list.evr = pevr.evr
-   AND full_list.arch_id = pkg.package_arch_id
-   AND SP.product_id in ( %s )
-   AND pn.name = :pkgname
-order by pkg.id
-""";
-
-_sql_find_pkgs_with_custom_channels = """
-SELECT  distinct
-        pkg.id AS id,
-        PN.name || '-' || evr_t_as_vre_simple(full_list.evr) || '.' || full_list.arch_label AS nvrea,
-        full_list.arch_label AS arch,
-        pkg.path
-  FROM  (
          SELECT  I_P.name_id name_id,
                  max(I_PE.evr) evr,
                  I_PA.id as arch_id,
                  I_PA.label as arch_label
-           FROM  suseProducts I_SP
-           JOIN  suseProductChannel I_PC ON I_SP.id = I_PC.product_id
-           JOIN  rhnChannel I_C ON I_PC.channel_id = I_C.id or I_PC.channel_id = I_C.parent_channel
-           JOIN  rhnChannelNewestPackage I_CNP ON I_C.id = I_CNP.channel_id
+           FROM  (
+                  select I_C.*
+                   from suseProducts I_SP
+                   JOIN suseProductChannel I_PC ON I_SP.id = I_PC.product_id
+                   JOIN rhnChannel I_C ON I_PC.channel_id = I_C.id
+                  WHERE  I_SP.product_id in ( %s )
+                  union
+                  select *
+                    from rhnChannel
+                   where org_id is not null
+                     and parent_channel in (
+                                            select pc.id
+                                              from rhnChannel pc
+                                             where pc.label = :parentchannel)
+                  ) channels
+           JOIN  rhnChannelNewestPackage I_CNP ON channels.id = I_CNP.channel_id
            JOIN  rhnPackage I_P ON I_CNP.package_id = I_P.id
            JOIN  rhnPackageEVR I_PE ON I_P.evr_id = I_PE.id
            JOIN  rhnPackageArch I_PA ON I_P.package_arch_id = I_PA.id
-          WHERE  I_SP.product_id in ( %s )
        GROUP BY  I_P.name_id, I_PA.label, I_PA.id
-       ) full_list,
-       suseProducts SP
-  join suseProductChannel PC ON sp.id = pc.product_id
-  join rhnChannel C ON pc.channel_id = c.id or pc.channel_id = c.parent_channel
-  join rhnChannelPackage CP ON CP.channel_id = C.id
-  join rhnPackage pkg ON CP.package_id = pkg.id
-  join rhnPackageEVR pevr on pkg.evr_id = pevr.id
-  join rhnPackageName pn on pkg.name_id = pn.id
+     ) full_list,
+       rhnPackage pkg
+       join rhnPackageName pn on pkg.name_id = pn.id
+       join rhnPackageEVR pevr on pkg.evr_id = pevr.id
+       join rhnChannelPackage CP on CP.package_id = pkg.id
  WHERE full_list.name_id = pkg.name_id
    AND full_list.evr = pevr.evr
    AND full_list.arch_id = pkg.package_arch_id
-   AND SP.product_id in ( %s )
    AND pn.name = :pkgname
 order by pkg.id
 """;
+
+_sql_find_root_channel_label = """
+select label
+from rhnChannel
+where id in (
+  select distinct c.parent_channel
+    from rhnChannel c
+    join suseProductChannel pc on pc.channel_id = c.id
+    join suseProducts p on pc.product_id = p.id
+   WHERE p.product_id in ( {0} )
+)
+""";
+
 
 def check_bootstrap_packages():
     """ Check, if bootstrap repo packages are installed """
@@ -120,6 +104,15 @@ def check_bootstrap_packages():
             print("* spacewalk-client-repository")
             print("Aborted.")
             sys.exit(1)
+
+def find_root_channel_labels(pdids):
+    """
+    Get root channel labels for selected distribution
+
+    :return: list of root channel labels
+    """
+    h = rhnSQL.Statement( _sql_find_root_channel_label.format(pdids))
+    return map(lambda x: x['label'], rhnSQL.fetchall_dict(h) or [])
 
 def list_labels():
     """
@@ -146,6 +139,26 @@ def create_repo(label, flush, additional=[]):
         'no-packages': None
     }
 
+    if options.usecustomchannels:
+        root_labels = find_root_channel_labels(pdids)
+        if options.parentchannel and options.parentchannel not in root_labels:
+            print("'{0}' not found in existing parent channel options '{1}'".format(options.parentchannel, root_labels))
+            sys.exit(1)
+        elif not options.parentchannel:
+            if len(root_labels) > 1:
+                print("Multiple options for parent channel found. Please use option --with-parent-channel <label>")
+                print("and choose one of:")
+                for l in root_labels:
+                    print("- {0}".format(l))
+                sys.exit(1)
+            elif len(root_labels) == 1:
+                options.parentchannel = root_labels[0]
+            else:
+                print("WARNING: no parent channel found. Execute without using custom channels")
+                options.parentchannel = ""
+    else:
+        options.parentchannel = ""
+
     if flush:
         print("Removing directory:", destdir)
         try:
@@ -165,16 +178,14 @@ def create_repo(label, flush, additional=[]):
         print("Creating bootstrap repo for {0}".format(label))
     print()
 
-    if options.usecustomchannels:
-        h = rhnSQL.prepare(rhnSQL.Statement(_sql_find_pkgs_with_custom_channels % (pdids, pdids)))
-    else:
-        h = rhnSQL.prepare(rhnSQL.Statement(_sql_find_pkgs % (pdids, pdids)))
+
+    h = rhnSQL.prepare(rhnSQL.Statement(_sql_find_pkgs % (pdids)))
     packagelist = mgr_bootstrap_data.DATA[label]['PKGLIST']
     packagelist.extend(additional)
     logging.debug("The bootstrap repo should contain the following packages: {0}".format(packagelist))
 
     for pkgname in packagelist:
-        h.execute(pkgname=pkgname)
+        h.execute(parentchannel=options.parentchannel, pkgname=pkgname)
         pkgs = h.fetchall_dict() or []
         logging.debug("Package {0} found {1} resulting packages:".format(
             pkgname, len(pkgs)))
@@ -229,6 +240,8 @@ parser.add_option('', '--datamodule', action="store", dest='datamodule',
                   help='Use an own datamodule (Default: mgr_bootstrap_data)')
 parser.add_option('', '--with-custom-channels', action='store_true', dest='usecustomchannels',
                   help='Take custom channels into account when searching for newest package versions')
+parser.add_option('', '--with-parent-channel', action="store", dest='parentchannel',
+                  help='use child channels below this parent')
 parser.add_option('-d', '--debug', action='store_true', dest='debug',
                   help='Enable debug mode')
 

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,6 @@
+- add new option --with-parent-channel to mgr-create-bootrap-repo
+  to specify parent channel to use if multiple options are available
+  (bsc#1104487)
 - add support for postgresql10 (FATE#325659)
 - bootstrap repos for SLE12 SP4 (bsc#1107117)
 - add support for Python 3


### PR DESCRIPTION
## What does this PR change?

We search for the parent channel. In case we find multiple (can happen with SLE15+) we ask to provide the parent label which should be used.
For this we introduce a new option.

Extra: I found a solution to work with just 1 query for with and without custom channel.


## Documentation

- https://github.com/SUSE/spacewalk/issues/6187

- [x] **DONE**

## Test coverage
- No tests: **manual tests**

- [x] **DONE**

## Links

Track https://github.com/SUSE/spacewalk/pull/6160
Fix # https://github.com/SUSE/spacewalk/issues/5472

- [x] **DONE**
