### PR TITLE
Use the correct docker image for koan tests

### DIFF
--- a/client/tools/spacewalk-koan/Makefile.spacewalk-koan
+++ b/client/tools/spacewalk-koan/Makefile.spacewalk-koan
@@ -16,7 +16,7 @@ include $(TOP)/Makefile.defs
 INSTALL_DATA    = $(INSTALL_BIN)
 
 # Docker tests variables
-DOCKER_IMAGE          = suma-head-spacewalkkoan
+DOCKER_IMAGE          = uyuni-master-spacewalkkoan
 DOCKER_REGISTRY       = registry.mgr.suse.de
 DOCKER_RUN_EXPORT     = "PYTHONPATH=/manager/client/tools/"
 DOCKER_VOLUMES        = -v "$(CURDIR)/../../../:/manager"


### PR DESCRIPTION
## What does this PR change?

Use the correct docker image for koan tests. It was using suma-head.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Fixing tests.

- [x] **DONE**

## Test coverage
- No tests: Fixing tests

- [x] **DONE**