### PR TITLE
Adapt "spacewalk-proxy-installer" to be Python 2/3 compatible

### DIFF
--- a/proxy/installer/spacewalk-proxy-installer.changes
+++ b/proxy/installer/spacewalk-proxy-installer.changes
@@ -1,3 +1,5 @@
+- Add support for Python 3 on spacewalk-proxy-installer
+
 -------------------------------------------------------------------
 Fri Oct 26 10:35:58 CEST 2018 - jgonzalez@suse.com
 

--- a/proxy/installer/spacewalk-proxy-installer.spec
+++ b/proxy/installer/spacewalk-proxy-installer.spec
@@ -22,9 +22,11 @@
 %{!?pylint_check: %global pylint_check 1}
 %endif
 
-%if 0%{?fedora}
+%if 0%{?suse_version} > 1320 || 0%{?fedora}
+# SLE15 and Fedora builds on Python 3
 %global build_py3   1
 %endif
+%define pythonX %{?build_py3:python3}%{!?build_py3:python2}
 
 Name:           spacewalk-proxy-installer
 Summary:        Spacewalk Proxy Server Installer
@@ -62,8 +64,8 @@ Requires:       chkconfig
 Requires:       libxslt
 Requires:       spacewalk-certs-tools >= 1.6.4
 %if 0%{?pylint_check}
-BuildRequires:  python2-rhn-client-tools
-BuildRequires:  spacewalk-python2-pylint
+BuildRequires:  %{pythonX}-rhn-client-tools
+BuildRequires:  spacewalk-%{pythonX}-pylint
 %endif
 BuildRequires:  /usr/bin/docbook2man
 
@@ -119,8 +121,12 @@ install -m 644 rhn-proxy-activate.8.gz $RPM_BUILD_ROOT%{_mandir}/man8/
 install -m 644 configure-proxy.sh.8.gz $RPM_BUILD_ROOT%{_mandir}/man8/
 install -m 640 jabberd/sm.xml jabberd/c2s.xml $RPM_BUILD_ROOT%{_usr}/share/rhn/installer/jabberd
 
+# Fixing shebang for Python 3
 %if 0%{?build_py3}
-sed -i 's|#!/usr/bin/python|#!/usr/bin/python3|' rhn-proxy-activate.py
+for i in $(find . -type f);
+do
+    sed -i '1s=^#!/usr/bin/\(python\|env python\)[0-9.]*=#!/usr/bin/python3=' $i;
+done
 %endif
 install -m 755 rhn-proxy-activate.py $RPM_BUILD_ROOT/%{_usr}/sbin/rhn-proxy-activate
 install -m 755 fetch-certificate.py  $RPM_BUILD_ROOT/%{_usr}/sbin/fetch-certificate
@@ -128,7 +134,7 @@ install -m 755 fetch-certificate.py  $RPM_BUILD_ROOT/%{_usr}/sbin/fetch-certific
 %check
 %if 0%{?pylint_check}
 # check coding style
-spacewalk-python2-pylint .
+spacewalk-%{pythonX}-pylint .
 %endif
 
 %files


### PR DESCRIPTION
## What does this PR change?

This PR adapts the `spacewalk-proxy-installer` package to be Python 2/3 compatible.

On this particular case, Python code was already migrated so we only need to do the necessary adjustments on the spec file.

## Links

Tracks https://github.com/SUSE/salt-board/issues/63

- [x] **DONE**
