### PR TITLE
Fix create bootstrap repo sle12s390

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -313,7 +313,6 @@ PKGLIST15 = [
     "python3-zypp-plugin-spacewalk",
     "libpgm-5_2-0",
     "libsodium23",
-    "libunwind",
     "libzmq5",
     "python3-Babel",
     "python3-certifi",
@@ -335,6 +334,10 @@ PKGLIST15 = [
     "salt",
     "python3-salt",
     "salt-minion",
+]
+
+PKGLIST15_NO_Z = [
+    "libunwind",
 ]
 
 DATA = {
@@ -615,11 +618,11 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/2/bootstrap/'
     },
     'SLE-15-aarch64' : {
-        'PDID' : [1589, 1709], 'PKGLIST' : PKGLIST15,
+        'PDID' : [1589, 1709], 'PKGLIST' : PKGLIST15 + PKGLIST15_NO_Z,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/0/bootstrap/'
     },
     'SLE-15-ppc64le' : {
-        'PDID' : [1588, 1710], 'PKGLIST' : PKGLIST15,
+        'PDID' : [1588, 1710], 'PKGLIST' : PKGLIST15 + PKGLIST15_NO_Z,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/0/bootstrap/'
     },
     'SLE-15-s390x' : {
@@ -627,7 +630,7 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/0/bootstrap/'
     },
     'SLE-15-x86_64' : {
-        'PDID' : [1576, 1712], 'PKGLIST' : PKGLIST15,
+        'PDID' : [1576, 1712], 'PKGLIST' : PKGLIST15 + PKGLIST15_NO_Z,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/0/bootstrap/'
     },
 }

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,6 @@
+- fix not found package on mgr-create-bootstrap-repo for SLE-15-s390x
+  (bsc#1116566)
+
 -------------------------------------------------------------------
 Fri Oct 26 10:49:25 CEST 2018 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

A package from bootstrap repo data is not available on s390x.
Remove that package only for this arch from the list.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **cannot be tested**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/6371
Tracks https://github.com/SUSE/spacewalk/pull/6377

- [x] **DONE**
