### PR TITLE
Fix package mappings for Debian systems

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageArch.java
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageArch.java
@@ -17,6 +17,7 @@ package com.redhat.rhn.domain.rhnpackage;
 import com.redhat.rhn.domain.BaseDomainHelper;
 import com.redhat.rhn.domain.common.ArchType;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -108,6 +109,17 @@ public class PackageArch extends BaseDomainHelper implements Comparable<PackageA
             builder.append("archType", this.getArchType());
         }
         return builder.toString();
+    }
+
+    /**
+     * Returns the channel architecture as a universal arch string, practically
+     * stripping away any arch type suffixes (e.g. "-deb"). The universal string is
+     * meant to be recognized in the whole linux ecosystem.
+     *
+     * @return a package architecture string
+     */
+    public String toUniversalArchString() {
+        return StringUtils.substringBeforeLast(getLabel(), "-deb");
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageEvr.java
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageEvr.java
@@ -183,12 +183,32 @@ public class PackageEvr implements Comparable {
     public String toString() {
         StringBuilder builder = new StringBuilder();
         if (StringUtils.isNumeric(getEpoch())) {
-            builder.append(getEpoch());
-            builder.append(":");
+            builder.append(getEpoch()).append(':');
+        }
+        builder.append(getVersion()).append('-').append(getRelease());
+        return builder.toString();
+    }
+
+    /**
+     * Return an EVR string representation in the format "[epoch:]version-release",
+     * stripping away any dummy release strings (e.g. "-X"). The universal string is
+     * meant to be recognized in the whole linux ecosystem.
+     *
+     * @return string representation of epoch, version and release
+     */
+    public String toUniversalEvrString() {
+        StringBuilder builder = new StringBuilder();
+
+        if (StringUtils.isNumeric(getEpoch())) {
+            builder.append(getEpoch()).append(':');
         }
         builder.append(getVersion());
-        builder.append("-");
-        builder.append(getRelease());
+
+        // Strip dummy release string
+        if (!getRelease().equals("X")) {
+            builder.append('-').append(getRelease());
+        }
+
         return builder.toString();
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/test/PackageArchTest.java
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/test/PackageArchTest.java
@@ -15,6 +15,7 @@
 package com.redhat.rhn.domain.rhnpackage.test;
 
 import com.redhat.rhn.domain.rhnpackage.PackageArch;
+import com.redhat.rhn.domain.rhnpackage.PackageFactory;
 import com.redhat.rhn.testing.RhnBaseTestCase;
 import com.redhat.rhn.testing.TestUtils;
 
@@ -38,5 +39,13 @@ public class PackageArchTest extends RhnBaseTestCase {
 
         assertNotNull(p1.getArchType());
         assertEquals(p1.getLabel(), p2.getLabel());
+    }
+
+    public void testToUniversalArchString() {
+        PackageArch archx86 = PackageFactory.lookupPackageArchByLabel("x86_64");
+        PackageArch archAmd64 = PackageFactory.lookupPackageArchByLabel("amd64-deb");
+
+        assertEquals("x86_64", archx86.toUniversalArchString());
+        assertEquals("amd64", archAmd64.toUniversalArchString());
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/test/PackageEvrTest.java
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/test/PackageEvrTest.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.domain.rhnpackage.test;
+
+import com.redhat.rhn.domain.rhnpackage.PackageEvr;
+import com.redhat.rhn.testing.BaseTestCaseWithUser;
+
+public class PackageEvrTest extends BaseTestCaseWithUser {
+
+    public void testToUniversalEvrString() {
+        PackageEvr evr1 = PackageEvrFactoryTest.createTestPackageEvr("1", "2.3.4", "5");
+        PackageEvr evr2 = PackageEvrFactoryTest.createTestPackageEvr(null, "1.2", "X");
+
+        assertEquals("1:2.3.4-5", evr1.toUniversalEvrString());
+        assertEquals("1.2", evr2.toUniversalEvrString());
+    }
+}

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -509,6 +509,64 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 .findAny().get().getStatus().equals(ActionFactory.STATUS_COMPLETED));
     }
 
+    /**
+     * Test the processing of packages.profileupdate job return event
+     * for Ubuntu 18.04.
+     *
+     * @throws Exception in case of an error
+     */
+    public void testPackagesProfileUpdateUbuntu() throws Exception {
+        // Prepare test objects: minion server, products and action
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
+        minion.setServerArch(ServerFactory.lookupServerArchByLabel("amd64-debian-linux"));
+        minion.setMinionId("minion.ubuntu.local");
+        Action action = ActionFactoryTest.createAction(
+                user, ActionFactory.TYPE_PACKAGES_REFRESH_LIST);
+        action.addServerAction(ActionFactoryTest.createServerAction(minion, action));
+
+        // Setup an event message from file contents
+        Optional<JobReturnEvent> event = JobReturnEvent.parse(
+                getJobReturnEvent("packages.profileupdate.ubuntu.json", action.getId()));
+        JobReturnEventMessage message = new JobReturnEventMessage(event.get());
+
+        // Process the event message
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
+        messageAction.execute(message);
+
+        // Verify the results
+        assertEquals(3, minion.getPackages().size());
+
+        // 'libgcc1' package
+        InstalledPackage pkg =
+                minion.getPackages().stream().filter(p -> "libgcc1".equals(p.getName().getName())).findFirst().get();
+        assertEquals("8.2.0", pkg.getEvr().getVersion());
+        assertEquals("1ubuntu2~18.04", pkg.getEvr().getRelease());
+        assertEquals("1", pkg.getEvr().getEpoch());
+        assertEquals("amd64-deb", pkg.getArch().getLabel());
+
+        // 'libefiboot1' package
+        pkg = minion.getPackages().stream().filter(p -> "libefiboot1".equals(p.getName().getName())).findFirst().get();
+        assertEquals("34", pkg.getEvr().getVersion());
+        assertEquals("1", pkg.getEvr().getRelease());
+        assertNull(pkg.getEvr().getEpoch());
+        assertEquals("amd64-deb", pkg.getArch().getLabel());
+
+        // 'init' package
+        pkg = minion.getPackages().stream().filter(p -> "init".equals(p.getName().getName())).findFirst().get();
+        assertEquals("1.51", pkg.getEvr().getVersion());
+        assertEquals("X", pkg.getEvr().getRelease());
+        assertNull(pkg.getEvr().getEpoch());
+        assertEquals("amd64-deb", pkg.getArch().getLabel());
+
+        // Verify OS family
+        assertEquals("Debian", minion.getOsFamily());
+
+        // Verify the action status
+        assertTrue(action.getServerActions().stream()
+                .filter(serverAction -> serverAction.getServer().equals(minion))
+                .findAny().get().getStatus().equals(ActionFactory.STATUS_COMPLETED));
+    }
+
 
     public void testHardwareProfileUpdateX86NoDmi()  throws Exception {
         testHardwareProfileUpdate("hardware.profileupdate.nodmi.x86.json", (server) -> {

--- a/java/code/src/com/suse/manager/reactor/messaging/test/packages.profileupdate.ubuntu.json
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/packages.profileupdate.ubuntu.json
@@ -1,0 +1,387 @@
+{
+  "tag": "salt/job/20160407084101455804/ret/minion.ubuntu.local",
+  "data": {
+    "fun_args": [
+      {
+        "mods": [
+          "packages.profileupdate"
+        ]
+      }
+    ],
+    "jid": "20160407084101455804",
+    "return": {
+        "module_|-packages_|-pkg.info_installed_|-run": {
+            "comment": "Module function pkg.info_installed executed",
+            "name": "pkg.info_installed",
+            "start_time": "17:34:36.995780",
+            "result": true,
+            "duration": 610.41,
+            "__run_num__": 2,
+            "__sls__": "packages.profileupdate",
+            "changes": {
+                "ret": {
+                    "libgcc1": {
+                        "build_date": "2018-07-28T06:13:41Z",
+                        "group": "libs",
+                        "description": "GCC support library\n Shared version of the support library, a library of internal subroutines\n that GCC uses to overcome shortcomings of particular machines, or\n special needs for some languages.\n",
+                        "url": "http://gcc.gnu.org/",
+                        "build_date_time_t": 1532758421,
+                        "install_date": "2018-11-01T21:30:01Z",
+                        "install_date_time_t": 1541107801,
+                        "source": "gcc-8",
+                        "version": "1:8.2.0-1ubuntu2~18.04",
+                        "packager": "Ubuntu Core developers <ubuntu-devel-discuss@lists.ubuntu.com>",
+                        "arch": "amd64",
+                        "name": "libgcc1"
+                    },
+                    "libefiboot1": {
+                        "build_date": "2018-02-13T17:07:12Z",
+                        "group": "libs",
+                        "description": "Library to manage UEFI variables\n Library to allow for the manipulation of UEFI variables related to booting.\n",
+                        "license": "GPL-2.0+, LGPL-2.0+",
+                        "url": "https://github.com/rhinstaller/efivar",
+                        "build_date_time_t": 1518541632,
+                        "install_date": "2018-11-01T21:46:05Z",
+                        "install_date_time_t": 1541108765,
+                        "source": "efivar",
+                        "version": "34-1",
+                        "packager": "Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>",
+                        "arch": "amd64",
+                        "name": "libefiboot1"
+                    },
+                    "init": {
+                        "build_date": "2017-10-25T15:38:42Z",
+                        "group": "metapackages",
+                        "description": "metapackage ensuring an init system is installed\n This package is a metapackage which allows you to select from the available\n init systems while ensuring that one of these is available on the system at\n all times.\n",
+                        "license": "BSD-3-clause, GPL-2+",
+                        "build_date_time_t": 1508945922,
+                        "install_date": "2018-11-01T21:29:19Z",
+                        "install_date_time_t": 1541107759,
+                        "source": "init-system-helpers",
+                        "version": "1.51",
+                        "packager": "Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>",
+                        "arch": "amd64",
+                        "name": "init"
+                    }
+                }
+            },
+            "__id__": "packages"
+        },
+        "cmd_|-ubunturelease_|-cat /etc/os-release_|-run": {
+            "comment": "Command \"cat /etc/os-release\" run",
+            "name": "cat /etc/os-release",
+            "start_time": "17:34:37.607547",
+            "result": true,
+            "duration": 37.363,
+            "__run_num__": 3,
+            "__sls__": "packages.profileupdate",
+            "changes": {
+                "pid": 384,
+                "retcode": 0,
+                "stderr": "",
+                "stdout": "NAME=\"Ubuntu\"\nVERSION=\"18.04.1 LTS (Bionic Beaver)\"\nID=ubuntu\nID_LIKE=debian\nPRETTY_NAME=\"Ubuntu 18.04.1 LTS\"\nVERSION_ID=\"18.04\"\nHOME_URL=\"https://www.ubuntu.com/\"\nSUPPORT_URL=\"https://help.ubuntu.com/\"\nBUG_REPORT_URL=\"https://bugs.launchpad.net/ubuntu/\"\nPRIVACY_POLICY_URL=\"https://www.ubuntu.com/legal/terms-and-policies/privacy-policy\"\nVERSION_CODENAME=bionic\nUBUNTU_CODENAME=bionic"
+            },
+            "__id__": "ubunturelease"
+        },
+        "module_|-sync_grains_|-saltutil.sync_grains_|-run": {
+            "comment": "Module function saltutil.sync_grains executed",
+            "name": "saltutil.sync_grains",
+            "start_time": "17:34:36.302401",
+            "result": true,
+            "duration": 645.792,
+            "__run_num__": 0,
+            "__sls__": "util.syncgrains",
+            "changes": {
+                "ret": []
+            },
+            "__id__": "sync_grains"
+        },
+        "module_|-grains_update_|-grains.items_|-run": {
+            "comment": "Module function grains.items executed",
+            "name": "grains.items",
+            "start_time": "17:34:37.645590",
+            "result": true,
+            "duration": 7.49,
+            "__run_num__": 4,
+            "__sls__": "packages.profileupdate",
+            "changes": {
+                "ret": {
+                    "additional_packages": [],
+                    "kernelrelease": "4.15.0-38-generic",
+                    "virtual": "kvm",
+                    "saltversioninfo": [
+                        2018,
+                        3,
+                        0,
+                        0
+                    ],
+                    "systemd": {
+                        "version": "237",
+                        "features": "+PAM +AUDIT +SELINUX +IMA +APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD -IDN2 +IDN -PCRE2 default-hierarchy=hybrid"
+                    },
+                    "uuid": "55f5685d-749d-4a34-bff2-412cef02f6a9",
+                    "hwaddr_interfaces": {
+                        "lo": "00:00:00:00:00:00",
+                        "ens3": "d2:2f:6f:d8:f3:b0"
+                    },
+                    "osfullname": "Ubuntu",
+                    "additional_network": 0,
+                    "init": "systemd",
+                    "lsb_distrib_id": "Ubuntu",
+                    "apparmor": 0,
+                    "pythonpath": [
+                        "/usr/bin",
+                        "/usr/lib/python2.7",
+                        "/usr/lib/python2.7/plat-x86_64-linux-gnu",
+                        "/usr/lib/python2.7/lib-tk",
+                        "/usr/lib/python2.7/lib-old",
+                        "/usr/lib/python2.7/lib-dynload",
+                        "/usr/local/lib/python2.7/dist-packages",
+                        "/usr/lib/python2.7/dist-packages"
+                    ],
+                    "cpu_flags": [
+                        "fpu",
+                        "de",
+                        "pse",
+                        "tsc",
+                        "msr",
+                        "pae",
+                        "mce",
+                        "cx8",
+                        "apic",
+                        "sep",
+                        "mtrr",
+                        "pge",
+                        "mca",
+                        "cmov",
+                        "pse36",
+                        "clflush",
+                        "mmx",
+                        "fxsr",
+                        "sse",
+                        "sse2",
+                        "syscall",
+                        "nx",
+                        "lm",
+                        "rep_good",
+                        "nopl",
+                        "xtopology",
+                        "cpuid",
+                        "pni",
+                        "cx16",
+                        "x2apic",
+                        "hypervisor",
+                        "lahf_lm",
+                        "pti"
+                    ],
+                    "cpu_model": "QEMU Virtual CPU version 2.5+",
+                    "oscodename": "bionic",
+                    "gpus": [
+                      {
+                            "model": "GD 5446",
+                            "vendor": "unknown"
+                        }
+                    ],
+                    "num_gpus": 1,
+                    "disks": [
+                        "loop1",
+                        "loop6",
+                        "loop4",
+                        "sr0",
+                        "loop2",
+                        "loop0",
+                        "loop7",
+                        "loop5",
+                        "vda",
+                        "loop3"
+                    ],
+                    "productname": "Standard PC (i440FX + PIIX, 1996)",
+                    "osarch": "amd64",
+                    "machine_id": "55f5685d749d4a34bff2412cef02f6a9",
+                    "biosversion": "1.0.0-prebuilt.qemu-project.org",
+                    "use_unreleased_updates": 0,
+                    "domain": "tf.local",
+                    "fqdns": [],
+                    "ip_interfaces": {
+                        "lo": [
+                            "127.0.0.1",
+                            "::1"
+                        ],
+                        "ens3": [
+                            "10.160.64.174",
+                            "2620:113:80c0:8080:10:160:68:69",
+                            "2620:113:80c0:8080:d02f:6fff:fed8:f3b0",
+                            "fe80::d02f:6fff:fed8:f3b0"
+                        ]
+                    },
+                    "mem_total": 481,
+                    "mirror": null,
+                    "server": "cb-suma.tf.local",
+                    "mdadm": [],
+                    "lsb_distrib_description": "Ubuntu 18.04.1 LTS",
+                    "product_version": "released",
+                    "use_avahi": 1,
+                    "localhost": "cb-min-ubuntu-3",
+                    "connect_to_additional_network": 1,
+                    "lsb_distrib_release": "18.04",
+                    "saltpath": "/usr/lib/python2.7/dist-packages/salt",
+                    "__suse_reserved_pkg_patches_support": true,
+                    "biosreleasedate": "04/01/2014",
+                    "host": "cb-min-ubuntu-3",
+                    "reset_ids": true,
+                    "osfinger": "Ubuntu-18.04",
+                    "manufacturer": "QEMU",
+                    "kernelversion": "#41-Ubuntu SMP Wed Oct 10 10:59:38 UTC 2018",
+                    "testsuite": 0,
+                    "ip4_gw": "10.160.255.254",
+                    "fqdn": "cb-min-ubuntu-3.tf.local",
+                    "os": "Ubuntu",
+                    "kernel": "Linux",
+                    "additional_repos": {},
+                    "use_released_updates": 0,
+                    "path": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+                    "SSDs": [],
+                    "susemanager": {
+                        "activation_key": "1-UBUNTU-BIONIC-DEFAULT"
+                    },
+                    "ps": "ps -efHww",
+                    "server_id": 435202551,
+                    "ip_gw": true,
+                    "auto_connect_to_master": false,
+                    "__suse_reserved_pkg_all_versions_support": true,
+                    "gid": 0,
+                    "master": "cb-suma.tf.local",
+                    "ipv4": [
+                        "10.160.64.174",
+                        "127.0.0.1"
+                    ],
+                    "dns": {
+                        "domain": "",
+                        "sortlist": [],
+                        "nameservers": [
+                            "127.0.0.53"
+                        ],
+                        "ip4_nameservers": [
+                            "127.0.0.53"
+                        ],
+                        "search": [],
+                        "ip6_nameservers": [],
+                        "options": []
+                    },
+                    "ipv6": [
+                        "::1",
+                        "2620:113:80c0:8080:10:160:68:69",
+                        "2620:113:80c0:8080:d02f:6fff:fed8:f3b0",
+                        "fe80::d02f:6fff:fed8:f3b0"
+                    ],
+                    "total_num_cpus": 1,
+                    "username": "root",
+                    "shell": "/bin/sh",
+                    "saltversion": "2018.3.0",
+                    "gpg_keys": [],
+                    "pythonversion": [
+                        2,
+                        7,
+                        15,
+                        "candidate",
+                        1
+                    ],
+                    "connect_to_base_network": 1,
+                    "cpuarch": "x86_64",
+                    "osrelease_info": [
+                        18,
+                        4
+                    ],
+                    "uid": 0,
+                    "zmqversion": "4.2.5",
+                    "serialnumber": "",
+                    "pid": 32744,
+                    "groupname": "root",
+                    "zfs_support": false,
+                    "timezone": "Europe/Berlin",
+                    "id": "cb-min-ubuntu-3.tf.local",
+                    "osrelease": "18.04",
+                    "ip6_interfaces": {
+                        "lo": [
+                            "::1"
+                        ],
+                        "ens3": [
+                            "2620:113:80c0:8080:10:160:68:69",
+                            "2620:113:80c0:8080:d02f:6fff:fed8:f3b0",
+                            "fe80::d02f:6fff:fed8:f3b0"
+                        ]
+                    },
+                    "num_cpus": 1,
+                    "hostname": "cb-min-ubuntu-3",
+                    "ip4_interfaces": {
+                        "lo": [
+                            "127.0.0.1"
+                        ],
+                        "ens3": [
+                            "10.160.64.174"
+                        ]
+                    },
+                    "role": "minion",
+                    "cpusockets": 1,
+                    "locale_info": {
+                        "detectedencoding": "UTF-8",
+                        "defaultlanguage": "en_US",
+                        "defaultencoding": "UTF-8"
+                    },
+                    "fqdn_ip4": [
+                        "10.160.64.174"
+                    ],
+                    "evil_minions_dump": 0,
+                    "fqdn_ip6": [
+                        "2620:113:80c0:8080:10:160:68:69"
+                    ],
+                    "nodename": "cb-min-ubuntu-3",
+                    "ip6_gw": "fe80::1",
+                    "osmajorrelease": 18,
+                    "os_family": "Debian",
+                    "pythonexecutable": "/usr/bin/python2",
+                    "swap_total": 0,
+                    "lsb_distrib_codename": "bionic"
+                }
+            },
+            "__id__": "grains_update"
+        },
+        "module_|-kernel_live_version_|-sumautil.get_kernel_live_version_|-run": {
+            "comment": "Module function sumautil.get_kernel_live_version executed",
+            "name": "sumautil.get_kernel_live_version",
+            "start_time": "17:34:37.653415",
+            "result": true,
+            "duration": 1.48,
+            "__run_num__": 5,
+            "__sls__": "packages.profileupdate",
+            "changes": {
+                "ret": null
+            },
+            "__id__": "kernel_live_version"
+        },
+        "module_|-sync_modules_|-saltutil.sync_modules_|-run": {
+            "comment": "Module function saltutil.sync_modules executed",
+            "name": "saltutil.sync_modules",
+            "start_time": "17:34:36.949199",
+            "result": true,
+            "duration": 46.431,
+            "__run_num__": 1,
+            "__sls__": "util.syncmodules",
+            "changes": {
+                "ret": []
+            },
+            "__id__": "sync_modules"
+        }
+    },
+    "retcode": 0,
+    "success": true,
+    "cmd": "_return",
+    "_stamp": "2016-04-07T08:41:02.846934",
+    "fun": "state.apply",
+    "out": "highstate",
+    "id": "minion.ubuntu.local",
+    "metadata": {
+      "suma-action-id": 59
+    }
+  }
+}

--- a/java/code/src/com/suse/manager/utils/PackageUtils.java
+++ b/java/code/src/com/suse/manager/utils/PackageUtils.java
@@ -67,7 +67,7 @@ public class PackageUtils {
         int releaseIndex = version.lastIndexOf('-');
         if (releaseIndex > 0) {
             // Strip away optional 'release'
-            release = version.substring(releaseIndex + 1, version.length());
+            release = version.substring(releaseIndex + 1);
             version = version.substring(0, releaseIndex);
         }
 

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -1097,14 +1097,9 @@ public class SaltUtils {
                 Long instantNow = new Date().getTime() / 1000L;
                 OSImageInspectSlsResult ret = result.getKiwiInspect().getChanges().getRet();
                 List<OSImageInspectSlsResult.Package> packages = ret.getPackages();
-                packages.stream().forEach(pkg -> {
-                    createImagePackageFromSalt(pkg.getName(),
-                            pkg.getEpoch().equals(StringUtils.EMPTY) ? null :
-                                    pkg.getEpoch(),
-                            pkg.getRelease(), pkg.getVersion(),
-                            Optional.of(instantNow),
-                            Optional.of(pkg.getArch()), imageInfo);
-                });
+                packages.forEach(pkg -> createImagePackageFromSalt(pkg.getName(), Optional.of(pkg.getEpoch()),
+                        Optional.of(pkg.getRelease()), pkg.getVersion(), Optional.of(instantNow),
+                        Optional.of(pkg.getArch()), imageInfo));
                 if ("pxe".equals(ret.getImage().getType())) {
                     String storeDirectory = OSImageStoreUtils.getOSImageStoreURIForOrg(
                             serverAction.getParentAction().getOrg());
@@ -1361,41 +1356,57 @@ public class SaltUtils {
      * @param server server this package will be added to
      * @return the InstalledPackage object
      */
-    private static InstalledPackage createPackageFromSalt(String name, Pkg.Info info,
-            Server server) {
+    private static InstalledPackage createPackageFromSalt(String name, Pkg.Info info, Server server) {
 
-        String epoch = info.getEpoch().orElse(null);
-        String release = info.getRelease().orElse("0");
-        String version = info.getVersion().get();
-        PackageEvr evr = PackageEvrFactory
-                .lookupOrCreatePackageEvr(epoch, version, release);
+        String serverArchTypeLabel = server.getServerArch().getArchType().getLabel();
 
         InstalledPackage pkg = new InstalledPackage();
-        pkg.setEvr(evr);
-        pkg.setArch(PackageFactory.lookupPackageArchByLabel(info.getArchitecture().get()));
+        pkg.setEvr(parsePackageEvr(info.getEpoch(), info.getVersion().get(), info.getRelease(), serverArchTypeLabel));
         pkg.setInstallTime(new Date(info.getInstallDateUnixTime().get() * 1000));
         pkg.setName(PackageFactory.lookupOrCreatePackageByName(name));
         pkg.setServer(server);
+
+        // Add -deb suffix to architectures for Debian systems
+        String pkgArch = info.getArchitecture().get();
+        if ("deb".equals(serverArchTypeLabel)) {
+            pkgArch += "-deb";
+        }
+        pkg.setArch(PackageFactory.lookupPackageArchByLabel(pkgArch));
+
         return pkg;
     }
 
-    private static ImagePackage createImagePackageFromSalt(
-            String name, Pkg.Info info, ImageInfo imageInfo) {
-        String epoch = info.getEpoch().orElse(null);
-        String release = info.getRelease().orElse("0");
-        String version = info.getVersion().get();
-        return createImagePackageFromSalt(name, epoch, release, version,
+    private static PackageEvr parsePackageEvr(Optional<String> epoch, String version, Optional<String> release,
+            String archTypeLabel) {
+
+        if ("deb".equals(archTypeLabel)) {
+            // We need additional parsing for deb package versions
+            return PackageEvrFactory.lookupOrCreatePackageEvr(PackageUtils.parseDebianEvr(version));
+        }
+
+        return PackageEvrFactory.lookupOrCreatePackageEvr(epoch.map(StringUtils::trimToNull).orElse(null), version,
+                release.orElse("0"));
+    }
+
+    private static ImagePackage createImagePackageFromSalt(String name, Pkg.Info info, ImageInfo imageInfo) {
+        return createImagePackageFromSalt(name, info.getEpoch(), info.getRelease(), info.getVersion().get(),
                 info.getInstallDateUnixTime(), info.getArchitecture(), imageInfo);
     }
 
-    private static ImagePackage createImagePackageFromSalt(String name, String epoch,
-            String release, String version, Optional<Long> installDateUnixTime,
-            Optional<String> architecture, ImageInfo imageInfo) {
-        PackageEvr evr =
-                PackageEvrFactory.lookupOrCreatePackageEvr(epoch, version, release);
+    private static ImagePackage createImagePackageFromSalt(String name, Optional<String> epoch,
+            Optional<String> release, String version, Optional<Long> installDateUnixTime, Optional<String> architecture,
+            ImageInfo imageInfo) {
 
+        String archType = imageInfo.getImageArch().getArchType().getLabel();
+        Optional<String> pkgArch = architecture.map(arch -> archType.equals("deb") ? arch + "-deb" : arch);
+        PackageEvr evr = parsePackageEvr(epoch, version, release, archType);
+        return createImagePackageFromSalt(name, evr, installDateUnixTime, pkgArch, imageInfo);
+    }
+
+    private static ImagePackage createImagePackageFromSalt(String name, PackageEvr pkgEvr,
+            Optional<Long> installDateUnixTime, Optional<String> architecture, ImageInfo imageInfo) {
         ImagePackage pkg = new ImagePackage();
-        pkg.setEvr(evr);
+        pkg.setEvr(pkgEvr);
         architecture.ifPresent(arch -> pkg.setArch(PackageFactory.lookupPackageArchByLabel(arch)));
         installDateUnixTime.ifPresent(udut -> pkg.setInstallTime(new Date(udut * 1000)));
         pkg.setName(PackageFactory.lookupOrCreatePackageByName(name));

--- a/java/code/src/com/suse/manager/utils/test/PackageUtilsTest.java
+++ b/java/code/src/com/suse/manager/utils/test/PackageUtilsTest.java
@@ -15,10 +15,8 @@
 package com.suse.manager.utils.test;
 
 import com.redhat.rhn.domain.rhnpackage.Package;
-import com.redhat.rhn.domain.rhnpackage.PackageArch;
 import com.redhat.rhn.domain.rhnpackage.PackageEvr;
 import com.redhat.rhn.domain.rhnpackage.PackageFactory;
-import com.redhat.rhn.domain.rhnpackage.test.PackageEvrFactoryTest;
 import com.redhat.rhn.domain.rhnpackage.test.PackageTest;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.suse.manager.utils.PackageUtils;
@@ -37,22 +35,6 @@ public class PackageUtilsTest extends BaseTestCaseWithUser {
 
         assertFalse(PackageUtils.isTypeRpm(pkgDeb));
         assertTrue(PackageUtils.isTypeDeb(pkgDeb));
-    }
-
-    public void testGetUniversalArchString() {
-        PackageArch archx86 = PackageFactory.lookupPackageArchByLabel("x86_64");
-        PackageArch archAmd64 = PackageFactory.lookupPackageArchByLabel("amd64-deb");
-
-        assertEquals("x86_64", PackageUtils.getUniversalArchString(archx86));
-        assertEquals("amd64", PackageUtils.getUniversalArchString(archAmd64));
-    }
-
-    public void testGetUniversalEvrString() {
-        PackageEvr evr1 = PackageEvrFactoryTest.createTestPackageEvr("1", "2.3.4", "5");
-        PackageEvr evr2 = PackageEvrFactoryTest.createTestPackageEvr(null, "1.2", "X");
-
-        assertEquals("1:2.3.4-5", PackageUtils.getUniversalEvrString(evr1));
-        assertEquals("1.2", PackageUtils.getUniversalEvrString(evr2));
     }
 
     /**

--- a/java/code/src/com/suse/manager/utils/test/PackageUtilsTest.java
+++ b/java/code/src/com/suse/manager/utils/test/PackageUtilsTest.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.utils.test;
+
+import com.redhat.rhn.domain.rhnpackage.Package;
+import com.redhat.rhn.domain.rhnpackage.PackageArch;
+import com.redhat.rhn.domain.rhnpackage.PackageEvr;
+import com.redhat.rhn.domain.rhnpackage.PackageFactory;
+import com.redhat.rhn.domain.rhnpackage.test.PackageEvrFactoryTest;
+import com.redhat.rhn.domain.rhnpackage.test.PackageTest;
+import com.redhat.rhn.testing.BaseTestCaseWithUser;
+import com.suse.manager.utils.PackageUtils;
+
+public class PackageUtilsTest extends BaseTestCaseWithUser {
+
+    public void testIsType() throws Exception {
+        Package pkgRpm = PackageTest.createTestPackage(user.getOrg());
+        pkgRpm.setPackageArch(PackageFactory.lookupPackageArchByLabel("x86_64"));
+
+        Package pkgDeb = PackageTest.createTestPackage(user.getOrg());
+        pkgDeb.setPackageArch(PackageFactory.lookupPackageArchByLabel("amd64-deb"));
+
+        assertTrue(PackageUtils.isTypeRpm(pkgRpm));
+        assertFalse(PackageUtils.isTypeDeb(pkgRpm));
+
+        assertFalse(PackageUtils.isTypeRpm(pkgDeb));
+        assertTrue(PackageUtils.isTypeDeb(pkgDeb));
+    }
+
+    public void testGetUniversalArchString() {
+        PackageArch archx86 = PackageFactory.lookupPackageArchByLabel("x86_64");
+        PackageArch archAmd64 = PackageFactory.lookupPackageArchByLabel("amd64-deb");
+
+        assertEquals("x86_64", PackageUtils.getUniversalArchString(archx86));
+        assertEquals("amd64", PackageUtils.getUniversalArchString(archAmd64));
+    }
+
+    public void testGetUniversalEvrString() {
+        PackageEvr evr1 = PackageEvrFactoryTest.createTestPackageEvr("1", "2.3.4", "5");
+        PackageEvr evr2 = PackageEvrFactoryTest.createTestPackageEvr(null, "1.2", "X");
+
+        assertEquals("1:2.3.4-5", PackageUtils.getUniversalEvrString(evr1));
+        assertEquals("1.2", PackageUtils.getUniversalEvrString(evr2));
+    }
+
+    /**
+     * Debian package versioning policy format: [epoch:]upstream_version[-debian_revision]
+     * Additional ':' and '-' characters are allowed in 'upstream_version'
+     * https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
+     *
+     * Tests:
+     *   - 1:2.3~.4a+b-5
+     *   - 2.3~.4a+b-5
+     *   - 2.3~.4a+b
+     *   - 1:2.3~.4a+b
+     *   - 1:2.3~.4a+b-5+abc.6~
+     *   - 1:2-3-4-5
+     *
+     */
+    public void testParseDebianEvr() {
+
+        PackageEvr evr;
+
+        evr = PackageUtils.parseDebianEvr("1:2.3~.4a+b-5");
+        assertEquals("1", evr.getEpoch());
+        assertEquals("2.3~.4a+b", evr.getVersion());
+        assertEquals("5", evr.getRelease());
+
+        evr = PackageUtils.parseDebianEvr("2.3~.4a+b-5");
+        assertNull(evr.getEpoch());
+        assertEquals("2.3~.4a+b", evr.getVersion());
+        assertEquals("5", evr.getRelease());
+
+        evr = PackageUtils.parseDebianEvr("2.3~.4a+b");
+        assertNull(evr.getEpoch());
+        assertEquals("2.3~.4a+b", evr.getVersion());
+        assertEquals("X", evr.getRelease());
+
+        evr = PackageUtils.parseDebianEvr("1:2.3~.4a+b");
+        assertEquals("1", evr.getEpoch());
+        assertEquals("2.3~.4a+b", evr.getVersion());
+        assertEquals("X", evr.getRelease());
+
+        evr = PackageUtils.parseDebianEvr("1:2.3~.4a+b-5+abc.6~");
+        assertEquals("1", evr.getEpoch());
+        assertEquals("2.3~.4a+b", evr.getVersion());
+        assertEquals("5+abc.6~", evr.getRelease());
+
+        evr = PackageUtils.parseDebianEvr("2-3-4-5");
+        assertNull(evr.getEpoch());
+        assertEquals("2-3-4", evr.getVersion());
+        assertEquals("5", evr.getRelease());
+    }
+}

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -965,9 +965,10 @@ public class SaltServerActionService {
     private Map<LocalCall<?>, List<MinionSummary>> packagesUpdateAction(
             List<MinionSummary> minionSummaries, PackageUpdateAction action) {
         Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
-        List<List<String>> pkgs = action.getDetails().stream().map(
-                d -> Arrays.asList(d.getPackageName().getName(), d.getArch().getName(), d.getEvr().toString())
-        ).collect(Collectors.toList());
+        List<List<String>> pkgs = action
+                .getDetails().stream().map(d -> Arrays.asList(d.getPackageName().getName(),
+                        d.getArch().toUniversalArchString(), d.getEvr().toUniversalEvrString()))
+                .collect(Collectors.toList());
         ret.put(State.apply(Arrays.asList(PACKAGES_PKGINSTALL),
                 Optional.of(singletonMap(PARAM_PKGS, pkgs))), minionSummaries);
         return ret;
@@ -976,9 +977,10 @@ public class SaltServerActionService {
     private Map<LocalCall<?>, List<MinionSummary>> packagesRemoveAction(
             List<MinionSummary> minionSummaries, PackageRemoveAction action) {
         Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
-        List<List<String>> pkgs = action.getDetails().stream().map(
-                d -> Arrays.asList(d.getPackageName().getName(), d.getArch().getName(), d.getEvr().toString())
-        ).collect(Collectors.toList());
+        List<List<String>> pkgs = action
+                .getDetails().stream().map(d -> Arrays.asList(d.getPackageName().getName(),
+                        d.getArch().toUniversalArchString(), d.getEvr().toUniversalEvrString()))
+                .collect(Collectors.toList());
         ret.put(State.apply(Arrays.asList(PACKAGES_PKGREMOVE),
                 Optional.of(singletonMap(PARAM_PKGS, pkgs))), minionSummaries);
         return ret;
@@ -1517,11 +1519,10 @@ public class SaltServerActionService {
     private LocalCall<?> prepareStagingTargets(Action actionIn, List<MinionSummary> minionSummaries) {
         LocalCall<?> call = null;
         if (actionIn.getActionType().equals(ActionFactory.TYPE_PACKAGES_UPDATE)) {
-            List<List<String>> args =
-                    ((PackageUpdateAction) actionIn).getDetails().stream().map(
-                            d -> Arrays.asList(d.getPackageName().getName(),
-                                    d.getArch().getName(), d.getEvr().toString())
-                    ).collect(Collectors.toList());
+            List<List<String>> args = ((PackageUpdateAction) actionIn)
+                    .getDetails().stream().map(d -> Arrays.asList(d.getPackageName().getName(),
+                            d.getArch().toUniversalArchString(), d.getEvr().toUniversalEvrString()))
+                    .collect(Collectors.toList());
             call = State.apply(Arrays.asList(PACKAGES_PKGDOWNLOAD),
                     Optional.of(Collections.singletonMap(PARAM_PKGS, args)));
             LOG.info("Executing staging of packages");

--- a/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
@@ -36,9 +36,11 @@ import com.redhat.rhn.domain.config.ConfigRevision;
 import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.rhnpackage.Package;
 import com.redhat.rhn.domain.rhnpackage.PackageFactory;
+import com.redhat.rhn.domain.rhnpackage.test.PackageEvrFactoryTest;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.MinionSummary;
 import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.domain.server.test.ServerFactoryTest;
 import com.redhat.rhn.manager.action.ActionChainManager;
@@ -152,6 +154,107 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
 
         Map<LocalCall<?>, List<MinionSummary>> result = SaltServerActionService.INSTANCE.callsForAction(updateAction, minionSummaries);
         RhnBaseTestCase.assertNotEmpty(result.values());
+    }
+
+    public void testPackageRemoveDebian() throws Exception {
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
+        minion.setServerArch(ServerFactory.lookupServerArchByLabel("amd64-debian-linux"));
+        List<MinionServer> mins = new ArrayList<>();
+        mins.add(minion);
+
+        List<MinionSummary> minionSummaries = mins.stream().
+                map(MinionSummary::new).collect(Collectors.toList());
+
+        Channel channel = ChannelFactoryTest.createTestChannel(user);
+        Package p = ErrataTestUtils.createTestPackage(user, channel, "amd64-deb");
+        p.setPackageEvr(PackageEvrFactoryTest.createTestPackageEvr(null, "1.0.0", "X"));
+
+        Map<String, Long> pkgMap = new HashMap<>();
+        pkgMap.put("name_id", p.getPackageName().getId());
+        pkgMap.put("evr_id", p.getPackageEvr().getId());
+        pkgMap.put("arch_id", p.getPackageArch().getId());
+
+        final ZonedDateTime now = ZonedDateTime.now(ZoneId.systemDefault());
+        Action action = ActionManager.createAction(user, ActionFactory.TYPE_PACKAGES_UPDATE,
+                "test action", Date.from(now.toInstant()));
+
+        ActionFactory.addServerToAction(minion, action);
+
+        ActionManager.addPackageActionDetails(Arrays.asList(action), Collections.singletonList(pkgMap));
+        TestUtils.flushAndEvict(action);
+        Action updateAction = ActionFactory.lookupById(action.getId());
+
+        Map<LocalCall<?>, List<MinionSummary>> result = SaltServerActionService.INSTANCE.callsForAction(updateAction,
+                minionSummaries);
+        assertEquals(1, result.size());
+        LocalCall<?> resultCall = result.keySet().iterator().next();
+        List<List<String>> resultPkgs = (List<List<String>>) ((Map) ((Map) resultCall.getPayload().get("kwarg")).get(
+                "pillar")).get("param_pkgs");
+
+        List<String> resultPkg =
+                resultPkgs.stream().filter(pkg -> p.getPackageName().getName().equals(pkg.get(0))).findFirst().get();
+
+        // Assert if the package EVRAs are sent to Salt correctly
+        assertEquals("amd64", resultPkg.get(1));
+        assertEquals("1.0.0", resultPkg.get(2));
+    }
+
+    public void testPackageUpdateDebian() throws Exception {
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
+        minion.setServerArch(ServerFactory.lookupServerArchByLabel("amd64-debian-linux"));
+        List<MinionServer> mins = new ArrayList<>();
+        mins.add(minion);
+
+        List<MinionSummary> minionSummaries = mins.stream().
+                map(MinionSummary::new).collect(Collectors.toList());
+
+        Channel channel = ChannelFactoryTest.createTestChannel(user);
+        Package p1 = ErrataTestUtils.createTestPackage(user, channel, "amd64-deb");
+        p1.setPackageEvr(PackageEvrFactoryTest.createTestPackageEvr(null, "1.0.0", "X"));
+        Package p2 = ErrataTestUtils.createTestPackage(user, channel, "amd64-deb");
+        p2.setPackageEvr(PackageEvrFactoryTest.createTestPackageEvr("1", "1.2", "1ubuntu1"));
+
+        List<Map<String, Long>> packageMaps = new ArrayList<>();
+        Map<String, Long> pkgMap = new HashMap<>();
+        pkgMap.put("name_id", p1.getPackageName().getId());
+        pkgMap.put("evr_id", p1.getPackageEvr().getId());
+        pkgMap.put("arch_id", p1.getPackageArch().getId());
+        packageMaps.add(pkgMap);
+
+        pkgMap = new HashMap<>();
+        pkgMap.put("name_id", p2.getPackageName().getId());
+        pkgMap.put("evr_id", p2.getPackageEvr().getId());
+        pkgMap.put("arch_id", p2.getPackageArch().getId());
+        packageMaps.add(pkgMap);
+
+        final ZonedDateTime now = ZonedDateTime.now(ZoneId.systemDefault());
+        Action action = ActionManager.createAction(user, ActionFactory.TYPE_PACKAGES_UPDATE,
+                "test action", Date.from(now.toInstant()));
+
+        ActionFactory.addServerToAction(minion, action);
+
+        ActionManager.addPackageActionDetails(Arrays.asList(action), packageMaps);
+        TestUtils.flushAndEvict(action);
+        Action updateAction = ActionFactory.lookupById(action.getId());
+
+        Map<LocalCall<?>, List<MinionSummary>> result = SaltServerActionService.INSTANCE.callsForAction(updateAction,
+                minionSummaries);
+        assertEquals(1, result.size());
+        LocalCall<?> resultCall = result.keySet().iterator().next();
+        List<List<String>> resultPkgs = (List<List<String>>) ((Map) ((Map) resultCall.getPayload().get("kwarg")).get(
+                "pillar")).get("param_pkgs");
+
+        List<String> resultP1 =
+                resultPkgs.stream().filter(pkg -> p1.getPackageName().getName().equals(pkg.get(0))).findFirst().get();
+        List<String> resultP2 =
+                resultPkgs.stream().filter(pkg -> p2.getPackageName().getName().equals(pkg.get(0))).findFirst().get();
+
+        // Assert if the package EVRAs are sent to Salt correctly
+        assertEquals("amd64", resultP1.get(1));
+        assertEquals("1.0.0", resultP1.get(2));
+
+        assertEquals("amd64", resultP2.get(1));
+        assertEquals("1:1.2-1ubuntu1", resultP2.get(2));
     }
 
     public void testDeployFiles() throws Exception {

--- a/susemanager-utils/susemanager-sls/salt/packages/pkginstall.sls
+++ b/susemanager-utils/susemanager-sls/salt/packages/pkginstall.sls
@@ -7,7 +7,9 @@ pkg_installed:
 {%- endif %}
     -   pkgs:
 {%- for pkg, arch, version in pillar.get('param_pkgs', []) %}
-    {%- if grains.get('__suse_reserved_pkg_all_versions_support', False) %}
+    {%- if grains['os_family'] == 'Debian' %}
+        - {{ pkg }}:{{ arch }}: {{ version }}
+    {%- elif grains.get('__suse_reserved_pkg_all_versions_support', False) %}
         - {{ pkg }}.{{ arch }}: {{ version }}
     {%- else %}
         - {{ pkg }}: {{ version }}

--- a/susemanager-utils/susemanager-sls/salt/packages/pkgremove.sls
+++ b/susemanager-utils/susemanager-sls/salt/packages/pkgremove.sls
@@ -3,7 +3,9 @@ pkg_removed:
   pkg.removed:
     -   pkgs:
 {%- for pkg, arch, version in pillar.get('param_pkgs', []) %}
-    {%- if grains.get('__suse_reserved_pkg_all_versions_support', False) %}
+    {%- if grains['os_family'] == 'Debian' %}
+        - {{ pkg }}:{{ arch }}: {{ version }}
+    {%- elif grains.get('__suse_reserved_pkg_all_versions_support', False) %}
         - {{ pkg }}.{{ arch }}: {{ version }}
     {%- else %}
         - {{ pkg }}: {{ version }}


### PR DESCRIPTION
Fix package version/architecture mappings for Debian systems.

## Problem
We need to fix mappings for the version and architecture of Debian packages both ways, while conforming to Uyuni's internal rules about package EVRAs.

Existing conditions/constraints:
1. Debian architectures have a suffix "-deb" on their names and labels.
2. Unlike rpm, deb packages may not have a 'release' in their version strings. `repo-sync` appends "-X" to such packages as the release string.

In order to get the packages recognized and matched by Uyuni, we need to apply those conditions on packages retrieved from the profile update.

On the other hand, these mappings must be reversed when calling package states (pkginstall, pkgremove, etc.)

## Test coverage
- [x] Unit tests

## Links

Fixes #384 