### PR TITLE
Explicitly require JDK11

### DIFF
--- a/branding/spacewalk-branding.changes
+++ b/branding/spacewalk-branding.changes
@@ -1,3 +1,5 @@
+- Explicitly require JDK11
+
 -------------------------------------------------------------------
 Wed Jan 16 12:21:41 CET 2019 - jgonzalez@suse.com
 

--- a/branding/spacewalk-branding.spec
+++ b/branding/spacewalk-branding.spec
@@ -46,7 +46,7 @@ URL:            https://github.com/uyuni-project/uyuni
 Source0:        https://github.com/spacewalkproject/spacewalk/archive/%{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 #BuildArch:  noarch
-BuildRequires:  java-devel >= 1.8.0
+BuildRequires:  java-devel >= 11
 BuildRequires:  nodejs
 BuildRequires:  nodejs-less
 Requires:       httpd

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Explicitly require JDK11
 - Update spec file to no longer install tomcat context file in cache directory (bsc#1111308)
 - Fix for duplicate key violation when cloning erratas that have no packages associated (bsc#1111686)
 - Improve performance for granting and revoking permissions to user for groups (bsc#1111810)

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -65,7 +65,7 @@ Requires:       concurrent
 Requires:       google-gson >= 2.2.4
 Requires:       httpcomponents-client
 Requires:       jakarta-commons-digester
-Requires:       java >= 1.8.0
+Requires:       java >= 11
 Requires:       classmate
 Requires:       ehcache >= 2.10.1
 Requires:       gnu-jaf
@@ -97,7 +97,7 @@ BuildRequires:  byte-buddy
 BuildRequires:  jpa-api
 BuildRequires:  hibernate-commons-annotations
 BuildRequires:  hibernate5
-BuildRequires:  java-devel >= 1.8.0
+BuildRequires:  java-devel >= 11
 BuildRequires:  javassist
 BuildRequires:  jboss-logging
 BuildRequires:  jsch
@@ -120,11 +120,11 @@ BuildRequires: pgjdbc-ng
 %else
 Requires:       cobbler20
 Requires:       jakarta-taglibs-standard
-Requires:       java >= 1:1.7.0
-Requires:       java-devel >= 1:1.7.0
+Requires:       java >= 11
+Requires:       java-devel >= 11
 Requires:       jpam
 Requires:       oscache
-BuildRequires:  java-devel >= 1:1.7.0
+BuildRequires:  java-devel >= 11
 BuildRequires:  jpam
 BuildRequires:  oscache
 
@@ -413,15 +413,15 @@ Requires:       bcel
 Requires:       c3p0 >= 0.9.1
 %if 0%{?suse_version}
 Requires:       cobbler >= 2.0.0
-Requires:       java >= 1.8.0
+Requires:       java >= 11
 Requires:       jsch
 Requires:       /sbin/unix2_chkpwd
 Requires:       tomcat-taglibs-standard
 %else
 Requires:       cobbler20
 Requires:       jakarta-taglibs-standard
-Requires:       java >= 1.7.0
-Requires:       java-devel >= 1.7.0
+Requires:       java >= 11
+Requires:       java-devel >= 11
 Requires:       jpam
 Requires:       oscache
 %endif

--- a/search-server/spacewalk-search/spacewalk-search.changes
+++ b/search-server/spacewalk-search/spacewalk-search.changes
@@ -1,3 +1,5 @@
+- Explicitly require JDK11
+
 -------------------------------------------------------------------
 Mon Dec 17 14:41:09 CET 2018 - jgonzalez@suse.com
 

--- a/search-server/spacewalk-search/spacewalk-search.spec
+++ b/search-server/spacewalk-search/spacewalk-search.spec
@@ -72,7 +72,7 @@ BuildRequires:  c3p0 >= 0.9.1
 BuildRequires:  cglib
 BuildRequires:  jakarta-commons-httpclient
 BuildRequires:  jakarta-oro
-BuildRequires:  java-devel >= 1.8.0
+BuildRequires:  java-devel >= 11
 BuildRequires:  javapackages-tools
 #BuildRequires: lucene
 BuildRequires:  objectweb-asm


### PR DESCRIPTION
## What does this PR change?

Explicitly require JDK11. Otherwise JDK8 can still get installed, as it's available at Leap 15.0 and SLE15 SP1.

There are other references at the `spec-tree` folder to JDK8, but we do not maintain that part of the code.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: A search at the [susemanager doc repository](https://github.com/SUSE/doc-susemanager) did not return any references to the Java/JDK version

- [x] **DONE**

## Test coverage
- No tests: Already covered by unit testing, OBS building and sumaform installation

- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/6855

- [x] **DONE**