### PR TITLE
Add check for ssh-file permissions (bsc#1114181)

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/utils/AbstractMinionBootstrapper.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/AbstractMinionBootstrapper.java
@@ -42,6 +42,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static java.util.Optional.of;
+import static com.suse.manager.webui.services.SaltConstants.SALT_SSH_DIR_PATH;
 
 /**
  * Base for bootstrapping systems using salt-ssh.
@@ -95,12 +96,12 @@ public abstract class AbstractMinionBootstrapper {
      * @return boolean about salt having correct file permissions
      */
     private boolean hasCorrectSSHFilePermissions() {
-        File dotSSHDir = new File("/var/lib/salt/.ssh");
+        File dotSSHDir = new File(SALT_SSH_DIR_PATH);
         //Directory gets created the first time a bootstrap happens - its absence is fine.
         if (!dotSSHDir.exists()) {
             return true;
         }
-        File knownHostsFile = new File("/var/lib/salt/.ssh/known_hosts");
+        File knownHostsFile = new File(SALT_SSH_DIR_PATH + "/known_hosts");
         return knownHostsFile.exists() && knownHostsFile.canRead() && knownHostsFile.canWrite();
     }
 
@@ -119,7 +120,8 @@ public abstract class AbstractMinionBootstrapper {
                 params.getFirstActivationKey(), defaultContactMethod);
 
         if (!hasCorrectSSHFilePermissions()) {
-            String responseMessage = "Cannot read/write '/var/lib/salt/.ssh/known_hosts'. Please check permissions.";
+            String responseMessage = "Cannot read/write '" + SALT_SSH_DIR_PATH + "/known_hosts'. " +
+                                     "Please check permissions.";
             LOG.error("Error during bootstrap: " + responseMessage);
             return new BootstrapResult(false, Optional.of(contactMethod), responseMessage);
         }

--- a/java/code/src/com/suse/manager/webui/services/SaltConstants.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltConstants.java
@@ -29,6 +29,8 @@ public class SaltConstants {
 
     public static final String SALT_FILE_GENERATION_TEMP_PATH = "/srv/susemanager/tmp";
 
+    public static final String SALT_SSH_DIR_PATH = "/var/lib/salt/.ssh";
+
     public static final String PILLAR_DATA_FILE_PREFIX = "pillar";
 
     public static final String PILLAR_IMAGE_DATA_FILE_PREFIX = "image";

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add check if ssh-file permissions are correct (bsc#1114181)
 - When removing cobbler system record, lookup by mac address as well if lookup by id fails(bsc#1110361)
 - increase maximum number of threads and open files for taskomatic (bsc#1111966)
 - Changed Strings for MenuTree Items to remove redundancy (bsc#1019847)


### PR DESCRIPTION
If the user manually removes an ssh-key from the
known_hosts file via ssh-keygen, the salt user
loses read/write permissions to that file and the
webUI can't bootstrap any minions anymore.

This fix checks if the right file permissions are
set and informs the user in the webUI about an
error regarding this issue.

cherry-pick from https://github.com/SUSE/spacewalk/pull/6318