### PR TITLE
Use obscpio instead of tarballs for OBS submissions

### DIFF
--- a/rel-eng/_service
+++ b/rel-eng/_service
@@ -1,0 +1,7 @@
+<services>
+  <service name="tar" mode="buildtime"/>
+  <service name="recompress" mode="buildtime">
+    <param name="file">*.tar</param>
+    <param name="compression">gz</param>
+  </service>
+</services>

--- a/rel-eng/build-packages-for-obs.sh
+++ b/rel-eng/build-packages-for-obs.sh
@@ -1,4 +1,5 @@
 #! /bin/bash
+BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 set -e
 #
 # For all packages in git:/rel-eng/packages (or defined in $PACKAGES)
@@ -112,7 +113,22 @@ while read PKG_NAME PKG_VER PKG_DIR; do
     continue 2
   fi
 
+  # Convert to obscpio
+  SPEC_VER=$(sed -n -e 's/^Version:\s*\(.*\)/\1/p' ${T_DIR}/${PKG_NAME}.spec)
+  SOURCE=$(sed -n -e 's/^Source0:\s*.*[[:space:]\/]\(.*\)/\1/p' ${T_DIR}/${PKG_NAME}.spec|sed -e "s/%{name}/${PKG_NAME}/"|sed -e "s/%{version}/${SPEC_VER}/")
+  FOLDER=$(tar -tf ${T_DIR}/${SOURCE}|head -1|sed -e 's/\///')
+  (cd ${T_DIR}; tar -xf ${SOURCE}; rm ${SOURCE}; mv ${FOLDER} ${PKG_NAME}; find ${PKG_NAME} | cpio --create --format=newc --reproducible > ${FOLDER}.obscpio; rm -rf ${PKG_NAME})
+  # Move to destination
   mv "$T_DIR" "$SRPM_DIR/$PKG_NAME"
+  # Copy service
+  cp ${BASE_DIR}/_service "${SRPM_DIR}/${PKG_NAME}"
+  # Create .obsinfo file
+  cat > "${SRPM_DIR}/${PKG_NAME}/${PKG_NAME}.obsinfo" <<EOF
+name: ${PKG_NAME}
+version: $(echo ${FOLDER}|sed -e "s/${PKG_NAME}-//")
+mtime: $(date +%s)
+commit: $(git rev-parse --verify HEAD)
+EOF
   # Release is handled by the Buildservice
   # Remove everything what prevents us from submitting
   sed -i 's/^Release.*$/Release:    1/i' $SRPM_DIR/$PKG_NAME/*.spec


### PR DESCRIPTION
## What does this PR change?

It changes submissions to OBS: tarballs are now sent as .obscpio.

Instead of changing tito, this untars the tarball and recompress it as .obscpio, to conform what OBS is expecting (changing the root folder).

Besides a _service is added, because OBS then needs to transform the .obscpio back to tarball (definition is at the new .obsinfo file).

The benefit for this, is saving storage at OBS: https://openbuildservice.org/2016/04/08/new_git_in_27/

Adrian confirmed we'll save storage even if we don't use the complete workflow described above.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: This is a transparent change, and does not affect users.

- [x] **DONE**

## Test coverage

- No tests: No tests for rel-eng tools.

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/5940

Once approved, IMHO this should be merged to 3.1 and 3.2.

- [x] **DONE**
