### PR TITLE
Allow matching empty system profile by FQDN on registration

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/MinionServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionServerFactory.java
@@ -20,6 +20,7 @@ import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.user.User;
 
+import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import org.apache.log4j.Logger;
 import org.hibernate.Criteria;
 import org.hibernate.Session;
@@ -31,6 +32,12 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Join;
+import javax.persistence.criteria.JoinType;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
 
 /**
  * MinionFactory - the singleton class used to fetch and store
@@ -225,5 +232,49 @@ public class MinionServerFactory extends HibernateFactory {
                 .asMinionServer()
                 .map(m -> m.getMinionId())
                 .orElseThrow(() -> new UnsupportedOperationException("Salt minion not found, id: " + serverId));
+    }
+
+    /**
+     * Find empty profile with a HW address matching some of given HW addresses.
+     *
+     * @param hwAddrs the set of HW addresses
+     * @throws java.lang.IllegalStateException When multiple empty profiles match given HW addresses
+     * @return the optional MinionServer with a HW address matching some of given HW addresses
+     */
+    public static Optional<MinionServer> findEmptyProfileByHwAddrs(Set<String> hwAddrs) {
+        if (hwAddrs.isEmpty()) {
+            return Optional.empty();
+        }
+
+        CriteriaBuilder builder = getSession().getCriteriaBuilder();
+        CriteriaQuery<MinionServer> query = builder.createQuery(MinionServer.class);
+        Root<MinionServer> root = query.distinct(true).from(MinionServer.class);
+
+        Join<MinionServer, NetworkInterface> nicJoin = root.join("networkInterfaces", JoinType.INNER);
+        Predicate hwAddrPredicate = nicJoin.get("hwaddr").in(hwAddrs);
+
+        query.where(hwAddrPredicate);
+
+        return getSession().createQuery(query).list().stream()
+                .filter(s -> s.hasEntitlement(EntitlementManager.BOOTSTRAP))
+                .reduce((s1, s2) -> { throw new IllegalStateException("Multiple matching systems found"); });
+    }
+
+    /**
+     * Find empty profile by hostname
+     *
+     * @param hostname the hostname
+     * @throws java.lang.IllegalStateException When multiple empty profiles match given hostname
+     * @return the optional MinionServer matching given hostname
+     */
+    public static Optional<MinionServer> findEmptyProfileByHostName(String hostname) {
+        CriteriaBuilder builder = getSession().getCriteriaBuilder();
+        CriteriaQuery<MinionServer> query = builder.createQuery(MinionServer.class);
+        Root<MinionServer> root = query.from(MinionServer.class);
+        query.where(builder.equal(root.get("hostname"), hostname));
+
+        return getSession().createQuery(query).list().stream()
+                .filter(s -> s.hasEntitlement(EntitlementManager.BOOTSTRAP))
+                .reduce((s1, s2) -> { throw new IllegalStateException("Multiple matching systems found"); });
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/server/test/MinionServerFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/MinionServerFactoryTest.java
@@ -22,7 +22,6 @@ import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 /**

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -5940,28 +5940,26 @@ public class SystemHandler extends BaseHandler {
 
     /**
      * Creates a system record in database for a system that is not (yet) registered.
+     * Either "hwAddress" or "hostname" prop must be specified in the "data" struct.
      * @param loggedInUser the currently logged in user
      * @param systemName server name
      * @param data the data about system
      * @return int - 1 on success, exception thrown otherwise.
      *
      * @xmlrpc.doc Creates a system record in database for a system that is not registered.
+     * Either "hwAddress" or "hostname" prop must be specified in the "data" struct.
      * @xmlrpc.param #session_key()
      * @xmlrpc.param #param_desc("string", "systemName", "System name")
      * @xmlrpc.param
      *  #struct("data")
      *      #prop_desc("string", "hwAddress", "The HW address of the network interface (MAC)")
+     *      #prop_desc("string", "hostname", "The hostname of the profile")
      *  #struct_end()
      * @xmlrpc.returntype #return_int_success()
      */
     public int createSystemProfile(User loggedInUser, String systemName, Map<String, Object> data) {
-        String hwAddress = (String) data.get("hwAddress");
-        if (hwAddress == null) {
-            throw new InvalidParameterException("The data does not contain required 'hwAddress' field.");
-        }
-
         try {
-            SystemManager.createSystemProfile(loggedInUser, systemName, hwAddress);
+            SystemManager.createSystemProfile(loggedInUser, systemName, data);
         }
         catch (IllegalStateException | IllegalArgumentException e) {
             throw new InvalidParameterException("Can't create system", e);

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -43,8 +43,8 @@ import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.server.CPU;
 import com.redhat.rhn.domain.server.InstalledPackage;
 import com.redhat.rhn.domain.server.MinionServer;
+import com.redhat.rhn.domain.server.MinionServerFactory;
 import com.redhat.rhn.domain.server.NetworkInterface;
-import com.redhat.rhn.domain.server.NetworkInterfaceFactory;
 import com.redhat.rhn.domain.server.Note;
 import com.redhat.rhn.domain.server.ProxyInfo;
 import com.redhat.rhn.domain.server.Server;
@@ -90,12 +90,11 @@ import com.redhat.rhn.manager.kickstart.cobbler.CobblerSystemRemoveCommand;
 import com.redhat.rhn.manager.rhnset.RhnSetDecl;
 import com.redhat.rhn.manager.user.UserManager;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
-
 import com.suse.manager.reactor.messaging.ChannelsChangedEventMessage;
 import com.suse.manager.webui.services.SaltStateGeneratorService;
 import com.suse.manager.webui.services.impl.SaltSSHService;
 import com.suse.manager.webui.services.impl.SaltService;
-
+import com.suse.utils.Opt;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.log4j.Logger;
@@ -122,6 +121,9 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+import static java.util.Optional.ofNullable;
 
 /**
  * SystemManager
@@ -389,20 +391,41 @@ public class SystemManager extends BaseManager {
     }
 
     /**
-     * Create an empty system profile with required values.
+     * Create an empty system profile with required values based on given data.
+     *
+     * The data must contain at least one of the following fields:
+     * - hwAddress - HW address of a NetworkInterface of the profile
+     * - hostname - hostname (FQDN) of the profile
      *
      * @param creator the creator user
      * @param systemName the system name
-     * @param hwAddress the hardware address
-     * @throws java.lang.IllegalStateException when a system with given hardware address already exists
-     * @throws java.lang.IllegalArgumentException when the format of the hardware address is invalid
+     * @param data the data of the new profile
+     * @throws java.lang.IllegalStateException when a system based on the input data already exists
+     * @throws java.lang.IllegalArgumentException when the input data contains insufficient information or
+     * if the format of the hardware address is invalid
      * @return the created system
      */
-    public static MinionServer createSystemProfile(User creator, String systemName, String hwAddress) {
-        if (NetworkInterfaceFactory.lookupNetworkInterfacesByHwAddress(hwAddress).findAny().isPresent()) {
-            throw new IllegalStateException("System(s) with network interface with HW address '" + hwAddress +
-                    "' already exists.");
+    public static MinionServer createSystemProfile(User creator, String systemName, Map<String, Object> data) {
+        Optional<String> hwAddress = ofNullable((String) data.get("hwAddress"));
+        Optional<String> hostname = ofNullable((String) data.get("hostname"));
+
+        // at least one identifier must be contained
+        if (!hwAddress.isPresent() && !hostname.isPresent()) {
+            throw new IllegalArgumentException("hwAddress or hostname key must be present.");
         }
+
+        Set<String> hwAddrs = hwAddress.map(a -> singleton(a)).orElse(emptySet());
+        if (findMatchingEmptyProfile(hostname, hwAddrs).isPresent()) {
+            throw new IllegalStateException("System(s) with hostname '" + hostname + "' or HW address '" +
+                    hwAddress + "' already exists.");
+        }
+
+        // craft unique id based on given data
+        String uniqueId = ">" + Arrays.asList(hwAddress, hostname)
+                .stream()
+                .flatMap(o -> Opt.stream(o))
+                .reduce((i1, i2) -> i1 + ">" + i2)
+                .get();
 
         MinionServer server = new MinionServer();
         server.setName(systemName);
@@ -410,9 +433,10 @@ public class SystemManager extends BaseManager {
 
         // Set network device information to the server so we have something to match with
         server.setCreator(creator);
-        server.setDigitalServerId(hwAddress);
-        server.setMachineId(hwAddress);
-        server.setMinionId(hwAddress);
+        hostname.ifPresent(n -> server.setHostname(n));
+        server.setDigitalServerId(uniqueId);
+        server.setMachineId(uniqueId);
+        server.setMinionId(uniqueId);
         server.setOs("(unknown)");
         server.setOsFamily("(unknown)");
         server.setRelease("(unknown)");
@@ -425,18 +449,34 @@ public class SystemManager extends BaseManager {
         ServerFactory.save(server);
         server.setBaseEntitlement(EntitlementManager.BOOTSTRAP);
 
-        NetworkInterface netInterface = new NetworkInterface();
-        netInterface.setHwaddr(hwAddress);
-        netInterface.setServer(server);
-        netInterface.setName("unknown");
-
-        if (!netInterface.isValid()) {
-            throw new IllegalArgumentException("Invalid network interface: " + netInterface);
-        }
-
-        ServerFactory.saveNetworkInterface(netInterface);
+        hwAddress.ifPresent(addr -> {
+            NetworkInterface netInterface = new NetworkInterface();
+            netInterface.setHwaddr(addr);
+            netInterface.setServer(server);
+            netInterface.setName("unknown");
+            if (!netInterface.isValid()) {
+                throw new IllegalArgumentException("Invalid network interface: " + netInterface);
+            }
+            ServerFactory.saveNetworkInterface(netInterface);
+        });
 
         return server;
+    }
+
+    /**
+     * Find matching empty profile based on hostname and HW addresses (in this order).
+     *
+     * @param hostname the hostname
+     * @param hwAddrs the set of HW addresses
+     * @return the matching empty profile
+     */
+    public static Optional<MinionServer> findMatchingEmptyProfile(Optional<String> hostname, Set<String> hwAddrs) {
+        Optional<MinionServer> hostnameMatch = hostname.flatMap(n -> MinionServerFactory.findEmptyProfileByHostName(n));
+        if (hostnameMatch.isPresent()) {
+            return hostnameMatch;
+        }
+        Optional<MinionServer> hwAddrMatch = MinionServerFactory.findEmptyProfileByHwAddrs(hwAddrs);
+        return hwAddrMatch;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -16,8 +16,12 @@ package com.redhat.rhn.manager.system.test;
 
 import static com.redhat.rhn.manager.action.test.ActionManagerTest.assertNotEmpty;
 import static com.redhat.rhn.testing.RhnBaseTestCase.reload;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
 
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
@@ -115,6 +119,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -1332,7 +1337,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
 
         HibernateFactory.getSession().flush();
 
-        SystemManager.updateServerChannels(user, server, Optional.of(base2), Arrays.asList(ch2_1, ch2_2), null);
+        SystemManager.updateServerChannels(user, server, of(base2), Arrays.asList(ch2_1, ch2_2), null);
 
         assertEquals(base2.getId(), server.getBaseChannel().getId());
         assertEquals(2, server.getChildChannels().size());
@@ -1361,7 +1366,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
 
         HibernateFactory.getSession().flush();
 
-        SystemManager.updateServerChannels(user, server, Optional.of(base2), Collections.emptyList(), null);
+        SystemManager.updateServerChannels(user, server, of(base2), Collections.emptyList(), null);
 
         assertEquals(base2.getId(), server.getBaseChannel().getId());
         assertEquals(0, server.getChildChannels().size());
@@ -1388,7 +1393,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
 
         HibernateFactory.getSession().flush();
 
-        SystemManager.updateServerChannels(user, server, Optional.empty(), Arrays.asList(ch2_1, ch2_2), null);
+        SystemManager.updateServerChannels(user, server, empty(), Arrays.asList(ch2_1, ch2_2), null);
 
         assertNull(server.getBaseChannel());
         assertEquals(0, server.getChildChannels().size());
@@ -1399,7 +1404,8 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
      */
     public void testCreateSystemProfile() {
         String hwAddr = "be:b0:bc:a3:a7:ad";
-        MinionServer minion = SystemManager.createSystemProfile(user, "test system", hwAddr);
+        Map<String, Object> data = singletonMap("hwAddress", hwAddr);
+        MinionServer minion = SystemManager.createSystemProfile(user, "test system", data);
         Server minionFromDb = SystemManager.lookupByIdAndOrg(minion.getId(), user.getOrg());
 
         // flush & refresh iface because generated="insert"
@@ -1408,9 +1414,9 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         HibernateFactory.getSession().refresh(minionFromDb);
 
         assertEquals("test system", minionFromDb.getName());
-        assertEquals(hwAddr, minion.getMinionId());
-        assertEquals(hwAddr, minion.getMachineId());
-        assertEquals(hwAddr, minion.getDigitalServerId());
+        assertEquals(">" + hwAddr, minion.getMinionId());
+        assertEquals(">" + hwAddr, minion.getMachineId());
+        assertEquals(">" + hwAddr, minion.getDigitalServerId());
         assertEquals("(unknown)", minion.getOs());
         assertEquals("(unknown)", minion.getOsFamily());
         assertEquals("(unknown)", minion.getRelease());
@@ -1433,7 +1439,8 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
     public void testListSystemProfile() throws Exception {
         UserTestUtils.addUserRole(user, RoleFactory.ORG_ADMIN);
         String hwAddr = "be:b0:bc:a3:a7:ad";
-        MinionServer emptyProfileMinion = SystemManager.createSystemProfile(user, "test system", hwAddr);
+        MinionServer emptyProfileMinion = SystemManager.createSystemProfile(user, "test system",
+                singletonMap("hwAddress", hwAddr));
         HibernateFactory.getSession().evict(emptyProfileMinion);
 
         ServerTestUtils.createTestSystem(user);
@@ -1459,7 +1466,8 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
     public void testListSystemProfileTradSystem() {
         UserTestUtils.addUserRole(user, RoleFactory.ORG_ADMIN);
         String hwAddr = "be:b0:bc:a3:a7:ad";
-        MinionServer emptyProfileMinion = SystemManager.createSystemProfile(user, "test system", hwAddr);
+        MinionServer emptyProfileMinion = SystemManager.createSystemProfile(user, "test system",
+                singletonMap("hwAddress", hwAddr));
         HibernateFactory.getSession().createNativeQuery("DELETE FROM suseMinionInfo").executeUpdate();
         HibernateFactory.getSession().evict(emptyProfileMinion);
 
@@ -1475,7 +1483,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         UserTestUtils.addUserRole(foreignUser, RoleFactory.ORG_ADMIN);
         UserTestUtils.addUserRole(user, RoleFactory.ORG_ADMIN);
         String hwAddr = "be:b0:bc:a3:a7:ad";
-        MinionServer emptyProfileMinion = SystemManager.createSystemProfile(user, "test system", hwAddr);
+        SystemManager.createSystemProfile(user, "test system", singletonMap("hwAddress", hwAddr));
 
         assertEquals(1, SystemManager.listEmptySystemProfiles(user, null).getTotalSize());
         assertEquals(0, SystemManager.listEmptySystemProfiles(foreignUser, null).getTotalSize());
@@ -1487,12 +1495,125 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
      */
     public void testCreateSystemProfileExistingHwAddress() {
         String hwAddr = "be:b0:bc:a3:a7:ad";
-        SystemManager.createSystemProfile(user, "test system", hwAddr);
+        Map<String, Object> data = singletonMap("hwAddress", hwAddr);
+        SystemManager.createSystemProfile(user, "test system", data);
         try {
-            SystemManager.createSystemProfile(user, "test system 2", hwAddr);
+            SystemManager.createSystemProfile(user, "test system 2", data);
             fail("System creation should have failed!");
         } catch (IllegalStateException e) {
             // no-op
         }
+    }
+
+    /**
+     * Tests finding an empty profile by hostname and HW addresses with "empty" arguments.
+     */
+    public void testFindByHostnameAndHwAddrsEmptyArgs() {
+        assertFalse(SystemManager.findMatchingEmptyProfile(empty(), emptySet()).isPresent());
+    }
+
+    /**
+     * Tests finding an empty profile with no NICS.
+     */
+    public void testFindByHostnameNoHwAddrs() throws Exception {
+        MinionServer minion = createEmptyProfile(of("myhost"), empty());
+
+        Optional<MinionServer> fromDb = SystemManager.findMatchingEmptyProfile(of("myhost"), emptySet());
+        assertEquals(minion, fromDb.get());
+
+        // minion with a HW address will also match
+        Optional<MinionServer> fromDb2 = SystemManager.findMatchingEmptyProfile(of("myhost"), singleton("11:22:33:44:55:66"));
+        assertEquals(minion, fromDb2.get());
+    }
+
+    /**
+     * Tests finding an empty profile with no hostname.
+     */
+    public void testFindByHostnameNoHostname() throws Exception {
+        String hwAddr = "11:22:33:44:55:66";
+        MinionServer minion = createEmptyProfile(empty(), of(hwAddr));
+
+        Optional<MinionServer> fromDb = SystemManager.findMatchingEmptyProfile(empty(), singleton(hwAddr));
+        assertEquals(minion, fromDb.get());
+
+        // minion with a hostname will also match
+        Optional<MinionServer> fromDb2 = SystemManager.findMatchingEmptyProfile(of("myhost"), singleton(hwAddr));
+        assertEquals(minion, fromDb2.get());
+    }
+
+    /**
+     * Tests finding an empty profile by hostname and HW addresses.
+     */
+    public void testFindByHostnameAndHwAddrs() throws Exception {
+        String hwAddr = "11:22:33:44:55:66";
+        MinionServer minion = createEmptyProfile(of("myhost"), of(hwAddr));
+
+        // lookup by hostname should match
+        Optional<MinionServer> fromDb = SystemManager.findMatchingEmptyProfile(of("myhost"), emptySet());
+        assertEquals(minion, fromDb.get());
+
+        // lookup by HW addr should match
+        Optional<MinionServer> fromDb2 = SystemManager.findMatchingEmptyProfile(empty(), singleton(hwAddr));
+        assertEquals(minion, fromDb2.get());
+
+        // lookup by hostname and HW addr should match
+        Optional<MinionServer> fromDb3 = SystemManager.findMatchingEmptyProfile(of("myhost"), singleton(hwAddr));
+        assertEquals(minion, fromDb3.get());
+
+        // lookup by hostname and HW addrs should match
+        Set<String> moreAddrs = new HashSet<>();
+        moreAddrs.add(hwAddr);
+        moreAddrs.add("11:22:33:44:55:77");
+        Optional<MinionServer> fromDb4 = SystemManager.findMatchingEmptyProfile(of("myhost"), moreAddrs);
+        assertEquals(minion, fromDb4.get());
+    }
+
+    /**
+     * Tests finding system (with multiple NICs) by hostname and HW addresses.
+     */
+    public void testFindByHostnameAndHwAddrsMoreNics() throws Exception {
+        String hwAddr = "11:22:33:44:55:66";
+        String hwAddr2 = "11:22:33:44:55:77";
+        MinionServer minion = createEmptyProfile(of("myhost"), of(hwAddr));
+        // add an extra iface with a different hw addr
+        NetworkInterface netInterface = new NetworkInterface();
+        netInterface.setHwaddr(hwAddr2);
+        netInterface.setServer(minion);
+        netInterface.setName("unknown2");
+        ServerFactory.saveNetworkInterface(netInterface);
+
+        // lookup by hostname should match
+        Optional<MinionServer> fromDb = SystemManager.findMatchingEmptyProfile(of("myhost"), emptySet());
+        assertEquals(minion, fromDb.get());
+
+        // lookup by multiple HW addrs should match
+        Set<String> hwAddrs = new HashSet<>();
+        hwAddrs.add(hwAddr);
+        hwAddrs.add(hwAddr2);
+        Optional<MinionServer> fromDb2 = SystemManager.findMatchingEmptyProfile(empty(), hwAddrs);
+        assertEquals(minion, fromDb2.get());
+
+        // lookup by single HW addr should match
+        String fstAddr = hwAddrs.iterator().next();
+        Optional<MinionServer> fromDb3 = SystemManager.findMatchingEmptyProfile(empty(), singleton(fstAddr));
+        assertEquals(minion, fromDb3.get());
+    }
+
+    /**
+     * Tests lookup of (non-matching) system by hostname and HW address.
+     */
+    public void testFindByHostnameAndHwAddrsNoMatch() throws Exception {
+        createEmptyProfile(of("myhost"), empty());
+        Optional<MinionServer> fromDb = SystemManager.findMatchingEmptyProfile(empty(), singleton("00:11:22:33:44:55"));
+        assertFalse(fromDb.isPresent());
+        Optional<MinionServer> fromDb2 = SystemManager.findMatchingEmptyProfile(of("otherhost"), emptySet());
+        assertFalse(fromDb2.isPresent());
+    }
+
+    private MinionServer createEmptyProfile(Optional<String> hostName, Optional<String> hwAddr) throws Exception {
+        Map<String, Object> data = new HashMap<>();
+        hostName.ifPresent(n -> data.put("hostname", n));
+        hwAddr.ifPresent(a -> data.put("hwAddress", a));
+        return SystemManager.createSystemProfile(user, hostName.orElse("test system"), data);
     }
 }

--- a/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
@@ -17,6 +17,7 @@ package com.suse.manager.reactor.test;
 import static com.redhat.rhn.testing.ErrataTestUtils.createTestChannelFamily;
 import static com.redhat.rhn.testing.ErrataTestUtils.createTestChannelProduct;
 import static com.redhat.rhn.testing.RhnBaseTestCase.assertContains;
+import static java.util.Collections.singletonMap;
 
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
@@ -720,10 +721,10 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                     will(returnValue(getGrains(MINION_ID, "rhel", null)));
 
                     allowing(saltServiceMock).runRemoteCommand(with(any(MinionList.class)), with("rpm -q --whatprovides --queryformat \"%{NAME}\\n\" redhat-release"));
-                    will(returnValue(Collections.singletonMap(MINION_ID, new Result<>(Xor.right("redhat-release-server\n")))));
+                    will(returnValue(singletonMap(MINION_ID, new Result<>(Xor.right("redhat-release-server\n")))));
 
                     allowing(saltServiceMock).runRemoteCommand(with(any(MinionList.class)), with("rpm -q --queryformat \"VERSION=%{VERSION}\\nPROVIDENAME=[%{PROVIDENAME},]\\nPROVIDEVERSION=[%{PROVIDEVERSION},]\\n\" redhat-release-server"));
-                    will(returnValue(Collections.singletonMap(MINION_ID, new Result<>(Xor.right("VERSION=7.2\n" +
+                    will(returnValue(singletonMap(MINION_ID, new Result<>(Xor.right("VERSION=7.2\n" +
                             "PROVIDENAME=config(redhat-release-server),redhat-release,redhat-release-server,redhat-release-server(x86-64),system-release,system-release(releasever),\n" +
                             "PROVIDEVERSION=7.2-9.el7,7.2-9.el7,7.2-9.el7,7.2-9.el7,7.2-9.el7,7Server,\n")))));
 
@@ -759,10 +760,10 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                     will(returnValue(getGrains(MINION_ID, "rhel", key)));
 
                     allowing(saltServiceMock).runRemoteCommand(with(any(MinionList.class)), with("rpm -q --whatprovides --queryformat \"%{NAME}\\n\" redhat-release"));
-                    will(returnValue(Collections.singletonMap(MINION_ID, new Result<>(Xor.right("redhat-release-server\n")))));
+                    will(returnValue(singletonMap(MINION_ID, new Result<>(Xor.right("redhat-release-server\n")))));
 
                     allowing(saltServiceMock).runRemoteCommand(with(any(MinionList.class)), with("rpm -q --queryformat \"VERSION=%{VERSION}\\nPROVIDENAME=[%{PROVIDENAME},]\\nPROVIDEVERSION=[%{PROVIDEVERSION},]\\n\" redhat-release-server"));
-                    will(returnValue(Collections.singletonMap(MINION_ID, new Result<>(Xor.right("VERSION=7.2\n" +
+                    will(returnValue(singletonMap(MINION_ID, new Result<>(Xor.right("VERSION=7.2\n" +
                             "PROVIDENAME=config(redhat-release-server),redhat-release,redhat-release-server,redhat-release-server(x86-64),system-release,system-release(releasever),\n" +
                             "PROVIDEVERSION=7.2-9.el7,7.2-9.el7,7.2-9.el7,7.2-9.el7,7.2-9.el7,7Server,\n")))));
 
@@ -803,10 +804,10 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                     will(returnValue(getGrains(MINION_ID, "res", null)));
 
                     allowing(saltServiceMock).runRemoteCommand(with(any(MinionList.class)), with("rpm -q --whatprovides --queryformat \"%{NAME}\\n\" redhat-release"));
-                    will(returnValue(Collections.singletonMap(MINION_ID, new Result<>(Xor.right("sles_es-release-server\n")))));
+                    will(returnValue(singletonMap(MINION_ID, new Result<>(Xor.right("sles_es-release-server\n")))));
 
                     allowing(saltServiceMock).runRemoteCommand(with(any(MinionList.class)), with("rpm -q --queryformat \"VERSION=%{VERSION}\\nPROVIDENAME=[%{PROVIDENAME},]\\nPROVIDEVERSION=[%{PROVIDEVERSION},]\\n\" sles_es-release-server"));
-                    will(returnValue(Collections.singletonMap(MINION_ID, new Result<>(Xor.right("VERSION=7.2\n" +
+                    will(returnValue(singletonMap(MINION_ID, new Result<>(Xor.right("VERSION=7.2\n" +
                             "PROVIDENAME=centos-release,config(sles_es-release-server),redhat-release,redhat-release-server,sles_es-release-server,sles_es-release-server(x86-64),system-release,system-release(releasever),\n" +
                             "PROVIDEVERSION=,7.2-9.el7.2.1,7.2-9.el7.2.1,7.2-9.el7.2.1,7.2-9.el7.2.1,7.2-9.el7.2.1,7.2-9.el7.2.1,7Server,\n")))));
 
@@ -841,11 +842,11 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
 
                     allowing(saltServiceMock).runRemoteCommand(with(any(MinionList.class)), with("rpm -q --whatprovides --queryformat \"%{NAME}\\n\" redhat-release"));
                     // Minion returns multiple release packages/versions
-                    will(returnValue(Collections.singletonMap(MINION_ID, new Result<>(Xor.right("redhat-release-server\nsles_es-release-server\nsles_es-release-server\nredhat-release-server\n")))));
+                    will(returnValue(singletonMap(MINION_ID, new Result<>(Xor.right("redhat-release-server\nsles_es-release-server\nsles_es-release-server\nredhat-release-server\n")))));
 
                     allowing(saltServiceMock).runRemoteCommand(with(any(MinionList.class)), with("rpm -q --queryformat \"VERSION=%{VERSION}\\nPROVIDENAME=[%{PROVIDENAME},]\\nPROVIDEVERSION=[%{PROVIDEVERSION},]\\n\" redhat-release-server"));
                     // Minion returns data for multiple release packages/versions
-                    will(returnValue(Collections.singletonMap(MINION_ID, new Result<>(Xor.right("VERSION=7.2\n" +
+                    will(returnValue(singletonMap(MINION_ID, new Result<>(Xor.right("VERSION=7.2\n" +
                             "PROVIDENAME=centos-release,config(sles_es-release-server),redhat-release,redhat-release-server,sles_es-release-server,sles_es-release-server(x86-64),system-release,system-release(releasever),\n" +
                             "PROVIDEVERSION=,7.2-9.el7.2.1,7.2-9.el7.2.1,7.2-9.el7.2.1,7.2-9.el7.2.1,7.2-9.el7.2.1,7.2-9.el7.2.1,7Server,\n" +
                             "VERSION=7.3\n" +
@@ -1116,7 +1117,8 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         ManagedServerGroup alreadyAssignedGroup = ServerGroupFactory.create("HWTYPE:idontmatch",
                 "HW group - assigned to empty profile beforehand", user.getOrg());
 
-        MinionServer emptyMinion = SystemManager.createSystemProfile(user, "empty profile", "00:11:22:33:44:55");
+        MinionServer emptyMinion = SystemManager.createSystemProfile(user, "empty profile",
+                singletonMap("hwAddress", "00:11:22:33:44:55"));
         ServerFactory.addServerToGroup(emptyMinion, alreadyAssignedGroup);
 
         executeTest(
@@ -1238,7 +1240,8 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
      * @throws Exception if anything goes wrong
      */
     public void testEmptyProfileRegistration() throws Exception {
-        MinionServer emptyMinion = SystemManager.createSystemProfile(user, "empty profile", "00:11:22:33:44:55");
+        MinionServer emptyMinion = SystemManager.createSystemProfile(user, "empty profile",
+               singletonMap("hwAddress", "00:11:22:33:44:55"));
         executeTest(
                 (saltServiceMock, key) -> new Expectations() {{
                     allowing(saltServiceMock).getMasterHostname(MINION_ID);
@@ -1295,12 +1298,14 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         final String hwAddress = "00:11:22:33:44:55";
 
         // assign some formula
-        MinionServer emptyMinion = SystemManager.createSystemProfile(user, "empty profile", hwAddress);
-        FormulaFactory.saveServerFormulas(hwAddress, Collections.singletonList(testFormula));
-        Map<String, Object> formulaContent = Collections.singletonMap("testKey", "testVal");
-        FormulaFactory.saveServerFormulaData(formulaContent, hwAddress, testFormula);
+        MinionServer emptyMinion = SystemManager.createSystemProfile(user, "empty profile",
+                singletonMap("hwAddress", "00:11:22:33:44:55"));
+        String minionId = ">" + hwAddress;
+        FormulaFactory.saveServerFormulas(minionId, Collections.singletonList(testFormula));
+        Map<String, Object> formulaContent = singletonMap("testKey", "testVal");
+        FormulaFactory.saveServerFormulaData(formulaContent, minionId, testFormula);
 
-        assertTrue(Paths.get(FormulaFactory.getPillarDir(), hwAddress + "_" + testFormula + ".json").toFile().exists());
+        assertTrue(Paths.get(FormulaFactory.getPillarDir(), ">" + hwAddress + "_" + testFormula + ".json").toFile().exists());
 
         executeTest(
                 (saltServiceMock, key) -> new Expectations() {{


### PR DESCRIPTION
## What does this PR change?
 
 Previously, the matching empty system profiles on registration was only done based on the HW addresses of the NICs of the profile.
 This PR allows also matching by FQDN: The user can specify a fully-qualified domain name in the `system.createSystemProfile` (as a `FQDN` field in `data`).
 When the actual machine is being registered, the empty profile is looked up by matching the machine grains and the `FQDN` and HW address of stored empty profiles.
 
 
 ## GUI diff
 
 No difference.
 
 - [x] **DONE**
 
 ## Documentation
 - [doc-susemanager](https://github.com/SUSE/doc-susemanager/issues/247)
 
 - [x] **DONE**
 
 ## Test coverage
 - Unit tests were added
 
 - [x] **DONE**
 
 ## Links
 
 Fixes https://github.com/SUSE/spacewalk/issues/6059
 
 Relevant branches (GitHub automatic links expected below):
  - Manager-3.2: https://github.com/SUSE/spacewalk/pull/6169
 
 - [x] **DONE**