### PR TITLE
Normalize pkg name when processing multiversion deltas from Salt (bsc#1114029)

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/test/apply_pkg_multiversion.new_format.json
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/apply_pkg_multiversion.new_format.json
@@ -1,0 +1,50 @@
+{
+  "pkg_|-pkg_installed_|-pkg_installed_|-installed": {
+    "__id__": "pkg_installed",
+    "__run_num__": 1,
+    "__sls__": "packages.pkginstall",
+    "changes": {
+      "glibc": {
+        "new": [
+          {
+            "arch": "x86_64",
+            "install_date_time_t": 1542273203,
+            "release": "260.el7",
+            "version": "2.17"
+          }
+        ],
+        "old": [
+          {
+            "arch": "x86_64",
+            "install_date_time_t": 1542273016,
+            "release": "55.el7",
+            "version": "2.17"
+          }
+        ]
+      },
+      "glibc.i686": {
+        "new": [
+          {
+            "arch": "i686",
+            "install_date_time_t": 1542273206,
+            "release": "260.el7",
+            "version": "2.17"
+          }
+        ],
+        "old": [
+          {
+            "arch": "i686",
+            "install_date_time_t": 1542273048,
+            "release": "55.el7",
+            "version": "2.17"
+          }
+        ]
+      }
+    },
+    "comment": "2 targeted packages were installed/updated.",
+    "duration": 27026.344,
+    "name": "pkg_installed",
+    "result": true,
+    "start_time": "10:13:06.485240"
+  }
+}

--- a/java/code/src/com/suse/manager/reactor/messaging/test/apply_pkg_multiversion_upgrade.new_format.json
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/apply_pkg_multiversion_upgrade.new_format.json
@@ -1,0 +1,50 @@
+{
+  "pkg_|-pkg_installed_|-pkg_installed_|-installed": {
+    "__id__": "pkg_installed",
+    "__run_num__": 1,
+    "__sls__": "packages.pkginstall",
+    "changes": {
+      "glibc": {
+        "new": [
+          {
+            "arch": "x86_64",
+            "install_date_time_t": 1542273503,
+            "release": "261.el7",
+            "version": "2.20"
+          }
+        ],
+        "old": [
+          {
+            "arch": "x86_64",
+            "install_date_time_t": 1542273203,
+            "release": "260.el7",
+            "version": "2.17"
+          }
+        ]
+      },
+      "glibc.i686": {
+        "new": [
+          {
+            "arch": "i686",
+            "install_date_time_t": 1542273506,
+            "release": "261.el7",
+            "version": "2.20"
+          }
+        ],
+        "old": [
+          {
+            "arch": "i686",
+            "install_date_time_t": 1542273206,
+            "release": "260.el7",
+            "version": "2.17"
+          }
+        ]
+      }
+    },
+    "comment": "2 targeted packages were installed/updated.",
+    "duration": 27026.344,
+    "name": "pkg_installed",
+    "result": true,
+    "start_time": "10:13:06.485240"
+  }
+}

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Normalize package names when processing multiversion deltas from Salt (bsc#1114029)
 - Performance improvements for group listings and detail page (bsc#1111810)
 - fix wrong counts of systems currency reports when a system belongs to more than one group (bsc#1114362)
 - Add check if ssh-file permissions are correct (bsc#1114181)


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue with the update of packages on the UI after we received a Salt package delta (after a update/install/remove action) which contains multiversion packages that contains the "arch" also as part of the package name.

When packages are referenced as "package.arch" on the Salt package delta, Uyuni won't successfully match the package with stored packages on the database. That makes the package profile is not upgraded properly.

## Test coverage

- Unit tests were added

- [x] **DONE**

## Links

Tracks: https://github.com/SUSE/spacewalk/issues/6249

- [x] **DONE**
