### PR TITLE
Fixes bug showing retrying notification actions result messages

### DIFF
--- a/web/html/src/manager/notifications/notification-messages.js
+++ b/web/html/src/manager/notifications/notification-messages.js
@@ -240,7 +240,7 @@ class NotificationMessages extends React.Component {
     return Network.post("/rhn/manager/notification-messages/retry-onboarding/" + minionId, "application/json").promise
       .then((data) => {
         const newMessage = { severity: data.severity, text: data.text };
-        this.setState((prevState, props) => ({ messages : prevState.message.concat([newMessage]) }));
+        this.setState((prevState, props) => ({ messages : prevState.messages.concat([newMessage]) }));
       })
       .catch(response => {
       });
@@ -250,7 +250,7 @@ class NotificationMessages extends React.Component {
     return Network.post("/rhn/manager/notification-messages/retry-reposync/" + channelId, "application/json").promise
       .then((data) => {
         const newMessage = { severity: data.severity, text: data.text };
-        this.setState((prevState, props) => ({ messages : prevState.message.concat([newMessage]) }));
+        this.setState((prevState, props) => ({ messages : prevState.messages.concat([newMessage]) }));
       })
       .catch(response => {
       });

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- fixes bug showing retrying notification actions result messages
 - Make datetimepicker update displayed time (bsc#1041999)
 - Nav and section scroll independently
 - change SCC sync backend to adapt quicker to SCC changes and improve


### PR DESCRIPTION
## What does this PR change?

Fixes bug showing retrying notification actions result messages

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**
Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
