### PR TITLE
Manager configure proxy

### DIFF
--- a/proxy/installer/spacewalk-proxy-installer.changes
+++ b/proxy/installer/spacewalk-proxy-installer.changes
@@ -1,5 +1,5 @@
 - Add support for Python 3 on spacewalk-proxy-installer
-
+- don't write invalid values to answer file for configure-proxy.sh
 -------------------------------------------------------------------
 Fri Oct 26 10:35:58 CEST 2018 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

If questions of the configure-proxy.sh script are answered by simply pressing ENTER, invalid answers (such as "y/N") get written to the answer file because ACCUMULATED_ANSWERS are being collected before the input gets interpreted. This PR fixes this issue. 3.1 is not affected.

Issue reported only internally, no bugzilla entry: https://github.com/SUSE/spacewalk/issues/5757