### PR TITLE
SuSEfirewall2 to firewalld

### DIFF
--- a/proxy/installer/configure-proxy.sh
+++ b/proxy/installer/configure-proxy.sh
@@ -87,18 +87,23 @@ HELP
 
 open_firewall_ports() {
 echo "Open needed firewall ports..."
-sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_TCP "http" > /dev/null 2>&1
-sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_TCP "https" > /dev/null 2>&1
-sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_TCP "xmpp-client" > /dev/null 2>&1
-sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_TCP "xmpp-server" > /dev/null 2>&1
-sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_TCP "tftp" > /dev/null 2>&1
-sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_UDP "tftp" > /dev/null 2>&1
+if [ -x /usr/bin/firewall-cmd ]; then
+  firewall-cmd --permanent --zone=public --add-service=suse-manager-proxy
+  firewall-cmd --state 2>/dev/null && firewall-cmd --reload
+else
+  sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_TCP "http" > /dev/null 2>&1
+  sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_TCP "https" > /dev/null 2>&1
+  sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_TCP "xmpp-client" > /dev/null 2>&1
+  sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_TCP "xmpp-server" > /dev/null 2>&1
+  sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_TCP "tftp" > /dev/null 2>&1
+  sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_UDP "tftp" > /dev/null 2>&1
 
-# ports needed for Salt
-sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_TCP "4505" > /dev/null 2>&1
-sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_TCP "4506" > /dev/null 2>&1
+  # ports needed for Salt
+  sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_TCP "4505" > /dev/null 2>&1
+  sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_TCP "4506" > /dev/null 2>&1
 
-systemctl try-restart SuSEfirewall2
+  systemctl try-restart SuSEfirewall2
+fi
 }
 
 parse_answer_file() {
@@ -701,8 +706,13 @@ open_firewall_ports
 default_or_input "Activate advertising proxy via SLP?" ACTIVATE_SLP "Y/n"
 ACTIVATE_SLP=$(yes_no $ACTIVATE_SLP)
 if [ $ACTIVATE_SLP -ne 0 ]; then
-    sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_TCP "427" > /dev/null 2>&1
-    sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_UDP "427" > /dev/null 2>&1
+    if [ -x /usr/bin/firewall-cmd ]; then
+        firewall-cmd --permanent --zone=public --add-service=slp
+	firewall-cmd --state 2>/dev/null && firewall-cmd --reload
+    else
+        sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_TCP "427" > /dev/null 2>&1
+        sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_UDP "427" > /dev/null 2>&1
+    fi
     if [ -x /usr/bin/systemctl ] ; then
         /usr/bin/systemctl enable slpd
         /usr/bin/systemctl start slpd

--- a/proxy/installer/spacewalk-proxy-installer.changes
+++ b/proxy/installer/spacewalk-proxy-installer.changes
@@ -1,3 +1,5 @@
+- configure firewalld if available
+
 -------------------------------------------------------------------
 Mon Dec 17 14:39:21 CET 2018 - jgonzalez@suse.com
 

--- a/proxy/installer/spacewalk-proxy-installer.spec
+++ b/proxy/installer/spacewalk-proxy-installer.spec
@@ -49,6 +49,11 @@ Requires:       apache2
 Requires:       glibc
 Requires(pre): spacewalk-proxy-common
 Requires:       spacewalk-proxy-salt
+%if 0%{?suse_version} > 1320
+Requires:       firewalld
+%else
+Requires:       SuSEfirewall2
+%endif
 %else
 Requires:       glibc-common
 
@@ -131,6 +136,11 @@ done
 install -m 755 rhn-proxy-activate.py $RPM_BUILD_ROOT/%{_usr}/sbin/rhn-proxy-activate
 install -m 755 fetch-certificate.py  $RPM_BUILD_ROOT/%{_usr}/sbin/fetch-certificate
 
+%if 0%{?suse_version} > 1320
+mkdir -p %{buildroot}/%{_prefix}/lib/firewalld/services
+install -m 0644 etc/firewalld/services/suse-manager-proxy.xml %{buildroot}/%{_prefix}/lib/firewalld/services
+%endif
+
 %check
 %if 0%{?pylint_check}
 # check coding style
@@ -155,5 +165,8 @@ spacewalk-%{pythonX}-pylint .
 %dir %{_usr}/share/doc/proxy
 %dir %{_usr}/share/rhn
 %dir %{_usr}/share/rhn/installer/jabberd
+%if 0%{?suse_version} > 1320
+%{_prefix}/lib/firewalld/services/suse-manager-proxy.xml
+%endif
 
 %changelog

--- a/proxy/installer/suse-manager-proxy.xml
+++ b/proxy/installer/suse-manager-proxy.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+	<short>SUSE Manager Proxy</short>
+	<description>SUSE Manager Proxy Server allows package caching and local package delivery services for groups of local servers from SUSE Manager Server.</description>
+        <port protocol="tcp" port="80"/>
+        <port protocol="tcp" port="443"/>
+        <port protocol="tcp" port="22"/>
+        <port protocol="tcp" port="5222"/>
+        <port protocol="tcp" port="5269"/>
+        <port protocol="tcp" port="4505"/>
+        <port protocol="tcp" port="4506">
+        <port protocol="udp" port="123"/>
+        <port protocol="udp" port="69"/>
+        <module name="nf_conntrack_tftp"/>
+</service>

--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -245,18 +245,23 @@ fi
 
 open_firewall_ports() {
 echo "Open needed firewall ports..."
-sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_TCP "http" > /dev/null 2>&1
-sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_TCP "https" > /dev/null 2>&1
-sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_TCP "xmpp-client" > /dev/null 2>&1
-sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_TCP "xmpp-server" > /dev/null 2>&1
-sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_TCP "tftp" > /dev/null 2>&1
-sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_UDP "tftp" > /dev/null 2>&1
+if [ -x /usr/bin/firewall-cmd ]; then
+  firewall-cmd --permanent --zone=public --add-service=suse-manager-server
+  firewall-cmd --state 2>/dev/null && firewall-cmd --reload
+else
+  sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_TCP "http" > /dev/null 2>&1
+  sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_TCP "https" > /dev/null 2>&1
+  sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_TCP "xmpp-client" > /dev/null 2>&1
+  sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_TCP "xmpp-server" > /dev/null 2>&1
+  sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_TCP "tftp" > /dev/null 2>&1
+  sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_UDP "tftp" > /dev/null 2>&1
 
-# ports needed for Salt
-sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_TCP "4505" > /dev/null 2>&1
-sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_TCP "4506" > /dev/null 2>&1
+  # ports needed for Salt
+  sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_TCP "4505" > /dev/null 2>&1
+  sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_TCP "4506" > /dev/null 2>&1
 
-systemctl condrestart SuSEfirewall2
+  systemctl condrestart SuSEfirewall2
+fi
 }
 
 check_re_install() {
@@ -837,10 +842,15 @@ fi
 
 if [ "$DO_SETUP" = "1" -o "$DO_MIGRATION" = "1" ]; then
     if [ "$ACTIVATE_SLP" = "y" ]; then
-	sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_TCP "427" > /dev/null 2>&1
-	sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_UDP "427" > /dev/null 2>&1
-	systemctl --quiet enable slpd
-	systemctl start slpd
+        if [ -x /usr/bin/firewall-cmd ]; then
+            firewall-cmd --permanent --zone=public --add-service=slp
+            firewall-cmd --state 2>/dev/null && firewall-cmd --reload
+        else
+            sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_TCP "427" > /dev/null 2>&1
+            sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_UDP "427" > /dev/null 2>&1
+        fi
+        systemctl --quiet enable slpd
+        systemctl start slpd
     fi
 fi
 

--- a/susemanager/etc/firewalld/services/suse-manager-server.xml
+++ b/susemanager/etc/firewalld/services/suse-manager-server.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+	<short>SUSE Manager Server</short>
+	<description>SUSE Manager Server is a systems management application that will inventory, provision, update and control your Linux machines.</description>
+	<port protocol="tcp" port="80"/>
+	<port protocol="tcp" port="443"/>
+	<port protocol="tcp" port="22"/>
+	<port protocol="tcp" port="5222"/>
+	<port protocol="tcp" port="5269"/>
+        <port protocol="tcp" port="4505"/>
+        <port protocol="tcp" port="4506">
+	<port protocol="udp" port="123"/>
+	<port protocol="udp" port="69"/>
+	<module name="nf_conntrack_tftp"/>
+</service>

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- configure firewalld if available
 - change SCC sync backend to adapt quicker to SCC changes and improve
   speed of syncing metadata and checking for channel dependencies
 

--- a/susemanager/susemanager.spec
+++ b/susemanager/susemanager.spec
@@ -71,7 +71,11 @@ Requires:       susemanager-tools
 Requires:       spacewalk-db-virtual
 Requires:       susemanager-branding
 # yast module dependency
+%if 0%{?suse_version} > 1320
+Requires:       firewalld
+%else
 Requires:       SuSEfirewall2
+%endif
 Requires:       postfix
 Requires:       yast2-users
 # mgr-setup want to call mksubvolume
@@ -133,12 +137,10 @@ ln -s mgr-setup %{buildroot}/%{_prefix}/lib/susemanager/bin/migration.sh
 ln -s pg-migrate-94-to-96.sh %{buildroot}/%{_prefix}/lib/susemanager/bin/pg-migrate.sh
 
 mkdir -p %{buildroot}/%{_prefix}/share/rhn/config-defaults
-mkdir -p %{buildroot}/%{_sysconfdir}/sysconfig/SuSEfirewall2.d/services
 mkdir -p %{buildroot}/%{_sysconfdir}/init.d
 mkdir -p %{buildroot}/%{_sysconfdir}/slp.reg.d
 mkdir -p %{buildroot}/%{_sysconfdir}/logrotate.d
 install -m 0644 rhn-conf/rhn_server_susemanager.conf %{buildroot}/%{_prefix}/share/rhn/config-defaults
-install -m 0644 etc/sysconfig/SuSEfirewall2.d/services/suse-manager-server %{buildroot}/%{_sysconfdir}/sysconfig/SuSEfirewall2.d/services/
 install -m 0644 etc/logrotate.d/susemanager-tools %{buildroot}/%{_sysconfdir}/logrotate.d
 install -m 0644 etc/slp.reg.d/susemanager.reg %{buildroot}/%{_sysconfdir}/slp.reg.d
 install -m 755 etc/init.d/susemanager %{buildroot}/%{_sysconfdir}/init.d
@@ -161,6 +163,14 @@ install -m 0644 yast/*.scr %{buildroot}%{_datadir}/YaST2/scrconf
 install -m 0644 yast/susemanager_setup_uyuni.desktop %{buildroot}%{_datadir}/applications/YaST2/susemanager_setup.desktop
 %else
 install -m 0644 yast/susemanager_setup.desktop %{buildroot}%{_datadir}/applications/YaST2/susemanager_setup.desktop
+%endif
+
+%if 0%{?suse_version} > 1320
+mkdir -p %{buildroot}/%{_prefix}/lib/firewalld/services
+install -m 0644 etc/firewalld/services/suse-manager-server.xml %{buildroot}/%{_prefix}/lib/firewalld/services
+%else
+mkdir -p %{buildroot}/%{_sysconfdir}/sysconfig/SuSEfirewall2.d/services
+install -m 0644 etc/sysconfig/SuSEfirewall2.d/services/suse-manager-server %{buildroot}/%{_sysconfdir}/sysconfig/SuSEfirewall2.d/services/
 %endif
 
 %check
@@ -236,11 +246,15 @@ fi
 %{_datadir}/YaST2/clients/*.rb
 %{_datadir}/YaST2/scrconf/*.scr
 %config /etc/YaST2/firstboot-susemanager.xml
-%config %{_sysconfdir}/sysconfig/SuSEfirewall2.d/services/suse-manager-server
 %config %{_sysconfdir}/slp.reg.d/susemanager.reg
 %{_sysconfdir}/init.d/susemanager
 %{_datadir}/applications/YaST2/susemanager_setup.desktop
 %attr(775,salt,susemanager) %dir /srv/www/os-images/
+%if 0%{?suse_version} > 1320
+%{_prefix}/lib/firewalld/services/suse-manager-server.xml
+%else
+%config %{_sysconfdir}/sysconfig/SuSEfirewall2.d/services/suse-manager-server
+%endif
 
 %files tools
 %defattr(-,root,root,-)


### PR DESCRIPTION
## What does this PR change?

Since OS version 15 SUSE uses firewalld instead of SuSEfirewall2. This PR replace the old firewall configuration and configure firewalld instead.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **Used tooling not named in the docs**

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/6703

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
