### PR TITLE
Add check for autoinstall-profile (bsc#1114115)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/kickstart/profile/ProfileHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/kickstart/profile/ProfileHandler.java
@@ -226,6 +226,23 @@ public class ProfileHandler extends BaseHandler {
         return 1;
     }
 
+    /**
+     * Adds a KickstartTree downloadUrl to a KickstartProfile
+     * @param ksdata The KickstartData of the KickstartProfile
+     * @param downloadUrl the downloadUrl of the KickstartTree
+     */
+    private void addUrlCommandToKickstartProfile(KickstartData ksdata, String downloadUrl) {
+        KickstartCommandName ksCmdName = null;
+        KickstartCommand ksCmd = null;
+
+        ksCmdName = KickstartFactory.lookupKickstartCommandName("url");
+        ksCmd = new KickstartCommand();
+        ksCmd.setCommandName(ksCmdName);
+        ksCmd.setArguments("--url " + downloadUrl);
+        ksdata.addCommand(ksCmd);
+        ksCmd.setKickstartData(ksdata);
+    }
+
 
     /**
      * Set the kickstart tree for a kickstart profile.
@@ -258,8 +275,18 @@ public class ProfileHandler extends BaseHandler {
         if (tree == null) {
             throw new NoSuchKickstartTreeException(kstreeLabel);
         }
-        KickstartCommand urlC = ksdata.getCommand("url");
-        urlC.setArguments("--url " + tree.getDefaultDownloadLocation());
+
+        boolean isAutoInstallProfile = ksdata.isSUSE();
+        if (!isAutoInstallProfile) {
+            KickstartCommand urlC = ksdata.getCommand("url");
+            if (urlC == null) {
+                addUrlCommandToKickstartProfile(ksdata, tree.getDefaultDownloadLocation());
+            }
+            else {
+                urlC.setArguments("--url " + tree.getDefaultDownloadLocation());
+            }
+        }
+
         KickstartDefaults ksdefault = ksdata.getKickstartDefaults();
         ksdefault.setKstree(tree);
         KickstartFactory.saveKickstartData(ksdata);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add check for yast autoinstall profiles when setting kickstartTree (bsc#1114115)
 - Fix handling of CVEs including multiple patches in CVE audit (bsc#1111963)
 - When changing basechannel the compatible old childchannels are now selected by default. (bsc#1110772)
 - fix scheduling jobs to prevent forever pending events (bsc#1114991)


### PR DESCRIPTION
This change adds a check in the setKickstartTree
method which prevents the ProfileHandler from
updating a non-existent KickstartCommand for
yast autoinstall profiles. This prevents a
NullPointerException.

The same error occurs when a new KickstartTree
is set for a kickstart profile which lacks the
`url` option. In this case a new KickstartCommand
gets added.

cherry-pick from https://github.com/SUSE/spacewalk/pull/6342