### PR TITLE
Add system overview tests for ubuntu minion

### DIFF
--- a/testsuite/features/allcli_overview_systems_details.feature
+++ b/testsuite/features/allcli_overview_systems_details.feature
@@ -16,6 +16,11 @@ Feature: The system details of each minion and client provides an overview of th
     Given I am on the Systems overview page of this "ceos-minion"
     Then I can see all system information for "ceos-minion"
 
+@ubuntu_minion
+  Scenario: Ubuntu minion grains are displayed correctly on the details page
+    Given I am on the Systems overview page of this "ubuntu-minion"
+    Then I can see all system information for "ubuntu-minion"
+
 @ssh_minion
   Scenario: SSH-managed minion grains are displayed correctly on the details page
     Given I am on the Systems overview page of this "ssh-minion"

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -35,8 +35,8 @@ Then(/^I can see all system information for "([^"]*)"$/) do |host|
   step %(I should see a "#{kernel_version.strip}" text)
   os_pretty_raw, _code = node.run('grep "PRETTY" /etc/os-release')
   os_pretty = os_pretty_raw.strip.split('=')[1].delete '"'
-  puts 'i should see os version: ' + os_pretty
-  # skip this test for centos systems
+  # skip this test for centos and ubuntu systems
+  puts 'i should see os version: ' + os_pretty if os_pretty.include? 'SUSE Linux'
   step %(I should see a "#{os_pretty}" text) if os_pretty.include? 'SUSE Linux'
 end
 


### PR DESCRIPTION
## What does this PR change?

Add reboot test for Ubuntu minions.
Same as CentOS test

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Just Cucumber test
- [x] **DONE**

## Test coverage
- No tests: Added Cucumber test

- [x] **DONE**