### PR TITLE
Empty system profiles XMLRPC tests

### DIFF
--- a/testsuite/features/min_empty_system_profiles.feature
+++ b/testsuite/features/min_empty_system_profiles.feature
@@ -1,0 +1,51 @@
+# Copyright (c) 2018 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: Empty minion profile operations
+
+  Scenario: Create an empty minion profile with HW address via XML-RPC API
+    Given I am logged in via XML-RPC system as user "admin" and password "admin"
+    When I call system.create_system_profile() with name "empty-profile" and HW address "00:11:22:33:44:55"
+    And I logout from XML-RPC system namespace
+
+  Scenario: Create an empty minion profile with hostname via XML-RPC API
+    Given I am logged in via XML-RPC system as user "admin" and password "admin"
+    When I call system.create_system_profile() with name "empty-profile-hostname" and hostname "min-retail.mgr.suse.de"
+    And I logout from XML-RPC system namespace
+
+  Scenario: Check the created empty minion profiles in Unprovisioned Systems page
+    Given I am authorized
+    And I navigate to "rhn/systems/BootstrapSystemList.do" page
+    And I wait until I see "empty-profile" text, refreshing the page
+    And I wait until I see "00:11:22:33:44:55" text, refreshing the page
+    And I wait until I see "empty-profile-hostname" text, refreshing the page
+  
+  Scenario: Check the empty profiles has the hostname set
+    Given I am authorized
+    And I navigate to "rhn/systems/BootstrapSystemList.do" page
+    And I follow "empty-profile-hostname"
+    Then I wait until I see "min-retail.mgr.suse.de" text, refreshing the page
+
+  Scenario: Check the empty minion profiles visible via XML-RPC
+    Given I am logged in via XML-RPC system as user "admin" and password "admin"
+    When I call system.list_empty_system_profiles(), "empty-profile" should be present in the result
+    When I call system.list_empty_system_profiles(), "empty-profile-hostname" should be present in the result
+
+  Scenario: Cleanup: Delete first empty minion profile
+    Given I am authorized
+    And I navigate to "rhn/systems/SystemList.do" page
+    When I follow "empty-profile"
+    When I follow "Delete System"
+    And I should see a "Confirm System Profile Deletion" text
+    And I click on "Delete Profile"
+    Then I wait until I see "has been deleted" text
+    
+  Scenario: Cleanup: Delete second empty minion profiles
+    Given I am authorized
+    And I navigate to "rhn/systems/SystemList.do" page
+    When I follow "empty-profile-hostname"
+    When I follow "Delete System"
+    And I should see a "Confirm System Profile Deletion" text
+    And I click on "Delete Profile"
+    Then I wait until I see "has been deleted" text
+

--- a/testsuite/features/min_empty_system_profiles.feature
+++ b/testsuite/features/min_empty_system_profiles.feature
@@ -28,8 +28,9 @@ Feature: Empty minion profile operations
 
   Scenario: Check the empty minion profiles visible via XML-RPC
     Given I am logged in via XML-RPC system as user "admin" and password "admin"
-    When I call system.list_empty_system_profiles(), "empty-profile" should be present in the result
-    When I call system.list_empty_system_profiles(), "empty-profile-hostname" should be present in the result
+    When I call system.list_empty_system_profiles()
+    Then "empty-profile" should be present in the result
+    And "empty-profile-hostname" should be present in the result
 
   Scenario: Cleanup: Delete first empty minion profile
     Given I am authorized

--- a/testsuite/features/min_empty_system_profiles.feature
+++ b/testsuite/features/min_empty_system_profiles.feature
@@ -17,8 +17,8 @@ Feature: Empty minion profile operations
     Given I am authorized
     And I navigate to "rhn/systems/BootstrapSystemList.do" page
     And I wait until I see "empty-profile" text, refreshing the page
-    And I wait until I see "00:11:22:33:44:55" text, refreshing the page
-    And I wait until I see "empty-profile-hostname" text, refreshing the page
+    And I wait until I see "00:11:22:33:44:55" text
+    And I wait until I see "empty-profile-hostname" text
   
   Scenario: Check the empty profiles has the hostname set
     Given I am authorized

--- a/testsuite/features/step_definitions/xmlrpc_common.rb
+++ b/testsuite/features/step_definitions/xmlrpc_common.rb
@@ -592,3 +592,18 @@ end
 When(/^I logout from XML\-RPC configchannel namespace$/) do
   cfgtest.logout
 end
+
+When(/^I call system.create_system_profile\(\) with name "([^"]*)" and HW address "([^"]*)"$/) do |name, hw_address|
+  profile_id = systest.create_system_profile(name, {'hwAddress' => hw_address})
+  refute_nil(profile_id)
+end
+
+When(/^I call system\.create_system_profile\(\) with name "([^"]*)" and hostname "([^"]*)"$/) do |name, hostname|
+  profile_id = systest.create_system_profile(name, {'hostname' => hostname})
+  refute_nil(profile_id)
+end
+
+When(/^I call system\.list_empty_system_profiles\(\), "([^"]*)" should be present in the result$/) do |profile_name|
+  profiles = systest.list_empty_system_profiles()
+  assert(profiles.select { |p| p['name'] == profile_name }.count == 1)
+end

--- a/testsuite/features/step_definitions/xmlrpc_common.rb
+++ b/testsuite/features/step_definitions/xmlrpc_common.rb
@@ -603,7 +603,10 @@ When(/^I call system\.create_system_profile\(\) with name "([^"]*)" and hostname
   refute_nil(profile_id)
 end
 
-When(/^I call system\.list_empty_system_profiles\(\), "([^"]*)" should be present in the result$/) do |profile_name|
-  profiles = systest.list_empty_system_profiles
-  assert(profiles.select { |p| p['name'] == profile_name }.count == 1)
+When(/^I call system\.list_empty_system_profiles\(\)$/) do
+  $output = systest.list_empty_system_profiles
+end
+
+Then(/^"([^"]*)" should be present in the result$/) do |profile_name|
+  assert($output.select { |p| p['name'] == profile_name }.count == 1)
 end

--- a/testsuite/features/step_definitions/xmlrpc_common.rb
+++ b/testsuite/features/step_definitions/xmlrpc_common.rb
@@ -594,16 +594,16 @@ When(/^I logout from XML\-RPC configchannel namespace$/) do
 end
 
 When(/^I call system.create_system_profile\(\) with name "([^"]*)" and HW address "([^"]*)"$/) do |name, hw_address|
-  profile_id = systest.create_system_profile(name, {'hwAddress' => hw_address})
+  profile_id = systest.create_system_profile(name, 'hwAddress' => hw_address)
   refute_nil(profile_id)
 end
 
 When(/^I call system\.create_system_profile\(\) with name "([^"]*)" and hostname "([^"]*)"$/) do |name, hostname|
-  profile_id = systest.create_system_profile(name, {'hostname' => hostname})
+  profile_id = systest.create_system_profile(name, 'hostname' => hostname)
   refute_nil(profile_id)
 end
 
 When(/^I call system\.list_empty_system_profiles\(\), "([^"]*)" should be present in the result$/) do |profile_name|
-  profiles = systest.list_empty_system_profiles()
+  profiles = systest.list_empty_system_profiles
   assert(profiles.select { |p| p['name'] == profile_name }.count == 1)
 end

--- a/testsuite/features/support/xmlrpc_system.rb
+++ b/testsuite/features/support/xmlrpc_system.rb
@@ -61,4 +61,30 @@ class XMLRPCSystemTest < XMLRPCBaseTest
   def create_system_record(name, kslabel, koptions, comment, netdevices)
     @connection.call('system.createSystemRecord', @sid, name, kslabel, koptions, comment, netdevices)
   end
+
+  # Create an empty system profile based on the given data
+  # == Parameters:
+  # name::
+  #    system profile name
+  # data::
+  #    map containing 'hwAddress' or 'hostname' key
+  # == Returns:
+  # The id of created system
+  # == Raises:
+  # An XMLRPC fault with a descriptive faultString if a matching profile
+  # already exists or if the given data is not sufficient for an empty
+  # profile creation.
+  #
+  def create_system_profile(name, data)
+    @connection.call('system.createSystemProfile', @sid, name, data)
+  end
+
+  # List empty system profiles
+  #
+  # == Returns:
+  # The list of empty system profiles
+  #
+  def list_empty_system_profiles()
+    @connection.call('system.listEmptySystemProfiles', @sid)
+  end
 end

--- a/testsuite/features/support/xmlrpc_system.rb
+++ b/testsuite/features/support/xmlrpc_system.rb
@@ -84,7 +84,7 @@ class XMLRPCSystemTest < XMLRPCBaseTest
   # == Returns:
   # The list of empty system profiles
   #
-  def list_empty_system_profiles()
+  def list_empty_system_profiles
     @connection.call('system.listEmptySystemProfiles', @sid)
   end
 end

--- a/testsuite/run_sets/testsuite.yml
+++ b/testsuite/run_sets/testsuite.yml
@@ -115,6 +115,7 @@
 - features/srv_notifications.feature
 - features/minkvm_guests.feature
 - features/minxen_guests.feature
+- features/min_empty_system_profiles.feature
 ## Secondary features END ##
 
 


### PR DESCRIPTION
## What does this PR change?
 
 Add cucumber tests for creating/listing empty system profiles.
 
 
 ## GUI diff
 
 No difference.
 
 - [x] **DONE**
 
 ## Documentation
 - No documentation needed: just tests
 
 - [x] **DONE**
 
 ## Test coverage
 - Only cucumber tests were added
 
 - [x] **DONE**
 
 ## Links
 
 Tracks https://github.com/SUSE/spacewalk/issues/5965
 
 - [x] **DONE**