### PR TITLE
Notification messages are now filtered by a config property

### DIFF
--- a/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -253,7 +253,12 @@ public class ConfigDefaults {
     public static final String NOTIFICATIONS_LIFETIME = "java.notifications_lifetime";
 
     /**
-     * Indicates the salt-api host to connect to (host)
+     * Notifications types to disable
+     */
+    public static final String NOTIFICATIONS_TYPE_DISABLED = "java.notifications_type_disabled";
+
+    /**
+     * Indicates the salt-api host to connect to (host
      */
     public static final String SALT_API_HOST = "java.salt_api_host";
 
@@ -918,5 +923,14 @@ public class ConfigDefaults {
      */
     public int getSaltEventsPerCommit() {
         return Config.get().getInt(SALT_EVENTS_PER_COMMIT, 1);
+    }
+
+
+    /**
+     * Returns the notifications type disabled.
+     * @return notifications type disabled
+     */
+    public List<String> getNotificationsTypeDisabled() {
+        return Config.get().getList(NOTIFICATIONS_TYPE_DISABLED);
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/notification/UserNotificationFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/UserNotificationFactory.java
@@ -15,6 +15,7 @@
 
 package com.redhat.rhn.domain.notification;
 
+import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.notification.types.NotificationData;
 import com.redhat.rhn.domain.org.Org;
@@ -66,12 +67,28 @@ public class UserNotificationFactory extends HibernateFactory {
     }
 
     /**
+     * Check if the given user notification is currently disabled
+     *
+     * @param userNotificationIn userNotification
+     * @return boolean if notification type is disabled
+     */
+    public static boolean isNotificationTypeDisabled(UserNotification userNotificationIn) {
+        List<String> disableNotificationsBy = ConfigDefaults.get().getNotificationsTypeDisabled();
+
+        return disableNotificationsBy.contains(userNotificationIn.getMessage().getType().name());
+    }
+
+    /**
      * Store {@link UserNotification} to the database.
      *
      * @param userNotificationIn userNotification
      */
     public static void store(UserNotification userNotificationIn) {
-        singleton.saveObject(userNotificationIn);
+        // We want to disable out the notifications defined on parameter: java.notifications_type_disabled
+        // They are still added to the SuseNotificationTable but not associated with any user
+        if (!isNotificationTypeDisabled(userNotificationIn)) {
+            singleton.saveObject(userNotificationIn);
+        }
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Disable notification types with 'java.notifications_type_disabled' in rhn.conf (bsc#1111910)
 - Fix the config channels assignment via SSM (bsc#1117759)
 - Introduce Loggerhead-module.js to store logs from the frontend
 - change SCC sync backend to adapt quicker to SCC changes and improve


### PR DESCRIPTION
## What does this PR change?

Add the possibility to filter notifications type through a configuration parameter.

The notifications are still added to the table SuseNotificationTable but they are not associated with any user on the table SuseUserNotification

## GUI diff

No difference.

- [x] **DONE**

## Documentation

https://github.com/SUSE/doc-susemanager/pull/306

- [x] **DONE**

## Test coverage
- No tests.

- [x] **DONE**

