### PR TITLE
Use default 'master' branch in Image profile URL if none is provided

### DIFF
--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- use default 'master' branch in OSImage profile URL (bsc#1108218)
 - Add Python linting makefile and PyLint configuration file
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

- provide consistency between Dockerfile and OSImage URLs (bsc#1108218)
- small fix: raise an exception if target directory does not exists in git checkout

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed.

- [X] **DONE**

## Test coverage
- No tests: No functionality change, covered by existing tests

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/6403

- [X] **DONE**