### PR TITLE
Adapt "spacewalk-proxy" code to be Python 2/3 compatible

### DIFF
--- a/proxy/proxy/apacheHandler.py
+++ b/proxy/proxy/apacheHandler.py
@@ -19,7 +19,12 @@
 # language imports
 import os
 import base64
-import xmlrpclib
+try:
+    #  python 2
+    import xmlrpclib
+except ImportError:
+    #  python 3
+    import xmlrpc.client as xmlrpclib
 import re
 
 # common imports
@@ -246,7 +251,7 @@ class apacheHandler(rhnApache):
         log_debug(6, "Ping URI: %s" % pingURL)
 
         hdrs = UserDictCase()
-        for k in req.headers_in.keys():
+        for k in list(req.headers_in.keys()):
             if k.lower() != 'range':  # we want checksum of whole file
                 hdrs[k] = re.sub(r'\n(?![ \t])|\r(?![ \t\n])', '', str(req.headers_in[k]))
 
@@ -361,7 +366,7 @@ class apacheHandler(rhnApache):
 
         try:
             ret = handlerObj.handler()
-        except rhnFault, e:
+        except rhnFault as e:
             return self.response(req, e)
 
         if rhnFlags.test("NeedEncoding"):
@@ -534,7 +539,7 @@ class apacheHandler(rhnApache):
             response = self.normalize(response)
             try:
                 response = rpclib.xmlrpclib.dumps(response, methodresponse=1)
-            except TypeError, e:
+            except TypeError as e:
                 log_debug(-1, "Error \"%s\" encoding response = %s" % (e, response))
                 Traceback("apacheHandler.response", req,
                           extra="Error \"%s\" encoding response = %s" % (e, response),
@@ -549,7 +554,7 @@ class apacheHandler(rhnApache):
         # we're about done here, patch up the headers
         output.process(response)
         # Copy the rest of the fields
-        for k, v in output.headers.items():
+        for k, v in list(output.headers.items()):
             if k.lower() == 'content-type':
                 # Content-type
                 req.content_type = v
@@ -586,7 +591,7 @@ class apacheHandler(rhnApache):
         for line in faultString.split('\n'):
             req.headers_out.add("X-RHN-Fault-String", line.strip())
         # And then send all the other things
-        for k, v in rhnFlags.get('outputTransportOptions').items():
+        for k, v in list(rhnFlags.get('outputTransportOptions').items()):
             setHeaderValue(req.headers_out, k, v)
         return apache.HTTP_NOT_FOUND
 

--- a/proxy/proxy/broker/rhnBroker.py
+++ b/proxy/proxy/broker/rhnBroker.py
@@ -18,7 +18,12 @@
 import time
 import socket
 import re
-from urlparse import urlparse, urlunparse
+try:
+    # python 3
+    from urllib.parse import urlparse, urlunparse
+except ImportError:
+    # python 2
+    from urlparse import urlparse, urlunparse
 
 # common module imports
 from rhn.UserDictCase import UserDictCase
@@ -257,7 +262,7 @@ class BrokerHandler(SharedHandler):
         tokens = []
 
         _oto = rhnFlags.get('outputTransportOptions')
-        if _oto.has_key('X-RHN-Proxy-Auth'):
+        if 'X-RHN-Proxy-Auth' in _oto:
             log_debug(5, '    (auth token prior): %s' % repr(_oto['X-RHN-Proxy-Auth']))
             tokens = _oto['X-RHN-Proxy-Auth'].split(',')
 

--- a/proxy/proxy/broker/rhnRepository.py
+++ b/proxy/proxy/broker/rhnRepository.py
@@ -472,8 +472,7 @@ def cache(stringObject, directory, filename, version):
     while tries > 0:
         # Try to create this new file
         try:
-            fd = os.open(tempfile, os.O_WRONLY | os.O_CREAT | os.O_EXCL,
-                         0o644)
+            fd = os.open(tempfile, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
         except OSError as e:
             if e.errno == 17:
                 # File exists; give it another try

--- a/proxy/proxy/broker/rhnRepository.py
+++ b/proxy/proxy/broker/rhnRepository.py
@@ -21,11 +21,21 @@
 import os
 import time
 import glob
-import cPickle
+try:
+    # python 3
+    import pickle as cPickle
+except ImportError:
+    # python 2
+    import cPickle
 import sys
 import types
 from operator import truth
-import xmlrpclib
+try:
+    #  python 2
+    import xmlrpclib
+except ImportError:
+    #  python3
+    import xmlrpc.client as xmlrpclib
 
 ## common imports
 from spacewalk.common.rhnLib import parseRPMName
@@ -83,7 +93,7 @@ class Repository(rhnRepository.Repository):
         # If the file name has parameters, it's a different kind of package.
         # Determine the architecture requested so we can construct an
         # appropriate filename.
-        if isinstance(pkgFilename, types.ListType):
+        if isinstance(pkgFilename, list):
             arch = pkgFilename[3]
             # Not certain if anything is needed here for Debian, but since what I've tested
             # works.   Leave it alone.
@@ -94,7 +104,7 @@ class Repository(rhnRepository.Repository):
                      pkgFilename[2],
                      pkgFilename[3])
 
-        if not mapping.has_key(pkgFilename):
+        if pkgFilename not in mapping:
             log_debug(3, "Package not in mapping: %s" % pkgFilename)
             raise NotLocalError
         # A list of possible file paths. Always a list, channel mappings are
@@ -132,9 +142,10 @@ class Repository(rhnRepository.Repository):
         try:
             retval = server.proxy.package_source_in_channel(
                 pkgFilename, self.channelName, self.clientInfo)
-        except xmlrpclib.Fault, e:
+        except xmlrpclib.Fault as e:
             raise rhnFault(1000,
                            _("Error retrieving source package: %s") % str(e)), None, sys.exc_info()[2]
+
         if not retval:
             raise rhnFault(17, _("Invalid SRPM package requested: %s")
                            % pkgFilename)
@@ -224,7 +235,7 @@ class Repository(rhnRepository.Repository):
 
         try:
             packageList = self._listPackages()
-        except xmlrpclib.ProtocolError, e:
+        except xmlrpclib.ProtocolError as e:
             errcode, errmsg = rpclib.reportError(e.headers)
             raise rhnFault(1000, "SpacewalkProxy error (xmlrpclib.ProtocolError): "
                            "errode=%s; errmsg=%s" % (errcode, errmsg)), None, sys.exc_info()[2]
@@ -462,8 +473,8 @@ def cache(stringObject, directory, filename, version):
         # Try to create this new file
         try:
             fd = os.open(tempfile, os.O_WRONLY | os.O_CREAT | os.O_EXCL,
-                         0644)
-        except OSError, e:
+                         0o644)
+        except OSError as e:
             if e.errno == 17:
                 # File exists; give it another try
                 tries = tries - 1

--- a/proxy/proxy/pm/rhn_package_manager
+++ b/proxy/proxy/pm/rhn_package_manager
@@ -19,12 +19,12 @@ if __name__ == '__main__':
 
     try:
         from PackageManager import rhn_package_manager
-    except ImportError, e:
+    except ImportError as e:
         sys.stderr.write("Unable to find package management libraries.\n"
                          "Path not correct? '%s'\n" % LIBPATH)
         raise
 
     try:
         rhn_package_manager.main()
-    except SystemExit, e:
+    except SystemExit as e:
         sys.exit(e.code)

--- a/proxy/proxy/pm/rhn_package_manager.py
+++ b/proxy/proxy/pm/rhn_package_manager.py
@@ -39,7 +39,12 @@ import os
 from xml.dom import minidom
 import sys
 import shutil
-import xmlrpclib
+try:
+    #  python 2
+    import xmlrpclib
+except ImportError:
+    #  python3
+    import xmlrpc.client as xmlrpclib
 from optparse import Option, OptionParser
 
 # RHN imports
@@ -158,7 +163,7 @@ def main():
 
     try:
         upload.uploadHeaders()
-    except UploadError, e:
+    except UploadError as e:
         sys.stderr.write("Upload error: %s\n" % e)
 
 
@@ -205,7 +210,7 @@ class UploadClass(uploadLib.UploadClass):
                                     "channel.xml.gz")
             if not os.access(xml_path, os.R_OK):
                 self.warn(0, "Could not find metadata for channel %s, skipping..." % channel)
-                print "Could not find metadata for channel %s, skipping..." % channel
+                print("Could not find metadata for channel %s, skipping..." % channel)
                 continue
             dom = minidom.parse(gzip.open(xml_path))
             # will only ever be the one
@@ -223,7 +228,7 @@ class UploadClass(uploadLib.UploadClass):
         try:
             uploadLib.UploadClass.setServer(self)
             uploadLib.call(self.server.packages.no_op, raise_protocol_error=True)
-        except xmlrpclib.ProtocolError, e:
+        except xmlrpclib.ProtocolError as e:
             if e.errcode == 404:
                 self.use_session = False
                 self.setURL('/XP')
@@ -322,7 +327,7 @@ class UploadClass(uploadLib.UploadClass):
         if not os.path.isdir(destdir):
             # Try to create it
             try:
-                os.makedirs(destdir, 0755)
+                os.makedirs(destdir, 0o755)
             except OSError:
                 self.warn(0, "Could not create directory %s" % destdir)
                 return
@@ -330,7 +335,7 @@ class UploadClass(uploadLib.UploadClass):
         shutil.copy2(filename, packagePath)
         # Make sure the file permissions are set correctly, so that Apache can
         # see the files
-        os.chmod(packagePath, 0644)
+        os.chmod(packagePath, 0o644)
 
     def _listChannelSource(self):
         self.die(1, "Listing source rpms not supported")
@@ -366,5 +371,5 @@ def rpmPackageName(p):
 if __name__ == '__main__':
     try:
         main()
-    except SystemExit, se:
+    except SystemExit as se:
         sys.exit(se.code)

--- a/proxy/proxy/pm/rhn_package_manager.py
+++ b/proxy/proxy/pm/rhn_package_manager.py
@@ -210,7 +210,7 @@ class UploadClass(uploadLib.UploadClass):
                                     "channel.xml.gz")
             if not os.access(xml_path, os.R_OK):
                 self.warn(0, "Could not find metadata for channel %s, skipping..." % channel)
-                print("Could not find metadata for channel %s, skipping..." % channel)
+                print("Could not find metadata for channel {}, skipping...".format(channel))
                 continue
             dom = minidom.parse(gzip.open(xml_path))
             # will only ever be the one

--- a/proxy/proxy/responseContext.py
+++ b/proxy/proxy/responseContext.py
@@ -119,23 +119,23 @@ class ResponseContext:
 
 if __name__ == "__main__":
     respContext = ResponseContext()
-    print "init   | context = " + str(respContext)
+    print("init   | context = " + str(respContext))
 
     respContext.remove()
-    print "remove | context = " + str(respContext)
+    print("remove | context = " + str(respContext))
 
     respContext.add()
-    print "add    | context = " + str(respContext)
+    print("add    | context = " + str(respContext))
 
     respContext.remove()
-    print "remove | context = " + str(respContext)
+    print("remove | context = " + str(respContext))
 
     respContext.add()
     respContext.add()
-    print "addadd | context = " + str(respContext)
+    print("addadd | context = " + str(respContext))
 
     respContext.clear()
-    print "clear  | context = " + str(respContext)
+    print("clear  | context = " + str(respContext))
 
     respContext.add()
-    print "add    | context = " + str(respContext)
+    print("add    | context = " + str(respContext))

--- a/proxy/proxy/rhnAuthCacheClient.py
+++ b/proxy/proxy/rhnAuthCacheClient.py
@@ -191,8 +191,8 @@ if __name__ == '__main__':
     s = Shelf(('localhost', 9999))
     s['1234'] = [1, 2, 3, 4, None, None]
     s['blah'] = 'testing 1 2 3'
-    print('Cached object s["1234"] = {}'.format(str(s['1234'])))
-    print('Cached object s["blah"] = {}'.format(str(s['blah'])))
+    print('Cached object s["1234"] = {}'.format(s['1234']))
+    print('Cached object s["blah"] = {}'.format(s['blah']))
     print("asdfrasdf" in s)
 
 #    print

--- a/proxy/proxy/rhnAuthCacheClient.py
+++ b/proxy/proxy/rhnAuthCacheClient.py
@@ -100,7 +100,7 @@ class Shelf:
             # FIXME: PROBLEM: this rhnFault will never reach the client
             raise rhnFault(1000,
                            _("Spacewalk Proxy error (issues connecting to auth cache). "
-                             "Please contact your system administrator")), None, sys.exc_info()[2]
+                             "Please contact your system administrator")).with_traceback(sys.exc_info()[2])
 
         wfile = sock.makefile("w")
 
@@ -122,7 +122,7 @@ class Shelf:
             # FIXME: PROBLEM: this rhnFault will never reach the client
             raise rhnFault(1000,
                            _("Spacewalk Proxy error (issues connecting to auth cache). "
-                             "Please contact your system administrator")), None, sys.exc_info()[2]
+                             "Please contact your system administrator")).with_traceback(sys.exc_info()[2])
 
         wfile.close()
 
@@ -140,7 +140,7 @@ class Shelf:
             # FIXME: PROBLEM: this rhnFault will never reach the client
             raise rhnFault(1000,
                            _("Spacewalk Proxy error (issues communicating to auth cache). "
-                             "Please contact your system administrator")), None, sys.exc_info()[2]
+                             "Please contact your system administrator")).with_traceback(sys.exc_info()[2])
         except Fault as e:
             rfile.close()
             sock.close()
@@ -169,7 +169,7 @@ class Shelf:
             import new
             _dict = {'args': args}
             # pylint: disable=bad-option-value,nonstandard-exception
-            raise new.instance(getattr(__builtins__, name), _dict), None, sys.exc_info()[2]
+            raise new.instance(getattr(__builtins__, name), _dict).with_traceback(sys.exc_info()[2])
 
         return params[0]
 

--- a/proxy/proxy/rhnAuthCacheClient.py
+++ b/proxy/proxy/rhnAuthCacheClient.py
@@ -21,7 +21,12 @@
 ## language imports
 import socket
 import sys
-from xmlrpclib import Fault
+try:
+    #  python 2
+    from xmlrpclib import Fault
+except ImportError:
+    #  python3
+    from xmlrpc.client import Fault
 
 ## local imports
 from spacewalk.common.rhnLog import log_debug, log_error
@@ -85,7 +90,7 @@ class Shelf:
 
         try:
             sock.connect(self.serverAddr)
-        except socket.error, e:
+        except socket.error as e:
             sock.close()
             methodname = None
             log_error("Error connecting to the auth cache: %s" % str(e))
@@ -124,7 +129,7 @@ class Shelf:
         rfile = sock.makefile("r")
         try:
             params, methodname = recv(rfile)
-        except CommunicationError, e:
+        except CommunicationError as e:
             log_error(e.faultString)
             rfile.close()
             sock.close()
@@ -136,7 +141,7 @@ class Shelf:
             raise rhnFault(1000,
                            _("Spacewalk Proxy error (issues communicating to auth cache). "
                              "Please contact your system administrator")), None, sys.exc_info()[2]
-        except Fault, e:
+        except Fault as e:
             rfile.close()
             sock.close()
             # If e.faultCode is 0, it's another exception
@@ -149,7 +154,7 @@ class Shelf:
                 # Not the expected type
                 raise
 
-            if not _dict.has_key('name'):
+            if 'name' not in _dict:
                 # Doesn't look like a marshalled exception
                 raise
 
@@ -186,9 +191,9 @@ if __name__ == '__main__':
     s = Shelf(('localhost', 9999))
     s['1234'] = [1, 2, 3, 4, None, None]
     s['blah'] = 'testing 1 2 3'
-    print 'Cached object s["1234"] = %s' % str(s['1234'])
-    print 'Cached object s["blah"] = %s' % str(s['blah'])
-    print s.has_key("asdfrasdf")
+    print('Cached object s["1234"] = %s' % str(s['1234']))
+    print('Cached object s["blah"] = %s' % str(s['blah']))
+    print("asdfrasdf" in s)
 
 #    print
 #    print 'And this will bomb (attempt to get non-existant data:'

--- a/proxy/proxy/rhnAuthCacheClient.py
+++ b/proxy/proxy/rhnAuthCacheClient.py
@@ -191,8 +191,8 @@ if __name__ == '__main__':
     s = Shelf(('localhost', 9999))
     s['1234'] = [1, 2, 3, 4, None, None]
     s['blah'] = 'testing 1 2 3'
-    print('Cached object s["1234"] = %s' % str(s['1234']))
-    print('Cached object s["blah"] = %s' % str(s['blah']))
+    print('Cached object s["1234"] = {}'.format(str(s['1234'])))
+    print('Cached object s["blah"] = {}'.format(str(s['blah'])))
     print("asdfrasdf" in s)
 
 #    print

--- a/proxy/proxy/rhnAuthProtocol.py
+++ b/proxy/proxy/rhnAuthProtocol.py
@@ -19,7 +19,12 @@
 import struct
 
 ## local imports
-from xmlrpclib import dumps, loads
+try:
+    #  python 2
+    from xmlrpclib import dumps, loads
+except ImportError:
+    #  python3
+    from xmlrpc.client import dumps, loads
 
 
 class CommunicationError(Exception):

--- a/proxy/proxy/rhnProxyAuth.py
+++ b/proxy/proxy/rhnProxyAuth.py
@@ -19,7 +19,12 @@
 import os
 import time
 import socket
-import xmlrpclib
+try:
+    #  python 2
+    import xmlrpclib
+except ImportError:
+    #  python3
+    import xmlrpc.client as xmlrpclib
 import sys
 # pylint: disable=E0611
 from hashlib import sha1
@@ -85,7 +90,7 @@ class ProxyAuth:
         mtime = None
         try:
             mtime = os.stat(ProxyAuth.__systemid_filename)[-2]
-        except IOError, e:
+        except IOError as e:
             log_error("unable to stat %s: %s" % (ProxyAuth.__systemid_filename, repr(e)))
             raise rhnFault(1000,
                       _("SUSE Manager Proxy error (SUSE Manager Proxy systemid has wrong permissions?). "
@@ -102,7 +107,7 @@ class ProxyAuth:
         # get systemid
         try:
             ProxyAuth.__systemid = open(ProxyAuth.__systemid_filename, 'r').read()
-        except IOError, e:
+        except IOError as e:
             log_error("unable to read %s" % ProxyAuth.__systemid_filename)
             raise rhnFault(1000,
                       _("SUSE Manager Proxy error (SUSE Manager Proxy systemid has wrong permissions?). "
@@ -247,20 +252,20 @@ problems, isn't running, or the token is somehow corrupt.
         for _i in range(self.__nRetries):
             try:
                 token = server.proxy.login(self.__systemid)
-            except (socket.error, socket.sslerror), e:
+            except (socket.error, socket.sslerror) as e:
                 if CFG.HTTP_PROXY:
                     # socket error, check to see if your HTTP proxy is running...
                     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                     httpProxy, httpProxyPort = CFG.HTTP_PROXY.split(':')
                     try:
                         s.connect((httpProxy, int(httpProxyPort)))
-                    except socket.error, e:
+                    except socket.error as e:
                         error = ['socket.error', 'HTTP Proxy not running? '
                                  '(%s) %s' % (CFG.HTTP_PROXY, e)]
                         # rather big problem: http proxy not running.
                         log_error("*** ERROR ***: %s" % error[1])
                         Traceback(mail=0)
-                    except socket.sslerror, e:
+                    except socket.sslerror as e:
                         error = ['socket.sslerror',
                                  '(%s) %s' % (CFG.HTTP_PROXY, e)]
                         # rather big problem: http proxy not running.
@@ -277,19 +282,19 @@ problems, isn't running, or the token is somehow corrupt.
                 token = None
                 time.sleep(.25)
                 continue
-            except SSL.SSL.Error, e:
+            except SSL.SSL.Error as e:
                 token = None
                 error = ['rhn.SSL.SSL.Error', repr(e), str(e)]
                 log_error(error)
                 Traceback(mail=0)
                 time.sleep(.25)
                 continue
-            except xmlrpclib.ProtocolError, e:
+            except xmlrpclib.ProtocolError as e:
                 token = None
                 log_error('xmlrpclib.ProtocolError', e)
                 time.sleep(.25)
                 continue
-            except xmlrpclib.Fault, e:
+            except xmlrpclib.Fault as e:
                 # Report it through the mail
                 # Traceback will try to walk over all the values
                 # in each stack frame, and eventually will try to stringify
@@ -309,7 +314,7 @@ problems, isn't running, or the token is somehow corrupt.
                 raise rhnFault(1000,
                           _("SUSE Manager Proxy error (during proxy login). "
                             "Please contact your system administrator.")), None, sys.exc_info()[2]
-            except Exception, e:
+            except Exception as e:
                 token = None
                 log_error("Unhandled exception", e)
                 Traceback(mail=0)

--- a/proxy/proxy/rhnShared.py
+++ b/proxy/proxy/rhnShared.py
@@ -15,7 +15,12 @@
 #
 
 # language imports
-import urllib
+try:
+    # python 3
+    import urllib.parse as urllib
+except ImportError:
+    # python 2
+    import urllib
 import socket
 import sys
 from types import ListType, TupleType
@@ -137,7 +142,7 @@ class SharedHandler:
 
         try:
             self.responseContext.getConnection().connect()
-        except socket.error, e:
+        except socket.error as e:
             log_error("Error opening connection", self.rhnParent, e)
             Traceback(mail=0)
             raise rhnFault(1000,
@@ -252,7 +257,7 @@ class SharedHandler:
             # Copy the incoming headers to headers_out
             headers = self.responseContext.getHeaders()
             if headers is not None:
-                for k in headers.keys():
+                for k in list(headers.keys()):
                     rhnLib.setHeaderValue(self.req.headers_out, k,
                                           self._get_header(k))
             else:
@@ -311,7 +316,7 @@ class SharedHandler:
         """ Copy the incoming headers. """
 
         hdrs = UserDictCase()
-        for k in req.headers_in.keys():
+        for k in list(req.headers_in.keys()):
             # XXX misa: is this enough? Shouldn't we care about multivalued
             # headers?
             hdrs[k] = req.headers_in[k]
@@ -348,7 +353,7 @@ class SharedHandler:
 
         # Put the headers into the output connection object
         http_connection = self.responseContext.getConnection()
-        for (k, vals) in hdrs.items():
+        for (k, vals) in list(hdrs.items()):
             if k.lower() in ['content_length', 'content-length']:
                 try:
                     size = int(vals)
@@ -440,7 +445,7 @@ class SharedHandler:
         # Iterate over each header in the response and place it in the request
         # output area.
 
-        for k in fromResponse.msg.keys():
+        for k in list(fromResponse.msg.keys()):
             # Get the value
             v = self._get_header(k, fromResponse.msg)
 

--- a/proxy/proxy/spacewalk-proxy.changes
+++ b/proxy/proxy/spacewalk-proxy.changes
@@ -1,3 +1,5 @@
+- Add support for Python 3 on spacewalk-proxy
+
 -------------------------------------------------------------------
 Fri Oct 26 10:33:16 CEST 2018 - jgonzalez@suse.com
 

--- a/proxy/proxy/spacewalk-proxy.spec
+++ b/proxy/proxy/spacewalk-proxy.spec
@@ -231,7 +231,7 @@ Conflicts:      rhns-satellite-tools
 A ZeroMQ Proxy for Salt Minions
 
 %prep
-%setup -q -n spacewalk-proxy-devel
+%setup -q
 
 %build
 make -f Makefile.proxy

--- a/proxy/proxy/spacewalk-proxy.spec
+++ b/proxy/proxy/spacewalk-proxy.spec
@@ -238,7 +238,7 @@ make -f Makefile.proxy
 
 # Fixing shebang for Python 3
 %if 0%{?build_py3}
-for i in `find . -type f`;
+for i in $(find . -type f);
 do
     sed -i '1s=^#!/usr/bin/\(python\|env python\)[0-9.]*=#!/usr/bin/python3=' $i;
 done


### PR DESCRIPTION
## What does this PR change?

This PR migrates "spacewalk-proxy" code to be Python 2/3 compatible.

Some notes:
- General fixes addressed by `2to3`.
- Fixed `xmlrpclib`, `urlparse` and `cPickle` import issues.
- Made the spec file to build package for Python3 on SLE15.

## Links

Tracks https://github.com/SUSE/salt-board/issues/62

- [x] **DONE**