### PR TITLE
Fix the config channels assignment via SSM (bsc#1117759)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/configuration/ssm/SubscribeConfirm.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/configuration/ssm/SubscribeConfirm.java
@@ -174,7 +174,10 @@ public class SubscribeConfirm extends RhnAction {
                 RhnSetDecl.CONFIG_CHANNELS_RANKING.get(user).getElements());
         Collections.sort(rankElements, new ConfigChannelSetComparator());
 
+        RhnSet selectedChannels = RhnSetDecl.CONFIG_CHANNELS.get(user);
+
         List<ConfigChannel> channels = ((List<RhnSetElement>) rankElements).stream()
+                .filter(elm -> selectedChannels.contains(elm.getElement()))
                 .map(elm -> cm.lookupConfigChannel(user, elm.getElement()))
                 .collect(Collectors.toList());
 

--- a/java/code/src/com/redhat/rhn/frontend/action/configuration/ssm/test/SubscribeConfirmTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/configuration/ssm/test/SubscribeConfirmTest.java
@@ -96,11 +96,12 @@ public class SubscribeConfirmTest extends RhnMockStrutsTestCase {
         channels.addElement(channel4.getId());
         RhnSetFactory.save(channels);
 
-        // Set ranking: 2, 4, 3
+        // Set ranking: 2, 4, 3, 1
         RhnSet channelRanking = RhnSetDecl.CONFIG_CHANNELS_RANKING.get(user);
         channelRanking.addElement(channel2.getId(), 0L);
         channelRanking.addElement(channel4.getId(), 1L);
         channelRanking.addElement(channel3.getId(), 2L);
+        channelRanking.addElement(channel1.getId(), 3L);
         RhnSetFactory.save(channelRanking);
 
         // Send confirm request
@@ -182,11 +183,12 @@ public class SubscribeConfirmTest extends RhnMockStrutsTestCase {
         channels.addElement(channel4.getId());
         RhnSetFactory.save(channels);
 
-        // Set ranking: 2, 4, 3
+        // Set ranking: 2, 4, 3, 1
         RhnSet channelRanking = RhnSetDecl.CONFIG_CHANNELS_RANKING.get(user);
         channelRanking.addElement(channel2.getId(), 0L);
         channelRanking.addElement(channel4.getId(), 1L);
         channelRanking.addElement(channel3.getId(), 2L);
+        channelRanking.addElement(channel1.getId(), 3L);
         RhnSetFactory.save(channelRanking);
 
         // Send confirm request

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix the config channels assignment via SSM (bsc#1117759)
 - Introduce Loggerhead-module.js to store logs from the frontend
 - change SCC sync backend to adapt quicker to SCC changes and improve
   speed of syncing metadata and checking for channel dependencies (bsc#1089121)


### PR DESCRIPTION
## What does this PR change?

Fixes the following situation:

> We have two servers, server1 and server2.
> We have two configuration channels, config1 and config2
> server1 is suscribed to  channel1
> server2  isn't suscribed to any config channel.
> We add both server1 and server2 to SSM in the web interface.
> Using the SSM, we suscribe them to channel2.
> As a result, we would expect that server1 is suscribed to channel1 and channel2, and that server2 is suscribed to channel2 only.
> But both servers are suscribed to both channels. 

My suspect is this commit: bb569349b0a4d843a091bfb88157f8214078cfb0
Here we change the way the new channels are assigned - we started using
`config_channel_ranking` RHN set instead of `config_channels`. The former set
can, however, contain more channels (all the channels that took place in the
ranking, in the example above it would be channels with id `1` and `2`).

This PR fixes this problem by filtering out the channels that aren't in the
`config_channels` set.
 
 ## GUI diff
 
 No difference.
 
 - [x] **DONE**
 
 ## Documentation
 - No documentation needed: bugfix
 
 - [x] **DONE**
 
 ## Test coverage
 - Unit tests were adjusted
 
 - [x] **DONE**
 
 ## Links
 
 Tracks https://github.com/SUSE/spacewalk/issues/6476
 
 - [x] **DONE**