### PR TITLE
When removing system record, lookup by mac address as well

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerSystemRemoveCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerSystemRemoveCommand.java
@@ -21,6 +21,7 @@ import com.redhat.rhn.manager.satellite.CobblerSyncCommand;
 
 import org.cobbler.SystemRecord;
 
+
 /**
  * @version $Rev$
  */
@@ -43,19 +44,11 @@ public class CobblerSystemRemoveCommand extends CobblerCommand {
      * @return ValidatorError if the remoev failed.
      */
     public ValidatorError store() {
-        String cobblerId = server.getCobblerId();
-        SystemRecord sr = null;
-
-        if (cobblerId != null) {
-            sr = SystemRecord.lookupById(CobblerXMLRPCHelper.getConnection(user),
-                cobblerId);
-        }
-
+        SystemRecord sr = lookupExisting(server);
         if (sr != null) {
             sr.remove();
             return new CobblerSyncCommand(user).store();
         }
-
         return null;
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerVirtualSystemCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerVirtualSystemCommand.java
@@ -116,7 +116,7 @@ public class CobblerVirtualSystemCommand extends CobblerSystemCreateCommand {
 
 
     @Override
-    protected SystemRecord lookupExisting() {
+    protected SystemRecord lookupExisting(Server server) {
         log.debug("lookupExisting called.");
 
         return SystemRecord.lookupByName(

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- When removing cobbler system record, lookup by mac address as well if lookup by id fails(bsc#1110361)
 - increase maximum number of threads and open files for taskomatic (bsc#1111966)
 - Changed Strings for MenuTree Items to remove redundancy (bsc#1019847)
 - Automatic cleanup of notification messages after a configurable lifetime


### PR DESCRIPTION
## What does this PR change?
Problem : When calling the deleteSystem function it deletes the web ui profile but not the cobbler profile.

If system record is created 1st thorugh xmlrpc api and then later a system in suma then no relation between cobbler system record and system in suma is created and now because of this if user delete the system from suma then cobbler profile is not deleted. With this PR, we try to find the system record in cobbler through cobblerId and if that returns no result then we go one step further and check by mac address and if we find a record then we delete that the system record as well.


## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation

- [x] **DONE**

## Test coverage
- No tests: *Already existed*

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**
