### PR TITLE
remove unused commons-pool dependency

### DIFF
--- a/java/buildconf/build-props.xml
+++ b/java/buildconf/build-props.xml
@@ -174,7 +174,7 @@
 	     xalan-j2 xalan-j2-serializer xerces-j2 xml-commons-apis simple-core ${ehcache}" />
 
   <property name="taskomatic.jar.dependencies"
-      value="${dist.jar.dependencies} commons-pool jsch" />
+      value="${dist.jar.dependencies} jsch" />
 
   <path id="bootjars">
     <fileset dir="${boot.lib.dir}" includes="*.jar" />

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -467,20 +467,11 @@ Requires:       apache-commons-cli
 Requires:       apache-commons-codec
 Requires:       apache-commons-lang3
 Requires:       apache-commons-logging
-%if 0%{?suse_version} < 1500
-Requires:       jakarta-commons-pool
-BuildRequires:  jakarta-commons-pool
-%else
-Requires:       apache-commons-pool
-BuildRequires:  apache-commons-pool
-%endif # 0%{?suse_version} < 1500
 %else
 Requires:       jakarta-commons-cli
 Requires:       jakarta-commons-codec
 Requires:       jakarta-commons-lang
 Requires:       jakarta-commons-logging
-Requires:       jakarta-commons-pool
-BuildRequires:  jakarta-commons-pool
 %endif # 0%{?suse_version}
 %endif # 0%{?fedora} || 0%{?rhel} >= 7
 Conflicts:      quartz < 2.0


### PR DESCRIPTION
## What does this PR change?

We cannot find a reason to keep this. It seems to be unused.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **no code changes**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
