### PR TITLE
Fix schedule runs

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/TaskoXmlRpcHandler.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskoXmlRpcHandler.java
@@ -364,6 +364,7 @@ public class TaskoXmlRpcHandler {
                     .withZoneSameInstant(ZoneId.systemDefault()).toInstant());
             TaskoSchedule schedule = new TaskoSchedule(orgId, bunch, label, params, start, null, null);
             TaskoFactory.save(schedule);
+            TaskoFactory.commitTransaction();
 
             // create job
             Date scheduleDate = TaskoQuartzHelper.createJob(schedule);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- fix scheduling jobs to prevent forever pending events (bsc#1114991)
 - Performance improvements for group listings and detail page (bsc#1111810)
 - fix wrong counts of systems currency reports when a system belongs to more than one group (bsc#1114362)
 - Add check if ssh-file permissions are correct (bsc#1114181)


### PR DESCRIPTION
## What does this PR change?

Depending on how you schedule a taskomatic jobs it can happen that a job stay forever in pending state. The reason is a race condition. Quartz scheduler expect a value in the database which might not be written when the job fires.

Solved by an extra commit transaction which was also used at other places for the same reason.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- was found by openQA tests and will fix it.

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/6329
Tracks https://github.com/SUSE/spacewalk/pull/6345

- [x] **DONE**
