### PR TITLE
remove unprintable ascii chars

### DIFF
--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -930,4 +930,4 @@ def _fix_encoding(text):
     if isinstance(text, str):
         return str.encode(text, 'utf-8')
     else:
-        return str(re.sub(u"(\u2018|\u2019)", "", text))
+        return text.encode("ascii", errors="ignore")

--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -930,4 +930,4 @@ def _fix_encoding(text):
     if isinstance(text, str):
         return str.encode(text, 'utf-8')
     else:
-        return str(text)
+        return str(re.sub(u"(\u2018|\u2019)", "", text))


### PR DESCRIPTION
## What does this PR change?

remove unprintable chars from string which makes sync failing

## GUI diff

Before:

```
uyuni:~ # spacewalk-repo-sync --channel sles11-sp4-pool-x86_64                                   
14:17:19 ======================================
14:17:19 | Channel: sles11-sp4-pool-x86_64
14:17:19 ======================================
14:17:19 Sync of channel started.
14:17:21 Repo URL: https://updates.suse.com/repo/$RCE/SLES11-SP4-Pool/sle-11-x86_64/?GiBeRiSh
14:17:21     Packages in repo:              2913
14:17:27     No new packages to sync.
14:17:27 
14:17:27   Patches in repo: 0.
14:17:27 Unexpected error: <type 'exceptions.UnicodeEncodeError'>
14:17:27 Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/spacewalk/satellite_tools/reposync.py", line 581, in sync
    self.import_products(plugin)
  File "/usr/lib/python2.7/site-packages/spacewalk/satellite_tools/reposync.py", line 1875, in import_products
    products = repo.get_products()
  File "/usr/lib/python2.7/site-packages/spacewalk/satellite_tools/repo_plugins/yum_src.py", line 570, in get_products
    p['description'] = _fix_encoding(product.find('description').text)
  File "/usr/lib/python2.7/site-packages/spacewalk/satellite_tools/repo_plugins/yum_src.py", line 926, in _fix_encoding
    return str(text)
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2019' in position 204: ordinal not in range(128)

```
Text that chokes it is next (from trace)
```
uyuni:~ # spacewalk-repo-sync --channel sles11-sp4-pool-x86_64
14:22:46 ======================================
14:22:46 | Channel: sles11-sp4-pool-x86_64
14:22:46 ======================================
14:22:46 Sync of channel started.
14:22:49 Repo URL: https://updates.suse.com/repo/$RCE/SLES11-SP4-Pool/sle-11-x86_64/?GiBeRiSh
14:22:49     Packages in repo:              2913
14:22:55     No new packages to sync.
14:22:55 
14:22:55   Patches in repo: 0.
SUSE Linux Enterprise offers a comprehensive
        suite of products built on a single code base.
        The platform addresses business needs from
        the smallest thin-client devices to the world’s
        most powerful high-performance computing
        and mainframe servers. SUSE Linux Enterprise
        offers common management tools and technology
        certifications across the platform, and
        each product is enterprise-class.
14:22:55 Unexpected error: <type 'exceptions.UnicodeEncodeError'>
14:22:55 Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/spacewalk/satellite_tools/reposync.py", line 581, in sync
    self.import_products(plugin)
  File "/usr/lib/python2.7/site-packages/spacewalk/satellite_tools/reposync.py", line 1875, in import_products
    products = repo.get_products()
  File "/usr/lib/python2.7/site-packages/spacewalk/satellite_tools/repo_plugins/yum_src.py", line 570, in get_products
    p['description'] = _fix_encoding(product.find('description').text)
  File "/usr/lib/python2.7/site-packages/spacewalk/satellite_tools/repo_plugins/yum_src.py", line 927, in _fix_encoding
    return str(text)
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2019' in position 204: ordinal not in range(128)

14:22:55 Total time: 0:00:09
```


After:

```
uyuni:~ # spacewalk-repo-sync --channel sles11-sp4-pool-x86_64
14:24:05 ======================================
14:24:05 | Channel: sles11-sp4-pool-x86_64
14:24:05 ======================================
14:24:05 Sync of channel started.
14:24:08 Repo URL: https://updates.suse.com/repo/$RCE/SLES11-SP4-Pool/sle-11-x86_64/?GiBeRiSh
14:24:08     Packages in repo:              2913
14:24:13     No new packages to sync.
14:24:13 
14:24:13   Patches in repo: 0.
14:24:19 Sync completed.
14:24:19 Total time: 0:00:13
uyuni:~ # 
```
- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already ran, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
