### PR TITLE
Adapt "spacewalk-reports" code to be Python 2/3 compatible

### DIFF
--- a/reporting/reports.py
+++ b/reporting/reports.py
@@ -3,7 +3,7 @@ import os
 import re
 import sys
 
-from six import reraise as raise_
+from six import reraise
 from spacewalk.common.rhnConfig import RHNOptions
 
 REPORT_DEFINITIONS = "/usr/share/spacewalk/reports/data"
@@ -31,7 +31,7 @@ class report:
                 try:
                         fd = open(full_path, 'r')
                 except (IOError):
-                        raise_(spacewalk_unknown_report, None, sys.exc_info()[2])
+                        reraise(spacewalk_unknown_report, None, sys.exc_info()[2])
                 tag = None
                 value = ''
                 re_comment = re.compile('^\s*#')

--- a/reporting/reports.py
+++ b/reporting/reports.py
@@ -3,7 +3,7 @@ import os
 import re
 import sys
 
-from spacewalk.common.usix import raise_with_tb
+from salt.ext import six
 from spacewalk.common.rhnConfig import RHNOptions
 
 REPORT_DEFINITIONS = "/usr/share/spacewalk/reports/data"
@@ -31,7 +31,7 @@ class report:
                 try:
                         fd = open(full_path, 'r')
                 except (IOError):
-                        raise_with_tb(spacewalk_unknown_report, sys.exc_info()[2])
+                        six.reraise(spacewalk_unknown_report, None, sys.exc_info()[2])
                 tag = None
                 value = ''
                 re_comment = re.compile('^\s*#')

--- a/reporting/reports.py
+++ b/reporting/reports.py
@@ -3,7 +3,7 @@ import os
 import re
 import sys
 
-from six import reraise
+from spacewalk.common.usix import raise_with_tb
 from spacewalk.common.rhnConfig import RHNOptions
 
 REPORT_DEFINITIONS = "/usr/share/spacewalk/reports/data"
@@ -31,7 +31,7 @@ class report:
                 try:
                         fd = open(full_path, 'r')
                 except (IOError):
-                        reraise(spacewalk_unknown_report, None, sys.exc_info()[2])
+                        raise_with_tb(spacewalk_unknown_report, sys.exc_info()[2])
                 tag = None
                 value = ''
                 re_comment = re.compile('^\s*#')

--- a/reporting/reports.py
+++ b/reporting/reports.py
@@ -82,7 +82,7 @@ class report:
                         self.column_indexes = {}
                         self.column_types = {}
                         self.column_descriptions = {}
-                        lines = [x for x in re.split('\s*\n\s*', value) if x != '']
+                        lines = filter(None, re.split('\s*\n\s*', value))
                         i = 0
                         for l in lines:
                                 description = None
@@ -101,7 +101,7 @@ class report:
                                         self.column_descriptions[c] = description
                                 i = i + 1
                 elif tag == 'params':
-                        lines = [x for x in re.split('\s*\n\s*', value) if x != '']
+                        lines = filter(None, re.split('\s*\n\s*', value))
                         for l in lines:
                                 ( p, v ) = re.split('\s+', l, 1)
                                 ( component, option ) = re.split('\.', v, 1)
@@ -116,7 +116,7 @@ class report:
                         # joined together and the second one is column
                         # whose value should be used to distinguish if
                         # we still have the same entity or not.
-                        for l in [x for x in re.split('\n', value) if x != '']:
+                        for l in filter(None, re.split('\n', value)):
                                 m = re.match('^\s*(\S+?)(\s*:\s*(\S*)\s*)?$', l)
                                 if m == None:
                                         continue

--- a/reporting/reports.py
+++ b/reporting/reports.py
@@ -3,6 +3,7 @@ import os
 import re
 import sys
 
+from six import reraise as raise_
 from spacewalk.common.rhnConfig import RHNOptions
 
 REPORT_DEFINITIONS = "/usr/share/spacewalk/reports/data"
@@ -30,7 +31,7 @@ class report:
                 try:
                         fd = open(full_path, 'r')
                 except (IOError):
-                        raise spacewalk_unknown_report, None, sys.exc_info()[2]
+                        raise_(spacewalk_unknown_report, None, sys.exc_info()[2])
                 tag = None
                 value = ''
                 re_comment = re.compile('^\s*#')
@@ -81,7 +82,7 @@ class report:
                         self.column_indexes = {}
                         self.column_types = {}
                         self.column_descriptions = {}
-                        lines = filter(lambda x: x != '', re.split('\s*\n\s*', value))
+                        lines = [x for x in re.split('\s*\n\s*', value) if x != '']
                         i = 0
                         for l in lines:
                                 description = None
@@ -100,7 +101,7 @@ class report:
                                         self.column_descriptions[c] = description
                                 i = i + 1
                 elif tag == 'params':
-                        lines = filter(lambda x: x != '', re.split('\s*\n\s*', value))
+                        lines = [x for x in re.split('\s*\n\s*', value) if x != '']
                         for l in lines:
                                 ( p, v ) = re.split('\s+', l, 1)
                                 ( component, option ) = re.split('\.', v, 1)
@@ -115,7 +116,7 @@ class report:
                         # joined together and the second one is column
                         # whose value should be used to distinguish if
                         # we still have the same entity or not.
-                        for l in filter(lambda x: x != '', re.split('\n', value)):
+                        for l in [x for x in re.split('\n', value) if x != '']:
                                 m = re.match('^\s*(\S+?)(\s*:\s*(\S*)\s*)?$', l)
                                 if m == None:
                                         continue

--- a/reporting/spacewalk-report
+++ b/reporting/spacewalk-report
@@ -240,7 +240,7 @@ if __name__ == '__main__':
                 tz.execute(tz=options.timezone)
 
             h = rhnSQL.prepare(the_sql)
-            h.execute(**dict(list(report.params.items()) + list(the_dict_where.items())))
+            h.execute(**dict(tuple(report.params.items()) + tuple(the_dict_where.items())))
 
             db_columns = [x[0].lower() for x in h.description]
             if db_columns != report.columns:

--- a/reporting/spacewalk-report
+++ b/reporting/spacewalk-report
@@ -28,6 +28,7 @@ def systemExit(code, msgs=None):
 
 import csv
 from optparse import Option, OptionParser
+from salt.ext import six
 import re
 import errno
 
@@ -190,11 +191,11 @@ if __name__ == '__main__':
             for column in where:
                 if column not in report.columns:
                     systemExit(-6, 'Unknown column [%s] in report [%s].' % (column, report_name))
-                for v in (val for _, vals in where[column].items() for val in vals):
+                for v in (val for _, vals in six.iteritems(where[column]) for val in vals):
                     if report.column_types[column] == 'i' and not re.match('^[0-9]+$', v):
                         systemExit(-7, 'Column [%s] in report [%s] only accepts integer value.' % (column, report_name))
 
-                for clause, values in where[column].items():
+                for clause, values in six.iteritems(where[column]):
                     l = []
                     for v in values:
                         l.append(':p%d' % pi)

--- a/reporting/spacewalk-report
+++ b/reporting/spacewalk-report
@@ -158,19 +158,19 @@ if __name__ == '__main__':
             need_exit = None
             if options.info:
                 if report.synopsis is not None:
-                    print report.synopsis
+                    print(report.synopsis)
                 else:
-                    print "No synopsis for report %s." % report_name
+                    print("No synopsis for report %s." % report_name)
                 if report.description is not None:
-                    print
-                    print report.description
+                    print()
+                    print(report.description)
                 need_exit = True
 
             if options.listfields or options.listfieldsinfo:
                 if options.info:
-                    print
-                    print "Fields in the report:"
-                    print
+                    print()
+                    print("Fields in the report:")
+                    print()
 
                 for c in report.columns:
                     text = c
@@ -178,7 +178,7 @@ if __name__ == '__main__':
                         text = "    %s" % c
                     if options.listfieldsinfo and c in report.column_descriptions:
                         text = "%s: %s" % (text, report.column_descriptions[c])
-                    print text
+                    print(text)
                 need_exit = True
 
             if need_exit:
@@ -190,11 +190,11 @@ if __name__ == '__main__':
             for column in where:
                 if column not in report.columns:
                     systemExit(-6, 'Unknown column [%s] in report [%s].' % (column, report_name))
-                for v in (val for _, vals in where[column].iteritems() for val in vals):
+                for v in (val for _, vals in list(where[column].items()) for val in vals):
                     if report.column_types[column] == 'i' and not re.match('^[0-9]+$', v):
                         systemExit(-7, 'Column [%s] in report [%s] only accepts integer value.' % (column, report_name))
 
-                for clause, values in where[column].iteritems():
+                for clause, values in list(where[column].items()):
                     l = []
                     for v in values:
                         l.append(':p%d' % pi)
@@ -239,9 +239,9 @@ if __name__ == '__main__':
                 tz.execute(tz=options.timezone)
 
             h = rhnSQL.prepare(the_sql)
-            h.execute(**dict(report.params.items() + the_dict_where.items()))
+            h.execute(**dict(list(report.params.items()) + list(the_dict_where.items())))
 
-            db_columns = map(lambda x: x[0].lower(), h.description)
+            db_columns = [x[0].lower() for x in h.description]
             if db_columns != report.columns:
                 systemExit(-3,
                     "Columns in report spec and in the database do not match:\nexpected %s\n     got %s" % (report.columns, db_columns))
@@ -252,7 +252,7 @@ if __name__ == '__main__':
             outrow = None
             multival_dupes = {}
             while row is not None:
-                if options.multivalonrows or not report.multival_column_names.keys():
+                if options.multivalonrows or not list(report.multival_column_names.keys()):
                     writer.writerow(row)
                     row = h.fetchone()
                     continue
@@ -265,7 +265,7 @@ if __name__ == '__main__':
                             break
 
                 if outrow is not None:
-                    for m in report.multival_columns_reverted.keys():
+                    for m in list(report.multival_columns_reverted.keys()):
                         if prevrow[m] != row[m]:
                             if m not in multival_dupes:
                                 multival_dupes[m] = {}
@@ -301,17 +301,17 @@ if __name__ == '__main__':
                         synopsis = report.synopsis
                     except:
                         None
-                    print "%s: %s" % (report_name, synopsis)
+                    print("%s: %s" % (report_name, synopsis))
                 else:
-                    print report_name
+                    print(report_name)
 
     except KeyboardInterrupt:
         systemExit(-1, "\nUser interrupted process.")
-    except (rhnSQL.SQLError, rhnSQL.SQLSchemaError, rhnSQL.SQLConnectError), e:
+    except (rhnSQL.SQLError, rhnSQL.SQLSchemaError, rhnSQL.SQLConnectError) as e:
         # really a stub for better exception handling in the future.
         sys.stderr.write("SQL error occurred, traceback follows...\n")
         raise
-    except IOError, e:
+    except IOError as e:
         if e.errno == errno.EPIPE:
             sys.exit(0)
         else:

--- a/reporting/spacewalk-report
+++ b/reporting/spacewalk-report
@@ -190,11 +190,11 @@ if __name__ == '__main__':
             for column in where:
                 if column not in report.columns:
                     systemExit(-6, 'Unknown column [%s] in report [%s].' % (column, report_name))
-                for v in (val for _, vals in list(where[column].items()) for val in vals):
+                for v in (val for _, vals in where[column].items() for val in vals):
                     if report.column_types[column] == 'i' and not re.match('^[0-9]+$', v):
                         systemExit(-7, 'Column [%s] in report [%s] only accepts integer value.' % (column, report_name))
 
-                for clause, values in list(where[column].items()):
+                for clause, values in where[column].items():
                     l = []
                     for v in values:
                         l.append(':p%d' % pi)
@@ -252,7 +252,7 @@ if __name__ == '__main__':
             outrow = None
             multival_dupes = {}
             while row is not None:
-                if options.multivalonrows or not list(report.multival_column_names.keys()):
+                if options.multivalonrows or not report.multival_column_names.keys():
                     writer.writerow(row)
                     row = h.fetchone()
                     continue
@@ -265,7 +265,7 @@ if __name__ == '__main__':
                             break
 
                 if outrow is not None:
-                    for m in list(report.multival_columns_reverted.keys()):
+                    for m in report.multival_columns_reverted.keys():
                         if prevrow[m] != row[m]:
                             if m not in multival_dupes:
                                 multival_dupes[m] = {}

--- a/reporting/spacewalk-report
+++ b/reporting/spacewalk-report
@@ -191,7 +191,7 @@ if __name__ == '__main__':
             for column in where:
                 if column not in report.columns:
                     systemExit(-6, 'Unknown column [%s] in report [%s].' % (column, report_name))
-                for v in (val for _, vals in six.iteritems(where[column]) for val in vals):
+                for v in (val for vals in col.values() for val in vals):
                     if report.column_types[column] == 'i' and not re.match('^[0-9]+$', v):
                         systemExit(-7, 'Column [%s] in report [%s] only accepts integer value.' % (column, report_name))
 

--- a/reporting/spacewalk-report
+++ b/reporting/spacewalk-report
@@ -191,7 +191,7 @@ if __name__ == '__main__':
             for column in where:
                 if column not in report.columns:
                     systemExit(-6, 'Unknown column [%s] in report [%s].' % (column, report_name))
-                for v in (val for vals in col.values() for val in vals):
+                for v in (val for vals in where[column].values() for val in vals):
                     if report.column_types[column] == 'i' and not re.match('^[0-9]+$', v):
                         systemExit(-7, 'Column [%s] in report [%s] only accepts integer value.' % (column, report_name))
 

--- a/reporting/spacewalk-reports.changes
+++ b/reporting/spacewalk-reports.changes
@@ -1,3 +1,5 @@
+- Add support for Python 3 on spacewalk-reports
+
 -------------------------------------------------------------------
 Fri Oct 26 10:41:44 CEST 2018 - jgonzalez@suse.com
 

--- a/reporting/spacewalk-reports.spec
+++ b/reporting/spacewalk-reports.spec
@@ -35,7 +35,7 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 Requires:       %{pythonX}
 Requires:       spacewalk-branding
-Requires:       %{pythonX}-spacewalk-usix
+Requires:       salt
 BuildRequires:  /usr/bin/docbook2man
 
 %description

--- a/reporting/spacewalk-reports.spec
+++ b/reporting/spacewalk-reports.spec
@@ -17,6 +17,12 @@
 #
 
 
+%if 0%{?suse_version} > 1320
+# SLE15 builds on Python 3
+%global build_py3   1
+%endif
+%define pythonX %{?build_py3:python3}%{!?build_py3:python2}
+
 Name:           spacewalk-reports
 Summary:        Script based reporting
 License:        GPL-2.0-only
@@ -27,8 +33,13 @@ URL:            https://github.com/uyuni-project/uyuni
 Source0:        https://github.com/spacewalkproject/spacewalk/archive/%{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
-Requires:       python
+Requires:       %{pythonX}
 Requires:       spacewalk-branding
+%if 0%{?build_py3}
+Requires:       python3-six
+%else
+Requires:       python-six
+%endif
 BuildRequires:  /usr/bin/docbook2man
 
 %description
@@ -50,6 +61,14 @@ install reports.py $RPM_BUILD_ROOT/%{_prefix}/share/spacewalk
 install -m 644 reports/data/* $RPM_BUILD_ROOT/%{_prefix}/share/spacewalk/reports/data
 install *.8 $RPM_BUILD_ROOT/%{_mandir}/man8
 chmod -x $RPM_BUILD_ROOT/%{_mandir}/man8/spacewalk-report.8*
+
+# Fixing shebang for Python 3
+%if 0%{?build_py3}
+for i in $(find . -type f);
+do
+    sed -i '1s=^#!/usr/bin/\(python\|env python\)[0-9.]*=#!/usr/bin/python3=' $i;
+done
+%endif
 
 %files
 %defattr(-,root,root)

--- a/reporting/spacewalk-reports.spec
+++ b/reporting/spacewalk-reports.spec
@@ -35,11 +35,7 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 Requires:       %{pythonX}
 Requires:       spacewalk-branding
-%if 0%{?build_py3}
-Requires:       python3-six
-%else
-Requires:       python-six
-%endif
+Requires:       %{pythonX}-spacewalk-usix
 BuildRequires:  /usr/bin/docbook2man
 
 %description


### PR DESCRIPTION
## What does this PR change?
This PR makes `spacewalk-reports` code and package python 3 compatible.

**NOTE**
Since the code raises exceptions with traceback [1], this PR makes `salt` as dependency of `spacewalk-report` to use the provided `salt.ext.six` module (already installed on the Uyuni server) as Python 2/3 compatibility module.

[1] - https://github.com/uyuni-project/uyuni/pull/283/files#diff-35d1bf42a9a5e520f3046b223393abc6L33

## Links

Tracks https://github.com/SUSE/salt-board/issues/61

- [x] **DONE**
