### PR TITLE
Add SUSE CA to uyuni-push-to-obs, required to push to IBS

### DIFF
--- a/susemanager-utils/testing/docker/master/uyuni-push-to-obs/add_packages.sh
+++ b/susemanager-utils/testing/docker/master/uyuni-push-to-obs/add_packages.sh
@@ -6,4 +6,5 @@ zypper --non-interactive in osc \
              git \
              tito \
 	     build \
-	     npm
+	     npm \
+	     ca-certificates-suse

--- a/susemanager-utils/testing/docker/master/uyuni-push-to-obs/add_repositories.sh
+++ b/susemanager-utils/testing/docker/master/uyuni-push-to-obs/add_repositories.sh
@@ -2,3 +2,4 @@
 set -e
 
 zypper ar -f https://download.opensuse.org/repositories/home:/mcalmer:/tito/openSUSE_Leap_15.0/home:mcalmer:tito.repo
+zypper ar -f http://download.suse.de/ibs/SUSE:/CA/openSUSE_Leap_15.0/SUSE:CA.repo

--- a/susemanager-utils/testing/docker/scripts/push-to-obs.sh
+++ b/susemanager-utils/testing/docker/scripts/push-to-obs.sh
@@ -52,7 +52,7 @@ cd ${REL_ENG_FOLDER}
 
 # If we have more than one destinations, keep SRPMS so we don't
 # need to rebuild for each submission
-if [ "$(echo ${DESTIONATIONS}|cut -d',' -f2)" != "" ]; then
+if [ "$(echo ${DESTINATIONS}|cut -d',' -f2)" != "" ]; then
   export KEEP_SRPMS=TRUE
 fi
 


### PR DESCRIPTION
## What does this PR change?

Unfortunately tests for #331 included pushing everything to a branch of Uyuni at OBS, but not to a branch of Head at IBS, so I did not notice the failure with the certificate (https://ci.suse.de/view/Manager/view/Manager-Head/job/manager-Head-2obs/16627/console)

This PR fixes the problem by installing ca-certificates-suse.

The image was already regenerated and pushed and is working at https://ci.suse.de/view/Manager/view/Manager-Head/job/manager-Head-2obs/16628/console

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: This is a transparent change, and does not affect users.

- [x] **DONE**

## Test coverage

- No tests: No tests for rel-eng tools.

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/5940

Once approved, IMHO this should be merged to 3.1 and 3.2.

- [x] **DONE**
