### PR TITLE
Fix spacecmd functionality related to config channels

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/config_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/config_queries.xml
@@ -477,7 +477,7 @@ ORDER BY  S.name
 
 
 <mode name="latest_files_in_namespace" class="com.redhat.rhn.frontend.dto.ConfigFileDto">
-  <query params="ccid,user_id">
+  <query params="ccid,user_id,include_init_sls">
 SELECT CF.id,
            CF.latest_config_revision_id,
        CFN.path,
@@ -495,7 +495,7 @@ SELECT CF.id,
    AND CR.config_file_id = CF.id
    AND CF.latest_config_revision_id = CR.id
    AND CR.config_file_type_id = CFT.id
-   AND (CFT.label != 'sls' OR CFN.path != '/init.sls')
+   AND (CFT.label != 'sls' OR CFN.path != '/init.sls' OR :include_init_sls)
 ORDER BY CFN.path
   </query>
 </mode>

--- a/java/code/src/com/redhat/rhn/frontend/action/configuration/channel/ChannelDeployConfirmAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/configuration/channel/ChannelDeployConfirmAction.java
@@ -96,7 +96,7 @@ public class ChannelDeployConfirmAction extends RhnAction {
 
         DataResult files = ConfigurationManager.getInstance().
             listCurrentFiles(user, cc, null,
-                    RhnSetDecl.CONFIG_CHANNEL_DEPLOY_REVISIONS.getLabel());
+                    RhnSetDecl.CONFIG_CHANNEL_DEPLOY_REVISIONS.getLabel(), false);
         DataList list = new DataList(files);
         list.setMode(files.getMode());
         list.setElaboratorParams(files.getElaborationParams());

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/configchannel/ConfigChannelHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/configchannel/ConfigChannelHandler.java
@@ -674,7 +674,7 @@ public class ConfigChannelHandler extends BaseHandler {
         ConfigChannel channel = configHelper.lookupGlobal(loggedInUser,
                                                                 channelLabel);
         ConfigurationManager cm = ConfigurationManager.getInstance();
-        return cm.listCurrentFiles(loggedInUser, channel, null);
+        return cm.listCurrentFiles(loggedInUser, channel, null, null, true);
     }
 
 

--- a/java/code/src/com/redhat/rhn/manager/configuration/ConfigurationManager.java
+++ b/java/code/src/com/redhat/rhn/manager/configuration/ConfigurationManager.java
@@ -1235,7 +1235,7 @@ public class ConfigurationManager extends BaseManager {
      */
     public DataResult<ConfigFileDto> listCurrentFiles(User user,
             ConfigChannel channel, PageControl pc) {
-        return listCurrentFiles(user, channel, pc, null);
+        return listCurrentFiles(user, channel, pc, null, false);
     }
 
     /**
@@ -1245,10 +1245,11 @@ public class ConfigurationManager extends BaseManager {
      * @param channel channel of interest
      * @param pc controller/elaborator for the list
      * @param setLabel label of set we care about, or NULL if we don't want to use a set
+     * @param includeInitSls should the /init.sls file be included? (for state channels)
      * @return list of com.redhat.rhn.frontend.dto.ConfigFileDto
      */
-    public DataResult listCurrentFiles(
-            User user, ConfigChannel channel, PageControl pc, String setLabel) {
+    public DataResult listCurrentFiles(User user, ConfigChannel channel, PageControl pc, String setLabel,
+            boolean includeInitSls) {
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("ccid", channel.getId());
         params.put("user_id", user.getId());
@@ -1258,6 +1259,7 @@ public class ConfigurationManager extends BaseManager {
             params.put("set_label", setLabel);
         }
         else {
+            params.put("include_init_sls", includeInitSls);
             m = ModeFactory.getMode("config_queries", "latest_files_in_namespace");
         }
         return (DataResult<ConfigFileDto>) makeDataResult(params, new HashMap(), pc, m);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- XMLRPC API: Include init.sls in channel file list (bsc#1111191)
 - Disable notification types with 'java.notifications_type_disabled' in rhn.conf (bsc#1111910)
 - Fix the config channels assignment via SSM (bsc#1117759)
 - Introduce Loggerhead-module.js to store logs from the frontend

--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,6 @@
+- Fix importing state channels using configchannel_import
+- Fix getting file info for latest revision (via configchannel_filedetails)
+
 -------------------------------------------------------------------
 Mon Dec 17 14:33:04 CET 2018 - jgonzalez@suse.com
 

--- a/spacecmd/src/lib/configchannel.py
+++ b/spacecmd/src/lib/configchannel.py
@@ -1241,6 +1241,11 @@ def import_configchannel_fromdetails(self, ccdetails):
                 logging.debug("Adding symlink %s" % filedetails)
                 ret = self.client.configchannel.createOrUpdateSymlink(
                     self.session, ccdetails['label'], path, filedetails)
+            elif filedetails['type'] == 'sls':
+                # Filter out everything except the file contents:
+                init_sls_details = {k:v for (k,v) in filedetails.items() if k in ['contents', 'contents_enc64']}
+                ret = self.client.configchannel.updateInitSls(
+                    self.session, ccdetails['label'], init_sls_details)
             else:
                 if filedetails['type'] == 'directory':
                     isdir = True

--- a/spacecmd/src/lib/configchannel.py
+++ b/spacecmd/src/lib/configchannel.py
@@ -205,7 +205,7 @@ def do_configchannel_filedetails(self, args):
 
     try:
         revision = int(args[2])
-    except ValueError:
+    except (ValueError, IndexError):
         pass
 
     # the server return a null exception if an invalid file is passed


### PR DESCRIPTION
# Description
 
 Multiple problems:
 
 * Main problem: When doing `configchannel_export` for a state
 channel, the `init.sls` file is missing.
 
 * `configchannel_import` function in spacecmd was also broken - I fixed it
 because I suppose that customer will also use import function (when he did
 export).
 
 * `configchannel_filedetails` function didn't work unless user entered specific
 file revision number. Fixed by handling appropriate exception.
 
 ### How to review
 Commit-by-commit.
 
 ## UI diff
 
 No difference.
 
 - [x] **DONE**
 
 ## Documentation
 - No documentation needed: bugfix
 
 - [x] **DONE**
 
 ## Tests
 - Unit tests were added
 
 - [x] **DONE**
 
 ## Links
 Fixes https://github.com/SUSE/spacewalk/issues/6046