### PR TITLE
Exit with an error if spacewalk-common-channels does not match any channel

### DIFF
--- a/utils/spacewalk-common-channels
+++ b/utils/spacewalk-common-channels
@@ -211,6 +211,10 @@ Create everything as well as unlimited activation key for every channel:
                 if name not in child_channels:
                     child_channels[name] = []
 
+    if not matching_channels:
+        sys.stderr.write("No channels matching your selection.\n")
+        sys.exit(2)
+                    
     for (base_channel_label, create_channel) in sorted(base_channels.items()):
 
         if key == None:

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,5 @@
+- Exit with an error if spacewalk-common-channels does not match
+  any channel
 - Fix typo at --phases option help
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Exit with an error if spacewalk-common-channels does not match any channel.

Previously the user did not get any message at all, not even with `-v` and of course Uyuni Server logs did not show anything.

Before:
```
client-test-server:~ # spacewalk-common-channels --verbose -u admin -p admin -a x86_64 opensuse_leap42_3-x86_64-update
client-test-server:~ #
```

Now:
```
client-test-server:~ # spacewalk-common-channels --verbose -u admin -p admin -a x86_64 opensuse_leap42_3-x86_64-update
No channels matching your selection.
client-test-server:~ #
```

Adding channels is still working fine:
```
client-test-server:~ # spacewalk-common-channels -u admin -p admin -a x86_64 opensuse_leap42_3 opensuse_leap42_3-updates opensuse_leap_42_3-uyuni-client-devel
client-test-server:~ #
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: Just adding more output for the user, but this is not mentioned at the doc.

- [x] **DONE**

## Test coverage
- No tests: Should be already covered.

- [x] **DONE**

## Links

Tracks: https://github.com/SUSE/spacewalk/issues/6177

- [x] **DONE**
