### PR TITLE
Fix: add Checkstyle rules for 2019

### DIFF
--- a/java/buildconf/LICENSE.txt
+++ b/java/buildconf/LICENSE.txt
@@ -1,5 +1,5 @@
 ^/\*\*$
-^ \* Copyright \(c\) (20(0\d|1[01234567])--)?201[012345678] (Red Hat, Inc.|SUSE LLC)$
+^ \* Copyright \(c\) (20(0\d|1[012345678])--)?201[0123456789] (Red Hat, Inc.|SUSE LLC)$
 ^ \*$
 ^ \* This software is licensed to you under the GNU General Public License,$
 ^ \* version 2 \(GPLv2\). There is NO WARRANTY for this software, express or$


### PR DESCRIPTION
## What does this PR change?

Adapt Checkstyle rules to take into account 2019 into Copyright year

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: this is internal stuff

- [X] **DONE**

## Test coverage
- No tests: this is internal stuff

- [X] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/6743 https://github.com/SUSE/spacewalk/pull/6744

- [x] **DONE**

## Changelogs
