### PR TITLE
fix dependencies to spacewalk-backend-libs

### DIFF
--- a/client/tools/mgr-push/mgr-push.spec
+++ b/client/tools/mgr-push/mgr-push.spec
@@ -108,7 +108,7 @@ Requires:       python3-spacewalk-usix
 BuildRequires:  python3-devel
 BuildRequires:  python3-rhn-client-tools
 BuildRequires:  python3-rpm-macros
-BuildRequires:  spacewalk-backend-libs > 1.8.33
+BuildRequires:  python3-spacewalk-backend-libs > 1.8.33
 
 %description -n python3-%{name}
 Python 3 specific files for rhnpush.

--- a/proxy/proxy/spacewalk-proxy.spec
+++ b/proxy/proxy/spacewalk-proxy.spec
@@ -46,7 +46,6 @@ BuildRequires:  spacewalk-python2-pylint
 BuildRequires:  mgr-push >= 4.0.0
 BuildRequires:  %{pythonX}-mgr-push
 BuildRequires:  spacewalk-backend >= 1.7.24
-BuildRequires:  spacewalk-backend-libs >= 1.7.24
 
 %define rhnroot %{_usr}/share/rhn
 %define destdir %{rhnroot}/proxy


### PR DESCRIPTION
## What does this PR change?

Use either spacewalk-backend-libs or python3-spacewalk-backend-libs.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **just deps**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
