### PR TITLE
Change openscap profile from common to standard in centos tradclient testsuite

### DIFF
--- a/testsuite/features/core_centos_tradclient.feature
+++ b/testsuite/features/core_centos_tradclient.feature
@@ -43,17 +43,18 @@ Feature: Be able to register a CentOS 7 traditional client and do some basic ope
     Given I am on the Systems overview page of this "ceos-traditional-client"
     When I follow "Audit" in the content area
     And I follow "Schedule" in the content area
-    And I enter "--profile common" as "params"
+    And I enter "--profile standard" as "params"
     And I enter "/usr/share/xml/scap/ssg/content/ssg-centos7-xccdf.xml" as "path"
     And I click on "Schedule"
     And I run "rhn_check -vvv" on "ceos-traditional-client"
     Then I should see a "XCCDF scan has been scheduled" text
+    And I wait until event "OpenSCAP xccdf scanning" is completed
 
 @centos_minion
   Scenario: Check the results of the OpenSCAP scan on the CentOS traditional client
     Given I am on the Systems overview page of this "ceos-traditional-client"
     When I follow "Audit" in the content area
-    And I follow "xccdf_org.open-scap_testresult_common"
+    And I follow "xccdf_org.open-scap_testresult_standard"
     Then I should see a "Details of XCCDF Scan" text
     And I should see a "RHEL-7" text
     And I should see a "XCCDF Rule Results" text


### PR DESCRIPTION
## What does this PR change?

Change openscap profile from common to standard in centos tradclient testsuite

This failure is related with a change of the following package: scap-security-guide

**Commit:** https://github.com/ComplianceAsCode/content/commit/eb9cb7e174b7107b880d1a540c50dfb27e20f9ad

Fixes https://github.com/SUSE/spacewalk/issues/6526
