### PR TITLE
MinionActionUtils: avoid NPE (bsc#1119271)

### DIFF
--- a/java/code/src/com/suse/manager/webui/utils/MinionActionUtils.java
+++ b/java/code/src/com/suse/manager/webui/utils/MinionActionUtils.java
@@ -19,18 +19,16 @@ import static com.suse.utils.Opt.flatMap;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.common.util.FileUtils;
+import com.redhat.rhn.domain.action.Action;
+import com.redhat.rhn.domain.action.ActionFactory;
+import com.redhat.rhn.domain.action.server.ServerAction;
+import com.redhat.rhn.domain.server.MinionServer;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
-import com.redhat.rhn.common.util.FileUtils;
-import com.redhat.rhn.common.conf.ConfigDefaults;
-import com.redhat.rhn.domain.action.ActionFactory;
-import com.redhat.rhn.domain.action.server.ServerAction;
-import com.redhat.rhn.domain.server.MinionServer;
 import com.suse.manager.reactor.messaging.JobReturnEventMessageAction;
 import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.webui.services.SaltActionChainGeneratorService;
@@ -46,6 +44,9 @@ import com.suse.salt.netapi.results.StateApplyResult;
 import com.suse.utils.Json;
 import org.apache.log4j.Logger;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -340,7 +341,8 @@ public class MinionActionUtils {
                 Matcher m = p.matcher(file.getFileName().toString());
                 if (m.find()) {
                     long actionId = Long.parseLong(m.group(1));
-                    if (ActionFactory.lookupById(actionId).allServersFinished()) {
+                    Action action = ActionFactory.lookupById(actionId);
+                    if (action == null || action.allServersFinished()) {
                         LOG.info("Deleting script file: " + file);
                         FileUtils.deleteFile(file);
                     }

--- a/java/code/src/com/suse/manager/webui/utils/test/MinionActionUtilsTest.java
+++ b/java/code/src/com/suse/manager/webui/utils/test/MinionActionUtilsTest.java
@@ -55,6 +55,21 @@ public class MinionActionUtilsTest extends BaseTestCaseWithUser {
     }
 
     /**
+     * Verify script is deleted in case no Action is there at all.
+     */
+    public void testCleanupScriptWithoutAction() throws Exception {
+        SaltUtils.INSTANCE.setScriptsDir(Files.createTempDirectory("scripts"));
+        Path scriptFile = Files.createFile(SaltUtils.INSTANCE.getScriptPath(123456L));
+
+        // Testing
+        MinionActionUtils.cleanupScriptActions();
+        assertFalse(Files.exists(scriptFile));
+
+        // Cleanup
+        Files.delete(SaltUtils.INSTANCE.getScriptsDir());
+    }
+
+    /**
      * Verify script is not deleted as long as not all servers have finished (e.g. PICKED_UP).
      */
     public void testCleanupScriptActionsPickedUp() throws Exception {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- avoid a NullPointerException error in Taskomatic (bsc#1119271)
 - XMLRPC API: Include init.sls in channel file list (bsc#1111191)
 - Disable notification types with 'java.notifications_type_disabled' in rhn.conf (bsc#1111910)
 - Fix the config channels assignment via SSM (bsc#1117759)


### PR DESCRIPTION
## What does this PR change?

Fixes a `NullPointerException` in Taskomatic logs:

```
com.redhat.rhn.taskomatic.task.MinionActionCleanup  - Stack trace:java.lang.NullPointerException
        at com.suse.manager.webui.utils.MinionActionUtils.lambda$cleanupScriptActions$27(MinionActionUtils.java:328)
        at com.suse.manager.webui.utils.MinionActionUtils$$Lambda$143.00000000000722D0.accept(Unknown Source)
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/6644

- [x] **DONE**
