### PR TITLE
Port to Python3: Fix with_traceback issue on Python 2

### DIFF
--- a/backend/server/action/distupgrade.py
+++ b/backend/server/action/distupgrade.py
@@ -13,6 +13,7 @@
 import sys
 from spacewalk.common.rhnLog import log_debug
 from spacewalk.common.rhnException import rhnFault
+from spacewalk.common.usix import raise_with_tb
 from spacewalk.server import rhnSQL
 from spacewalk.server.rhnChannel import subscribe_channels, unsubscribe_channels
 from spacewalk.server.rhnLib import InvalidAction, ShadowAction
@@ -113,9 +114,9 @@ def upgrade(serverId, actionId, dry_run=0):
             # channel is already subscribed, ignore it
             pass
         else:
-            raise InvalidAction(str(f)).with_traceback(sys.exc_info()[2])
+            raise_with_tb(InvalidAction(str(f)), sys.exc_info()[2])
     except Exception as e:
-        raise InvalidAction(str(e)).with_traceback(sys.exc_info()[2])
+        raise_with_tb(InvalidAction(str(e)), sys.exc_info()[2])
 
     rhnSQL.commit()
 

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Fix issue raising exceptions 'with_traceback' on Python 2
 - Hide Python traceback and show only error message (bsc#1110427)
 
 -------------------------------------------------------------------

--- a/proxy/proxy/rhnAuthCacheClient.py
+++ b/proxy/proxy/rhnAuthCacheClient.py
@@ -33,6 +33,7 @@ from spacewalk.common.rhnLog import log_debug, log_error
 from spacewalk.common.rhnTB import Traceback
 from spacewalk.common.rhnException import rhnFault
 from spacewalk.common.rhnTranslate import _
+from spacewalk.common.usix import raise_with_tb
 from rhnAuthProtocol import CommunicationError, send, recv
 
 #
@@ -98,9 +99,9 @@ class Shelf:
               Error connecting to the the authentication cache daemon.
               Make sure it is started on %s""" % str(self.serverAddr))
             # FIXME: PROBLEM: this rhnFault will never reach the client
-            raise rhnFault(1000,
-                           _("Spacewalk Proxy error (issues connecting to auth cache). "
-                             "Please contact your system administrator")).with_traceback(sys.exc_info()[2])
+            raise_with_tb(
+                rhnFault(1000, _("Spacewalk Proxy error (issues connecting to auth cache). "
+                                 "Please contact your system administrator")), sys.exc_info()[2])
 
         wfile = sock.makefile("w")
 
@@ -120,9 +121,9 @@ class Shelf:
                      Error sending to the authentication cache daemon.
                      Make sure the authentication cache daemon is started""")
             # FIXME: PROBLEM: this rhnFault will never reach the client
-            raise rhnFault(1000,
-                           _("Spacewalk Proxy error (issues connecting to auth cache). "
-                             "Please contact your system administrator")).with_traceback(sys.exc_info()[2])
+            raise_with_tb(
+                rhnFault(1000, _("Spacewalk Proxy error (issues connecting to auth cache). "
+                                 "Please contact your system administrator")), sys.exc_info()[2])
 
         wfile.close()
 
@@ -138,9 +139,9 @@ class Shelf:
                       Error receiving from the authentication cache daemon.
                       Make sure the authentication cache daemon is started""")
             # FIXME: PROBLEM: this rhnFault will never reach the client
-            raise rhnFault(1000,
-                           _("Spacewalk Proxy error (issues communicating to auth cache). "
-                             "Please contact your system administrator")).with_traceback(sys.exc_info()[2])
+            raise_with_tb(
+                rhnFault(1000, _("Spacewalk Proxy error (issues communicating to auth cache). "
+                                 "Please contact your system administrator")), sys.exc_info()[2])
         except Fault as e:
             rfile.close()
             sock.close()
@@ -169,7 +170,7 @@ class Shelf:
             import new
             _dict = {'args': args}
             # pylint: disable=bad-option-value,nonstandard-exception
-            raise new.instance(getattr(__builtins__, name), _dict).with_traceback(sys.exc_info()[2])
+            raise_with_tb(new.instance(getattr(__builtins__, name), _dict), sys.exc_info()[2])
 
         return params[0]
 

--- a/proxy/proxy/spacewalk-proxy.spec
+++ b/proxy/proxy/spacewalk-proxy.spec
@@ -38,6 +38,7 @@ Source0:        https://github.com/spacewalkproject/spacewalk/archive/%{name}-%{
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  %{pythonX}
 BuildArch:      noarch
+Requires:       %{pythonX}-spacewalk-usix
 Requires:       httpd
 %if 0%{?pylint_check}
 BuildRequires:  spacewalk-python2-pylint

--- a/tftpsync/susemanager-tftpsync/MultipartPostHandler.py
+++ b/tftpsync/susemanager-tftpsync/MultipartPostHandler.py
@@ -46,7 +46,7 @@ except ImportError:
     from urllib2 import build_opener, HTTPHandler, BaseHandler
 
 import mimetools, mimetypes
-import os, stat
+import os, six, stat
 
 class Callable:
     def __init__(self, anycallable):
@@ -72,7 +72,8 @@ class MultipartPostHandler(BaseHandler):
                          v_vars.append((key, value))
             except TypeError:
                 systype, value, traceback = sys.exc_info()
-                raise TypeError("not a valid non-string sequence or mapping object").with_traceback(traceback)
+                six.reraise(TypeError, "not a valid non-string sequence or mapping object", traceback)
+
 
             if len(v_files) == 0:
                 data = urlencode(v_vars, doseq)

--- a/tftpsync/susemanager-tftpsync/susemanager-tftpsync.changes
+++ b/tftpsync/susemanager-tftpsync/susemanager-tftpsync.changes
@@ -1,3 +1,5 @@
+- Fix issue raising exceptions 'with_traceback' on Python 2
+
 -------------------------------------------------------------------
 Fri Oct 26 10:53:58 CEST 2018 - jgonzalez@suse.com
 

--- a/tftpsync/susemanager-tftpsync/susemanager-tftpsync.spec
+++ b/tftpsync/susemanager-tftpsync/susemanager-tftpsync.spec
@@ -35,9 +35,11 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Requires(pre):  cobbler
 %if 0%{?build_py3}
 Requires:       python3
+Requires:       python3-six
 BuildRequires:  python3-devel
 %else
 Requires:       python
+Requires:       python-six
 BuildRequires:  python-devel
 %endif
 


### PR DESCRIPTION
## What does this PR change?
On previous PRs related with the migration to Python 3, we've introduced the use of `Exception.with_traceback()` which is only supported on Python 3.

This PR fixes those bad cases by using `raise_with_tb` implementation from `spacewalk-usix` and alternatively `python-six` in the particular case of `susemanager-tftpsync` package.

**NOTE:** I'm only adding new changelog entries to those packages which were already released for Uyuni.
