### PR TITLE
Turn pointy brackets to underscores for empty profiles

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -421,10 +421,11 @@ public class SystemManager extends BaseManager {
         }
 
         // craft unique id based on given data
-        String uniqueId = ">" + Arrays.asList(hwAddress, hostname)
+        String delimiter = "_";
+        String uniqueId = delimiter + Arrays.asList(hwAddress, hostname)
                 .stream()
                 .flatMap(o -> Opt.stream(o))
-                .reduce((i1, i2) -> i1 + ">" + i2)
+                .reduce((i1, i2) -> i1 + delimiter + i2)
                 .get();
 
         MinionServer server = new MinionServer();

--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -1414,9 +1414,9 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         HibernateFactory.getSession().refresh(minionFromDb);
 
         assertEquals("test system", minionFromDb.getName());
-        assertEquals(">" + hwAddr, minion.getMinionId());
-        assertEquals(">" + hwAddr, minion.getMachineId());
-        assertEquals(">" + hwAddr, minion.getDigitalServerId());
+        assertEquals("_" + hwAddr, minion.getMinionId());
+        assertEquals("_" + hwAddr, minion.getMachineId());
+        assertEquals("_" + hwAddr, minion.getDigitalServerId());
         assertEquals("(unknown)", minion.getOs());
         assertEquals("(unknown)", minion.getOsFamily());
         assertEquals("(unknown)", minion.getRelease());

--- a/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
@@ -1300,12 +1300,12 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         // assign some formula
         MinionServer emptyMinion = SystemManager.createSystemProfile(user, "empty profile",
                 singletonMap("hwAddress", "00:11:22:33:44:55"));
-        String minionId = ">" + hwAddress;
+        String minionId = "_" + hwAddress;
         FormulaFactory.saveServerFormulas(minionId, Collections.singletonList(testFormula));
         Map<String, Object> formulaContent = singletonMap("testKey", "testVal");
         FormulaFactory.saveServerFormulaData(formulaContent, minionId, testFormula);
 
-        assertTrue(Paths.get(FormulaFactory.getPillarDir(), ">" + hwAddress + "_" + testFormula + ".json").toFile().exists());
+        assertTrue(Paths.get(FormulaFactory.getPillarDir(), "_" + hwAddress + "_" + testFormula + ".json").toFile().exists());
 
         executeTest(
                 (saltServiceMock, key) -> new Expectations() {{


### PR DESCRIPTION
## What does this PR change?
 
 Turn pointy brackets to underscores for empty profiles delimiters. These delimeters are part of formula files generated on the FS and underscores look better there.
 
 
 ## GUI diff
 
 No difference.
 
 - [x] **DONE**
 
 ## Documentation
 - No documentation needed
 
 ## Test coverage
 - Unit tests were adjusted
 
 - [x] **DONE**
 
 ## Links
 
 - [x] **DONE**
 
 # Requesting a pull to uyuni-project:master from hustodemon:use-underscores-for-empty-profiles
 #
 # Write a message for this pull request. The first block
 # of text is the title and the rest is the description.