### PR TITLE
spacewalk-setup: fix build broken by Python 3 patch

### DIFF
--- a/spacewalk/setup/spacewalk-setup.spec
+++ b/spacewalk/setup/spacewalk-setup.spec
@@ -136,6 +136,8 @@ for i in $(find . -type f);
 do
     sed -i '1s=^#!/usr/bin/\(python\|env python\)[0-9.]*=#!/usr/bin/python3=' $i;
 done
+# timestamp of Makefile must always be newer than Makefile.PL, else build will fail
+touch Makefile
 %endif
 
 # Fix python executable in Perl code


### PR DESCRIPTION
## What does this PR change?

It fixes builds of spacewalk-setup in some OS/architecture combinations.

Background: The specfile uses `find` to mass patch shebang lines to be compatible with Python 3. The following conditions verify:

- `find` visits files in inode order, which varies on CPU architecture and in general is not deterministic
- `sed -i` touches all files (irrespective if they were changed or not), see: https://stackoverflow.com/a/27075334
- Perl is picky about the timestamps of `Makefile` and `Makefile.PL` (as the latter is used to generate the former) - if `Makefile` is older than `Makefile.PL` the build will fail

As a result, build fails at least on SLE 15 SP1 on x86_64.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **build problem fixed**

- [x] **DONE**

## Test coverage
- No tests: **build only**

- [x] **DONE**

## Links

No relevant links.

- [x] **DONE**
