### PR TITLE
Changed MenuTree Names (bsc#1019847) 

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -591,14 +591,8 @@
           <context context-type="sourcefile">Navigation Menu</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="Manage Software Channels">
-        <source>Manage Software Channels</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">Navigation Menu</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="Manage Software Packages">
-        <source>Manage Software Packages</source>
+      <trans-unit id="Manage">
+        <source>Manage</source>
         <context-group name="ctx">
           <context context-type="sourcefile">Navigation Menu</context>
         </context-group>
@@ -875,6 +869,12 @@
       </trans-unit>
       <trans-unit id="Systems">
         <source>Systems</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">Navigation Menu</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="System List">
+        <source>System List</source>
         <context-group name="ctx">
           <context context-type="sourcefile">Navigation Menu</context>
         </context-group>

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -403,6 +403,12 @@
           <context context-type="sourcefile">Navigation Menu</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="Channel List">
+        <source>Channel List</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">Navigation Menu</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="Client Configuration">
         <source>Client Configuration</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/nav/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/nav/StringResource_en_US.xml
@@ -267,13 +267,13 @@
         </context-group>
       </trans-unit>
       <trans-unit id="config.nav.managed">
-        <source>Managed Systems</source>
+        <source>Managed</source>
         <context-group name="ctx">
           <context context-type="sourcefile">Configuration Navigation Menu</context>
         </context-group>
       </trans-unit>
       <trans-unit id="config.nav.target">
-        <source>Target Systems</source>
+        <source>Target</source>
         <context-group name="ctx">
           <context context-type="sourcefile">Configuration Navigation Menu</context>
         </context-group>
@@ -285,25 +285,25 @@
         </context-group>
       </trans-unit>
       <trans-unit id="config.nav.channels">
-        <source>Configuration Channels</source>
+        <source>Channels</source>
         <context-group name="ctx">
           <context context-type="sourcefile">Configuration Navigation Menu</context>
         </context-group>
       </trans-unit>
       <trans-unit id="config.nav.files">
-        <source>Configuration Files</source>
+        <source>Files</source>
         <context-group name="ctx">
           <context context-type="sourcefile">Configuration Navigation Menu</context>
         </context-group>
       </trans-unit>
       <trans-unit id="config.nav.globalfiles">
-        <source>Centrally Managed Files</source>
+        <source>Centrally Managed</source>
         <context-group name="ctx">
           <context context-type="sourcefile">Configuration Navigation Menu</context>
         </context-group>
       </trans-unit>
       <trans-unit id="config.nav.localfiles">
-        <source>Locally Managed Files</source>
+        <source>Locally Managed</source>
         <context-group name="ctx">
           <context context-type="sourcefile">Configuration Navigation Menu</context>
         </context-group>
@@ -657,6 +657,12 @@
       </trans-unit>
       <trans-unit id="Patches">
         <source>Patches</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">Navigation Menu</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="Patch List">
+        <source>Patch List</source>
         <context-group name="ctx">
           <context context-type="sourcefile">Navigation Menu</context>
         </context-group>
@@ -1023,6 +1029,9 @@
       </group>
       <trans-unit id="Deployment">
         <source>Deployment</source>
+      </trans-unit>
+      <trans-unit id="Image List">
+        <source>Image List</source>
       </trans-unit>
     </body>
   </file>

--- a/java/code/src/com/suse/manager/webui/menu/MenuTree.java
+++ b/java/code/src/com/suse/manager/webui/menu/MenuTree.java
@@ -203,9 +203,9 @@ public class MenuTree {
                 .addChild(new MenuItem("Clone Errata").withPrimaryUrl("/rhn/errata/manage/CloneErrata.do")
                     .withDir("/rhn/errata/manage/clone").withVisibility(checkAcl(user, "user_role(channel_admin)"))));
 
-            // Software
+            // (Software) Channels
             nodes.add(new MenuItem("Software").withIcon("spacewalk-icon-software-channels")
-                .addChild(new MenuItem("Channels").withDir("/rhn/channels")
+                .addChild(new MenuItem("Channel List").withDir("/rhn/channels")
                     .addChild(new MenuItem("channel.nav.all").withPrimaryUrl("/rhn/software/channels/All.do"))
                     .addChild(new MenuItem("channel.nav.vendor").withPrimaryUrl("/rhn/software/channels/Vendor.do")
                         .withVisibility(checkAcl(user, "is_satellite()")))

--- a/java/code/src/com/suse/manager/webui/menu/MenuTree.java
+++ b/java/code/src/com/suse/manager/webui/menu/MenuTree.java
@@ -79,7 +79,7 @@ public class MenuTree {
             // Systems
             nodes.add(new MenuItem("Systems").withIcon("fa-desktop").withDir("/rhn/systems/details").withDir("/rhn/manager/systems/details")
                 .addChild(new MenuItem("Overview").withPrimaryUrl("/rhn/systems/Overview.do"))
-                .addChild(new MenuItem("Systems").addChild(new MenuItem("All").withPrimaryUrl("/rhn/systems/SystemList.do"))
+                .addChild(new MenuItem("System List").addChild(new MenuItem("All").withPrimaryUrl("/rhn/systems/SystemList.do"))
                     .addChild(new MenuItem("Physical Systems").withPrimaryUrl("/rhn/systems/PhysicalList.do"))
                     .addChild(new MenuItem("Virtual Systems").withPrimaryUrl("/rhn/systems/VirtualList.do"))
                     .addChild(new MenuItem("Bare Metal Systems").withPrimaryUrl("/rhn/systems/BootstrapSystemList.do"))
@@ -176,7 +176,7 @@ public class MenuTree {
 
             // Images
             nodes.add(new MenuItem("Images").withIcon("spacewalk-icon-manage-configuration-files")
-                .addChild(new MenuItem("Images").withPrimaryUrl("/rhn/manager/cm/images")
+                .addChild(new MenuItem("Image List").withPrimaryUrl("/rhn/manager/cm/images")
                     .withDir("/rhn/manager/cm/images"))
                 .addChild(new MenuItem("Build").withPrimaryUrl("/rhn/manager/cm/build")
                     .withDir("/rhn/manager/cm/build").withVisibility(adminRoles.get("image")))
@@ -187,7 +187,7 @@ public class MenuTree {
 
             // Patches
             nodes.add(new MenuItem("Patches").withIcon("spacewalk-icon-patches")
-                .addChild(new MenuItem("Patches").withPrimaryUrl("/rhn/errata/RelevantErrata.do").withDir("/rhn/errata")
+                .addChild(new MenuItem("Patch List").withPrimaryUrl("/rhn/errata/RelevantErrata.do").withDir("/rhn/errata")
                     .addChild(new MenuItem("Relevant").withPrimaryUrl("/rhn/errata/RelevantErrata.do")
                         .withAltUrl("/rhn/errata/RelevantBugErrata.do").withAltUrl("/rhn/errata/RelevantEnhancementErrata.do")
                         .withAltUrl("/rhn/errata/RelevantSecurityErrata.do"))
@@ -203,7 +203,7 @@ public class MenuTree {
                 .addChild(new MenuItem("Clone Errata").withPrimaryUrl("/rhn/errata/manage/CloneErrata.do")
                     .withDir("/rhn/errata/manage/clone").withVisibility(checkAcl(user, "user_role(channel_admin)"))));
 
-            // Channels
+            // Software
             nodes.add(new MenuItem("Software").withIcon("spacewalk-icon-software-channels")
                 .addChild(new MenuItem("Channels").withDir("/rhn/channels")
                     .addChild(new MenuItem("channel.nav.all").withPrimaryUrl("/rhn/software/channels/All.do"))
@@ -215,14 +215,14 @@ public class MenuTree {
                     .addChild(new MenuItem("channel.nav.retired").withPrimaryUrl("/rhn/software/channels/Retired.do")))
                 .addChild(
                     new MenuItem("Package Search").withPrimaryUrl("/rhn/channels/software/Search.do").withDir("/rhn/software/packages"))
-                .addChild(new MenuItem("Manage Software Channels").withDir("/rhn/channels/manage")
-                    .addChild(new MenuItem("Overview").withPrimaryUrl("/rhn/channels/manage/Manage.do")
+                .addChild(new MenuItem("Manage").withDir("/rhn/channels/manage")
+                    .addChild(new MenuItem("Channels").withPrimaryUrl("/rhn/channels/manage/Manage.do")
                         .withAltUrl("/rhn/channels/manage/errata/Add.do").withAltUrl("/rhn/channels/manage/errata/AddRedHatErrata.do")
                         .withAltUrl("/rhn/channels/manage/errata/AddCustomErrata.do")
                         .withAltUrl("/rhn/channels/manage/errata/ConfirmErrataAdd.do"))
-                    .addChild(new MenuItem("Manage Software Packages").withPrimaryUrl("/rhn/software/manage/packages/PackageList.do")
+                    .addChild(new MenuItem("Packages").withPrimaryUrl("/rhn/software/manage/packages/PackageList.do")
                         .withDir("/rhn/software/manage/packages").withVisibility(checkAcl(user, "user_role(channel_admin)")))
-                    .addChild(new MenuItem("Manage Repositories").withPrimaryUrl("/rhn/channels/manage/repos/RepoList.do")
+                    .addChild(new MenuItem("Repositories").withPrimaryUrl("/rhn/channels/manage/repos/RepoList.do")
                         .withAltUrl("/rhn/channels/manage/repos/RepoEdit.do").withAltUrl("/rhn/channels/manage/repos/RepoCreate.do")
                         .withDir("/rhn/channels/manage/repos").withVisibility(checkAcl(user, "user_role(channel_admin)"))))
                 .addChild(new MenuItem("Distribution Channel Mapping").withPrimaryUrl("/rhn/channels/manage/DistChannelMap.do")

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Changed Strings for MenuTree Items to remove redundancy (bsc#1019847)
 - Automatic cleanup of notification messages after a configurable lifetime
 - Fix 'image deployed' event data parsing (bsc#1110316)
 - Handle 'image deployed' salt event by executing post-deployment procedures

--- a/testsuite/features/allcli_config_channel.feature
+++ b/testsuite/features/allcli_config_channel.feature
@@ -7,7 +7,7 @@ Feature: Management of configuration of all types of clients in a single channel
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Create Config Channel"
     And I enter "Mixed Channel" as "cofName"
     And I enter "mixedchannel" as "cofLabel"
@@ -19,7 +19,7 @@ Feature: Management of configuration of all types of clients in a single channel
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Mixed Channel"
     And I follow "Create Configuration File or Directory"
     And I enter "/etc/s-mgr/config" as "cffPath"
@@ -76,7 +76,7 @@ Feature: Management of configuration of all types of clients in a single channel
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
     And I run "rhn-actions-control --enable-all" on "sle-client"
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Mixed Channel"
     And I follow "Deploy all configuration files to all subscribed systems"
     Then I should see a "/etc/s-mgr/config" link
@@ -126,7 +126,7 @@ Feature: Management of configuration of all types of clients in a single channel
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Mixed Channel"
     And I follow "Systems" in the content area
     And I check the "ceos-minion" client
@@ -139,7 +139,7 @@ Feature: Management of configuration of all types of clients in a single channel
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Mixed Channel"
     And I follow "Systems" in the content area
     And I check the "ssh-minion" client
@@ -213,7 +213,7 @@ Feature: Management of configuration of all types of clients in a single channel
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Mixed Channel"
     And I follow "Systems" in the content area
     And I check the "sle-client" client
@@ -225,7 +225,7 @@ Feature: Management of configuration of all types of clients in a single channel
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Mixed Channel"
     And I follow "Delete Channel"
     And I click on "Delete Config Channel"

--- a/testsuite/features/core_srv_channels_add.feature
+++ b/testsuite/features/core_srv_channels_add.feature
@@ -11,9 +11,9 @@ Feature: Adding channels
     And I follow "Home" in the left menu
 
   Scenario: Add a base channel
-    When I follow "Channels"
-    And I follow "Manage Software Channels" in the left menu
-    And I follow "Overview" in the left menu
+    When I follow "Software"
+    And I follow "Manage" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Create Channel"
     And I enter "Test Base Channel" as "Channel Name"
     And I enter "test_base_channel" as "Channel Label"
@@ -25,9 +25,9 @@ Feature: Adding channels
     Then I should see a "Channel Test Base Channel created." text
 
   Scenario: Add a child channel
-    When I follow "Channels"
-    And I follow "Manage Software Channels" in the left menu
-    And I follow "Overview" in the left menu
+    When I follow "Software"
+    And I follow "Manage" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Create Channel"
     When I enter "Test Child Channel" as "Channel Name"
     And I enter "test_child_channel" as "Channel Label"
@@ -39,9 +39,9 @@ Feature: Adding channels
     Then I should see a "Channel Test Child Channel created." text
 
   Scenario: Add a base test channel for i586
-    When I follow "Channels"
-    And I follow "Manage Software Channels" in the left menu
-    And I follow "Overview" in the left menu
+    When I follow "Software"
+    And I follow "Manage" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Create Channel"
     And I enter "Test-Channel-i586" as "Channel Name"
     And I enter "test-channel-i586" as "Channel Label"
@@ -53,9 +53,9 @@ Feature: Adding channels
     Then I should see a "Channel Test-Channel-i586 created." text
 
   Scenario: Add a child channel to the i586 test channel
-    When I follow "Channels"
-    And I follow "Manage Software Channels" in the left menu
-    And I follow "Overview" in the left menu
+    When I follow "Software"
+    And I follow "Manage" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Create Channel"
     And I enter "Test-Channel-i586 Child Channel" as "Channel Name"
     And I enter "test-channel-i586-child-channel" as "Channel Label"
@@ -67,9 +67,9 @@ Feature: Adding channels
     Then I should see a "Channel Test-Channel-i586 Child Channel created." text
 
   Scenario: Add a test base channel for x86_64
-    When I follow "Channels"
-    And I follow "Manage Software Channels" in the left menu
-    And I follow "Overview" in the left menu
+    When I follow "Software"
+    And I follow "Manage" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Create Channel"
     And I enter "Test-Channel-x86_64" as "Channel Name"
     And I enter "test-channel-x86_64" as "Channel Label"
@@ -81,9 +81,9 @@ Feature: Adding channels
     Then I should see a "Channel Test-Channel-x86_64 created." text
 
   Scenario: Add a child channel to the x86_64 test channel
-    When I follow "Channels"
-    And I follow "Manage Software Channels" in the left menu
-    And I follow "Overview" in the left menu
+    When I follow "Software"
+    And I follow "Manage" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Create Channel"
     And I enter "Test-Channel-x86_64 Child Channel" as "Channel Name"
     And I enter "test-channel-x86_64-child-channel" as "Channel Label"
@@ -95,9 +95,9 @@ Feature: Adding channels
     Then I should see a "Channel Test-Channel-x86_64 Child Channel created." text
 
   Scenario: Add Fedora x86_64 base channel
-    When I follow "Channels"
-    And I follow "Manage Software Channels" in the left menu
-    And I follow "Overview" in the left menu
+    When I follow "Software"
+    And I follow "Manage" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Create Channel"
     And I enter "Fedora x86_64 Channel" as "Channel Name"
     And I enter "fedora-x86_64-channel" as "Channel Label"
@@ -109,9 +109,9 @@ Feature: Adding channels
     Then I should see a "Channel Fedora x86_64 Channel created." text
 
   Scenario: Fail when trying to add a duplicate channel
-     When I follow "Channels"
-     And I follow "Manage Software Channels" in the left menu
-     And I follow "Overview" in the left menu
+     When I follow "Software"
+     And I follow "Manage" in the left menu
+     And I follow "Channels" in the left menu
      And I follow "Create Channel"
      And I enter "Test Base Channel" as "Channel Name"
      And I enter "test_base_channel" as "Channel Label"
@@ -123,9 +123,9 @@ Feature: Adding channels
      Then I should see a "The channel name 'Test Base Channel' is already in use, please enter a different name" text
 
   Scenario: Fail when trying to use invalid characters in the channel label
-      When I follow "Channels"
-      And I follow "Manage Software Channels" in the left menu
-      And I follow "Overview" in the left menu
+      When I follow "Software"
+      And I follow "Manage" in the left menu
+      And I follow "Channels" in the left menu
       And I follow "Create Channel"
       And I enter "test123" as "Channel Name"
       And I enter "tesT123" as "Channel Label"
@@ -134,9 +134,9 @@ Feature: Adding channels
       Then I should see a "Invalid channel label, please see the format described below" text
 
   Scenario: Fail when trying to use invalid characters in the channel name
-      When I follow "Channels"
-      And I follow "Manage Software Channels" in the left menu
-      And I follow "Overview" in the left menu
+      When I follow "Software"
+      And I follow "Manage" in the left menu
+      And I follow "Channels" in the left menu
       And I follow "Create Channel"
       And I enter "!test123" as "Channel Name"
       And I enter "test123" as "Channel Label"
@@ -145,9 +145,9 @@ Feature: Adding channels
       Then I should see a "Invalid channel name, please see the format described below" text
 
   Scenario: Fail when trying to use reserved names for channels
-    When I follow "Channels"
-     And I follow "Manage Software Channels" in the left menu
-     And I follow "Overview" in the left menu
+    When I follow "Software"
+     And I follow "Manage" in the left menu
+     And I follow "Channels" in the left menu
      And I follow "Create Channel"
      And I enter "SLE-12-Cloud-Compute5-Pool for x86_64" as "Channel Name"
      And I enter "test123" as "Channel Label"
@@ -156,9 +156,9 @@ Feature: Adding channels
     Then I should see a "The channel name 'SLE-12-Cloud-Compute5-Pool for x86_64' is reserved, please enter a different name" text
 
   Scenario: Fail when trying to use reserved labels for channels
-    When I follow "Channels"
-     And I follow "Manage Software Channels" in the left menu
-     And I follow "Overview" in the left menu
+    When I follow "Software"
+     And I follow "Manage" in the left menu
+     And I follow "Channels" in the left menu
      And I follow "Create Channel"
      And I enter "test123" as "Channel Name"
      And I enter "sle-we12-pool-x86_64-sap" as "Channel Label"
@@ -167,9 +167,9 @@ Feature: Adding channels
     Then I should see a "The channel label 'sle-we12-pool-x86_64-sap' is reserved, please enter a different name" text
 
   Scenario: Create a channel that will be changed
-    When I follow "Channels"
-     And I follow "Manage Software Channels" in the left menu
-     And I follow "Overview" in the left menu
+    When I follow "Software"
+     And I follow "Manage" in the left menu
+     And I follow "Channels" in the left menu
      And I follow "Create Channel"
      And I enter "aaaSLE-12-Cloud-Compute5-Pool for x86_64" as "Channel Name"
      And I enter "sle-we12aaa-pool-x86_64-sap" as "Channel Label"
@@ -178,9 +178,9 @@ Feature: Adding channels
     Then I should see a "Channel aaaSLE-12-Cloud-Compute5-Pool for x86_64 created." text
 
   Scenario: Fail when trying to change the channel name to a reserved name
-    When I follow "Channels"
-     And I follow "Manage Software Channels" in the left menu
-     And I follow "Overview" in the left menu
+    When I follow "Software"
+     And I follow "Manage" in the left menu
+     And I follow "Channels" in the left menu
      And I follow "aaaSLE-12-Cloud-Compute5-Pool for x86_64"
      And I enter "SLE-12-Cloud-Compute5-Pool for x86_64" as "Channel Name"
      And I click on "Update Channel"

--- a/testsuite/features/core_srv_create_repository.feature
+++ b/testsuite/features/core_srv_create_repository.feature
@@ -10,9 +10,9 @@ Feature: Add a repository to a channel
   Scenario: Add a test repository for x86_64
     Given I am authorized as "testing" with password "testing"
     When I follow "Home" in the left menu
-    And I follow "Channels"
-    And I follow "Manage Software Channels" in the left menu
-    And I follow "Manage Repositories" in the left menu
+    And I follow "Channel List"
+    And I follow "Manage" in the left menu
+    And I follow "Repositories" in the left menu
     And I follow "Create Repository"
     And I enter "Test-Repository-x86_64" as "label"
     And I enter "http://localhost/pub/TestRepo/" as "url"
@@ -23,9 +23,9 @@ Feature: Add a repository to a channel
   Scenario: Disable metadata check for the x86_64 test repository
     Given I am authorized as "testing" with password "testing"
     When I follow "Home" in the left menu
-    And I follow "Channels"
-    And I follow "Manage Software Channels" in the left menu
-    And I follow "Manage Repositories" in the left menu
+    And I follow "Channel List"
+    And I follow "Manage" in the left menu
+    And I follow "Repositories" in the left menu
     And I follow "Test-Repository-x86_64"
     And I uncheck "metadataSigned"
     And I click on "Update Repository"
@@ -35,9 +35,9 @@ Feature: Add a repository to a channel
   Scenario: Add the repository to the x86_64 channel
     Given I am authorized as "testing" with password "testing"
     When I follow "Home" in the left menu
-    And I follow "Channels"
-    And I follow "Manage Software Channels" in the left menu
-    And I follow "Overview" in the left menu
+    And I follow "Channel List"
+    And I follow "Manage" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Test-Channel-x86_64"
     And I follow "Repositories" in the content area
     And I select the "Test-Repository-x86_64" repo
@@ -48,10 +48,10 @@ Feature: Add a repository to a channel
     Given I am authorized as "testing" with password "testing"
     When I enable source package syncing
     And I follow "Home" in the left menu
-    And I follow "Channels"
-    And I follow "Manage Software Channels" in the left menu
-    And I follow "Manage Repositories" in the left menu
-    And I follow "Overview" in the left menu
+    And I follow "Channel List"
+    And I follow "Manage" in the left menu
+    And I follow "Repositories" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Test-Channel-x86_64"
     And I follow "Repositories" in the content area
     And I follow "Sync"
@@ -61,9 +61,9 @@ Feature: Add a repository to a channel
   Scenario: Add a test repository for i586
     Given I am authorized as "testing" with password "testing"
     When I follow "Home" in the left menu
-    And I follow "Channels"
-    And I follow "Manage Software Channels" in the left menu
-    And I follow "Manage Repositories" in the left menu
+    And I follow "Channel List"
+    And I follow "Manage" in the left menu
+    And I follow "Repositories" in the left menu
     And I follow "Create Repository"
     And I enter "Test-Repository-i586" as "label"
     And I enter "file:///srv/www/htdocs/pub/TestRepo/" as "url"
@@ -74,9 +74,9 @@ Feature: Add a repository to a channel
   Scenario: Add the repository to the i586 channel
     Given I am authorized as "testing" with password "testing"
     When I follow "Home" in the left menu
-    And I follow "Channels"
-    And I follow "Manage Software Channels" in the left menu
-    And I follow "Overview" in the left menu
+    And I follow "Channel List"
+    And I follow "Manage" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Test-Channel-i586"
     And I follow "Repositories" in the content area
     And I select the "Test-Repository-i586" repo
@@ -87,9 +87,9 @@ Feature: Add a repository to a channel
     Given I am authorized as "testing" with password "testing"
     When I disable source package syncing
     And I follow "Home" in the left menu
-    And I follow "Channels"
-    And I follow "Manage Software Channels" in the left menu
-    And I follow "Overview" in the left menu
+    And I follow "Channel List"
+    And I follow "Manage" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Test-Channel-i586"
     And I follow "Repositories" in the content area
     And I follow "Sync"
@@ -120,7 +120,7 @@ Feature: Add a repository to a channel
   Scenario: Reposync handles wrong encoding on RPM attributes
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
-    And I follow "Channels"
+    And I follow "Channel List"
     And I follow "Test-Channel-x86_64"
     And I follow "Packages" in the content area
     Then I should see a "blackhole-dummy" text

--- a/testsuite/features/core_srv_push_package.feature
+++ b/testsuite/features/core_srv_push_package.feature
@@ -17,14 +17,14 @@ Feature: Push a package with unset vendor
   Scenario: Push a package with unset vendor
     When I push package "/root/subscription-tools-1.0-0.noarch.rpm" into "test_base_channel" channel
     And I follow "Software" in the left menu
-    And I follow "Channels" in the left menu
-    And I follow "Channels > All" in the left menu
+    And I follow "Channel List" in the left menu
+    And I follow "Channel List > All" in the left menu
     Then I should see package "subscription-tools-1.0-0.noarch" in channel "Test Base Channel"
 
   Scenario: Check vendor of package displayed in web UI
     When I follow "Software" in the left menu
-    And I follow "Channels" in the left menu
-    And I follow "Channels > All" in the left menu
+    And I follow "Channel List" in the left menu
+    And I follow "Channel List > All" in the left menu
     And I follow "Test Base Channel"
     And I follow "Packages"
     And I follow "subscription-tools-1.0-0.noarch"

--- a/testsuite/features/core_srv_systemspage.feature
+++ b/testsuite/features/core_srv_systemspage.feature
@@ -27,7 +27,7 @@ Feature: Main landing page texts and links
     And I should see a Sign Out link
 
   Scenario: Check sidebar link destination for Systems
-    When I click Systems, under Systems node
+    When I click System List, under Systems node
     Then I should see a "All" link in the left menu
     And I should see a "Physical Systems" link in the left menu
     And I should see a "Virtual Systems" link in the left menu
@@ -45,63 +45,63 @@ Feature: Main landing page texts and links
     And I should see a "Systems" text
 
   Scenario: Check sidebar link destination for Systems => Physical Systems
-    When I click Systems, under Systems node
+    When I click System List, under Systems node
     And I follow "Physical Systems" in the left menu
     Then I should see a "Physical Systems" text
     And I should see a "No systems." text
     And the current path is "/rhn/systems/PhysicalList.do"
 
   Scenario: Check sidebar link destination for Systems => Virtual Systems
-    When I click Systems, under Systems node
+    When I click System List, under Systems node
     And I follow "Virtual Systems" in the left menu
     Then I should see a "Virtual Systems" text
     And I should see a "No Virtual Systems." text
     And the current path is "/rhn/systems/VirtualList.do"
 
   Scenario: Check sidebar link destination for Systems => Out of Date
-    When I click Systems, under Systems node
+    When I click System List, under Systems node
     And I follow "Out of Date" in the left menu
     Then I should see a "Out of Date Systems" text
     And I should see a "No systems." text
     And the current path is "/rhn/systems/OutOfDate.do"
 
   Scenario: Check sidebar link destination for Systems => Requiring Reboot
-    When I click Systems, under Systems node
+    When I click System List, under Systems node
     And I follow "Requiring Reboot" in the left menu
     Then I should see a "Systems Requiring Reboot" text
     And I should see a "No systems." text
     And the current path is "/rhn/systems/RequiringReboot.do"
 
   Scenario: Check sidebar link destination for Systems => Non Compliant
-    When I click Systems, under Systems node
+    When I click System List, under Systems node
     And I follow "Non Compliant" in the left menu
     Then I should see a "Non Compliant Systems" text
     And I should see a "No systems." text
     And the current path is "/rhn/systems/ExtraPackagesSystems.do"
 
   Scenario: Check sidebar link destination for Systems => Without System Type
-    When I click Systems, under Systems node
+    When I click System List, under Systems node
     And I follow "Without System Type" in the left menu
     Then I should see a "Systems without System Type" text
     And I should see a "No systems." text
     And the current path is "/rhn/systems/Unentitled.do"
 
   Scenario: Check sidebar link destination for Systems => Ungrouped
-    When I click Systems, under Systems node
+    When I click System List, under Systems node
     And I follow "Ungrouped" in the left menu
     Then I should see a "Ungrouped Systems" text
     And I should see a "No systems." text
     And the current path is "/rhn/systems/Ungrouped.do"
 
   Scenario: Check sidebar link destination for Systems => Inactive
-    When I click Systems, under Systems node
+    When I click System List, under Systems node
     And I follow "Inactive" in the left menu
     Then I should see a "Inactive Systems" text
     And I should see a "No systems." text
     And the current path is "/rhn/systems/Inactive.do"
 
   Scenario: Check sidebar link destination for Systems => Recently Registered
-    When I click Systems, under Systems node
+    When I click System List, under Systems node
     And I follow "Recently Registered" in the left menu
     Then I should see a "Recently Registered Systems" text
     And I should see a "No systems." text
@@ -109,14 +109,14 @@ Feature: Main landing page texts and links
     And the current path is "/rhn/systems/Registered.do"
 
   Scenario: Check sidebar link destination for Systems => Proxy
-    When I click Systems, under Systems node
+    When I click System List, under Systems node
     And I follow "Proxy" in the left menu
     Then I should see a "Proxy Servers" text
     And I should see a "No systems." text
     And the current path is "/rhn/systems/ProxyList.do"
 
   Scenario: Check sidebar link destination for Systems => Duplicate Systems
-    When I click Systems, under Systems node
+    When I click System List, under Systems node
     And I follow "Duplicate Systems" in the left menu
     Then I should see a "Duplicate Systems" text
     And I should see a "No systems." text
@@ -127,14 +127,14 @@ Feature: Main landing page texts and links
     And I should see a "Duplicate MAC Address" link
 
   Scenario: Check sidebar link destination for Systems => System Currency
-    When I click Systems, under Systems node
+    When I click System List, under Systems node
     And I follow "System Currency" in the left menu
     Then I should see a "System Currency Report" text
     And I should see a "No systems." text
     And the current path is "/rhn/systems/SystemCurrency.do"
 
   Scenario: Check sidebar link destination for Systems => System Types
-    When I click Systems, under Systems node
+    When I click System List, under Systems node
     And I follow "System Types" in the left menu
     Then I should see a "System Types" text
     And I should see a "Management:" text

--- a/testsuite/features/min_action_chain.feature
+++ b/testsuite/features/min_action_chain.feature
@@ -71,7 +71,7 @@ Feature: Action chain on salt minions
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Create Config Channel"
     And I enter "Action Chain Channel" as "cofName"
     And I enter "actionchainchannel" as "cofLabel"
@@ -83,7 +83,7 @@ Feature: Action chain on salt minions
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Action Chain Channel"
     And I follow "Create Configuration File or Directory"
     And I enter "/etc/action-chain.cnf" as "cffPath"
@@ -110,7 +110,7 @@ Feature: Action chain on salt minions
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Action Chain Channel"
     And I follow "Deploy Files" in the content area
     And I click on "Deploy All Files"
@@ -298,7 +298,7 @@ Feature: Action chain on salt minions
     Given I am authorized as "admin" with password "admin"
     And I follow "Home" in the left menu
     When I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Action Chain Channel"
     And I follow "Systems" in the content area
     And I check the "sle-minion" client
@@ -309,7 +309,7 @@ Feature: Action chain on salt minions
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Action Chain Channel"
     And I follow "Delete Channel"
     And I click on "Delete Config Channel"

--- a/testsuite/features/min_activationkey.feature
+++ b/testsuite/features/min_activationkey.feature
@@ -15,7 +15,7 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Create Config Channel"
     And I enter "Key Channel" as "cofName"
     And I enter "keychannel" as "cofLabel"
@@ -27,7 +27,7 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Key Channel"
     And I follow "Create Configuration File or Directory"
     And I enter "/etc/euler.conf" as "cffPath"
@@ -118,7 +118,7 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Key Channel"
     And I follow "Delete Channel"
     And I click on "Delete Config Channel"

--- a/testsuite/features/min_config_state_channel.feature
+++ b/testsuite/features/min_config_state_channel.feature
@@ -9,7 +9,7 @@ Feature: Configuration state channels
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Create State Channel"
     Then I should see a "New Config Channel" text
     When I enter "My State Channel" as "cofName"
@@ -36,7 +36,7 @@ Feature: Configuration state channels
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "My State Channel"
     Then I should see a "1 system subscribed" text
     When I follow "View/Edit 'init.sls' File"
@@ -58,7 +58,7 @@ Feature: Configuration state channels
     Given I am authorized as "admin" with password "admin"
     And I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "My State Channel"
     And I follow "View/Edit 'init.sls' File"
     When I follow "Delete This File Revision"
@@ -70,7 +70,7 @@ Feature: Configuration state channels
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "My State Channel"
     And I follow "Delete Channel"
     Then I should see a "Are you sure you want to delete this config channel?" text

--- a/testsuite/features/min_salt_formulas.feature
+++ b/testsuite/features/min_salt_formulas.feature
@@ -120,7 +120,7 @@ Feature: Use salt formulas
      And I should see a "Locale" text
      When I check the "locale" formula
      And I click on "Save"
-     And I follow "Target Systems"
+     And I follow "Target"
      And I check the "sle-minion" client
      And I click on "Add Systems"
      Then I should see a "1 systems were added to locale-formula-group server group." text

--- a/testsuite/features/min_state_config_channel.feature
+++ b/testsuite/features/min_state_config_channel.feature
@@ -9,7 +9,7 @@ Feature: State Configuration channels
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Create State Channel"
     Then I should see a "New Config Channel" text
     When I enter "My State Channel" as "cofName"
@@ -26,7 +26,7 @@ Feature: State Configuration channels
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Create State Channel"
     Then I should see a "New Config Channel" text
     When I enter "My State Channel" as "cofName"
@@ -43,7 +43,7 @@ Feature: State Configuration channels
     Given I am authorized as "admin" with password "admin"
     When I create channel "statechannel3" from spacecmd of type "state"
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     Then I should see a "statechannel3" text
     And  I update init.sls from spacecmd with content "touch /root/statechannel3:\n  cmd.run:\n    - creates: /root/statechannel3" for channel "statechannel3"
 
@@ -100,7 +100,7 @@ Feature: State Configuration channels
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow first "My State Channel"
     And I follow "Delete Channel"
     Then I should see a "Are you sure you want to delete this config channel?" text
@@ -112,7 +112,7 @@ Feature: State Configuration channels
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow first "My State Channel"
     And I follow "Delete Channel"
     Then I should see a "Are you sure you want to delete this config channel?" text
@@ -124,7 +124,7 @@ Feature: State Configuration channels
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow first "statechannel3"
     And I follow "Delete Channel"
     Then I should see a "Are you sure you want to delete this config channel?" text

--- a/testsuite/features/minssh_action_chain.feature
+++ b/testsuite/features/minssh_action_chain.feature
@@ -88,7 +88,7 @@ Feature: Salt SSH action chain
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Create Config Channel"
     And I enter "Action Chain Channel" as "cofName"
     And I enter "actionchainchannel" as "cofLabel"
@@ -101,7 +101,7 @@ Feature: Salt SSH action chain
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Action Chain Channel"
     And I follow "Create Configuration File or Directory"
     And I enter "/etc/action-chain.cnf" as "cffPath"
@@ -130,7 +130,7 @@ Feature: Salt SSH action chain
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Action Chain Channel"
     And I follow "Deploy Files" in the content area
     And I click on "Deploy All Files"
@@ -285,7 +285,7 @@ Feature: Salt SSH action chain
     Given I am authorized as "admin" with password "admin"
     And I follow "Home" in the left menu
     When I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Action Chain Channel"
     And I follow "Systems" in the content area
     And I check the "ssh-minion" client
@@ -297,7 +297,7 @@ Feature: Salt SSH action chain
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Action Chain Channel"
     And I follow "Delete Channel"
     And I click on "Delete Config Channel"

--- a/testsuite/features/srv_check_channels_page.feature
+++ b/testsuite/features/srv_check_channels_page.feature
@@ -9,17 +9,17 @@ Feature: The channels page
   Scenario: Completeness of the channels page
     Given I am authorized as "admin" with password "admin"
     When I follow "Software" in the left menu
-    And I follow "Channels" in the left menu
-    And I follow "Channels > All" in the left menu
+    And I follow "Channel List" in the left menu
+    And I follow "Channel List > All" in the left menu
     Then I should see a "Full Software Channel List" text
-    And I should see a "Software Channels" link in the left menu
+    And I should see a "Channel List" link in the left menu
     And I should see a "All" link in the left menu
     And I should see a "Popular" link in the left menu
     And I should see a "My Channels" link in the left menu
     And I should see a "Shared" link in the left menu
     And I should see a "Retired" link in the left menu
     And I should see a "Package Search" link in the left menu
-    And I should see a "Manage Software Channels" link in the left menu
+    And I should see a "Manage" link in the left menu
     And I should see a "All" link in the content area
     And I should see a "Popular" link in the content area
     And I should see a "My Channels" link in the content area
@@ -29,16 +29,16 @@ Feature: The channels page
   Scenario: Popular channels
     Given I am authorized as "admin" with password "admin"
     When I follow "Software" in the left menu
-    And I follow "Channels" in the left menu
-    And I follow "Channels > All" in the left menu
+    And I follow "Channel List" in the left menu
+    And I follow "Channel List > All" in the left menu
     And I follow "Popular" in the left menu
     Then I should see a "Popular" text
 
   Scenario: Check packages in test channel
     Given I am authorized as "admin" with password "admin"
     When I follow "Software" in the left menu
-    And I follow "Channels" in the left menu
-    And I follow "Channels > All" in the left menu
+    And I follow "Channel List" in the left menu
+    And I follow "Channel List > All" in the left menu
     And I follow "Test-Channel-x86_64"
     And I follow "Packages"
     Then I should see package "andromeda-dummy-2.0-1.1.noarch"
@@ -51,8 +51,8 @@ Feature: The channels page
   Scenario: Check package metadata
     Given I am authorized as "admin" with password "admin"
     When I follow "Software" in the left menu
-    And I follow "Channels" in the left menu
-    And I follow "Channels > All" in the left menu
+    And I follow "Channel List" in the left menu
+    And I follow "Channel List > All" in the left menu
     And I follow "Test-Channel-x86_64"
     And I follow "Packages"
     And I follow "andromeda-dummy-2.0-1.1.noarch"
@@ -66,8 +66,8 @@ Feature: The channels page
   Scenario: Check package dependencies page
     Given I am authorized as "admin" with password "admin"
     When I follow "Software" in the left menu
-    And I follow "Channels" in the left menu
-    And I follow "Channels > All" in the left menu
+    And I follow "Channel List" in the left menu
+    And I follow "Channel List > All" in the left menu
     And I follow "Test-Channel-x86_64"
     And I follow "Packages"
     And I follow "andromeda-dummy-2.0-1.1.noarch"
@@ -79,8 +79,8 @@ Feature: The channels page
   Scenario: Check package change log page
     Given I am authorized as "admin" with password "admin"
     When I follow "Software" in the left menu
-    And I follow "Channels" in the left menu
-    And I follow "Channels > All" in the left menu
+    And I follow "Channel List" in the left menu
+    And I follow "Channel List > All" in the left menu
     And I follow "Test-Channel-x86_64"
     And I follow "Packages"
     And I follow "andromeda-dummy-2.0-1.1.noarch"
@@ -91,8 +91,8 @@ Feature: The channels page
   Scenario: Check package file list page
     Given I am authorized as "admin" with password "admin"
     When I follow "Software" in the left menu
-    And I follow "Channels" in the left menu
-    And I follow "Channels > All" in the left menu
+    And I follow "Channel List" in the left menu
+    And I follow "Channel List > All" in the left menu
     And I follow "Test-Channel-x86_64"
     And I follow "Packages"
     And I follow "andromeda-dummy-2.0-1.1.noarch"

--- a/testsuite/features/srv_check_sync_source_packages.feature
+++ b/testsuite/features/srv_check_sync_source_packages.feature
@@ -9,8 +9,8 @@ Feature: Check if source packages were successfully synced
   Background:
     Given I am authorized as "admin" with password "admin"
     When I follow "Software" in the left menu
-    And I follow "Channels" in the left menu
-    And I follow "Channels > All" in the left menu
+    And I follow "Channel List" in the left menu
+    And I follow "Channel List > All" in the left menu
 
   Scenario: Check sources for noarch package
     When I follow "Test-Channel-x86_64"

--- a/testsuite/features/srv_clone_channel_npn.feature
+++ b/testsuite/features/srv_clone_channel_npn.feature
@@ -108,14 +108,14 @@ Feature: Clone a channel
     And I click on "Delete Channel"
     Then I should see a "Clone of Test-Channel-x86_64" text
     And I should see a "has been deleted." text
-    Given I follow "Overview" in the left menu
+    Given I follow "Channels" in the left menu
     When I follow "Clone 2 of Test-Channel-x86_64"
     And I follow "Delete software channel"
     And I check "unsubscribeSystems"
     And I click on "Delete Channel"
     Then I should see a "Clone 2 of Test-Channel-x86_64" text
     And I should see a "has been deleted." text
-    Given I follow "Overview" in the left menu
+    Given I follow "Channels" in the left menu
     When I follow "Clone 3 of Test-Channel-x86_64"
     And I follow "Delete software channel"
     And I check "unsubscribeSystems"

--- a/testsuite/features/srv_create_group.feature
+++ b/testsuite/features/srv_create_group.feature
@@ -28,7 +28,7 @@ Feature: Create a group
   Scenario: Add a system to the group
     Given I am on the groups page
     When I follow "newgroup"
-    And I follow "Target Systems"
+    And I follow "Target"
     And I check the "sle-client" client
     And I click on "Add Systems"
     Then I should see a "1 systems were added to newgroup server group." text

--- a/testsuite/features/srv_patches_page.feature
+++ b/testsuite/features/srv_patches_page.feature
@@ -100,8 +100,8 @@ Feature: Patches page
   Scenario: Assert that patch is now in test base channel
     Given I am on the patches page
     And I follow "Software" in the left menu
-    And I follow "Channels" in the left menu
-    And I follow "Channels > All" in the left menu
+    And I follow "Channel List" in the left menu
+    And I follow "Channel List > All" in the left menu
     And I follow "Test Base Channel"
     And I follow "Patches" in the content area
     Then I should see a "Test Patch" text

--- a/testsuite/features/srv_virtual_host_manager.feature
+++ b/testsuite/features/srv_virtual_host_manager.feature
@@ -47,7 +47,7 @@ Feature: Virtual host manager web UI
     And I wait until I see "10.162.186.111" text, refreshing the page
     When I follow "10.162.186.111"
     Then I should see a "OS: VMware ESXi" text
-    When I click Systems, under Systems node
+    When I click System List, under Systems node
     And I follow "Virtual Systems" in the left menu
     Then I should see a "vCenter" text
      And I should see a "NSX-l3gateway" text

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -337,7 +337,7 @@ end
 
 Then(/^I should see package "([^"]*)" in channel "([^"]*)"$/) do |pkg, channel|
   steps %(
-    And I follow "Channels > All" in the left menu
+    And I follow "Channel List > All" in the left menu
     And I follow "#{channel}"
     And I follow "Packages"
     Then I should see package "#{pkg}"

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -271,10 +271,10 @@ When(/^I enter "(.*?)" in the editor$/) do |arg1|
   page.execute_script("ace.edit('contents-editor').insert('#{arg1}')")
 end
 
-When(/^I click Systems, under Systems node$/) do
+When(/^I click System List, under Systems node$/) do
   find(:xpath, "//div[@id=\"nav\"]/nav/ul/li[contains(@class, 'active')
        and contains(@class, 'open')
-       and contains(@class,'node')]/ul/li/div/a/span[contains(.,'Systems')]").click
+       and contains(@class,'node')]/ul/li/div/a/span[contains(.,'System List')]").click
 end
 
 Given(/^I am not authorized$/) do

--- a/testsuite/features/trad_action_chain.feature
+++ b/testsuite/features/trad_action_chain.feature
@@ -86,7 +86,7 @@ Feature: Action chain on traditional clients
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Create Config Channel"
     And I enter "Action Chain Channel" as "cofName"
     And I enter "actionchainchannel" as "cofLabel"
@@ -98,7 +98,7 @@ Feature: Action chain on traditional clients
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Action Chain Channel"
     And I follow "Create Configuration File or Directory"
     And I enter "/etc/action-chain.cnf" as "cffPath"
@@ -125,7 +125,7 @@ Feature: Action chain on traditional clients
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Action Chain Channel"
     And I follow "Deploy Files" in the content area
     And I click on "Deploy All Files"
@@ -251,7 +251,7 @@ Feature: Action chain on traditional clients
     Given I am authorized as "admin" with password "admin"
     And I follow "Home" in the left menu
     When I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Action Chain Channel"
     And I follow "Systems" in the content area
     And I check the "sle-client" client
@@ -262,7 +262,7 @@ Feature: Action chain on traditional clients
     Given I am authorized as "admin" with password "admin"
     And I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Action Chain Channel"
     And I follow "Delete Channel"
     And I click on "Delete Config Channel"

--- a/testsuite/features/trad_baremetal_discovery.feature
+++ b/testsuite/features/trad_baremetal_discovery.feature
@@ -35,7 +35,7 @@ Feature: Bare metal discovery
 
   Scenario: See the client in unprovisioned systems list
     Given I am on the Systems page
-    And I click Systems, under Systems node 
+    And I click System List, under Systems node 
     And I follow "Unprovisioned Systems" in the left menu
     Then I should see a "Unprovisioned Systems" text
     And I should see a "Detected on" text
@@ -52,7 +52,7 @@ Feature: Bare metal discovery
 
   Scenario: Check unprovisioned system details
     Given I am on the Systems page
-    And I click Systems, under Systems node 
+    And I click System List, under Systems node 
     When I follow this "sle-client" link
     Then I should see a "Details" link in the content area
     And I should not see a "Software" link in the content area

--- a/testsuite/features/trad_config_channel.feature
+++ b/testsuite/features/trad_config_channel.feature
@@ -7,7 +7,7 @@ Feature: Configuration management of traditional clients
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Create Config Channel"
     And I enter "Test Channel" as "cofName"
     And I enter "testchannel" as "cofLabel"
@@ -28,7 +28,7 @@ Feature: Configuration management of traditional clients
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Create Config Channel"
     And I enter "Test Channel" as "cofName"
     And I enter "testchannel" as "cofLabel"
@@ -41,7 +41,7 @@ Feature: Configuration management of traditional clients
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Create Config Channel"
     And I enter "Test Channel2" as "cofName"
     And I enter "!testchannel" as "cofLabel"
@@ -54,7 +54,7 @@ Feature: Configuration management of traditional clients
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Create Config Channel"
     And I enter "New Test Channel" as "cofName"
     And I enter "newtestchannel" as "cofLabel"
@@ -75,7 +75,7 @@ Feature: Configuration management of traditional clients
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "New Test Channel"
     And I follow "Create Configuration File or Directory"
     And I enter "/etc/mgr-test-file.cnf" as "cffPath"
@@ -98,8 +98,8 @@ Feature: Configuration management of traditional clients
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Files" in the left menu
-    And I follow "Centrally Managed Files" in the left menu
+    And I follow "Files" in the left menu
+    And I follow "Centrally Managed" in the left menu
     Then I should see a table line with "/etc/mgr-test-file.cnf", "New Test Channel", "1 system"
 
   Scenario: Check centrally managed files of SLES client
@@ -114,7 +114,7 @@ Feature: Configuration management of traditional clients
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
     And I run "rhn-actions-control --enable-all" on "sle-client"
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "New Test Channel"
     And I follow "Deploy all configuration files to all subscribed systems"
     Then I should see a "/etc/mgr-test-file.cnf" link
@@ -198,7 +198,7 @@ Feature: Configuration management of traditional clients
     Given I am authorized as "admin" with password "admin"
     And I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    When I follow "Configuration Channels" in the left menu
+    When I follow "Channels" in the left menu
     And I follow "New Test Channel"
     And I follow "Create Configuration File or Directory"
     And I enter "/tmp/mycache.txt" as "cffPath"
@@ -243,8 +243,8 @@ Feature: Configuration management of traditional clients
     And I should see a "Centrally-managed Configuration Files" text
     And I should see a "Locally-managed Configuration Files" text
     And I should see a "Overview" link in the left menu
-    And I should see a "Configuration Channels" link in the left menu
-    And I should see a "Configuration Files" link in the left menu
+    And I should see a "Channels" link in the left menu
+    And I should see a "Files" link in the left menu
     And I should see a "Systems" link in the left menu
     And I should see a "View Systems with Managed Configuration Files" link
     And I should see a "View All Managed Configuration Files" link
@@ -258,8 +258,8 @@ Feature: Configuration management of traditional clients
     And I follow "Configuration" in the left menu
     And I follow "Overview" in the left menu
     And I follow "View Systems with Managed Configuration Files"
-    Then I should see a "Managed Systems" link in the left menu
-    And I should see a "Target Systems" link in the left menu
+    Then I should see a "Managed" link in the left menu
+    And I should see a "Target" link in the left menu
 
   Scenario: Show All Managed Configuration Files page
     Given I am authorized as "admin" with password "admin"
@@ -267,8 +267,8 @@ Feature: Configuration management of traditional clients
     And I follow "Configuration" in the left menu
     And I follow "Overview" in the left menu
     And I follow "View All Managed Configuration Files"
-    Then I should see a "Centrally Managed Files" link in the left menu
-    And I should see a "Locally Managed Files" link in the left menu
+    Then I should see a "Centrally Managed" link in the left menu
+    And I should see a "Locally Managed" link in the left menu
 
   Scenario: Show All Managed Configuration Channels page
     Given I am authorized as "admin" with password "admin"
@@ -284,14 +284,14 @@ Feature: Configuration management of traditional clients
     And I follow "Configuration" in the left menu
     And I follow "Overview" in the left menu
     And I follow "Enable Configuration Management on Systems"
-    Then I should see a "Managed Systems" link in the left menu
-    And I should see a "Target Systems" link in the left menu
+    Then I should see a "Managed" link in the left menu
+    And I should see a "Target" link in the left menu
 
   Scenario: Cleanup: remove system from new configuration channel
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "New Test Channel"
     And I follow "Systems" in the content area
     And I check the "sle-client" client
@@ -302,7 +302,7 @@ Feature: Configuration management of traditional clients
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Test Channel"
     And I follow "Delete Channel"
     And I click on "Delete Config Channel"
@@ -311,7 +311,7 @@ Feature: Configuration management of traditional clients
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "New Test Channel"
     And I follow "Delete Channel"
     And I click on "Delete Config Channel"

--- a/testsuite/features/trad_need_reboot.feature
+++ b/testsuite/features/trad_need_reboot.feature
@@ -11,7 +11,7 @@ Feature: Reboot required after patch
     And I follow "Home" in the left menu
     And I follow "Systems" in the left menu
     And I follow "Overview" in the left menu
-    When I click Systems, under Systems node
+    When I click System List, under Systems node
     Then I should see a "All" link in the left menu
     And  I follow "All" in the left menu
     Then I should see a "Requiring Reboot" link in the left menu
@@ -42,13 +42,13 @@ Feature: Reboot required after patch
     And I click on "Apply Patches"
     And I click on "Confirm"
     And I run "rhn_check -vvv" on "sle-client"
-    And I follow "Overview" in the left menu
-    And I click Systems, under Systems node
+    And I follow "Software" in the left menu
+    And I click System List, under Systems node
     And I follow "All" in the left menu
     And I follow this "sle-client" link
     Then I should see a "The system requires a reboot" text
-    And I follow "Overview" in the left menu
-    And I click Systems, under Systems node
+    And I follow "Software" in the left menu
+    And I click System List, under Systems node
     And I follow "Requiring Reboot" in the left menu
     Then I should see "sle-client" as link
 

--- a/testsuite/features/trad_weak_deps.feature
+++ b/testsuite/features/trad_weak_deps.feature
@@ -6,8 +6,8 @@ Feature: Weak dependencies in the package page and in the metadata on the client
   Background:
     Given I am authorized as "admin" with password "admin"
     When I follow "Software" in the left menu
-    And I follow "Channels" in the left menu
-    And I follow "Channels > All" in the left menu
+    And I follow "Channel List" in the left menu
+    And I follow "Channel List > All" in the left menu
 
   Scenario: Pre-requisite: remove packages before weak-dependancies test
    When I run "zypper -n in virgo-dummy" on "sle-client" without error control


### PR DESCRIPTION
## What does this PR change?

Updated localization Strings for the Menu on the
left hand side of the web UI.
This is an attempt to remove redundant 
names so that it is easier to navigate
the site for the user.

This PR is ported from https://github.com/SUSE/spacewalk/pull/5929

## GUI diff

See https://github.com/SUSE/spacewalk/pull/5929

- [X] **DONE**

## Documentation

https://github.com/uyuni-project/uyuni/issues/271

- [x] **DONE**

## Test coverage
No Errors on local testsuite for 3.1
Uyuni-testsuite couldn't be run due to postgres errors when creating an activation key.
(Seems to be unrelated to the changes in this PR)

- [ ] **DONE**

https://github.com/SUSE/spacewalk/issues/5854
https://bugzilla.suse.com/show_bug.cgi?id=1019847

## Relevant branches (GitHub automatic links expected below):

- Uyuni

- [X] **DONE**
