### PR TITLE
Use current time instead of start of epoch for the last boot time of empty profiles

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -444,7 +444,7 @@ public class SystemManager extends BaseManager {
         server.setSecret(RandomStringUtils.randomAlphanumeric(64));
         server.setAutoUpdate("N");
         server.setContactMethod(ServerFactory.findContactMethodByLabel("default"));
-        server.setLastBoot(new Long(0));
+        server.setLastBoot(System.currentTimeMillis() / 1000);
         server.setServerArch(ServerFactory.lookupServerArchByLabel("x86_64-redhat-linux"));
         server.updateServerInfo();
         ServerFactory.save(server);


### PR DESCRIPTION
## What does this PR change?
 
 ^^^. The start of epoch looked awkward - the last boot time was "49 years" ago in the web ui.
 
 ## GUI diff
 
 No structural difference.
 
 - [x] **DONE**
 
 ## Documentation
 - No documentation needed: bugfix
 
 - [x] **DONE**
 
 ## Test coverage
 - No tests: no tests needed
 
 - [x] **DONE**
 
 ## Links
 
 Tracks https://github.com/SUSE/spacewalk/issues/5908
 
 - [x] **DONE**