### PR TITLE
Fix ugly space on tooltip when using firefox on page sp migration

### DIFF
--- a/java/code/webapp/WEB-INF/pages/systems/spmigration/spmigration-target.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/spmigration/spmigration-target.jsp
@@ -91,11 +91,9 @@
                             <ul class="form-control-static products-list">
                                 <c:set var="itemCounter" scope="page" value="0" />
                                 <c:forEach items="${targetProducts}" var="target">
-                                    <li title="
-                                        <c:if test="${!target.isEveryChannelSynced}">
-                                            <bean:message key="spmigration.jsp.target.notSyncedChannels" />
-                                            <c:out value="${target.missingChannelsMessage}" />
-                                        </c:if>">
+                                    <li <c:if test="${!target.isEveryChannelSynced}">
+                                                title="<bean:message key="spmigration.jsp.target.notSyncedChannels" />
+                                                    <c:out value="${target.missingChannelsMessage}" />"</c:if>>
                                         <input type="radio" name="targetProductSelected"
                                             id="target${target.serializedProductIDs}"
                                             value="${target.serializedProductIDs}"


### PR DESCRIPTION
## What does this PR change?

Fix ugly space on tooltip when using firefox on page sp migration.

Note: This was only happening on Firefox. 

## Links

Fixes https://github.com/SUSE/spacewalk/issues/6166

- [x] **DONE**
