### PR TITLE
Update rack gem to 1.6.11 (fixes CVE-2018-16471)

### DIFF
--- a/testsuite/Gemfile
+++ b/testsuite/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # FIXME: these gems cannot be updated to major, because
 # they requires Ruby version >= 2.2. (we need first to upgrade ruby to 2.2.2)
 gem 'cucumber', '2.0.0'
-gem 'rack', '1.6.8'
+gem 'rack', '1.6.11'
 gem 'rack-test', '0.7.0'
 # This gems are latest stable
 gem 'capybara', '2.16.0'


### PR DESCRIPTION
## What does this PR change?

Update rack gem to 1.6.11 (fixes CVE-2018-16471).

Tested locally and working fine:
```
module.ctl.module.controller.libvirt_domain.domain (remote-exec):           ID: install_gems_via_bundle
module.ctl.module.controller.libvirt_domain.domain (remote-exec):     Function: cmd.run
module.ctl.module.controller.libvirt_domain.domain (remote-exec):         Name: bundle.ruby2.1 install --gemfile /root/spacewalk/testsuite/Gemfile
module.ctl.module.controller.libvirt_domain.domain (remote-exec):       Result: True
module.ctl.module.controller.libvirt_domain.domain (remote-exec):      Comment: Command "bundle.ruby2.1 install --gemfile /root/spacewalk/testsuite/Gemfile" run
module.ctl.module.controller.libvirt_domain.domain (remote-exec):      Started: 13:10:27.517591
module.ctl.module.controller.libvirt_domain.domain (remote-exec):     Duration: 255238.871 ms
module.ctl.module.controller.libvirt_domain.domain (remote-exec):      Changes:
module.ctl.module.controller.libvirt_domain.domain (remote-exec):               ----------                                                                                                                                                                                     
module.ctl.module.controller.libvirt_domain.domain (remote-exec):               pid:
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   3191
module.ctl.module.controller.libvirt_domain.domain (remote-exec):               retcode:
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   0
module.ctl.module.controller.libvirt_domain.domain (remote-exec):               stderr:
module.ctl.module.controller.libvirt_domain.domain (remote-exec):               stdout:
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Don't run Bundler as root. Bundler can
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   ask for sudo if it is needed, and
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   installing your bundle as root will
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   break this application for all non-root
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   users on this machine.
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Fetching gem metadata from https://rubygems.org/........
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Fetching version metadata from https://rubygems.org/..
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Resolving dependencies.........
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Installing rake 12.3.0
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Installing public_suffix 3.0.3
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Installing addressable 2.5.2
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Installing builder 3.2.3
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Installing mini_mime 1.0.1
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Installing mini_portile2 2.3.0
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Installing nokogiri 1.8.2 with native extensions
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Installing rack 1.6.11
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Installing rack-test 0.7.0
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Installing xpath 2.1.0
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Installing capybara 2.16.0
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Installing ffi 1.9.25 with native extensions
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Installing childprocess 0.9.0
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Installing multi_json 1.13.1
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Installing gherkin 2.12.2 with native extensions
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Installing cucumber-core 1.1.3
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Installing diff-lcs 1.3
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Installing multi_test 0.1.2
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Installing cucumber 2.0.0
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Installing docile 1.1.5
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Installing json 2.1.0 with native extensions
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Installing jwt 2.1.0
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Installing mime-types-data 3.2018.0812
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Installing mime-types 3.1
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Installing net-ssh 4.2.0
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Installing rubyzip 1.2.2
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Installing selenium-webdriver 3.8.0
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Installing simplecov-html 0.10.2
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Installing simplecov 0.15.1
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Using twopence 0.3.8
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Installing websocket 1.2.5
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Installing websocket-extensions 0.1.3
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Installing websocket-driver 0.7.0 with native extensions
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Using bundler 1.10.6
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Bundle complete! 14 Gemfile dependencies, 34 gems now installed.
module.ctl.module.controller.libvirt_domain.domain (remote-exec):                   Use `bundle show [gemname]` to see where a bundled gem is installed.
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Testsuite dependency.

- [x] **DONE**

## Test coverage
- No tests: Covered by cucumber.

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/6348

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already ran, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
