### PR TITLE
Prevent excessive DEBUG logging from "mgr_events" engine

### DIFF
--- a/susemanager-utils/susemanager-sls/modules/engines/mgr_events.py
+++ b/susemanager-utils/susemanager-sls/modules/engines/mgr_events.py
@@ -140,9 +140,9 @@ class Responder:
         else:
             log.debug("%s: Discarding event -> %s", __name__, tag)
 
-    def debug_log(self):
-        log.debug("%s: queue_size -> %s", __name__, self.counter)
-        log.debug("%s: tokens -> %s", __name__, self.tokens)
+    def trace_log(self):
+        log.trace("%s: queue_size -> %s", __name__, self.counter)
+        log.trace("%s: tokens -> %s", __name__, self.tokens)
 
     @tornado.gen.coroutine
     def add_event_to_queue(self, raw):
@@ -158,7 +158,7 @@ class Responder:
     def add_token(self):
         self.tokens = min(self.tokens + 1, self.config['commit_burst'])
         self.attempt_commit()
-        self.debug_log()
+        self.trace_log()
         self.event_bus.io_loop.call_later(self.config['commit_interval'], self.add_token)
 
     def attempt_commit(self):

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- Prevent excessive DEBUG logging from mgr_events engine
+
 -------------------------------------------------------------------
 Wed Jan 16 12:27:07 CET 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR prevents excessive logging from `mgr_events` engine when Salt master is running with `log_level: debug`. Currently, the `mgr_events` engine produces two log messages per second, which completely pollute the Salt master log file when running in debug mode:

```console
...
2019-01-17 17:45:26,593 [salt.loaded.int.rawmodule.state:2258][DEBUG   ][9073] Remaining event matches: -2
2019-01-17 17:45:26,594 [salt.loaded.ext.engines.mgr_events:140 ][DEBUG   ][8274] salt.loaded.ext.engines.mgr_events: Discarding event -> salt/auth
2019-01-17 17:45:26,631 [salt.loaded.ext.engines.mgr_events:143 ][DEBUG   ][8274] salt.loaded.ext.engines.mgr_events: queue_size -> 0
2019-01-17 17:45:26,631 [salt.loaded.ext.engines.mgr_events:144 ][DEBUG   ][8274] salt.loaded.ext.engines.mgr_events: tokens -> 100
2019-01-17 17:45:27,632 [salt.loaded.ext.engines.mgr_events:143 ][DEBUG   ][8274] salt.loaded.ext.engines.mgr_events: queue_size -> 0
2019-01-17 17:45:27,632 [salt.loaded.ext.engines.mgr_events:144 ][DEBUG   ][8274] salt.loaded.ext.engines.mgr_events: tokens -> 100
2019-01-17 17:45:28,633 [salt.loaded.ext.engines.mgr_events:143 ][DEBUG   ][8274] salt.loaded.ext.engines.mgr_events: queue_size -> 0
2019-01-17 17:45:28,634 [salt.loaded.ext.engines.mgr_events:144 ][DEBUG   ][8274] salt.loaded.ext.engines.mgr_events: tokens -> 100
2019-01-17 17:45:29,635 [salt.loaded.ext.engines.mgr_events:143 ][DEBUG   ][8274] salt.loaded.ext.engines.mgr_events: queue_size -> 0
2019-01-17 17:45:29,635 [salt.loaded.ext.engines.mgr_events:144 ][DEBUG   ][8274] salt.loaded.ext.engines.mgr_events: tokens -> 100
2019-01-17 17:45:30,636 [salt.loaded.ext.engines.mgr_events:143 ][DEBUG   ][8274] salt.loaded.ext.engines.mgr_events: queue_size -> 0
2019-01-17 17:45:30,637 [salt.loaded.ext.engines.mgr_events:144 ][DEBUG   ][8274] salt.loaded.ext.engines.mgr_events: tokens -> 100
...
```

In Salt, the DEBUG mode should not produce that massive logging when there is actually no activity. This behavior fits better in the TRACE mode. 


## Documentation
- No documentation needed: **no documentation needed**

- [x] **DONE**

## Test coverage
- No tests: **no tests needed**

- [x] **DONE**
