### PR TITLE
Less files are now served by webpack and not proxied

### DIFF
--- a/web/html/src/build/webpack.config.js
+++ b/web/html/src/build/webpack.config.js
@@ -59,6 +59,7 @@ module.exports = (env, argv) => {
       new webpack.DllReferencePlugin({
         manifest: path.resolve(__dirname, "../dist/vendors/vendors-manifest.json"),
       }),
+      new CopyWebpackPlugin([{ from: path.resolve(__dirname, "../../../../branding/css"), to: path.resolve(__dirname, "../dist/css") }]),
       new CopyWebpackPlugin([{ from: path.resolve(__dirname, "../../javascript"), to: path.resolve(__dirname, "../dist/javascript") }])
     ],
     devServer: {


### PR DESCRIPTION
## What does this PR change?

Less files are now served by webpack and not proxied.

The hot reload of css still doesn't work with this solution. It's possible to do it, but it includes a bit more of effort with the current architecture. 

To enable hot reload of css through webpack we need to compile the less files with it, and atm it's hard because the less compilation depends on files provided at runtime or obs, for instance, the patternfly package: https://build.suse.de/package/show/Devel:Galaxy:Manager:3.2/susemanager-frontend-libs

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

