### PR TITLE
fetch packages from correct channel

### DIFF
--- a/susemanager/src/mgr-create-bootstrap-repo
+++ b/susemanager/src/mgr-create-bootstrap-repo
@@ -44,7 +44,8 @@ SELECT distinct
          SELECT  I_P.name_id name_id,
                  max(I_PE.evr) evr,
                  I_PA.id as arch_id,
-                 I_PA.label as arch_label
+                 I_PA.label as arch_label,
+                 (CASE WHEN channels.parent_channel IS NULL THEN channels.id ELSE channels.parent_channel END) as root
            FROM  (
                   select I_C.*
                    from suseProducts I_SP
@@ -64,15 +65,17 @@ SELECT distinct
            JOIN  rhnPackage I_P ON I_CNP.package_id = I_P.id
            JOIN  rhnPackageEVR I_PE ON I_P.evr_id = I_PE.id
            JOIN  rhnPackageArch I_PA ON I_P.package_arch_id = I_PA.id
-       GROUP BY  I_P.name_id, I_PA.label, I_PA.id
+       GROUP BY  I_P.name_id, I_PA.label, I_PA.id, root
      ) full_list,
        rhnPackage pkg
        join rhnPackageName pn on pkg.name_id = pn.id
        join rhnPackageEVR pevr on pkg.evr_id = pevr.id
        join rhnChannelPackage CP on CP.package_id = pkg.id
+       join rhnChannel c on CP.channel_id = c.id
  WHERE full_list.name_id = pkg.name_id
    AND full_list.evr = pevr.evr
    AND full_list.arch_id = pkg.package_arch_id
+   AND (c.parent_channel = full_list.root OR c.id = full_list.root)
    AND pn.name = :pkgname
 order by pkg.id
 """;
@@ -87,7 +90,8 @@ SELECT distinct
          SELECT  I_P.name_id name_id,
                  max(I_PE.evr) evr,
                  I_PA.id as arch_id,
-                 I_PA.label as arch_label
+                 I_PA.label as arch_label,
+                 (CASE WHEN channels.parent_channel IS NULL THEN channels.id ELSE channels.parent_channel END) as root
            FROM  (
                   select *
                     from rhnChannel
@@ -102,15 +106,17 @@ SELECT distinct
            JOIN  rhnPackage I_P ON I_CNP.package_id = I_P.id
            JOIN  rhnPackageEVR I_PE ON I_P.evr_id = I_PE.id
            JOIN  rhnPackageArch I_PA ON I_P.package_arch_id = I_PA.id
-       GROUP BY  I_P.name_id, I_PA.label, I_PA.id
+       GROUP BY  I_P.name_id, I_PA.label, I_PA.id, root
      ) full_list,
        rhnPackage pkg
        join rhnPackageName pn on pkg.name_id = pn.id
        join rhnPackageEVR pevr on pkg.evr_id = pevr.id
        join rhnChannelPackage CP on CP.package_id = pkg.id
+       join rhnChannel c on CP.channel_id = c.id
  WHERE full_list.name_id = pkg.name_id
    AND full_list.evr = pevr.evr
    AND full_list.arch_id = pkg.package_arch_id
+   AND (c.parent_channel = full_list.root OR c.id = full_list.root)
    AND pn.name = :pkgname
 order by pkg.id
 """;

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- fetch packages from correct channel when creating a bootstrap
+  repository
 - adapt mgr-create-bootstrap-repo for Uyuni and let it create
   bootstrap repos for openSUSE and CentOS
 - fix not found package on mgr-create-bootstrap-repo for SLE-15-s390x


### PR DESCRIPTION
## What does this PR change?

While creating the bootstrap repo it can happen that a wrong channel is used to get the package from.
This happens if two channels have different packages with same NEVRA .

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal bug fix**

- [x] **DONE**

## Test coverage
- No tests: **do not test bootstrap repo creation**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already ran, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
