### PR TITLE
Testsuite - formulas for system group check

### DIFF
--- a/testsuite/features/allcli_system_group.feature
+++ b/testsuite/features/allcli_system_group.feature
@@ -57,7 +57,15 @@ Feature: Create a group
     Then I should see a "Selected Systems List" text
     And I should see "sle-client" as link
     And I should see "sle-minion" as link
-  
+
+  Scenario: Check formula page is rendered for the system group
+    Given I am on the groups page
+    When I follow "new-systems-group"
+    And I follow "Formulas"
+    Then I should see a "Choose formulas:" text
+    And I should see a "General System Configuration" text
+    And the "locale" formula should be unchecked
+
   Scenario: Remove SLE client from new group
     Given I am on the Systems overview page of this "sle-client"
     When I follow "Groups"


### PR DESCRIPTION
## What does this PR change?

PR adds test scenario "Check formula page is rendered for the system group" for checking availability of formula page for created system group.

## GUI diff

No difference.

## Links

Port of https://github.com/SUSE/spacewalk/pull/6820