### PR TITLE
Testsuite (uyuni): wait until child channels from previous base channels are loaded before picking a new one

### DIFF
--- a/testsuite/features/allcli_software_channels.feature
+++ b/testsuite/features/allcli_software_channels.feature
@@ -35,6 +35,7 @@ Feature: Chanel subscription via SSM
     Given I am on the Systems overview page of this "sle-minion"
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
     Then radio button "Test-Channel-x86_64" is checked
     And I wait until I do not see "Loading..." text
     And I should see "Test-Channel-x86_64 Child Channel" as unchecked
@@ -43,6 +44,7 @@ Feature: Chanel subscription via SSM
     Given I am on the Systems overview page of this "sle-client"
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
     Then radio button "Test-Channel-x86_64" is checked
     And I wait until I do not see "Loading..." text
     And I should see "Test-Channel-x86_64 Child Channel" as unchecked
@@ -71,6 +73,7 @@ Feature: Chanel subscription via SSM
     Given I am on the Systems overview page of this "sle-minion"
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
     Then radio button "Test Base Channel" is checked
     And I wait until I do not see "Loading..." text
     And I should see "Test Child Channel" as checked
@@ -79,6 +82,7 @@ Feature: Chanel subscription via SSM
     Given I am on the Systems overview page of this "sle-client"
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
     Then radio button "Test Base Channel" is checked
     And I wait until I do not see "Loading..." text
     And I should see "Test Child Channel" as checked
@@ -130,6 +134,7 @@ Feature: Chanel subscription via SSM
     Given I am on the Systems overview page of this "sle-minion"
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
     And I check radio button "Test-Channel-x86_64"
     And I wait until I do not see "Loading..." text
     And I wait until I see "Test-Channel-x86_64 Child Channel" text
@@ -145,6 +150,7 @@ Feature: Chanel subscription via SSM
     Given I am on the Systems overview page of this "sle-client"
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
     And I check radio button "Test-Channel-x86_64"
     And I wait until I do not see "Loading..." text
     And I wait until I see "Test-Channel-x86_64 Child Channel" text

--- a/testsuite/features/allcli_software_channels_dependencies.feature
+++ b/testsuite/features/allcli_software_channels_dependencies.feature
@@ -9,6 +9,7 @@ Feature: Chanel subscription with recommended/required dependencies
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     # check that the required channel by the base one is selected and disabled
+    And I wait until I do not see "Loading..." text
     And I check radio button "SLE-Product-SLES15-Pool for x86_64"
     And I wait until I do not see "Loading..." text
     Then I should see the child channel "SLE-Product-SLES15-Updates for x86_64" "selected" and "disabled"

--- a/testsuite/features/core_centos_salt_ssh.feature
+++ b/testsuite/features/core_centos_salt_ssh.feature
@@ -58,6 +58,7 @@ Feature: Bootstrap a SSH-managed CentOS minion and do some basic operations on i
     Given I am on the Systems overview page of this "ceos-minion"
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
     And I check radio button "Test Base Channel"
     And I wait until I do not see "Loading..." text
     And I click on "Next"

--- a/testsuite/features/core_min_bootstrap.feature
+++ b/testsuite/features/core_min_bootstrap.feature
@@ -83,6 +83,7 @@ Feature: Be able to bootstrap a Salt minion via the GUI
     Given I am on the Systems overview page of this "sle-minion"
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
     And I check radio button "Test-Channel-x86_64"
     And I wait until I do not see "Loading..." text
     And I click on "Next"

--- a/testsuite/features/core_min_salt_ssh.feature
+++ b/testsuite/features/core_min_salt_ssh.feature
@@ -39,6 +39,7 @@ Feature: Be able to bootstrap a Salt host managed via salt-ssh
     Given I am on the Systems overview page of this "ssh-minion"
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
     And I check radio button "Test-Channel-x86_64"
     And I wait until I do not see "Loading..." text
     And I click on "Next"

--- a/testsuite/features/min_bootstrap_xmlrpc.feature
+++ b/testsuite/features/min_bootstrap_xmlrpc.feature
@@ -44,6 +44,7 @@ Feature: Register a Salt minion via XML-RPC API
     Given I am on the Systems overview page of this "sle-minion"
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
     And I check radio button "Test-Channel-x86_64"
     And I wait until I do not see "Loading..." text
     And I click on "Next"

--- a/testsuite/features/min_salt_minions_page.feature
+++ b/testsuite/features/min_salt_minions_page.feature
@@ -85,6 +85,7 @@ Feature: Management of minion keys
     Given I am on the Systems overview page of this "sle-minion"
     When I follow "Software" in the content area
     Then I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
     And I check radio button "Test-Channel-x86_64"
     And I wait until I do not see "Loading..." text
     And I click on "Next"

--- a/testsuite/features/minssh_bootstrap_xmlrpc.feature
+++ b/testsuite/features/minssh_bootstrap_xmlrpc.feature
@@ -48,6 +48,7 @@ Feature: Register a salt-ssh system via XML-RPC
     Given I am on the Systems overview page of this "ssh-minion"
     When I follow "Software" in the content area
     Then I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
     And I check radio button "Test-Channel-x86_64"
     And I wait until I do not see "Loading..." text
     And I click on "Next"


### PR DESCRIPTION
## What does this PR change?

Wait until child channels from previous base channels are loaded before picking a new one.

Related with the PR: https://github.com/uyuni-project/uyuni/pull/298 and commit https://github.com/uyuni-project/uyuni/pull/298/commits/d40929a1f0674b75ccedca0d29935d66c2c5e263

This wasn't a problem on HEAD because it seems the child channels are loading way faster on Head than Uyuni