### PR TITLE
New root for jade templates and new way of defining frontend pages/routes

### DIFF
--- a/java/code/src/com/suse/manager/webui/Router.java
+++ b/java/code/src/com/suse/manager/webui/Router.java
@@ -324,14 +324,14 @@ public class Router implements SparkApplication {
         notFound((request, response) -> {
             Map<String, Object> data = new HashMap<>();
             data.put("currentUrl", request.pathInfo());
-            return jade.render(new ModelAndView(data, "errors/404.jade"));
+            return jade.render(new ModelAndView(data, "templates/errors/404.jade"));
         });
 
         exception(NotFoundException.class, (exception, request, response) -> {
             response.status(HttpStatus.SC_NOT_FOUND);
             Map<String, Object> data = new HashMap<>();
             data.put("currentUrl", request.pathInfo());
-            response.body(jade.render(new ModelAndView(data, "errors/404.jade")));
+            response.body(jade.render(new ModelAndView(data, "templates/errors/404.jade")));
         });
     }
 

--- a/java/code/src/com/suse/manager/webui/controllers/CVEAuditController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/CVEAuditController.java
@@ -64,7 +64,7 @@ public class CVEAuditController {
      */
     public static ModelAndView cveAuditView(Request req, Response res, User user) {
         Map<String, Object> model = new HashMap<>();
-        return new ModelAndView(model, "audit/cve.jade");
+        return new ModelAndView(model, "templates/audit/cve.jade");
     }
 
     private enum AuditTarget {

--- a/java/code/src/com/suse/manager/webui/controllers/FormulaCatalogController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/FormulaCatalogController.java
@@ -53,7 +53,7 @@ public class FormulaCatalogController {
     public static ModelAndView list(Request request, Response response, User user) {
         Map<String, Object> data = new HashMap<>();
         data.put("info", FlashScopeHelper.flash(request));
-        return new ModelAndView(data, "formula_catalog/list.jade");
+        return new ModelAndView(data, "templates/formula_catalog/list.jade");
     }
 
     /**
@@ -84,7 +84,7 @@ public class FormulaCatalogController {
 
         Map<String, Object> data = new HashMap<>();
         data.put("formulaName", formulaName);
-        return new ModelAndView(data, "formula_catalog/formula.jade");
+        return new ModelAndView(data, "templates/formula_catalog/formula.jade");
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/controllers/FormulaController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/FormulaController.java
@@ -99,7 +99,7 @@ public class FormulaController {
                 ServerGroupFactory.lookupByIdAndOrg(Long.valueOf(serverGroupId),
                 user.getOrg()).getName());
         data.put("formula_id", request.params("formula_id"));
-        return new ModelAndView(data, "groups/formula.jade");
+        return new ModelAndView(data, "templates/groups/formula.jade");
     }
 
     /**
@@ -239,7 +239,7 @@ public class FormulaController {
         data.put("groupName",
                 ServerGroupFactory.lookupByIdAndOrg(Long.valueOf(serverGroupId),
                 user.getOrg()).getName());
-        return new ModelAndView(data, "groups/formulas.jade");
+        return new ModelAndView(data, "templates/groups/formulas.jade");
     }
 
     /**
@@ -333,7 +333,7 @@ public class FormulaController {
         Map<String, Object> data = new HashMap<>();
         data.put("server", ServerFactory.lookupById(new Long(request.queryParams("sid"))));
         data.put("formula_id", request.params("formula_id"));
-        return new ModelAndView(data, "minion/formula.jade");
+        return new ModelAndView(data, "templates/minion/formula.jade");
     }
 
     /**
@@ -348,7 +348,7 @@ public class FormulaController {
            User user) {
        Map<String, Object> data = new HashMap<>();
        data.put("server", ServerFactory.lookupById(new Long(request.queryParams("sid"))));
-       return new ModelAndView(data, "minion/formulas.jade");
+       return new ModelAndView(data, "templates/minion/formulas.jade");
    }
 
     private static String errorResponse(Response response, List<String> errs) {

--- a/java/code/src/com/suse/manager/webui/controllers/ImageBuildController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/ImageBuildController.java
@@ -123,7 +123,7 @@ public class ImageBuildController {
                     .map(ServerAction::getServerId).map(id -> "&host=" + id).orElse("");
             res.redirect("/rhn/manager/cm/build?version=" + i.getVersion() + hostId +
                     "&profile=" + i.getProfile().getProfileId());
-            return new ModelAndView(model, "content_management/build.jade");
+            return new ModelAndView(model, "templates/content_management/build.jade");
         }).orElseGet(() -> {
             throw new NotFoundException();
         });
@@ -157,7 +157,7 @@ public class ImageBuildController {
             return null;
         }
 
-        return new ModelAndView(model, "content_management/build.jade");
+        return new ModelAndView(model, "templates/content_management/build.jade");
     }
 
     /**
@@ -170,7 +170,7 @@ public class ImageBuildController {
      */
     public static ModelAndView importView(Request req, Response res, User user) {
         Map<String, Object> model = new HashMap<>();
-        return new ModelAndView(model, "content_management/import.jade");
+        return new ModelAndView(model, "templates/content_management/import.jade");
     }
 
     /**
@@ -226,7 +226,7 @@ public class ImageBuildController {
         model.put("isAdmin", user.hasRole(ADMIN_ROLE));
         Map<String, GathererModule> modules = new GathererRunner().listModules();
         model.put("isRuntimeInfoEnabled", ImagesUtil.isImageRuntimeInfoEnabled());
-        return new ModelAndView(model, "content_management/view.jade");
+        return new ModelAndView(model, "templates/content_management/view.jade");
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/controllers/ImageProfileController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/ImageProfileController.java
@@ -83,7 +83,7 @@ public class ImageProfileController {
     public static ModelAndView listView(Request req, Response res, User user) {
         Map<String, Object> data = new HashMap<>();
         data.put("isAdmin", user.hasRole(ADMIN_ROLE));
-        return new ModelAndView(data, "content_management/list-profiles.jade");
+        return new ModelAndView(data, "templates/content_management/list-profiles.jade");
     }
 
     /**
@@ -104,7 +104,7 @@ public class ImageProfileController {
         data.put("activationKeys", getActivationKeys(user));
         data.put("customDataKeys", getCustomDataKeys(user.getOrg()));
         data.put("imageTypesDataFromTheServer", GSON.toJson(imageTypesDataFromTheServer));
-        return new ModelAndView(data, "content_management/edit-profile.jade");
+        return new ModelAndView(data, "templates/content_management/edit-profile.jade");
     }
 
     /**
@@ -141,7 +141,7 @@ public class ImageProfileController {
         data.put("activationKeys", getActivationKeys(user));
         data.put("customDataKeys", getCustomDataKeys(user.getOrg()));
         data.put("imageTypesDataFromTheServer", GSON.toJson(imageTypesDataFromTheServer));
-        return new ModelAndView(data, "content_management/edit-profile.jade");
+        return new ModelAndView(data, "templates/content_management/edit-profile.jade");
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/controllers/ImageStoreController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/ImageStoreController.java
@@ -70,7 +70,7 @@ public class ImageStoreController {
     public static ModelAndView listView(Request req, Response res, User user) {
         Map<String, Object> data = new HashMap<>();
         data.put("is_admin", user.hasRole(ADMIN_ROLE));
-        return new ModelAndView(data, "content_management/list-stores.jade");
+        return new ModelAndView(data, "templates/content_management/list-stores.jade");
     }
 
     /**
@@ -83,7 +83,7 @@ public class ImageStoreController {
      */
     public static ModelAndView createView(Request req, Response res, User user) {
         return new ModelAndView(new HashMap<String, Object>(),
-                "content_management/edit-store.jade");
+                "templates/content_management/edit-store.jade");
     }
 
     /**
@@ -116,7 +116,7 @@ public class ImageStoreController {
 
         Map<String, Object> data = new HashMap<>();
         data.put("store_id", storeId);
-        return new ModelAndView(data, "content_management/edit-store.jade");
+        return new ModelAndView(data, "templates/content_management/edit-store.jade");
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/controllers/MinionController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/MinionController.java
@@ -63,7 +63,7 @@ public class MinionController {
      */
     public static ModelAndView list(Request request, Response response, User user) {
         Map<String, Object> data = new HashMap<>();
-        return new ModelAndView(data, "minion/list.jade");
+        return new ModelAndView(data, "templates/minion/list.jade");
     }
 
     /**
@@ -75,7 +75,7 @@ public class MinionController {
      */
     public static ModelAndView cmd(Request request, Response response) {
         request.session().removeAttribute(MinionsAPI.SALT_CMD_RUN_TARGETS);
-        return new ModelAndView(new HashMap<>(), "minion/cmd.jade");
+        return new ModelAndView(new HashMap<>(), "templates/minion/cmd.jade");
     }
 
     /**
@@ -105,7 +105,7 @@ public class MinionController {
         Map<String, Object> data = new HashMap<>();
         Server server = ServerFactory.lookupById(new Long(serverId));
         data.put("server", server);
-        return new ModelAndView(data, "minion/packages.jade");
+        return new ModelAndView(data, "templates/minion/packages.jade");
     }
 
     /**
@@ -120,7 +120,7 @@ public class MinionController {
         Map<String, Object> data = new HashMap<>();
         data.put("orgId", orgId);
         data.put("orgName", OrgFactory.lookupById(new Long(orgId)).getName());
-        return new ModelAndView(data, "org/custom.jade");
+        return new ModelAndView(data, "templates/org/custom.jade");
     }
 
     /**
@@ -136,7 +136,7 @@ public class MinionController {
         Map<String, Object> data = new HashMap<>();
         data.put("orgId", user.getOrg().getId());
         data.put("orgName", user.getOrg().getName());
-        return new ModelAndView(data, "yourorg/custom.jade");
+        return new ModelAndView(data, "templates/yourorg/custom.jade");
     }
 
     /**
@@ -154,7 +154,7 @@ public class MinionController {
         data.put("groupId", orgId);
         data.put("groupName", ServerGroupFactory.lookupByIdAndOrg(new Long(orgId),
                 user.getOrg()).getName());
-        return new ModelAndView(data, "groups/custom.jade");
+        return new ModelAndView(data, "templates/groups/custom.jade");
     }
 
     /**
@@ -183,7 +183,7 @@ public class MinionController {
                 user.getOrg()).getName());
         data.put("minions", Json.GSON.toJson(minions));
         addActionChains(user, data);
-        return new ModelAndView(data, "groups/highstate.jade");
+        return new ModelAndView(data, "templates/groups/highstate.jade");
     }
 
     /**
@@ -202,7 +202,7 @@ public class MinionController {
         Map<String, Object> data = new HashMap<>();
         data.put("minions", Json.GSON.toJson(minions));
         addActionChains(user, data);
-        return new ModelAndView(data, "ssm/highstate.jade");
+        return new ModelAndView(data, "templates/ssm/highstate.jade");
     }
 
     /**
@@ -217,7 +217,7 @@ public class MinionController {
         Map<String, Object> data = new HashMap<>();
         Server server = ServerFactory.lookupById(new Long(serverId));
         data.put("server", server);
-        return new ModelAndView(data, "minion/custom.jade");
+        return new ModelAndView(data, "templates/minion/custom.jade");
     }
 
     /**
@@ -234,7 +234,7 @@ public class MinionController {
         Server server = ServerFactory.lookupById(new Long(serverId));
         data.put("server", server);
         addActionChains(user, data);
-        return new ModelAndView(data, "minion/highstate.jade");
+        return new ModelAndView(data, "templates/minion/highstate.jade");
     }
 
     /**
@@ -276,6 +276,6 @@ public class MinionController {
                 .collect(Collectors.toList());
         data.put("availableActivationKeys", Json.GSON.toJson(visibleBootstrapKeys));
         data.put("proxies", Json.GSON.toJson(proxies));
-        return new ModelAndView(data, "minion/bootstrap.jade");
+        return new ModelAndView(data, "templates/minion/bootstrap.jade");
     }
 }

--- a/java/code/src/com/suse/manager/webui/controllers/NotificationMessageController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/NotificationMessageController.java
@@ -65,7 +65,7 @@ public class NotificationMessageController {
      * @return the ModelAndView object to render the page
      */
     public static ModelAndView getList(Request request, Response response, User user) {
-        return new ModelAndView(new HashMap<>(), "notification-messages/list.jade");
+        return new ModelAndView(new HashMap<>(), "templates/notification-messages/list.jade");
     }
 
 

--- a/java/code/src/com/suse/manager/webui/controllers/ProductsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/ProductsController.java
@@ -83,7 +83,7 @@ public class ProductsController {
         data.put(REFRESH_NEEDED, String.valueOf(SCCCachingFactory.refreshNeeded()));
         data.put(REFRESH_RUNNING, String.valueOf(latestRun != null && latestRun.getEndTime() == null));
 
-        return new ModelAndView(data, "products/show.jade");
+        return new ModelAndView(data, "templates/products/show.jade");
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/controllers/SubscriptionMatchingController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/SubscriptionMatchingController.java
@@ -56,7 +56,7 @@ public class SubscriptionMatchingController {
      * @return the ModelAndView object to render the page
      */
     public static ModelAndView show(Request request, Response response, User user) {
-        return new ModelAndView(new HashMap<>(), "subscription-matching/show.jade");
+        return new ModelAndView(new HashMap<>(), "templates/subscription-matching/show.jade");
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/controllers/TaskoTop.java
+++ b/java/code/src/com/suse/manager/webui/controllers/TaskoTop.java
@@ -50,7 +50,7 @@ public class TaskoTop {
      * @return the ModelAndView object to render the page
      */
     public static ModelAndView show(Request request, Response response, User user) {
-        return new ModelAndView(new HashMap<>(), "taskotop/show.jade");
+        return new ModelAndView(new HashMap<>(), "templates/taskotop/show.jade");
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/controllers/VirtualGuestsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/VirtualGuestsController.java
@@ -111,7 +111,7 @@ public class VirtualGuestsController {
         data.put("salt_entitled", server.hasEntitlement(EntitlementManager.SALT));
         data.put("is_admin", user.hasRole(RoleFactory.ORG_ADMIN));
 
-        return new ModelAndView(data, "virtualization/guests/show.jade");
+        return new ModelAndView(data, "templates/virtualization/guests/show.jade");
     }
 
     /**
@@ -333,7 +333,7 @@ public class VirtualGuestsController {
         /* For the rest of the template */
         data.put("guestUuid", guestUuid);
         data.put("isSalt", host.hasEntitlement(EntitlementManager.SALT));
-        return new ModelAndView(data, "virtualization/guests/edit.jade");
+        return new ModelAndView(data, "templates/virtualization/guests/edit.jade");
     }
 
     private static String triggerGuestUpdateAction(Server host,

--- a/java/code/src/com/suse/manager/webui/controllers/VirtualHostManagerController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/VirtualHostManagerController.java
@@ -85,7 +85,7 @@ public class VirtualHostManagerController {
      */
     public static ModelAndView list(Request request, Response response, User user) {
         Map<String, Object> data = new HashMap<>();
-        return new ModelAndView(data, "virtualhostmanager/list.jade");
+        return new ModelAndView(data, "templates/virtualhostmanager/list.jade");
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/controllers/VisualizationController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/VisualizationController.java
@@ -49,7 +49,7 @@ public class VisualizationController {
                 "/rhn/manager/api/visualization/virtualization-hierarchy/data");
         data.put("view", "virtualization-hierarchy");
         request.attribute("legends", "visualization");
-        return new ModelAndView(data, "visualization/hierarchy.jade");
+        return new ModelAndView(data, "templates/visualization/hierarchy.jade");
     }
 
     /**
@@ -80,7 +80,7 @@ public class VisualizationController {
         data.put("endpoint", "/rhn/manager/api/visualization/proxy-hierarchy/data");
         data.put("view", "proxy-hierarchy");
         request.attribute("legends", "visualization");
-        return new ModelAndView(data, "visualization/hierarchy.jade");
+        return new ModelAndView(data, "templates/visualization/hierarchy.jade");
     }
 
     /**
@@ -112,7 +112,7 @@ public class VisualizationController {
                 "systems-with-managed-groups/data");
         data.put("view", "grouping");
         request.attribute("legends", "visualization");
-        return new ModelAndView(data, "visualization/hierarchy.jade");
+        return new ModelAndView(data, "templates/visualization/hierarchy.jade");
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/templates/system-common.jade
+++ b/java/code/src/com/suse/manager/webui/templates/system-common.jade
@@ -1,6 +1,6 @@
 // Common header part for System pages
 // Needs the Server object passed as 'server' and 'inSSM' value to be set
-include common.jade
+include ./common.jade
 
 - var system_icon = "fa-desktop"
 if server.bootstrap

--- a/java/code/src/com/suse/manager/webui/utils/SparkApplicationHelper.java
+++ b/java/code/src/com/suse/manager/webui/utils/SparkApplicationHelper.java
@@ -45,7 +45,7 @@ import spark.template.jade.JadeTemplateEngine;
  */
 public class SparkApplicationHelper {
 
-    private static final String TEMPLATE_ROOT = "com/suse/manager/webui/templates";
+    private static final String TEMPLATE_ROOT = "com/suse/manager/webui";
     private static final Gson GSON = new GsonBuilder().create();
 
     /**

--- a/web/html/src/manager/index.js
+++ b/web/html/src/manager/index.js
@@ -1,5 +1,15 @@
 /* eslint-disable */
-const pages = {
+
+/*
+How to add a new route:
+All the routes exported on the files '<*folder_name*>/index.js' will be automatically registered.
+Check the file content-management/index.js for an example
+*/
+
+const { readdirSync, statSync } = require('fs')
+const { join } = require('path')
+
+const oldPagesEntries = {
   'polyfill': './manager/polyfill.js',
   'errors/not-found': './manager/errors/not-found.js',
   'visualization/hierarchy': './manager/visualization/hierarchy.js',
@@ -43,11 +53,40 @@ const pages = {
   'activation-key/activation-key-channels.renderer': './manager/activation-key/activation-key-channels.renderer.js',
 }
 
-Object.keys(pages).forEach((key) => {
-  pages["javascript/manager/" + key] = pages[key];
-  delete pages[key]
+const readDirs = p => readdirSync(p).filter(f => statSync(join(p, f)).isDirectory())
+const dirs = readDirs("./manager");
+
+const dirsWithRoutes = dirs.filter(dir => {
+  try {
+    return require(`./${dir}`).entries
+  } catch(e){
+    return false;
+  };
+})
+
+
+const newPagesEntries = dirsWithRoutes.reduce((newRoutes, nextDir) => {
+  const nextDirRoutes = require(`./${nextDir}`).entries;
+  const nextDirRoutesFormated = nextDirRoutes.reduce((routesFormated, nextRoute) => {
+    const formatedKey = `${nextDir}/${nextRoute.split('.').slice(0, -1).join('.')}`;
+    const formatedValue = `./manager/${nextDir}/${nextRoute}`;
+
+    return {
+      ...routesFormated,
+      ...{[formatedKey]: formatedValue}
+    }
+  }, {});
+
+  return {...newRoutes, ...nextDirRoutesFormated};
+}, {});
+
+const allPages = {...oldPagesEntries, ...newPagesEntries};
+
+Object.keys(allPages).forEach((key) => {
+  allPages["javascript/manager/" + key] = allPages[key];
+  delete allPages[key]
 });
 
 module.exports = {
-  pages
+  pages: allPages
 }


### PR DESCRIPTION
## What does this PR change?

Backport structural part of https://github.com/uyuni-project/uyuni/pull/414

- New root for jade templates
- New way of defining frontend pages/routes.

@cbosdo after merging this PR you will need to adapt the jade template paths on your PRs. "templates/*"

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed.

- [x] **DONE**

## Test coverage
- No tests.

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
