### PR TITLE
Fix typo at spacewalk-common-channels.ini

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -612,7 +612,7 @@ gpgkey_fingerprint = %(_uyuni_client_gpgkey_fingerprint)s
 yumrepo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/SLE12-Uyuni-Client-Tools/SLE_12/
 
 [sles12-sp4-uyuni-client-devel]
-name     = Uyuni Client Tools 4.0 for SLES12 SP4 (Development)
+name     = Uyuni Client Tools for SLES12 SP4 (Development)
 archs    =  x86_64, s390x, aarch64, ppc64le
 base_channels = sles12-sp4-pool-%(arch)s
 checksum = sha256
@@ -632,7 +632,7 @@ gpgkey_fingerprint = %(_uyuni_client_gpgkey_fingerprint)s
 yumrepo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/
 
 [sles15-uyuni-client-devel]
-name     = Uyuni Client Tools 4.0 for SLES15 (Development)
+name     = Uyuni Client Tools for SLES15 (Development)
 archs    =  x86_64, s390x, aarch64, ppc64le
 base_channels = sle-product-sles15-pool-%(arch)s
 checksum = sha256


### PR DESCRIPTION
## What does this PR change?

We do not include version on description of Uyuni Client Tools channels.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Just fixing a typo at a description

- [x] **DONE**

## Test coverage
- No tests: Just fixing a typo at a description

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/6177

- [ ] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already ran, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
