### PR TITLE
Allow bootstrapping minions with a pending minion key (bsc#1119727)

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/utils/AbstractMinionBootstrapper.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/AbstractMinionBootstrapper.java
@@ -25,6 +25,7 @@ import com.redhat.rhn.manager.token.ActivationKeyManager;
 import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.webui.services.impl.SaltSSHService;
 import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.impl.SaltService.KeyStatus;
 import com.suse.manager.webui.utils.gson.BootstrapParameters;
 import com.suse.manager.webui.utils.gson.BootstrapHostsJson;
 import com.suse.salt.netapi.calls.modules.State;
@@ -263,7 +264,7 @@ public abstract class AbstractMinionBootstrapper {
             return Collections.singletonList(activationKeyErrorMessage.get());
         }
 
-        if (saltService.keyExists(input.getHost())) {
+        if (saltService.keyExists(input.getHost(), KeyStatus.ACCEPTED, KeyStatus.DENIED, KeyStatus.REJECTED)) {
             return Collections.singletonList("A salt key for this" +
                     " host (" + input.getHost() +
                     ") seems to already exist, please check!");

--- a/java/code/src/com/suse/manager/webui/controllers/utils/RegularMinionBootstrapper.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/RegularMinionBootstrapper.java
@@ -21,6 +21,7 @@ import com.redhat.rhn.domain.user.User;
 import com.suse.manager.reactor.messaging.ApplyStatesEventMessage;
 import com.suse.manager.webui.services.impl.MinionPendingRegistrationService;
 import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.impl.SaltService.KeyStatus;
 import com.suse.manager.webui.utils.InputValidator;
 import com.suse.manager.webui.utils.gson.BootstrapParameters;
 import com.suse.manager.webui.utils.gson.BootstrapHostsJson;
@@ -105,7 +106,7 @@ public class RegularMinionBootstrapper extends AbstractMinionBootstrapper {
 
         // If a key is pending for this minion, temporarily reject it
         boolean weRejectedIt = false;
-        if (saltService.keyPending(minionId)) {
+        if (saltService.keyExists(minionId, KeyStatus.UNACCEPTED)) {
             LOG.info("Pending key exists for " + minionId + ", rejecting...");
             saltService.rejectKey(minionId);
             weRejectedIt = true;

--- a/java/code/src/com/suse/manager/webui/controllers/utils/test/AbstractMinionBootstrapperTestBase.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/test/AbstractMinionBootstrapperTestBase.java
@@ -128,6 +128,8 @@ public abstract class AbstractMinionBootstrapperTestBase extends JMockBaseTestCa
         context().checking(new Expectations() {{
             allowing(saltServiceMock).keyExists("myhost");
             will(returnValue(false));
+            allowing(saltServiceMock).keyPending("myhost");
+            will(returnValue(false));
 
             allowing(saltServiceMock).generateKeysAndAccept("myhost", false);
             will(returnValue(keyPair));
@@ -181,6 +183,8 @@ public abstract class AbstractMinionBootstrapperTestBase extends JMockBaseTestCa
             will(returnValue(of(key.getKey())));
 
             allowing(saltServiceMock).keyExists("myhost");
+            will(returnValue(false));
+            allowing(saltServiceMock).keyPending("myhost");
             will(returnValue(false));
 
             Key.Pair keyPair = mockKeyPair();

--- a/java/code/src/com/suse/manager/webui/controllers/utils/test/AbstractMinionBootstrapperTestBase.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/test/AbstractMinionBootstrapperTestBase.java
@@ -7,6 +7,7 @@ import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 import com.suse.manager.webui.controllers.utils.AbstractMinionBootstrapper;
 import com.suse.manager.webui.controllers.utils.AbstractMinionBootstrapper.BootstrapResult;
 import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.impl.SaltService.KeyStatus;
 import com.suse.manager.webui.utils.gson.BootstrapParameters;
 import com.suse.manager.webui.utils.gson.BootstrapHostsJson;
 import com.suse.salt.netapi.calls.modules.State;
@@ -52,7 +53,7 @@ public abstract class AbstractMinionBootstrapperTestBase extends JMockBaseTestCa
         setEmptyActivationKeys(input);
 
         context().checking(new Expectations() {{
-            allowing(saltServiceMock).keyExists("myhost");
+            allowing(saltServiceMock).keyExists("myhost", KeyStatus.ACCEPTED, KeyStatus.DENIED, KeyStatus.REJECTED);
             will(returnValue(true));
         }});
 
@@ -107,7 +108,7 @@ public abstract class AbstractMinionBootstrapperTestBase extends JMockBaseTestCa
         setEmptyActivationKeys(input);
 
         context().checking(new Expectations() {{
-            allowing(saltServiceMock).keyExists("myhost");
+            allowing(saltServiceMock).keyExists("myhost", KeyStatus.ACCEPTED, KeyStatus.DENIED, KeyStatus.REJECTED);
             will(returnValue(false));
         }});
 
@@ -126,9 +127,9 @@ public abstract class AbstractMinionBootstrapperTestBase extends JMockBaseTestCa
         Key.Pair keyPair = mockKeyPair();
 
         context().checking(new Expectations() {{
-            allowing(saltServiceMock).keyExists("myhost");
+            allowing(saltServiceMock).keyExists("myhost", KeyStatus.ACCEPTED, KeyStatus.DENIED, KeyStatus.REJECTED);
             will(returnValue(false));
-            allowing(saltServiceMock).keyPending("myhost");
+            allowing(saltServiceMock).keyExists("myhost", KeyStatus.UNACCEPTED);
             will(returnValue(false));
 
             allowing(saltServiceMock).generateKeysAndAccept("myhost", false);
@@ -182,9 +183,9 @@ public abstract class AbstractMinionBootstrapperTestBase extends JMockBaseTestCa
             allowing(input).getFirstActivationKey();
             will(returnValue(of(key.getKey())));
 
-            allowing(saltServiceMock).keyExists("myhost");
+            allowing(saltServiceMock).keyExists("myhost", KeyStatus.ACCEPTED, KeyStatus.DENIED, KeyStatus.REJECTED);
             will(returnValue(false));
-            allowing(saltServiceMock).keyPending("myhost");
+            allowing(saltServiceMock).keyExists("myhost", KeyStatus.UNACCEPTED);
             will(returnValue(false));
 
             Key.Pair keyPair = mockKeyPair();

--- a/java/code/src/com/suse/manager/webui/controllers/utils/test/RegularMinionBootstrapperTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/test/RegularMinionBootstrapperTest.java
@@ -50,6 +50,8 @@ public class RegularMinionBootstrapperTest extends AbstractMinionBootstrapperTes
         context().checking(new Expectations() {{
             allowing(saltServiceMock).keyExists("myhost");
             will(returnValue(false));
+            allowing(saltServiceMock).keyPending("myhost");
+            will(returnValue(false));
 
             allowing(saltServiceMock).generateKeysAndAccept("myhost", false);
             will(returnValue(keyPair));

--- a/java/code/src/com/suse/manager/webui/controllers/utils/test/RegularMinionBootstrapperTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/test/RegularMinionBootstrapperTest.java
@@ -7,6 +7,7 @@ import com.redhat.rhn.domain.token.ActivationKey;
 import com.redhat.rhn.domain.token.test.ActivationKeyTest;
 
 import com.suse.manager.webui.controllers.utils.AbstractMinionBootstrapper.BootstrapResult;
+import com.suse.manager.webui.services.impl.SaltService.KeyStatus;
 import com.suse.manager.webui.controllers.utils.ContactMethodUtil;
 import com.suse.manager.webui.controllers.utils.RegularMinionBootstrapper;
 import com.suse.manager.webui.utils.gson.BootstrapParameters;
@@ -48,9 +49,9 @@ public class RegularMinionBootstrapperTest extends AbstractMinionBootstrapperTes
         Key.Pair keyPair = mockKeyPair();
 
         context().checking(new Expectations() {{
-            allowing(saltServiceMock).keyExists("myhost");
+            allowing(saltServiceMock).keyExists("myhost", KeyStatus.ACCEPTED, KeyStatus.DENIED, KeyStatus.REJECTED);
             will(returnValue(false));
-            allowing(saltServiceMock).keyPending("myhost");
+            allowing(saltServiceMock).keyExists("myhost", KeyStatus.UNACCEPTED);
             will(returnValue(false));
 
             allowing(saltServiceMock).generateKeysAndAccept("myhost", false);

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -373,6 +373,17 @@ public class SaltService {
     }
 
     /**
+     * For a given minion id check if there is a key pending in "Unaccepted Keys".
+     *
+     * @param id the minion id to look for in "Unaccepted Keys"
+     * @return true if there is a key with the given id, false otherwise
+     */
+    public boolean keyPending(String id) {
+        Key.Names keys = getKeys();
+        return keys.getUnacceptedMinions().contains(id);
+    }
+
+    /**
      * Get the minion keys from salt with their respective status and fingerprint.
      *
      * @return the keys with their respective status and fingerprint as returned from salt
@@ -1052,6 +1063,17 @@ public class SaltService {
             return callSync(call);
         }
         return Optional.of(MgrUtilRunner.ExecResult.success());
+    }
+
+    /**
+     * Delete a Salt key from the "Rejected Keys" category using the mgrutil runner.
+     *
+     * @param minionId the minionId to look for in "Rejected Keys"
+     * @return the result of the runner call as a map
+     */
+    public Optional<MgrUtilRunner.ExecResult> deleteRejectedKey(String minionId) {
+        RunnerCall<MgrUtilRunner.ExecResult> call = MgrUtilRunner.deleteRejectedKey(minionId);
+        return callSync(call);
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -156,6 +156,13 @@ public class SaltService {
     private final ScheduledExecutorService scheduledExecutorService =
             Executors.newScheduledThreadPool(5);
 
+    /**
+     * Enum of all the available status for Salt keys.
+     */
+    public enum KeyStatus {
+        ACCEPTED, DENIED, UNACCEPTED, REJECTED
+    }
+
     // Prevent instantiation
     SaltService() {
         RequestConfig requestConfig = RequestConfig.custom()
@@ -360,27 +367,24 @@ public class SaltService {
     }
 
     /**
-     * For a given minion id check if there is a key in any status excluding keys pending for registration.
+     * For a given minion id check if there is a key in any of the given status. If no status is given as parameter,
+     * all the available status are considered.
      *
      * @param id the id to check for
+     * @param statusIn array of key status to consider
      * @return true if there is a key with the given id, false otherwise
      */
-    public boolean keyExists(String id) {
-        Key.Names keys = getKeys();
-        return keys.getMinions().contains(id) ||
-                keys.getRejectedMinions().contains(id) ||
-                keys.getDeniedMinions().contains(id);
-    }
+    public boolean keyExists(String id, KeyStatus... statusIn) {
+        final Set<KeyStatus> status = new HashSet<>(Arrays.asList(statusIn));
+        if (status.isEmpty()) {
+            status.addAll(Arrays.asList(KeyStatus.values()));
+        }
 
-    /**
-     * For a given minion id check if there is a key pending in "Unaccepted Keys".
-     *
-     * @param id the minion id to look for in "Unaccepted Keys"
-     * @return true if there is a key with the given id, false otherwise
-     */
-    public boolean keyPending(String id) {
         Key.Names keys = getKeys();
-        return keys.getUnacceptedMinions().contains(id);
+        return status.contains(KeyStatus.ACCEPTED) && keys.getMinions().contains(id) ||
+                status.contains(KeyStatus.DENIED) && keys.getDeniedMinions().contains(id) ||
+                status.contains(KeyStatus.UNACCEPTED) && keys.getUnacceptedMinions().contains(id) ||
+                status.contains(KeyStatus.REJECTED) && keys.getRejectedMinions().contains(id);
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -360,7 +360,7 @@ public class SaltService {
     }
 
     /**
-     * For a given id check if there is a minion key in any status.
+     * For a given minion id check if there is a key in any status excluding keys pending for registration.
      *
      * @param id the id to check for
      * @return true if there is a key with the given id, false otherwise
@@ -368,7 +368,6 @@ public class SaltService {
     public boolean keyExists(String id) {
         Key.Names keys = getKeys();
         return keys.getMinions().contains(id) ||
-                keys.getUnacceptedMinions().contains(id) ||
                 keys.getRejectedMinions().contains(id) ||
                 keys.getDeniedMinions().contains(id);
     }

--- a/java/code/src/com/suse/manager/webui/services/impl/runner/MgrUtilRunner.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/runner/MgrUtilRunner.java
@@ -75,6 +75,20 @@ public class MgrUtilRunner {
     }
 
     /**
+     * Remove a Salt key from the "Rejected Keys" category.
+     * @param minionId the minionId to look for in "Rejected Keys"
+     * @return the execution result
+     */
+    public static RunnerCall<ExecResult> deleteRejectedKey(String minionId) {
+        Map<String, Object> args = new LinkedHashMap<>();
+        args.put("minion", minionId);
+        RunnerCall<ExecResult> call =
+                new RunnerCall<>("mgrutil.delete_rejected_key", Optional.of(args),
+                        new TypeToken<ExecResult>() { });
+        return call;
+    }
+
+    /**
      * Generate a ssh key pair.
      * @param path path where to generate the keys
      * @return the execution result

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Allow bootstrapping minions with a pending minion key being present (bsc#1119727)
 - Fix cloning channels when managing the same errata for both vendor and private orgs (bsc#1111686)
 - Hide 'unknown virtual host manager' when virtual host manager of all hosts is known (bsc#1119320)
 - Add REST API to retrieve VM definition

--- a/susemanager-utils/susemanager-sls/modules/runners/mgrutil.py
+++ b/susemanager-utils/susemanager-sls/modules/runners/mgrutil.py
@@ -12,6 +12,22 @@ log = logging.getLogger(__name__)
 GROUP_OWNER = 'susemanager'
 
 
+def delete_rejected_key(minion):
+    '''
+    Delete a previously rejected minion key from minions_rejected
+    :param minion: the minion id to look for
+    :return: map containing returncode and stdout/stderr
+    '''
+    path_rejected = "/etc/salt/pki/master/minions_rejected/"
+    path = os.path.normpath(path_rejected + minion)
+    if not path.startswith(path_rejected):
+        return {"returncode": -1, "stderr": "Unexpected path: " + path}
+    if os.path.isfile(path):
+        cmd = ['rm', path]
+        return _cmd(cmd)
+    return {"returncode": 0}
+
+
 def ssh_keygen(path):
     '''
     Generate SSH keys using the given path.


### PR DESCRIPTION
## What does this PR change?

This patch should allow to bootstrap minions even if a minion key is present in "Unaccepted Keys" for the respective minion id (hostname of the system to be bootstrapped).

## GUI diff

No difference.

## Documentation

- No documentation needed: this is a usability / convenience feature and implements expected behavior.

- [x] **DONE**

## Test coverage

- Existing unit tests were adapted.

- [x] **DONE**

## Links

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1119727
Tracks: https://github.com/SUSE/spacewalk/pull/6631

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
