### PR TITLE
Use new step ^I click on "([^"]+)" in row "([^"]+)"$

### DIFF
--- a/testsuite/features/srv_create_group.feature
+++ b/testsuite/features/srv_create_group.feature
@@ -40,7 +40,7 @@ Feature: Create a group
 
   Scenario: Add the new group to SSM
     Given I am on the groups page
-    When I click on "Use in SSM" for "newgroup"
+    When I click on "Use in SSM" in row "newgroup"
     Then I should see a "system selected" text
     And I should see a "Selected Systems List" text
     And I should see "sle-client" as link

--- a/testsuite/features/srv_group_union_intersection.feature
+++ b/testsuite/features/srv_group_union_intersection.feature
@@ -58,7 +58,7 @@ Feature: Work with Union and Intersection buttons in the group list
 
   Scenario: Add the new group to SSM
     Given I am on the groups page
-    When I click on "Use in SSM" for "sles"
+    When I click on "Use in SSM" in row "sles"
     And I should see a "systems selected" text
     And I should see a "Selected Systems List" text
     Then I should see "sle-client" as link


### PR DESCRIPTION
## What does this PR change?

Since the replacement of cucumber step definition
/^I click on "([^"]+)" for "([^"]+)"$/ by
^I click on "([^"]+)" in row "([^"]+)"$ some of the old step uses
needed to be changed.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: testsuite fix

- [X] **DONE**

## Test coverage
- No tests: fixing test suite

- [X] **DONE**

## Links

- [X] **DONE**
