### PR TITLE
wait until credential verification succeeded

### DIFF
--- a/testsuite/features/core_srv_setup_wizard.feature
+++ b/testsuite/features/core_srv_setup_wizard.feature
@@ -20,6 +20,7 @@ Feature: The Setup Wizard
     And I view the primary subscription list
     And I click on "Close"
     Then I should not see a "asdf" text
+    And I see verification succeeded
 
   Scenario: Play with the products page
     Given I am on the Admin page

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -429,6 +429,13 @@ When(/^I click the channel list of product "(.*?)"$/) do |product|
 end
 
 Then(/^I see verification succeeded/) do
+  10.times do
+    begin
+      break if find('i.text-success')
+    rescue Capybara::ElementNotFound
+      sleep 3
+    end
+  end
   find('i.text-success')
 end
 


### PR DESCRIPTION
## What does this PR change?

Wait for success message before continue with the next tests

## Links

Tracks https://github.com/SUSE/spacewalk/pull/6692

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
