### PR TITLE
Testsuite: remove channel/errata check for a patched system

### DIFF
--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Hide already applied errata and channel entries from the output list in
+  audit.listSystemsByPatchStatus (bsc#1111963)
 - Handle with an error message if state file fails to render (bsc#1110757)
 - use a Salt engine to process return results (bsc#1099988)
 - Add check for yast autoinstall profiles when setting kickstartTree (bsc#1114115)

--- a/testsuite/features/srv_cve_audit.feature
+++ b/testsuite/features/srv_cve_audit.feature
@@ -116,8 +116,6 @@ Feature: CVE Audit
     Given I am logged in via XML-RPC cve audit as user "admin" and password "admin"
     When I call audit.list_systems_by_patch_status with CVE identifier "CVE-1999-9999"
     Then I should get status "PATCHED" for this client
-    And I should get the test-channel
-    And I should get the "milkyway-dummy-2345" patch
     Then I logout from XML-RPC cve audit namespace
 
   Scenario: Cleanup: remove installed packages


### PR DESCRIPTION
This PR removes the additional checks in CVE audit for channel and patch information for a patched system.

### Problem
`audit.listSystemsByPatchStatus` used to return the relevant patch and channel info even for `PATCHED` systems, but this is not the case anymore since #326.

At first look, it may seem that including installed patch/channel info could be more informative, but in some cases, it leads to confusing results:

The output is confusing when the system is in a partly patched state, having only part of the patches installed. In this case, the output will show both installed and missing patches for the CVE, without telling which one is already installed.

### Solution
In the end, I decided to keep the change and removed the extra cases from the testsuite instead.
Since keeping the change means that #326 introduces an API change, I added an extra changelog entry as well.

The unit test introduced with #326 already checks for the absence of the applied patches in the output.

## GUI diff

*XMLRPC output from `audit.listSystemsByPatchStatus` before/after #326*
Before:

```
[{'errata_advisories': ['already-applied-patch'], 'patch_status': 'PATCHED', 'system_id': 1000010000, 'channel_labels': ['my-test-channel']}]
```
After:
```
[{'errata_advisories': [], 'patch_status': 'PATCHED', 'system_id': 1000010000, 'channel_labels': []}]
```
