### PR TITLE
[WIP] Fix OutOfMemory when generating repo metadata with lots of packages (bsc#1115776)

### DIFF
--- a/java/code/src/com/redhat/rhn/common/hibernate/ConnectionManager.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/ConnectionManager.java
@@ -20,6 +20,22 @@ import static java.util.Optional.ofNullable;
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.finder.FinderFactory;
+import com.redhat.rhn.domain.image.DockerfileProfile;
+import com.redhat.rhn.domain.image.ImageBuildHistory;
+import com.redhat.rhn.domain.image.ImageInfo;
+import com.redhat.rhn.domain.image.ImageInfoCustomDataValue;
+import com.redhat.rhn.domain.image.ImageOverview;
+import com.redhat.rhn.domain.image.ImagePackage;
+import com.redhat.rhn.domain.image.ImageProfile;
+import com.redhat.rhn.domain.image.ImageRepoDigest;
+import com.redhat.rhn.domain.image.ImageStore;
+import com.redhat.rhn.domain.image.ImageStoreType;
+import com.redhat.rhn.domain.image.KiwiProfile;
+import com.redhat.rhn.domain.image.ProfileCustomDataValue;
+import com.redhat.rhn.domain.notification.NotificationMessage;
+import com.redhat.rhn.domain.notification.UserNotification;
+import com.redhat.rhn.domain.rhnpackage.PackageRepodata;
+import com.redhat.rhn.domain.server.virtualhostmanager.VirtualHostManagerNodeInfo;
 
 import org.apache.log4j.Logger;
 import org.hibernate.HibernateException;
@@ -193,9 +209,21 @@ class ConnectionManager {
             }
 
             //TODO: Fix auto-discovery (see commit: e92b062)
-            AnnotationRegistry.getAnnotationClasses().forEach(c -> {
-                config.addAnnotatedClass(c);
-            });
+            config.addAnnotatedClass(ImageStore.class);
+            config.addAnnotatedClass(ImageStoreType.class);
+            config.addAnnotatedClass(DockerfileProfile.class);
+            config.addAnnotatedClass(KiwiProfile.class);
+            config.addAnnotatedClass(ImageProfile.class);
+            config.addAnnotatedClass(ProfileCustomDataValue.class);
+            config.addAnnotatedClass(ImageInfo.class);
+            config.addAnnotatedClass(ImageInfoCustomDataValue.class);
+            config.addAnnotatedClass(ImageOverview.class);
+            config.addAnnotatedClass(ImagePackage.class);
+            config.addAnnotatedClass(ImageBuildHistory.class);
+            config.addAnnotatedClass(ImageRepoDigest.class);
+            config.addAnnotatedClass(VirtualHostManagerNodeInfo.class);
+            config.addAnnotatedClass(NotificationMessage.class);
+            config.addAnnotatedClass(UserNotification.class);
 
             // add empty varchar warning interceptor
             EmptyVarcharInterceptor interceptor = new EmptyVarcharInterceptor();

--- a/java/code/src/com/redhat/rhn/domain/channel/Channel.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/Channel.hbm.xml
@@ -122,6 +122,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
             <one-to-many class="com.redhat.rhn.domain.channel.ClonedChannel"/>
         </set>
 
+        <one-to-one name="packageRepodata" fetch="select" class="com.redhat.rhn.domain.rhnpackage.PackageRepodata">
+        </one-to-one>
+
         <set name="suseProductChannels" table="SUSEProductChannel" inverse="true">
             <key column="channel_id"/>
             <one-to-many class="com.redhat.rhn.domain.product.SUSEProductChannel"/>
@@ -145,6 +148,11 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         <![CDATA[
                 from com.redhat.rhn.domain.channel.Channel as c where c.org is null
                                                 and parentChannel is null order by c.name]]>
+    </query>
+
+    <query name="Channel.findPackages">
+        <![CDATA[
+                from com.redhat.rhn.domain.rhnpackage.Package p where :channel member of p.channels]]>
     </query>
 
     <sql-query name="Channel.findCompatCustomBaseChsSSMNoBase">

--- a/java/code/src/com/redhat/rhn/domain/channel/Channel.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/Channel.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import com.redhat.rhn.domain.rhnpackage.PackageRepodata;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -90,6 +91,7 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
     private String supportPolicy;
     private String updateTag;
     private Set<ClonedChannel> clonedChannels = new HashSet<ClonedChannel>();
+    private PackageRepodata packageRepodata;
     private Set<SUSEProductChannel> suseProductChannels = new HashSet<>();
 
     /**
@@ -901,6 +903,20 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
      */
     public Channel getOriginal() {
         throw new UnsupportedOperationException();
+    }
+
+    /**
+     * @return packageRepodata to get
+     */
+    public PackageRepodata getPackageRepodata() {
+        return packageRepodata;
+    }
+
+    /**
+     * @param packageRepodataIn to set
+     */
+    public void setPackageRepodata(PackageRepodata packageRepodataIn) {
+        this.packageRepodata = packageRepodataIn;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
@@ -31,6 +31,8 @@ import com.redhat.rhn.manager.ssm.SsmChannelDto;
 
 import org.apache.log4j.Logger;
 import org.hibernate.Criteria;
+import org.hibernate.ScrollMode;
+import org.hibernate.ScrollableResults;
 import org.hibernate.Session;
 import org.hibernate.criterion.MatchMode;
 import org.hibernate.criterion.Projections;
@@ -1327,6 +1329,18 @@ public class ChannelFactory extends HibernateFactory {
         criteria.add(Restrictions.eq("product", product));
         criteria.add(Restrictions.eq("version", version));
         return (ChannelProduct) criteria.uniqueResult();
+    }
+
+    /**
+     * Get all packages in the given channel.
+     * @param channel the channel
+     * @return all packages
+     */
+    public static ScrollableResults findChannelPackages(Channel channel) {
+        return getSession().getNamedQuery("Channel.findPackages")
+                .setParameter("channel", channel)
+                .setReadOnly(true)
+                .scroll(ScrollMode.FORWARD_ONLY);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/Package.java
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/Package.java
@@ -70,8 +70,8 @@ public class Package extends BaseDomainHelper {
     private PackageArch packageArch;
     private Set<PackageKey> packageKeys = new HashSet();
 
-    private Long headerStart = new Long(0L);
-    private Long headerEnd = new Long(0L);
+    private Long headerStart = -1L;
+    private Long headerEnd = -1L;
 
     private Set<PackageProvides> provides = new HashSet();
     private Set<PackageRequires> requires = new HashSet();

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/Package.java
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/Package.java
@@ -78,6 +78,8 @@ public class Package extends BaseDomainHelper {
     private Set<PackageObsoletes> obsoletes = new HashSet();
     private Set<PackageConflicts> conflicts = new HashSet();
 
+    private PackageRepodata packageRepodata;
+
     /**
      * @param lockPendingIn Set pending status. Default is False.
      */
@@ -680,6 +682,20 @@ public class Package extends BaseDomainHelper {
      */
     public void setHeaderEnd(Long headerEndIn) {
         this.headerEnd = headerEndIn;
+    }
+
+    /**
+     * @return packageRepodata to get
+     */
+    public PackageRepodata getPackageRepodata() {
+        return packageRepodata;
+    }
+
+    /**
+     * @param packageRepodataIn to set
+     */
+    public void setPackageRepodata(PackageRepodata packageRepodataIn) {
+        this.packageRepodata = packageRepodataIn;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageRepodata.java
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageRepodata.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2018 SUSE LLC
+ * <p>
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ * <p>
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.domain.rhnpackage;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.Lob;
+import javax.persistence.MapsId;
+import javax.persistence.OneToOne;
+
+@Entity
+public class PackageRepodata {
+
+    @Id
+    @Column(name = "package_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "package_id")
+    @MapsId
+    private Package thePackage; // sorry, package is a keyword in java
+
+    @Lob
+    @Column(name = "primary_xml")
+    private byte[] primaryXml;
+
+    @Lob
+    @Column(name = "filelist")
+    private byte[] filelist;
+
+    @Lob
+    @Column(name = "other")
+    private byte[] other;
+
+    /**
+     * @return id to get
+     */
+    public Long getId() {
+        return id;
+    }
+
+    /**
+     * @param idIn to set
+     */
+    public void setId(Long idIn) {
+        this.id = idIn;
+    }
+
+    /**
+     * @return thePackage to get
+     */
+    public Package getThePackage() {
+        return thePackage;
+    }
+
+    /**
+     * @param thePackageIn to set
+     */
+    public void setThePackage(Package thePackageIn) {
+        this.thePackage = thePackageIn;
+    }
+
+    /**
+     * @return primaryXml to get
+     */
+    public byte[] getPrimaryXml() {
+        return primaryXml;
+    }
+
+    public String getPrimaryXmlAsString() {
+        return new String(primaryXml); // TODO encoding
+    }
+
+    /**
+     * @param primaryXmlIn to set
+     */
+    public void setPrimaryXml(byte[] primaryXmlIn) {
+        this.primaryXml = primaryXmlIn;
+    }
+
+    /**
+     * @return filelist to get
+     */
+    public byte[] getFilelist() {
+        return filelist;
+    }
+
+
+    public String getFilelistXml() {
+        return new String(filelist); // TODO encoding
+    }
+    /**
+     * @param filelistIn to set
+     */
+    public void setFilelist(byte[] filelistIn) {
+        this.filelist = filelistIn;
+    }
+
+    /**
+     * @return other to get
+     */
+    public byte[] getOther() {
+        return other;
+    }
+
+    /**
+     * @param otherIn to set
+     */
+    public void setOther(byte[] otherIn) {
+        this.other = otherIn;
+    }
+
+
+    public String getOtherXml() {
+        return new String(other); // TODO encoding
+    }
+}

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageRepodata.java
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageRepodata.java
@@ -15,6 +15,8 @@
 
 package com.redhat.rhn.domain.rhnpackage;
 
+import org.hibernate.annotations.Type;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -23,8 +25,10 @@ import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
 import javax.persistence.MapsId;
 import javax.persistence.OneToOne;
+import javax.persistence.Table;
 
 @Entity
+@Table(name = "rhnPackageRepodata")
 public class PackageRepodata {
 
     @Id
@@ -34,19 +38,19 @@ public class PackageRepodata {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "package_id")
     @MapsId
-    private Package thePackage; // sorry, package is a keyword in java
+    private Package thePackage; // package is a keyword in java
 
-    @Lob
+    @Type(type = "org.hibernate.type.TextType")
     @Column(name = "primary_xml")
-    private byte[] primaryXml;
+    private String primaryXml;
 
-    @Lob
+    @Type(type = "org.hibernate.type.TextType")
     @Column(name = "filelist")
-    private byte[] filelist;
+    private String filelistXml;
 
-    @Lob
+    @Type(type = "org.hibernate.type.TextType")
     @Column(name = "other")
-    private byte[] other;
+    private String otherXml;
 
     /**
      * @return id to get
@@ -79,55 +83,42 @@ public class PackageRepodata {
     /**
      * @return primaryXml to get
      */
-    public byte[] getPrimaryXml() {
+    public String getPrimaryXml() {
         return primaryXml;
-    }
-
-    public String getPrimaryXmlAsString() {
-        return new String(primaryXml); // TODO encoding
     }
 
     /**
      * @param primaryXmlIn to set
      */
-    public void setPrimaryXml(byte[] primaryXmlIn) {
+    public void setPrimaryXml(String primaryXmlIn) {
         this.primaryXml = primaryXmlIn;
     }
 
     /**
      * @return filelist to get
      */
-    public byte[] getFilelist() {
-        return filelist;
-    }
-
-
     public String getFilelistXml() {
-        return new String(filelist); // TODO encoding
+        return filelistXml;
     }
+
     /**
      * @param filelistIn to set
      */
-    public void setFilelist(byte[] filelistIn) {
-        this.filelist = filelistIn;
+    public void setFilelistXml(String filelistIn) {
+        this.filelistXml = filelistIn;
     }
 
     /**
      * @return other to get
      */
-    public byte[] getOther() {
-        return other;
+    public String getOtherXml() {
+        return otherXml;
     }
 
     /**
      * @param otherIn to set
      */
-    public void setOther(byte[] otherIn) {
-        this.other = otherIn;
-    }
-
-
-    public String getOtherXml() {
-        return new String(other); // TODO encoding
+    public void setOtherXml(String otherIn) {
+        this.otherXml = otherIn;
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/Package_satellite.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/Package_satellite.hbm.xml
@@ -28,6 +28,8 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         <property name="headerSignature" type="string" column="header_sig"/>
         <property name="copyright"       type="string" column="copyright"/>
         <property name="cookie"          type="string" column="cookie"/>
+        <property name="headerStart"     type="long"   column="header_start"/>
+        <property name="headerEnd"       type="long"   column="header_end"/>
         <property name="lastModified"    type="timestamp"   column="last_modified"/>
         <property name="created"         type="timestamp"   column="created"/>
         <property name="modified"        type="timestamp"   column="modified"/>

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/Package_satellite.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/Package_satellite.hbm.xml
@@ -131,6 +131,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                      class="com.redhat.rhn.domain.rhnpackage.PackageArch"
                      column="package_arch_id"
                          cascade="none"/>
+        <one-to-one name="packageRepodata"
+                    class="com.redhat.rhn.domain.rhnpackage.PackageRepodata"
+                    fetch="select"/>
 
 
 

--- a/java/code/src/com/redhat/rhn/manager/rhnpackage/PackageManager.java
+++ b/java/code/src/com/redhat/rhn/manager/rhnpackage/PackageManager.java
@@ -1533,15 +1533,9 @@ public class PackageManager extends BaseManager {
     public static synchronized void createRepoEntrys(Long cid) {
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("cid", cid);
-        try {
-            WriteMode writeMode = ModeFactory.getWriteMode("Package_queries",
-                "create_repo_entrys");
-            writeMode.executeUpdate(params);
-            HibernateFactory.commitTransaction();
-        }
-        catch (Exception e) {
-            HibernateFactory.rollbackTransaction();
-        }
+        WriteMode writeMode = ModeFactory.getWriteMode("Package_queries",
+            "create_repo_entrys");
+        writeMode.executeUpdate(params);
     }
 
     private static void updateRepoEntry(Long packageId, String xml, String type) {

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/FilelistsXmlWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/FilelistsXmlWriter.java
@@ -83,9 +83,9 @@ public class FilelistsXmlWriter extends RepomdWriter {
      *
      * @param pkgDto pkg info to add to xml
      */
-    public void addPackage(PackageDto pkgDto) {
+    public void addPackage(com.redhat.rhn.domain.rhnpackage.Package pkgDto) {
         try {
-            String xml = pkgDto.getFilelistXml();
+            String xml = pkgDto.getPackageRepodata().getFilelistXml();
             if (ConfigDefaults.get().useDBRepodata() && !StringUtils.isEmpty(xml)) {
                 if (xml != null) {
                     handler.addCharacters(xml);
@@ -119,7 +119,7 @@ public class FilelistsXmlWriter extends RepomdWriter {
      * @param pkgId package Id info
      * @throws SAXException sax exception
      */
-    private void addPackageFiles(PackageDto pkgDto,
+    private void addPackageFiles(com.redhat.rhn.domain.rhnpackage.Package pkgDto,
             SimpleContentHandler localHandler) throws SAXException {
         Long pkgId = pkgDto.getId();
         Collection<PackageCapabilityDto> files = TaskManager

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/OtherXmlWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/OtherXmlWriter.java
@@ -82,10 +82,10 @@ public class OtherXmlWriter extends RepomdWriter {
      *
      * @param pkgDto pkg info to add to xml
      */
-    public void addPackage(PackageDto pkgDto) {
+    public void addPackage(com.redhat.rhn.domain.rhnpackage.Package pkgDto) {
 
         try {
-            String xml = pkgDto.getOtherXml();
+            String xml = pkgDto.getPackageRepodata().getOtherXml();
             if (ConfigDefaults.get().useDBRepodata() && !StringUtils.isEmpty(xml)) {
                 if (xml != null) {
                     handler.addCharacters(xml);
@@ -121,7 +121,7 @@ public class OtherXmlWriter extends RepomdWriter {
      * @throws SAXException sax exception
      * @throws SQLException sql exception
      */
-    private void addPackageChangelog(PackageDto pkgDto,
+    private void addPackageChangelog(com.redhat.rhn.domain.rhnpackage.Package pkgDto,
             SimpleContentHandler tmpHandler) throws SAXException, SQLException {
 
         Long pkgId = pkgDto.getId();

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/PrimaryXmlWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/PrimaryXmlWriter.java
@@ -87,7 +87,7 @@ public class PrimaryXmlWriter extends RepomdWriter {
      */
     public void addPackage(com.redhat.rhn.domain.rhnpackage.Package pkgDto) {
         try {
-            String xml = pkgDto.getPackageRepodata().getPrimaryXmlAsString();
+            String xml = pkgDto.getPackageRepodata().getPrimaryXml();
 
             if (ConfigDefaults.get().useDBRepodata() && !StringUtils.isEmpty(xml)) {
 

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/RepomdWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/RepomdWriter.java
@@ -16,7 +16,6 @@ package com.redhat.rhn.taskomatic.task.repomd;
 
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.rhnpackage.Package;
-import com.redhat.rhn.frontend.dto.PackageDto;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
@@ -103,19 +102,19 @@ public abstract class RepomdWriter {
      * @throws SAXException SAX exception
      */
     protected static void addPackageBoilerplate(SimpleContentHandler handler,
-            PackageDto pkgDto) throws SAXException {
+            com.redhat.rhn.domain.rhnpackage.Package pkgDto) throws SAXException {
         long pkgId = pkgDto.getId().longValue();
         SimpleAttributesImpl attr = new SimpleAttributesImpl();
-        attr.addAttribute("pkgid", sanitize(pkgId, pkgDto.getChecksum()));
-        attr.addAttribute("name", sanitize(pkgId, pkgDto.getName()));
-        attr.addAttribute("arch", sanitize(pkgId, pkgDto.getArchLabel()));
+        attr.addAttribute("pkgid", sanitize(pkgId, pkgDto.getChecksum().getChecksum()));
+        attr.addAttribute("name", sanitize(pkgId, pkgDto.getPackageName().getName()));
+        attr.addAttribute("arch", sanitize(pkgId, pkgDto.getPackageArch().getLabel()));
         handler.startElement("package", attr);
 
         attr.clear();
-        attr.addAttribute("ver", sanitize(pkgId, pkgDto.getVersion()));
-        attr.addAttribute("rel", sanitize(pkgId, pkgDto.getRelease()));
+        attr.addAttribute("ver", sanitize(pkgId, pkgDto.getPackageEvr().getVersion()));
+        attr.addAttribute("rel", sanitize(pkgId, pkgDto.getPackageEvr().getRelease()));
         attr.addAttribute("epoch", sanitize(pkgId,
-                getPackageEpoch(pkgDto.getEpoch())));
+                getPackageEpoch(pkgDto.getPackageEvr().getEpoch())));
         handler.startElement("version", attr);
         handler.endElement("version");
     }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/SuseDataXmlWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/SuseDataXmlWriter.java
@@ -78,7 +78,7 @@ public class SuseDataXmlWriter extends RepomdWriter {
      *
      * @param pkgDto pkg info to add to xml
      */
-    public void addPackage(PackageDto pkgDto) {
+    public void addPackage(com.redhat.rhn.domain.rhnpackage.Package pkgDto) {
         long pkgId = pkgDto.getId().longValue();
         List<String> eulas = new EulaManager().getEulasForPackage(pkgId);
 

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/test/RpmRepositoryWriterTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/test/RpmRepositoryWriterTest.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2018 SUSE LLC
+ * <p>
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ * <p>
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.taskomatic.task.repomd.test;
+
+import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.channel.ChannelFactory;
+import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
+import com.redhat.rhn.domain.rhnpackage.Package;
+import com.redhat.rhn.domain.rhnpackage.PackageCapability;
+import com.redhat.rhn.domain.rhnpackage.PackageProvides;
+import com.redhat.rhn.domain.rhnpackage.PackageRequires;
+import com.redhat.rhn.domain.rhnpackage.test.PackageCapabilityTest;
+import com.redhat.rhn.manager.rhnpackage.PackageManager;
+import com.redhat.rhn.manager.rhnpackage.test.PackageManagerTest;
+import com.redhat.rhn.taskomatic.task.repomd.RpmRepositoryWriter;
+import com.redhat.rhn.testing.BaseTestCaseWithUser;
+import com.redhat.rhn.testing.TestUtils;
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.GZIPInputStream;
+
+public class RpmRepositoryWriterTest extends BaseTestCaseWithUser {
+
+    private Path mountPointDir;
+
+    public void testWriteRepomdFiles() throws Exception {
+        mountPointDir = Files.createTempDirectory("rpmrepotest");
+        RpmRepositoryWriter writer = new RpmRepositoryWriter("rhn/repodata", mountPointDir.toAbsolutePath().toString());
+
+        Channel channel = ChannelFactoryTest.createTestChannel(user);
+        channel.setChecksumType(ChannelFactory.findChecksumTypeByLabel("sha256"));
+        Package pkg1 = PackageManagerTest.addPackageToChannel("pkg1", channel);
+
+        PackageProvides prov1 = new PackageProvides();
+        PackageCapability provCap = PackageCapabilityTest.createTestCapability("capProv1");
+        prov1.setCapability(provCap);
+        prov1.setPack(pkg1);
+        prov1.setSense(0L);
+        pkg1.getProvides().add(prov1);
+
+        PackageRequires req1 = new PackageRequires();
+        PackageCapability reqCap = PackageCapabilityTest.createTestCapability("capReq1");
+        req1.setCapability(reqCap);
+        req1.setPack(pkg1);
+        req1.setSense(0L);
+        pkg1.getRequires().add(req1);
+
+        PackageManager.createRepoEntrys(channel.getId());
+
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().clear();
+
+        writer.writeRepomdFiles(channel);
+
+        String repomdExpected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<repomd xmlns=\"http://linux.duke.edu/metadata/repo\"><data type=\"primary\"><location href=\"repodata/primary.xml.gz\"/><checksum type=\"sha256\">61d08b336c520bdfade052b808616e5a80e5eec29d82c2e7dbbd58bc7ee93864</checksum><open-checksum type=\"sha256\">d515cc563a9cf6dfe2f0fbe999bbcec0d495f4c7e1cd09286d7df74c58300e1b</open-checksum><timestamp>1544711985</timestamp></data><data type=\"filelists\"><location href=\"repodata/filelists.xml.gz\"/><checksum type=\"sha256\">b6528b97a62a107e9357d406e1d22be971ca55d4332abbc1bb0e9b84c3139d99</checksum><open-checksum type=\"sha256\">9e1aca5fd324f66bbedd27f6dfc722da83354374a6808010886e93e09795bb30</open-checksum><timestamp>1544711985</timestamp></data><data type=\"other\"><location href=\"repodata/other.xml.gz\"/><checksum type=\"sha256\">4fa5ac10cf38edc497f18e41f537e1ef24a2fb4d0b537c96248433ca3a51b975</checksum><open-checksum type=\"sha256\">a50ffc2416654509bb720263a0ab090c3c53739305e8f637422f81937fabd700</open-checksum><timestamp>1544711985</timestamp></data><data type=\"susedata\"><location href=\"repodata/susedata.xml.gz\"/><checksum type=\"sha256\">2818aff4276b64a24abb2e60fc97d152abee478c35a5f4b04015c7704e8b7cfe</checksum><open-checksum type=\"sha256\">20c9750a06ddcc9b783504433cbc1eaea14c08889770f19274fa3f91bcbbd37f</open-checksum><timestamp>1544711985</timestamp></data></repomd>";
+        repomdExpected = cleanupRepomd(repomdExpected);
+
+        String primaryXmlExpected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<metadata packages=\"1\" xmlns=\"http://linux.duke.edu/metadata/common\" xmlns:rpm=\"http://linux.duke.edu/metadata/rpm\"><package type=\"rpm\"><name>pkg1</name><arch>noarch</arch><version ver=\"1.0.0\" rel=\"1\" epoch=\"1\"/><checksum type=\"md5\" pkgid=\"YES\">$1$jrBDaf62$URlwK4AAEVCdcWhcZdcSK1</checksum><summary>Created by RHN-JAVA unit tests. Please disregard.</summary><description>RHN-JAVA Package Test</description><packager/><url/><time file=\"1544723761\" build=\"1544723761\"/><size package=\"42\" archive=\"42\" installed=\"42\"/><location href=\"getPackage/$1$RAiHwOUL$bcHCUHDdGcmVfklrxaRVC1\"/><format><rpm:license>Red Hat - RHN - 2005</rpm:license><rpm:vendor>Rhn-Java</rpm:vendor><rpm:group>4XwfQEUNzkDr3</rpm:group><rpm:buildhost>foo2</rpm:buildhost><rpm:sourcerpm>ZL4ke7jOwX6Tz</rpm:sourcerpm><rpm:header-range start=\"-1\" end=\"-1\"/><rpm:provides><rpm:entry name=\"capProv1\" flags=\"GE\" epoch=\"0\" ver=\"\" rel=\"1.0\"/></rpm:provides><rpm:requires><rpm:entry name=\"capReq1\" flags=\"GE\" epoch=\"0\" ver=\"\" rel=\"1.0\"/></rpm:requires><rpm:conflicts/><rpm:obsoletes/><rpm:recommends/><rpm:suggests/><rpm:supplements/><rpm:enhances/></format></package></metadata>";
+
+        primaryXmlExpected = cleanupPrimaryXml(primaryXmlExpected);
+        Path channelDir = mountPointDir.resolve("rhn").resolve("repodata").resolve(channel.getLabel());
+
+
+        File repomdXml = channelDir.resolve("repomd.xml").toFile();
+
+        try (FileInputStream fin = new FileInputStream(repomdXml)) {
+            String xml = TestUtils.readAll(fin);
+
+            assertEquals(repomdExpected, cleanupRepomd(xml));
+
+        }
+        catch (IOException e) {
+            fail(e.getMessage());
+        }
+
+        File primaryXmlGz = channelDir.resolve("primary.xml.gz").toFile();
+
+        try (FileInputStream fin = new FileInputStream(primaryXmlGz); InputStream gzipStream = new GZIPInputStream(fin)) {
+            String primaryXmlStr = TestUtils.readAll(gzipStream);
+
+            primaryXmlStr = cleanupPrimaryXml(primaryXmlStr);
+
+
+            assertEquals(primaryXmlExpected, primaryXmlStr);
+        }
+        catch (IOException e) {
+            fail(e.getMessage());
+        }
+
+
+    }
+
+    private String cleanupRepomd(String str) {
+        String ret = str.trim().replaceFirst("<checksum type=\"sha256\">.*</checksum>", "<checksum type=\"sha256\">xxx</checksum>");
+        ret = ret.replaceFirst("<open-checksum type=\"sha256\">.*</open-checksum>", "<open-checksum type=\"sha256\">xxx</open-checksum>");
+        ret = ret.replaceFirst("<timestamp>.*</timestamp>", "<timestamp>123</timestamp>");
+        return ret;
+    }
+
+    private String cleanupPrimaryXml(String str) {
+        String ret = str.trim().replaceFirst(">.*?</checksum>", ">xxx</checksum>");
+        ret = ret.replaceFirst("<time file=\"\\d+\" build=\"\\d+\"/>", "<time file=\"123\" build=\"123\"/>");
+        ret = ret.replaceFirst("<location href=\"getPackage/.*?\"/>", "<location href=\"getPackage/xxx\"/>");
+        ret = ret.replaceFirst("<rpm:sourcerpm>.*?</rpm:sourcerpm>", "<rpm:sourcerpm>xxx</rpm:sourcerpm>");
+        ret = ret.replaceFirst("<rpm:group>.*?</rpm:group>", "<rpm:group>xxx</rpm:group>");
+        return ret;
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        FileUtils.deleteDirectory(mountPointDir.toFile());
+    }
+}


### PR DESCRIPTION
## What does this PR change?

[This query](https://github.com/uyuni-project/uyuni/blob/master/java/code/src/com/redhat/rhn/taskomatic/task/repomd/RpmRepositoryWriter.java#L200) loads all packages for a given channel. In the case of RES6/7 this results in DataSet containing a large number of PackageDto objects. Each RES channels has about 32k+ of packages. 

This PR uses Hibernate to load the packages and evicts the entities from the Session as they're processed.

## GUI diff

No difference.

## Documentation
- No documentation needed: bugfix

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/6335



