### PR TITLE
Adapt to new async salt-netapi API

### DIFF
--- a/java/buildconf/build-props.xml
+++ b/java/buildconf/build-props.xml
@@ -133,7 +133,7 @@
              regexp ${jmock-jars} strutstest" / -->
 
   <!-- SUSE extra dependencies: build and runtime -->
-  <property name="suse-common-jars" value="jade4j jose4j salt-netapi-client spark-core spark-template-jade httpclient httpcore simpleclient simpleclient_common simpleclient_servlet simpleclient_httpserver" />
+  <property name="suse-common-jars" value="jade4j jose4j salt-netapi-client spark-core spark-template-jade httpclient httpcore httpasyncclient httpcore-nio simpleclient simpleclient_common simpleclient_servlet simpleclient_httpserver" />
 
   <!-- SUSE extra dependencies: runtime only -->
   <property name="suse-runtime-jars" value="commons-jexl ${commons-lang} concurrentlinkedhashmap-lru

--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -40,8 +40,10 @@
         <dependency org="suse" name="hibernate-core" rev="5.2.2" />
         <dependency org="suse" name="hibernate-ehcache" rev="5.2.2" />
         <dependency org="suse" name="hibernate-jpa-2.1-api" rev="1.0.0" />
+        <dependency org="suse" name="httpasyncclient" rev="4.1.3" />
         <dependency org="suse" name="httpclient" rev="4.5" />
         <dependency org="suse" name="httpcore" rev="4.4.1" />
+        <dependency org="suse" name="httpcore-nio" rev="4.4.6" />
         <dependency org="suse" name="jacocoant" rev="0.7.7" />
         <dependency org="suse" name="jade4j" rev="1.0.7" />
         <dependency org="suse" name="jaf" rev="1.0.2" />
@@ -73,7 +75,7 @@
         <dependency org="suse" name="redstone-xmlrpc" rev="1.1_20071120" />
         <dependency org="suse" name="redstone-xmlrpc-client" rev="1.1_20071120" />
         <dependency org="suse" name="regexp" rev="1.4" />
-        <dependency org="suse" name="salt-netapi-client" rev="0.14.0" />
+        <dependency org="suse" name="salt-netapi-client" rev="0.15.0-SNAPSHOT" />
         <dependency org="suse" name="simpleclient" rev="0.3.0" />
         <dependency org="suse" name="simpleclient_common" rev="0.3.0" />
         <dependency org="suse" name="simpleclient_servlet" rev="0.3.0" />

--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -75,7 +75,7 @@
         <dependency org="suse" name="redstone-xmlrpc" rev="1.1_20071120" />
         <dependency org="suse" name="redstone-xmlrpc-client" rev="1.1_20071120" />
         <dependency org="suse" name="regexp" rev="1.4" />
-        <dependency org="suse" name="salt-netapi-client" rev="0.15.0-SNAPSHOT" />
+        <dependency org="suse" name="salt-netapi-client" rev="0.15.0" />
         <dependency org="suse" name="simpleclient" rev="0.3.0" />
         <dependency org="suse" name="simpleclient_common" rev="0.3.0" />
         <dependency org="suse" name="simpleclient_servlet" rev="0.3.0" />

--- a/java/code/src/com/suse/manager/reactor/SaltReactor.java
+++ b/java/code/src/com/suse/manager/reactor/SaltReactor.java
@@ -52,7 +52,6 @@ import com.suse.manager.webui.utils.salt.SystemIdGenerateEvent;
 import com.suse.salt.netapi.exception.SaltException;
 import org.apache.log4j.Logger;
 
-import javax.websocket.CloseReason;
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -133,9 +132,8 @@ public class SaltReactor implements EventListener {
      * {@inheritDoc}
      */
     @Override
-    public void eventStreamClosed(CloseReason closeReason) {
-        LOG.warn("Event stream closed: " + closeReason.getReasonPhrase() +
-                " [" + closeReason.getCloseCode() + "]");
+    public void eventStreamClosed(int code, String phrase) {
+        LOG.warn("Event stream closed: " + phrase + " [" + code + "]");
 
         if (!isStopped) {
             LOG.warn("Reconnecting to the Salt event bus...");

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -82,7 +82,7 @@ Requires:       jose4j
 Requires:       objectweb-asm
 Requires:       pam-modules
 Requires:       prometheus-client-java
-Requires:       salt-netapi-client >= 0.14.0
+Requires:       salt-netapi-client >= 0.15.0
 Requires:       snakeyaml
 Requires:       spark-core
 Requires:       spark-template-jade
@@ -109,10 +109,11 @@ BuildRequires:  statistics
 BuildRequires:  log4j
 # Spark and Salt integration
 BuildRequires:  httpcomponents-client
+BuildRequires:  httpcomponents-asyncclient
 BuildRequires:  jade4j
 BuildRequires:  jose4j
 BuildRequires:  prometheus-client-java
-BuildRequires:  salt-netapi-client >= 0.14.0
+BuildRequires:  salt-netapi-client >= 0.15.0
 BuildRequires:  spark-core
 BuildRequires:  spark-template-jade
 BuildRequires:  velocity
@@ -917,6 +918,8 @@ fi
 %{jardir}/commons-lang3.jar
 %{jardir}/httpclient.jar
 %{jardir}/httpcore.jar
+%{jardir}/httpcore-nio.jar
+%{jardir}/httpasyncclient.jar
 %{jardir}/jade4j.jar
 %{jardir}/jose4j.jar
 %{jardir}/salt-netapi-client.jar


### PR DESCRIPTION
## What does this PR change?

It adapts the code to the new async salt-netapi API. The code does not make use of the async behavior yet but simply blocks on the Future. Since exceptions are handled differently with CompletableFutures there is a function adaptException which tries to restore the old behavior as close as possible.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **no user visible change**

- [x] **DONE**

## Test coverage
- No tests: **already covered by unit and integration tests**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/6225

- [x] **DONE**
