### PR TITLE
Add instructions about the changelog test to the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,3 +31,13 @@ Fixes #
 Tracks # **add downstream PR, if any**
 
 - [ ] **DONE**
+
+## Changelogs
+
+Copy the following sentence as a new comment if you don't need changelog entries:
+
+> gitarro no changelog needed !!!
+
+If the test `changelog_test`already run, then add another new comment with the following text:
+
+> gitarro rerun changelog_test !!!


### PR DESCRIPTION
## What does this PR change?

Add instructions about the changelog test to the PR template.

Adding the commands to the description does NOT provoke gitarro removing the description, as seen at https://github.com/SUSE/spacewalk/pull/6471

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- This is documentation

- [x] **DONE**

## Test coverage

- No tests: This is documentation, about tests.

- [x] **DONE**

## Links

As discussed at retrospective.

- [x] **DONE**
