### PR TITLE
Install products sle15minion during bootstrap

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
@@ -22,6 +22,8 @@ import com.redhat.rhn.domain.entitlement.Entitlement;
 import com.redhat.rhn.domain.product.SUSEProduct;
 import com.redhat.rhn.domain.product.SUSEProductChannel;
 import com.redhat.rhn.domain.product.SUSEProductFactory;
+import com.redhat.rhn.domain.rhnpackage.Package;
+import com.redhat.rhn.domain.rhnpackage.PackageFactory;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerFactory;
@@ -96,6 +98,10 @@ public class RegistrationUtils {
         String minionId = minion.getMinionId();
         // get hardware and network async
         triggerHardwareRefresh(minion);
+
+        // Get the product packages from subscribed channels and install them.
+        List<Package> prodPkgs = PackageFactory.findMissingProductPackagesOnServer(minion.getId());
+        StateFactory.addPackagesToNewStateRevision(minion, Optional.ofNullable(minion.getCreator().getId()), prodPkgs);
 
         LOG.info("Finished minion registration: " + minionId);
 

--- a/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
@@ -101,7 +101,7 @@ public class RegistrationUtils {
 
         // Get the product packages from subscribed channels and install them.
         List<Package> prodPkgs = PackageFactory.findMissingProductPackagesOnServer(minion.getId());
-        StateFactory.addPackagesToNewStateRevision(minion, Optional.ofNullable(minion.getCreator().getId()), prodPkgs);
+        StateFactory.addPackagesToNewStateRevision(minion, creator.map(c -> c.getId()), prodPkgs);
 
         LOG.info("Finished minion registration: " + minionId);
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- install product packages during bootstrapping minions (bsc#1104680)
 - remove Oracle support
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

This makes a change to minion bootstrapping where all the available product rpms are installed based on subscribed channels. The traditional client bootstrapping does this automatically during the rhnreg_ks part.

## Links

Tracks https://github.com/SUSE/spacewalk/pull/6622

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already ran, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
