### PR TITLE
Fix CVE audit logic for CVEs with multiple erratas

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/cve_audit_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/cve_audit_queries.xml
@@ -137,15 +137,11 @@
             SELECT system_id FROM affected_and_patched
         )
     )
-    SELECT * FROM (
-        SELECT *
-          FROM affected_and_patched
-          UNION ALL (
-            SELECT *
-              FROM not_affected
-          )
-    ) X
-    ORDER BY X.system_id, X.channel_rank, X.errata_id NULLS LAST
+    SELECT * FROM affected_and_patched
+      UNION ALL (
+        SELECT * FROM not_affected
+    )
+    ORDER BY system_id, channel_rank, errata_id NULLS LAST
   </query>
 </mode>
 

--- a/java/code/src/com/redhat/rhn/manager/rhnpackage/PackageManager.java
+++ b/java/code/src/com/redhat/rhn/manager/rhnpackage/PackageManager.java
@@ -608,7 +608,6 @@ public class PackageManager extends BaseManager {
             session = HibernateFactory.getSession();
             return (PackageName)session.getNamedQuery("PackageName.findByName")
                                        .setString("name", name)
-                                       .setCacheable(true)
                                        .uniqueResult();
         }
         catch (HibernateException e) {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix handling of CVEs including multiple patches in CVE audit (bsc#1111963)
 - When changing basechannel the compatible old childchannels are now selected by default. (bsc#1110772)
 - fix scheduling jobs to prevent forever pending events (bsc#1114991)
 - Performance improvements for group listings and detail page (bsc#1111810)


### PR DESCRIPTION
Refactor the CVE audit code from the ground up, utilizing some Java 8 features, so it's much more readable.

**This PR is a complete overhaul of the CVE audit logic.** So side-by-side diffs might not make sense.

This can be considered a successor of "Manager 3.2 cve refactoring logic". This PR includes the applicable changes originally introduced with it (thanks, @ncounter).

The original problem is when a CVE involves multiple patches, the logic is unstable when suggesting the user which patch to apply. Depending on the ranks of channels containing each of the erratas, the UI might show an already installed errata instead of the missing one.
https://bugzilla.suse.com/1111963

![2420](https://user-images.githubusercontent.com/1103552/47725814-8ff1f900-dc59-11e8-8798-149033e0cd61.jpg)
*@ncounter's drawing that perfectly describes the problem*

## GUI diff
- No difference.

## Documentation
- No documentation needed: Bugfix

## Test coverage
- Unit tests were added