### PR TITLE
Manager pg10 supportconfig

### DIFF
--- a/backend/satellite_tools/spacewalk-debug
+++ b/backend/satellite_tools/spacewalk-debug
@@ -329,6 +329,14 @@ if [ $? == 0 ]; then
 	PGSQL_ROOT="/opt/rh/postgresql92/root"
 fi
 
+PGMAJOR=`psql --version | cut -f 3 -d" " | cut -b 1`
+
+if [ "$PGMAJOR" = 9 ]; then
+    PGLOGDIR="pg_log"
+else
+    PGLOGDIR="log"
+fi
+
 # PostgreSQL configuration
 if [ -f $PGSQL_ROOT/var/lib/pgsql/postgresql.conf ] ; then
   echo "    * copying postgresql.conf"
@@ -351,14 +359,15 @@ fi
 ls $PGSQL_ROOT/var/lib/pgsql/data/*.conf 2>/dev/null | xargs -I file cp -fa file $DIR/database
 
 # compress postgres logs
-if [ -d $PGSQL_ROOT/var/lib/pgsql/data/pg_log ]; then
+if [ -d $PGSQL_ROOT/var/lib/pgsql/data/$PGLOGDIR ]; then
 
-    PGSQL_LOGS_SIZE=$(du -s $PGSQL_ROOT/var/lib/pgsql/data/pg_log | cut -d'/' -f1)
+    PGSQL_LOGS_SIZE=$(du -s $PGSQL_ROOT/var/lib/pgsql/data/$PGLOGDIR | cut -d'/' -f1)
     if [ $PGSQL_LOGS_SIZE -gt $MAX_PGSQL_LOGS_SIZE ]; then
-        echo "    * $PGSQL_ROOT/var/lib/pgsql/data/pg_log exceeded the maximum size allowed. Please copy it separately."
+        echo "    * $PGSQL_ROOT/var/lib/pgsql/data/$PGLOGDIR exceeded the maximum size allowed. Please copy it separately."
         echo "PostgreSQL logs exceeded the maximum size of $MAX_PGSQL_LOGS_SIZE bytes" >> $DIR/database/warning
     else
-        for pg_log in $(ls $PGSQL_ROOT/var/lib/pgsql/data/pg_log/* 2>/dev/null); do
+        echo "    * copying logfiles"
+        for pg_log in $(ls $PGSQL_ROOT/var/lib/pgsql/data/$PGLOGDIR/* 2>/dev/null); do
             cat $pg_log | gzip > $DIR/database/$(basename $pg_log).gz
         done
     fi

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,6 +1,6 @@
 - Fix issue raising exceptions 'with_traceback' on Python 2
 - Hide Python traceback and show only error message (bsc#1110427)
-
+- honor renamed postgresql10 log directory for supportconfig
 -------------------------------------------------------------------
 Fri Oct 26 10:06:41 CEST 2018 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

With postgresql10 the directory for the database log files has been renamed from "pg_log" to just "log". Make sure to provide the logfiles independently from the postgresql version.