### PR TITLE
build-props.xml: fixes for Hibernate 5.3

### DIFF
--- a/java/buildconf/build-props.xml
+++ b/java/buildconf/build-props.xml
@@ -75,11 +75,11 @@
 
   <property name="hibernate3.6deps" value="hibernate3/hibernate-ehcache-3 hibernate3/hibernate-c3p0-3 hibernate3/hibernate-core-3 ${hibernate-commons-annotations} slf4j/api jboss-logging javassist slf4j/log4j12 ${ehcache} hibernate-jpa-2.0-api"/>
 
-  <property name="hibernate5.2deps" value="hibernate-ehcache-5 hibernate-c3p0-5 hibernate-core-5 ${hibernate-commons-annotations} slf4j/api jboss-logging javassist slf4j/log4j12 ${ehcache} hibernate-jpa-2.1-api classmate statistics"/>
+  <property name="hibernate5deps" value="hibernate-ehcache-5 hibernate-c3p0-5 hibernate-core-5 ${hibernate-commons-annotations} slf4j/api jboss-logging javassist slf4j/log4j12 ${ehcache} classmate statistics"/>
 
   <available file="${java.lib.dir}/hibernate3.jar" type="file" property="hibernate" value="${hibernate3.2deps}" />
   <available file="${java.lib.dir}/hibernate3/hibernate-core-3.jar" type="file" property="hibernate" value="${hibernate3.6deps}" />
-  <available file="${java.lib.dir}/hibernate-core-5.jar" type="file" property="hibernate" value="${hibernate5.2deps}" />
+  <available file="${java.lib.dir}/hibernate-core-5.jar" type="file" property="hibernate" value="${hibernate5deps}" />
 
   <condition property="jmock-jars"
                 value="jmock jmock-cglib"


### PR DESCRIPTION
## What does this PR change?

It fixes a build problem against Hibernate 5.3.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **build code only**

- [x] **DONE**

## Test coverage
- No tests: **abundantly covered by existing tests**

- [x] **DONE**

## Links
- [x] **DONE**
