### PR TITLE
Manager bsc1121787

### DIFF
--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -176,12 +176,6 @@ cleanup_hostname() {
 }
 
 setup_db_postgres() {
-    grep POSTGRES_LANG /etc/sysconfig/postgresql > /dev/null 2>&1
-    if [ $? = 0 ]; then
-        sed -i -e "s/^POSTGRES_LANG.*$/POSTGRES_LANG=\"en_US.UTF-8\"/" /etc/sysconfig/postgresql
-    else
-        echo "POSTGRES_LANG=\"en_US.UTF-8\"" >> /etc/sysconfig/postgresql
-    fi
     systemctl --quiet enable postgresql 2>&1
     systemctl start postgresql
     su - postgres -c "createdb -E UTF8 $MANAGER_DB_NAME ; echo \"CREATE ROLE $MANAGER_USER PASSWORD '$MANAGER_PASS' SUPERUSER NOCREATEDB NOCREATEROLE INHERIT LOGIN;\" | psql"

--- a/susemanager/bin/pg-migrate-96-to-10.sh
+++ b/susemanager/bin/pg-migrate-96-to-10.sh
@@ -85,7 +85,11 @@ mkdir /var/lib/pgsql/data
 chown postgres:postgres /var/lib/pgsql/data
 
 echo "`date +"%H:%M:%S"`   Initialize new postgresql 10 database..."
-su -s /bin/bash - postgres -c "initdb -D /var/lib/pgsql/data"
+. /etc/sysconfig/postgresql
+if [ -z $POSTGRES_LANG ]; then
+    POSTGRES_LANG="en_US.UTF-8"
+fi
+su -s /bin/bash - postgres -c "initdb -D /var/lib/pgsql/data --locale=$POSTGRES_LANG"
 if [ $? -eq 0 ]; then
     echo "`date +"%H:%M:%S"`   Successfully initialized new postgresql 10 database."
 else

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- ensure POSTGRES_LANG is correctly set (bsc#1121787)
 - add bootstrap repo definition for OES 2018 SP1 (bsc#1116826) 
 - configure firewalld if available
 - change SCC sync backend to adapt quicker to SCC changes and improve

--- a/susemanager/susemanager.spec
+++ b/susemanager/susemanager.spec
@@ -207,6 +207,16 @@ if [ ! -d /srv/tftpboot ]; then
   chmod 750 /srv/tftpboot
   chown wwwrun:tftp /srv/tftpboot
 fi
+# make sure our database will use correct encoding
+. /etc/sysconfig/postgresql
+if [ -z $POSTGRES_LANG ]; then
+    grep "^POSTGRES_LANG" /etc/sysconfig/postgresql > /dev/null 2>&1
+    if [ $? = 0 ]; then
+        sed -i -e "s/^POSTGRES_LANG.*$/POSTGRES_LANG=\"en_US.UTF-8\"/" /etc/sysconfig/postgresql
+    else
+        echo "POSTGRES_LANG=\"en_US.UTF-8\"" >> /etc/sysconfig/postgresql
+    fi
+fi
 # XE appliance overlay file created this with different user
 chown root.root /etc/sysconfig
 # ensure susemanager group can write in all subdirs under /var/spacewalk/systems


### PR DESCRIPTION
## What does this PR change?

POSTGRES_LANG should be set to the required value en_US.UTF-8 from the very beginning. During database migrations encoding needs to be explicitly specified to deal with systems that got their language/encoding changed. Still there might be systems using a wrong encoding; ensure those special cases can be migrated as well continuing using the wrong encoding.
