### PR TITLE
Panel.js: HeadingLevel should be headingLevel

### DIFF
--- a/web/html/src/components/panels/Panel.js
+++ b/web/html/src/components/panels/Panel.js
@@ -1,7 +1,7 @@
 const React = require('react');
 
 type Props = {
-  HeadingLevel: string,
+  headingLevel: string,
   title?: string,
   icon?: string,
   header?: string,


### PR DESCRIPTION
## What does this PR change?

This typo made flow and eslint fail.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: eslint fixes

- [X] **DONE**

## Test coverage
- No tests: fixes test failure

- [X] **DONE**

## Links

- [X] **DONE**
