### PR TITLE
Adapt 'list errata' queries to be compatible with Oracle

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/errata/impl/PublishedErrata.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/errata/impl/PublishedErrata.hbm.xml
@@ -247,7 +247,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
 
     <sql-query name="PublishedErrata.listAvailableToOrgByIds">
         <![CDATA[SELECT E.*, 0 as clazz_
-                 FROM rhnErrata as E
+                 FROM rhnErrata E
                  WHERE E.id in (:eids)
                      AND (E.org_id = :orgId
                           OR EXISTS (SELECT 1

--- a/java/code/src/com/redhat/rhn/domain/errata/impl/UnpublishedErrata.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/errata/impl/UnpublishedErrata.hbm.xml
@@ -93,7 +93,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
     </query>
     <sql-query name="UnpublishedErrata.listAvailableToOrgByIds">
         <![CDATA[SELECT E.*, 0 as clazz_
-                 FROM rhnErrataTmp as E
+                 FROM rhnErrataTmp E
                  WHERE E.id in (:eids)
                      AND (E.org_id = :orgId
                           OR EXISTS (SELECT 1


### PR DESCRIPTION
## What does this PR change?

Adapts the syntax of "list errata" queries to be compatible with Oracle.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: test fix

- [x] **DONE**

## Test coverage
- No tests: tests exist already

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/6331

- [ ] **DONE**
