### PR TITLE
check for blank config value as it might return null

### DIFF
--- a/java/code/src/com/suse/manager/utils/MailHelper.java
+++ b/java/code/src/com/suse/manager/utils/MailHelper.java
@@ -20,6 +20,8 @@ import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.common.messaging.Mail;
 import com.redhat.rhn.common.messaging.SmtpMail;
 import java.net.UnknownHostException;
+
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import java.net.InetAddress;
 
@@ -145,7 +147,7 @@ public class MailHelper {
      */
     public static String[] getAdminRecipientsFromConfig() {
         Config c = Config.get();
-        return c.getString("web.traceback_mail").equals("") ?
+        return StringUtils.isBlank(c.getString("web.traceback_mail")) ?
                 new String[]{"root@localhost"} :
                 c.getStringArray("web.traceback_mail");
     }


### PR DESCRIPTION
## What does this PR change?

Config.getString() return null when the key is not found. So we should check for blank to decide if we have a value or not.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **internal**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/6378

- [x] **DONE**
