### PR TITLE
Follow-up for file-permission check (bsc#1114181)

### DIFF
--- a/spacewalk/config/etc/sudoers.d/spacewalk
+++ b/spacewalk/config/etc/sudoers.d/spacewalk
@@ -15,3 +15,8 @@ tomcat  ALL=(root)      NOPASSWD: CONFIG_RHN
 # commands via sudo even without a real tty
 Defaults:tomcat !requiretty
 Defaults:apache !requiretty
+
+# These two commands allow tomcat and apache to check permissions of
+# the minion bootstrap ssh-known_hosts file
+apache  ALL=(root)      NOPASSWD: /usr/bin/ls -la /var/lib/salt/.ssh/known_hosts
+tomcat  ALL=(root)      NOPASSWD: /usr/bin/ls -la /var/lib/salt/.ssh/known_hosts

--- a/spacewalk/config/spacewalk-config.changes
+++ b/spacewalk/config/spacewalk-config.changes
@@ -1,3 +1,5 @@
+- Add permissions for tomcat & apache to check bootstrap ssh file (bsc#1114181)
+
 -------------------------------------------------------------------
 Fri Oct 26 10:11:12 CEST 2018 - jgonzalez@suse.com
 


### PR DESCRIPTION
Changes the ssh-file permission check to a
ssh-file ownership check. This corrects a bug
in the previous PR where tomcat checks if it
can read/write, whereas it should be salt that
needs these permissions.

Follow-up commit for https://github.com/SUSE/spacewalk/pull/6318