### PR TITLE
Bind /srv/mirror for OBS submissions

### DIFF
--- a/susemanager-utils/testing/automation/push-to-obs.sh
+++ b/susemanager-utils/testing/automation/push-to-obs.sh
@@ -53,4 +53,4 @@ fi
 PUSH_CMD="/manager/susemanager-utils/testing/docker/scripts/push-to-obs.sh -d '${DESTINATIONS}' -c /tmp/.oscrc ${VERBOSE} ${TEST}"
 
 docker pull $REGISTRY/$PUSH2OBS_CONTAINER
-docker run --rm=true -v "$GITROOT:/manager" --mount type=bind,source=${CREDENTIALS},target=/tmp/.oscrc $REGISTRY/$PUSH2OBS_CONTAINER /bin/bash -c "${PUSH_CMD}"
+docker run --rm=true -v "$GITROOT:/manager" -v "/srv/mirror:/srv/mirror" --mount type=bind,source=${CREDENTIALS},target=/tmp/.oscrc $REGISTRY/$PUSH2OBS_CONTAINER /bin/bash -c "${PUSH_CMD}"


### PR DESCRIPTION
## What does this PR change?

Bind /srv/mirror for OBS submissions, for Jenkins executions, so we avoid https://ci.suse.de/view/Manager/view/Manager-Head/job/manager-Head-2obs/16625/consoleFull

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: This is a transparent change, and does not affect users.

- [x] **DONE**

## Test coverage

- No tests: No tests for rel-eng tools.

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/5940

Once approved, IMHO this should be merged to 3.1 and 3.2.

- [x] **DONE**
