### PR TITLE
Minor change in ubuntu salt-ssh test

### DIFF
--- a/testsuite/features/core_ubuntu_salt_ssh.feature
+++ b/testsuite/features/core_ubuntu_salt_ssh.feature
@@ -59,7 +59,7 @@ Feature: Bootstrap a SSH-managed Ubuntu minion and do some basic operations on i
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
-    And I check radio button "Test Base Channel"
+    And I check radio button "Test-Channel-Deb-AMD64"
     And I wait until I do not see "Loading..." text
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text


### PR DESCRIPTION
## What does this PR change?

The software channel "Test Base Channel" no longer exists for Ubuntu minions in the testsuite.
Therefore the test case now uses "Test-Channel-Deb-AMD64"

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: just tests

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**
