### PR TITLE
require correct python version for osa-dispatcher

### DIFF
--- a/client/tools/mgr-osad/mgr-osad.spec
+++ b/client/tools/mgr-osad/mgr-osad.spec
@@ -187,7 +187,7 @@ Group:          System Environment/Daemons
 Obsoletes:      osa-dispatcher < %{oldversion}
 Provides:       osa-dispatcher = %{oldversion}
 Requires:       lsof
-Requires:       python2-mgr-osa-dispatcher = %{version}-%{release}
+Requires:       %{pythonX}-mgr-osa-dispatcher = %{version}-%{release}
 Requires:       spacewalk-backend-server >= 1.2.32
 Conflicts:      %{name} < %{version}-%{release}
 Conflicts:      %{name} > %{version}-%{release}


### PR DESCRIPTION
## What does this PR change?

mgr-osa-dispatcher contains python version independent files. It should require the correct python version depending on the OS.

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: **internal**

- [ ] **DONE**

## Test coverage
- No tests: **just deps**

- [ ] **DONE**

## Links

- [ ] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
