### PR TITLE
Add Ubuntu salt-ssh tests

### DIFF
--- a/testsuite/features/core_ubuntu_salt_ssh.feature
+++ b/testsuite/features/core_ubuntu_salt_ssh.feature
@@ -1,0 +1,68 @@
+# Copyright (c) 2016-2018 SUSE LLC
+# Licensed under the terms of the MIT license.
+#
+#  0) delete Ubuntu minion from previous non-SSH tests
+#  1) bootstrap a new Ubuntu minion via salt-ssh
+#  2) subscribe it to a base channel for testing
+
+Feature: Bootstrap a SSH-managed Ubuntu minion and do some basic operations on it
+
+@ubuntu_minion
+  Scenario: Delete the Ubuntu minion
+    When I am on the Systems overview page of this "ubuntu-minion"
+    And I follow "Delete System"
+    Then I should see a "Confirm System Profile Deletion" text
+    When I click on "Delete Profile"
+    Then I should see a "has been deleted" text
+    And "ubuntu-minion" should not be registered
+
+@ubuntu_minion
+  Scenario: Don't use Salt for a SSH-managed Ubuntu minion
+    When I stop salt-minion on "ubuntu-minion"
+    And I uninstall Salt packages from "ubuntu-minion"
+    And I delete "ubuntu-minion" key in the Salt master
+
+@ubuntu_minion
+  Scenario: Bootstrap a SSH-managed Ubuntu minion
+    Given I am authorized
+    When I go to the bootstrapping page
+    Then I should see a "Bootstrap Minions" text
+    When I check "manageWithSSH"
+    And I enter the hostname of "ubuntu-minion" as "hostname"
+    And I enter "linux" as "password"
+    And I select the hostname of the proxy from "proxies"
+    And I click on "Bootstrap"
+    Then I wait until I see "Successfully bootstrapped host! " text
+    And I navigate to "rhn/systems/Overview.do" page
+    And I wait until I see the name of "ubuntu-minion", refreshing the page
+    And I wait until onboarding is completed for "ubuntu-minion"
+
+@proxy
+@ubuntu_minion
+  Scenario: Check connection from SSH-managed Ubuntu minion to proxy
+    Given I am on the Systems overview page of this "ubuntu-minion"
+    When I follow "Details" in the content area
+    And I follow "Connection" in the content area
+    Then I should see "proxy" hostname
+
+@proxy
+@ubuntu_minion
+  Scenario: Check registration on proxy of SSH-managed Ubuntu minion
+    Given I am on the Systems overview page of this "proxy"
+    When I follow "Details" in the content area
+    And I follow "Proxy" in the content area
+    Then I should see "ubuntu-minion" hostname
+
+@ubuntu_minion
+  Scenario: Subscribe the SSH-managed Ubuntu minion to a base channel
+    Given I am on the Systems overview page of this "ubuntu-minion"
+    When I follow "Software" in the content area
+    And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
+    And I check radio button "Test Base Channel"
+    And I wait until I do not see "Loading..." text
+    And I click on "Next"
+    Then I should see a "Confirm Software Channel Change" text
+    When I click on "Confirm"
+    Then I should see a "Changing the channels has been scheduled." text
+    And I wait until event "Subscribe channels scheduled by admin" is completed

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -690,6 +690,8 @@ When(/^I uninstall Salt packages from "(.*?)"$/) do |host|
     target.run("test -e /usr/bin/zypper && zypper --non-interactive remove -y salt salt-minion", false)
   elsif ['ceos-minion'].include?(host)
     target.run("test -e /usr/bin/yum && yum -y remove salt salt-minion", false)
+  elsif ['ubuntu-minion'].include?(host)
+    target.run("test -e /usr/bin/apt && apt -y remove salt-common salt-minion", false)
   end
 end
 

--- a/testsuite/run_sets/testsuite.yml
+++ b/testsuite/run_sets/testsuite.yml
@@ -33,6 +33,7 @@
 - features/min_centos_salt_install_package_and_patch.feature
 - features/core_centos_salt_ssh.feature
 #- features/core_ubuntu_salt.feature
+#- features/core_ubuntu_salt_ssh.feature
 # these features sync real channels (last core features)
 #- features/core_srv_sync_channels.feature
 #- features/core_srv_setup_wizard.feature


### PR DESCRIPTION
## What does this PR change?

Add tests for bootstrapping Ubuntu minion via salt-ssh

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Just Cucumber tests
- [x] **DONE**

## Test coverage
- It's nothing but tests

- [x] **DONE**

## Links

- [x] **DONE**
