### PR TITLE
Add dropdown number list to jump to a specific table page

### DIFF
--- a/branding/css/susemanager-theme.less
+++ b/branding/css/susemanager-theme.less
@@ -1302,3 +1302,10 @@ input:disabled+label {
   color: @spacewalk-gray;
 }
 
+select.small-select {
+  height: 1.8em;
+  line-height: 1.8em;
+  padding: 0 0.5em;
+  width: auto;
+  text-align: center;
+}

--- a/branding/spacewalk-branding.changes
+++ b/branding/spacewalk-branding.changes
@@ -1,3 +1,5 @@
+- Add dropdown number list to jump to a specific table page
+
 -------------------------------------------------------------------
 Thu Jan 31 09:41:23 CET 2019 - jgonzalez@suse.com
 

--- a/web/html/src/components/pagination.js
+++ b/web/html/src/components/pagination.js
@@ -22,7 +22,11 @@ const PaginationBlock = (props) => {
 
   return (
     <div>
-      <div className="table-page-information">{t("Page {0} of {1}", currentPage, lastPage)}</div>
+      <PageSelector
+        onChange={(p) => onPageChange(p)}
+        currentValue={currentPage}
+        lastPage={lastPage}
+      />
       {pagination}
     </div>
   );
@@ -42,6 +46,34 @@ const ItemsPerPageSelector = (props) =>
       {[5,10,15,25,50,100,250,500].map((o) => <option value={o} key={o}>{o}</option>)}
   </select>
 ;
+
+const PageSelector = (props) => {
+  if (props.lastPage > 1) {
+    return (
+      <div className="table-page-information">
+        {t('Page')}
+        &nbsp;
+        <select className="display-number small-select"
+          defaultValue={props.currentValue}
+          value={props.currentValue}
+          onChange={(e) => props.onChange(parseInt(e.target.value))}>
+            {Array.from(Array(props.lastPage)).map((o, i) => <option value={i + 1} key={i + 1}>{i + 1}</option>)}
+        </select>
+        &nbsp;
+        {t('of')}
+        &nbsp;
+        {props.lastPage}
+      </div>
+    )
+  }
+  else {
+    return (
+      <div className="table-page-information">
+        {t('Page {0} of {1}', props.currentValue, props.lastPage)}
+      </div>
+    )
+  }
+}
 
 
 module.exports = {

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Add dropdown number list to jump to a specific table page
 - Fix nodejs tests
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

If table pages are more than one, it adds a dropdown list of page numbers to let the user jump directly to another page instead of using `first|prev|next|last` buttons only.

**Note**: this is valid in new ReactJS tables only

## GUI diff

Before:
![screenshot from 2018-12-29 15-27-17](https://user-images.githubusercontent.com/7080830/50539304-9f6cc000-0b7e-11e9-8e32-d7fd8cd1033f.png)


After:
![screenshot from 2018-12-29 15-26-13](https://user-images.githubusercontent.com/7080830/50539305-a398dd80-0b7e-11e9-9158-ac876f0a7805.png)


- [x] **DONE**

## Documentation
- No documentation needed: nothing to document here.
@Loquacity : I am keeping the practice to ping you on small UI changes in case you need to keep track of them for the next documentation build process. This change, as maybe others, is not that relevant to have a wording description/explanation, but just make sure it goes in into fresh screenshots.

- [x] **DONE**

## Test coverage
- No tests: nothing to test

- [x] **DONE**

## Links

Fixes # none
Tracks # none

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
