### PR TITLE
specify python version of rhnlib explicit

### DIFF
--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -84,10 +84,11 @@ Requires:       %{pythonX}
 Requires:       rpm-python
 # /etc/rhn is provided by spacewalk-proxy-common or by spacewalk-config
 Requires:       /etc/rhn
-Requires:       rhnlib >= 2.5.74
 %if 0%{?build_py3}
 Requires:       python3-%{name}-libs >= %{version}
+Requires:       python3-rhnlib >= 2.5.74
 %else
+Requires:       python2-rhnlib >= 2.5.74
 Requires:       %{name}-libs >= %{version}
 %endif
 # for Debian support
@@ -118,11 +119,12 @@ BuildRequires:  python2-spacewalk-usix
 %if 0%{?build_py3}
 BuildRequires:  python3-gzipstream
 BuildRequires:  python3-rhn-client-tools
+BuildRequires:  python3-rhnlib >= 2.5.74
 %else
 BuildRequires:  python2-gzipstream
 BuildRequires:  python2-rhn-client-tools
+BuildRequires:  python2-rhnlib >= 2.5.74
 %endif
-BuildRequires:  rhnlib >= 2.5.74
 BuildRequires:  rpm-python
 BuildRequires:  %{python_prefix}-debian
 
@@ -457,10 +459,11 @@ Requires:       %{m2crypto}
 Requires:       python-requests
 %if 0%{?build_py3}
 Requires:       python3-spacewalk-usix
+Requires:       python3-rhnlib  >= 2.5.57
 %else
 Requires:       python2-spacewalk-usix
+Requires:       python2-rhnlib  >= 2.5.57
 %endif
-Requires:       rhnlib  >= 2.5.57
 %if 0%{?fedora} || 0%{?rhel}
 BuildRequires:  python-requests
 %endif

--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -140,7 +140,7 @@ Requires:       python2-spacewalk-usix
 %endif
 
 %if 0%{?suse_version}
-Requires:       python-pycurl
+Requires:       %{pythonX}-pycurl
 %endif
 
 # we don't really want to require this redhat-release, so we protect


### PR DESCRIPTION
## What does this PR change?

`rhnlib` is only provided by the python2 variant. So be explicit which python version we need to build and run.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **fix dependencies**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
