### PR TITLE
XMLRPC: Method for creating empty profile returns created or matched profile id (if found

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/MinionServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionServerFactory.java
@@ -255,7 +255,7 @@ public class MinionServerFactory extends HibernateFactory {
 
         query.where(hwAddrPredicate);
 
-        return getSession().createQuery(query).list().stream()
+        return getSession().createQuery(query).stream()
                 .filter(s -> s.hasEntitlement(EntitlementManager.BOOTSTRAP))
                 .reduce((s1, s2) -> { throw new IllegalStateException("Multiple matching systems found"); });
     }
@@ -273,7 +273,7 @@ public class MinionServerFactory extends HibernateFactory {
         Root<MinionServer> root = query.from(MinionServer.class);
         query.where(builder.equal(root.get("hostname"), hostname));
 
-        return getSession().createQuery(query).list().stream()
+        return getSession().createQuery(query).stream()
                 .filter(s -> s.hasEntitlement(EntitlementManager.BOOTSTRAP))
                 .reduce((s1, s2) -> { throw new IllegalStateException("Multiple matching systems found"); });
     }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -679,12 +679,13 @@ public class SystemHandler extends BaseHandler {
     }
 
     /**
-     * Returns a list of empty system profiles visible to user (created by createSystemProfile).
+     * Returns a list of empty system profiles visible to user (created by getOrCreateEmptySystemProfile).
      *
      * @param loggedInUser - the user
      * @return array of empty system profiles
      *
-     * @xmlrpc.doc Returns a list of empty system profiles visible to user (created by the createSystemProfile method).
+     * @xmlrpc.doc Returns a list of empty system profiles visible to user
+     *     (created by the getOrCreateEmptySystemProfile method).
      * @xmlrpc.param #session_key()
      *
      * @xmlrpc.returntype
@@ -5939,7 +5940,7 @@ public class SystemHandler extends BaseHandler {
     }
 
     /**
-     * Creates a system record in database for a system that is not (yet) registered.
+     * Gets or creates a system record in database for a system that is not (yet) registered.
      * Either "hwAddress" or "hostname" prop must be specified in the "data" struct.
      * @param loggedInUser the currently logged in user
      * @param systemName server name
@@ -5956,16 +5957,15 @@ public class SystemHandler extends BaseHandler {
      *      #prop_desc("string", "hostname", "The hostname of the profile")
      *  #struct_end()
      * @xmlrpc.returntype #return_int_success()
+     * @xmlrpc.returntype int system id - The id of the system
      */
-    public int createSystemProfile(User loggedInUser, String systemName, Map<String, Object> data) {
+    public int getOrCreateSystemProfile(User loggedInUser, String systemName, Map<String, Object> data) {
         try {
-            SystemManager.createSystemProfile(loggedInUser, systemName, data);
+            return SystemManager.getOrCreateEmptySystemProfile(loggedInUser, systemName, data).getId().intValue();
         }
         catch (IllegalStateException | IllegalArgumentException e) {
             throw new InvalidParameterException("Can't create system", e);
         }
-
-        return 1;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -148,7 +148,6 @@ import com.redhat.rhn.testing.UserTestUtils;
 
 import java.util.Arrays;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class SystemHandlerTest extends BaseHandlerTestCase {
 
@@ -2615,7 +2614,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
      */
     public void testCreateSystemProfileNoHwAddress() throws Exception {
         try {
-            getMockedHandler().createSystemProfile(admin, "test system", Collections.emptyMap());
+            getMockedHandler().getOrCreateSystemProfile(admin, "test system", Collections.emptyMap());
             fail("An exception should have been thrown.");
         } catch (InvalidParameterException e) {
             // no-op
@@ -2628,7 +2627,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
      */
     public void testCreateSystemProfile() throws Exception {
         String hwAddress = "aa:bb:cc:dd:ee:00";
-        int result = getMockedHandler().createSystemProfile(admin, "test system",
+        int result = getMockedHandler().getOrCreateSystemProfile(admin, "test system",
                 Collections.singletonMap("hwAddress", hwAddress));
         List<NetworkInterface> nics = NetworkInterfaceFactory
                 .lookupNetworkInterfacesByHwAddress(hwAddress)

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -444,7 +444,7 @@ public class SystemManager extends BaseManager {
         server.setSecret(RandomStringUtils.randomAlphanumeric(64));
         server.setAutoUpdate("N");
         server.setContactMethod(ServerFactory.findContactMethodByLabel("default"));
-        server.setLastBoot(new Long(0));
+        server.setLastBoot(System.currentTimeMillis() / 1000);
         server.setServerArch(ServerFactory.lookupServerArchByLabel("x86_64-redhat-linux"));
         server.updateServerInfo();
         ServerFactory.save(server);

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -405,7 +405,8 @@ public class SystemManager extends BaseManager {
      * if the format of the hardware address is invalid
      * @return the created system
      */
-    public static MinionServer createSystemProfile(User creator, String systemName, Map<String, Object> data) {
+    public static MinionServer getOrCreateEmptySystemProfile(User creator, String systemName,
+            Map<String, Object> data) {
         Optional<String> hwAddress = ofNullable((String) data.get("hwAddress"));
         Optional<String> hostname = ofNullable((String) data.get("hostname"));
 
@@ -415,9 +416,9 @@ public class SystemManager extends BaseManager {
         }
 
         Set<String> hwAddrs = hwAddress.map(a -> singleton(a)).orElse(emptySet());
-        if (findMatchingEmptyProfile(hostname, hwAddrs).isPresent()) {
-            throw new IllegalStateException("System(s) with hostname '" + hostname + "' or HW address '" +
-                    hwAddress + "' already exists.");
+        Optional<MinionServer> matchingEmptyProfile = findMatchingEmptyProfile(hostname, hwAddrs);
+        if (matchingEmptyProfile.isPresent()) {
+            return matchingEmptyProfile.get();
         }
 
         // craft unique id based on given data
@@ -499,7 +500,7 @@ public class SystemManager extends BaseManager {
     }
 
     /**
-     * Lists empty system profiles (created by createSystemProfile).
+     * Lists empty system profiles (created by getOrCreateEmptySystemProfile).
      *
      * @param user user viewing the systems
      * @param pc page control

--- a/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
@@ -57,13 +57,11 @@ import com.redhat.rhn.domain.user.UserFactory;
 import com.redhat.rhn.manager.action.ActionManager;
 import com.redhat.rhn.manager.distupgrade.test.DistUpgradeManagerTest;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
-import com.redhat.rhn.manager.formula.FormulaManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 import com.redhat.rhn.testing.ConfigTestUtils;
 import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
-import com.redhat.rhn.testing.ServerGroupTestUtils;
 import com.redhat.rhn.testing.ServerTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
@@ -1117,7 +1115,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         ManagedServerGroup alreadyAssignedGroup = ServerGroupFactory.create("HWTYPE:idontmatch",
                 "HW group - assigned to empty profile beforehand", user.getOrg());
 
-        MinionServer emptyMinion = SystemManager.createSystemProfile(user, "empty profile",
+        MinionServer emptyMinion = SystemManager.getOrCreateEmptySystemProfile(user, "empty profile",
                 singletonMap("hwAddress", "00:11:22:33:44:55"));
         ServerFactory.addServerToGroup(emptyMinion, alreadyAssignedGroup);
 
@@ -1240,7 +1238,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
      * @throws Exception if anything goes wrong
      */
     public void testEmptyProfileRegistration() throws Exception {
-        MinionServer emptyMinion = SystemManager.createSystemProfile(user, "empty profile",
+        MinionServer emptyMinion = SystemManager.getOrCreateEmptySystemProfile(user, "empty profile",
                singletonMap("hwAddress", "00:11:22:33:44:55"));
         executeTest(
                 (saltServiceMock, key) -> new Expectations() {{
@@ -1298,7 +1296,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         final String hwAddress = "00:11:22:33:44:55";
 
         // assign some formula
-        MinionServer emptyMinion = SystemManager.createSystemProfile(user, "empty profile",
+        MinionServer emptyMinion = SystemManager.getOrCreateEmptySystemProfile(user, "empty profile",
                 singletonMap("hwAddress", "00:11:22:33:44:55"));
         String minionId = "_" + hwAddress;
         FormulaFactory.saveServerFormulas(minionId, Collections.singletonList(testFormula));

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- XMLRPC: Change the createSystemProfile to getOrCreateSystemProfile which returns profile id
 - Add check if ssh-file permissions are correct (bsc#1114181)
 - When removing cobbler system record, lookup by mac address as well if lookup by id fails(bsc#1110361)
 - increase maximum number of threads and open files for taskomatic (bsc#1111966)


### PR DESCRIPTION
## What does this PR change?
Previously, the `createEmptyProfile` method threw an exception, when a matching profile was found.
This method is renamed in this PR to `getOrCreateSystemProfile` which returns system id:
- in the "create" case, the id of the newly created system is returned
- in the "existing" case, the id of existing matching system is returned
 
 
 
 ## GUI diff
 
 No difference.
 
 - [x] **DONE**
 
 ## Documentation
 - [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)
 
 - [ ] **DONE**
 
 ## Test coverage
 - No tests: adjusted jUnit tests
 - [x] **DONE**
 
 ## Links
 
 Tracks https://github.com/SUSE/spacewalk/issues/6180
 
 - [x] **DONE**