### PR TITLE
Fix base channel selection, when there is no base channel selected (testsuite)

### DIFF
--- a/web/html/src/manager/channels/subscribe-channels/subscribe-channels.js
+++ b/web/html/src/manager/channels/subscribe-channels/subscribe-channels.js
@@ -43,7 +43,7 @@ type ChannelDto = {
   custom: boolean,
   subscribable: boolean,
   recommended: boolean,
-  compatibleChannelPreviousSelection?: boolean,
+  compatibleChannelPreviousSelection?: number,
 }
 
 type SystemChannelsState = {
@@ -98,16 +98,21 @@ class SystemChannels extends React.Component<SystemChannelsProps, SystemChannels
     Network.get(`/rhn/manager/api/systems/${this.props.serverId}/channels`)
       .promise.then(data => {
         const base : ChannelDto = data.data && data.data.base ? data.data.base : this.getNoBase();
+        const childrenIds = data.data.children ? data.data.children.map(c => c.id) : [];
         this.setState({
           originalBase: base,
           selectedBase: base,
-          selectedChildrenIds: new Map([[base.id, new Set(data.data.children.map(c => c.id))]]),
-          assignedChildrenIds : new Set(data.data.children.map(c => c.id)),
+          selectedChildrenIds: new Map([[base.id, new Set(childrenIds)]]),
+          assignedChildrenIds : new Set(childrenIds),
         });
         if (data.data && data.data.base) {
           this.getAccessibleChildren(data.data.base.id);
+        } else {
+          this.setState({
+            dependencyDataAvailable: true,
+          })
         }
-      })
+    })
       .catch(this.handleResponseError);
 
     Network.get(`/rhn/manager/api/systems/${this.props.serverId}/channels-available-base`)


### PR DESCRIPTION
## What does this PR change?

This PR fix to things:

- When there isn't a base channel associated the none default channel wasn't being selected.
- Fix the flag dependencyDataAvailable to true, when the none channel is selected.

This problem already existed but only started to have a bigger impact with this: https://github.com/uyuni-project/uyuni/pull/298/commits/d40929a1f0674b75ccedca0d29935d66c2c5e263
