### PR TITLE
XMLRPC: Method for creating empty profile returns created or matched profile id (if found)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/MinionServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionServerFactory.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.domain.server;
 
+import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 
 import com.redhat.rhn.common.hibernate.HibernateFactory;
@@ -27,7 +28,6 @@ import org.hibernate.Session;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -157,7 +157,7 @@ public class MinionServerFactory extends HibernateFactory {
     public static List<MinionServer> lookupByMinionIds(Set<String> minionIds) {
         //NOTE: this is needed since empty sets produce invalid sql statemensts
         if (minionIds.isEmpty()) {
-            return Collections.emptyList();
+            return emptyList();
         }
         else {
             return ServerFactory.getSession().createCriteria(MinionServer.class)
@@ -218,7 +218,7 @@ public class MinionServerFactory extends HibernateFactory {
      */
     public static List<MinionServer> findMinionsByServerIds(List<Long> serverIds) {
         return !serverIds.isEmpty() ?
-                ServerFactory.lookupByServerIds(serverIds, "Server.findMinionsByServerIds") : Collections.emptyList();
+                ServerFactory.lookupByServerIds(serverIds, "Server.findMinionsByServerIds") : emptyList();
     }
 
     /**
@@ -235,15 +235,14 @@ public class MinionServerFactory extends HibernateFactory {
     }
 
     /**
-     * Find empty profile with a HW address matching some of given HW addresses.
+     * Find empty profiles with a HW address matching some of given HW addresses.
      *
      * @param hwAddrs the set of HW addresses
-     * @throws java.lang.IllegalStateException When multiple empty profiles match given HW addresses
-     * @return the optional MinionServer with a HW address matching some of given HW addresses
+     * @return the List of MinionServer with a HW address matching some of given HW addresses
      */
-    public static Optional<MinionServer> findEmptyProfileByHwAddrs(Set<String> hwAddrs) {
+    public static List<MinionServer> findEmptyProfilesByHwAddrs(Set<String> hwAddrs) {
         if (hwAddrs.isEmpty()) {
-            return Optional.empty();
+            return emptyList();
         }
 
         CriteriaBuilder builder = getSession().getCriteriaBuilder();
@@ -257,17 +256,16 @@ public class MinionServerFactory extends HibernateFactory {
 
         return getSession().createQuery(query).stream()
                 .filter(s -> s.hasEntitlement(EntitlementManager.BOOTSTRAP))
-                .reduce((s1, s2) -> { throw new IllegalStateException("Multiple matching systems found"); });
+                .collect(toList());
     }
 
     /**
-     * Find empty profile by hostname
+     * Find empty profiles by hostname
      *
      * @param hostname the hostname
-     * @throws java.lang.IllegalStateException When multiple empty profiles match given hostname
-     * @return the optional MinionServer matching given hostname
+     * @return the List of MinionServer matching given hostname
      */
-    public static Optional<MinionServer> findEmptyProfileByHostName(String hostname) {
+    public static List<MinionServer> findEmptyProfilesByHostName(String hostname) {
         CriteriaBuilder builder = getSession().getCriteriaBuilder();
         CriteriaQuery<MinionServer> query = builder.createQuery(MinionServer.class);
         Root<MinionServer> root = query.from(MinionServer.class);
@@ -275,6 +273,6 @@ public class MinionServerFactory extends HibernateFactory {
 
         return getSession().createQuery(query).stream()
                 .filter(s -> s.hasEntitlement(EntitlementManager.BOOTSTRAP))
-                .reduce((s1, s2) -> { throw new IllegalStateException("Multiple matching systems found"); });
+                .collect(toList());
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/server/MinionServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionServerFactory.java
@@ -255,7 +255,7 @@ public class MinionServerFactory extends HibernateFactory {
 
         query.where(hwAddrPredicate);
 
-        return getSession().createQuery(query).list().stream()
+        return getSession().createQuery(query).stream()
                 .filter(s -> s.hasEntitlement(EntitlementManager.BOOTSTRAP))
                 .reduce((s1, s2) -> { throw new IllegalStateException("Multiple matching systems found"); });
     }
@@ -273,7 +273,7 @@ public class MinionServerFactory extends HibernateFactory {
         Root<MinionServer> root = query.from(MinionServer.class);
         query.where(builder.equal(root.get("hostname"), hostname));
 
-        return getSession().createQuery(query).list().stream()
+        return getSession().createQuery(query).stream()
                 .filter(s -> s.hasEntitlement(EntitlementManager.BOOTSTRAP))
                 .reduce((s1, s2) -> { throw new IllegalStateException("Multiple matching systems found"); });
     }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/SystemsExistFaultException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/SystemsExistFaultException.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2018 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.frontend.xmlrpc;
+
+import com.redhat.rhn.FaultException;
+
+import java.util.List;
+
+/**
+ * Fault signalizing existence of systems with given IDs.
+ */
+public class SystemsExistFaultException extends FaultException {
+
+    /**
+     * Standard constructor
+     *
+     * @param systemIds the system ids
+     */
+    public SystemsExistFaultException(List<Long> systemIds) {
+        super(1100, "systemsExist", "Existing system IDs: [" + systemIds.stream()
+                .map(id -> id.toString())
+                .reduce((id1, id2) -> id1 + "," + id2)
+                .orElse("") + "]");
+    }
+
+}

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -117,6 +117,7 @@ import com.redhat.rhn.frontend.xmlrpc.ProfileNoBaseChannelException;
 import com.redhat.rhn.frontend.xmlrpc.RhnXmlRpcServer;
 import com.redhat.rhn.frontend.xmlrpc.SnapshotTagAlreadyExistsException;
 import com.redhat.rhn.frontend.xmlrpc.SystemIdInstantiationException;
+import com.redhat.rhn.frontend.xmlrpc.SystemsExistFaultException;
 import com.redhat.rhn.frontend.xmlrpc.SystemsNotDeletedException;
 import com.redhat.rhn.frontend.xmlrpc.TaskomaticApiException;
 import com.redhat.rhn.frontend.xmlrpc.UndefinedCustomFieldsException;
@@ -146,6 +147,7 @@ import com.redhat.rhn.manager.satellite.SystemCommandExecutor;
 import com.redhat.rhn.manager.system.DuplicateSystemGrouping;
 import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.manager.system.SystemsExistException;
 import com.redhat.rhn.manager.system.UpdateBaseChannelCommand;
 import com.redhat.rhn.manager.system.UpdateChildChannelsCommand;
 import com.redhat.rhn.manager.system.VirtualizationActionCommand;
@@ -5939,15 +5941,20 @@ public class SystemHandler extends BaseHandler {
     }
 
     /**
-     * Creates a system record in database for a system that is not (yet) registered.
+     * Creates a system profile in database for a system that is not (yet) registered.
      * Either "hwAddress" or "hostname" prop must be specified in the "data" struct.
      * @param loggedInUser the currently logged in user
-     * @param systemName server name
+     * @param systemName system name
      * @param data the data about system
-     * @return int - 1 on success, exception thrown otherwise.
+     * @throws SystemsExistFaultException - when system(s) matching given data exists
+     * @throws java.lang.IllegalArgumentException when the input data contains insufficient information or
+     * if the format of the hardware address is invalid
+     * @return int - ID of the created system on success, exception thrown otherwise.
      *
      * @xmlrpc.doc Creates a system record in database for a system that is not registered.
      * Either "hwAddress" or "hostname" prop must be specified in the "data" struct.
+     * If a system(s) matching given data exists, a SystemsExistFaultException is thrown which
+     * contains matching system IDs in its message.
      * @xmlrpc.param #session_key()
      * @xmlrpc.param #param_desc("string", "systemName", "System name")
      * @xmlrpc.param
@@ -5955,17 +5962,18 @@ public class SystemHandler extends BaseHandler {
      *      #prop_desc("string", "hwAddress", "The HW address of the network interface (MAC)")
      *      #prop_desc("string", "hostname", "The hostname of the profile")
      *  #struct_end()
-     * @xmlrpc.returntype #return_int_success()
+     * @xmlrpc.returntype int systemId - The id of the created system
      */
     public int createSystemProfile(User loggedInUser, String systemName, Map<String, Object> data) {
         try {
-            SystemManager.createSystemProfile(loggedInUser, systemName, data);
+            return SystemManager.createSystemProfile(loggedInUser, systemName, data).getId().intValue();
         }
-        catch (IllegalStateException | IllegalArgumentException e) {
+        catch (SystemsExistException e) {
+            throw new SystemsExistFaultException(e.getSystemIds());
+        }
+        catch (IllegalArgumentException e) {
             throw new InvalidParameterException("Can't create system", e);
         }
-
-        return 1;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -2634,9 +2634,10 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
                 .lookupNetworkInterfacesByHwAddress(hwAddress)
                 .collect(Collectors.toList());
 
-        assertEquals(1, result);
         assertEquals(1, nics.size());
-        assertEquals("test system", nics.get(0).getServer().getName());
+        Server server = nics.get(0).getServer();
+        assertEquals("test system", server.getName());
+        assertEquals(result, server.getId().intValue());
     }
 
     private SystemHandler getMockedHandler() throws Exception {

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -400,7 +400,7 @@ public class SystemManager extends BaseManager {
      * @param creator the creator user
      * @param systemName the system name
      * @param data the data of the new profile
-     * @throws java.lang.IllegalStateException when a system based on the input data already exists
+     * @throws SystemsExistException when a system based on the input data already exists
      * @throws java.lang.IllegalArgumentException when the input data contains insufficient information or
      * if the format of the hardware address is invalid
      * @return the created system
@@ -415,9 +415,9 @@ public class SystemManager extends BaseManager {
         }
 
         Set<String> hwAddrs = hwAddress.map(a -> singleton(a)).orElse(emptySet());
-        if (!findMatchingEmptyProfiles(hostname, hwAddrs).isEmpty()) {
-            throw new IllegalStateException("System(s) with hostname '" + hostname + "' or HW address '" +
-                    hwAddress + "' already exists.");
+        List<MinionServer> matchingProfiles = findMatchingEmptyProfiles(hostname, hwAddrs);
+        if (!matchingProfiles.isEmpty()) {
+            throw new SystemsExistException(matchingProfiles.stream().map(p -> p.getId()).collect(Collectors.toList()));
         }
 
         // craft unique id based on given data

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -415,7 +415,7 @@ public class SystemManager extends BaseManager {
         }
 
         Set<String> hwAddrs = hwAddress.map(a -> singleton(a)).orElse(emptySet());
-        if (findMatchingEmptyProfile(hostname, hwAddrs).isPresent()) {
+        if (!findMatchingEmptyProfiles(hostname, hwAddrs).isEmpty()) {
             throw new IllegalStateException("System(s) with hostname '" + hostname + "' or HW address '" +
                     hwAddress + "' already exists.");
         }
@@ -465,19 +465,22 @@ public class SystemManager extends BaseManager {
     }
 
     /**
-     * Find matching empty profile based on hostname and HW addresses (in this order).
+     * Find matching empty profiles based on hostname and HW addresses (in this order).
      *
      * @param hostname the hostname
      * @param hwAddrs the set of HW addresses
-     * @return the matching empty profile
+     * @return the List of matching empty profiles
      */
-    public static Optional<MinionServer> findMatchingEmptyProfile(Optional<String> hostname, Set<String> hwAddrs) {
-        Optional<MinionServer> hostnameMatch = hostname.flatMap(n -> MinionServerFactory.findEmptyProfileByHostName(n));
-        if (hostnameMatch.isPresent()) {
-            return hostnameMatch;
+    public static List<MinionServer> findMatchingEmptyProfiles(Optional<String> hostname, Set<String> hwAddrs) {
+        List<MinionServer> hostnameMatches = hostname
+                .map(n -> MinionServerFactory.findEmptyProfilesByHostName(n))
+                .orElse(emptyList());
+        if (!hostnameMatches.isEmpty()) {
+            return hostnameMatches;
         }
-        Optional<MinionServer> hwAddrMatch = MinionServerFactory.findEmptyProfileByHwAddrs(hwAddrs);
-        return hwAddrMatch;
+
+        List<MinionServer> hwAddrMatches = MinionServerFactory.findEmptyProfilesByHwAddrs(hwAddrs);
+        return hwAddrMatches;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/system/SystemsExistException.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemsExistException.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2018 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.manager.system;
+
+import java.util.List;
+
+/**
+ * Exception signalizing existence of systems with given IDs.
+ */
+public class SystemsExistException extends RuntimeException {
+
+    private List<Long> systemIds;
+
+    /**
+     * Standard constructor
+     * @param systemIdsIn the system ids
+     */
+    public SystemsExistException(List<Long> systemIdsIn) {
+        this.systemIds = systemIdsIn;
+    }
+
+    /**
+     * Gets the systemIds.
+     *
+     * @return systemIds
+     */
+    public List<Long> getSystemIds() {
+        return systemIds;
+    }
+
+}

--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -91,6 +91,7 @@ import com.redhat.rhn.manager.rhnpackage.test.PackageManagerTest;
 import com.redhat.rhn.manager.rhnset.RhnSetDecl;
 import com.redhat.rhn.manager.rhnset.RhnSetManager;
 import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.manager.system.SystemsExistException;
 import com.redhat.rhn.manager.user.UserManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.testing.ChannelTestUtils;
@@ -1496,12 +1497,12 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
     public void testCreateSystemProfileExistingHwAddress() {
         String hwAddr = "be:b0:bc:a3:a7:ad";
         Map<String, Object> data = singletonMap("hwAddress", hwAddr);
-        SystemManager.createSystemProfile(user, "test system", data);
+        MinionServer profile = SystemManager.createSystemProfile(user, "test system", data);
         try {
             SystemManager.createSystemProfile(user, "test system 2", data);
             fail("System creation should have failed!");
-        } catch (IllegalStateException e) {
-            // no-op
+        } catch (SystemsExistException e) {
+            assertEquals(singletonList(profile.getId()), e.getSystemIds());
         }
     }
 

--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -1509,7 +1509,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
      * Tests finding an empty profile by hostname and HW addresses with "empty" arguments.
      */
     public void testFindByHostnameAndHwAddrsEmptyArgs() {
-        assertFalse(SystemManager.findMatchingEmptyProfile(empty(), emptySet()).isPresent());
+        assertTrue(SystemManager.findMatchingEmptyProfiles(empty(), emptySet()).isEmpty());
     }
 
     /**
@@ -1518,12 +1518,14 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
     public void testFindByHostnameNoHwAddrs() throws Exception {
         MinionServer minion = createEmptyProfile(of("myhost"), empty());
 
-        Optional<MinionServer> fromDb = SystemManager.findMatchingEmptyProfile(of("myhost"), emptySet());
-        assertEquals(minion, fromDb.get());
+        List<MinionServer> fromDb = SystemManager.findMatchingEmptyProfiles(of("myhost"), emptySet());
+        assertEquals(1, fromDb.size());
+        assertEquals(minion, fromDb.get(0));
 
         // minion with a HW address will also match
-        Optional<MinionServer> fromDb2 = SystemManager.findMatchingEmptyProfile(of("myhost"), singleton("11:22:33:44:55:66"));
-        assertEquals(minion, fromDb2.get());
+        List<MinionServer> fromDb2 = SystemManager.findMatchingEmptyProfiles(of("myhost"), singleton("11:22:33:44:55:66"));
+        assertEquals(1, fromDb2.size());
+        assertEquals(minion, fromDb2.get(0));
     }
 
     /**
@@ -1533,12 +1535,14 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         String hwAddr = "11:22:33:44:55:66";
         MinionServer minion = createEmptyProfile(empty(), of(hwAddr));
 
-        Optional<MinionServer> fromDb = SystemManager.findMatchingEmptyProfile(empty(), singleton(hwAddr));
-        assertEquals(minion, fromDb.get());
+        List<MinionServer> fromDb = SystemManager.findMatchingEmptyProfiles(empty(), singleton(hwAddr));
+        assertEquals(1, fromDb.size());
+        assertEquals(minion, fromDb.get(0));
 
         // minion with a hostname will also match
-        Optional<MinionServer> fromDb2 = SystemManager.findMatchingEmptyProfile(of("myhost"), singleton(hwAddr));
-        assertEquals(minion, fromDb2.get());
+        List<MinionServer> fromDb2 = SystemManager.findMatchingEmptyProfiles(of("myhost"), singleton(hwAddr));
+        assertEquals(1, fromDb2.size());
+        assertEquals(minion, fromDb2.get(0));
     }
 
     /**
@@ -1549,23 +1553,27 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         MinionServer minion = createEmptyProfile(of("myhost"), of(hwAddr));
 
         // lookup by hostname should match
-        Optional<MinionServer> fromDb = SystemManager.findMatchingEmptyProfile(of("myhost"), emptySet());
-        assertEquals(minion, fromDb.get());
+        List<MinionServer> fromDb = SystemManager.findMatchingEmptyProfiles(of("myhost"), emptySet());
+        assertEquals(1, fromDb.size());
+        assertEquals(minion, fromDb.get(0));
 
         // lookup by HW addr should match
-        Optional<MinionServer> fromDb2 = SystemManager.findMatchingEmptyProfile(empty(), singleton(hwAddr));
-        assertEquals(minion, fromDb2.get());
+        List<MinionServer> fromDb2 = SystemManager.findMatchingEmptyProfiles(empty(), singleton(hwAddr));
+        assertEquals(1, fromDb2.size());
+        assertEquals(minion, fromDb2.get(0));
 
         // lookup by hostname and HW addr should match
-        Optional<MinionServer> fromDb3 = SystemManager.findMatchingEmptyProfile(of("myhost"), singleton(hwAddr));
-        assertEquals(minion, fromDb3.get());
+        List<MinionServer> fromDb3 = SystemManager.findMatchingEmptyProfiles(of("myhost"), singleton(hwAddr));
+        assertEquals(1, fromDb3.size());
+        assertEquals(minion, fromDb3.get(0));
 
         // lookup by hostname and HW addrs should match
         Set<String> moreAddrs = new HashSet<>();
         moreAddrs.add(hwAddr);
         moreAddrs.add("11:22:33:44:55:77");
-        Optional<MinionServer> fromDb4 = SystemManager.findMatchingEmptyProfile(of("myhost"), moreAddrs);
-        assertEquals(minion, fromDb4.get());
+        List<MinionServer> fromDb4 = SystemManager.findMatchingEmptyProfiles(of("myhost"), moreAddrs);
+        assertEquals(1, fromDb4.size());
+        assertEquals(minion, fromDb4.get(0));
     }
 
     /**
@@ -1583,20 +1591,23 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         ServerFactory.saveNetworkInterface(netInterface);
 
         // lookup by hostname should match
-        Optional<MinionServer> fromDb = SystemManager.findMatchingEmptyProfile(of("myhost"), emptySet());
-        assertEquals(minion, fromDb.get());
+        List<MinionServer> fromDb = SystemManager.findMatchingEmptyProfiles(of("myhost"), emptySet());
+        assertEquals(1, fromDb.size());
+        assertEquals(minion, fromDb.get(0));
 
         // lookup by multiple HW addrs should match
         Set<String> hwAddrs = new HashSet<>();
         hwAddrs.add(hwAddr);
         hwAddrs.add(hwAddr2);
-        Optional<MinionServer> fromDb2 = SystemManager.findMatchingEmptyProfile(empty(), hwAddrs);
-        assertEquals(minion, fromDb2.get());
+        List<MinionServer> fromDb2 = SystemManager.findMatchingEmptyProfiles(empty(), hwAddrs);
+        assertEquals(1, fromDb2.size());
+        assertEquals(minion, fromDb2.get(0));
 
         // lookup by single HW addr should match
         String fstAddr = hwAddrs.iterator().next();
-        Optional<MinionServer> fromDb3 = SystemManager.findMatchingEmptyProfile(empty(), singleton(fstAddr));
-        assertEquals(minion, fromDb3.get());
+        List<MinionServer> fromDb3 = SystemManager.findMatchingEmptyProfiles(empty(), singleton(fstAddr));
+        assertEquals(1, fromDb3.size());
+        assertEquals(minion, fromDb3.get(0));
     }
 
     /**
@@ -1604,10 +1615,10 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
      */
     public void testFindByHostnameAndHwAddrsNoMatch() throws Exception {
         createEmptyProfile(of("myhost"), empty());
-        Optional<MinionServer> fromDb = SystemManager.findMatchingEmptyProfile(empty(), singleton("00:11:22:33:44:55"));
-        assertFalse(fromDb.isPresent());
-        Optional<MinionServer> fromDb2 = SystemManager.findMatchingEmptyProfile(of("otherhost"), emptySet());
-        assertFalse(fromDb2.isPresent());
+        List<MinionServer> fromDb = SystemManager.findMatchingEmptyProfiles(empty(), singleton("00:11:22:33:44:55"));
+        assertTrue(fromDb.isEmpty());
+        List<MinionServer> fromDb2 = SystemManager.findMatchingEmptyProfiles(of("otherhost"), emptySet());
+        assertTrue(fromDb2.isEmpty());
     }
 
     private MinionServer createEmptyProfile(Optional<String> hostName, Optional<String> hwAddr) throws Exception {

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -527,7 +527,19 @@ public class RegisterMinionEventMessageAction implements MessageAction {
                 minion.getHistory().add(historyEvent);
 
                 return minion;
-            }).orElseGet(() -> SystemManager.findMatchingEmptyProfile(fqdn, hwAddrs).orElseGet(MinionServer::new));
+            }).orElseGet(() -> findMatchingEmptyProfiles(fqdn, hwAddrs).orElseGet(MinionServer::new));
+    }
+
+    private Optional<MinionServer> findMatchingEmptyProfiles(Optional<String> hostname, Set<String> hwAddrs) {
+        List<MinionServer> matchingEmptyProfiles = SystemManager.findMatchingEmptyProfiles(hostname, hwAddrs);
+        if (matchingEmptyProfiles.isEmpty()) {
+            return empty();
+        }
+        if (matchingEmptyProfiles.size() == 1) {
+            return of(matchingEmptyProfiles.get(0));
+        }
+        throw new IllegalStateException(matchingEmptyProfiles.size() + " matching empty profiles found when matching" +
+                " with " + hostname.map(n -> "hostname: " + n + " and ").orElse("") + " HW addresseses: " + hwAddrs);
     }
 
     /**


### PR DESCRIPTION
Previously, the `createEmptyProfile` method threw an exception, when a matching profile was found.
 This method is renamed in this PR to `getOrCreateSystemProfile` which returns system id:
 - in the "create" case, the id of the newly created system is returned
 - in the "existing" case, the id of existing matching system is returned
  
  ## GUI diff
  
  No difference.
  
  - [x] **DONE**
  
  ## Documentation
  - [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)
  
  - [ ] **DONE**
  
  ## Test coverage
  - No tests: adjusted jUnit tests
  - [x] **DONE**
  
  ## Links
  
  Tracks https://github.com/SUSE/spacewalk/issues/6180
  
  - [x] **DONE**