### PR TITLE
Missing check when filtering products

### DIFF
--- a/web/html/src/manager/products.js
+++ b/web/html/src/manager/products.js
@@ -423,7 +423,7 @@ class Products extends React.Component {
   };
 
   searchData = (datum, criteria) => {
-    if (criteria) {
+    if (criteria && datum.label) {
       return (datum.label).toLowerCase().includes(criteria.toLowerCase());
     }
     return true;


### PR DESCRIPTION
## What does this PR change?

Missing check when filtering products.

This started to be a problem after React 16 upgrade, because it changed the way the errors while Rendering are handled