### PR TITLE
Reset channel assignments when base channel changes on registration (bsc#1118917)

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
@@ -305,6 +305,14 @@ public class RegistrationUtils {
                 )
         );
 
+        Channel assignedBaseChannel = server.getBaseChannel();
+        if (assignedBaseChannel != null && channelsToAssign.stream()
+                .filter(channel -> channel.isBaseChannel())
+                .anyMatch(baseChannel -> !baseChannel.equals(assignedBaseChannel))) {
+            // if base channel is going to be changed, we reset all current assignments
+            server.getChannels().clear();
+        }
+
         channelsToAssign.forEach(server::addChannel);
     }
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Reset channel assignments when base channel changes on registration (bsc#1118917)
 - Removed 'Manage Channels' shortcut for vendor channels (bsc#1115978)
 - Allow bootstrapping minions with a pending minion key being present (bsc#1119727)
 - Fix cloning channels when managing the same errata for both vendor and private orgs (bsc#1111686)


### PR DESCRIPTION
## What does this PR change?
 
 When a system is registered in SUMA, channels are added to it (based on various decisions (activation key, installed products)).
 However, when system already exists in SUMA (and has channels assigned) and the registration code triggers (image on a retail terminal changes) and the installed product has changed in the meantime (at least for retail scenario this is possible), channels of the new installed products are **added** to the system without the old channels being removed.
 
 The fix detects possible base channel change and resets the assigned channels before adding new ones.
 
 ## GUI diff
 
 No difference.
 
 - [x] **DONE**
 
 ## Documentation
 - No documentation needed: bugfix
 - [x] **DONE**
 
 ## Test coverage
 - Unit tests were added
 
 - [x] **DONE**
 
 ## Links
 
 Fixes https://github.com/SUSE/spacewalk/issues/6591
 
 Downsteam:   https://github.com/SUSE/spacewalk/pull/6730

 - [x] **DONE**