### PR TITLE
Testsuite: various retail fixes

### DIFF
--- a/testsuite/features/core_proxy_branch_network.feature
+++ b/testsuite/features/core_proxy_branch_network.feature
@@ -136,5 +136,7 @@ Feature: Setup SUSE Manager for Retail branch network
 @private_net
   Scenario: Set up the terminals too
     When I set up the private network on the terminals
-    Then terminal "sle-minion" should have got a retail network IP address
+    Then terminal "sle-client" should have got a retail network IP address
+    And name resolution should work on terminal "sle-client"
+    And terminal "sle-minion" should have got a retail network IP address
     And name resolution should work on terminal "sle-minion"

--- a/testsuite/features/profiles/Docker/Dockerfile
+++ b/testsuite/features/profiles/Docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.mgr.suse.de/toaster-sles12sp3-products
-MAINTAINER Dario Maiocchi "dmaiocchi@suse.com"
+MAINTAINER Admin User "noemail@example.com"
 
 ARG repo
 ARG cert

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS6/config.xml
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS6/config.xml
@@ -30,16 +30,16 @@
       <file name="drivers/block/virtio_blk.ko" />
     </drivers>
     <repository type="rpm-md" >
-        <source path="http://euklid.nue.suse.com/mirror/SuSE/build.suse.de/SUSE/Products/SLE-SERVER/12-SP3/x86_64/product/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-SERVER/12-SP3/x86_64/product/"/>
     </repository>
     <repository type="rpm-md" >
-        <source path="http://euklid.nue.suse.com/mirror/SuSE/build.suse.de/SUSE/Updates/SLE-SERVER/12-SP3/x86_64/update/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-SERVER/12-SP3/x86_64/update/"/>
     </repository>
     <repository type="rpm-md" >
-        <source path="http://euklid.nue.suse.com/mirror/SuSE/build.suse.de/SUSE/Products/SLE-Manager-Tools/12/x86_64/product/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Manager-Tools/12/x86_64/product/"/>
     </repository>
     <repository type="rpm-md" >
-        <source path="http://euklid.nue.suse.com/mirror/SuSE/build.suse.de/SUSE/Updates/SLE-Manager-Tools/12/x86_64/update/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Manager-Tools/12/x86_64/update/"/>
     </repository>
     <packages type="image">
         <package name="patterns-sles-Minimal"/>

--- a/testsuite/features/proxy_retail_pxeboot.feature
+++ b/testsuite/features/proxy_retail_pxeboot.feature
@@ -201,7 +201,6 @@ Feature: PXE boot a Retail terminal
     And I press "Add Item" in partitions section
     And I enter "p2" in second partition id field
     And I enter "/" in second mount point field
-    And I select "ext4" in second filesystem format field
     And I enter "POS_Image_JeOS6" in second OS image field
     And I click on "Save Formula"
     Then I should see a "Formula saved!" text

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -663,10 +663,12 @@ Then(/^terminal "([^"]*)" should have got a retail network IP address$/) do |hos
 end
 
 Then(/^name resolution should work on terminal "([^"]*)"$/) do |host|
-  # We ping the traditional client, using its domain name provided by the branch server
   node = get_target(host)
-  output, return_code = node.run("ping -c1 client.example.org")
-  raise "Name resolution for branch network on terminal #{host} doesn't work: #{output}" unless return_code.zero?
+  # We test name resolution (and connectivity) both inside and outside of branch network
+  ["proxy.example.org", "download.suse.de"].each do |dest|
+    output, return_code = node.run("ping -c1 #{dest}")
+    raise "Name resolution for branch network on terminal #{host} doesn't work: #{output}" unless return_code.zero?
+  end
 end
 
 When(/^I configure the proxy$/) do


### PR DESCRIPTION
Port of 
 * SUSE/spacewalk#6582 (more tests to catch DNS problems)
 * SUSE/spacewalk#6639 (fixed saltboot misconfiguration)

Plus
 * use better repos for PXE boot image
