### PR TITLE
user_role_check must always return a value

### DIFF
--- a/schema/spacewalk/postgres/packages/rhn_channel.pkb
+++ b/schema/spacewalk/postgres/packages/rhn_channel.pkb
@@ -474,6 +474,11 @@ update pg_settings set setting = 'rhn_channel,' || setting where name = 'search_
           WHERE channel_id = channel_id_in AND
             user_id = user_id_in AND
             role = role_in;
+
+         if result IS NULL then
+           result := 0;
+         end if;
+
          RETURN result;
     end$$ language plpgsql;
 

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.2-to-susemanager-schema-4.0.3/201-rhn_channel.pkb.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.2-to-susemanager-schema-4.0.3/201-rhn_channel.pkb.sql.postgresql
@@ -474,6 +474,11 @@ update pg_settings set setting = 'rhn_channel,' || setting where name = 'search_
           WHERE channel_id = channel_id_in AND
             user_id = user_id_in AND
             role = role_in;
+
+         if result IS NULL then
+           result := 0;
+         end if;
+
          RETURN result;
     end$$ language plpgsql;
 


### PR DESCRIPTION
## What does this PR change?

Fix NPE while listing Virtual Systems in test features/srv_virtual_host_manager.feature

The PL/SQL function user_role_check must always return a value (0 or 1) even if the input parameter channel_id is NULL.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- fixes cucumber test

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already ran, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
