### PR TITLE
Revert CVE audit SQL query for Oracle support

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/cve_audit_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/cve_audit_queries.xml
@@ -137,11 +137,15 @@
             SELECT system_id FROM affected_and_patched
         )
     )
-    SELECT * FROM affected_and_patched
-      UNION ALL (
-        SELECT * FROM not_affected
-    )
-    ORDER BY system_id, channel_rank, errata_id NULLS LAST
+    SELECT * FROM (
+        SELECT *
+          FROM affected_and_patched
+          UNION ALL (
+            SELECT *
+              FROM not_affected
+          )
+    ) X
+    ORDER BY X.system_id, X.channel_rank, X.errata_id NULLS LAST
   </query>
 </mode>
 


### PR DESCRIPTION
This is a follow-up fix for #326 