### PR TITLE
Fix Form onChange handlers after refactoring

### DIFF
--- a/web/html/src/manager/image-build.js
+++ b/web/html/src/manager/image-build.js
@@ -106,8 +106,8 @@ class BuildImage extends React.Component {
       });
   }
 
-  handleProfileChange(event) {
-    this.changeProfile(event.target.value);
+  handleProfileChange(name, value) {
+    this.changeProfile(value);
   }
 
   changeProfile(id) {

--- a/web/html/src/manager/image-import.js
+++ b/web/html/src/manager/image-import.js
@@ -213,8 +213,8 @@ class ImageImport extends React.Component {
     }
   }
 
-  handleActivationKeyChange(event) {
-    this.getChannels(event.target.value);
+  handleActivationKeyChange(name, value) {
+    this.getChannels(value);
   }
 
   renderActivationKeySelect() {

--- a/web/html/src/manager/image-profile-edit.js
+++ b/web/html/src/manager/image-profile-edit.js
@@ -75,7 +75,7 @@ class CreateImageProfile extends React.Component {
         });
         this.getChannels(data.activationKey.key);
         this.getImageStores(typeMap[data.imageType].storeType);
-        this.handleImageStoreChange({target: {value: data.store}});
+        this.handleImageStoreChange(undefined, data.store);
       } else {
         window.location = "/rhn/manager/cm/imageprofiles/create";
       }
@@ -105,17 +105,17 @@ class CreateImageProfile extends React.Component {
     });
   }
 
-  handleTokenChange(event) {
-    this.getChannels(event.target.value);
+  handleTokenChange(name, value) {
+    this.getChannels(value);
   }
 
-  handleImageTypeChange(event) {
-    const storeType = typeMap[event.target.value].storeType;
+  handleImageTypeChange(name, value) {
+    const storeType = typeMap[value].storeType;
     this.getImageStores(storeType);
   }
 
-  handleImageStoreChange(event) {
-    const storeLabel = event.target.value;
+  handleImageStoreChange(name, storeLabel) {
+    const storeLabel = value;
     Network.get("/rhn/manager/api/cm/imagestores/find/" + storeLabel)
       .promise.then(res => {
         this.setState({


### PR DESCRIPTION
## What does this PR change?

The input refactoring changed the onChange signature on all Form input
components. They now take name and value parameters rather than the
complete event.

Adapt the client code to the new handler signature.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: internal fixes

- [X] **DONE**

## Test coverage
- No tests: fixes broken cucumber tests

- [X] **DONE**

## Links

Fixes SUSE/spacewalk#6285

- [X] **DONE**
