### PR TITLE
Removed shortcut for vendor channels (bsc#1115978)

### DIFF
--- a/java/code/src/com/redhat/rhn/common/security/acl/Access.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/Access.java
@@ -419,6 +419,22 @@ public class Access extends BaseHandler {
     }
 
     /**
+     * Returns true if the user is channel admin of the corresponding channel.
+     * If the channel is a vendor channel, the return value is false.
+     * @param ctx acl context (includes the channel cid and the user name)
+     * @param params parameters for acl (ignored)
+     * @return true if the user is channel admin of the corresponding channel.
+     */
+    public boolean aclUserIsChannelAdmin(Object ctx, String[] params) {
+        Map map = (Map) ctx;
+        Long cid = getAsLong(map.get("cid"));
+        User user = (User) map.get("user");
+        Channel chan = ChannelManager.lookupByIdAndUser(cid, user);
+
+        return UserManager.verifyChannelAdmin(user, chan);
+    }
+
+    /**
      * Returns true if the query param exists.
      * @param ctx acl context
      * @param params parameters for acl (ignored)

--- a/java/code/webapp/WEB-INF/pages/channel/all.jsp
+++ b/java/code/webapp/WEB-INF/pages/channel/all.jsp
@@ -20,7 +20,7 @@ function showFiltered() {
 <rhn:toolbar base="h1" icon="header-channel"
              creationUrl="/rhn/channels/manage/Edit.do"
              creationType="channel"
-             creationAcl="user_role(org_admin)"
+             creationAcl="user_role(channel_admin)"
              helpUrl="/rhn/help/reference/en-US/ref.webui.channels.jsp">
   <bean:message key="channels.all.jsp.toolbar"/>
 </rhn:toolbar>

--- a/java/code/webapp/WEB-INF/pages/channel/custom.jsp
+++ b/java/code/webapp/WEB-INF/pages/channel/custom.jsp
@@ -21,7 +21,7 @@ function showFiltered() {
              helpUrl="/rhn/help/reference/en-US/ref.webui.channels.jsp#s3-sm-channel-list-my"
              creationUrl="/rhn/channels/manage/Edit.do"
              creationType="channel"
-             creationAcl="user_role(org_admin)">
+             creationAcl="user_role(channel_admin)">
   <bean:message key="channel.nav.custom"/>
 </rhn:toolbar>
 

--- a/java/code/webapp/WEB-INF/pages/channel/popular.jsp
+++ b/java/code/webapp/WEB-INF/pages/channel/popular.jsp
@@ -21,7 +21,7 @@
              helpUrl="/rhn/help/reference/en-US/ref.webui.channels.jsp#s3-sm-channel-list-popular"
              creationUrl="/rhn/channels/manage/Edit.do"
              creationType="channel"
-             creationAcl="user_role(org_admin)">
+             creationAcl="user_role(channel_admin)">
     <bean:message key="channel.nav.popular"/>
 </rhn:toolbar>
 

--- a/java/code/webapp/WEB-INF/pages/channel/retired.jsp
+++ b/java/code/webapp/WEB-INF/pages/channel/retired.jsp
@@ -21,7 +21,7 @@ function showFiltered() {
              helpUrl="/rhn/help/reference/en-US/ref.webui.channels.jsp#s3-sm-channel-list-retired"
              creationUrl="/rhn/channels/manage/Edit.do"
              creationType="channel"
-             creationAcl="user_role(org_admin)">
+             creationAcl="user_role(channel_admin)">
   <bean:message key="channels.retired.jsp.toolbar"/>
 </rhn:toolbar>
 

--- a/java/code/webapp/WEB-INF/pages/channel/shared.jsp
+++ b/java/code/webapp/WEB-INF/pages/channel/shared.jsp
@@ -24,7 +24,7 @@ function showFiltered() {
    helpUrl="/rhn/help/reference/en-US/ref.webui.channels.jsp#s3-sm-channel-list-shared"
    creationUrl="/rhn/channels/manage/Edit.do"
    creationType="channel"
-   creationAcl="user_role(org_admin)">
+   creationAcl="user_role(channel_admin)">
   <bean:message key="channel.nav.shared"/>
 </rhn:toolbar>
 

--- a/java/code/webapp/WEB-INF/pages/channel/vendor.jsp
+++ b/java/code/webapp/WEB-INF/pages/channel/vendor.jsp
@@ -18,10 +18,7 @@ function showFiltered() {
 
 <body onLoad="onLoadStuff(3); showFiltered();">
 <rhn:toolbar base="h1" icon="header-channel" imgAlt="channels.overview.toolbar.imgAlt"
-             helpUrl="/rhn/help/reference/en-US/ref.webui.channels.jsp#s3-sm-channel-list-redhat"
-             creationUrl="/rhn/channels/manage/Edit.do"
-             creationType="channel"
-             creationAcl="user_role(org_admin)">
+             helpUrl="/rhn/help/reference/en-US/ref.webui.channels.jsp#s3-sm-channel-list-redhat">
   <bean:message key="channel.nav.vendor"/>
 </rhn:toolbar>
 

--- a/java/code/webapp/WEB-INF/pages/common/fragments/channel/channel_header.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/channel/channel_header.jspf
@@ -7,7 +7,7 @@
             miscUrl="/rhn/channels/manage/Edit.do?cid=${param.cid}"
             miscIcon="item-edit"
             miscText="toolbar.misc.manage_channel"
-            miscAcl="user_role(org_admin)">
+            miscAcl="user_is_channel_admin()">
         <c:out value="${channel_name}" escapeXml="true"/>
 </rhn:toolbar>
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Removed 'Manage Channels' shortcut for vendor channels (bsc#1115978)
 - Automatically schedule an Action to refresh minion repos after deletion of an assigned channel (bsc#1115029)
 - Performance improvements in channel management functionalities (bsc#1114877)
 - Hide already applied errata and channel entries from the output list in


### PR DESCRIPTION
Removed the "Manage Channel" shortcut in the top right corner for vendor channels (introduced here: https://github.com/SUSE/spacewalk/pull/5988). Following the link resulted in a permission error.
(Had to add a new ACL Handler, because the existing ones didn't allow checking if a user has admin rights for a channel.)

This fix also removes the "Create Channel" shotcut on the vendor page of the software channel overview. This should prevent confusion since you can't create a vendor channel.

cherry-pick from https://github.com/SUSE/spacewalk/pull/6359