### PR TITLE
fix channel guessing

### DIFF
--- a/backend/common/suseLib.py
+++ b/backend/common/suseLib.py
@@ -388,7 +388,7 @@ def findAllExtensionProductsOf(baseId, rootId):
 
 def channelForProduct(product, ostarget, parent_id=None, org_id=None,
                       user_id=None):
-    """Find Channels for a given product and ostarget.
+    """Find mandatory Channels for a given product and ostarget.
 
     If parent_id is None, a base channel is requested.
     Otherwise only channels are returned which have this id
@@ -428,6 +428,7 @@ def channelForProduct(product, ostarget, parent_id=None, org_id=None,
         JOIN suseOSTarget sot ON sot.channel_arch_id = c.channel_arch_id
         JOIN rhnChannelArch ca ON c.channel_arch_id = ca.id
         WHERE spc.product_id = :pid
+          AND spc.mandatory = 'Y'
           AND sot.os = :ostarget
           AND c.parent_channel %s""" % parent_statement)
     h.execute(**vals)

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/distupgrade_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/distupgrade_queries.xml
@@ -37,6 +37,7 @@
       FROM rhnChannel C
       JOIN suseProductChannel spc on C.id = spc.channel_id
      WHERE spc.product_id IN (%s)
+       AND spc.mandatory = 'Y'
        AND C.parent_channel = :base_channel_id
   </query>
 </mode>

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/test_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/test_queries.xml
@@ -549,25 +549,6 @@ SELECT 1 FROM dual
     </query>
 </mode>
 
-<write-mode name="insert_into_suseproductchannel">
-  <query params="product_id, channel_id, channel_label, parent_channel_label">
-    INSERT INTO suseproductchannel (
-      id,
-      product_id,
-      channel_id,
-      channel_label,
-      parent_channel_label
-    )
-    VALUES  (
-      sequence_nextval('suse_product_channel_id_seq'),
-      :product_id,
-      :channel_id,
-      :channel_label,
-      :parent_channel_label
-    )
-  </query>
-</write-mode>
-
 <write-mode name="delete_all_servers">
   <query>
     DELETE FROM rhnserver


### PR DESCRIPTION
## What does this PR change?

As we changed the suseProductChannel table not containing only mandatory channels we need to filter when guessing channels for a product.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **only traditional**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/6694

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
