### PR TITLE
Manager - Fix bug when managing the same errata for vendor and private orgs - bsc#1111686

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Channel_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Channel_queries.xml
@@ -706,7 +706,7 @@ SELECT  1
 </mode>
 
 <mode name="org_errata_channels">
-  <query params="org_id, eid">
+  <query params="org_id">
 SELECT C.id as channel_id,
        C.id as id,
        C.label as label,
@@ -716,7 +716,7 @@ SELECT C.id as channel_id,
        LEFT OUTER JOIN rhnChannel C2 ON C.parent_channel = C2.id,
        rhnAvailableChannels AC,
        rhnChannelErrata EC
- WHERE EC.errata_id = :eid
+ WHERE EC.errata_id IN (%s)
    AND AC.org_id = :org_id
    AND AC.channel_id = EC.channel_id
    AND EC.channel_id = C.id

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Errata_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Errata_queries.xml
@@ -1396,10 +1396,10 @@ ORDER BY EBL.bug_id
 </mode>
 
 <mode name="cves_for_errata" class="com.redhat.rhn.frontend.dto.CVE">
-  <query params="eid">
+  <query params="">
 SELECT  CVE.name
   FROM  rhnCVE CVE, rhnErrataCVE ECVE
- WHERE  ECVE.errata_id = :eid
+ WHERE  ECVE.errata_id IN (%s)
    AND  ECVE.cve_id = CVE.id
 ORDER BY UPPER(CVE.name)
   </query>

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
@@ -630,8 +630,8 @@ where a.user_id = :formvar_uid
    <elaborator name="entitlements" />
 </mode>
 
-<mode name="affected_by_errata_no_selectable" class="com.redhat.rhn.frontend.dto.SystemOverview">
-  <query params="eid, user_id">
+<mode name="affected_by_errata_no_selectable" class="com.redhat.rhn.frontend.dto.SystemOverview" >
+  <query params="user_id">
 select * from (
   SELECT  DISTINCT S.id as system_id,
                                         S.name as system_name,
@@ -640,7 +640,7 @@ select * from (
     FROM  rhnServerNeededErrataCache SNEC,
           rhnEntitledServers S,
           rhnUserServerPerms USP
-   WHERE  SNEC.errata_id = :eid
+   WHERE  SNEC.errata_id IN (%s)
      AND  USP.user_id = :user_id
      AND  S.id = USP.server_id
      AND  S.id = SNEC.server_id

--- a/java/code/src/com/redhat/rhn/domain/errata/ErrataFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/errata/ErrataFactory.java
@@ -149,7 +149,7 @@ public class ErrataFactory extends HibernateFactory {
                 retval.addAll(erratas);
             }
             else {
-                erratas = ErrataFactory.lookupErrataByAdvisoryNameAndOrg(identifier, org);
+                erratas = ErrataFactory.lookupVendorAndUserErrataByAdvisoryAndOrg(identifier, org);
                 if (erratas != null && !erratas.isEmpty()) {
                     retval.addAll(erratas);
                 }
@@ -714,20 +714,17 @@ public class ErrataFactory extends HibernateFactory {
      * @param org the organization
      * @return Returns the errata corresponding to the passed in advisory name.
      */
-    public static List<Errata> lookupErrataByAdvisoryNameAndOrg(String advisory, Org org) {
-        Session session = null;
-        List<Errata> retval = null;
-
+    public static List<Errata> lookupVendorAndUserErrataByAdvisoryAndOrg(String advisory, Org org) {
         //look for a published errata first
-        session = HibernateFactory.getSession();
-        retval = session.getNamedQuery("PublishedErrata.findByAdvisoryNameAndOrg")
+        Session session = HibernateFactory.getSession();
+        List<Errata> retval = session.getNamedQuery("PublishedErrata.findVendorAnUserErrataByAdvisoryNameAndOrg")
                 .setParameter("advisory", advisory)
                 .setParameter("org", org)
                 .getResultList();
 
         //if nothing was found, check the unpublished errata table
-        if (retval == null || retval.isEmpty()) {
-            retval = session.getNamedQuery("UnpublishedErrata.findByAdvisoryNameAndOrg")
+        if (retval.isEmpty()) {
+            retval = session.getNamedQuery("UnpublishedErrata.findVendorAnUserErrataByAdvisoryNameAndOrg")
                     .setParameter("advisory", advisory)
                     .setParameter("org", org)
                     .getResultList();
@@ -736,26 +733,25 @@ public class ErrataFactory extends HibernateFactory {
     }
 
     /**
-     * Look up an errata by the advisory name. This is a unique field in the db and this
-     * method is needed to help us see if a created/edited advisoryName is unique.
+     * Retrieves the errata that with the given advisory and a given Org.
      * @param advisory The advisory to lookup
      * @param org User organization
      * @return Returns the errata corresponding to the passed in advisory name.
      */
-    public static Errata lookupByAdvisory(String advisory, Org org) {
+    public static Errata lookupByAdvisoryAndOrg(String advisory, Org org) {
         Session session = null;
         Errata retval = null;
         //  try {
         //look for a published errata first
         session = HibernateFactory.getSession();
-        retval = (Errata) session.getNamedQuery("PublishedErrata.findByAdvisoryName")
+        retval = (Errata) session.getNamedQuery("PublishedErrata.findByAdvisoryNameAndOrg")
                 .setParameter("advisory", advisory)
                 .setParameter("org", org)
                 .uniqueResult();
         //if nothing was found, check the unpublished errata table
         if (retval == null) {
             retval = (Errata)
-                    session.getNamedQuery("UnpublishedErrata.findByAdvisoryName")
+                    session.getNamedQuery("UnpublishedErrata.findByAdvisoryNameAndOrg")
                     .setParameter("advisory", advisory)
                     .setParameter("org", org)
                     .uniqueResult();

--- a/java/code/src/com/redhat/rhn/domain/errata/ErrataFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/errata/ErrataFactory.java
@@ -655,11 +655,11 @@ public class ErrataFactory extends HibernateFactory {
     public static Errata lookupById(Long id) {
         //Look for published Errata first
         Session session = HibernateFactory.getSession();
-        Errata errata = (Errata) session.get(PublishedErrata.class, id);
+        Errata errata = session.get(PublishedErrata.class, id);
 
         //If we nothing was found, look for it in the Unpublished Errata table...
         if (errata == null) {
-            errata = (Errata) session.get(UnpublishedErrata.class, id);
+            errata = session.get(UnpublishedErrata.class, id);
         }
         return errata;
     }
@@ -704,6 +704,33 @@ public class ErrataFactory extends HibernateFactory {
             log.error("Error loading ActionArchTypes from DB", he);
             throw new
             HibernateRuntimeException("Error loading ActionArchTypes from db");
+        }
+        return retval;
+    }
+
+    /**
+     * Retrieves the errata that belongs to a vendor or a given organization, given an advisory name.
+     * @param advisory The advisory to lookup
+     * @param org the organization
+     * @return Returns the errata corresponding to the passed in advisory name.
+     */
+    public static List<Errata> lookupErrataByAdvisoryNameAndOrg(String advisory, Org org) {
+        Session session = null;
+        List<Errata> retval = null;
+
+        //look for a published errata first
+        session = HibernateFactory.getSession();
+        retval = session.getNamedQuery("PublishedErrata.findByAdvisoryNameAndOrg")
+                .setParameter("advisory", advisory)
+                .setParameter("org", org)
+                .getResultList();
+
+        //if nothing was found, check the unpublished errata table
+        if (retval == null || retval.isEmpty()) {
+            retval = session.getNamedQuery("UnpublishedErrata.findByAdvisoryNameAndOrg")
+                    .setParameter("advisory", advisory)
+                    .setParameter("org", org)
+                    .getResultList();
         }
         return retval;
     }
@@ -1225,7 +1252,7 @@ public class ErrataFactory extends HibernateFactory {
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("from_cid", fromCid);
         params.put("to_cid", toCid);
-        return (DataResult<ErrataOverview>) mode.execute(params);
+        return mode.execute(params);
     }
 
     /**
@@ -1240,7 +1267,7 @@ public class ErrataFactory extends HibernateFactory {
                 "published_owned_unmodified_cloned_errata");
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("org_id", orgId);
-        return (DataResult<OwnedErrata>) mode.execute(params);
+        return mode.execute(params);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/errata/impl/PublishedErrata.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/errata/impl/PublishedErrata.hbm.xml
@@ -99,12 +99,12 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                 where e.id in (:list)]]>
     </query>
 
-    <query name="PublishedErrata.findByAdvisoryName">
+    <query name="PublishedErrata.findByAdvisoryNameAndOrg">
         <![CDATA[from com.redhat.rhn.domain.errata.impl.PublishedErrata as e
                  where e.advisoryName = :advisory and ((:org is not null and e.org = :org) or (:org is null and e.org is null))]]>
     </query>
     
-    <query name="PublishedErrata.findByAdvisoryNameAndOrg">
+    <query name="PublishedErrata.findVendorAnUserErrataByAdvisoryNameAndOrg">
         <![CDATA[from com.redhat.rhn.domain.errata.impl.PublishedErrata as e
                  where e.advisoryName = :advisory and (e.org = :org or e.org is null)]]>
     </query>

--- a/java/code/src/com/redhat/rhn/domain/errata/impl/PublishedErrata.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/errata/impl/PublishedErrata.hbm.xml
@@ -101,7 +101,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
 
     <query name="PublishedErrata.findByAdvisoryName">
         <![CDATA[from com.redhat.rhn.domain.errata.impl.PublishedErrata as e
-                 where e.advisoryName = :advisory and (e.org = :org or e.org is null)]]>
+                 where e.advisoryName = :advisory and ((:org is not null and e.org = :org) or (:org is null and e.org is null))]]>
     </query>
     <query name="PublishedErrata.findSameInChannels">
         <![CDATA[

--- a/java/code/src/com/redhat/rhn/domain/errata/impl/PublishedErrata.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/errata/impl/PublishedErrata.hbm.xml
@@ -103,6 +103,12 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         <![CDATA[from com.redhat.rhn.domain.errata.impl.PublishedErrata as e
                  where e.advisoryName = :advisory and ((:org is not null and e.org = :org) or (:org is null and e.org is null))]]>
     </query>
+    
+    <query name="PublishedErrata.findByAdvisoryNameAndOrg">
+        <![CDATA[from com.redhat.rhn.domain.errata.impl.PublishedErrata as e
+                 where e.advisoryName = :advisory and (e.org = :org or e.org is null)]]>
+    </query>
+    
     <query name="PublishedErrata.findSameInChannels">
         <![CDATA[
         from com.redhat.rhn.domain.errata.impl.PublishedErrata as e

--- a/java/code/src/com/redhat/rhn/domain/errata/impl/UnpublishedErrata.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/errata/impl/UnpublishedErrata.hbm.xml
@@ -78,12 +78,12 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                 class="com.redhat.rhn.domain.errata.impl.PublishedErrata" />
         </joined-subclass>
     </class>
-    <query name="UnpublishedErrata.findByAdvisoryName">
+    <query name="UnpublishedErrata.findByAdvisoryNameAndOrg">
         <![CDATA[from com.redhat.rhn.domain.errata.impl.UnpublishedErrata as e
                  where e.advisoryName = :advisory and ((:org is not null and e.org = :org) or (:org is null and e.org is null))]]>
     </query>
     
-    <query name="UnpublishedErrata.findByAdvisoryNameAndOrg">
+    <query name="UnpublishedErrata.findVendorAnUserErrataByAdvisoryNameAndOrg">
         <![CDATA[from com.redhat.rhn.domain.errata.impl.UnpublishedErrata as e
                  where e.advisoryName = :advisory and (e.org = :org or org is null)]]>
     </query>

--- a/java/code/src/com/redhat/rhn/domain/errata/impl/UnpublishedErrata.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/errata/impl/UnpublishedErrata.hbm.xml
@@ -80,7 +80,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
     </class>
     <query name="UnpublishedErrata.findByAdvisoryName">
         <![CDATA[from com.redhat.rhn.domain.errata.impl.UnpublishedErrata as e
-                 where e.advisoryName = :advisory and (e.org = :org or org is null)]]>
+                 where e.advisoryName = :advisory and ((:org is not null and e.org = :org) or (:org is null and e.org is null))]]>
     </query>
     <query name="UnpublishedErrata.findByAdvisory">
         <![CDATA[from com.redhat.rhn.domain.errata.impl.UnpublishedErrata as e

--- a/java/code/src/com/redhat/rhn/domain/errata/impl/UnpublishedErrata.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/errata/impl/UnpublishedErrata.hbm.xml
@@ -82,6 +82,12 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         <![CDATA[from com.redhat.rhn.domain.errata.impl.UnpublishedErrata as e
                  where e.advisoryName = :advisory and ((:org is not null and e.org = :org) or (:org is null and e.org is null))]]>
     </query>
+    
+    <query name="UnpublishedErrata.findByAdvisoryNameAndOrg">
+        <![CDATA[from com.redhat.rhn.domain.errata.impl.UnpublishedErrata as e
+                 where e.advisoryName = :advisory and (e.org = :org or org is null)]]>
+    </query>
+    
     <query name="UnpublishedErrata.findByAdvisory">
         <![CDATA[from com.redhat.rhn.domain.errata.impl.UnpublishedErrata as e
                  where e.advisory = :advisory and (e.org = :org or org is null)]]>

--- a/java/code/src/com/redhat/rhn/domain/errata/test/ErrataFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/errata/test/ErrataFactoryTest.java
@@ -14,6 +14,9 @@
  */
 package com.redhat.rhn.domain.errata.test;
 
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+
 import com.redhat.rhn.common.db.datasource.ModeFactory;
 import com.redhat.rhn.common.db.datasource.WriteMode;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
@@ -43,13 +46,17 @@ import com.redhat.rhn.testing.ChannelTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
+import com.suse.utils.Opt;
+
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 
 /**
  * ErrataFactoryTest
@@ -358,8 +365,19 @@ public class ErrataFactoryTest extends BaseTestCaseWithUser {
      * @throws Exception something bad happened
      */
     public static Errata createTestErrata(Long orgId) throws Exception {
+        return createTestErrata(orgId, empty());
+    }
+
+    /**
+     * Create an Errata for testing and commit it to the DB.
+     * @param orgId the Org who owns this Errata
+     * @param advisory if specified, the advisory name
+     * @return Errata created
+     * @throws Exception something bad happened
+     */
+    public static Errata createTestErrata(Long orgId, Optional<String> advisory) throws Exception {
         Errata e = ErrataFactory.createPublishedErrata();
-        fillOutErrata(e, orgId);
+        fillOutErrata(e, orgId, advisory);
         ErrataFactory.save(e);
         return e;
     }
@@ -373,26 +391,34 @@ public class ErrataFactoryTest extends BaseTestCaseWithUser {
      */
     public static Errata createCriticalTestErrata(Long orgId) throws Exception {
         Errata e = ErrataFactory.createPublishedErrata();
-        fillOutErrata(e, orgId);
+        fillOutErrata(e, orgId, empty());
         e.setAdvisoryType(ErrataFactory.ERRATA_TYPE_SECURITY);
         ErrataFactory.save(e);
         return e;
     }
 
     public static Errata createTestPublishedErrata(Long orgId) throws Exception {
+        return createTestPublishedErrata(orgId, empty());
+    }
+
+    public static Errata createTestPublishedErrata(Long orgId, Optional<String> advisory) throws Exception {
         //just pass to createTestErrata since published is the default
-        return createTestErrata(orgId);
+        return createTestErrata(orgId, advisory);
     }
 
     public static Errata createTestUnpublishedErrata(Long orgId) throws Exception {
+        return createTestUnpublishedErrata(orgId, empty());
+    }
+
+    public static Errata createTestUnpublishedErrata(Long orgId, Optional<String> advisory) throws Exception {
         Errata e = ErrataFactory.createUnpublishedErrata();
-        fillOutErrata(e, orgId);
+        fillOutErrata(e, orgId, advisory);
         ErrataFactory.save(e);
         return e;
     }
 
-    private static void fillOutErrata(Errata e, Long orgId) throws Exception {
-        String name = "JAVA Test " + TestUtils.randomString();
+    private static void fillOutErrata(Errata e, Long orgId, Optional<String> advisory) throws Exception {
+        String name = Opt.fold(advisory, () -> "JAVA Test " + TestUtils.randomString(), Function.identity());
         Org org = null;
         if (orgId != null) {
             org = OrgFactory.lookupById(orgId);

--- a/java/code/src/com/redhat/rhn/domain/errata/test/ErrataFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/errata/test/ErrataFactoryTest.java
@@ -184,6 +184,46 @@ public class ErrataFactoryTest extends BaseTestCaseWithUser {
         assertEquals(unpubid, errata.getId());
     }
 
+    public void testCreateAndLookupErrataNullOrg() throws Exception {
+        //create a published errata with null Org
+        Errata published = createTestPublishedErrata(null);
+        assertTrue(published instanceof PublishedErrata);
+        assertNotNull(published.getId());
+        Long pubid = published.getId();
+        String pubname = published.getAdvisoryName();
+
+        //unpublished
+        Errata unpublished = createTestUnpublishedErrata(null);
+        assertTrue(unpublished instanceof UnpublishedErrata);
+        assertNotNull(unpublished.getId());
+        Long unpubid = unpublished.getId();
+        String unpubname = unpublished.getAdvisoryName();
+
+        //Lookup the published errata by null Org
+        Errata errata = ErrataFactory.lookupById(pubid);
+        assertTrue(errata instanceof PublishedErrata);
+        assertEquals(pubid, errata.getId());
+        errata = ErrataFactory.lookupByAdvisory(pubname, null);
+        assertTrue(errata instanceof PublishedErrata);
+        assertEquals(pubname, errata.getAdvisoryName());
+
+        //Lookup the published errata by user's Org
+        errata = ErrataFactory.lookupByAdvisory(pubname, user.getOrg());
+        assertNull(errata);
+
+        //Lookup the unpublished errata by null Org
+        errata = ErrataFactory.lookupById(unpubid);
+        assertTrue(errata instanceof UnpublishedErrata);
+        assertEquals(unpubid, errata.getId());
+        errata = ErrataFactory.lookupByAdvisory(unpubname, null);
+        assertTrue(errata instanceof UnpublishedErrata);
+        assertEquals(unpubid, errata.getId());
+
+        //Lookup the unpublished errata by user's Org
+        errata = ErrataFactory.lookupByAdvisory(unpubname, user.getOrg());
+        assertNull(errata);
+    }
+
     public void testLastModified() throws Exception {
         Errata published = createTestPublishedErrata(user.getOrg().getId());
         published = reload(published);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
@@ -2269,7 +2269,7 @@ public class ChannelSoftwareHandler extends BaseHandler {
         // make sure our errata exist in the "from" channel
         for (String erratumName : errataNames) {
             Errata toMerge = ErrataManager.lookupByAdvisory(erratumName,
-                    loggedInUser.getOrg());
+                    mergeFrom.getOrg());
 
             for (Errata erratum : sourceErrata) {
                 if (erratum.getAdvisoryName().equals(toMerge.getAdvisoryName())) {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
@@ -1549,7 +1549,7 @@ public class ChannelSoftwareHandler extends BaseHandler {
 
         for (String erratumName : errataNames) {
             Errata erratum = ErrataManager.lookupByAdvisory(erratumName,
-                    loggedInUser.getOrg());
+                    channel.getOrg());
 
             if (erratum != null) {
                 errataToRemove.add(erratum);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
@@ -1548,7 +1548,7 @@ public class ChannelSoftwareHandler extends BaseHandler {
         HashSet<Errata> errataToRemove = new HashSet<Errata>();
 
         for (String erratumName : errataNames) {
-            Errata erratum = ErrataManager.lookupByAdvisory(erratumName,
+            Errata erratum = ErrataManager.lookupByAdvisoryAndOrg(erratumName,
                     channel.getOrg());
 
             if (erratum != null) {
@@ -2268,7 +2268,7 @@ public class ChannelSoftwareHandler extends BaseHandler {
 
         // make sure our errata exist in the "from" channel
         for (String erratumName : errataNames) {
-            Errata toMerge = ErrataManager.lookupByAdvisory(erratumName,
+            Errata toMerge = ErrataManager.lookupByAdvisoryAndOrg(erratumName,
                     mergeFrom.getOrg());
 
             for (Errata erratum : sourceErrata) {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandler.java
@@ -526,15 +526,18 @@ public class ErrataHandler extends BaseHandler {
     }
 
     /**
-     * ListAffectedSystems
+     * Return the list of systems affected by the errata with the given advisory name.
+     * For those errata that are present in both vendor and user organizations under the same advisory name,
+     * this method retrieves the affected systems by both of them.
      * @param loggedInUser The current user
      * @param advisoryName The advisory name of the errata
      * @return Returns an object array containing the system ids and system name
      * @throws FaultException A FaultException is thrown if the errata corresponding to
      * advisoryName cannot be found.
      *
-     * @xmlrpc.doc Return the list of systems affected by the erratum with
-     * advisory name.
+     * @xmlrpc.doc Return the list of systems affected by the errata with the given advisory name.
+     * For those errata that are present in both vendor and user organizations under the same advisory name,
+     * this method retrieves the affected systems by both of them.
      * @xmlrpc.param #session_key()
      * @xmlrpc.param #param("string", "advisoryName")
      * @xmlrpc.returntype
@@ -546,9 +549,10 @@ public class ErrataHandler extends BaseHandler {
             throws FaultException {
 
         // Get the logged in user
-        Errata errata = lookupErrata(advisoryName, loggedInUser.getOrg());
+        List<Errata> erratas = lookupErrataByAdvisoryNameAndOrg(advisoryName, loggedInUser.getOrg());
+        List<Long> errataIds = erratas.stream().map(Errata::getId).collect(Collectors.toList());
 
-        DataResult dr = ErrataManager.systemsAffectedXmlRpc(loggedInUser, errata.getId());
+        DataResult dr = ErrataManager.systemsAffectedXmlRpc(loggedInUser, errataIds);
 
         return dr.toArray();
     }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandler.java
@@ -625,16 +625,20 @@ public class ErrataHandler extends BaseHandler {
     }
 
     /**
-     * Returns a list of channels (represented by a map) that the given erratum is
-     * applicable to.
+     * Returns a list of channels (represented by a map) applicable to the errata
+     * with the given advisory name.
+     * For those errata that are present in both vendor and user organizations under the same advisory name,
+     * this method retrieves the list of channels applicable of both of them.
      * @param loggedInUser The current user
      * @param advisoryName The advisory name of the erratum
      * @return Returns an array of channels for the erratum
      * @throws FaultException A FaultException is thrown if the errata corresponding to the
      * given advisoryName cannot be found
      *
-     * @xmlrpc.doc Returns a list of channels applicable to the erratum
+     * @xmlrpc.doc Returns a list of channels applicable to the errata
      * with the given advisory name.
+     * For those errata that are present in both vendor and user organizations under the same advisory name,
+     * this method retrieves the list of channels applicable of both of them.
      * @xmlrpc.param #session_key()
      * @xmlrpc.param #param("string", "advisoryName")
      * @xmlrpc.returntype
@@ -651,9 +655,10 @@ public class ErrataHandler extends BaseHandler {
             throws FaultException {
 
         // Get the logged in user
-        Errata errata = lookupErrata(advisoryName, loggedInUser.getOrg());
+        List<Errata> erratas = lookupErrataByAdvisoryNameAndOrg(advisoryName, loggedInUser.getOrg());
+        List<Long> errataIds = erratas.stream().map(Errata::getId).collect(Collectors.toList());
 
-        return ErrataManager.applicableChannels(errata.getId(),
+        return ErrataManager.applicableChannels(errataIds,
                 loggedInUser.getOrg().getId(), null, Map.class).toArray();
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandler.java
@@ -17,6 +17,10 @@
  */
 package com.redhat.rhn.frontend.xmlrpc.errata;
 
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+import static java.util.stream.Collectors.toMap;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -26,11 +30,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Category;
 import org.apache.log4j.Logger;
 
 import com.redhat.rhn.FaultException;
@@ -552,7 +553,7 @@ public class ErrataHandler extends BaseHandler {
 
         // Get the logged in user
         List<Errata> erratas = lookupErrataByAdvisoryNameAndOrg(advisoryName, loggedInUser.getOrg());
-        List<Long> errataIds = erratas.stream().map(Errata::getId).collect(Collectors.toList());
+        List<Long> errataIds = erratas.stream().map(Errata::getId).collect(toList());
 
         DataResult dr = ErrataManager.systemsAffectedXmlRpc(loggedInUser, errataIds);
 
@@ -591,7 +592,7 @@ public class ErrataHandler extends BaseHandler {
         List<Errata> erratas = lookupErrataByAdvisoryNameAndOrg(advisoryName, loggedInUser.getOrg());
 
         return (Map<Long, String>) erratas.stream().flatMap(e -> e.getBugs().stream())
-                .collect(Collectors.toMap(Bug::getId, Bug::getSummary));
+                .collect(toMap(Bug::getId, Bug::getSummary));
     }
 
     /**
@@ -619,7 +620,7 @@ public class ErrataHandler extends BaseHandler {
 
         Set<String> keywords = erratas.stream()
                 .flatMap(e -> e.getKeywords().stream().map(Keyword::getKeyword))
-                .collect(Collectors.toSet());
+                .collect(toSet());
 
         return keywords.toArray();
     }
@@ -656,7 +657,7 @@ public class ErrataHandler extends BaseHandler {
 
         // Get the logged in user
         List<Errata> erratas = lookupErrataByAdvisoryNameAndOrg(advisoryName, loggedInUser.getOrg());
-        List<Long> errataIds = erratas.stream().map(Errata::getId).collect(Collectors.toList());
+        List<Long> errataIds = erratas.stream().map(Errata::getId).collect(toList());
 
         return ErrataManager.applicableChannels(errataIds,
                 loggedInUser.getOrg().getId(), null, Map.class).toArray();
@@ -727,11 +728,11 @@ public class ErrataHandler extends BaseHandler {
     public Set listCves(User loggedInUser, String advisoryName) throws FaultException {
         // Get the logged in user
         List<Errata> erratas = lookupErrataByAdvisoryNameAndOrg(advisoryName, loggedInUser.getOrg());
-        List<Long> errataIds = erratas.stream().map(Errata::getId).collect(Collectors.toList());
+        List<Long> errataIds = erratas.stream().map(Errata::getId).collect(toList());
 
         DataResult dr = ErrataManager.errataCVEs(errataIds);
 
-        return (Set) dr.stream().map(cve -> ((CVE) cve).getName()).collect(Collectors.toSet());
+        return (Set) dr.stream().map(cve -> ((CVE) cve).getName()).collect(toSet());
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandler.java
@@ -1036,6 +1036,12 @@ public class ErrataHandler extends BaseHandler {
             throw new NoSuchChannelException();
         }
 
+        Org errataOrg = loggedInUser.getOrg();
+        Channel original = ChannelFactory.lookupOriginalChannel(channel);
+        if (original != null) {
+            errataOrg = original.getOrg();
+        }
+
         //if calling cloneAsOriginal, do additional checks to verify a clone
         if (inheritPackages) {
             if (!channel.isCloned()) {
@@ -1043,12 +1049,11 @@ public class ErrataHandler extends BaseHandler {
                         channel.getLabel());
             }
 
-            Channel original = ChannelFactory.lookupOriginalChannel(channel);
-
             if (original == null) {
                 throw new InvalidChannelException("Cannot access original " +
                         "of the channel: " + channel.getLabel());
             }
+
             // check access to the original
             if (ChannelFactory.lookupByIdAndUser(original.getId(), loggedInUser) == null) {
                 throw new LookupException("User " + loggedInUser.getLogin() +
@@ -1065,7 +1070,7 @@ public class ErrataHandler extends BaseHandler {
         List<Long> errataIds = new ArrayList<Long>();
         //We loop through once, making sure all the errata exist
         for (String advisory : advisoryNames) {
-            Errata toClone = lookupErrata(advisory, loggedInUser.getOrg());
+            Errata toClone = lookupErrata(advisory, errataOrg);
             errataToClone.add(toClone);
             errataIds.add(toClone.getId());
         }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandler.java
@@ -907,6 +907,28 @@ public class ErrataHandler extends BaseHandler {
     }
 
     /**
+     * Retrieves the errata that belongs to a vendor or a given organization, given an advisory name
+     * Throw a Fault exception if the errata is not found
+     * @param advisoryName The advisory name for the erratum you're looking for
+     * @param org the organization
+     * @return Returns the errata or a Fault Exception
+     * @throws FaultException Occurs when the erratum is not found
+     */
+    private List<Errata> lookupErrataByAdvisoryNameAndOrg(String advisoryName, Org org) throws FaultException {
+        List<Errata> erratas = ErrataManager.lookupErrataByAdvisoryNameAndOrg(advisoryName, org);
+
+        /*
+         * ErrataManager.lookupByAdvisory() could return null, so we need to check
+         * and throw a no_such_errata exception if the errata was not found.
+         */
+        if (erratas == null || erratas.isEmpty()) {
+            throw new FaultException(-208, "no_such_patch",
+                                     "The patch " + advisoryName + " cannot be found.");
+        }
+        return erratas;
+    }
+
+    /**
      * Private helper method to lookup an errata and throw a Fault exception if it isn't
      * found
      * @param advisoryName The advisory name for the erratum you're looking for

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandler.java
@@ -222,10 +222,10 @@ public class ErrataHandler extends BaseHandler {
      */
     public Map<String, Object> getDetails(User loggedInUser, String advisoryName)
             throws FaultException {
-        // Get the logged in user. We don't care what roles this user has, we
+     // Get the logged in user. We don't care what roles this user has, we
         // just want to make sure the caller is logged in.
 
-        Errata errata = lookupErrata(advisoryName, loggedInUser.getOrg());
+        Errata errata = lookupErratumByAdvisoryNameAndOrg(advisoryName, loggedInUser.getOrg());
 
         Map<String, Object> errataMap = new HashMap<String, Object>();
 
@@ -911,7 +911,23 @@ public class ErrataHandler extends BaseHandler {
     }
 
     /**
-     * Retrieves the errata that belongs to a vendor or a given organization, given an advisory name
+     * Retrieves the errata that belongs to a given organization, given an advisory name.
+     * If there is not any, returns the vendor errata with the same name.
+     * Throw a Fault exception if the errata is not found
+     * @param advisoryName The advisory name for the erratum you're looking for
+     * @param org the organization
+     * @return Returns the errata or a Fault Exception
+     * @throws FaultException Occurs when the erratum is not found
+     */
+    private Errata lookupErratumByAdvisoryNameAndOrg(String advisoryName, Org org) throws FaultException {
+        List<Errata> erratas = lookupErrataByAdvisoryNameAndOrg(advisoryName, org);
+
+       return erratas.stream().filter(e -> e.getOrg().getId() == org.getId())
+                .findFirst().orElse(erratas.stream().findFirst().orElse(null));
+    }
+
+    /**
+     * Retrieves the list of errata that belongs to a vendor or a given organization, given an advisory name.
      * Throw a Fault exception if the errata is not found
      * @param advisoryName The advisory name for the erratum you're looking for
      * @param org the organization

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandler.java
@@ -225,7 +225,7 @@ public class ErrataHandler extends BaseHandler {
         // Get the logged in user. We don't care what roles this user has, we
         // just want to make sure the caller is logged in.
 
-        Errata errata = lookupErrataReadOnly(advisoryName, loggedInUser.getOrg());
+        Errata errata = lookupErrata(advisoryName, loggedInUser.getOrg());
 
         Map<String, Object> errataMap = new HashMap<String, Object>();
 
@@ -778,7 +778,7 @@ public class ErrataHandler extends BaseHandler {
     public List<Map> listPackages(User loggedInUser, String advisoryName)
             throws FaultException {
         // Get the logged in user
-        Errata errata = lookupErrataReadOnly(advisoryName, loggedInUser.getOrg());
+        Errata errata = lookupErrata(advisoryName, loggedInUser.getOrg());
 
         List<Map> toRet = new ArrayList<Map>();
         for (Iterator iter = errata.getPackages().iterator(); iter.hasNext();) {
@@ -928,28 +928,6 @@ public class ErrataHandler extends BaseHandler {
                                      "The patch " + advisoryName + " cannot be found.");
         }
         return erratas;
-    }
-
-    /**
-     * Private helper method to lookup an errata and throw a Fault exception if it isn't
-     * found
-     * @param advisoryName The advisory name for the erratum you're looking for
-     * @return Returns the errata or a Fault Exception
-     * @throws FaultException Occurs when the erratum is not found
-     */
-    private Errata lookupErrataReadOnly(String advisoryName, Org org)
-            throws FaultException {
-        Errata errata = ErrataManager.lookupByAdvisory(advisoryName, org);
-
-        /*
-         * ErrataManager.lookupByAdvisory() could return null, so we need to check
-         * and throw a no_such_errata exception if the errata was not found.
-         */
-        if (errata == null) {
-            throw new FaultException(-208, "no_such_errata",
-                    "The errata " + advisoryName + " cannot be found.");
-        }
-        return errata;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandler.java
@@ -324,12 +324,6 @@ public class ErrataHandler extends BaseHandler {
 
         Errata errata = lookupErrata(advisoryName, loggedInUser.getOrg());
 
-        if (errata.getOrg() == null) {
-            // Errata in the null org should not be modified; therefore, this is
-            // considered an invalid errata for this request
-            throw new InvalidErrataException(errata.getAdvisoryName());
-        }
-
         // confirm that the user only provided valid keys in the map
         Set<String> validKeys = new HashSet<String>();
         validKeys.add("synopsis");
@@ -816,12 +810,6 @@ public class ErrataHandler extends BaseHandler {
         // Get the logged in user
         Errata errata = lookupErrata(advisoryName, loggedInUser.getOrg());
 
-        if (errata.getOrg() == null) {
-            // Errata in the null org should not be modified; therefore, this is
-            // considered an invalid errata for this request
-            throw new InvalidErrataException(errata.getAdvisoryName());
-        }
-
         int packagesAdded = 0;
         for (Integer packageId : packageIds) {
 
@@ -872,12 +860,6 @@ public class ErrataHandler extends BaseHandler {
         // Get the logged in user
         Errata errata = lookupErrata(advisoryName, loggedInUser.getOrg());
 
-        if (errata.getOrg() == null) {
-            // Errata in the null org should not be modified; therefore, this is
-            // considered an invalid errata for this request
-            throw new InvalidErrataException(errata.getAdvisoryName());
-        }
-
         int packagesRemoved = 0;
         for (Integer packageId : packageIds) {
 
@@ -921,15 +903,6 @@ public class ErrataHandler extends BaseHandler {
             throw new FaultException(-208, "no_such_patch",
                                      "The patch " + advisoryName + " cannot be found.");
         }
-        /**
-         * errata with org_id of null are public, but ones with an org id of !null are not
-         * need to make sure here that everything is checked correclty
-         */
-        if (errata.getOrg() != null && !errata.getOrg().equals(org)) {
-            throw new FaultException(-209, "no_rights_to_access",
-                    "You don't have rights to access " + advisoryName + " patch.");
-        }
-
         return errata;
     }
 
@@ -952,23 +925,7 @@ public class ErrataHandler extends BaseHandler {
             throw new FaultException(-208, "no_such_errata",
                     "The errata " + advisoryName + " cannot be found.");
         }
-        /**
-         * errata with org_id of null are public, but ones with an org id of !null are not
-         * need to make sure here that everything is checked correclty
-         */
-
-        if (errata.getOrg() == null || errata.getOrg().equals(org)) {
-            return errata;
-        }
-        Set<Channel> errataChannels = errata.getChannels();
-        List<Channel> orgChannels = org.getAccessibleChannels();
-        for (Channel channel : errataChannels) {
-           if (orgChannels.contains(channel)) {
-               return errata;
-           }
-        }
-        throw new FaultException(-209, "no_rights_to_access",
-                "You don't have rights to access " + advisoryName + " errata.");
+        return errata;
     }
 
     /**
@@ -1372,12 +1329,6 @@ public class ErrataHandler extends BaseHandler {
     public Integer delete(User loggedInUser, String advisoryName)
             throws FaultException {
         Errata errata = lookupErrata(advisoryName, loggedInUser.getOrg());
-
-        if (errata.getOrg() == null) {
-            // Errata in the null org should not be modified; therefore, this is
-            // considered an invalid errata for this request
-            throw new InvalidErrataException(errata.getAdvisoryName());
-        }
 
         ErrataManager.deleteErratum(loggedInUser, errata);
         return 1;

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/test/ErrataHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/test/ErrataHandlerTest.java
@@ -39,6 +39,7 @@ import com.redhat.rhn.testing.UserTestUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
@@ -226,7 +227,7 @@ public class ErrataHandlerTest extends BaseHandlerTestCase {
     public void testApplicableToChannels() throws Exception {
         Errata errata = ErrataFactoryTest.createTestErrata(user.getOrg().getId());
 
-        DataResult dr = ErrataManager.applicableChannels(errata.getId(),
+        DataResult dr = ErrataManager.applicableChannels(Arrays.asList(errata.getId()),
                             user.getOrg().getId(), null, Map.class);
 
         Object[] channels = handler.applicableToChannels(admin, errata.getAdvisory());
@@ -411,7 +412,7 @@ public class ErrataHandlerTest extends BaseHandlerTestCase {
         // delete a published erratum
         int result = handler.delete(admin, errata.getAdvisory());
         assertEquals(1, result);
-        errata = (Errata) TestUtils.reload(errata);
+        errata = TestUtils.reload(errata);
         assertNull(errata);
 
         errata = ErrataFactoryTest.createTestUnpublishedErrata(user.getOrg().getId());
@@ -422,7 +423,7 @@ public class ErrataHandlerTest extends BaseHandlerTestCase {
         // delete an unpublished erratum
         result = handler.delete(admin, errata.getAdvisory());
         assertEquals(1, result);
-        errata = (Errata) TestUtils.reload(errata);
+        errata = TestUtils.reload(errata);
         assertNull(errata);
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/test/ErrataHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/test/ErrataHandlerTest.java
@@ -239,7 +239,7 @@ public class ErrataHandlerTest extends BaseHandlerTestCase {
 
         DataResult dr = ErrataManager.errataCVEs(errata.getId());
 
-        List cves = handler.listCves(admin, errata.getAdvisory());
+        Set cves = handler.listCves(admin, errata.getAdvisory());
 
         assertEquals(dr.size(), cves.size());
     }

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -840,20 +840,17 @@ public class ErrataManager extends BaseManager {
     /**
      * Returns the system id and system names of the systems affected by a given errata
      * @param user The logged in user
-     * @param eid The id of the errata in question
+     * @param eids The ids of the erratas
      * @return Returns the system id and system names of the systems affected by a
      * given errata
      */
-    public static DataResult systemsAffectedXmlRpc(User user, Long eid) {
+    public static DataResult systemsAffectedXmlRpc(User user, List<Long> eids) {
         SelectMode m = ModeFactory.getMode("System_queries",
                 "affected_by_errata_no_selectable",
                 Map.class);
         Map<String, Object> params = new HashMap<String, Object>();
-        params.put("eid", eid);
         params.put("user_id", user.getId());
-        Map<String, Object> elabParams = new HashMap<String, Object>();
-        elabParams.put("eid", eid);
-        return makeDataResult(params, elabParams, null, m);
+        return m.execute(params, eids);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -743,8 +743,8 @@ public class ErrataManager extends BaseManager {
      * @param org User organization
      * @return Returns the requested Errata
      */
-    public static Errata lookupByAdvisory(String advisoryName, Org org) {
-        return ErrataFactory.lookupByAdvisory(advisoryName, org);
+    public static Errata lookupByAdvisoryAndOrg(String advisoryName, Org org) {
+        return ErrataFactory.lookupByAdvisoryAndOrg(advisoryName, org);
     }
 
     /**
@@ -753,8 +753,8 @@ public class ErrataManager extends BaseManager {
      * @param org the organization
      * @return Returns the requested Errata
      */
-    public static List<Errata> lookupErrataByAdvisoryNameAndOrg(String advisoryName, Org org) {
-        return ErrataFactory.lookupErrataByAdvisoryNameAndOrg(advisoryName, org);
+    public static List<Errata> lookupVendorAndUserErrataByAdvisoryAndOrg(String advisoryName, Org org) {
+        return ErrataFactory.lookupVendorAndUserErrataByAdvisoryAndOrg(advisoryName, org);
     }
 
     /**
@@ -1033,7 +1033,7 @@ public class ErrataManager extends BaseManager {
      * otherwise.
      */
     public static boolean advisoryNameIsUnique(Long eid, String name, Org org) {
-        Errata e = lookupByAdvisory(name, org);
+        Errata e = lookupByAdvisoryAndOrg(name, org);
         //If we can't find an errata, then the advisoryName is unique
         if (e == null) {
             return true;

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -1098,14 +1098,14 @@ public class ErrataManager extends BaseManager {
 
 
     /**
-     * Get a list of channels applicable to the erratum
-     * @param eid The id of the erratum
+     * Get a list of channels applicable to a list of erratas
+     * @param eids The ids of the erratas
      * @param orgid The id for the org we want to lookup against
      * @param pc The page control for the user
      * @param clazz The class you would like the return values represented as
-     * @return List of applicable channels for the erratum (that the org has access to)
+     * @return List of applicable channels for the erratas (that the org has access to)
      */
-    public static DataResult applicableChannels(Long eid, Long orgid,
+    public static DataResult applicableChannels(List<Long> eids, Long orgid,
             PageControl pc, Class clazz) {
         SelectMode m;
         if (clazz == null) {
@@ -1117,8 +1117,7 @@ public class ErrataManager extends BaseManager {
 
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("org_id", orgid);
-        params.put("eid", eid);
-        return makeDataResult(params, params, pc, m);
+        return m.execute(params, eids);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -747,6 +747,16 @@ public class ErrataManager extends BaseManager {
     }
 
     /**
+     * Retrieves the errata that belongs to a vendor or a given organization, given an advisory name.
+     * @param advisoryName The advisory name of the errata you're looking for
+     * @param org the organization
+     * @return Returns the requested Errata
+     */
+    public static List<Errata> lookupErrataByAdvisoryNameAndOrg(String advisoryName, Org org) {
+        return ErrataFactory.lookupErrataByAdvisoryNameAndOrg(advisoryName, org);
+    }
+
+    /**
      * Looks up errata by CVE string
      * @param cve errata's CVE string
      * @return Errata if found, otherwise null

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -87,6 +87,7 @@ import org.apache.log4j.Logger;
 import java.io.File;
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -911,12 +912,20 @@ public class ErrataManager extends BaseManager {
      * @return common vulnerabilities and exposures
      */
     public static DataResult errataCVEs(Long eid) {
+        return errataCVEs(Arrays.asList(eid));
+    }
+
+    /**
+     * Returns a list of CVEs for a list of errata ids
+     * @param eids The errata ids
+     * @return common vulnerabilities and exposures
+     */
+    public static DataResult errataCVEs(List<Long> eids) {
         SelectMode m = ModeFactory.getMode("Errata_queries", "cves_for_errata");
 
-        Map<String, Object> params = new HashMap<String, Object>();
-        params.put("eid", eid);
-        return m.execute(params);
+        return m.execute(new HashMap<String, Object>(), eids);
     }
+
 
     /**
      * Returns a list of keywords for an errata

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix cloning channels when managing the same errata for both vendor and private orgs (bsc#1111686)
 - Hide 'unknown virtual host manager' when virtual host manager of all hosts is known (bsc#1119320)
 - Add REST API to retrieve VM definition
 - Nav and section scroll independently


### PR DESCRIPTION
## What does this PR change?

Adapt the behavior of several features for the cases we manage the same errata for both vendor and private organizations.

It also fix a bug produced in such cases when cloning channels.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Documentation was updated for the XML-RPC API

- [x] **DONE**

## Test coverage
- Unit tests were add/updated

- [x] **DONE**

## Links

Fixes https://bugzilla.suse.com/1117613 and partly https://bugzilla.suse.com/1111686
Tracks https://github.com/SUSE/spacewalk/pull/6497

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already ran, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
