### PR TITLE
Avoid adding the parameter OldBaseChannelIdParam when the default basehannel is selected

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/SystemsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/SystemsController.java
@@ -335,7 +335,7 @@ public class SystemsController {
             catch (Exception e) {
                 // This is not a critical feature for this request, we want to keep moving forward anyway
                 // but log that something unexpected happened
-                LOG.error("An oldBaseChannelId parameter wasn't provided when fetching childchannels", e);
+                LOG.error("A wrong oldBaseChannelId parameter was provided when fetching childchannels", e);
             }
 
             try {

--- a/web/html/src/manager/channels/subscribe-channels/subscribe-channels.js
+++ b/web/html/src/manager/channels/subscribe-channels/subscribe-channels.js
@@ -126,7 +126,8 @@ class SystemChannels extends React.Component<SystemChannelsProps, SystemChannels
 
   getAccessibleChildren = (newBaseId: number) => {
     if (!this.state.availableChildren.has(newBaseId)) {
-      const queryString = this.state.originalBase ? `?oldBaseChannelId=${this.state.originalBase.id}` : '';
+      const shouldIncludeOldBaseChannelIdParam = this.state.originalBase && this.state.originalBase.id !== this.getNoBase().id;
+      const queryString = shouldIncludeOldBaseChannelIdParam && this.state.originalBase ? `?oldBaseChannelId=${this.state.originalBase.id}` : '';
       Network.get(`/rhn/manager/api/systems/${this.props.serverId}/channels/${newBaseId}/accessible-children${queryString}`).promise
         .then((data: JsonResult<Array<ChannelDto>>) => {
           const newChildren = new Map(


### PR DESCRIPTION
## What does this PR change?

Avoid adding the parameter OldBaseChannelIdParam when the default basehannel (none channel) is selected

Typical case when two bugs together are harmless but can be really noisy alone, even without a big impact :) 

Related with fix: https://github.com/uyuni-project/uyuni/pull/343