### PR TITLE
Testsuite(uyuni): Make sure the image store is really created

### DIFF
--- a/testsuite/features/core_srv_docker_profiles.feature
+++ b/testsuite/features/core_srv_docker_profiles.feature
@@ -43,6 +43,8 @@ Feature: Prepare server for using Docker
     And I enter "galaxy-registry" as "label"
     And I enter "registry.mgr.suse.de" as "uri"
     And I click on "create-btn"
+    Then I wait until table row contains a "galaxy-registry" text
+    And I should see a "Items 1 - 1 of 1" text
 
   Scenario: Create a simple image profile without activation key
     Given I am authorized as "admin" with password "admin"

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -376,6 +376,19 @@ When(/^I wait until table row for "([^"]*)" contains button "([^"]*)"$/) do |tex
   end
 end
 
+When(/^I wait until table row contains a "([^"]*)" text$/) do |text|
+  begin
+    Timeout.timeout(DEFAULT_TIMEOUT) do
+      loop do
+        break if has_xpath?("//div[@class=\"table-responsive\"]/table/tbody/tr[.//td[contains(.,'#{text}')]]")
+        sleep 1
+      end
+    end
+  rescue Timeout::Error
+    raise "Couldn't find #{text} in any row"
+  end
+end
+
 # login, logout steps
 
 Given(/^I am authorized as "([^"]*)" with password "([^"]*)"$/) do |arg1, arg2|


### PR DESCRIPTION
## What does this PR change?

Make sure the image store galaxy-registry is really created.

This fix might also prevent a race condition of the image store not being created at all. Sometimes there are test failure due to the image store galaxy-registry not being created, and my wild guess is that this test abort before the ajax request has time to reach the server.
