### PR TITLE
fix unittest - use local configuration file

### DIFF
--- a/client/rhel/spacewalk-client-tools/test/testConfig.py
+++ b/client/rhel/spacewalk-client-tools/test/testConfig.py
@@ -24,7 +24,7 @@ class TestConfig(unittest.TestCase):
         pass
 
     def tearDown(self):
-        config.cfg == None
+        config.cfg = None
         testutils.restoreConfig()
 
     def testEmptyInit(self):


### PR DESCRIPTION
## What does this PR change?

fixes unit test tear down so that non-global config can be used, e.i. one specified via test_up2date = "../etc-conf/up2date.config"

## GUI diff

No difference.

## Documentation
- No documentation needed: typo in unittest

## Test coverage
- No tests:  typo in existing test fixed

## Links

## Changelogs
gitarro no changelog needed !!!

