### PR TITLE
yum-utils not needed always

### DIFF
--- a/spacewalk/package/spacewalk.spec
+++ b/spacewalk/package/spacewalk.spec
@@ -81,7 +81,6 @@ Requires:       spacewalk-certs-tools
 Requires:       pxe-default-image
 Requires:       spacewalk-config
 Requires:       spacewalk-schema
-Requires:       yum-utils
 
 Requires:       virtual-host-gatherer
 Recommends:     virtual-host-gatherer-VMware


### PR DESCRIPTION
## What does this PR change?

yum-utils seems to be required directly by spacewalk-utils and cobbler. No need to get it installed always by require it in spacewalk-common.

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: **internal**

- [ ] **DONE**

## Test coverage
- No tests: **only deps**

- [ ] **DONE**

## Links

- [ ] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
