### PR TITLE
Fix log4j configuration for frontendlogs

### DIFF
--- a/java/code/src/log4j.properties
+++ b/java/code/src/log4j.properties
@@ -74,3 +74,4 @@ log4j.appender.FrontendLogControllerAppender.MaxBackupIndex=30
 log4j.appender.FrontendLogControllerAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.FrontendLogControllerAppender.layout.ConversionPattern=%d [%t] %-5p %c - %m%n
 log4j.logger.com.suse.manager.webui.controllers.FrontendLogController=TRACE,FrontendLogControllerAppender
+log4j.additivity.com.suse.manager.webui.controllers.FrontendLogController=false

--- a/java/code/src/log4j.properties
+++ b/java/code/src/log4j.properties
@@ -67,8 +67,8 @@ log4j.logger.com.redhat.rhn.frontend.action.LogoutAction=INFO
 log4j.logger.com.redhat.rhn.manager.content.ContentSyncManager=INFO
 
 ## Frontend logs
-log4j.appender.FrontendLogControllerAppender=com.redhat.rhn.common.FallbackAppender
-log4j.appender.FrontendLogControllerAppender.file=/var/log/rhn/rhn_web_frontend.log
+log4j.appender.FrontendLogControllerAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.FrontendLogControllerAppender.File=/var/log/rhn/rhn_web_frontend.log
 log4j.appender.FrontendLogControllerAppender.MaxFileSize=10MB
 log4j.appender.FrontendLogControllerAppender.MaxBackupIndex=30
 log4j.appender.FrontendLogControllerAppender.layout=org.apache.log4j.PatternLayout

--- a/web/html/javascript/loggerhead.js
+++ b/web/html/javascript/loggerhead.js
@@ -1,3 +1,8 @@
+/*
+* Source code available at
+* https://github.com/ncounter/loggerhead/blob/master/for-old-browser/loggerhead.js
+*/
+
 'use strict';
 
 var Loggerhead = {};


### PR DESCRIPTION
## What does this PR change?

Fix `log4j` configuration for `frontend-log` mechanism:
- let the `rhn_web_frontend.log` file be a `rolling file`
- prevent duplication of messages in both root-log and frontend-log

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: nothing relevant

- [x] **DONE**

## Test coverage
- No tests: nothing to be tested

- [x] **DONE**

## Links

Fixes #
Tracks # 

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
