### PR TITLE
New menu look&feel

### DIFF
--- a/branding/css/susemanager-login.less
+++ b/branding/css/susemanager-login.less
@@ -119,6 +119,7 @@ body.login-page {
     font-size: 14px
   }
   footer {
+    border-bottom: 8px solid @susemanager-green;
     border-top-width: 0px;
     background-color: @spacewalk-blue-light;
     position: fixed;

--- a/branding/css/susemanager-login.less
+++ b/branding/css/susemanager-login.less
@@ -125,6 +125,10 @@ body.login-page {
     padding-bottom: 0;
     padding-left: 0;
     .gray-text;
+    div.wrapper {
+      background-size: auto 30px;
+      min-height: 35px;
+    }
     div {
       text-align: center!important;
     }

--- a/branding/css/susemanager-login.less
+++ b/branding/css/susemanager-login.less
@@ -5,25 +5,23 @@
    font-style: normal;
 }
 
-/* SCC Login */
+/* SUSE Manager Login */
 body.login-page {
   background: @spacewalk-blue-light;
   font-size: 16px;
-  font-weight: normal;
-  font-family: arial;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   width: 100%;
   overflow: auto;
   margin-top: 0px;
+  color: @spacewalk-gray-light;
 }
 .login-page {
   .text-left;
   .wrap {
-    width: 960px;
+    width: 1024px;
     margin: 0 auto;
-    box-sizing:border-box;
-    -moz-box-sizing:border-box; /* Firefox */
+    box-sizing: border-box;
   }
   .navbar-header {
     margin-left: 10px;
@@ -44,9 +42,6 @@ body.login-page {
   .Raleway-font {
     font-family: 'Raleway', sans-serif;
     font-weight: 300
-  }
-  .gray-text {
-    color: @spacewalk-gray;
   }
   .btn-dark {
     color: @susemanager-green;
@@ -119,19 +114,16 @@ body.login-page {
     font-size: 14px
   }
   footer {
-    border-bottom: 8px solid @susemanager-green;
+    border-bottom: 16px solid @susemanager-green;
     border-top-width: 0px;
     background-color: @spacewalk-blue-light;
     position: fixed;
-    padding-bottom: 0;
+    padding-bottom: 1em;
     padding-left: 0;
-    .gray-text;
+    color: @spacewalk-gray;
     div.wrapper {
       background-size: auto 30px;
       min-height: 35px;
-    }
-    div {
-      text-align: center!important;
     }
     .wrap {
       > div {

--- a/branding/css/susemanager-theme.less
+++ b/branding/css/susemanager-theme.less
@@ -142,7 +142,15 @@ section {
     padding: 0;
     position: fixed;
     #nav nav ul.level1 {
-      overflow-y: auto!important;
+      overflow-y: auto !important;
+      &::-webkit-scrollbar {
+        width: 7px;
+      }
+      &::-webkit-scrollbar-thumb {
+        border-radius: 10px;
+        -webkit-box-shadow: inset 0 0 6px rgba(0,178,226,0.5);
+        background: rgba(0,178,226,0.5);
+      }
     }
   }
 

--- a/branding/css/susemanager-theme.less
+++ b/branding/css/susemanager-theme.less
@@ -21,7 +21,7 @@ header {
   width: 100%;
   border: none;
   border-radius: 0;
-  border-bottom: 3px solid darken(@susemanager-green, 10%);
+  border-bottom: 2px solid darken(@susemanager-green, 10%);
   margin-bottom: 0;
   padding: 12px 10px;
   background: @spacewalk-header;

--- a/branding/css/susemanager-theme.less
+++ b/branding/css/susemanager-theme.less
@@ -39,10 +39,10 @@ header {
 footer {
   border-top: 2px solid darken(@susemanager-green, 10%);
   background: @spacewalk-footer;
-  padding: 6px 0 6px 12px;
+  padding: 6px 12px;
   color: @spacewalk-footer-text;
   font-weight: normal;
-  font-size: 0.9em;
+  font-size: 1em;
   height: auto;
   min-height: auto;
   clear: both;
@@ -70,7 +70,8 @@ footer {
   }
 
   div.wrapper {
-    background: url('/img/susemanager/logo-footer-small.png') no-repeat right center;
+    background: url('/img/susemanager/logo-footer.png') no-repeat right center;
+    background-size: auto 20px;
     min-height: 28px;
     padding-right: 55px!important;
     > div {

--- a/branding/css/susemanager-theme.less
+++ b/branding/css/susemanager-theme.less
@@ -366,13 +366,9 @@ header, nav.navbar-pf {
 #nav {
   font-size: 1.1em;
   nav {
-    > * {
-      margin-top: 1em;
-    }
     //Search box
     .nav-tool-box {
       text-align: center;
-      padding: 0 0.5em;
       position: relative;
       input, button {
         margin: auto;
@@ -380,12 +376,13 @@ header, nav.navbar-pf {
       }
       input {
         background-color: @spacewalk-blue;
-        border-color: @spacewalk-gray-dark;
+        border-color: @spacewalk-blue-light;
         border-style: solid;
         border-radius: 0;
         border-width: 0 0 1px 0;
         color: @spacewalk-gray-light;
-        padding-right: 2.3em;
+        padding-right: 3em;
+        height: 3em;
       }
       input:focus {
         box-shadow: none;
@@ -393,7 +390,7 @@ header, nav.navbar-pf {
       .input-right-icon {
         color: @spacewalk-aside-menu-search-clear;
         position: absolute;
-        top: 0.2em;
+        top: .4em;
         right: 0;
         font-size: 1.2em;
         cursor: pointer;
@@ -456,7 +453,7 @@ header, nav.navbar-pf {
           font-size: inherit;
           position: absolute;
           right: 0.5em;
-          top: 0.4em;
+          top: 0.5em;
         }
         > a {
           display: inline-block;

--- a/branding/css/susemanager-theme.less
+++ b/branding/css/susemanager-theme.less
@@ -382,22 +382,29 @@ header, nav.navbar-pf {
       }
       input {
         background-color: @spacewalk-blue;
-        border-color: @spacewalk-blue-light;
+        border-color: @spacewalk-gray;
+        border-style: solid;
+        border-radius: 0;
+        border-width: 0 0 1px 0;
         color: @spacewalk-gray-light;
+        padding: 4px 2px;
       }
-      .clear {
+      input:focus {
+        box-shadow: none;
+      }
+      .input-right-icon {
         color: @spacewalk-aside-menu-search-clear;
         position: absolute;
         top: 0;
         right: 0;
-        font-size: 1.4em;
+        font-size: 1.3em;
         cursor: pointer;
-        margin-right: 20px;
+        margin-right: 15px;
         margin-top: 4px;
         padding: 0;
-        &:hover {
-          color: @spacewalk-aside-menu-search-clear-hover;
-        }
+      }
+      .clear:hover {
+        color: @spacewalk-aside-menu-search-clear-hover;
       }
     }
     a, .node-text {

--- a/branding/css/susemanager-theme.less
+++ b/branding/css/susemanager-theme.less
@@ -167,7 +167,6 @@ section {
 }
 
 #breadcrumb {
-  margin-left: 40px;
   color: @spacewalk-gray;
   display: inline-block;
   span {
@@ -197,16 +196,13 @@ section {
 
 header, nav.navbar-pf {
   .navbar-toggle {
-    display: block;
-    position: absolute;
-    top: 10px;
-    left: 10px;
+    display: inline-block;
+    float: none;
     margin: 0;
-    border: 1px solid @spacewalk-gray-dark;
-    padding: 2px 8px;
-    border-radius: 2px;
+    padding: 0;
     i {
       margin: 0;
+      font-size: 1.5em;
     }
   }
   .navbar-toggle:hover {

--- a/branding/css/susemanager-theme.less
+++ b/branding/css/susemanager-theme.less
@@ -371,11 +371,15 @@ header, nav.navbar-pf {
 
 //Nav menu in left column
 #nav {
+  font-size: 1.1em;
   nav {
-    padding: 10px 0 0 0;
+    > * {
+      margin-top: 1em;
+    }
+    //Search box
     .nav-tool-box {
       text-align: center;
-      padding: 0 10px;
+      padding: 0 0.5em;
       position: relative;
       input, button {
         margin: auto;
@@ -383,12 +387,12 @@ header, nav.navbar-pf {
       }
       input {
         background-color: @spacewalk-blue;
-        border-color: @spacewalk-gray;
+        border-color: @spacewalk-gray-dark;
         border-style: solid;
         border-radius: 0;
         border-width: 0 0 1px 0;
         color: @spacewalk-gray-light;
-        padding: 4px 2px;
+        padding-right: 2.3em;
       }
       input:focus {
         box-shadow: none;
@@ -396,105 +400,33 @@ header, nav.navbar-pf {
       .input-right-icon {
         color: @spacewalk-aside-menu-search-clear;
         position: absolute;
-        top: 0;
+        top: 0.2em;
         right: 0;
-        font-size: 1.3em;
+        font-size: 1.2em;
         cursor: pointer;
-        margin-right: 15px;
-        margin-top: 4px;
+        margin-right: 1em;
         padding: 0;
       }
       .clear:hover {
         color: @spacewalk-aside-menu-search-clear-hover;
       }
     }
-    a, .node-text {
-      display: inline-block;
-      padding: 8px 2px;
-      color: @spacewalk-aside-menu-hyperlink;
-      // width: 100%;
-      vertical-align: middle;
-    }
-    a:hover, a:focus,
-    .node-text:hover, .node-text:focus {
-      text-decoration: none;
-      color: @spacewalk-aside-menu-hyperlink-hover;
-    }
-    .node-text a:hover, .leafLink a:hover {
-      text-decoration: underline;
-    }
-    i.submenuIcon {
-      display: inline-block;
-      font-size: inherit;
-      height: 100%;
-      width: 19px;
-      margin: 0 8px 0 -27px;
-      text-align: center;
-      cursor: default;
-    }
-    ul, li {
+    //Menu
+    ul {
       padding: 0;
-      margin: 0;
       list-style: none;
       font-size: 1em;
       display: block;
-    }
-    li {
-      position: relative;
-    }
-    div.nodeLink, div.leafLink {
-      margin-left: 18px;
-      display: block;
-      border-right: 4px solid transparent;
-    }
-    div.leafLink > a {
-      width: 100%;
-    }
-    div.nodeLink {
-      .node-text {
-        display: inline-block;
-        width: 100%;
-      }
-    }
-    /* First Level */
-    > ul {
-      margin-top: 10px;
-      > li:last-of-type {
-        border-bottom: 1px solid darken(@spacewalk-blue-light, 5%);
-      }
-      > li {
-        border-top: 1px solid darken(@spacewalk-blue-light, 5%);
-        > div {
-          > a {
-            padding: 8px 2px 8px 8px;
-            color: @spacewalk-aside-menu-hyperlink;
-            > span {
-              display: inline-block;
-              vertical-align: middle;
-            }
-          }
-        }
-      }
-    }
-    /* Every level */
-    li.active > div > * {
-      color: @spacewalk-aside-menu-active;
-    }
-    ul {
-      padding-left: 8px;
       li {
-        a, .node-text {
-          border-right: 4px solid transparent;
-          span {
-            padding-right: 10px;
+        padding: 0;
+        list-style: none;
+        font-size: 1em;
+        display: block;
+        position: relative;
+        div {
+          a {
+            padding: 4px 10px;
           }
-        }
-      }
-      > li {
-        > .nodeLink:hover,
-        > .leafLink:hover {
-          border-right-color: @spacewalk-aside-menu-hyperlink-hover;
-          background-color: @spacewalk-blue-light;
         }
       }
       li.node.open {
@@ -502,36 +434,81 @@ header, nav.navbar-pf {
           display: block;
         }
       }
-      /* Second Level */
-      ul {
-        padding-bottom: 10px;
-        background-color: @spacewalk-blue;
-        padding-top: 1px;
-        li {
-          > div {
-            > a, .node-text {
-              padding-left: 10px;
-              background-image: url('/img/susemanager/sub-list.png');
-              background-repeat: no-repeat;
-              background-position: left center;
-              i {
-                font-size: 1em;
+      // active
+      li.active > .nodeLink {
+        color: @susemanager-green;
+      }
+      li.active > .leafLink {
+        background-color: @spacewalk-aside-menu-active;
+        border-radius: 0 2px 2px 0;
+      }
+      // nodeLink and leafLink
+      div.nodeLink,
+      div.leafLink {
+        color: @spacewalk-gray-light;
+        border-left: 3px solid transparent;
+        a {
+          display: block;
+          color: inherit;
+          width: auto;
+        }
+      }
+      div.nodeLink:hover,
+      div.leafLink:hover {
+        border-left: 3px solid @susemanager-green;
+      }
+      // nodeLink only
+      div.nodeLink {
+        > i.submenuIcon {
+          font-size: inherit;
+          position: absolute;
+          right: 0.5em;
+          top: 0.4em;
+        }
+        > a {
+          display: inline-block;
+        }
+        > a:hover {
+          color: @spacewalk-gray-light;
+        }
+      }
+      div.nodeLink:hover {
+        color: @spacewalk-aside-menu-active;
+      }
+    }
+    /* First Level */
+    > ul {
+      margin-top: 10px;
+      padding-right: 10px;
+      > li {
+        > div {
+          > a {
+            padding: 8px 2px;
+          }
+        }
+        > div.nodeLink {
+          padding-left: 0.8em;
+        }
+        /* Second Level */
+        > ul {
+          padding-bottom: 10px;
+          > li {
+            > div {
+              > a {
+                padding-left: 2.5em;
+              }
+            }
+            /* Third Level */
+            > ul {
+              > li {
+                > div {
+                  > a {
+                    padding-left: 4em;
+                  }
+                }
               }
             }
           }
-        }
-        > li:last-of-type > div > a,
-        > li:last-of-type > div > .node-text  {
-          background-image: url('/img/susemanager/sub-list-last.png');
-        }
-        > li:last-of-type ul {
-          background-image: none;
-        }
-        /* Third Level */
-        ul {
-          margin-left: 18px;
-          background-image: url('/img/susemanager/sub-list-line.png');
-          background-repeat: repeat-y;
         }
       }
     }

--- a/branding/css/susemanager-theme.less
+++ b/branding/css/susemanager-theme.less
@@ -404,14 +404,16 @@ header, nav.navbar-pf {
       display: inline-block;
       padding: 8px 2px;
       color: @spacewalk-aside-menu-hyperlink;
-      width: 100%;
+      // width: 100%;
       vertical-align: middle;
-      cursor:pointer;
     }
     a:hover, a:focus,
     .node-text:hover, .node-text:focus {
       text-decoration: none;
       color: @spacewalk-aside-menu-hyperlink-hover;
+    }
+    .node-text a:hover, .leafLink a:hover {
+      text-decoration: underline;
     }
     i.submenuIcon {
       display: inline-block;
@@ -443,27 +445,7 @@ header, nav.navbar-pf {
     div.nodeLink {
       .node-text {
         display: inline-block;
-        width: 85%;
-      }
-      a.direct-link {
-        background: none;
-        width: 15%;
-        text-align: center;
-        border-left: 1px dashed #333;
-        color: @spacewalk-gray;
-        padding-left: 0px;
-        padding-right: 0px;
-        i {
-          font-size: 0.8em;
-          width: 15px;
-          display: inline-block;
-          text-align: center;
-          margin: 0 auto;
-        }
-      }
-      a.direct-link:hover {
-        background-color: lighten(@spacewalk-blue-light, 5%);
-        color: @spacewalk-aside-menu-hyperlink-hover;
+        width: 100%;
       }
     }
     /* First Level */

--- a/branding/css/susemanager-theme.less
+++ b/branding/css/susemanager-theme.less
@@ -141,7 +141,7 @@ section {
     /* erasing the predefined paddings in the columns */
     padding: 0;
     position: fixed;
-    #nav {
+    #nav nav ul.level1 {
       overflow-y: auto!important;
     }
   }
@@ -365,43 +365,43 @@ header, nav.navbar-pf {
 //Nav menu in left column
 #nav {
   font-size: 1.1em;
-  nav {
-    //Search box
-    .nav-tool-box {
-      text-align: center;
-      position: relative;
-      input, button {
-        margin: auto;
-        vertical-align: top;
-      }
-      input {
-        background-color: @spacewalk-blue;
-        border-color: @spacewalk-blue-light;
-        border-style: solid;
-        border-radius: 0;
-        border-width: 0 0 1px 0;
-        color: @spacewalk-gray-light;
-        padding-right: 3em;
-        height: 3em;
-      }
-      input:focus {
-        box-shadow: none;
-      }
-      .input-right-icon {
-        color: @spacewalk-aside-menu-search-clear;
-        position: absolute;
-        top: .4em;
-        right: 0;
-        font-size: 1.2em;
-        cursor: pointer;
-        margin-right: 1em;
-        padding: 0;
-      }
-      .clear:hover {
-        color: @spacewalk-aside-menu-search-clear-hover;
-      }
+  //Search box
+  .nav-tool-box {
+    text-align: center;
+    position: relative;
+    input, button {
+      margin: auto;
+      vertical-align: top;
     }
-    //Menu
+    input {
+      background-color: @spacewalk-blue;
+      border-color: @spacewalk-blue-light;
+      border-style: solid;
+      border-radius: 0;
+      border-width: 0 0 1px 0;
+      color: @spacewalk-gray-light;
+      padding-right: 3em;
+      height: 3em;
+    }
+    input:focus {
+      box-shadow: none;
+    }
+    .input-right-icon {
+      color: @spacewalk-aside-menu-search-clear;
+      position: absolute;
+      top: .4em;
+      right: 0;
+      font-size: 1.2em;
+      cursor: pointer;
+      margin-right: 1em;
+      padding: 0;
+    }
+    .clear:hover {
+      color: @spacewalk-aside-menu-search-clear-hover;
+    }
+  }
+  //Menu
+  nav {
     ul {
       padding: 0;
       list-style: none;
@@ -445,7 +445,7 @@ header, nav.navbar-pf {
       }
       div.nodeLink:hover,
       div.leafLink:hover {
-        border-left: 3px solid @susemanager-green;
+        border-left-color: @susemanager-green;
       }
       // nodeLink only
       div.nodeLink {
@@ -468,7 +468,8 @@ header, nav.navbar-pf {
     }
     /* First Level */
     > ul {
-      margin-top: 10px;
+      padding-top: 10px;
+      padding-bottom: 10px;
       padding-right: 10px;
       > li {
         > div {

--- a/branding/css/susemanager-theme.less
+++ b/branding/css/susemanager-theme.less
@@ -354,7 +354,7 @@ header, nav.navbar-pf {
   font-size: 1.5em;
   padding: 0;
   text-align: center;
-  background-color: rgba(0, 192, 129, 0.2);
+  background-color: rgba(77, 211, 167, 0.2);
   color: @spacewalk-gray-dark;
   border: 1px solid rgba(0, 192, 129, 0.2);
   i {

--- a/branding/css/susemanager-theme.less
+++ b/branding/css/susemanager-theme.less
@@ -405,14 +405,12 @@ header, nav.navbar-pf {
     ul {
       padding: 0;
       list-style: none;
-      font-size: 1em;
       display: block;
       li {
         padding: 0;
         list-style: none;
         font-size: 1em;
         display: block;
-        position: relative;
         div {
           a {
             padding: 4px 10px;
@@ -449,11 +447,16 @@ header, nav.navbar-pf {
       }
       // nodeLink only
       div.nodeLink {
+        position: relative;
+        > i {
+          font-size: 1.3em;
+          vertical-align: text-bottom;
+        }
         > i.submenuIcon {
-          font-size: inherit;
+          font-size: 1.1em;
           position: absolute;
           right: 0.5em;
-          top: 0.5em;
+          top: 0.3em;
         }
         > a {
           display: inline-block;
@@ -479,6 +482,9 @@ header, nav.navbar-pf {
         }
         > div.nodeLink {
           padding-left: 0.8em;
+          > i.submenuIcon {
+            top: 0.6em;
+          }
         }
         /* Second Level */
         > ul {
@@ -486,7 +492,7 @@ header, nav.navbar-pf {
           > li {
             > div {
               > a {
-                padding-left: 2.5em;
+                padding-left: 3em;
               }
             }
             /* Third Level */
@@ -494,7 +500,7 @@ header, nav.navbar-pf {
               > li {
                 > div {
                   > a {
-                    padding-left: 4em;
+                    padding-left: 5em;
                   }
                 }
               }

--- a/branding/css/susemanager-theme.less
+++ b/branding/css/susemanager-theme.less
@@ -327,7 +327,7 @@ header, nav.navbar-pf {
     line-height: 1.2em;
     font-size: 1.6em;
     display: inline-block;
-    vertical-align: middle;
+    vertical-align: baseline;
     color: @spacewalk-gray-light;
     > i {
       display: none;

--- a/branding/css/susemanager-theme.less
+++ b/branding/css/susemanager-theme.less
@@ -37,12 +37,12 @@ header {
 }
 
 footer {
-  border-top: 2px solid darken(@susemanager-green, 10%);
+  border-top: 1px solid @spacewalk-blue-light;
   background: @spacewalk-footer;
-  padding: 6px 12px;
+  padding: 3px 12px;
   color: @spacewalk-footer-text;
   font-weight: normal;
-  font-size: 1em;
+  font-size: 0.9em;
   height: auto;
   min-height: auto;
   clear: both;
@@ -78,13 +78,6 @@ footer {
       padding: 3px 0 2px 0;
     }
   }
-}
-
-.bottom-line {
-  height: 8px;
-  width: 100%;
-  background: @susemanager-green;
-  display: none;
 }
 
 /* titles */

--- a/branding/css/susemanager-variables.less
+++ b/branding/css/susemanager-variables.less
@@ -15,7 +15,7 @@
 @spacewalk-yellow-dark:  #c5b345; // yellow-dark
 @spacewalk-yellow:       #ffef8d; // yellow
 @spacewalk-red:          #a42800; // red
-@spacewalk-background:   #f7f7f7;
+@spacewalk-background:   #fcfcfc;
 @spacewalk-blue:         #00243e; // dark blue
 @spacewalk-blue-light:   #003258; // light blue
 @spacewalk-violet:       #841781;

--- a/branding/css/susemanager-variables.less
+++ b/branding/css/susemanager-variables.less
@@ -15,13 +15,13 @@
 @spacewalk-yellow-dark:  #c5b345; // yellow-dark
 @spacewalk-yellow:       #ffef8d; // yellow
 @spacewalk-red:          #a42800; // red
-@spacewalk-background:   #fcfcfc;
-@spacewalk-blue:         #00243e; // dark blue
-@spacewalk-blue-light:   #003258; // light blue
+@spacewalk-background:   #FFF;
+@spacewalk-blue:         #0D2C40; // blue
+@spacewalk-blue-light:   #314C5D; // light blue
 @spacewalk-violet:       #841781;
 @spacewalk-gray-light-background: #ebebeb;
 @spacewalk-header:       @spacewalk-blue;
-@spacewalk-aside:        @spacewalk-blue-light;
+@spacewalk-aside:        @spacewalk-blue;
 @spacewalk-notification-badge: @spacewalk-orange-light;
 
 /* Main colour */

--- a/branding/java/code/src/com/redhat/rhn/branding/strings/StringResource_en_US.xml
+++ b/branding/java/code/src/com/redhat/rhn/branding/strings/StringResource_en_US.xml
@@ -2086,7 +2086,7 @@ tree will not be usable for autoinstalling.
 
       <!-- Content Management -->
       <trans-unit id="contentmanagement.nav.title">
-        <source>Content Lifecycle Management</source>
+        <source>Content Lifecycle</source>
       </trans-unit>
       <trans-unit id="contentmanagement.nav.projects">
         <source>Projects</source>

--- a/branding/spacewalk-branding.changes
+++ b/branding/spacewalk-branding.changes
@@ -1,3 +1,4 @@
+- New menu look&feel
 - Fix dropdown background in dark themed Firefox
 
 -------------------------------------------------------------------

--- a/java/code/webapp/WEB-INF/includes/footer.jsp
+++ b/java/code/webapp/WEB-INF/includes/footer.jsp
@@ -15,4 +15,3 @@
     <div><c:out value="${custom_footer}" escapeXml="false"/></div>
   </c:if>
 </div>
-<div class="bottom-line"></div>

--- a/testsuite/features/srv_content_lifecycle.feature
+++ b/testsuite/features/srv_content_lifecycle.feature
@@ -1,11 +1,11 @@
 # Copyright (c) 2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-Feature: Content lifecycle management
+Feature: Content lifecycle
 
   Scenario: Create a content lifecycle project
     Given I am authorized as "admin" with password "admin"
-    When I follow "Content Lifecycle Management"
+    When I follow "Content Lifecycle"
     And I follow "Projects"
     Then I should see a "Content Lifecycle Projects" text
     And I should see a "There are no entries to show." text
@@ -21,7 +21,7 @@ Feature: Content lifecycle management
 
   Scenario: Verify the content lifecycle project page
     Given I am authorized as "admin" with password "admin"
-    When I follow "Content Lifecycle Management"
+    When I follow "Content Lifecycle"
     And  I follow "Projects"
     Then I should see a "clp_name" text
     And I should see a "clp_desc" text
@@ -34,7 +34,7 @@ Feature: Content lifecycle management
 
   Scenario: Add a source to the project
     Given I am authorized as "admin" with password "admin"
-    When I follow "Content Lifecycle Management"
+    When I follow "Content Lifecycle"
     And I follow "Projects"
     And I follow "clp_name"
     And I follow "Edit Sources"
@@ -50,7 +50,7 @@ Feature: Content lifecycle management
 
   Scenario: Add environments to the project
     Given I am authorized as "admin" with password "admin"
-    When I follow "Content Lifecycle Management"
+    When I follow "Content Lifecycle"
     And I follow "Projects"
     And I follow "clp_name"
     Then I should see a "No environments created" text
@@ -79,7 +79,7 @@ Feature: Content lifecycle management
 
   Scenario: Build the sources in the project
     Given I am authorized as "admin" with password "admin"
-    When I follow "Content Lifecycle Management"
+    When I follow "Content Lifecycle"
     And I follow "Projects"
     And I follow "clp_name"
     Then I should see a "not built" text in the environment "qa_name"
@@ -94,7 +94,7 @@ Feature: Content lifecycle management
 
   Scenario: Promote promote the sources in the project
     Given I am authorized as "admin" with password "admin"
-    When I follow "Content Lifecycle Management"
+    When I follow "Content Lifecycle"
     And I follow "Projects"
     Then I should see a "clp_name" text
     And I should see a "clp_desc" text
@@ -113,7 +113,7 @@ Feature: Content lifecycle management
 
   Scenario: Add new sources and promote again
     Given I am authorized as "admin" with password "admin"
-    When I follow "Content Lifecycle Management"
+    When I follow "Content Lifecycle"
     And I follow "Projects"
     And I follow "clp_name"
     Then I should see a "Build (0)" text

--- a/web/html/javascript/spacewalk-essentials.js
+++ b/web/html/javascript/spacewalk-essentials.js
@@ -184,14 +184,15 @@ function adjustDistanceForFixedHeader() {
 // Make columns 100% in height
 function columnHeight() {
   const aside = $('.spacewalk-main-column-layout aside');
+  const navToolBox = $('.spacewalk-main-column-layout aside .nav-tool-box');
   const headerHeight = $('header').outerHeight();
   const footerHeight = $('footer').outerHeight();
   const winHeight = $(window).height();
   // // Column height should equal the window height minus the header and footer height
   aside.css('height', winHeight - headerHeight);
   // aside.css('padding-bottom', footerHeight);
-  const nav = $('.spacewalk-main-column-layout aside #nav');
-  nav.css('height', aside.outerHeight() - footerHeight);
+  const nav = $('.spacewalk-main-column-layout aside #nav nav ul.level1');
+  nav.css('height', aside.outerHeight() - navToolBox.outerHeight() - footerHeight);
 };
 
 $(document).on('click', '.navbar-toggle', function() {

--- a/web/html/javascript/susemanager-login.js
+++ b/web/html/javascript/susemanager-login.js
@@ -3,7 +3,7 @@ $(document).on("ready", function() {
   const footer = $('footer');
   footer.remove();
   $('body').append(footer);
-
+  $("#scroll-top").remove();
   $("aside").remove();
   $('.navbar-toggle').remove();
   formFocus('loginForm', 'username');

--- a/web/html/src/manager/menu.js
+++ b/web/html/src/manager/menu.js
@@ -199,16 +199,11 @@ class Breadcrumb extends React.Component {
         <span>></span>
         {
           breadcrumbArray.map((a, i) => {
-            const htmlElement =
-            (
-              a.submenu ?
-              <Link url={a.submenu[0].primaryUrl}
-                  label={a.label} target={a.target} />
-              :
-              <span className="level">{a.label}</span>
-            );
             return (
-              <span key={a.label + '_' + i}>{htmlElement}{ i == breadcrumbArray.length -1 ? null : <span>></span>}</span>
+              <span key={a.label + '_' + i}>
+                <Link url={a.submenu ? a.submenu[0].primaryUrl : a.primaryUrl} label={a.label} target={a.target} />
+                { i == breadcrumbArray.length -1 ? null : '>'}
+              </span>
             );
           })
         }

--- a/web/html/src/manager/menu.js
+++ b/web/html/src/manager/menu.js
@@ -11,35 +11,20 @@ const Link = (props) =>
   </a>
   ;
 
-const NodeLink = (props) =>
-  <div className={props.cssClass} onClick={props.handleClick}>
-    {props.preIcon ? <i className={'fa ' + props.preIcon}></i> : null}
+const Node = (props) =>
+  <div className={props.isLeaf ? " leafLink " : " nodeLink "} onClick={props.handleClick}>
     {
       props.icon ?
       <i className={'fa ' + props.icon}></i>
       : null
     }
     <Link url={props.url} target={props.target} label={props.label} />
-  </div>
-;
-
-const Node = (props) =>
-  <div className={props.isLeaf ? " leafLink " : " nodeLink "} >
-    {
-      props.isLeaf ?
-        <Link url={props.url} target={props.target} label={props.label} />
+    { props.isLeaf ?
+        null
         :
-        <NodeLink url={props.url}
-          target={props.target}
-          cssClass="node-text"
-          handleClick={props.handleClick}
-          label={props.label}
-          icon={props.icon}
-          preIcon={ !props.isSearchActive ?
-            'submenuIcon ' + (props.isOpen ? "fa fa-angle-up" : "fa fa-angle-down")
-            : null
-          }
-        />
+        (!props.isSearchActive ?
+          <i className={'submenuIcon ' + (props.isOpen ? "fa fa-angle-up" : "fa fa-angle-down")}></i>
+          : null)
     }
   </div>;
 

--- a/web/html/src/manager/menu.js
+++ b/web/html/src/manager/menu.js
@@ -153,13 +153,19 @@ class Nav extends React.Component {
   };
 
   render() {
+    const isSearchActive = this.state.search != null && this.state.search.length > 0;
     return (
-      <nav className={this.state.search != null && this.state.search.length > 0 ? '' : 'collapsed'}>
+      <nav className={isSearchActive > 0 ? '' : 'collapsed'}>
         <div className="nav-tool-box">
           <input type="text" className="form-control" name="nav-search" id="nav-search" value={this.state.search}
             onChange={this.onSearch} placeholder="Search page" />
-          <span className="clear">
-            <i className="fa fa-times-circle-o no-margin" onClick={this.closeEmAll} title={t('Clear Menu')}></i>
+          <span className={"input-right-icon " +  (isSearchActive ? "clear" : "")}>
+            {
+              isSearchActive ?
+                <i className="fa fa-times-circle-o no-margin" onClick={this.closeEmAll} title={t('Clear Menu')}></i>
+                :
+                <i className="fa fa-search no-margin" title={t('Filter menu')}></i>
+            }
           </span>
         </div>
         <MenuLevel level={1} elements={JSONMenu} searchString={this.state.search} forceCollapse={this.state.forceCollapse} />

--- a/web/html/src/manager/menu.js
+++ b/web/html/src/manager/menu.js
@@ -4,29 +4,40 @@ const React = require("react");
 const ReactDOM = require("react-dom");
 
 const Link = (props) =>
-  <a href={props.url} className={props.cssClass} target={props.target}
-    title={props.title} onClick={props.handleClick}>
+  <a href={props.url} className={props.cssClass} target={props.target} title={props.title}>
     {props.responsiveLabel}
     {props.label}
   </a>
   ;
 
-const Node = (props) =>
-  <div className={props.isLeaf ? " leafLink " : " nodeLink "} onClick={props.handleClick}>
-    {
-      props.icon ?
-      <i className={'fa ' + props.icon}></i>
-      : null
+class Node extends React.Component {
+  handleClick = (event) => {
+    // if the click is triggered on a link, do not toggle the menu, just offload the page and go to the requested link
+    if (!event.target.href) {
+      this.props.handleClick();
     }
-    <Link url={props.url} target={props.target} label={props.label} />
-    { props.isLeaf ?
-        null
-        :
-        (!props.isSearchActive ?
-          <i className={'submenuIcon ' + (props.isOpen ? "fa fa-angle-up" : "fa fa-angle-down")}></i>
-          : null)
-    }
-  </div>;
+  };
+
+  render() {
+    return (
+      <div className={this.props.isLeaf ? " leafLink " : " nodeLink "} onClick={(event) => this.handleClick(event)}>
+        {
+          this.props.icon ?
+          <i className={'fa ' + this.props.icon}></i>
+          : null
+        }
+        <Link url={this.props.url} target={this.props.target} label={this.props.label} onClick={(event) => this.handleClick(event)} />
+        { this.props.isLeaf ?
+            null
+            :
+            (!this.props.isSearchActive ?
+              <i className={'submenuIcon ' + (this.props.isOpen ? "fa fa-angle-up" : "fa fa-angle-down")}></i>
+              : null)
+        }
+      </div>
+    );
+  }
+}
 
 class Element extends React.Component {
   state = {

--- a/web/html/src/manager/menu.js
+++ b/web/html/src/manager/menu.js
@@ -6,35 +6,40 @@ const ReactDOM = require("react-dom");
 const Link = (props) =>
   <a href={props.url} className={props.cssClass} target={props.target}
     title={props.title} onClick={props.handleClick}>
-    {props.preIcon ? <i className={'fa ' + props.preIcon}></i> : null}
-    {
-      props.icon ?
-      <i className={'fa ' + props.icon}></i>
-      : null
-    }
     {props.responsiveLabel}
     {props.label}
   </a>
   ;
 
 const NodeLink = (props) =>
+  <div className={props.cssClass} onClick={props.handleClick}>
+    {props.preIcon ? <i className={'fa ' + props.preIcon}></i> : null}
+    {
+      props.icon ?
+      <i className={'fa ' + props.icon}></i>
+      : null
+    }
+    <Link url={props.url} target={props.target} label={props.label} />
+  </div>
+;
+
+const Node = (props) =>
   <div className={props.isLeaf ? " leafLink " : " nodeLink "} >
     {
       props.isLeaf ?
-      <Link url={props.url} target={props.target} label={props.label} />
-      : <Link url="#" target={props.target} cssClass="node-text" handleClick={props.handleClick}
-          label={props.label} icon={props.icon}
+        <Link url={props.url} target={props.target} label={props.label} />
+        :
+        <NodeLink url={props.url}
+          target={props.target}
+          cssClass="node-text"
+          handleClick={props.handleClick}
+          label={props.label}
+          icon={props.icon}
           preIcon={ !props.isSearchActive ?
-            'submenuIcon ' + (props.isOpen ? "fa fa-angle-down" : "fa fa-angle-right")
+            'submenuIcon ' + (props.isOpen ? "fa fa-angle-up" : "fa fa-angle-down")
             : null
-          }/>
-    }
-    {
-      !props.isLeaf ?
-      <Link url={props.url} title={props.completeUrlLabel}
-        label={<i className="fa fa-dot-circle-o"></i>}
-        cssClass="direct-link" target={props.target} />
-      : null
+          }
+        />
     }
   </div>;
 
@@ -95,7 +100,7 @@ class Element extends React.Component {
           (this.isLeaf(element) ? " leaf " : " node ")
           }
         >
-          <NodeLink isLeaf={this.isLeaf(element)} url={this.getUrl(element)}
+          <Node isLeaf={this.isLeaf(element)} url={this.getUrl(element)}
               label={element.label} target={element.target}
               completeUrlLabel={this.getCompleteUrlLabel(element)}
               handleClick={this.isLeaf(element) ? null : this.toggleView}

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- New menu look&feel
 - Remove feature preview message from Formulas pages
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Update menu style to a fresh look and feel.

*Highlights*:
- get rid of the `dot-circle direct-link`, use the node text instead
- get rid of left list lines to keep aligned the menu level with the siblings
- let only the menu scroll, the menu search box stays fixed instead
- better footer icon image
- smaller footer box
- let the last element of the breadcrumb be a link as well
- on `webkit` engine based browsers, use a custom smaller and lighter `nav scrollbar`


## GUI diff

Before:
![old-menu](https://user-images.githubusercontent.com/7080830/57098968-9aca3b00-6d1b-11e9-94c1-113beec08983.png)

After:
![Screenshot from 2019-05-04 22-01-05](https://user-images.githubusercontent.com/7080830/57184200-2547a180-6eb8-11e9-9fff-1a99ba4f2bc0.png)



- [x] **DONE**

## Documentation
- @Loquacity pinging you here because of two reasons:
  - documentation will need fresh screenshots
  - should we document the new behavior in a *textual written mode*? if yes, how? So far I plan to explain the new behavior during a training-demo, but  I have no idea about the *paper/written* mode.

- [x] **DONE**

## Test coverage
- No tests: test coverage is already in place

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
