### PR TITLE
Testsuite: Fix notifications cucumber tests after react 16 upgrade

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -766,7 +766,7 @@ end
 
 And(/^I delete it via the "([^"]*)" button$/) do |target_button|
   if count_table_items != '0'
-    xpath_for_delete_button = "//button[.//span[contains(text(), '#{target_button}')]]"
+    xpath_for_delete_button = "//button[contains(text(), '#{target_button}')]"
     raise unless find(:xpath, xpath_for_delete_button).click
 
     step %(I wait until I see "1 message deleted successfully." text)
@@ -775,7 +775,7 @@ end
 
 And(/^I mark as read it via the "([^"]*)" button$/) do |target_button|
   if count_table_items != '0'
-    xpath_for_read_button = "//button[.//span[contains(text(), '#{target_button}')]]"
+    xpath_for_read_button = "//button[contains(text(), '#{target_button}')]"
     raise unless find(:xpath, xpath_for_read_button).click
 
     step %(I wait until I see "1 message read status updated successfully." text)


### PR DESCRIPTION
## What does this PR change?

Fix notifications cucumber tests after react 16 upgrade.

Basically react on older versions to match his internal state with the dom, used a special data attribute, data-reactid, which no longer happens on the most recent version. Hence that span tag is not generated anymore by react.

Before Upgrade:
`<span data-reactid=".1.1:4.0.0.1.1">Delete selected messages</span>`

After Upgrade:
`"Delete selected messages"`

