### PR TITLE
spacewalk-java: fix build-time dependencies

### DIFF
--- a/java/buildconf/build-props.xml
+++ b/java/buildconf/build-props.xml
@@ -75,7 +75,7 @@
 
   <property name="hibernate3.6deps" value="hibernate3/hibernate-ehcache-3 hibernate3/hibernate-c3p0-3 hibernate3/hibernate-core-3 ${hibernate-commons-annotations} slf4j/api jboss-logging javassist slf4j/log4j12 ${ehcache} hibernate-jpa-2.0-api"/>
 
-  <property name="hibernate5deps" value="hibernate-ehcache-5 hibernate-c3p0-5 hibernate-core-5 ${hibernate-commons-annotations} slf4j/api jboss-logging javassist slf4j/log4j12 ${ehcache} classmate statistics"/>
+  <property name="hibernate5deps" value="hibernate-ehcache-5 hibernate-c3p0-5 hibernate-core-5 ${hibernate-commons-annotations} slf4j/api jakarta-persistence-api byte-buddy jboss-logging javassist slf4j/log4j12 ${ehcache} classmate statistics"/>
 
   <available file="${java.lib.dir}/hibernate3.jar" type="file" property="hibernate" value="${hibernate3.2deps}" />
   <available file="${java.lib.dir}/hibernate3/hibernate-core-3.jar" type="file" property="hibernate" value="${hibernate3.6deps}" />

--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -8,11 +8,12 @@
         <dependency org="suse" name="asm" rev="1.5.3" />
         <dependency org="suse" name="asm-attrs" rev="1.5.3" />
         <dependency org="suse" name="bcel" rev="5.1" />
+        <dependency org="suse" name="byte-buddy" rev="1.8.17" />
         <dependency org="suse" name="c3p0" rev="0.9.5_pre8" />
         <dependency org="suse" name="cglib" rev="2.1.3" />
         <dependency org="suse" name="cglib-nodep" rev="2.2.3" />
         <dependency org="suse" name="checkstyle-all" rev="6.11.2" />
-        <dependency org="suse" name="classmate" rev="1.3.0" />
+        <dependency org="suse" name="classmate" rev="1.3.4" />
         <dependency org="suse" name="commons-beanutils" rev="1.9.2" />
         <dependency org="suse" name="commons-cli" rev="1.2" />
         <dependency org="suse" name="commons-codec" rev="1.8" />
@@ -35,11 +36,10 @@
         <dependency org="suse" name="gsbase" rev="2.0.1" />
         <dependency org="suse" name="hamcrest-core" rev="1.3" />
         <dependency org="suse" name="hamcrest-library" rev="1.3" />
-        <dependency org="suse" name="hibernate-c3p0" rev="5.2.2" />
-        <dependency org="suse" name="hibernate-commons-annotations" rev="5.0.1" />
-        <dependency org="suse" name="hibernate-core" rev="5.2.2" />
-        <dependency org="suse" name="hibernate-ehcache" rev="5.2.2" />
-        <dependency org="suse" name="hibernate-jpa-2.1-api" rev="1.0.0" />
+        <dependency org="suse" name="hibernate-c3p0" rev="5.3.7" />
+        <dependency org="suse" name="hibernate-commons-annotations" rev="5.0.4" />
+        <dependency org="suse" name="hibernate-core" rev="5.3.7" />
+        <dependency org="suse" name="hibernate-ehcache" rev="5.3.7" />
         <dependency org="suse" name="httpasyncclient" rev="4.1.3" />
         <dependency org="suse" name="httpclient" rev="4.5" />
         <dependency org="suse" name="httpcore" rev="4.4.1" />
@@ -47,6 +47,7 @@
         <dependency org="suse" name="jacocoant" rev="0.7.7" />
         <dependency org="suse" name="jade4j" rev="1.0.7" />
         <dependency org="suse" name="jaf" rev="1.0.2" />
+        <dependency org="suse" name="jakarta-persistence-api" rev="2.2.2" />
         <dependency org="suse" name="jasper" rev="8.0.23" />
         <dependency org="suse" name="jasper-el" rev="8.0.23" />
         <dependency org="suse" name="javassist" rev="3.20.0" />

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -69,6 +69,8 @@ Requires:       java >= 1.8.0
 Requires:       classmate
 Requires:       ehcache >= 2.10.1
 Requires:       gnu-jaf
+Requires:       byte-buddy
+Requires:       jpa-api
 Requires:       hibernate-commons-annotations
 Requires:       hibernate5
 Requires:       jade4j
@@ -91,6 +93,8 @@ BuildRequires:  apache-commons-lang3
 BuildRequires:  classmate
 BuildRequires:  ehcache >= 2.10.1
 BuildRequires:  google-gson >= 2.2.4
+BuildRequires:  byte-buddy
+BuildRequires:  jpa-api
 BuildRequires:  hibernate-commons-annotations
 BuildRequires:  hibernate5
 BuildRequires:  java-devel >= 1.8.0


### PR DESCRIPTION
## What does this PR change?

It addresses dependencies that changes with the newer Hibernate versions so that the package builds again.

## GUI diff

No difference.
- [x] **DONE**

## Documentation
- No documentation needed: **internal changes only**
- [x] **DONE**

## Test coverage
- No tests: **abundantly covered by unit tests already**
- [x] **DONE**

## Links
- [x] **DONE**
