### PR TITLE
move the credentials test at the end

### DIFF
--- a/testsuite/features/core_srv_setup_wizard.feature
+++ b/testsuite/features/core_srv_setup_wizard.feature
@@ -3,25 +3,6 @@
 
 Feature: The Setup Wizard
 
-@no_mirror
-  Scenario: Set up some credentials
-    Given I am on the Admin page
-    When I follow "Organization Credentials" in the content area
-    And I want to add a new credential
-    And I enter "asdf" as "edit-user"
-    And I enter "asdf" as "edit-password"
-    And I click on "Save"
-    Then I should see a "asdf" text
-    When I make the credentials primary
-    And I view the primary subscription list for asdf
-    Then I should see a "No subscriptions available" text
-    When I click on "Close"
-    And I delete the primary credentials
-    And I view the primary subscription list
-    And I click on "Close"
-    Then I should not see a "asdf" text
-    And I see verification succeeded
-
   Scenario: Play with the products page
     Given I am on the Admin page
     # Order matters here, refresh first
@@ -72,3 +53,22 @@ Feature: The Setup Wizard
     Then I should see a "Product Channels" text
     And I should see a "Mandatory Channels" text
     And I should see a "Optional Channels" text
+
+@no_mirror
+  Scenario: Set up some credentials
+    Given I am on the Admin page
+    When I follow "Organization Credentials" in the content area
+    And I want to add a new credential
+    And I enter "asdf" as "edit-user"
+    And I enter "asdf" as "edit-password"
+    And I click on "Save"
+    Then I should see a "asdf" text
+    When I make the credentials primary
+    And I view the primary subscription list for asdf
+    Then I should see a "No subscriptions available" text
+    When I click on "Close"
+    And I delete the primary credentials
+    And I view the primary subscription list
+    And I click on "Close"
+    Then I should not see a "asdf" text
+    And I see verification succeeded


### PR DESCRIPTION
## What does this PR change?

We are playing wild with the credentials page. Better to do it after the important product page tests.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **testsuite changes**

- [x] **DONE**

## Test coverage
- Cucumber tests were modified

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/6698

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
