### PR TITLE
Remove "yum" dependency from "spacewalk-backend" spec file

### DIFF
--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -133,7 +133,6 @@ BuildRequires:  rpm-python
 BuildRequires:  %{python_prefix}-debian
 
 BuildRequires:  %{m2crypto}
-BuildRequires:  yum
 %endif
 Requires(pre): %{apache_pkg}
 Requires:       %{apache_pkg}


### PR DESCRIPTION
## What does this PR change?

This PR removes "yum" as dependency of the "spacewalk-backend" package since we don't have to collect all not desired Python 2 packages when building. There is still the "yum" code around but this will be replaced during work for alpha2.

## Documentation
- No documentation needed: **Changes on spec file**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [X] **DONE**

## Test coverage
- No tests: **Changes on the spec file**
- Unit tests were added
- Cucumber tests were added

- [X] **DONE**

## Changelogs

gitarro no changelog needed !!!