### PR TITLE
clean directories which are generated by yarn as user root

### DIFF
--- a/susemanager-utils/testing/docker/scripts/push-to-obs.sh
+++ b/susemanager-utils/testing/docker/scripts/push-to-obs.sh
@@ -68,4 +68,7 @@ for DESTINATION in $(echo ${DESTINATIONS}|tr ',' ' '); do
   ./push-packages-to-obs.sh
 done
 
-# Clean
+# Clean directories generated as user root
+rm -r ./susemanager-frontend/susemanager-nodejs-sdk-devel/node_modules
+rm -r ./web/html/src/node_modules
+rm -r ./web/html/src/dist


### PR DESCRIPTION
## What does this PR change?

We call the build scripts now in a container. The build scripts call "yarn" which generate new directories as user root when running as container.
This change remove them after the task is done.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **internal**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
