### PR TITLE
Adapt "spacewalk-setup" code to be Python 2/3 compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ yarn-error.log
 java/out
 out/
 java/buildconf/checkstyle.cache.src
+reports/

--- a/spacewalk/setup/bin/cobbler20-setup
+++ b/spacewalk/setup/bin/cobbler20-setup
@@ -1,14 +1,17 @@
 #!/usr/bin/python
-from yaml import load
-from Cheetah.Template import Template
-from socket import gethostbyname, gethostname
-import shutil
-from os.path import exists, join, dirname, basename, isdir, isfile
+
+# pylint: disable=invalid-name,pointless-string-statement,import-error,protected-access
+from os.path import exists, join, basename, isdir, isfile
 from os import system, chmod
+from socket import gethostname
+import shutil
 import sys
 import re
 
+from yaml import load
 from spacewalk.common import rhnConfig
+from Cheetah.Template import Template
+
 
 TEMPLATES_DIR = '/usr/share/cobbler/installer_templates'
 MODULES_TEMPLATE = join(TEMPLATES_DIR, 'modules.conf.template')
@@ -51,8 +54,8 @@ def ask_yes_no(question, default_val = None):
     return ans.lower() == 'y'
 
 def gen_template(template, answers, output):
-        t = Template(file=template, searchList=answers)
-        open(output,"w").write(t.respond())
+    t = Template(file=template, searchList=answers)
+    open(output,"w").write(t.respond())
 
 def main():
     answers = dict(loadFile(DEFAULTS))
@@ -72,8 +75,7 @@ def main():
 
     conf_lines = open(rhnConfig._CONFIG_FILE).read()
     if not m.search(conf_lines):
-        system ("echo 'cobbler.host = %s' >> %s " % (answers['server'],
-                      rhnConfig._CONFIG_FILE))
+        system("echo 'cobbler.host = %s' >> %s " % (answers['server'], rhnConfig._CONFIG_FILE))
     system("cobbler sync")
 
 

--- a/spacewalk/setup/bin/cobbler20-setup
+++ b/spacewalk/setup/bin/cobbler20-setup
@@ -65,9 +65,9 @@ def main():
     gen_template(SETTINGS_TEMPLATE, answers, TEMP_SETTINGS)
     gen_template(MODULES_TEMPLATE, answers, TEMP_MODULES)
     copy(TEMP_SETTINGS, SETTINGS)
-    chmod(SETTINGS, 0644)
+    chmod(SETTINGS, 0o644)
     copy(TEMP_MODULES, MODULES)
-    chmod(MODULES, 0644)
+    chmod(MODULES, 0o644)
     m = re.compile(r"^cobbler\.host\s*=\s*", re.MULTILINE)
 
     conf_lines = open(rhnConfig._CONFIG_FILE).read()

--- a/spacewalk/setup/bin/cobbler20-setup
+++ b/spacewalk/setup/bin/cobbler20-setup
@@ -5,7 +5,6 @@ from os.path import exists, join, basename, isdir, isfile
 from os import system, chmod
 from socket import gethostname
 import shutil
-import re
 
 from yaml import load
 from spacewalk.common import rhnConfig

--- a/spacewalk/setup/bin/cobbler20-setup
+++ b/spacewalk/setup/bin/cobbler20-setup
@@ -73,13 +73,13 @@ def main():
     copy(TEMP_MODULES, MODULES)
     chmod(MODULES, 0o644)
 
-    cobbler_host = None
+    cobbler_host = False
     with open(rhnConfig._CONFIG_FILE) as fh:
         for line in fh.readlines():
-            if line.startswith('cobbler.host = '):
+            if '=' in line and line.startswith('cobbler.host'):
                 cobbler_host = True
                 break
-    if cobbler_host is None:
+    if not cobbler_host:
         with open(rhnConfig._CONFIG_FILE, 'a') as fh:
             fh.write('cobbler.host = {}\n'.format(answers['server']))
     system("cobbler sync")

--- a/spacewalk/setup/bin/cobbler20-setup
+++ b/spacewalk/setup/bin/cobbler20-setup
@@ -72,11 +72,16 @@ def main():
     chmod(SETTINGS, 0o644)
     copy(TEMP_MODULES, MODULES)
     chmod(MODULES, 0o644)
-    m = re.compile(r"^cobbler\.host\s*=\s*", re.MULTILINE)
 
-    conf_lines = open(rhnConfig._CONFIG_FILE).read()
-    if not m.search(conf_lines):
-        system("echo 'cobbler.host = %s' >> %s " % (answers['server'], rhnConfig._CONFIG_FILE))
+    cobbler_host = None
+    with open(rhnConfig._CONFIG_FILE) as fh:
+        for line in fh.readlines():
+            if line.startswith('cobbler.host = '):
+                cobbler_host = True
+                break
+    if cobbler_host is None:
+        with open(rhnConfig._CONFIG_FILE, 'a') as fh:
+            fh.write('cobbler.host = {}\n'.format(answers['server']))
     system("cobbler sync")
 
 

--- a/spacewalk/setup/bin/cobbler20-setup
+++ b/spacewalk/setup/bin/cobbler20-setup
@@ -5,11 +5,11 @@ from os.path import exists, join, basename, isdir, isfile
 from os import system, chmod
 from socket import gethostname
 import shutil
-import sys
 import re
 
 from yaml import load
 from spacewalk.common import rhnConfig
+from salt.ext import six
 from Cheetah.Template import Template
 
 
@@ -44,7 +44,7 @@ def ask_yes_no(question, default_val = None):
         default_val = 'n'
         default_q   = '[y/N]'
 
-    if sys.version_info[0] == 3:
+    if six.PY3:
         raw_input = input
 
     ans = raw_input(question + " " + default_q + "?")

--- a/spacewalk/setup/bin/cobbler20-setup
+++ b/spacewalk/setup/bin/cobbler20-setup
@@ -41,6 +41,9 @@ def ask_yes_no(question, default_val = None):
         default_val = 'n'
         default_q   = '[y/N]'
 
+    if sys.version_info[0] == 3:
+        raw_input = input
+
     ans = raw_input(question + " " + default_q + "?")
     if not ans:
         return default_val == 'y'

--- a/spacewalk/setup/bin/cobbler20-setup
+++ b/spacewalk/setup/bin/cobbler20-setup
@@ -55,7 +55,8 @@ def ask_yes_no(question, default_val = None):
 
 def gen_template(template, answers, output):
     t = Template(file=template, searchList=answers)
-    open(output,"w").write(t.respond())
+    with open(output, 'w') as tfh:
+        tfh.write(t.respond())
 
 def main():
     answers = dict(loadFile(DEFAULTS))

--- a/spacewalk/setup/share/embedded_diskspace_check.py
+++ b/spacewalk/setup/share/embedded_diskspace_check.py
@@ -134,7 +134,7 @@ def getNeeds(needsDict=None):
     unfulfilled = {}
     fulfilled = {}
 
-    for mountpoint, paths in list(mp2pMap.items()):
+    for mountpoint, paths in mp2pMap.items():
         totalNeeds = 0
         for path in paths:
             totalNeeds = totalNeeds + needsDict[path]
@@ -169,7 +169,7 @@ def main(needsDict=None):
     if unfulfilled:
         sys.stderr.write("ERROR: diskspace does not meet minimum system "
                          "requirements:\n")
-        items = list(unfulfilled.items())
+        items = unfulfilled.items()
         lenItems = len(items)
         for mountpoint, data in items:
             paths, totalNeeds, freespace = data

--- a/spacewalk/setup/share/embedded_diskspace_check.py
+++ b/spacewalk/setup/share/embedded_diskspace_check.py
@@ -11,8 +11,7 @@
 import os
 import sys
 import stat
-import string
-import statvfs
+import statvfs  # pylint: disable=import-error
 
 # these numbers are for *after* package installation.
 DEFAULT_NEEDS = {'/rhnsat':          12*(2**30),  # 12GB
@@ -20,7 +19,7 @@ DEFAULT_NEEDS = {'/rhnsat':          12*(2**30),  # 12GB
 
 
 def _listify(seq):
-    if type(seq) not in [type([]), type(())]:
+    if type(seq) not in [type([]), type(())]:  # pylint: disable=unidiomatic-typecheck
         seq = [seq]
     return seq
 
@@ -38,9 +37,7 @@ def _abspath(path):
     # cleanup absolute path:
     if os.path.exists(path) and os.path.islink(path):
         path = os.readlink(path)
-    path = os.path.abspath(
-             os.path.expanduser(
-               os.path.expandvars(path)))
+    path = os.path.abspath(os.path.expanduser(os.path.expandvars(path)))
     return path
 
 
@@ -108,7 +105,7 @@ def paths2freespace(paths):
     return pathsd
 
 
-def getNeeds(needsDict=None):
+def getNeeds(needsDict=None):  # pylint: disable=redefined-outer-name
     """ returns two dictionaries of fulfilled and unfilled space per
         mountpoint:
 
@@ -158,7 +155,7 @@ def _humanReadable(n):
     return s
 
 
-def main(needsDict=None):
+def main(needsDict=None):  # pylint: disable=redefined-outer-name
     """ determine failed needs if any given needsDict.
         needsDict is by default DEFAULT_NEEDS (see top of module)
     """
@@ -178,7 +175,7 @@ def main(needsDict=None):
            Relevant paths serviced by mountpoint: %s
            Disk space needed:    %s bytes (app. %s)
            Disk space available: %s bytes (app. %s)
-""" % (mountpoint, string.join(paths, ', '),
+""" % (mountpoint, ", ".join(paths),
        totalNeeds, _humanReadable(totalNeeds),
        freespace, _humanReadable(freespace))
             sys.stderr.write(msg)
@@ -195,7 +192,6 @@ def main(needsDict=None):
 if __name__ == "__main__":
     needsDict = {}
     if sys.argv:
-        for i, dir in enumerate(sys.argv[1::2]):
+        for i, dir in enumerate(sys.argv[1::2]):  # pylint: disable=redefined-builtin
             needsDict[dir] = int(sys.argv[i*2+2]) * 2**20 # in MB
     sys.exit(main(needsDict) or 0)
-

--- a/spacewalk/setup/share/embedded_diskspace_check.py
+++ b/spacewalk/setup/share/embedded_diskspace_check.py
@@ -21,7 +21,7 @@ DEFAULT_NEEDS = {'/rhnsat':          12*(2**30),  # 12GB
 
 
 def _listify(seq):
-    if type(seq) not in [type([]), type(())]:  # pylint: disable=unidiomatic-typecheck
+    if not isinstance(seq, (list, tuple)):
         seq = [seq]
     return seq
 

--- a/spacewalk/setup/share/embedded_diskspace_check.py
+++ b/spacewalk/setup/share/embedded_diskspace_check.py
@@ -8,6 +8,8 @@
     Author: Todd Warner <taw@redhat.com>
 """
 
+from salt.ext import six
+
 import os
 import sys
 import stat
@@ -101,7 +103,7 @@ def paths2freespace(paths):
         f_bavail = _statvfs[statvfs.F_BAVAIL] # non-super user space
         f_bsize = _statvfs[statvfs.F_BSIZE] # respective blocksize
         # build dict indexed by path
-        pathsd[path] = int(f_bavail)*f_bsize
+        pathsd[path] = (six.PY3 and int or long)(f_bavail) * f_bsize
     return pathsd
 
 

--- a/spacewalk/setup/share/embedded_diskspace_check.py
+++ b/spacewalk/setup/share/embedded_diskspace_check.py
@@ -31,7 +31,7 @@ def _unique(seq):
     useq = {}
     for elem in seq:
         useq[elem] = 1
-    return useq.keys()
+    return list(useq.keys())
 
 
 def _abspath(path):
@@ -86,7 +86,7 @@ def paths2mountpoints(paths):
     for path in paths:
         mpoint = _mountpoint(path)
         pathsd[path] = mpoint
-        if not mpointsd.has_key(mpoint):
+        if mpoint not in mpointsd:
             mpointsd[mpoint] = []
         mpointsd[mpoint].append(path)
     return pathsd, mpointsd
@@ -104,7 +104,7 @@ def paths2freespace(paths):
         f_bavail = _statvfs[statvfs.F_BAVAIL] # non-super user space
         f_bsize = _statvfs[statvfs.F_BSIZE] # respective blocksize
         # build dict indexed by path
-        pathsd[path] = long(f_bavail)*f_bsize
+        pathsd[path] = int(f_bavail)*f_bsize
     return pathsd
 
 
@@ -128,13 +128,13 @@ def getNeeds(needsDict=None):
     """
 
     needsDict = needsDict or DEFAULT_NEEDS
-    mp2pMap = paths2mountpoints(needsDict.keys())[1]
-    mp2fsMap = paths2freespace(mp2pMap.keys())
+    mp2pMap = paths2mountpoints(list(needsDict.keys()))[1]
+    mp2fsMap = paths2freespace(list(mp2pMap.keys()))
 
     unfulfilled = {}
     fulfilled = {}
 
-    for mountpoint, paths in mp2pMap.items():
+    for mountpoint, paths in list(mp2pMap.items()):
         totalNeeds = 0
         for path in paths:
             totalNeeds = totalNeeds + needsDict[path]
@@ -169,7 +169,7 @@ def main(needsDict=None):
     if unfulfilled:
         sys.stderr.write("ERROR: diskspace does not meet minimum system "
                          "requirements:\n")
-        items = unfulfilled.items()
+        items = list(unfulfilled.items())
         lenItems = len(items)
         for mountpoint, data in items:
             paths, totalNeeds, freespace = data

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,5 +1,7 @@
+- Add support for Python 3 on spacewalk-setup
 - use a Salt engine to process return results (bsc#1099988)
 - increase maximum number of threads and open files for taskomatic (bsc#1111966)
+
 -------------------------------------------------------------------
 Fri Oct 26 10:42:58 CEST 2018 - jgonzalez@suse.com
 

--- a/spacewalk/setup/spacewalk-setup.spec
+++ b/spacewalk/setup/spacewalk-setup.spec
@@ -24,7 +24,7 @@
 %define pythonX %{?build_py3:python3}%{!?build_py3:python2}
 
 %if 0%{?suse_version}
-%{!?pylint_check: %global pylint_check 1}
+%{!?pylint_check: %global pylint_check 0}
 %define apache_user wwwrun
 %define apache_group www
 %define misc_path /srv/

--- a/spacewalk/setup/spacewalk-setup.spec
+++ b/spacewalk/setup/spacewalk-setup.spec
@@ -24,6 +24,7 @@
 %define pythonX %{?build_py3:python3}%{!?build_py3:python2}
 
 %if 0%{?suse_version}
+%{!?pylint_check: %global pylint_check 1}
 %define apache_user wwwrun
 %define apache_group www
 %define misc_path /srv/
@@ -82,6 +83,10 @@ Requires:       %{pythonX}-certifi
 BuildRequires:  perl-libwww-perl
 %else
 Requires:       %{sbinpath}/restorecon
+%endif
+%if 0%{?pylint_check}
+BuildRequires:  spacewalk-%{pythonX}-pylint
+BuildRequires:  %{pythonX}-setuptools
 %endif
 Requires:       cobbler >= 2.0.0
 Requires:       perl-Satcon
@@ -247,6 +252,12 @@ exit 0
 
 %check
 make test
+%if 0%{?pylint_check}
+# check coding style
+pylint --rcfile /etc/spacewalk-python3-pylint.rc \
+    $RPM_BUILD_ROOT%{_datadir}/spacewalk/setup/*.py \
+    $RPM_BUILD_ROOT%{_bindir}/cobbler20-setup
+%endif
 
 %files
 %defattr(-,root,root,-)

--- a/susemanager-utils/testing/automation/spacewalk-pylint.sh
+++ b/susemanager-utils/testing/automation/spacewalk-pylint.sh
@@ -1,0 +1,147 @@
+#! /bin/sh
+
+HERE=`dirname $0`
+. $HERE/VERSION
+GITROOT=`readlink -f $HERE/../../../`
+
+# fake usix.py
+if [ ! -e $GITROOT/backend/common/usix.py ]; then
+    ln -sf ../../usix/common/usix.py $GITROOT/backend/common/usix.py
+fi
+
+DOCKER_RUN_EXPORT="PYTHONPATH=/manager/client/rhel/rhnlib/:/manager/client/rhel/rhn-client-tools/src"
+
+SPACEWALK_FILES="
+manager/susemanager/src/
+manager/spacewalk/
+manager/backend/
+manager/client/rhel/rhnlib/rhn/
+manager/proxy/proxy/
+manager/proxy/installer/fetch-certificate.py
+manager/proxy/installer/rhn-proxy-activate.py
+manager/proxy/proxy/wsgi/xmlrpc.py
+manager/proxy/proxy/wsgi/xmlrpc_redirect.py
+manager/reporting/reports.py
+manager/susemanager-utils/susemanager-sls/src/
+manager/utils/
+manager/spacewalk/certs-tools/
+manager/spacewalk/setup/share/embedded_diskspace_check.py
+manager/suseRegisterInfo/suseRegister/
+
+manager/client/debian/apt-spacewalk/packages.py
+manager/client/debian/apt-spacewalk/post_invoke.py
+manager/client/debian/apt-spacewalk/pre_invoke.py
+manager/client/rhel/yum-rhn-plugin/actions/errata.py
+manager/client/rhel/yum-rhn-plugin/actions/packages.py
+manager/client/rhel/yum-rhn-plugin/rhnplugin.py
+manager/client/rhel/dnf-plugin-spacewalk/actions/errata.py
+manager/client/rhel/dnf-plugin-spacewalk/actions/packages.py
+manager/client/rhel/dnf-plugin-spacewalk/spacewalk.py
+manager/client/rhel/spacewalk-client-tools/src/actions/
+manager/client/rhel/spacewalk-client-tools/src/bin/rhn-profile-sync.py
+manager/client/rhel/spacewalk-client-tools/src/bin/rhn_check.py
+manager/client/rhel/spacewalk-client-tools/src/bin/rhn_register.py
+manager/client/rhel/spacewalk-client-tools/src/bin/rhnreg_ks.py
+manager/client/rhel/spacewalk-client-tools/src/bin/spacewalk-channel.py
+manager/client/rhel/spacewalk-client-tools/src/bin/spacewalk-update-status.py
+manager/client/rhel/spacewalk-client-tools/src/firstboot-legacy-rhel6/rhn_choose_channel.py
+manager/client/rhel/spacewalk-client-tools/src/firstboot-legacy-rhel6/rhn_choose_server_gui.py
+manager/client/rhel/spacewalk-client-tools/src/firstboot-legacy-rhel6/rhn_create_profile_gui.py
+manager/client/rhel/spacewalk-client-tools/src/firstboot-legacy-rhel6/rhn_finish_gui.py
+manager/client/rhel/spacewalk-client-tools/src/firstboot-legacy-rhel6/rhn_login_gui.py
+manager/client/rhel/spacewalk-client-tools/src/firstboot-legacy-rhel6/rhn_provide_certificate_gui.py
+manager/client/rhel/spacewalk-client-tools/src/firstboot-legacy-rhel6/rhn_register.py
+manager/client/rhel/spacewalk-client-tools/src/firstboot-legacy-rhel6/rhn_review_gui.py
+manager/client/rhel/spacewalk-client-tools/src/firstboot-legacy-rhel6/rhn_start_gui.py
+manager/client/rhel/spacewalk-client-tools/src/up2date_client/
+manager/client/tools/spacewalk-abrt/src/spacewalk_abrt/
+manager/client/tools/spacewalk-koan/actions/kickstart.py
+manager/client/tools/spacewalk-koan/actions/kickstart_guest.py
+manager/client/tools/spacewalk-koan/spacewalkkoan/
+manager/client/tools/spacewalk-client-cert/clientcert.py
+manager/client/tools/spacewalk-oscap/scap.py
+manager/client/tools/mgr-cfg/actions/
+manager/client/tools/mgr-cfg/config_client/
+manager/client/tools/mgr-cfg/config_common/
+manager/client/tools/mgr-cfg/config_management/
+manager/client/tools/mgr-custom-info/rhn-custom-info.py
+manager/client/tools/mgr-osad/invocation.py
+manager/client/tools/mgr-osad/src/
+manager/client/tools/mgr-push/
+manager/client/tools/mgr-virtualization/actions/image.py
+manager/client/tools/mgr-virtualization/actions/virt.py
+manager/client/tools/mgr-virtualization/virtualization/
+
+manager/scripts/clone-errata/rhn-clone-errata.py
+manager/scripts/datasource-query-usage.py
+manager/scripts/devel/cobbler-api-example.py
+manager/scripts/find-unused-tags.py
+manager/scripts/link-tree.py
+manager/scripts/ncsu-rhntools/config.py
+manager/scripts/ncsu-rhntools/getRealmHosts.py
+manager/scripts/ncsu-rhntools/rhnapi.py
+manager/scripts/ncsu-rhntools/rhnstats/pysqlite.py
+manager/scripts/ncsu-rhntools/rhnstats/rhndb.py
+manager/scripts/ncsu-rhntools/rhnstats/rhnstats.py
+manager/scripts/ncsu-rhntools/rhnstats/schema.py
+manager/scripts/ncsu-rhntools/groupSummary.py
+manager/scripts/ncsu-rhntools/oldSystems.py
+manager/scripts/ncsu-rhntools/subscribeRHN.py
+manager/scripts/ncsu-rhntools/findpackages.py
+manager/scripts/gen-eclipse.py
+manager/scripts/update_symlinks.py
+manager/search-server/spacewalk-doc-indexes/create_urls_per_language.py
+manager/search-server/spacewalk-search/scripts/search.py
+manager/search-server/spacewalk-search/scripts/search.admin.updateIndex.test.py
+manager/spacecmd/src/lib/activationkey.py
+manager/spacecmd/src/lib/argumentparser.py
+manager/spacecmd/src/lib/configchannel.py
+manager/spacecmd/src/lib/distribution.py
+manager/spacecmd/src/lib/kickstart.py
+manager/spacecmd/src/lib/misc.py
+manager/spacecmd/src/lib/package.py
+manager/spacecmd/src/lib/api.py
+manager/spacecmd/src/lib/cryptokey.py
+manager/spacecmd/src/lib/custominfo.py
+manager/spacecmd/src/lib/errata.py
+manager/spacecmd/src/lib/filepreservation.py
+manager/spacecmd/src/lib/org.py
+manager/spacecmd/src/lib/repo.py
+manager/spacecmd/src/lib/report.py
+manager/spacecmd/src/lib/scap.py
+manager/spacecmd/src/lib/schedule.py
+manager/spacecmd/src/lib/shell.py
+manager/spacecmd/src/lib/snippet.py
+manager/spacecmd/src/lib/ssm.py
+manager/spacecmd/src/lib/system.py
+manager/spacecmd/src/lib/user.py
+manager/spacecmd/src/lib/utils.py
+manager/spacecmd/src/lib/group.py
+manager/spacecmd/src/lib/softwarechannel.py
+
+manager/tftpsync/susemanager-tftpsync/sync_post_tftpd_proxies.py
+manager/tftpsync/susemanager-tftpsync/MultipartPostHandler.py
+manager/usix/
+manager/susemanager-utils/nagios-plugin/check_suma_common.py
+manager/susemanager-utils/performance/locust/00_Core_LoginAndSystemOverview.py
+manager/susemanager-utils/susemanager-sls/modules/pillar/suma_minion.py
+manager/susemanager-utils/susemanager-sls/modules/runners/mgrk8s.py
+manager/susemanager-utils/susemanager-sls/modules/runners/kiwi-image-collect.py
+manager/susemanager-utils/susemanager-sls/modules/runners/mgrutil.py
+manager/susemanager-utils/susemanager-sls/modules/tops/mgr_master_tops.py
+manager/susemanager-utils/susemanager-sls/salt/channels/yum-susemanager-plugin/susemanagerplugin.py
+manager/susemanager-utils/susemanager-sls/src/
+"
+
+PYLINT_CMD="pylint --disable=E0203,E0611,E1101,E1102,C0111,I0011,R0801 --ignore=test --output-format=parseable --rcfile /manager/spacewalk/pylint/spacewalk-pylint.rc --reports=y"
+
+docker pull $REGISTRY/$PYLINT_CONTAINER
+docker run --rm=true -e $DOCKER_RUN_EXPORT -v "$GITROOT:/manager" $REGISTRY/$PGSQL_CONTAINER /bin/sh -c "mkdir -p /manager/reports; $PYLINT_CMD `echo $SPACEWALK_FILES` > /manager/reports/pylint.log || :"
+
+if [ $? -ne 0 ]; then
+   EXIT=1
+fi
+
+rm -f $GITROOT/backend/common/usix.py*
+
+exit $EXIT

--- a/susemanager-utils/testing/docker/master/uyuni-master-pgsql/Dockerfile
+++ b/susemanager-utils/testing/docker/master/uyuni-master-pgsql/Dockerfile
@@ -18,3 +18,7 @@ RUN sh /root/setup-db-postgres.sh
 
 ADD postgresql.conf /var/lib/pgsql/data/postgresql.conf
 
+RUN zypper in -y python-pip
+
+RUN pip install --upgrade pylint==1.8 astroid==1.6.5
+


### PR DESCRIPTION
## What does this PR change?

This PR makes `spacewalk-setup` code and package compatible with Python 3.

**NOTE:** This package includes some Perl code that externally calls Python executable, so the spec file is changing the reference to this executable to `python3` in case the package is built for Python 3.

## Links

Tracks https://github.com/SUSE/salt-board/issues/60

- [x] **DONE**
