### PR TITLE
Add check for malformed YAML file (bsc#1110757)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/salt/ApplyStatesAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/salt/ApplyStatesAction.java
@@ -22,6 +22,7 @@ import com.redhat.rhn.domain.user.User;
 import org.apache.commons.lang3.StringEscapeUtils;
 
 import java.util.Comparator;
+import java.util.List;
 
 /**
  * ApplyStatesAction - Action class representing the application of Salt states.
@@ -76,7 +77,14 @@ public class ApplyStatesAction extends Action {
 
     private String formatStateApplyResult(ApplyStatesActionResult result) {
         StringBuilder retval = new StringBuilder();
-        result.getResult().stream()
+        List<StateResult> resultList = result.getResult();
+        if (resultList.isEmpty()) {
+            retval.append("<strong><span class='text-danger'>");
+            retval.append("Error: Could not parse state file. Please check YAML syntax.");
+            retval.append("</span></strong>");
+            return retval.toString();
+        }
+        resultList.stream()
         .sorted(
                 new Comparator<StateResult>() {
                     public int compare(StateResult r1, StateResult r2) {

--- a/java/code/src/com/redhat/rhn/domain/action/salt/ApplyStatesAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/salt/ApplyStatesAction.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.domain.action.salt;
 
+import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFormatter;
 import com.redhat.rhn.domain.server.Server;
@@ -23,6 +24,7 @@ import org.apache.commons.lang3.StringEscapeUtils;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * ApplyStatesAction - Action class representing the application of Salt states.
@@ -77,14 +79,15 @@ public class ApplyStatesAction extends Action {
 
     private String formatStateApplyResult(ApplyStatesActionResult result) {
         StringBuilder retval = new StringBuilder();
-        List<StateResult> resultList = result.getResult();
-        if (resultList.isEmpty()) {
+        Optional<List<StateResult>> resultList = result.getResult();
+        if (!resultList.isPresent()) {
+            LocalizationService ls = LocalizationService.getInstance();
             retval.append("<strong><span class='text-danger'>");
-            retval.append("Error: Could not parse state file. Please check YAML syntax.");
+            retval.append("Error: " + ls.getMessage("system.event.details.syntaxerror"));
             retval.append("</span></strong>");
             return retval.toString();
         }
-        resultList.stream()
+        resultList.get().stream()
         .sorted(
                 new Comparator<StateResult>() {
                     public int compare(StateResult r1, StateResult r2) {

--- a/java/code/src/com/redhat/rhn/domain/action/salt/ApplyStatesActionResult.java
+++ b/java/code/src/com/redhat/rhn/domain/action/salt/ApplyStatesActionResult.java
@@ -25,6 +25,7 @@ import java.io.Serializable;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * ApplyStatesActionResult
@@ -117,9 +118,9 @@ public class ApplyStatesActionResult implements Serializable {
     }
 
     /**
-     * @return a list of state results
+     * @return Optional with list of state results or empty
      */
-    public List<StateResult> getResult() {
+    public Optional<List<StateResult>> getResult() {
         Yaml yaml = new Yaml();
         List<StateResult> result = new LinkedList<>();
         try {
@@ -130,9 +131,9 @@ public class ApplyStatesActionResult implements Serializable {
             });
         }
         catch (ConstructorException ce) {
-            return new LinkedList<>();
+            return Optional.empty();
         }
-        return result;
+        return Optional.of(result);
     }
 
     @Override

--- a/java/code/src/com/redhat/rhn/domain/action/salt/ApplyStatesActionResult.java
+++ b/java/code/src/com/redhat/rhn/domain/action/salt/ApplyStatesActionResult.java
@@ -19,6 +19,7 @@ import com.redhat.rhn.common.hibernate.HibernateFactory;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.ConstructorException;
 
 import java.io.Serializable;
 import java.util.LinkedList;
@@ -120,12 +121,17 @@ public class ApplyStatesActionResult implements Serializable {
      */
     public List<StateResult> getResult() {
         Yaml yaml = new Yaml();
-        @SuppressWarnings("unchecked")
-        Map<String, Map<String, Object>> payload = yaml.loadAs(getOutputContents(), Map.class);
         List<StateResult> result = new LinkedList<>();
-        payload.entrySet().stream().forEach(e -> {
-            result.add(new StateResult(e));
-        });
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Map<String, Object>> payload = yaml.loadAs(getOutputContents(), Map.class);
+            payload.entrySet().stream().forEach(e -> {
+                result.add(new StateResult(e));
+            });
+        }
+        catch (ConstructorException ce) {
+            return new LinkedList<>();
+        }
         return result;
     }
 

--- a/java/code/src/com/redhat/rhn/domain/action/test/ApplyStatesActionResultTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/test/ApplyStatesActionResultTest.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2018 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.domain.action.test;
+
+import com.redhat.rhn.domain.action.salt.ApplyStatesActionResult;
+import com.redhat.rhn.domain.action.salt.StateResult;
+import com.redhat.rhn.testing.RhnBaseTestCase;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+
+import junit.framework.Assert;
+import junit.framework.AssertionFailedError;
+
+
+/**
+ * ApplyStatesActionResultTest
+ */
+public class ApplyStatesActionResultTest extends RhnBaseTestCase {
+
+    /**
+     * Tests getResult Method for invalid Output
+     * @throws AssertionFailedError exception if test fails
+     */
+    public void testGetOptionalEmptyForMalformedOutput() throws AssertionFailedError {
+        ApplyStatesActionResult stateResult = new ApplyStatesActionResult();
+        stateResult.setOutput("Gibberish".getBytes(StandardCharsets.UTF_8));
+        Optional<List<StateResult>> result = stateResult.getResult();
+
+        Assert.assertFalse(result.isPresent());
+    }
+
+    /**
+     * Tests getResult Method for valid Output
+     * @throws AssertionFailedError exception if test fails
+     */
+    public void testResultIsPresentForValidStateRun() throws AssertionFailedError {
+        ApplyStatesActionResult stateResult = new ApplyStatesActionResult();
+
+        String stdout  =
+                "cmd_|-date_|-date_|-run:\n" +
+                "    comment: Command \"date\" run\n" +
+                "    name: date\n" +
+                "    start_time: '08:17:16.063154'\n" +
+                "    result: true\n" +
+                "    duration: 36.353\n" +
+                "    __run_num__: 0.0\n" +
+                "    __sls__: manager_org_1.testchannel\n" +
+                "    changes:\n" +
+                "        pid: 1346.0\n" +
+                "        retcode: 0.0\n" +
+                "        stderr: ''\n" +
+                "        stdout: Wed Nov 28 08:17:16 CET 2018\n" +
+                "    __id__: date\n";
+
+        stateResult.setOutput(stdout.getBytes(StandardCharsets.UTF_8));
+
+        Optional<List<StateResult>> result = stateResult.getResult();
+
+        Assert.assertTrue(result.isPresent());
+    }
+}

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -11445,6 +11445,9 @@ the &lt;strong&gt;Red Hat Enterprise Linux System Administration Guide.&lt;/stro
         <trans-unit id="system.event.details.returned">
           <source>Client execution returned &lt;pre&gt;{0}&lt;/pre&gt; (code {1})</source>
         </trans-unit>
+        <trans-unit id="system.event.details.syntaxerror">
+          <source>Could not parse state file. Please check YAML syntax.</source>
+        </trans-unit>
         <trans-unit id="system.event.rescheduleText">
           <source>This history event was caused by a failed scheduled action.&lt;br /&gt;If you have corrected the problem, you may reschedule the action below.</source>
         </trans-unit>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add check to prevent internal exception for invalid state file (bsc#1110757)
 - use a Salt engine to process return results (bsc#1099988)
 - Add check for yast autoinstall profiles when setting kickstartTree (bsc#1114115)
 - Fix handling of CVEs including multiple patches in CVE audit (bsc#1111963)

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,4 +1,4 @@
-- Add check to prevent internal exception for invalid state file (bsc#1110757)
+- Handle with an error message if state file fails to render (bsc#1110757)
 - use a Salt engine to process return results (bsc#1099988)
 - Add check for yast autoinstall profiles when setting kickstartTree (bsc#1114115)
 - Fix handling of CVEs including multiple patches in CVE audit (bsc#1111963)


### PR DESCRIPTION
Add a check which prevents an unhandles internal
exception when the user wants to read the output
of a state with invalid YAML syntax.

Now it reports back an error message to the user.

cherry-pick from https://github.com/SUSE/spacewalk/pull/6406