### PR TITLE
Fill list of packages for Yum traditional clients

### DIFF
--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -246,7 +246,8 @@ def getRegistrationStackSh(saltEnabled):
     """
     PKG_NAME = saltEnabled and ['salt', 'salt-minion'] or ['spacewalk-check', 'spacewalk-client-setup',
                                                            'spacewalk-client-tools', 'zypp-plugin-spacewalk']
-    PKG_NAME_YUM = saltEnabled and ['salt', 'salt-minion'] or []
+    PKG_NAME_YUM = saltEnabled and ['salt', 'salt-minion'] or ['spacewalk-check', 'spacewalk-client-setup',
+                                                               'spacewalk-client-tools', 'yum-rhn-plugin']
 
     PKG_NAME_UPDATE = list(PKG_NAME)
     PKG_NAME_UPDATE.extend(['zypper', 'openssl'])

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,4 @@
+- Add client packages for Yum based distributions
 - enhance bootstrap-repo urls for Centos and Opensuse
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Fill list of packages for Yum traditional clients.

So we can bootstrap CentOS6/7. This should work with any other Yum traditional clients.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Internal change

- [x] **DONE**

## Test coverage
- No tests: Will be covered when we add more clients to the cucumber testsuite.

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/6177

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already ran, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
