### PR TITLE
unix2_chkpwd was moved to pam in SLE15

### DIFF
--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -78,7 +78,7 @@ Requires:       javassist
 Requires:       jboss-logging
 Requires:       jose4j
 Requires:       objectweb-asm
-Requires:       pam-modules
+Requires:       /sbin/unix2_chkpwd
 Requires:       prometheus-client-java
 Requires:       salt-netapi-client >= 0.15.0
 Requires:       snakeyaml
@@ -102,7 +102,6 @@ BuildRequires:  javassist
 BuildRequires:  jboss-logging
 BuildRequires:  jsch
 BuildRequires:  objectweb-asm
-BuildRequires:  pam-modules
 BuildRequires:  snakeyaml
 BuildRequires:  statistics
 # SUSE additional build requirements
@@ -416,7 +415,7 @@ Requires:       c3p0 >= 0.9.1
 Requires:       cobbler >= 2.0.0
 Requires:       java >= 1.8.0
 Requires:       jsch
-Requires:       pam-modules
+Requires:       /sbin/unix2_chkpwd
 Requires:       tomcat-taglibs-standard
 %else
 Requires:       cobbler20

--- a/susemanager-utils/testing/docker/master/uyuni-master-base/add_packages.sh
+++ b/susemanager-utils/testing/docker/master/uyuni-master-base/add_packages.sh
@@ -50,7 +50,7 @@ zypper --non-interactive in ant \
              ant-junit \
              apache-ivy \
              java-1_8_0-openjdk-devel \
-             pam-modules \
+             pam \
              sudo \
              tar
 


### PR DESCRIPTION
## What does this PR change?

We use unix2_chkpwd to perform pam authentication from java. This binary was moved from pam-modules to pam package in SLE15. Use file provides where possible.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **internal**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/6704

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
