### PR TITLE
Let nav and section scroll independently

### DIFF
--- a/branding/css/susemanager-login.less
+++ b/branding/css/susemanager-login.less
@@ -120,8 +120,8 @@ body.login-page {
   }
   footer {
     border-top-width: 0px;
-    background-color: transparent;
-    position: relative;
+    background-color: @spacewalk-blue-light;
+    position: fixed;
     padding-bottom: 0;
     padding-left: 0;
     .gray-text;

--- a/branding/css/susemanager-responsive-rules.less
+++ b/branding/css/susemanager-responsive-rules.less
@@ -7,6 +7,7 @@
       border-bottom: 0;
       padding-left: 0;
       padding-right: 0;
+      position: fixed;
     }
   }
 }
@@ -38,9 +39,11 @@
   .spacewalk-main-column-layout {
     aside {
       .make-xs-column(3);
+      position: fixed;
     }
     section {
       .make-xs-column(9);
+      float: right;
     }
   }
 }
@@ -248,7 +251,7 @@
   .sideleg-always-visible;
 
   .spacewalk-main-column-layout {
-    aside, section{
+    aside, section, #nav {
       overflow-y: visible!important;
       height: auto!important;
     }

--- a/branding/css/susemanager-theme.less
+++ b/branding/css/susemanager-theme.less
@@ -15,6 +15,7 @@ a, a:hover {
 }
 header {
   position: fixed;
+  top: 0;
   height:auto;
   z-index: 1000;
   width: 100%;
@@ -144,7 +145,11 @@ section {
     background: @spacewalk-aside;
     border-right: 1px solid @spacewalk-aside-border;
     /* erasing the predefined paddings in the columns */
-    padding: 1em 0 2em 0;
+    padding: 0;
+    position: fixed;
+    #nav {
+      overflow-y: auto!important;
+    }
   }
 
   /* fixing margins in the 1st and last columns */
@@ -154,6 +159,8 @@ section {
     padding-right: 2em;
     padding-top: 0;
     padding-bottom: 2em;
+    overflow-y: auto!important;
+    float: right;
   }
 }
 
@@ -336,9 +343,8 @@ header, nav.navbar-pf {
 
 //Nav menu in left column
 #nav {
-  margin-bottom: 60px;
   nav {
-    padding: 0px;
+    padding: 10px 0 0 0;
     .nav-tool-box {
       text-align: center;
       padding: 0 10px;

--- a/branding/css/susemanager-theme.less
+++ b/branding/css/susemanager-theme.less
@@ -341,6 +341,33 @@ header, nav.navbar-pf {
   }
 }
 
+#scroll-top {
+  display: none;
+  position: fixed;
+  bottom: 5px;
+  right: 3px;
+  cursor: pointer;
+  z-index: 1000;
+  border-radius: 20px;
+  width: 35px;
+  height: 35px;
+  font-size: 1.5em;
+  padding: 0;
+  text-align: center;
+  background-color: rgba(0, 192, 129, 0.2);
+  color: @spacewalk-gray-dark;
+  border: 1px solid rgba(0, 192, 129, 0.2);
+  i {
+    margin: 0 auto;
+    height: 26px;
+  }
+}
+#scroll-top:hover {
+  background-color: rgba(0, 192, 129, 0.9);
+  color: @spacewalk-gray-light;
+  border: 1px solid darken(@susemanager-green, 10%);
+}
+
 //Nav menu in left column
 #nav {
   nav {
@@ -372,32 +399,6 @@ header, nav.navbar-pf {
           color: @spacewalk-aside-menu-search-clear-hover;
         }
       }
-    }
-    #scroll-top {
-      display: none;
-      position: fixed;
-      bottom: 5px;
-      right: 3px;
-      cursor: pointer;
-      z-index: 1000;
-      border-radius: 20px;
-      width: 35px;
-      height: 35px;
-      font-size: 1.5em;
-      padding: 0;
-      text-align: center;
-      background-color: rgba(0, 192, 129, 0.2);
-      color: @spacewalk-gray-dark;
-      border: 1px solid rgba(0, 192, 129, 0.2);
-      i {
-        margin: 0 auto;
-        height: 26px;
-      }
-    }
-    #scroll-top:hover {
-      background-color: rgba(0, 192, 129, 0.9);
-      color: @spacewalk-gray-light;
-      border: 1px solid darken(@susemanager-green, 10%);
     }
     a, .node-text {
       display: inline-block;

--- a/branding/spacewalk-branding.changes
+++ b/branding/spacewalk-branding.changes
@@ -1,3 +1,5 @@
+- Nav and section scroll independently
+
 -------------------------------------------------------------------
 Mon Dec 17 14:35:08 CET 2018 - jgonzalez@suse.com
 

--- a/java/code/webapp/WEB-INF/decorators/layout_c.jsp
+++ b/java/code/webapp/WEB-INF/decorators/layout_c.jsp
@@ -52,5 +52,6 @@
       </section>
       <script src='/javascript/manager/menu.bundle.js'></script>
     </div>
+    <button id="scroll-top"><i class='fa fa-angle-up'></i></button>
   </body>
 </html:html>

--- a/java/code/webapp/WEB-INF/includes/header.jsp
+++ b/java/code/webapp/WEB-INF/includes/header.jsp
@@ -7,7 +7,7 @@
 <c:set var="custom_header" scope="page" value="${rhn:getConfig('java.custom_header')}" />
 
 <div class="navbar-header">
-  <a href="#" class="navbar-toggle" data-toggle="collapse" data-target="#spacewalk-aside">
+  <a href="#" class="navbar-toggle">
     <i class="fa fa-bars" aria-hidden="true"></i>
   </a>
   <div id="breadcrumb"></div>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Nav and section scroll independently
 - Listen to salt libvirt events to update VMs state
 - avoid a NullPointerException error in Taskomatic (bsc#1119271)
 - XMLRPC API: Include init.sls in channel file list (bsc#1111191)

--- a/web/html/javascript/spacewalk-essentials.js
+++ b/web/html/javascript/spacewalk-essentials.js
@@ -61,7 +61,7 @@ $(window).resize(function () {
 
 // On section#spacewalk-content scroll
 function scrollTopBehavior() {
-  $('section#spacewalk-content').scroll(function() {
+  $(window).scroll(function() {
     if($(this).scrollTop() > 100) {
       $('#scroll-top').show();
     } else {
@@ -69,6 +69,10 @@ function scrollTopBehavior() {
     }
 
     sstScrollBehavior();
+  });
+
+  $(document).on('click', '#scroll-top', function() {
+    window.scrollTo(0,0);
   });
 }
 

--- a/web/html/javascript/spacewalk-essentials.js
+++ b/web/html/javascript/spacewalk-essentials.js
@@ -32,6 +32,8 @@ $(document).on("ready", function(){
 
   // Show character length for textarea
   addTextareaLengthNotification();
+
+  scrollTopBehavior();
 });
 
 
@@ -57,17 +59,19 @@ $(window).resize(function () {
   alignContentDimensions();
 });
 
-// On window scroll
-$(window).scroll(function () {
-  if ((document.documentElement.scrollTop || document.body.scrollTop) < 100) {
-    $('#scroll-top').hide();
-  }
-  else {
-    $('#scroll-top').show();
-  }
+// On section#spacewalk-content scroll
+function scrollTopBehavior() {
+  $('section#spacewalk-content').scroll(function() {
+    if($(this).scrollTop() > 100) {
+      $('#scroll-top').show();
+    } else {
+      $('#scroll-top').hide();
+    }
 
-  sstScrollBehavior();
-});
+    sstScrollBehavior();
+  });
+}
+
 
 // A container function for what should be fired
 // to set HTML tag dimensions
@@ -91,7 +95,7 @@ function sstScrollBehaviorSetup(sst) {
 
   // override the empty function hooked on window.scroll event                                              │
   sstScrollBehavior = function() {
-    var currentScroll = $(window).scrollTop();
+    var currentScroll = $('section#spacewalk-content').scrollTop();
     if (currentScroll >= fixedTop) {
       sst.after(adjustSpaceObject);
       $(sst).addClass('fixed');
@@ -170,25 +174,27 @@ function sstStyle() {
 // padding-top equals the header height to be fully visible
 function adjustDistanceForFixedHeader() {
   // subtract 1px in case the outerHeight comes to us already upper rounded
-  $('.spacewalk-main-column-layout').css('padding-top', $('header').outerHeight()-1);
+  $('body').css('padding-top', $('header').outerHeight());
 }
 
 // Make columns 100% in height
 function columnHeight() {
   const aside = $('.spacewalk-main-column-layout aside');
-  const section = $('.spacewalk-main-column-layout section');
-  aside.css('min-height', 0);
-  section.css('min-height', 0);
   const headerHeight = $('header').outerHeight();
-  const footerHeight = $('.login-page footer').outerHeight();
-  const docHeight = $(document).height();
-  // Column heights should equal the document height minus the header height and footer height
-  aside.css('min-height', docHeight - headerHeight - footerHeight + 1);
-  // responsive rule: the aside block is layered on top of section,
-  // and when it is shown, its height increase the docHeight
-  const asideHeight = aside.is(':hidden') ? 0 : aside.outerHeight();
-  section.css('min-height', docHeight - headerHeight - asideHeight - footerHeight);
+  const footerHeight = $('footer').outerHeight();
+  const winHeight = $(window).height();
+  // // Column height should equal the window height minus the header and footer height
+  aside.css('height', winHeight - headerHeight);
+  // aside.css('padding-bottom', footerHeight);
+  const nav = $('.spacewalk-main-column-layout aside #nav');
+  nav.css('height', aside.outerHeight() - footerHeight);
 };
+
+$(document).on('click', '.navbar-toggle', function() {
+  $('aside').toggleClass('in');
+  $('aside').toggleClass('collapse');
+  columnHeight();
+});
 
 // returns an object that can be passed to DWR renderer as a callback
 // puts rendered HTML in #divId, opens an alert with the same text if
@@ -480,6 +486,10 @@ $(document).click(function (e) {
       toggleButton.trigger('click');
     }
   });
+});
+
+$(document).on('click', '.navbar-toggle', function() {
+  $('aside').toggle();
 });
 
 /* prevent jumping to the top of the page because

--- a/web/html/src/manager/menu.js
+++ b/web/html/src/manager/menu.js
@@ -147,10 +147,6 @@ class Nav extends React.Component {
     this.setState({search: '', forceCollapse: true});
   };
 
-  scrollToTop = () => {
-    document.getElementById('spacewalk-content').scrollTop = 0;
-  };
-
   render() {
     return (
       <nav className={this.state.search != null && this.state.search.length > 0 ? '' : 'collapsed'}>
@@ -162,7 +158,6 @@ class Nav extends React.Component {
           </span>
         </div>
         <MenuLevel level={1} elements={JSONMenu} searchString={this.state.search} forceCollapse={this.state.forceCollapse} />
-        <button id="scroll-top" onClick={this.scrollToTop}><i className='fa fa-angle-up'></i></button>
       </nav>
     );
   }

--- a/web/html/src/manager/menu.js
+++ b/web/html/src/manager/menu.js
@@ -148,7 +148,7 @@ class Nav extends React.Component {
   };
 
   scrollToTop = () => {
-    window.scrollTo(0, 0);
+    document.getElementById('spacewalk-content').scrollTop = 0;
   };
 
   render() {

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Nav and section scroll independently
 - change SCC sync backend to adapt quicker to SCC changes and improve
   speed of syncing metadata and checking for channel dependencies
 


### PR DESCRIPTION
## What does this PR change?

Let the menu `nav` and the content `section` scroll independently

## GUI diff

Before:
### top
![top](https://user-images.githubusercontent.com/7080830/50082404-291ca500-01f1-11e9-8af1-82251da83fb6.png)
### both scrolled
![scrolled](https://user-images.githubusercontent.com/7080830/50082412-2cb02c00-01f1-11e9-89fa-4d091925c9c3.png)


After:
### top
![top2](https://user-images.githubusercontent.com/7080830/50082467-59644380-01f1-11e9-9147-af0f76f4e11f.png)

### section scrolled
![sectionscroll](https://user-images.githubusercontent.com/7080830/50082470-5bc69d80-01f1-11e9-848d-ada52119a901.png)

### nav scrolled
![navscroll](https://user-images.githubusercontent.com/7080830/50082475-5e28f780-01f1-11e9-9938-2d5ca3869b20.png)


- [ ] **DONE**

## Documentation
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)
@Loquacity : just pinging you for now to let you have under your hands whenever screenshots will be picked up for the new documentation of SUSE Manager 4.0

- [x] **DONE**

## Test coverage
- No tests: nothing to test here

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/6330

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already ran, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
