### PR TITLE
Hide 'unknown virtual host manager' when virtual host manager of all hosts is known (bsc#1119320)

### DIFF
--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Hide 'unknown virtual host manager' when virtual host manager of all hosts is known (bsc#1119320)
 - Add REST API to retrieve VM definition
 - Nav and section scroll independently
 - Listen to salt libvirt events to update VMs state


### PR DESCRIPTION
## What does this PR change?
 
 When the association of all virtual host to their virtual host managers is
 known, there is no point in displaying "Unknown virtual host manager" bubble in
 the visualization (it would have no children).
 
 ## GUI diff
 
 Before:
 
![ss-before](https://user-images.githubusercontent.com/1412268/50008018-203e9000-ffb3-11e8-95c7-51a83abee61b.png)

 After:
![ss-after](https://user-images.githubusercontent.com/1412268/50008025-259bda80-ffb3-11e8-81ba-7dde6185493e.png)
 

 - [x] **DONE**
 
 ## Documentation
 - No documentation needed: bugfix
 - [x] **DONE**
 
 ## Test coverage
 - Unit tests were added
 
 - [x] **DONE**
 
 ## Links
 
 Fixes https://github.com/SUSE/spacewalk/issues/6618
 
 - [x] **DONE**