### PR TITLE
Fix conflict of react 16 with jquery bootstrap tables (testsuite)

### DIFF
--- a/web/html/src/components/config-channels.js
+++ b/web/html/src/components/config-channels.js
@@ -388,16 +388,18 @@ class ConfigChannels extends React.Component {
               <RankingTable items={currentAssignment} onUpdate={this.onUpdateRanking} emptyMsg={t("There are no states assigned.")}/>
             </div>
             :
-            <table className="table table-striped">
-              <thead>
-                <tr>
-                  <th>{t("Channel Name")}</th>
-                  <th>{t("Channel Label")}</th>
-                  <th>{t("Assign")}</th>
-                </tr>
-              </thead>
-              {this.tableBody()}
-            </table>
+            <span>
+              <table className="table table-striped">
+                <thead>
+                  <tr>
+                    <th>{t("Channel Name")}</th>
+                    <th>{t("Channel Label")}</th>
+                    <th>{t("Assign")}</th>
+                  </tr>
+                </thead>
+                {this.tableBody()}
+              </table>
+            </span>
           }
 
           <SaltStatePopup saltState={this.state.showSaltState} onClosePopUp={this.onClosePopUp}/>


### PR DESCRIPTION
## What does this PR change?

This indeed a weird bug. 

My guess, that makes sense, is that bootstrap is modifying the DOM with the classname table, making react losing control of it, so throwing up an error when it tries to remove it due to the state.rank variable change to true.

Error: `Uncaught DOMException: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.`

Now the question is: Why this wasn't a problem before?

Basically react on older versions to match his internal state with the dom, used a special data attribute, data-reactid, which no longer happens on the most recent version. Hence that span tag is not generated anymore by react, having react trying to remove directly the <table> element and not the previously generated <span>.
