### PR TITLE
improve test for salt-master port to detect IPv4/IPv6 binds

### DIFF
--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -133,13 +133,13 @@ When(/^I apply state "([^"]*)" to "([^"]*)"$/) do |state, host|
 end
 
 Then(/^salt\-api should be listening on local port (\d+)$/) do |port|
-  $output, _code = $server.run("ss -nta | grep #{port}")
+  $output, _code = $server.run("ss -ntl | grep #{port}")
   assert_match(/127.0.0.1:#{port}/, $output)
 end
 
 Then(/^salt\-master should be listening on public port (\d+)$/) do |port|
-  $output, _code = $server.run("ss -nta | grep #{port}")
-  assert_match(/\*:#{port}/, $output)
+  $output, _code = $server.run("ss -ntl | grep #{port}")
+  assert_match(/(0.0.0.0|\*|\[::\]):#{port}/, $output)
 end
 
 Then(/^the system should have a base channel set$/) do


### PR DESCRIPTION
## What does this PR change?

Improve test for salt-master port.

- show only listenting items 
- allow 0.0.0.0:4505 **or** [::]:4505 **or** *:4505
  (IPv4 only, IPv6 only or IPv4 and IPv6)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **fix testcase**

- [x] **DONE**

## Test coverage
- fixes cucumber test

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/6578

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already ran, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
