### PR TITLE
Use /etc/SuSE-release for client bootstrapping

### DIFF
--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -414,10 +414,12 @@ if [ "$INSTALLER" == zypper ]; then
     local PATCHLEVEL=""
     if [ -r /etc/SuSE-release ]; then
       grep -q 'Enterprise' /etc/SuSE-release && BASE='sle'
+      eval $(grep '^\(VERSION\|PATCHLEVEL\)' /etc/SuSE-release | tr -d '[:blank:]')
       if [ "$BASE" != "sle" ]; then
          grep -q 'openSUSE' /etc/SuSE-release && BASE='opensuse'
+         VERSION="$(grep '^\(VERSION\)' /etc/SuSE-release | tr -d '[:blank:]' | sed -n 's/.*=\([[:digit:]]\+\).*/\\1/p')"
+         PATCHLEVEL="$(grep '^\(VERSION\)' /etc/SuSE-release | tr -d '[:blank:]' | sed -n 's/.*\.\([[:digit:]]*\).*/\\1/p')"
       fi
-      eval $(grep '^\(VERSION\|PATCHLEVEL\)' /etc/SuSE-release | tr -d '[:blank:]')
     elif [ -r /etc/os-release ]; then
       grep -q 'Enterprise' /etc/os-release && BASE='sle'
       if [ "$BASE" != "sle" ]; then

--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -414,6 +414,9 @@ if [ "$INSTALLER" == zypper ]; then
     local PATCHLEVEL=""
     if [ -r /etc/SuSE-release ]; then
       grep -q 'Enterprise' /etc/SuSE-release && BASE='sle'
+      if [ "$BASE" != "sle" ]; then
+         grep -q 'openSUSE' /etc/SuSE-release && BASE='opensuse'
+      fi
       eval $(grep '^\(VERSION\|PATCHLEVEL\)' /etc/SuSE-release | tr -d '[:blank:]')
     elif [ -r /etc/os-release ]; then
       grep -q 'Enterprise' /etc/os-release && BASE='sle'


### PR DESCRIPTION
## What does this PR change?

Use /etc/SuSE-release for client bootstrapping (this is an extension of #359)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Bugfix

- [x] **DONE**

## Test coverage
- No tests: Not covered yet

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/6177

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already ran, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
