### PR TITLE
require rhnlib with correct python version

### DIFF
--- a/proxy/proxy/spacewalk-proxy.spec
+++ b/proxy/proxy/spacewalk-proxy.spec
@@ -192,7 +192,7 @@ Spacewalk Proxy components.
 Summary:        Custom Channel Package Manager for the Spacewalk Proxy Server
 Group:          Applications/Internet
 Requires:       %{pythonX}
-Requires:       rhnlib >= 2.5.56
+Requires:       %{pythonX}-rhnlib >= 2.5.56
 Requires:       mgr-push >= 4.0.0
 Requires:       spacewalk-backend >= 1.7.24
 # proxy isn't Python 3 yet


### PR DESCRIPTION
## What does this PR change?

require rhnlib with correct python version

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **just deps**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
