### PR TITLE
Automatic cleanup of notification messages

### DIFF
--- a/branding/java/code/src/com/redhat/rhn/branding/strings/StringResource_en_US.xml
+++ b/branding/java/code/src/com/redhat/rhn/branding/strings/StringResource_en_US.xml
@@ -2055,6 +2055,9 @@ tree will not be usable for autoinstalling.
       <trans-unit id="bunch.jsp.description.minion-action-cleanup-bunch">
           <source>Cleanup actions for Minions</source>
       </trans-unit>
+      <trans-unit id="bunch.jsp.description.notifications-cleanup-bunch">
+          <source>Cleanup expired notification messages</source>
+      </trans-unit>
 
       <!-- Server Contact Methods -->
       <trans-unit id="server.contact-method.label">

--- a/branding/spacewalk-branding.changes
+++ b/branding/spacewalk-branding.changes
@@ -1,3 +1,4 @@
+- Automatic cleanup of notification messages after a configurable lifetime
 - ActivationKey base and child channel in a reactjs component
 - New messages are added for XMLRPC API for state channels
 

--- a/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -247,6 +247,10 @@ public class ConfigDefaults {
      */
     public static final String KIWI_OS_IMAGE_BUILDING_ENABLED = "java.kiwi_os_image_building_enabled";
 
+    /**
+     * Lifetime of notification messages in days
+     */
+    public static final String NOTIFICATIONS_LIFETIME = "java.notifications_lifetime";
 
     /**
      * Indicates the salt-api host to connect to (host)
@@ -872,5 +876,13 @@ public class ConfigDefaults {
      */
     public boolean isMetadataSigningEnabled() {
         return Config.get().getBoolean(SIGN_METADATA);
+    }
+
+    /**
+     * Returns the notifications lifetime.
+     * @return notifications lifetime
+     */
+    public int getNotificationsLifetime() {
+        return Config.get().getInt(NOTIFICATIONS_LIFETIME, 30);
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/notification/UserNotificationFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/UserNotificationFactory.java
@@ -27,6 +27,7 @@ import com.suse.manager.webui.websocket.Notification;
 import org.apache.log4j.Logger;
 
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -34,6 +35,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaDelete;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
 
@@ -216,6 +218,32 @@ public class UserNotificationFactory extends HibernateFactory {
                 builder.equal(root.get("messageId"), messageIdIn));
 
         return getSession().createQuery(query).uniqueResultOptional();
+    }
+
+    /**
+     * List all notification messages from the database.
+     *
+     * @return list of all notifications from the database
+     */
+    public static List<NotificationMessage> listAllNotificationMessages() {
+        CriteriaBuilder builder = getSession().getCriteriaBuilder();
+        CriteriaQuery<NotificationMessage> criteria = builder.createQuery(NotificationMessage.class);
+        criteria.from(NotificationMessage.class);
+        return getSession().createQuery(criteria).getResultList();
+    }
+
+    /**
+     * Delete all notification messages that were created before a given date.
+     *
+     * @param before all notifications created before this date will be deleted
+     * @return int number of deleted notification messages
+     */
+    public static int deleteNotificationMessagesBefore(Date before) {
+        CriteriaBuilder builder = getSession().getCriteriaBuilder();
+        CriteriaDelete<NotificationMessage> delete = builder.createCriteriaDelete(NotificationMessage.class);
+        Root<NotificationMessage> root = delete.from(NotificationMessage.class);
+        delete.where(builder.lessThan(root.<Date>get("created"), before));
+        return getSession().createQuery(delete).executeUpdate();
     }
 
     @Override

--- a/java/code/src/com/redhat/rhn/domain/notification/test/NotificationFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/test/NotificationFactoryTest.java
@@ -22,7 +22,9 @@ import com.redhat.rhn.domain.notification.types.OnboardingFailed;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 
+import java.time.Instant;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 
 import static java.util.Optional.empty;
@@ -75,4 +77,25 @@ public class NotificationFactoryTest extends BaseTestCaseWithUser {
         assertEquals(1, UserNotificationFactory.listAllByUser(user).size());
     }
 
+    public final void testDeleteNotificationMessagesBefore() {
+        // Clean up all notifications that might be present
+        if (UserNotificationFactory.listAllNotificationMessages().size() > 0) {
+            UserNotificationFactory.deleteNotificationMessagesBefore(Date.from(Instant.now()));
+        }
+        assertEquals(0, UserNotificationFactory.listAllNotificationMessages().size());
+
+        // Create a notification
+        NotificationMessage msg = UserNotificationFactory.createNotificationMessage(new OnboardingFailed("minion1"));
+        UserNotificationFactory.storeNotificationMessageFor(msg, Collections.singleton(RoleFactory.CHANNEL_ADMIN), empty());
+
+        // Should not be deleted
+        int result = UserNotificationFactory.deleteNotificationMessagesBefore(msg.getCreated());
+        assertEquals(0, result);
+        assertEquals(1, UserNotificationFactory.listAllNotificationMessages().size());
+
+        // Should be deleted
+        result = UserNotificationFactory.deleteNotificationMessagesBefore(Date.from(Instant.now()));
+        assertEquals(1, result);
+        assertEquals(0, UserNotificationFactory.listAllNotificationMessages().size());
+    }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/NotificationsCleanup.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/NotificationsCleanup.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2018 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.taskomatic.task;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
+import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.domain.notification.UserNotificationFactory;
+
+/**
+ * Cleanup of notification messages after a configurable lifetime.
+ */
+public class NotificationsCleanup extends RhnJavaJob {
+
+    @Override
+    public void execute(JobExecutionContext arg0In) throws JobExecutionException {
+        if (log.isDebugEnabled()) {
+            log.debug("start notifications cleanup");
+        }
+
+        // Measure time and calculate the total duration
+        long start = System.currentTimeMillis();
+
+        int lifetime = ConfigDefaults.get().getNotificationsLifetime();
+        Date before = Date.from(LocalDate.now().atStartOfDay().minusDays(lifetime)
+                .atZone(ZoneId.systemDefault()).toInstant());
+        log.info("Deleting all notification messages created before: " + before);
+        int deleted = UserNotificationFactory.deleteNotificationMessagesBefore(before);
+        log.info("Notification messages deleted: " + deleted);
+
+        if (log.isDebugEnabled()) {
+            long duration = System.currentTimeMillis() - start;
+            log.debug("Total duration was: " + duration + " ms");
+        }
+    }
+}

--- a/java/conf/rhn_java.conf
+++ b/java/conf/rhn_java.conf
@@ -171,3 +171,7 @@ java.salt_api_port = 9080
 
 # If true, Kiwi OS Image building feature preview will be enabled
 java.kiwi_os_image_building_enabled = true
+
+# Configure the lifetime of notification messages in days
+java.notifications_lifetime = 30
+

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Automatic cleanup of notification messages after a configurable lifetime
 - Fix 'image deployed' event data parsing (bsc#1110316)
 - Handle 'image deployed' salt event by executing post-deployment procedures
 - Allow listing empty system profiles via XMLRPC

--- a/schema/spacewalk/common/data/rhnTaskoBunch.sql
+++ b/schema/spacewalk/common/data/rhnTaskoBunch.sql
@@ -105,4 +105,7 @@ INSERT INTO rhnTaskoBunch (id, name, description, org_bunch)
 INSERT INTO rhnTaskoBunch (id, name, description, org_bunch)
    VALUES (sequence_nextval('rhn_tasko_bunch_id_seq'), 'minion-action-chain-cleanup-bunch', 'Cleanup actions chains for Minions', null);
 
+INSERT INTO rhnTaskoBunch (id, name, description, org_bunch)
+   VALUES (sequence_nextval('rhn_tasko_bunch_id_seq'), 'notifications-cleanup-bunch', 'Cleanup expired notification messages', null);
+
 commit;

--- a/schema/spacewalk/common/data/rhnTaskoSchedule.sql
+++ b/schema/spacewalk/common/data/rhnTaskoSchedule.sql
@@ -146,4 +146,9 @@ INSERT INTO rhnTaskoSchedule (id, job_label, bunch_id, active_from, cron_expr)
         (SELECT id FROM rhnTaskoBunch WHERE name='minion-action-chain-cleanup-bunch'),
         current_timestamp, '0 0 * * * ?');
 
+INSERT INTO rhnTaskoSchedule (id, job_label, bunch_id, active_from, cron_expr)
+    VALUES (sequence_nextval('rhn_tasko_schedule_id_seq'), 'notifications-cleanup-default',
+        (SELECT id FROM rhnTaskoBunch WHERE name='notifications-cleanup-bunch'),
+        current_timestamp, '0 0 0 ? * *');
+
 commit;

--- a/schema/spacewalk/common/data/rhnTaskoTask.sql
+++ b/schema/spacewalk/common/data/rhnTaskoTask.sql
@@ -107,4 +107,7 @@ INSERT INTO rhnTaskoTask (id, name, class)
 INSERT INTO rhnTaskoTask (id, name, class)
    VALUES (sequence_nextval('rhn_tasko_task_id_seq'), 'minion-action-chain-cleanup', 'com.redhat.rhn.taskomatic.task.MinionActionChainCleanup');
 
+INSERT INTO rhnTaskoTask (id, name, class)
+   VALUES (sequence_nextval('rhn_tasko_task_id_seq'), 'notifications-cleanup', 'com.redhat.rhn.taskomatic.task.NotificationsCleanup');
+
 commit;

--- a/schema/spacewalk/common/data/rhnTaskoTemplate.sql
+++ b/schema/spacewalk/common/data/rhnTaskoTemplate.sql
@@ -231,4 +231,11 @@ INSERT INTO rhnTaskoTemplate (id, bunch_id, task_id, ordering, start_if)
                         0,
                         null);
 
+INSERT INTO rhnTaskoTemplate (id, bunch_id, task_id, ordering, start_if)
+            VALUES (sequence_nextval('rhn_tasko_template_id_seq'),
+                        (SELECT id FROM rhnTaskoBunch WHERE name='notifications-cleanup-bunch'),
+                        (SELECT id FROM rhnTaskoTask WHERE name='notifications-cleanup'),
+                        0,
+                        null);
+
 commit;

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Automatic cleanup of notification messages after a configurable lifetime
 - Add missing minion-action-chain-cleanup to db init scripts
 
 -------------------------------------------------------------------

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.2-to-susemanager-schema-4.0.3/100-notifications-cleanup.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.2-to-susemanager-schema-4.0.3/100-notifications-cleanup.sql
@@ -1,0 +1,35 @@
+INSERT INTO rhnTaskoBunch (id, name, description, org_bunch)
+    SELECT sequence_nextval('rhn_tasko_bunch_id_seq'), 'notifications-cleanup-bunch', 'Cleanup expired notification messages', null
+    FROM dual WHERE NOT EXISTS (
+        SELECT 1 FROM rhnTaskoBunch WHERE
+        name='notifications-cleanup-bunch'
+    );
+
+INSERT INTO rhnTaskoSchedule (id, job_label, bunch_id, active_from, cron_expr)
+    SELECT sequence_nextval('rhn_tasko_schedule_id_seq'), 'notifications-cleanup-default',
+        (SELECT id FROM rhnTaskoBunch WHERE name='notifications-cleanup-bunch'),
+        current_timestamp, '0 0 0 ? * *'
+    FROM dual WHERE NOT EXISTS (
+        SELECT 1 FROM rhnTaskoSchedule WHERE
+        job_label='notifications-cleanup-default'
+    );
+
+INSERT INTO rhnTaskoTask (id, name, class)
+    SELECT sequence_nextval('rhn_tasko_task_id_seq'), 'notifications-cleanup', 'com.redhat.rhn.taskomatic.task.NotificationsCleanup'
+    FROM dual WHERE NOT EXISTS (
+        SELECT 1 FROM rhnTaskoTask WHERE
+        name='notifications-cleanup'
+    );
+
+INSERT INTO rhnTaskoTemplate (id, bunch_id, task_id, ordering, start_if)
+    SELECT sequence_nextval('rhn_tasko_template_id_seq'),
+                        (SELECT id FROM rhnTaskoBunch WHERE name='notifications-cleanup-bunch'),
+                        (SELECT id FROM rhnTaskoTask WHERE name='notifications-cleanup'),
+                        0,
+                        null
+    FROM dual WHERE NOT EXISTS (
+        SELECT 1 FROM rhnTaskoTemplate WHERE
+        bunch_id=(SELECT id FROM rhnTaskoBunch WHERE name='notifications-cleanup-bunch') AND
+        task_id=(SELECT id FROM rhnTaskoTask WHERE name='notifications-cleanup')
+    );
+


### PR DESCRIPTION
## What does this PR change?

This patch is adding a taskomatic job to automatically clean up notification messages after a configurable `NOTIFICATIONS_LIFETIME` (defaulting to 30 days).

## Documentation

- [doc-susemanager](https://github.com/SUSE/doc-susemanager) Issue was created as https://github.com/SUSE/doc-susemanager/issues/256

- [x] **DONE**

## Test coverage

- Unit tests were added

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/6239

- [x] **DONE**
