### PR TITLE
Fix npe to get channel arch

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -1618,7 +1618,7 @@ public class ContentSyncManager {
         Channel dbChannel = new Channel();
         dbChannel.setBaseDir("/dev/null");
         // from product
-        dbChannel.setChannelArch(MgrSyncUtils.getChannelArch(product.getArch()));
+        dbChannel.setChannelArch(MgrSyncUtils.getChannelArch(product.getArch(), label));
         dbChannel.setChannelFamily(product.getChannelFamily());
         // Checksum type is only a dummy here. spacewalk-repo-sync will update it
         // and set it to the type used in the (last) repo to hash the primary file

--- a/java/code/src/com/redhat/rhn/manager/content/MgrSyncUtils.java
+++ b/java/code/src/com/redhat/rhn/manager/content/MgrSyncUtils.java
@@ -48,6 +48,8 @@ public class MgrSyncUtils {
     private static final String OFFICIAL_NOVELL_UPDATE_HOST = "nu.novell.com";
     private static final List<String> OFFICIAL_UPDATE_HOSTS =
             Arrays.asList("updates.suse.com", OFFICIAL_NOVELL_UPDATE_HOST);
+    private static final List<String> PRODUCT_ARCHS = Arrays.asList("i586", "ia64", "ppc64le", "ppc64", "ppc",
+            "s390x", "s390", "x86_64", "aarch64");
 
     // No instances should be created
     private MgrSyncUtils() {
@@ -105,11 +107,18 @@ public class MgrSyncUtils {
     /**
      * Handle special cases where SUSE arch names differ from the RedHat ones.
      *
-     * @param packageArch channel that we want to get the arch from
+     * @param packageArch we want to get the arch from
+     * @param channelLabel alternative try to find the arch in the channelLabel
      * @return channel arch object
      */
-    public static ChannelArch getChannelArch(PackageArch packageArch) {
-        String arch = packageArch.getLabel();
+    public static ChannelArch getChannelArch(PackageArch packageArch, String channelLabel) {
+        String arch = "x86_64";
+        if (packageArch != null) {
+            arch = packageArch.getLabel();
+        }
+        else {
+            arch = PRODUCT_ARCHS.stream().filter(a -> channelLabel.contains(a)).findFirst().orElse(arch);
+        }
         if (arch.equals("i686") || arch.equals("i586") ||
                 arch.equals("i486") || arch.equals("i386")) {
             arch = "ia32";

--- a/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
@@ -1007,7 +1007,7 @@ public class ContentSyncManagerTest extends BaseTestCaseWithUser {
         assertTrue("Debuginfo Pool channel not found", foundDebugPool);
         Map<MgrSyncStatus, List<MgrSyncChannelDto>> collect = channels.stream().collect(Collectors.groupingBy(c -> c.getStatus()));
         assertEquals(2, collect.get(MgrSyncStatus.INSTALLED).size());
-        assertEquals(60, collect.get(MgrSyncStatus.AVAILABLE).size());
+        assertEquals(62, collect.get(MgrSyncStatus.AVAILABLE).size());
     }
 
     /**
@@ -1067,6 +1067,7 @@ public class ContentSyncManagerTest extends BaseTestCaseWithUser {
         csm.addChannel("sles12-pool-x86_64", null);
         csm.addChannel("sles12-updates-x86_64", null);
         csm.addChannel("sle-module-legacy12-debuginfo-pool-x86_64", null);
+        csm.addChannel("rhel-x86_64-server-7", null);
 
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().clear();
@@ -1091,6 +1092,11 @@ public class ContentSyncManagerTest extends BaseTestCaseWithUser {
             assertEquals(false, pc.isMandatory());
             assertEquals(1150L, pc.getProduct().getProductId());
         }
+        assertTrue(csm.listChannels().stream().anyMatch(c -> c.getLabel().equals("rhel-x86_64-server-7")));
+        assertTrue(csm.listChannels()
+                .stream()
+                .filter(c -> c.getLabel().equals("rhel-x86_64-server-7"))
+                .anyMatch(c -> c.getStatus().equals(MgrSyncStatus.INSTALLED)));
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/content/test/smallBase/additional_repositories.json
+++ b/java/code/src/com/redhat/rhn/manager/content/test/smallBase/additional_repositories.json
@@ -1,0 +1,52 @@
+[
+    {
+        "id" : -71,
+        "url" : "http://localhost/pub/repositories/empty/",
+        "name" : "rhel-i386-server-5",
+        "distro_target" : "i386",
+        "description" : "RES 5",
+        "enabled" : true,
+        "autorefresh" : false,
+        "installer_updates" : false
+    },
+    {
+        "id" : -72,
+        "url" : "http://localhost/pub/repositories/empty/",
+        "name" : "rhel-x86_64-server-5",
+        "distro_target" : "x86_64",
+        "description" : "RES 5",
+        "enabled" : true,
+        "autorefresh" : false,
+        "installer_updates" : false
+    },
+    {
+        "id" : -73,
+        "url" : "http://localhost/pub/repositories/empty/",
+        "name" : "rhel-i386-server-6",
+        "distro_target" : "i386",
+        "description" : "RES 6",
+        "enabled" : true,
+        "autorefresh" : false,
+        "installer_updates" : false
+    },
+    {
+        "id" : -74,
+        "url" : "http://localhost/pub/repositories/empty/",
+        "name" : "rhel-x86_64-server-6",
+        "distro_target" : "x86_64",
+        "description" : "RES 6",
+        "enabled" : true,
+        "autorefresh" : false,
+        "installer_updates" : false
+    },
+    {
+        "id" : -75,
+        "url" : "http://localhost/pub/repositories/empty/",
+        "name" : "rhel-x86_64-server-7",
+        "distro_target" : "x86_64",
+        "description" : "RES 7",
+        "enabled" : true,
+        "autorefresh" : false,
+        "installer_updates" : false
+    }
+]

--- a/java/code/src/com/redhat/rhn/manager/content/test/smallBase/product_tree.json
+++ b/java/code/src/com/redhat/rhn/manager/content/test/smallBase/product_tree.json
@@ -90,6 +90,36 @@
         "channel_name": "OES11-SP3-Pool for x86_64"
     },
     {
+        "channel_label": "oes2018-sle-module-web-scripting-12-sp2-updates-x86_64",
+        "parent_channel_label": "oes2018-pool-x86_64",
+        "product_id": 45,
+        "repository_id": -69,
+        "parent_product_id": null,
+        "root_product_id": 45,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://nu.novell.com/repo/$RCE/OES2018-SLE-Modules-Web-Scripting-12-SP2-Updates/sle-12-x86_64/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "OES2018-SLE-Module-Web-Scripting-12-SP2-Updates for x86_64"
+    },
+    {
+        "channel_label": "oes2018-sle-module-web-scripting-12-sp2-pool-x86_64",
+        "parent_channel_label": "oes2018-pool-x86_64",
+        "product_id": 45,
+        "repository_id": -68,
+        "parent_product_id": null,
+        "root_product_id": 45,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://nu.novell.com/repo/$RCE/OES2018-SLE-Modules-Web-Scripting-12-SP2-Pool/sle-12-x86_64/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "OES2018-SLE-Module-Web-Scripting-12-SP2-Pool for x86_64"
+    },
+    {
         "channel_label": "oes2018-sle-sdk-12-sp2-debuginfo-updates-x86_64",
         "parent_channel_label": "oes2018-pool-x86_64",
         "product_id": 45,
@@ -102,7 +132,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "OES2018-SLE-SDK-12-SP2-Debuginfo-Updates x86_64"
+        "channel_name": "OES2018-SLE-SDK-12-SP2-Debuginfo-Updates for x86_64"
     },
     {
         "channel_label": "oes2018-sle-sdk-12-sp2-debuginfo-pool-x86_64",
@@ -117,7 +147,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "OES2018-SLE-SDK-12-SP2-Debuginfo-Pool x86_64"
+        "channel_name": "OES2018-SLE-SDK-12-SP2-Debuginfo-Pool for x86_64"
     },
     {
         "channel_label": "oes2018-sle-sdk-12-sp2-updates-x86_64",
@@ -132,7 +162,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "OES2018-SLE-SDK-12-SP2-Updates x86_64"
+        "channel_name": "OES2018-SLE-SDK-12-SP2-Updates for x86_64"
     },
     {
         "channel_label": "oes2018-sle-sdk-12-sp2-pool-x86_64",
@@ -147,7 +177,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "OES2018-SLE-SDK-12-SP2-Pool x86_64"
+        "channel_name": "OES2018-SLE-SDK-12-SP2-Pool for x86_64"
     },
     {
         "channel_label": "oes2018-sle-manager-tools-12-sp2-updates-x86_64",
@@ -162,7 +192,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "OES2018-SLE-Manager-Tools-12-SP2-Updates x86_64"
+        "channel_name": "OES2018-SLE-Manager-Tools-12-SP2-Updates for x86_64"
     },
     {
         "channel_label": "oes2018-sle-manager-tools-12-sp2-pool-x86_64",
@@ -177,7 +207,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "OES2018-SLE-Manager-Tools-12-SP2-Pool x86_64"
+        "channel_name": "OES2018-SLE-Manager-Tools-12-SP2-Pool for x86_64"
     },
     {
         "channel_label": "oes2018-sle-manager-tools-12-sp2-debuginfo-updates-x86_64",
@@ -192,7 +222,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "OES2018-SLE-Manager-Tools-12-SP2-Debuginfo-Updates x86_64"
+        "channel_name": "OES2018-SLE-Manager-Tools-12-SP2-Debuginfo-Updates for x86_64"
     },
     {
         "channel_label": "oes2018-sle-manager-tools-12-sp2-debuginfo-pool-x86_64",
@@ -207,7 +237,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "OES2018-SLE-Manager-Tools-12-SP2-Debuginfo-Pool x86_64"
+        "channel_name": "OES2018-SLE-Manager-Tools-12-SP2-Debuginfo-Pool for x86_64"
     },
     {
         "channel_label": "oes2018-sle-module-containers-12-sp2-debuginfo-updates-x86_64",
@@ -358,6 +388,456 @@
         "signed": true,
         "recommended": false,
         "channel_name": "OES2018-Pool for x86_64"
+    },
+    {
+        "channel_label": "oes2018-sp1-sle-module-toolchain12-debuginfo-updates-x86_64",
+        "parent_channel_label": "oes2018-sp1-pool-x86_64",
+        "product_id": 46,
+        "repository_id": -60,
+        "parent_product_id": null,
+        "root_product_id": 46,
+        "update_tag": "SLE-Module-Toolchain",
+        "url": "https://nu.novell.com/repo/$RCE/OES2018-SP1-SLE-Module-Toolchain12-Debuginfo-Updates/sle-12-x86_64/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "OES2018-SP1-SLE-Module-Toolchain12-Debuginfo-Updates for x86_64"
+    },
+    {
+        "channel_label": "oes2018-sp1-sle-module-toolchain12-debuginfo-pool-x86_64",
+        "parent_channel_label": "oes2018-sp1-pool-x86_64",
+        "product_id": 46,
+        "repository_id": -59,
+        "parent_product_id": null,
+        "root_product_id": 46,
+        "update_tag": "SLE-Module-Toolchain",
+        "url": "https://nu.novell.com/repo/$RCE/OES2018-SP1-SLE-Module-Toolchain12-Debuginfo-Pool/sle-12-x86_64/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "OES2018-SP1-SLE-Module-Toolchain12-Debuginfo-Pool for x86_64"
+    },
+    {
+        "channel_label": "oes2018-sp1-sle-module-toolchain12-updates-x86_64",
+        "parent_channel_label": "oes2018-sp1-pool-x86_64",
+        "product_id": 46,
+        "repository_id": -58,
+        "parent_product_id": null,
+        "root_product_id": 46,
+        "update_tag": "SLE-Module-Toolchain",
+        "url": "https://nu.novell.com/repo/$RCE/OES2018-SP1-SLE-Module-Toolchain12-Updates/sle-12-x86_64/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "OES2018-SP1-SLE-Module-Toolchain12-Updates for x86_64"
+    },
+    {
+        "channel_label": "oes2018-sp1-sle-module-toolchain12-pool-x86_64",
+        "parent_channel_label": "oes2018-sp1-pool-x86_64",
+        "product_id": 46,
+        "repository_id": -57,
+        "parent_product_id": null,
+        "root_product_id": 46,
+        "update_tag": "SLE-Module-Toolchain",
+        "url": "https://nu.novell.com/repo/$RCE/OES2018-SP1-SLE-Module-Toolchain12-Pool/sle-12-x86_64/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "OES2018-SP1-SLE-Module-Toolchain12-Pool for x86_64"
+    },
+    {
+        "channel_label": "oes2018-sp1-sle-module-web-scripting12-debuginfo-updates-x86_64",
+        "parent_channel_label": "oes2018-sp1-pool-x86_64",
+        "product_id": 46,
+        "repository_id": -56,
+        "parent_product_id": null,
+        "root_product_id": 46,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://nu.novell.com/repo/$RCE/OES2018-SP1-SLE-Module-Web-Scripting12-Debuginfo-Updates/sle-12-x86_64/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "OES2018-SP1-SLE-Module-Web-Scripting12-Debuginfo-Updates for x86_64"
+    },
+    {
+        "channel_label": "oes2018-sp1-sle-module-web-scripting12-debuginfo-pool-x86_64",
+        "parent_channel_label": "oes2018-sp1-pool-x86_64",
+        "product_id": 46,
+        "repository_id": -55,
+        "parent_product_id": null,
+        "root_product_id": 46,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://nu.novell.com/repo/$RCE/OES2018-SP1-SLE-Module-Web-Scripting12-Debuginfo-Pool/sle-12-x86_64/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "OES2018-SP1-SLE-Module-Web-Scripting12-Debuginfo-Pool for x86_64"
+    },
+    {
+        "channel_label": "oes2018-sp1-sle-module-web-scripting12-updates-x86_64",
+        "parent_channel_label": "oes2018-sp1-pool-x86_64",
+        "product_id": 46,
+        "repository_id": -54,
+        "parent_product_id": null,
+        "root_product_id": 46,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://nu.novell.com/repo/$RCE/OES2018-SP1-SLE-Module-Web-Scripting12-Updates/sle-12-x86_64/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "OES2018-SP1-SLE-Module-Web-Scripting12-Updates for x86_64"
+    },
+    {
+        "channel_label": "oes2018-sp1-sle-module-web-scripting12-pool-x86_64",
+        "parent_channel_label": "oes2018-sp1-pool-x86_64",
+        "product_id": 46,
+        "repository_id": -53,
+        "parent_product_id": null,
+        "root_product_id": 46,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://nu.novell.com/repo/$RCE/OES2018-SP1-SLE-Module-Web-Scripting12-Pool/sle-12-x86_64/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "OES2018-SP1-SLE-Module-Web-Scripting12-Pool for x86_64"
+    },
+    {
+        "channel_label": "oes2018-sp1-sle-module-public-cloud12-debuginfo-updates-x86_64",
+        "parent_channel_label": "oes2018-sp1-pool-x86_64",
+        "product_id": 46,
+        "repository_id": -52,
+        "parent_product_id": null,
+        "root_product_id": 46,
+        "update_tag": "SLE-Module-Public-Cloud",
+        "url": "https://nu.novell.com/repo/$RCE/OES2018-SP1-SLE-Module-Public-Cloud12-Debuginfo-Updates/sle-12-x86_64/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "OES2018-SP1-SLE-Module-Public-Cloud12-Debuginfo-Updates for x86_64"
+    },
+    {
+        "channel_label": "oes2018-sp1-sle-module-public-cloud12-debuginfo-pool-x86_64",
+        "parent_channel_label": "oes2018-sp1-pool-x86_64",
+        "product_id": 46,
+        "repository_id": -51,
+        "parent_product_id": null,
+        "root_product_id": 46,
+        "update_tag": "SLE-Module-Public-Cloud",
+        "url": "https://nu.novell.com/repo/$RCE/OES2018-SP1-SLE-Module-Public-Cloud12-Debuginfo-Pool/sle-12-x86_64/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "OES2018-SP1-SLE-Module-Public-Cloud12-Debuginfo-Pool for x86_64"
+    },
+    {
+        "channel_label": "oes2018-sp1-sle-module-public-cloud12-updates-x86_64",
+        "parent_channel_label": "oes2018-sp1-pool-x86_64",
+        "product_id": 46,
+        "repository_id": -50,
+        "parent_product_id": null,
+        "root_product_id": 46,
+        "update_tag": "SLE-Module-Public-Cloud",
+        "url": "https://nu.novell.com/repo/$RCE/OES2018-SP1-SLE-Module-Public-Cloud12-Updates/sle-12-x86_64/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "OES2018-SP1-SLE-Module-Public-Cloud12-Updates for x86_64"
+    },
+    {
+        "channel_label": "oes2018-sp1-sle-module-public-cloud12-pool-x86_64",
+        "parent_channel_label": "oes2018-sp1-pool-x86_64",
+        "product_id": 46,
+        "repository_id": -49,
+        "parent_product_id": null,
+        "root_product_id": 46,
+        "update_tag": "SLE-Module-Public-Cloud",
+        "url": "https://nu.novell.com/repo/$RCE/OES2018-SP1-SLE-Module-Public-Cloud12-Pool/sle-12-x86_64/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "OES2018-SP1-SLE-Module-Public-Cloud12-Pool for x86_64"
+    },
+    {
+        "channel_label": "oes2018-sp1-sle-sdk-12-sp3-debuginfo-updates-x86_64",
+        "parent_channel_label": "oes2018-sp1-pool-x86_64",
+        "product_id": 46,
+        "repository_id": -48,
+        "parent_product_id": null,
+        "root_product_id": 46,
+        "update_tag": "SLE-SDK",
+        "url": "https://nu.novell.com/repo/$RCE/OES2018-SP1-SLE-SDK-12-SP3-Debuginfo-Updates/sle-12-x86_64/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "OES2018-SP1-SLE-SDK-12-SP3-Debuginfo-Updates for x86_64"
+    },
+    {
+        "channel_label": "oes2018-sp1-sle-sdk-12-sp3-debuginfo-pool-x86_64",
+        "parent_channel_label": "oes2018-sp1-pool-x86_64",
+        "product_id": 46,
+        "repository_id": -47,
+        "parent_product_id": null,
+        "root_product_id": 46,
+        "update_tag": "SLE-SDK",
+        "url": "https://nu.novell.com/repo/$RCE/OES2018-SP1-SLE-SDK-12-SP3-Debuginfo-Pool/sle-12-x86_64/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "OES2018-SP1-SLE-SDK-12-SP3-Debuginfo-Pool for x86_64"
+    },
+    {
+        "channel_label": "oes2018-sp1-sle-sdk-12-sp3-updates-x86_64",
+        "parent_channel_label": "oes2018-sp1-pool-x86_64",
+        "product_id": 46,
+        "repository_id": -46,
+        "parent_product_id": null,
+        "root_product_id": 46,
+        "update_tag": "SLE-SDK",
+        "url": "https://nu.novell.com/repo/$RCE/OES2018-SP1-SLE-SDK-12-SP3-Updates/sle-12-x86_64/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "OES2018-SP1-SLE-SDK-12-SP3-Updates for x86_64"
+    },
+    {
+        "channel_label": "oes2018-sp1-sle-sdk-12-sp3-pool-x86_64",
+        "parent_channel_label": "oes2018-sp1-pool-x86_64",
+        "product_id": 46,
+        "repository_id": -45,
+        "parent_product_id": null,
+        "root_product_id": 46,
+        "update_tag": "SLE-SDK",
+        "url": "https://nu.novell.com/repo/$RCE/OES2018-SP1-SLE-SDK-12-SP3-Pool/sle-12-x86_64/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "OES2018-SP1-SLE-SDK-12-SP3-Pool for x86_64"
+    },
+    {
+        "channel_label": "oes2018-sp1-sle-manager-tools12-updates-x86_64",
+        "parent_channel_label": "oes2018-sp1-pool-x86_64",
+        "product_id": 46,
+        "repository_id": -44,
+        "parent_product_id": null,
+        "root_product_id": 46,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://nu.novell.com/repo/$RCE/OES2018-SP1-SLE-Manager-Tools12-Updates/sle-12-x86_64/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "OES2018-SP1-SLE-Manager-Tools12-Updates for x86_64"
+    },
+    {
+        "channel_label": "oes2018-sp1-sle-manager-tools12-pool-x86_64",
+        "parent_channel_label": "oes2018-sp1-pool-x86_64",
+        "product_id": 46,
+        "repository_id": -43,
+        "parent_product_id": null,
+        "root_product_id": 46,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://nu.novell.com/repo/$RCE/OES2018-SP1-SLE-Manager-Tools12-Pool/sle-12-x86_64/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "OES2018-SP1-SLE-Manager-Tools12-Pool for x86_64"
+    },
+    {
+        "channel_label": "oes2018-sp1-sle-manager-tools12-debuginfo-updates-x86_64",
+        "parent_channel_label": "oes2018-sp1-pool-x86_64",
+        "product_id": 46,
+        "repository_id": -42,
+        "parent_product_id": null,
+        "root_product_id": 46,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://nu.novell.com/repo/$RCE/OES2018-SP1-SLE-Manager-Tools12-Debuginfo-Updates/sle-12-x86_64/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "OES2018-SP1-SLE-Manager-Tools12-Debuginfo-Updates for x86_64"
+    },
+    {
+        "channel_label": "oes2018-sp1-sle-manager-tools12-debuginfo-pool-x86_64",
+        "parent_channel_label": "oes2018-sp1-pool-x86_64",
+        "product_id": 46,
+        "repository_id": -41,
+        "parent_product_id": null,
+        "root_product_id": 46,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://nu.novell.com/repo/$RCE/OES2018-SP1-SLE-Manager-Tools12-Debuginfo-Pool/sle-12-x86_64/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "OES2018-SP1-SLE-Manager-Tools12-Debuginfo-Pool for x86_64"
+    },
+    {
+        "channel_label": "oes2018-sp1-sle-module-containers12-debuginfo-updates-x86_64",
+        "parent_channel_label": "oes2018-sp1-pool-x86_64",
+        "product_id": 46,
+        "repository_id": -40,
+        "parent_product_id": null,
+        "root_product_id": 46,
+        "update_tag": "SLE-Module-Containers",
+        "url": "https://nu.novell.com/repo/$RCE/OES2018-SP1-SLE-Module-Containers12-Debuginfo-Updates/sle-12-x86_64/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "OES2018-SP1-SLE-Module-Containers12-Debuginfo-Updates for x86_64"
+    },
+    {
+        "channel_label": "oes2018-sp1-sle-module-containers12-debuginfo-pool-x86_64",
+        "parent_channel_label": "oes2018-sp1-pool-x86_64",
+        "product_id": 46,
+        "repository_id": -39,
+        "parent_product_id": null,
+        "root_product_id": 46,
+        "update_tag": "SLE-Module-Containers",
+        "url": "https://nu.novell.com/repo/$RCE/OES2018-SP1-SLE-Module-Containers12-Debuginfo-Pool/sle-12-x86_64/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "OES2018-SP1-SLE-Module-Containers12-Debuginfo-Pool for x86_64"
+    },
+    {
+        "channel_label": "oes2018-sp1-sle-module-containers12-updates-x86_64",
+        "parent_channel_label": "oes2018-sp1-pool-x86_64",
+        "product_id": 46,
+        "repository_id": -38,
+        "parent_product_id": null,
+        "root_product_id": 46,
+        "update_tag": "SLE-Module-Containers",
+        "url": "https://nu.novell.com/repo/$RCE/OES2018-SP1-SLE-Module-Containers12-Updates/sle-12-x86_64/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "OES2018-SP1-SLE-Module-Containers12-Updates for x86_64"
+    },
+    {
+        "channel_label": "oes2018-sp1-sle-module-containers12-pool-x86_64",
+        "parent_channel_label": "oes2018-sp1-pool-x86_64",
+        "product_id": 46,
+        "repository_id": -37,
+        "parent_product_id": null,
+        "root_product_id": 46,
+        "update_tag": "SLE-Module-Containers",
+        "url": "https://nu.novell.com/repo/$RCE/OES2018-SP1-SLE-Module-Containers12-Pool/sle-12-x86_64/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "OES2018-SP1-SLE-Module-Containers12-Pool for x86_64"
+    },
+    {
+        "channel_label": "oes2018-sp1-sles12-sp3-updates-x86_64",
+        "parent_channel_label": "oes2018-sp1-pool-x86_64",
+        "product_id": 46,
+        "repository_id": -36,
+        "parent_product_id": null,
+        "root_product_id": 46,
+        "update_tag": "SLE-SERVER",
+        "url": "https://nu.novell.com/repo/$RCE/OES2018-SP1-SLES12-SP3-Updates/sle-12-x86_64/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "OES2018-SP1-SLES12-SP3-Updates for x86_64"
+    },
+    {
+        "channel_label": "oes2018-sp1-sles12-sp3-pool-x86_64",
+        "parent_channel_label": "oes2018-sp1-pool-x86_64",
+        "product_id": 46,
+        "repository_id": -35,
+        "parent_product_id": null,
+        "root_product_id": 46,
+        "update_tag": "SLE-SERVER",
+        "url": "https://nu.novell.com/repo/$RCE/OES2018-SP1-SLES12-SP3-Pool/sle-12-x86_64/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": false,
+        "recommended": false,
+        "channel_name": "OES2018-SP1-SLES12-SP3-Pool for x86_64"
+    },
+    {
+        "channel_label": "oes2018-sp1-sles12-sp3-debuginfo-updates-x86_64",
+        "parent_channel_label": "oes2018-sp1-pool-x86_64",
+        "product_id": 46,
+        "repository_id": -34,
+        "parent_product_id": null,
+        "root_product_id": 46,
+        "update_tag": "SLE-SERVER",
+        "url": "https://nu.novell.com/repo/$RCE/OES2018-SP1-SLES12-SP3-Debuginfo-Updates/sle-12-x86_64/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": false,
+        "recommended": false,
+        "channel_name": "OES2018-SP1-SLES12-SP3-Debuginfo-Updates for x86_64"
+    },
+    {
+        "channel_label": "oes2018-sp1-sles12-sp3-debuginfo-pool-x86_64",
+        "parent_channel_label": "oes2018-sp1-pool-x86_64",
+        "product_id": 46,
+        "repository_id": -33,
+        "parent_product_id": null,
+        "root_product_id": 46,
+        "update_tag": "SLE-SERVER",
+        "url": "https://nu.novell.com/repo/$RCE/OES2018-SP1-SLES12-SP3-Debuginfo-Pool/sle-12-x86_64/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": false,
+        "recommended": false,
+        "channel_name": "OES2018-SP1-SLES12-SP3-Debuginfo-Pool for x86_64"
+    },
+    {
+        "channel_label": "oes2018-sp1-updates-x86_64",
+        "parent_channel_label": "oes2018-sp1-pool-x86_64",
+        "product_id": 46,
+        "repository_id": -32,
+        "parent_product_id": null,
+        "root_product_id": 46,
+        "update_tag": null,
+        "url": "https://nu.novell.com/repo/$RCE/OES2018-SP1-Updates/sle-12-x86_64/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": false,
+        "recommended": false,
+        "channel_name": "OES2018-SP1-Updates for x86_64"
+    },
+    {
+        "channel_label": "oes2018-sp1-pool-x86_64",
+        "parent_channel_label": null,
+        "product_id": 46,
+        "repository_id": -31,
+        "parent_product_id": null,
+        "root_product_id": 46,
+        "update_tag": null,
+        "url": "https://nu.novell.com/repo/$RCE/OES2018-SP1-Pool/sle-12-x86_64/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": false,
+        "recommended": false,
+        "channel_name": "OES2018-SP1-Pool for x86_64"
     },
     {
         "channel_label": "sles10-sp3-pool-s390x",
@@ -4470,36 +4950,6 @@
         "channel_name": "SLE11-HAE-SP1-Pool for i586"
     },
     {
-        "channel_label": "sle11-hae-sp1-updates-i586-vmware",
-        "parent_channel_label": "sles11-sp1-vmware-pool-i586",
-        "product_id": 959,
-        "repository_id": 944,
-        "parent_product_id": 996,
-        "root_product_id": 996,
-        "update_tag": "sleshasp1",
-        "url": "https://updates.suse.com/repo/$RCE/SLE11-HAE-SP1-Updates/sle-11-i586/",
-        "release_stage": "released",
-        "mandatory": true,
-        "signed": true,
-        "recommended": false,
-        "channel_name": "SLE11-HAE-SP1-Updates for i586 VMWare"
-    },
-    {
-        "channel_label": "sle11-hae-sp1-pool-i586-vmware",
-        "parent_channel_label": "sles11-sp1-vmware-pool-i586",
-        "product_id": 959,
-        "repository_id": 945,
-        "parent_product_id": 996,
-        "root_product_id": 996,
-        "update_tag": "sleshasp1",
-        "url": "https://updates.suse.com/repo/$RCE/SLE11-HAE-SP1-Pool/sle-11-i586/",
-        "release_stage": "released",
-        "mandatory": true,
-        "signed": true,
-        "recommended": false,
-        "channel_name": "SLE11-HAE-SP1-Pool for i586 VMWare"
-    },
-    {
         "channel_label": "sle11-hae-sp2-pool-x86_64",
         "parent_channel_label": "sles11-sp1-pool-x86_64",
         "product_id": 961,
@@ -4588,36 +5038,6 @@
         "signed": true,
         "recommended": false,
         "channel_name": "SLE11-HAE-SP1-Updates for x86_64"
-    },
-    {
-        "channel_label": "sle11-hae-sp1-pool-x86_64-vmware",
-        "parent_channel_label": "sles11-sp1-vmware-pool-x86_64",
-        "product_id": 967,
-        "repository_id": 946,
-        "parent_product_id": 996,
-        "root_product_id": 996,
-        "update_tag": "sleshasp1",
-        "url": "https://updates.suse.com/repo/$RCE/SLE11-HAE-SP1-Pool/sle-11-x86_64/",
-        "release_stage": "released",
-        "mandatory": true,
-        "signed": true,
-        "recommended": false,
-        "channel_name": "SLE11-HAE-SP1-Pool for x86_64 VMWare"
-    },
-    {
-        "channel_label": "sle11-hae-sp1-updates-x86_64-vmware",
-        "parent_channel_label": "sles11-sp1-vmware-pool-x86_64",
-        "product_id": 967,
-        "repository_id": 953,
-        "parent_product_id": 996,
-        "root_product_id": 996,
-        "update_tag": "sleshasp1",
-        "url": "https://updates.suse.com/repo/$RCE/SLE11-HAE-SP1-Updates/sle-11-x86_64/",
-        "release_stage": "released",
-        "mandatory": true,
-        "signed": true,
-        "recommended": false,
-        "channel_name": "SLE11-HAE-SP1-Updates for x86_64 VMWare"
     },
     {
         "channel_label": "sle11-hae-sp3-updates-x86_64",
@@ -7692,7 +8112,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates s390x"
+        "channel_name": "SLE-Manager-Tools12-Updates for s390x"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-s390x",
@@ -7707,7 +8127,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates s390x"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for s390x"
     },
     {
         "channel_label": "sle-manager-tools12-pool-s390x",
@@ -7722,7 +8142,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool s390x"
+        "channel_name": "SLE-Manager-Tools12-Pool for s390x"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-s390x",
@@ -7737,7 +8157,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool s390x"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for s390x"
     },
     {
         "channel_label": "sles12-updates-ppc64le",
@@ -7812,7 +8232,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates ppc64le"
+        "channel_name": "SLE-Manager-Tools12-Updates for ppc64le"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-ppc64le",
@@ -7827,7 +8247,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates ppc64le"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for ppc64le"
     },
     {
         "channel_label": "sle-manager-tools12-pool-ppc64le",
@@ -7842,7 +8262,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool ppc64le"
+        "channel_name": "SLE-Manager-Tools12-Pool for ppc64le"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-ppc64le",
@@ -7857,7 +8277,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool ppc64le"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for ppc64le"
     },
     {
         "channel_label": "sles12-updates-x86_64",
@@ -7932,7 +8352,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates x86_64"
+        "channel_name": "SLE-Manager-Tools12-Updates for x86_64"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-x86_64",
@@ -7947,7 +8367,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates x86_64"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for x86_64"
     },
     {
         "channel_label": "sle-manager-tools12-pool-x86_64",
@@ -7962,7 +8382,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool x86_64"
+        "channel_name": "SLE-Manager-Tools12-Pool for x86_64"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-x86_64",
@@ -7977,7 +8397,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool x86_64"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for x86_64"
     },
     {
         "channel_label": "sle-12-ga-desktop-nvidia-driver-x86_64",
@@ -8067,7 +8487,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates x86_64 SLED"
+        "channel_name": "SLE-Manager-Tools12-Updates for x86_64 SLED"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-x86_64-sled",
@@ -8082,7 +8502,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates x86_64 SLED"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for x86_64 SLED"
     },
     {
         "channel_label": "sle-manager-tools12-pool-x86_64-sled",
@@ -8097,7 +8517,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool x86_64 SLED"
+        "channel_name": "SLE-Manager-Tools12-Pool for x86_64 SLED"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-x86_64-sled",
@@ -8112,13 +8532,13 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool x86_64 SLED"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for x86_64 SLED"
     },
     {
         "channel_label": "rhel-x86_64-server-5",
         "parent_channel_label": null,
         "product_id": 1122,
-        "repository_id": -32,
+        "repository_id": -72,
         "parent_product_id": null,
         "root_product_id": 1122,
         "update_tag": null,
@@ -8133,7 +8553,7 @@
         "channel_label": "rhel-i386-server-5",
         "parent_channel_label": null,
         "product_id": 1122,
-        "repository_id": -31,
+        "repository_id": -71,
         "parent_product_id": null,
         "root_product_id": 1122,
         "update_tag": null,
@@ -9048,7 +9468,7 @@
         "channel_label": "rhel-x86_64-server-6",
         "parent_channel_label": null,
         "product_id": 1138,
-        "repository_id": -34,
+        "repository_id": -74,
         "parent_product_id": null,
         "root_product_id": 1138,
         "update_tag": null,
@@ -9063,7 +9483,7 @@
         "channel_label": "rhel-i386-server-6",
         "parent_channel_label": null,
         "product_id": 1138,
-        "repository_id": -33,
+        "repository_id": -73,
         "parent_product_id": null,
         "root_product_id": 1138,
         "update_tag": null,
@@ -9597,7 +10017,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Updates for ppc64le SAP-SP1"
+        "channel_name": "SLE-Module-Legacy12-Updates for ppc64le SAP SP1"
     },
     {
         "channel_label": "sle-module-legacy12-debuginfo-updates-ppc64le-sap-sp1",
@@ -9612,7 +10032,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Debuginfo-Updates for ppc64le SAP-SP1"
+        "channel_name": "SLE-Module-Legacy12-Debuginfo-Updates for ppc64le SAP SP1"
     },
     {
         "channel_label": "sle-module-legacy12-pool-ppc64le-sap-sp1",
@@ -9627,7 +10047,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Pool for ppc64le SAP-SP1"
+        "channel_name": "SLE-Module-Legacy12-Pool for ppc64le SAP SP1"
     },
     {
         "channel_label": "sle-module-legacy12-debuginfo-pool-ppc64le-sap-sp1",
@@ -9642,7 +10062,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Debuginfo-Pool for ppc64le SAP-SP1"
+        "channel_name": "SLE-Module-Legacy12-Debuginfo-Pool for ppc64le SAP SP1"
     },
     {
         "channel_label": "sle-module-legacy12-updates-ppc64le-sap-sp2",
@@ -9657,7 +10077,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Updates for ppc64le SAP-SP2"
+        "channel_name": "SLE-Module-Legacy12-Updates for ppc64le SAP SP2"
     },
     {
         "channel_label": "sle-module-legacy12-debuginfo-updates-ppc64le-sap-sp2",
@@ -9672,7 +10092,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Debuginfo-Updates for ppc64le SAP-SP2"
+        "channel_name": "SLE-Module-Legacy12-Debuginfo-Updates for ppc64le SAP SP2"
     },
     {
         "channel_label": "sle-module-legacy12-pool-ppc64le-sap-sp2",
@@ -9687,7 +10107,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Pool for ppc64le SAP-SP2"
+        "channel_name": "SLE-Module-Legacy12-Pool for ppc64le SAP SP2"
     },
     {
         "channel_label": "sle-module-legacy12-debuginfo-pool-ppc64le-sap-sp2",
@@ -9702,7 +10122,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Debuginfo-Pool for ppc64le SAP-SP2"
+        "channel_name": "SLE-Module-Legacy12-Debuginfo-Pool for ppc64le SAP SP2"
     },
     {
         "channel_label": "sle-module-legacy12-updates-ppc64le-sap-sp3",
@@ -9717,7 +10137,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Updates for ppc64le SAP-SP3"
+        "channel_name": "SLE-Module-Legacy12-Updates for ppc64le SAP SP3"
     },
     {
         "channel_label": "sle-module-legacy12-debuginfo-updates-ppc64le-sap-sp3",
@@ -9732,7 +10152,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Debuginfo-Updates for ppc64le SAP-SP3"
+        "channel_name": "SLE-Module-Legacy12-Debuginfo-Updates for ppc64le SAP SP3"
     },
     {
         "channel_label": "sle-module-legacy12-pool-ppc64le-sap-sp3",
@@ -9747,7 +10167,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Pool for ppc64le SAP-SP3"
+        "channel_name": "SLE-Module-Legacy12-Pool for ppc64le SAP SP3"
     },
     {
         "channel_label": "sle-module-legacy12-debuginfo-pool-ppc64le-sap-sp3",
@@ -9762,7 +10182,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Debuginfo-Pool for ppc64le SAP-SP3"
+        "channel_name": "SLE-Module-Legacy12-Debuginfo-Pool for ppc64le SAP SP3"
     },
     {
         "channel_label": "sle-module-legacy12-updates-ppc64le-sp4",
@@ -9773,7 +10193,7 @@
         "root_product_id": 1626,
         "update_tag": "SLE-Module-Legacy",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/12/ppc64le/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -9788,7 +10208,7 @@
         "root_product_id": 1626,
         "update_tag": "SLE-Module-Legacy",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/12/ppc64le/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -9803,7 +10223,7 @@
         "root_product_id": 1626,
         "update_tag": "SLE-Module-Legacy",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/12/ppc64le/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -9818,7 +10238,7 @@
         "root_product_id": 1626,
         "update_tag": "SLE-Module-Legacy",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/12/ppc64le/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -9833,11 +10253,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-Module-Legacy",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/12/ppc64le/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Updates for ppc64le SAP-SP4"
+        "channel_name": "SLE-Module-Legacy12-Updates for ppc64le SAP SP4"
     },
     {
         "channel_label": "sle-module-legacy12-debuginfo-updates-ppc64le-sap-sp4",
@@ -9848,11 +10268,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-Module-Legacy",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/12/ppc64le/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Debuginfo-Updates for ppc64le SAP-SP4"
+        "channel_name": "SLE-Module-Legacy12-Debuginfo-Updates for ppc64le SAP SP4"
     },
     {
         "channel_label": "sle-module-legacy12-pool-ppc64le-sap-sp4",
@@ -9863,11 +10283,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-Module-Legacy",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/12/ppc64le/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Pool for ppc64le SAP-SP4"
+        "channel_name": "SLE-Module-Legacy12-Pool for ppc64le SAP SP4"
     },
     {
         "channel_label": "sle-module-legacy12-debuginfo-pool-ppc64le-sap-sp4",
@@ -9878,11 +10298,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-Module-Legacy",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/12/ppc64le/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Debuginfo-Pool for ppc64le SAP-SP4"
+        "channel_name": "SLE-Module-Legacy12-Debuginfo-Pool for ppc64le SAP SP4"
     },
     {
         "channel_label": "sle-module-legacy12-updates-s390x",
@@ -10133,7 +10553,7 @@
         "root_product_id": 1627,
         "update_tag": "SLE-Module-Legacy",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/12/s390x/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -10148,7 +10568,7 @@
         "root_product_id": 1627,
         "update_tag": "SLE-Module-Legacy",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/12/s390x/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -10163,7 +10583,7 @@
         "root_product_id": 1627,
         "update_tag": "SLE-Module-Legacy",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/12/s390x/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -10178,7 +10598,7 @@
         "root_product_id": 1627,
         "update_tag": "SLE-Module-Legacy",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/12/s390x/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -10377,7 +10797,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Updates for x86_64 SAP-SP1"
+        "channel_name": "SLE-Module-Legacy12-Updates for x86_64 SAP SP1"
     },
     {
         "channel_label": "sle-module-legacy12-debuginfo-updates-x86_64-sap-sp1",
@@ -10392,7 +10812,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Debuginfo-Updates for x86_64 SAP-SP1"
+        "channel_name": "SLE-Module-Legacy12-Debuginfo-Updates for x86_64 SAP SP1"
     },
     {
         "channel_label": "sle-module-legacy12-pool-x86_64-sap-sp1",
@@ -10407,7 +10827,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Pool for x86_64 SAP-SP1"
+        "channel_name": "SLE-Module-Legacy12-Pool for x86_64 SAP SP1"
     },
     {
         "channel_label": "sle-module-legacy12-debuginfo-pool-x86_64-sap-sp1",
@@ -10422,7 +10842,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Debuginfo-Pool for x86_64 SAP-SP1"
+        "channel_name": "SLE-Module-Legacy12-Debuginfo-Pool for x86_64 SAP SP1"
     },
     {
         "channel_label": "sle-module-legacy12-updates-x86_64-sp2",
@@ -10497,7 +10917,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Updates for x86_64 SAP-SP2"
+        "channel_name": "SLE-Module-Legacy12-Updates for x86_64 SAP SP2"
     },
     {
         "channel_label": "sle-module-legacy12-debuginfo-updates-x86_64-sap-sp2",
@@ -10512,7 +10932,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Debuginfo-Updates for x86_64 SAP-SP2"
+        "channel_name": "SLE-Module-Legacy12-Debuginfo-Updates for x86_64 SAP SP2"
     },
     {
         "channel_label": "sle-module-legacy12-pool-x86_64-sap-sp2",
@@ -10527,7 +10947,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Pool for x86_64 SAP-SP2"
+        "channel_name": "SLE-Module-Legacy12-Pool for x86_64 SAP SP2"
     },
     {
         "channel_label": "sle-module-legacy12-debuginfo-pool-x86_64-sap-sp2",
@@ -10542,7 +10962,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Debuginfo-Pool for x86_64 SAP-SP2"
+        "channel_name": "SLE-Module-Legacy12-Debuginfo-Pool for x86_64 SAP SP2"
     },
     {
         "channel_label": "sle-module-legacy12-updates-x86_64-sp3",
@@ -10617,7 +11037,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Updates for x86_64 SAP-SP3"
+        "channel_name": "SLE-Module-Legacy12-Updates for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-module-legacy12-debuginfo-updates-x86_64-sap-sp3",
@@ -10632,7 +11052,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Debuginfo-Updates for x86_64 SAP-SP3"
+        "channel_name": "SLE-Module-Legacy12-Debuginfo-Updates for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-module-legacy12-pool-x86_64-sap-sp3",
@@ -10647,7 +11067,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Pool for x86_64 SAP-SP3"
+        "channel_name": "SLE-Module-Legacy12-Pool for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-module-legacy12-debuginfo-pool-x86_64-sap-sp3",
@@ -10662,7 +11082,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Debuginfo-Pool for x86_64 SAP-SP3"
+        "channel_name": "SLE-Module-Legacy12-Debuginfo-Pool for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-module-legacy12-updates-x86_64-sp4",
@@ -10673,7 +11093,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Module-Legacy",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/12/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -10688,7 +11108,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Module-Legacy",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/12/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -10703,7 +11123,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Module-Legacy",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/12/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -10718,7 +11138,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Module-Legacy",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/12/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -10737,7 +11157,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLE-Module-Legacy12-Updates for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-module-legacy12-debuginfo-updates-x86_64-hpc-sp2",
@@ -10752,7 +11172,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Debuginfo-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLE-Module-Legacy12-Debuginfo-Updates for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-module-legacy12-pool-x86_64-hpc-sp2",
@@ -10767,7 +11187,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLE-Module-Legacy12-Pool for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-module-legacy12-debuginfo-pool-x86_64-hpc-sp2",
@@ -10782,7 +11202,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Debuginfo-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLE-Module-Legacy12-Debuginfo-Pool for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-module-legacy12-updates-x86_64-hpc-sp3",
@@ -10797,7 +11217,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLE-Module-Legacy12-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-module-legacy12-debuginfo-updates-x86_64-hpc-sp3",
@@ -10812,7 +11232,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Debuginfo-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLE-Module-Legacy12-Debuginfo-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-module-legacy12-pool-x86_64-hpc-sp3",
@@ -10827,7 +11247,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Pool for x86_64 HPC-SP3"
+        "channel_name": "SLE-Module-Legacy12-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-module-legacy12-debuginfo-pool-x86_64-hpc-sp3",
@@ -10842,7 +11262,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Debuginfo-Pool for x86_64 HPC-SP3"
+        "channel_name": "SLE-Module-Legacy12-Debuginfo-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-module-legacy12-updates-x86_64-sap-sp4",
@@ -10853,11 +11273,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-Module-Legacy",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/12/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Updates for x86_64 SAP-SP4"
+        "channel_name": "SLE-Module-Legacy12-Updates for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-module-legacy12-debuginfo-updates-x86_64-sap-sp4",
@@ -10868,11 +11288,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-Module-Legacy",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/12/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Debuginfo-Updates for x86_64 SAP-SP4"
+        "channel_name": "SLE-Module-Legacy12-Debuginfo-Updates for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-module-legacy12-pool-x86_64-sap-sp4",
@@ -10883,11 +11303,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-Module-Legacy",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/12/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Pool for x86_64 SAP-SP4"
+        "channel_name": "SLE-Module-Legacy12-Pool for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-module-legacy12-debuginfo-pool-x86_64-sap-sp4",
@@ -10898,11 +11318,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-Module-Legacy",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/12/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Debuginfo-Pool for x86_64 SAP-SP4"
+        "channel_name": "SLE-Module-Legacy12-Debuginfo-Pool for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-module-legacy12-updates-x86_64-hpc-sp4",
@@ -10913,11 +11333,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Module-Legacy",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/12/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Updates for x86_64 HPC-SP4"
+        "channel_name": "SLE-Module-Legacy12-Updates for x86_64 HPC SP4"
     },
     {
         "channel_label": "sle-module-legacy12-debuginfo-updates-x86_64-hpc-sp4",
@@ -10928,11 +11348,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Module-Legacy",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/12/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Debuginfo-Updates for x86_64 HPC-SP4"
+        "channel_name": "SLE-Module-Legacy12-Debuginfo-Updates for x86_64 HPC SP4"
     },
     {
         "channel_label": "sle-module-legacy12-pool-x86_64-hpc-sp4",
@@ -10943,11 +11363,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Module-Legacy",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/12/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Pool for x86_64 HPC-SP4"
+        "channel_name": "SLE-Module-Legacy12-Pool for x86_64 HPC SP4"
     },
     {
         "channel_label": "sle-module-legacy12-debuginfo-pool-x86_64-hpc-sp4",
@@ -10958,11 +11378,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Module-Legacy",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/12/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Legacy12-Debuginfo-Pool for x86_64 HPC-SP4"
+        "channel_name": "SLE-Module-Legacy12-Debuginfo-Pool for x86_64 HPC SP4"
     },
     {
         "channel_label": "sle-module-web-scripting12-updates-ppc64le",
@@ -11217,7 +11637,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Updates for ppc64le SAP-SP1"
+        "channel_name": "SLE-Module-Web-Scripting12-Updates for ppc64le SAP SP1"
     },
     {
         "channel_label": "sle-module-web-scripting12-debuginfo-updates-ppc64le-sap-sp1",
@@ -11232,7 +11652,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Updates for ppc64le SAP-SP1"
+        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Updates for ppc64le SAP SP1"
     },
     {
         "channel_label": "sle-module-web-scripting12-pool-ppc64le-sap-sp1",
@@ -11247,7 +11667,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Pool for ppc64le SAP-SP1"
+        "channel_name": "SLE-Module-Web-Scripting12-Pool for ppc64le SAP SP1"
     },
     {
         "channel_label": "sle-module-web-scripting12-debuginfo-pool-ppc64le-sap-sp1",
@@ -11262,7 +11682,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Pool for ppc64le SAP-SP1"
+        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Pool for ppc64le SAP SP1"
     },
     {
         "channel_label": "sle-module-web-scripting12-updates-ppc64le-sap-sp2",
@@ -11277,7 +11697,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Updates for ppc64le SAP-SP2"
+        "channel_name": "SLE-Module-Web-Scripting12-Updates for ppc64le SAP SP2"
     },
     {
         "channel_label": "sle-module-web-scripting12-debuginfo-updates-ppc64le-sap-sp2",
@@ -11292,7 +11712,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Updates for ppc64le SAP-SP2"
+        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Updates for ppc64le SAP SP2"
     },
     {
         "channel_label": "sle-module-web-scripting12-pool-ppc64le-sap-sp2",
@@ -11307,7 +11727,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Pool for ppc64le SAP-SP2"
+        "channel_name": "SLE-Module-Web-Scripting12-Pool for ppc64le SAP SP2"
     },
     {
         "channel_label": "sle-module-web-scripting12-debuginfo-pool-ppc64le-sap-sp2",
@@ -11322,7 +11742,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Pool for ppc64le SAP-SP2"
+        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Pool for ppc64le SAP SP2"
     },
     {
         "channel_label": "sle-module-web-scripting12-updates-ppc64le-sap-sp3",
@@ -11337,7 +11757,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Updates for ppc64le SAP-SP3"
+        "channel_name": "SLE-Module-Web-Scripting12-Updates for ppc64le SAP SP3"
     },
     {
         "channel_label": "sle-module-web-scripting12-debuginfo-updates-ppc64le-sap-sp3",
@@ -11352,7 +11772,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Updates for ppc64le SAP-SP3"
+        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Updates for ppc64le SAP SP3"
     },
     {
         "channel_label": "sle-module-web-scripting12-pool-ppc64le-sap-sp3",
@@ -11367,7 +11787,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Pool for ppc64le SAP-SP3"
+        "channel_name": "SLE-Module-Web-Scripting12-Pool for ppc64le SAP SP3"
     },
     {
         "channel_label": "sle-module-web-scripting12-debuginfo-pool-ppc64le-sap-sp3",
@@ -11382,7 +11802,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Pool for ppc64le SAP-SP3"
+        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Pool for ppc64le SAP SP3"
     },
     {
         "channel_label": "sle-module-web-scripting12-updates-ppc64le-sp4",
@@ -11393,7 +11813,7 @@
         "root_product_id": 1626,
         "update_tag": "SLE-Module-Web-Scripting",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/12/ppc64le/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -11408,7 +11828,7 @@
         "root_product_id": 1626,
         "update_tag": "SLE-Module-Web-Scripting",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/12/ppc64le/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -11423,7 +11843,7 @@
         "root_product_id": 1626,
         "update_tag": "SLE-Module-Web-Scripting",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/12/ppc64le/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -11438,7 +11858,7 @@
         "root_product_id": 1626,
         "update_tag": "SLE-Module-Web-Scripting",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/12/ppc64le/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -11453,11 +11873,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-Module-Web-Scripting",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/12/ppc64le/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Updates for ppc64le SAP-SP4"
+        "channel_name": "SLE-Module-Web-Scripting12-Updates for ppc64le SAP SP4"
     },
     {
         "channel_label": "sle-module-web-scripting12-debuginfo-updates-ppc64le-sap-sp4",
@@ -11468,11 +11888,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-Module-Web-Scripting",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/12/ppc64le/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Updates for ppc64le SAP-SP4"
+        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Updates for ppc64le SAP SP4"
     },
     {
         "channel_label": "sle-module-web-scripting12-pool-ppc64le-sap-sp4",
@@ -11483,11 +11903,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-Module-Web-Scripting",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/12/ppc64le/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Pool for ppc64le SAP-SP4"
+        "channel_name": "SLE-Module-Web-Scripting12-Pool for ppc64le SAP SP4"
     },
     {
         "channel_label": "sle-module-web-scripting12-debuginfo-pool-ppc64le-sap-sp4",
@@ -11498,11 +11918,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-Module-Web-Scripting",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/12/ppc64le/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Pool for ppc64le SAP-SP4"
+        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Pool for ppc64le SAP SP4"
     },
     {
         "channel_label": "sle-module-web-scripting12-updates-s390x",
@@ -11753,7 +12173,7 @@
         "root_product_id": 1627,
         "update_tag": "SLE-Module-Web-Scripting",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/12/s390x/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -11768,7 +12188,7 @@
         "root_product_id": 1627,
         "update_tag": "SLE-Module-Web-Scripting",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/12/s390x/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -11783,7 +12203,7 @@
         "root_product_id": 1627,
         "update_tag": "SLE-Module-Web-Scripting",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/12/s390x/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -11798,7 +12218,7 @@
         "root_product_id": 1627,
         "update_tag": "SLE-Module-Web-Scripting",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/12/s390x/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -11997,7 +12417,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Updates for x86_64 SAP-SP1"
+        "channel_name": "SLE-Module-Web-Scripting12-Updates for x86_64 SAP SP1"
     },
     {
         "channel_label": "sle-module-web-scripting12-debuginfo-updates-x86_64-sap-sp1",
@@ -12012,7 +12432,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Updates for x86_64 SAP-SP1"
+        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Updates for x86_64 SAP SP1"
     },
     {
         "channel_label": "sle-module-web-scripting12-pool-x86_64-sap-sp1",
@@ -12027,7 +12447,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Pool for x86_64 SAP-SP1"
+        "channel_name": "SLE-Module-Web-Scripting12-Pool for x86_64 SAP SP1"
     },
     {
         "channel_label": "sle-module-web-scripting12-debuginfo-pool-x86_64-sap-sp1",
@@ -12042,7 +12462,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Pool for x86_64 SAP-SP1"
+        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Pool for x86_64 SAP SP1"
     },
     {
         "channel_label": "sle-module-web-scripting12-updates-x86_64-sp2",
@@ -12117,7 +12537,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Updates for x86_64 SAP-SP2"
+        "channel_name": "SLE-Module-Web-Scripting12-Updates for x86_64 SAP SP2"
     },
     {
         "channel_label": "sle-module-web-scripting12-debuginfo-updates-x86_64-sap-sp2",
@@ -12132,7 +12552,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Updates for x86_64 SAP-SP2"
+        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Updates for x86_64 SAP SP2"
     },
     {
         "channel_label": "sle-module-web-scripting12-pool-x86_64-sap-sp2",
@@ -12147,7 +12567,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Pool for x86_64 SAP-SP2"
+        "channel_name": "SLE-Module-Web-Scripting12-Pool for x86_64 SAP SP2"
     },
     {
         "channel_label": "sle-module-web-scripting12-debuginfo-pool-x86_64-sap-sp2",
@@ -12162,7 +12582,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Pool for x86_64 SAP-SP2"
+        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Pool for x86_64 SAP SP2"
     },
     {
         "channel_label": "sle-module-web-scripting12-updates-x86_64-sp3",
@@ -12237,7 +12657,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Updates for x86_64 SAP-SP3"
+        "channel_name": "SLE-Module-Web-Scripting12-Updates for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-module-web-scripting12-debuginfo-updates-x86_64-sap-sp3",
@@ -12252,7 +12672,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Updates for x86_64 SAP-SP3"
+        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Updates for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-module-web-scripting12-pool-x86_64-sap-sp3",
@@ -12267,7 +12687,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Pool for x86_64 SAP-SP3"
+        "channel_name": "SLE-Module-Web-Scripting12-Pool for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-module-web-scripting12-debuginfo-pool-x86_64-sap-sp3",
@@ -12282,7 +12702,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Pool for x86_64 SAP-SP3"
+        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Pool for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-module-web-scripting12-updates-x86_64-sp4",
@@ -12293,7 +12713,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Module-Web-Scripting",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/12/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -12308,7 +12728,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Module-Web-Scripting",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/12/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -12323,7 +12743,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Module-Web-Scripting",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/12/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -12338,7 +12758,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Module-Web-Scripting",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/12/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -12357,7 +12777,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLE-Module-Web-Scripting12-Updates for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-module-web-scripting12-debuginfo-updates-x86_64-hpc-sp2",
@@ -12372,7 +12792,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Updates for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-module-web-scripting12-pool-x86_64-hpc-sp2",
@@ -12387,7 +12807,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLE-Module-Web-Scripting12-Pool for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-module-web-scripting12-debuginfo-pool-x86_64-hpc-sp2",
@@ -12402,7 +12822,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Pool for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-module-web-scripting12-updates-x86_64-hpc-sp3",
@@ -12417,7 +12837,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLE-Module-Web-Scripting12-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-module-web-scripting12-debuginfo-updates-x86_64-hpc-sp3",
@@ -12432,7 +12852,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-module-web-scripting12-pool-x86_64-hpc-sp3",
@@ -12447,7 +12867,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Pool for x86_64 HPC-SP3"
+        "channel_name": "SLE-Module-Web-Scripting12-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-module-web-scripting12-debuginfo-pool-x86_64-hpc-sp3",
@@ -12462,7 +12882,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Pool for x86_64 HPC-SP3"
+        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-module-web-scripting12-updates-x86_64-sap-sp4",
@@ -12473,11 +12893,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-Module-Web-Scripting",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/12/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Updates for x86_64 SAP-SP4"
+        "channel_name": "SLE-Module-Web-Scripting12-Updates for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-module-web-scripting12-debuginfo-updates-x86_64-sap-sp4",
@@ -12488,11 +12908,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-Module-Web-Scripting",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/12/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Updates for x86_64 SAP-SP4"
+        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Updates for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-module-web-scripting12-pool-x86_64-sap-sp4",
@@ -12503,11 +12923,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-Module-Web-Scripting",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/12/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Pool for x86_64 SAP-SP4"
+        "channel_name": "SLE-Module-Web-Scripting12-Pool for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-module-web-scripting12-debuginfo-pool-x86_64-sap-sp4",
@@ -12518,11 +12938,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-Module-Web-Scripting",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/12/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Pool for x86_64 SAP-SP4"
+        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Pool for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-module-web-scripting12-updates-x86_64-hpc-sp4",
@@ -12533,11 +12953,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Module-Web-Scripting",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/12/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Updates for x86_64 HPC-SP4"
+        "channel_name": "SLE-Module-Web-Scripting12-Updates for x86_64 HPC SP4"
     },
     {
         "channel_label": "sle-module-web-scripting12-debuginfo-updates-x86_64-hpc-sp4",
@@ -12548,11 +12968,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Module-Web-Scripting",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/12/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Updates for x86_64 HPC-SP4"
+        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Updates for x86_64 HPC SP4"
     },
     {
         "channel_label": "sle-module-web-scripting12-pool-x86_64-hpc-sp4",
@@ -12563,11 +12983,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Module-Web-Scripting",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/12/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Pool for x86_64 HPC-SP4"
+        "channel_name": "SLE-Module-Web-Scripting12-Pool for x86_64 HPC SP4"
     },
     {
         "channel_label": "sle-module-web-scripting12-debuginfo-pool-x86_64-hpc-sp4",
@@ -12578,11 +12998,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Module-Web-Scripting",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/12/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Pool for x86_64 HPC-SP4"
+        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Pool for x86_64 HPC SP4"
     },
     {
         "channel_label": "sle-ha-geo12-updates-s390x",
@@ -15777,7 +16197,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Updates for x86_64 SAP-SP1"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Updates for x86_64 SAP SP1"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-debuginfo-updates-x86_64-sap-sp1",
@@ -15792,7 +16212,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Updates for x86_64 SAP-SP1"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Updates for x86_64 SAP SP1"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-pool-x86_64-sap-sp1",
@@ -15807,7 +16227,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Pool for x86_64 SAP-SP1"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Pool for x86_64 SAP SP1"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-debuginfo-pool-x86_64-sap-sp1",
@@ -15822,7 +16242,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Pool for x86_64 SAP-SP1"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Pool for x86_64 SAP SP1"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-updates-x86_64-sp2",
@@ -15897,7 +16317,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Updates for x86_64 SAP-SP2"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Updates for x86_64 SAP SP2"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-debuginfo-updates-x86_64-sap-sp2",
@@ -15912,7 +16332,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Updates for x86_64 SAP-SP2"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Updates for x86_64 SAP SP2"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-pool-x86_64-sap-sp2",
@@ -15927,7 +16347,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Pool for x86_64 SAP-SP2"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Pool for x86_64 SAP SP2"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-debuginfo-pool-x86_64-sap-sp2",
@@ -15942,7 +16362,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Pool for x86_64 SAP-SP2"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Pool for x86_64 SAP SP2"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-updates-x86_64-sp3",
@@ -16017,7 +16437,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Updates for x86_64 SAP-SP3"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Updates for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-debuginfo-updates-x86_64-sap-sp3",
@@ -16032,7 +16452,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Updates for x86_64 SAP-SP3"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Updates for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-pool-x86_64-sap-sp3",
@@ -16047,7 +16467,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Pool for x86_64 SAP-SP3"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Pool for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-debuginfo-pool-x86_64-sap-sp3",
@@ -16062,7 +16482,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Pool for x86_64 SAP-SP3"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Pool for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-updates-x86_64-sp4",
@@ -16073,7 +16493,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Module-Adv-Systems-Management",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Adv-Systems-Management/12/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -16088,7 +16508,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Module-Adv-Systems-Management",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Adv-Systems-Management/12/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -16103,7 +16523,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Module-Adv-Systems-Management",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Adv-Systems-Management/12/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -16118,7 +16538,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Module-Adv-Systems-Management",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Adv-Systems-Management/12/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -16137,7 +16557,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Updates for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-debuginfo-updates-x86_64-hpc-sp2",
@@ -16152,7 +16572,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Updates for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-pool-x86_64-hpc-sp2",
@@ -16167,7 +16587,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Pool for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-debuginfo-pool-x86_64-hpc-sp2",
@@ -16182,7 +16602,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Pool for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-updates-x86_64-hpc-sp3",
@@ -16197,7 +16617,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-debuginfo-updates-x86_64-hpc-sp3",
@@ -16212,7 +16632,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-pool-x86_64-hpc-sp3",
@@ -16227,7 +16647,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Pool for x86_64 HPC-SP3"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-debuginfo-pool-x86_64-hpc-sp3",
@@ -16242,7 +16662,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Pool for x86_64 HPC-SP3"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-updates-x86_64-sap-sp4",
@@ -16253,11 +16673,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-Module-Adv-Systems-Management",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Adv-Systems-Management/12/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Updates for x86_64 SAP-SP4"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Updates for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-debuginfo-updates-x86_64-sap-sp4",
@@ -16268,11 +16688,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-Module-Adv-Systems-Management",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Adv-Systems-Management/12/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Updates for x86_64 SAP-SP4"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Updates for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-pool-x86_64-sap-sp4",
@@ -16283,11 +16703,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-Module-Adv-Systems-Management",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Adv-Systems-Management/12/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Pool for x86_64 SAP-SP4"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Pool for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-debuginfo-pool-x86_64-sap-sp4",
@@ -16298,11 +16718,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-Module-Adv-Systems-Management",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Adv-Systems-Management/12/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Pool for x86_64 SAP-SP4"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Pool for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-updates-x86_64-hpc-sp4",
@@ -16313,11 +16733,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Module-Adv-Systems-Management",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Adv-Systems-Management/12/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Updates for x86_64 HPC-SP4"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Updates for x86_64 HPC SP4"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-debuginfo-updates-x86_64-hpc-sp4",
@@ -16328,11 +16748,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Module-Adv-Systems-Management",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Adv-Systems-Management/12/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Updates for x86_64 HPC-SP4"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Updates for x86_64 HPC SP4"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-pool-x86_64-hpc-sp4",
@@ -16343,11 +16763,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Module-Adv-Systems-Management",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Adv-Systems-Management/12/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Pool for x86_64 HPC-SP4"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Pool for x86_64 HPC SP4"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-debuginfo-pool-x86_64-hpc-sp4",
@@ -16358,11 +16778,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Module-Adv-Systems-Management",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Adv-Systems-Management/12/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Pool for x86_64 HPC-SP4"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Pool for x86_64 HPC SP4"
     },
     {
         "channel_label": "sle-module-public-cloud12-updates-ppc64le",
@@ -16617,7 +17037,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Updates for ppc64le SAP-SP1"
+        "channel_name": "SLE-Module-Public-Cloud12-Updates for ppc64le SAP SP1"
     },
     {
         "channel_label": "sle-module-public-cloud12-debuginfo-updates-ppc64le-sap-sp1",
@@ -16632,7 +17052,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Updates for ppc64le SAP-SP1"
+        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Updates for ppc64le SAP SP1"
     },
     {
         "channel_label": "sle-module-public-cloud12-pool-ppc64le-sap-sp1",
@@ -16647,7 +17067,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Pool for ppc64le SAP-SP1"
+        "channel_name": "SLE-Module-Public-Cloud12-Pool for ppc64le SAP SP1"
     },
     {
         "channel_label": "sle-module-public-cloud12-debuginfo-pool-ppc64le-sap-sp1",
@@ -16662,7 +17082,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Pool for ppc64le SAP-SP1"
+        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Pool for ppc64le SAP SP1"
     },
     {
         "channel_label": "sle-module-public-cloud12-updates-ppc64le-sap-sp2",
@@ -16677,7 +17097,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Updates for ppc64le SAP-SP2"
+        "channel_name": "SLE-Module-Public-Cloud12-Updates for ppc64le SAP SP2"
     },
     {
         "channel_label": "sle-module-public-cloud12-debuginfo-updates-ppc64le-sap-sp2",
@@ -16692,7 +17112,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Updates for ppc64le SAP-SP2"
+        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Updates for ppc64le SAP SP2"
     },
     {
         "channel_label": "sle-module-public-cloud12-pool-ppc64le-sap-sp2",
@@ -16707,7 +17127,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Pool for ppc64le SAP-SP2"
+        "channel_name": "SLE-Module-Public-Cloud12-Pool for ppc64le SAP SP2"
     },
     {
         "channel_label": "sle-module-public-cloud12-debuginfo-pool-ppc64le-sap-sp2",
@@ -16722,7 +17142,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Pool for ppc64le SAP-SP2"
+        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Pool for ppc64le SAP SP2"
     },
     {
         "channel_label": "sle-module-public-cloud12-updates-ppc64le-sap-sp3",
@@ -16737,7 +17157,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Updates for ppc64le SAP-SP3"
+        "channel_name": "SLE-Module-Public-Cloud12-Updates for ppc64le SAP SP3"
     },
     {
         "channel_label": "sle-module-public-cloud12-debuginfo-updates-ppc64le-sap-sp3",
@@ -16752,7 +17172,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Updates for ppc64le SAP-SP3"
+        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Updates for ppc64le SAP SP3"
     },
     {
         "channel_label": "sle-module-public-cloud12-pool-ppc64le-sap-sp3",
@@ -16767,7 +17187,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Pool for ppc64le SAP-SP3"
+        "channel_name": "SLE-Module-Public-Cloud12-Pool for ppc64le SAP SP3"
     },
     {
         "channel_label": "sle-module-public-cloud12-debuginfo-pool-ppc64le-sap-sp3",
@@ -16782,7 +17202,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Pool for ppc64le SAP-SP3"
+        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Pool for ppc64le SAP SP3"
     },
     {
         "channel_label": "sle-module-public-cloud12-updates-ppc64le-sp4",
@@ -16793,7 +17213,7 @@
         "root_product_id": 1626,
         "update_tag": "SLE-Module-Public-Cloud",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/12/ppc64le/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -16808,7 +17228,7 @@
         "root_product_id": 1626,
         "update_tag": "SLE-Module-Public-Cloud",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/12/ppc64le/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -16823,7 +17243,7 @@
         "root_product_id": 1626,
         "update_tag": "SLE-Module-Public-Cloud",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/12/ppc64le/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -16838,7 +17258,7 @@
         "root_product_id": 1626,
         "update_tag": "SLE-Module-Public-Cloud",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/12/ppc64le/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -16853,11 +17273,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-Module-Public-Cloud",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/12/ppc64le/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Updates for ppc64le SAP-SP4"
+        "channel_name": "SLE-Module-Public-Cloud12-Updates for ppc64le SAP SP4"
     },
     {
         "channel_label": "sle-module-public-cloud12-debuginfo-updates-ppc64le-sap-sp4",
@@ -16868,11 +17288,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-Module-Public-Cloud",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/12/ppc64le/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Updates for ppc64le SAP-SP4"
+        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Updates for ppc64le SAP SP4"
     },
     {
         "channel_label": "sle-module-public-cloud12-pool-ppc64le-sap-sp4",
@@ -16883,11 +17303,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-Module-Public-Cloud",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/12/ppc64le/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Pool for ppc64le SAP-SP4"
+        "channel_name": "SLE-Module-Public-Cloud12-Pool for ppc64le SAP SP4"
     },
     {
         "channel_label": "sle-module-public-cloud12-debuginfo-pool-ppc64le-sap-sp4",
@@ -16898,11 +17318,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-Module-Public-Cloud",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/12/ppc64le/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Pool for ppc64le SAP-SP4"
+        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Pool for ppc64le SAP SP4"
     },
     {
         "channel_label": "sle-module-public-cloud12-updates-s390x",
@@ -17153,7 +17573,7 @@
         "root_product_id": 1627,
         "update_tag": "SLE-Module-Public-Cloud",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/12/s390x/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -17168,7 +17588,7 @@
         "root_product_id": 1627,
         "update_tag": "SLE-Module-Public-Cloud",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/12/s390x/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -17183,7 +17603,7 @@
         "root_product_id": 1627,
         "update_tag": "SLE-Module-Public-Cloud",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/12/s390x/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -17198,7 +17618,7 @@
         "root_product_id": 1627,
         "update_tag": "SLE-Module-Public-Cloud",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/12/s390x/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -17397,7 +17817,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Updates for x86_64 SAP-SP1"
+        "channel_name": "SLE-Module-Public-Cloud12-Updates for x86_64 SAP SP1"
     },
     {
         "channel_label": "sle-module-public-cloud12-debuginfo-updates-x86_64-sap-sp1",
@@ -17412,7 +17832,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Updates for x86_64 SAP-SP1"
+        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Updates for x86_64 SAP SP1"
     },
     {
         "channel_label": "sle-module-public-cloud12-pool-x86_64-sap-sp1",
@@ -17427,7 +17847,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Pool for x86_64 SAP-SP1"
+        "channel_name": "SLE-Module-Public-Cloud12-Pool for x86_64 SAP SP1"
     },
     {
         "channel_label": "sle-module-public-cloud12-debuginfo-pool-x86_64-sap-sp1",
@@ -17442,7 +17862,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Pool for x86_64 SAP-SP1"
+        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Pool for x86_64 SAP SP1"
     },
     {
         "channel_label": "sle-module-public-cloud12-updates-x86_64-sp2",
@@ -17517,7 +17937,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Updates for x86_64 SAP-SP2"
+        "channel_name": "SLE-Module-Public-Cloud12-Updates for x86_64 SAP SP2"
     },
     {
         "channel_label": "sle-module-public-cloud12-debuginfo-updates-x86_64-sap-sp2",
@@ -17532,7 +17952,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Updates for x86_64 SAP-SP2"
+        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Updates for x86_64 SAP SP2"
     },
     {
         "channel_label": "sle-module-public-cloud12-pool-x86_64-sap-sp2",
@@ -17547,7 +17967,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Pool for x86_64 SAP-SP2"
+        "channel_name": "SLE-Module-Public-Cloud12-Pool for x86_64 SAP SP2"
     },
     {
         "channel_label": "sle-module-public-cloud12-debuginfo-pool-x86_64-sap-sp2",
@@ -17562,7 +17982,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Pool for x86_64 SAP-SP2"
+        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Pool for x86_64 SAP SP2"
     },
     {
         "channel_label": "sle-module-public-cloud12-updates-x86_64-sp3",
@@ -17637,7 +18057,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Updates for x86_64 SAP-SP3"
+        "channel_name": "SLE-Module-Public-Cloud12-Updates for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-module-public-cloud12-debuginfo-updates-x86_64-sap-sp3",
@@ -17652,7 +18072,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Updates for x86_64 SAP-SP3"
+        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Updates for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-module-public-cloud12-pool-x86_64-sap-sp3",
@@ -17667,7 +18087,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Pool for x86_64 SAP-SP3"
+        "channel_name": "SLE-Module-Public-Cloud12-Pool for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-module-public-cloud12-debuginfo-pool-x86_64-sap-sp3",
@@ -17682,7 +18102,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Pool for x86_64 SAP-SP3"
+        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Pool for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-module-public-cloud12-updates-x86_64-sp4",
@@ -17693,7 +18113,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Module-Public-Cloud",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/12/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -17708,7 +18128,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Module-Public-Cloud",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/12/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -17723,7 +18143,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Module-Public-Cloud",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/12/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -17738,7 +18158,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Module-Public-Cloud",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/12/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -17757,7 +18177,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLE-Module-Public-Cloud12-Updates for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-module-public-cloud12-debuginfo-updates-x86_64-hpc-sp2",
@@ -17772,7 +18192,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Updates for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-module-public-cloud12-pool-x86_64-hpc-sp2",
@@ -17787,7 +18207,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLE-Module-Public-Cloud12-Pool for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-module-public-cloud12-debuginfo-pool-x86_64-hpc-sp2",
@@ -17802,7 +18222,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Pool for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-module-public-cloud12-updates-x86_64-hpc-sp3",
@@ -17817,7 +18237,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLE-Module-Public-Cloud12-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-module-public-cloud12-debuginfo-updates-x86_64-hpc-sp3",
@@ -17832,7 +18252,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-module-public-cloud12-pool-x86_64-hpc-sp3",
@@ -17847,7 +18267,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Pool for x86_64 HPC-SP3"
+        "channel_name": "SLE-Module-Public-Cloud12-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-module-public-cloud12-debuginfo-pool-x86_64-hpc-sp3",
@@ -17862,7 +18282,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Pool for x86_64 HPC-SP3"
+        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-module-public-cloud12-updates-x86_64-sap-sp4",
@@ -17873,11 +18293,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-Module-Public-Cloud",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/12/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Updates for x86_64 SAP-SP4"
+        "channel_name": "SLE-Module-Public-Cloud12-Updates for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-module-public-cloud12-debuginfo-updates-x86_64-sap-sp4",
@@ -17888,11 +18308,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-Module-Public-Cloud",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/12/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Updates for x86_64 SAP-SP4"
+        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Updates for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-module-public-cloud12-pool-x86_64-sap-sp4",
@@ -17903,11 +18323,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-Module-Public-Cloud",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/12/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Pool for x86_64 SAP-SP4"
+        "channel_name": "SLE-Module-Public-Cloud12-Pool for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-module-public-cloud12-debuginfo-pool-x86_64-sap-sp4",
@@ -17918,11 +18338,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-Module-Public-Cloud",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/12/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Pool for x86_64 SAP-SP4"
+        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Pool for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-module-public-cloud12-updates-x86_64-hpc-sp4",
@@ -17933,11 +18353,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Module-Public-Cloud",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/12/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Updates for x86_64 HPC-SP4"
+        "channel_name": "SLE-Module-Public-Cloud12-Updates for x86_64 HPC SP4"
     },
     {
         "channel_label": "sle-module-public-cloud12-debuginfo-updates-x86_64-hpc-sp4",
@@ -17948,11 +18368,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Module-Public-Cloud",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/12/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Updates for x86_64 HPC-SP4"
+        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Updates for x86_64 HPC SP4"
     },
     {
         "channel_label": "sle-module-public-cloud12-pool-x86_64-hpc-sp4",
@@ -17963,11 +18383,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Module-Public-Cloud",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/12/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Pool for x86_64 HPC-SP4"
+        "channel_name": "SLE-Module-Public-Cloud12-Pool for x86_64 HPC SP4"
     },
     {
         "channel_label": "sle-module-public-cloud12-debuginfo-pool-x86_64-hpc-sp4",
@@ -17978,11 +18398,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Module-Public-Cloud",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/12/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Pool for x86_64 HPC-SP4"
+        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Pool for x86_64 HPC SP4"
     },
     {
         "channel_label": "suse-cloud-4-pool-x86_64",
@@ -18567,7 +18987,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "IBM-DLPAR-SDK"
+        "channel_name": "IBM-DLPAR-SDK for ppc64le"
     },
     {
         "channel_label": "ibm-dlpar-adv-toolchain",
@@ -18582,7 +19002,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "IBM-DLPAR-Adv-Toolchain"
+        "channel_name": "IBM-DLPAR-Adv-Toolchain for ppc64le"
     },
     {
         "channel_label": "ibm-dlpar-sdk-sp1",
@@ -18597,7 +19017,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "IBM-DLPAR-SDK SP1"
+        "channel_name": "IBM-DLPAR-SDK for ppc64le SP1"
     },
     {
         "channel_label": "ibm-dlpar-adv-toolchain-sp1",
@@ -18612,7 +19032,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "IBM-DLPAR-Adv-Toolchain SP1"
+        "channel_name": "IBM-DLPAR-Adv-Toolchain for ppc64le SP1"
     },
     {
         "channel_label": "ibm-dlpar-sdk-sp2",
@@ -18627,7 +19047,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "IBM-DLPAR-SDK SP2"
+        "channel_name": "IBM-DLPAR-SDK for ppc64le SP2"
     },
     {
         "channel_label": "ibm-dlpar-adv-toolchain-sp2",
@@ -18642,7 +19062,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "IBM-DLPAR-Adv-Toolchain SP2"
+        "channel_name": "IBM-DLPAR-Adv-Toolchain for ppc64le SP2"
     },
     {
         "channel_label": "ibm-dlpar-sdk-sp3",
@@ -18657,7 +19077,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "IBM-DLPAR-SDK SP3"
+        "channel_name": "IBM-DLPAR-SDK for ppc64le SP3"
     },
     {
         "channel_label": "ibm-dlpar-adv-toolchain-sp3",
@@ -18672,7 +19092,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "IBM-DLPAR-Adv-Toolchain SP3"
+        "channel_name": "IBM-DLPAR-Adv-Toolchain for ppc64le SP3"
     },
     {
         "channel_label": "ibm-dlpar-sdk-sap-sp1",
@@ -18687,7 +19107,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "IBM-DLPAR-SDK SAP-SP1"
+        "channel_name": "IBM-DLPAR-SDK for ppc64le SAP SP1"
     },
     {
         "channel_label": "ibm-dlpar-adv-toolchain-sap-sp1",
@@ -18702,7 +19122,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "IBM-DLPAR-Adv-Toolchain SAP-SP1"
+        "channel_name": "IBM-DLPAR-Adv-Toolchain for ppc64le SAP SP1"
     },
     {
         "channel_label": "ibm-dlpar-sdk-sap-sp2",
@@ -18717,7 +19137,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "IBM-DLPAR-SDK SAP-SP2"
+        "channel_name": "IBM-DLPAR-SDK for ppc64le SAP SP2"
     },
     {
         "channel_label": "ibm-dlpar-adv-toolchain-sap-sp2",
@@ -18732,7 +19152,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "IBM-DLPAR-Adv-Toolchain SAP-SP2"
+        "channel_name": "IBM-DLPAR-Adv-Toolchain for ppc64le SAP SP2"
     },
     {
         "channel_label": "ibm-dlpar-sdk-sap-sp3",
@@ -18747,7 +19167,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "IBM-DLPAR-SDK SAP-SP3"
+        "channel_name": "IBM-DLPAR-SDK for ppc64le SAP SP3"
     },
     {
         "channel_label": "ibm-dlpar-adv-toolchain-sap-sp3",
@@ -18762,7 +19182,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "IBM-DLPAR-Adv-Toolchain SAP-SP3"
+        "channel_name": "IBM-DLPAR-Adv-Toolchain for ppc64le SAP SP3"
     },
     {
         "channel_label": "ibm-dlpar-sdk-sp4",
@@ -18777,7 +19197,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "IBM-DLPAR-SDK SP4"
+        "channel_name": "IBM-DLPAR-SDK for ppc64le SP4"
     },
     {
         "channel_label": "ibm-dlpar-adv-toolchain-sp4",
@@ -18792,7 +19212,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "IBM-DLPAR-Adv-Toolchain SP4"
+        "channel_name": "IBM-DLPAR-Adv-Toolchain for ppc64le SP4"
     },
     {
         "channel_label": "ibm-dlpar-sdk-sap-sp4",
@@ -18807,7 +19227,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "IBM-DLPAR-SDK SAP-SP4"
+        "channel_name": "IBM-DLPAR-SDK for ppc64le SAP SP4"
     },
     {
         "channel_label": "ibm-dlpar-adv-toolchain-sap-sp4",
@@ -18822,7 +19242,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "IBM-DLPAR-Adv-Toolchain SAP-SP4"
+        "channel_name": "IBM-DLPAR-Adv-Toolchain for ppc64le SAP SP4"
     },
     {
         "channel_label": "ibm-dlpar-utils",
@@ -18837,7 +19257,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "IBM-DLPAR-utils"
+        "channel_name": "IBM-DLPAR-utils for ppc64le"
     },
     {
         "channel_label": "ibm-dlpar-utils-sp1",
@@ -18852,7 +19272,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "IBM-DLPAR-utils SP1"
+        "channel_name": "IBM-DLPAR-utils for ppc64le SP1"
     },
     {
         "channel_label": "ibm-dlpar-utils-sp2",
@@ -18867,7 +19287,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "IBM-DLPAR-utils SP2"
+        "channel_name": "IBM-DLPAR-utils for ppc64le SP2"
     },
     {
         "channel_label": "ibm-dlpar-utils-sp3",
@@ -18882,7 +19302,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "IBM-DLPAR-utils SP3"
+        "channel_name": "IBM-DLPAR-utils for ppc64le SP3"
     },
     {
         "channel_label": "ibm-dlpar-utils-sap-sp1",
@@ -18897,7 +19317,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "IBM-DLPAR-utils SAP-SP1"
+        "channel_name": "IBM-DLPAR-utils for ppc64le SAP SP1"
     },
     {
         "channel_label": "ibm-dlpar-utils-sap-sp2",
@@ -18912,7 +19332,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "IBM-DLPAR-utils SAP-SP2"
+        "channel_name": "IBM-DLPAR-utils for ppc64le SAP SP2"
     },
     {
         "channel_label": "ibm-dlpar-utils-sap-sp3",
@@ -18927,7 +19347,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "IBM-DLPAR-utils SAP-SP3"
+        "channel_name": "IBM-DLPAR-utils for ppc64le SAP SP3"
     },
     {
         "channel_label": "ibm-dlpar-utils-sp4",
@@ -18942,7 +19362,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "IBM-DLPAR-utils SP4"
+        "channel_name": "IBM-DLPAR-utils for ppc64le SP4"
     },
     {
         "channel_label": "ibm-dlpar-utils-sap-sp4",
@@ -18957,13 +19377,13 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "IBM-DLPAR-utils SAP-SP4"
+        "channel_name": "IBM-DLPAR-utils for ppc64le SAP SP4"
     },
     {
         "channel_label": "rhel-x86_64-server-7",
         "parent_channel_label": null,
         "product_id": 1251,
-        "repository_id": -35,
+        "repository_id": -75,
         "parent_product_id": null,
         "root_product_id": 1251,
         "update_tag": null,
@@ -19212,7 +19632,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Live-Patching12-Updates for x86_64 SAP-SP1"
+        "channel_name": "SLE-Live-Patching12-Updates for x86_64 SAP SP1"
     },
     {
         "channel_label": "sle-live-patching12-debuginfo-updates-x86_64-sap-sp1",
@@ -19227,7 +19647,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Live-Patching12-Debuginfo-Updates for x86_64 SAP-SP1"
+        "channel_name": "SLE-Live-Patching12-Debuginfo-Updates for x86_64 SAP SP1"
     },
     {
         "channel_label": "sle-live-patching12-pool-x86_64-sap-sp1",
@@ -19242,7 +19662,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Live-Patching12-Pool for x86_64 SAP-SP1"
+        "channel_name": "SLE-Live-Patching12-Pool for x86_64 SAP SP1"
     },
     {
         "channel_label": "sle-live-patching12-debuginfo-pool-x86_64-sap-sp1",
@@ -19257,7 +19677,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Live-Patching12-Debuginfo-Pool for x86_64 SAP-SP1"
+        "channel_name": "SLE-Live-Patching12-Debuginfo-Pool for x86_64 SAP SP1"
     },
     {
         "channel_label": "sle-live-patching12-updates-x86_64-sp2",
@@ -19332,7 +19752,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Live-Patching12-Updates for x86_64 SAP-SP2"
+        "channel_name": "SLE-Live-Patching12-Updates for x86_64 SAP SP2"
     },
     {
         "channel_label": "sle-live-patching12-debuginfo-updates-x86_64-sap-sp2",
@@ -19347,7 +19767,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Live-Patching12-Debuginfo-Updates for x86_64 SAP-SP2"
+        "channel_name": "SLE-Live-Patching12-Debuginfo-Updates for x86_64 SAP SP2"
     },
     {
         "channel_label": "sle-live-patching12-pool-x86_64-sap-sp2",
@@ -19362,7 +19782,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Live-Patching12-Pool for x86_64 SAP-SP2"
+        "channel_name": "SLE-Live-Patching12-Pool for x86_64 SAP SP2"
     },
     {
         "channel_label": "sle-live-patching12-debuginfo-pool-x86_64-sap-sp2",
@@ -19377,7 +19797,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Live-Patching12-Debuginfo-Pool for x86_64 SAP-SP2"
+        "channel_name": "SLE-Live-Patching12-Debuginfo-Pool for x86_64 SAP SP2"
     },
     {
         "channel_label": "sle-live-patching12-updates-x86_64-hpc-sp2",
@@ -19392,7 +19812,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Live-Patching12-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLE-Live-Patching12-Updates for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-live-patching12-debuginfo-updates-x86_64-hpc-sp2",
@@ -19407,7 +19827,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Live-Patching12-Debuginfo-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLE-Live-Patching12-Debuginfo-Updates for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-live-patching12-pool-x86_64-hpc-sp2",
@@ -19422,7 +19842,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Live-Patching12-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLE-Live-Patching12-Pool for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-live-patching12-debuginfo-pool-x86_64-hpc-sp2",
@@ -19437,7 +19857,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Live-Patching12-Debuginfo-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLE-Live-Patching12-Debuginfo-Pool for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle11-hae-sp4-pool-i586",
@@ -19962,7 +20382,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Updates for ppc64le SAP-SP1"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Updates for ppc64le SAP SP1"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-debuginfo-updates-ppc64le-sap-sp1",
@@ -19977,7 +20397,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Updates for ppc64le SAP-SP1"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Updates for ppc64le SAP SP1"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-pool-ppc64le-sap-sp1",
@@ -19992,7 +20412,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Pool for ppc64le SAP-SP1"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Pool for ppc64le SAP SP1"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-debuginfo-pool-ppc64le-sap-sp1",
@@ -20007,7 +20427,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Pool for ppc64le SAP-SP1"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Pool for ppc64le SAP SP1"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-updates-ppc64le-sap-sp2",
@@ -20022,7 +20442,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Updates for ppc64le SAP-SP2"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Updates for ppc64le SAP SP2"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-debuginfo-updates-ppc64le-sap-sp2",
@@ -20037,7 +20457,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Updates for ppc64le SAP-SP2"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Updates for ppc64le SAP SP2"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-pool-ppc64le-sap-sp2",
@@ -20052,7 +20472,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Pool for ppc64le SAP-SP2"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Pool for ppc64le SAP SP2"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-debuginfo-pool-ppc64le-sap-sp2",
@@ -20067,7 +20487,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Pool for ppc64le SAP-SP2"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Pool for ppc64le SAP SP2"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-updates-ppc64le-sap-sp3",
@@ -20082,7 +20502,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Updates for ppc64le SAP-SP3"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Updates for ppc64le SAP SP3"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-debuginfo-updates-ppc64le-sap-sp3",
@@ -20097,7 +20517,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Updates for ppc64le SAP-SP3"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Updates for ppc64le SAP SP3"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-pool-ppc64le-sap-sp3",
@@ -20112,7 +20532,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Pool for ppc64le SAP-SP3"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Pool for ppc64le SAP SP3"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-debuginfo-pool-ppc64le-sap-sp3",
@@ -20127,7 +20547,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Pool for ppc64le SAP-SP3"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Pool for ppc64le SAP SP3"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-updates-ppc64le-sp4",
@@ -20138,7 +20558,7 @@
         "root_product_id": 1626,
         "update_tag": "SLE-Module-Adv-Systems-Management",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Adv-Systems-Management/12/ppc64le/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -20153,7 +20573,7 @@
         "root_product_id": 1626,
         "update_tag": "SLE-Module-Adv-Systems-Management",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Adv-Systems-Management/12/ppc64le/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -20168,7 +20588,7 @@
         "root_product_id": 1626,
         "update_tag": "SLE-Module-Adv-Systems-Management",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Adv-Systems-Management/12/ppc64le/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -20183,7 +20603,7 @@
         "root_product_id": 1626,
         "update_tag": "SLE-Module-Adv-Systems-Management",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Adv-Systems-Management/12/ppc64le/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -20198,11 +20618,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-Module-Adv-Systems-Management",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Adv-Systems-Management/12/ppc64le/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Updates for ppc64le SAP-SP4"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Updates for ppc64le SAP SP4"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-debuginfo-updates-ppc64le-sap-sp4",
@@ -20213,11 +20633,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-Module-Adv-Systems-Management",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Adv-Systems-Management/12/ppc64le/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Updates for ppc64le SAP-SP4"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Updates for ppc64le SAP SP4"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-pool-ppc64le-sap-sp4",
@@ -20228,11 +20648,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-Module-Adv-Systems-Management",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Adv-Systems-Management/12/ppc64le/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Pool for ppc64le SAP-SP4"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Pool for ppc64le SAP SP4"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-debuginfo-pool-ppc64le-sap-sp4",
@@ -20243,11 +20663,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-Module-Adv-Systems-Management",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Adv-Systems-Management/12/ppc64le/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Pool for ppc64le SAP-SP4"
+        "channel_name": "SLE-Module-Adv-Systems-Management12-Debuginfo-Pool for ppc64le SAP SP4"
     },
     {
         "channel_label": "sle-module-adv-systems-management12-updates-s390x",
@@ -20498,7 +20918,7 @@
         "root_product_id": 1627,
         "update_tag": "SLE-Module-Adv-Systems-Management",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Adv-Systems-Management/12/s390x/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -20513,7 +20933,7 @@
         "root_product_id": 1627,
         "update_tag": "SLE-Module-Adv-Systems-Management",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Adv-Systems-Management/12/s390x/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -20528,7 +20948,7 @@
         "root_product_id": 1627,
         "update_tag": "SLE-Module-Adv-Systems-Management",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Adv-Systems-Management/12/s390x/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -20543,7 +20963,7 @@
         "root_product_id": 1627,
         "update_tag": "SLE-Module-Adv-Systems-Management",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Adv-Systems-Management/12/s390x/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -21702,7 +22122,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates x86_64 SAP"
+        "channel_name": "SLE-Manager-Tools12-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-x86_64-sap",
@@ -21717,7 +22137,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates x86_64 SAP"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-manager-tools12-pool-x86_64-sap",
@@ -21732,7 +22152,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool x86_64 SAP"
+        "channel_name": "SLE-Manager-Tools12-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-x86_64-sap",
@@ -21747,7 +22167,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool x86_64 SAP"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-12-sap-updates-x86_64",
@@ -22092,7 +22512,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates x86_64 SP1"
+        "channel_name": "SLE-Manager-Tools12-Updates for x86_64 SP1"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-x86_64-sp1",
@@ -22107,7 +22527,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates x86_64 SP1"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for x86_64 SP1"
     },
     {
         "channel_label": "sle-manager-tools12-pool-x86_64-sp1",
@@ -22122,7 +22542,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool x86_64 SP1"
+        "channel_name": "SLE-Manager-Tools12-Pool for x86_64 SP1"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-x86_64-sp1",
@@ -22137,7 +22557,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool x86_64 SP1"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for x86_64 SP1"
     },
     {
         "channel_label": "sles12-sp1-updates-x86_64",
@@ -22272,7 +22692,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP1-Updates for x86_64 SLED-SP1"
+        "channel_name": "SLE-SDK12-SP1-Updates for x86_64 SLED"
     },
     {
         "channel_label": "sle-sdk12-sp1-debuginfo-updates-x86_64-sled-sp1",
@@ -22287,7 +22707,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP1-Debuginfo-Updates for x86_64 SLED-SP1"
+        "channel_name": "SLE-SDK12-SP1-Debuginfo-Updates for x86_64 SLED"
     },
     {
         "channel_label": "sle-sdk12-sp1-pool-x86_64-sled-sp1",
@@ -22302,7 +22722,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP1-Pool for x86_64 SLED-SP1"
+        "channel_name": "SLE-SDK12-SP1-Pool for x86_64 SLED"
     },
     {
         "channel_label": "sle-sdk12-sp1-debuginfo-pool-x86_64-sled-sp1",
@@ -22317,7 +22737,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP1-Debuginfo-Pool for x86_64 SLED-SP1"
+        "channel_name": "SLE-SDK12-SP1-Debuginfo-Pool for x86_64 SLED"
     },
     {
         "channel_label": "sle-sdk12-sp1-updates-x86_64-sap-sp1",
@@ -22332,7 +22752,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP1-Updates for x86_64 SAP-SP1"
+        "channel_name": "SLE-SDK12-SP1-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-sdk12-sp1-debuginfo-updates-x86_64-sap-sp1",
@@ -22347,7 +22767,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP1-Debuginfo-Updates for x86_64 SAP-SP1"
+        "channel_name": "SLE-SDK12-SP1-Debuginfo-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-sdk12-sp1-pool-x86_64-sap-sp1",
@@ -22362,7 +22782,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP1-Pool for x86_64 SAP-SP1"
+        "channel_name": "SLE-SDK12-SP1-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-sdk12-sp1-debuginfo-pool-x86_64-sap-sp1",
@@ -22377,7 +22797,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP1-Debuginfo-Pool for x86_64 SAP-SP1"
+        "channel_name": "SLE-SDK12-SP1-Debuginfo-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-ha12-sp1-updates-x86_64",
@@ -23022,7 +23442,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Updates for x86_64 SAP-SP1"
+        "channel_name": "SLE-Module-Containers12-Updates for x86_64 SAP SP1"
     },
     {
         "channel_label": "sle-module-containers12-debuginfo-updates-x86_64-sap-sp1",
@@ -23037,7 +23457,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Debuginfo-Updates for x86_64 SAP-SP1"
+        "channel_name": "SLE-Module-Containers12-Debuginfo-Updates for x86_64 SAP SP1"
     },
     {
         "channel_label": "sle-module-containers12-pool-x86_64-sap-sp1",
@@ -23052,7 +23472,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Pool for x86_64 SAP-SP1"
+        "channel_name": "SLE-Module-Containers12-Pool for x86_64 SAP SP1"
     },
     {
         "channel_label": "sle-module-containers12-debuginfo-pool-x86_64-sap-sp1",
@@ -23067,7 +23487,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Debuginfo-Pool for x86_64 SAP-SP1"
+        "channel_name": "SLE-Module-Containers12-Debuginfo-Pool for x86_64 SAP SP1"
     },
     {
         "channel_label": "sle-module-containers12-updates-x86_64-sp2",
@@ -23142,7 +23562,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Updates for x86_64 SAP-SP2"
+        "channel_name": "SLE-Module-Containers12-Updates for x86_64 SAP SP2"
     },
     {
         "channel_label": "sle-module-containers12-debuginfo-updates-x86_64-sap-sp2",
@@ -23157,7 +23577,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Debuginfo-Updates for x86_64 SAP-SP2"
+        "channel_name": "SLE-Module-Containers12-Debuginfo-Updates for x86_64 SAP SP2"
     },
     {
         "channel_label": "sle-module-containers12-pool-x86_64-sap-sp2",
@@ -23172,7 +23592,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Pool for x86_64 SAP-SP2"
+        "channel_name": "SLE-Module-Containers12-Pool for x86_64 SAP SP2"
     },
     {
         "channel_label": "sle-module-containers12-debuginfo-pool-x86_64-sap-sp2",
@@ -23187,7 +23607,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Debuginfo-Pool for x86_64 SAP-SP2"
+        "channel_name": "SLE-Module-Containers12-Debuginfo-Pool for x86_64 SAP SP2"
     },
     {
         "channel_label": "sle-module-containers12-updates-x86_64-sp3",
@@ -23262,7 +23682,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Updates for x86_64 SAP-SP3"
+        "channel_name": "SLE-Module-Containers12-Updates for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-module-containers12-debuginfo-updates-x86_64-sap-sp3",
@@ -23277,7 +23697,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Debuginfo-Updates for x86_64 SAP-SP3"
+        "channel_name": "SLE-Module-Containers12-Debuginfo-Updates for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-module-containers12-pool-x86_64-sap-sp3",
@@ -23292,7 +23712,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Pool for x86_64 SAP-SP3"
+        "channel_name": "SLE-Module-Containers12-Pool for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-module-containers12-debuginfo-pool-x86_64-sap-sp3",
@@ -23307,7 +23727,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Debuginfo-Pool for x86_64 SAP-SP3"
+        "channel_name": "SLE-Module-Containers12-Debuginfo-Pool for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-module-containers12-updates-x86_64-sp4",
@@ -23318,7 +23738,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Module-Containers",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Containers/12/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -23333,7 +23753,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Module-Containers",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Containers/12/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -23348,7 +23768,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Module-Containers",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Containers/12/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -23363,7 +23783,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Module-Containers",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Containers/12/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -23382,7 +23802,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLE-Module-Containers12-Updates for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-module-containers12-debuginfo-updates-x86_64-hpc-sp2",
@@ -23397,7 +23817,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Debuginfo-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLE-Module-Containers12-Debuginfo-Updates for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-module-containers12-pool-x86_64-hpc-sp2",
@@ -23412,7 +23832,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLE-Module-Containers12-Pool for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-module-containers12-debuginfo-pool-x86_64-hpc-sp2",
@@ -23427,7 +23847,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Debuginfo-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLE-Module-Containers12-Debuginfo-Pool for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-module-containers12-updates-x86_64-hpc-sp3",
@@ -23442,7 +23862,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLE-Module-Containers12-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-module-containers12-debuginfo-updates-x86_64-hpc-sp3",
@@ -23457,7 +23877,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Debuginfo-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLE-Module-Containers12-Debuginfo-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-module-containers12-pool-x86_64-hpc-sp3",
@@ -23472,7 +23892,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Pool for x86_64 HPC-SP3"
+        "channel_name": "SLE-Module-Containers12-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-module-containers12-debuginfo-pool-x86_64-hpc-sp3",
@@ -23487,7 +23907,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Debuginfo-Pool for x86_64 HPC-SP3"
+        "channel_name": "SLE-Module-Containers12-Debuginfo-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-module-containers12-updates-x86_64-sap-sp4",
@@ -23498,11 +23918,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-Module-Containers",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Containers/12/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Updates for x86_64 SAP-SP4"
+        "channel_name": "SLE-Module-Containers12-Updates for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-module-containers12-debuginfo-updates-x86_64-sap-sp4",
@@ -23513,11 +23933,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-Module-Containers",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Containers/12/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Debuginfo-Updates for x86_64 SAP-SP4"
+        "channel_name": "SLE-Module-Containers12-Debuginfo-Updates for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-module-containers12-pool-x86_64-sap-sp4",
@@ -23528,11 +23948,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-Module-Containers",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Containers/12/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Pool for x86_64 SAP-SP4"
+        "channel_name": "SLE-Module-Containers12-Pool for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-module-containers12-debuginfo-pool-x86_64-sap-sp4",
@@ -23543,11 +23963,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-Module-Containers",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Containers/12/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Debuginfo-Pool for x86_64 SAP-SP4"
+        "channel_name": "SLE-Module-Containers12-Debuginfo-Pool for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-module-containers12-updates-x86_64-hpc-sp4",
@@ -23558,11 +23978,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Module-Containers",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Containers/12/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Updates for x86_64 HPC-SP4"
+        "channel_name": "SLE-Module-Containers12-Updates for x86_64 HPC SP4"
     },
     {
         "channel_label": "sle-module-containers12-debuginfo-updates-x86_64-hpc-sp4",
@@ -23573,11 +23993,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Module-Containers",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Containers/12/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Debuginfo-Updates for x86_64 HPC-SP4"
+        "channel_name": "SLE-Module-Containers12-Debuginfo-Updates for x86_64 HPC SP4"
     },
     {
         "channel_label": "sle-module-containers12-pool-x86_64-hpc-sp4",
@@ -23588,11 +24008,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Module-Containers",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Containers/12/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Pool for x86_64 HPC-SP4"
+        "channel_name": "SLE-Module-Containers12-Pool for x86_64 HPC SP4"
     },
     {
         "channel_label": "sle-module-containers12-debuginfo-pool-x86_64-hpc-sp4",
@@ -23603,11 +24023,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Module-Containers",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Containers/12/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Debuginfo-Pool for x86_64 HPC-SP4"
+        "channel_name": "SLE-Module-Containers12-Debuginfo-Pool for x86_64 HPC SP4"
     },
     {
         "channel_label": "sle-manager-tools12-updates-x86_64-sled-sp1",
@@ -23622,7 +24042,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates x86_64 SLED-SP1"
+        "channel_name": "SLE-Manager-Tools12-Updates for x86_64 SLED SP1"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-x86_64-sled-sp1",
@@ -23637,7 +24057,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates x86_64 SLED-SP1"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for x86_64 SLED SP1"
     },
     {
         "channel_label": "sle-manager-tools12-pool-x86_64-sled-sp1",
@@ -23652,7 +24072,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool x86_64 SLED-SP1"
+        "channel_name": "SLE-Manager-Tools12-Pool for x86_64 SLED SP1"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-x86_64-sled-sp1",
@@ -23667,7 +24087,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool x86_64 SLED-SP1"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for x86_64 SLED SP1"
     },
     {
         "channel_label": "sled12-sp1-updates-x86_64",
@@ -23757,7 +24177,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates ppc64le SP1"
+        "channel_name": "SLE-Manager-Tools12-Updates for ppc64le SP1"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-ppc64le-sp1",
@@ -23772,7 +24192,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates ppc64le SP1"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for ppc64le SP1"
     },
     {
         "channel_label": "sle-manager-tools12-pool-ppc64le-sp1",
@@ -23787,7 +24207,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool ppc64le SP1"
+        "channel_name": "SLE-Manager-Tools12-Pool for ppc64le SP1"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-ppc64le-sp1",
@@ -23802,7 +24222,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool ppc64le SP1"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for ppc64le SP1"
     },
     {
         "channel_label": "sles12-sp1-updates-ppc64le",
@@ -23877,7 +24297,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates s390x SP1"
+        "channel_name": "SLE-Manager-Tools12-Updates for s390x SP1"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-s390x-sp1",
@@ -23892,7 +24312,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates s390x SP1"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for s390x SP1"
     },
     {
         "channel_label": "sle-manager-tools12-pool-s390x-sp1",
@@ -23907,7 +24327,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool s390x SP1"
+        "channel_name": "SLE-Manager-Tools12-Pool for s390x SP1"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-s390x-sp1",
@@ -23922,7 +24342,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool s390x SP1"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for s390x SP1"
     },
     {
         "channel_label": "sles12-sp1-updates-s390x",
@@ -24117,7 +24537,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA-GEO12-SP1-Updates for x86_64 SAP-SP1"
+        "channel_name": "SLE-HA-GEO12-SP1-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-ha-geo12-sp1-debuginfo-updates-x86_64-sap-sp1",
@@ -24132,7 +24552,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA-GEO12-SP1-Debuginfo-Updates for x86_64 SAP-SP1"
+        "channel_name": "SLE-HA-GEO12-SP1-Debuginfo-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-ha-geo12-sp1-pool-x86_64-sap-sp1",
@@ -24147,7 +24567,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA-GEO12-SP1-Pool for x86_64 SAP-SP1"
+        "channel_name": "SLE-HA-GEO12-SP1-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-ha-geo12-sp1-debuginfo-pool-x86_64-sap-sp1",
@@ -24162,7 +24582,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA-GEO12-SP1-Debuginfo-Pool for x86_64 SAP-SP1"
+        "channel_name": "SLE-HA-GEO12-SP1-Debuginfo-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-we12-sp1-updates-x86_64",
@@ -24237,7 +24657,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-12-SP1-GA-Desktop-nVidia-Driver for x86_64 WE-SP1"
+        "channel_name": "SLE-12-SP1-GA-Desktop-nVidia-Driver for x86_64 WE"
     },
     {
         "channel_label": "sle-we12-sp1-updates-x86_64-sap-sp1",
@@ -24252,7 +24672,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-WE12-SP1-Updates for x86_64 SAP-SP1"
+        "channel_name": "SLE-WE12-SP1-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-we12-sp1-debuginfo-updates-x86_64-sap-sp1",
@@ -24267,7 +24687,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-WE12-SP1-Debuginfo-Updates for x86_64 SAP-SP1"
+        "channel_name": "SLE-WE12-SP1-Debuginfo-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-we12-sp1-pool-x86_64-sap-sp1",
@@ -24282,7 +24702,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-WE12-SP1-Pool for x86_64 SAP-SP1"
+        "channel_name": "SLE-WE12-SP1-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-we12-sp1-debuginfo-pool-x86_64-sap-sp1",
@@ -24297,7 +24717,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-WE12-SP1-Debuginfo-Pool for x86_64 SAP-SP1"
+        "channel_name": "SLE-WE12-SP1-Debuginfo-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-12-sp1-ga-desktop-nvidia-driver-x86_64-we-sap-sp1",
@@ -24312,7 +24732,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-12-SP1-GA-Desktop-nVidia-Driver for x86_64 WE-SAP-SP1"
+        "channel_name": "SLE-12-SP1-GA-Desktop-nVidia-Driver for x86_64 WE-SAP"
     },
     {
         "channel_label": "sle-module-toolchain12-updates-ppc64le",
@@ -24567,7 +24987,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Updates for ppc64le SAP-SP1"
+        "channel_name": "SLE-Module-Toolchain12-Updates for ppc64le SAP SP1"
     },
     {
         "channel_label": "sle-module-toolchain12-debuginfo-updates-ppc64le-sap-sp1",
@@ -24582,7 +25002,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Updates for ppc64le SAP-SP1"
+        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Updates for ppc64le SAP SP1"
     },
     {
         "channel_label": "sle-module-toolchain12-pool-ppc64le-sap-sp1",
@@ -24597,7 +25017,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Pool for ppc64le SAP-SP1"
+        "channel_name": "SLE-Module-Toolchain12-Pool for ppc64le SAP SP1"
     },
     {
         "channel_label": "sle-module-toolchain12-debuginfo-pool-ppc64le-sap-sp1",
@@ -24612,7 +25032,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Pool for ppc64le SAP-SP1"
+        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Pool for ppc64le SAP SP1"
     },
     {
         "channel_label": "sle-module-toolchain12-updates-ppc64le-sap-sp2",
@@ -24627,7 +25047,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Updates for ppc64le SAP-SP2"
+        "channel_name": "SLE-Module-Toolchain12-Updates for ppc64le SAP SP2"
     },
     {
         "channel_label": "sle-module-toolchain12-debuginfo-updates-ppc64le-sap-sp2",
@@ -24642,7 +25062,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Updates for ppc64le SAP-SP2"
+        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Updates for ppc64le SAP SP2"
     },
     {
         "channel_label": "sle-module-toolchain12-pool-ppc64le-sap-sp2",
@@ -24657,7 +25077,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Pool for ppc64le SAP-SP2"
+        "channel_name": "SLE-Module-Toolchain12-Pool for ppc64le SAP SP2"
     },
     {
         "channel_label": "sle-module-toolchain12-debuginfo-pool-ppc64le-sap-sp2",
@@ -24672,7 +25092,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Pool for ppc64le SAP-SP2"
+        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Pool for ppc64le SAP SP2"
     },
     {
         "channel_label": "sle-module-toolchain12-updates-ppc64le-sap-sp3",
@@ -24687,7 +25107,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Updates for ppc64le SAP-SP3"
+        "channel_name": "SLE-Module-Toolchain12-Updates for ppc64le SAP SP3"
     },
     {
         "channel_label": "sle-module-toolchain12-debuginfo-updates-ppc64le-sap-sp3",
@@ -24702,7 +25122,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Updates for ppc64le SAP-SP3"
+        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Updates for ppc64le SAP SP3"
     },
     {
         "channel_label": "sle-module-toolchain12-pool-ppc64le-sap-sp3",
@@ -24717,7 +25137,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Pool for ppc64le SAP-SP3"
+        "channel_name": "SLE-Module-Toolchain12-Pool for ppc64le SAP SP3"
     },
     {
         "channel_label": "sle-module-toolchain12-debuginfo-pool-ppc64le-sap-sp3",
@@ -24732,7 +25152,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Pool for ppc64le SAP-SP3"
+        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Pool for ppc64le SAP SP3"
     },
     {
         "channel_label": "sle-module-toolchain12-updates-ppc64le-sp4",
@@ -24743,7 +25163,7 @@
         "root_product_id": 1626,
         "update_tag": "SLE-Module-Toolchain",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Toolchain/12/ppc64le/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -24758,7 +25178,7 @@
         "root_product_id": 1626,
         "update_tag": "SLE-Module-Toolchain",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Toolchain/12/ppc64le/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -24773,7 +25193,7 @@
         "root_product_id": 1626,
         "update_tag": "SLE-Module-Toolchain",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Toolchain/12/ppc64le/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -24788,7 +25208,7 @@
         "root_product_id": 1626,
         "update_tag": "SLE-Module-Toolchain",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Toolchain/12/ppc64le/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -24803,11 +25223,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-Module-Toolchain",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Toolchain/12/ppc64le/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Updates for ppc64le SAP-SP4"
+        "channel_name": "SLE-Module-Toolchain12-Updates for ppc64le SAP SP4"
     },
     {
         "channel_label": "sle-module-toolchain12-debuginfo-updates-ppc64le-sap-sp4",
@@ -24818,11 +25238,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-Module-Toolchain",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Toolchain/12/ppc64le/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Updates for ppc64le SAP-SP4"
+        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Updates for ppc64le SAP SP4"
     },
     {
         "channel_label": "sle-module-toolchain12-pool-ppc64le-sap-sp4",
@@ -24833,11 +25253,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-Module-Toolchain",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Toolchain/12/ppc64le/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Pool for ppc64le SAP-SP4"
+        "channel_name": "SLE-Module-Toolchain12-Pool for ppc64le SAP SP4"
     },
     {
         "channel_label": "sle-module-toolchain12-debuginfo-pool-ppc64le-sap-sp4",
@@ -24848,11 +25268,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-Module-Toolchain",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Toolchain/12/ppc64le/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Pool for ppc64le SAP-SP4"
+        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Pool for ppc64le SAP SP4"
     },
     {
         "channel_label": "sle-module-toolchain12-updates-s390x",
@@ -25103,7 +25523,7 @@
         "root_product_id": 1627,
         "update_tag": "SLE-Module-Toolchain",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Toolchain/12/s390x/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -25118,7 +25538,7 @@
         "root_product_id": 1627,
         "update_tag": "SLE-Module-Toolchain",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Toolchain/12/s390x/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -25133,7 +25553,7 @@
         "root_product_id": 1627,
         "update_tag": "SLE-Module-Toolchain",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Toolchain/12/s390x/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -25148,7 +25568,7 @@
         "root_product_id": 1627,
         "update_tag": "SLE-Module-Toolchain",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Toolchain/12/s390x/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -25347,7 +25767,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Updates for x86_64 SAP-SP1"
+        "channel_name": "SLE-Module-Toolchain12-Updates for x86_64 SAP SP1"
     },
     {
         "channel_label": "sle-module-toolchain12-debuginfo-updates-x86_64-sap-sp1",
@@ -25362,7 +25782,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Updates for x86_64 SAP-SP1"
+        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Updates for x86_64 SAP SP1"
     },
     {
         "channel_label": "sle-module-toolchain12-pool-x86_64-sap-sp1",
@@ -25377,7 +25797,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Pool for x86_64 SAP-SP1"
+        "channel_name": "SLE-Module-Toolchain12-Pool for x86_64 SAP SP1"
     },
     {
         "channel_label": "sle-module-toolchain12-debuginfo-pool-x86_64-sap-sp1",
@@ -25392,7 +25812,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Pool for x86_64 SAP-SP1"
+        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Pool for x86_64 SAP SP1"
     },
     {
         "channel_label": "sle-module-toolchain12-updates-x86_64-sp2",
@@ -25467,7 +25887,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Updates for x86_64 SAP-SP2"
+        "channel_name": "SLE-Module-Toolchain12-Updates for x86_64 SAP SP2"
     },
     {
         "channel_label": "sle-module-toolchain12-debuginfo-updates-x86_64-sap-sp2",
@@ -25482,7 +25902,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Updates for x86_64 SAP-SP2"
+        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Updates for x86_64 SAP SP2"
     },
     {
         "channel_label": "sle-module-toolchain12-pool-x86_64-sap-sp2",
@@ -25497,7 +25917,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Pool for x86_64 SAP-SP2"
+        "channel_name": "SLE-Module-Toolchain12-Pool for x86_64 SAP SP2"
     },
     {
         "channel_label": "sle-module-toolchain12-debuginfo-pool-x86_64-sap-sp2",
@@ -25512,7 +25932,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Pool for x86_64 SAP-SP2"
+        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Pool for x86_64 SAP SP2"
     },
     {
         "channel_label": "sle-module-toolchain12-updates-x86_64-sp3",
@@ -25587,7 +26007,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Updates for x86_64 SAP-SP3"
+        "channel_name": "SLE-Module-Toolchain12-Updates for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-module-toolchain12-debuginfo-updates-x86_64-sap-sp3",
@@ -25602,7 +26022,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Updates for x86_64 SAP-SP3"
+        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Updates for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-module-toolchain12-pool-x86_64-sap-sp3",
@@ -25617,7 +26037,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Pool for x86_64 SAP-SP3"
+        "channel_name": "SLE-Module-Toolchain12-Pool for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-module-toolchain12-debuginfo-pool-x86_64-sap-sp3",
@@ -25632,7 +26052,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Pool for x86_64 SAP-SP3"
+        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Pool for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-module-toolchain12-updates-x86_64-sp4",
@@ -25643,7 +26063,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Module-Toolchain",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Toolchain/12/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -25658,7 +26078,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Module-Toolchain",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Toolchain/12/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -25673,7 +26093,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Module-Toolchain",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Toolchain/12/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -25688,7 +26108,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Module-Toolchain",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Toolchain/12/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -25707,7 +26127,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLE-Module-Toolchain12-Updates for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-module-toolchain12-debuginfo-updates-x86_64-hpc-sp2",
@@ -25722,7 +26142,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Updates for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-module-toolchain12-pool-x86_64-hpc-sp2",
@@ -25737,7 +26157,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLE-Module-Toolchain12-Pool for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-module-toolchain12-debuginfo-pool-x86_64-hpc-sp2",
@@ -25752,7 +26172,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Pool for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-module-toolchain12-updates-x86_64-hpc-sp3",
@@ -25767,7 +26187,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLE-Module-Toolchain12-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-module-toolchain12-debuginfo-updates-x86_64-hpc-sp3",
@@ -25782,7 +26202,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-module-toolchain12-pool-x86_64-hpc-sp3",
@@ -25797,7 +26217,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Pool for x86_64 HPC-SP3"
+        "channel_name": "SLE-Module-Toolchain12-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-module-toolchain12-debuginfo-pool-x86_64-hpc-sp3",
@@ -25812,7 +26232,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Pool for x86_64 HPC-SP3"
+        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-module-toolchain12-updates-x86_64-sap-sp4",
@@ -25823,11 +26243,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-Module-Toolchain",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Toolchain/12/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Updates for x86_64 SAP-SP4"
+        "channel_name": "SLE-Module-Toolchain12-Updates for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-module-toolchain12-debuginfo-updates-x86_64-sap-sp4",
@@ -25838,11 +26258,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-Module-Toolchain",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Toolchain/12/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Updates for x86_64 SAP-SP4"
+        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Updates for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-module-toolchain12-pool-x86_64-sap-sp4",
@@ -25853,11 +26273,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-Module-Toolchain",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Toolchain/12/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Pool for x86_64 SAP-SP4"
+        "channel_name": "SLE-Module-Toolchain12-Pool for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-module-toolchain12-debuginfo-pool-x86_64-sap-sp4",
@@ -25868,11 +26288,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-Module-Toolchain",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Toolchain/12/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Pool for x86_64 SAP-SP4"
+        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Pool for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-module-toolchain12-updates-x86_64-hpc-sp4",
@@ -25883,11 +26303,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Module-Toolchain",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Toolchain/12/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Updates for x86_64 HPC-SP4"
+        "channel_name": "SLE-Module-Toolchain12-Updates for x86_64 HPC SP4"
     },
     {
         "channel_label": "sle-module-toolchain12-debuginfo-updates-x86_64-hpc-sp4",
@@ -25898,11 +26318,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Module-Toolchain",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Toolchain/12/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Updates for x86_64 HPC-SP4"
+        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Updates for x86_64 HPC SP4"
     },
     {
         "channel_label": "sle-module-toolchain12-pool-x86_64-hpc-sp4",
@@ -25913,11 +26333,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Module-Toolchain",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Toolchain/12/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Pool for x86_64 HPC-SP4"
+        "channel_name": "SLE-Module-Toolchain12-Pool for x86_64 HPC SP4"
     },
     {
         "channel_label": "sle-module-toolchain12-debuginfo-pool-x86_64-hpc-sp4",
@@ -25928,11 +26348,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Module-Toolchain",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Toolchain/12/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Pool for x86_64 HPC-SP4"
+        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Pool for x86_64 HPC SP4"
     },
     {
         "channel_label": "suse-enterprise-storage-2-updates-x86_64",
@@ -26127,7 +26547,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP1-Updates for ppc64le SAP-SP1"
+        "channel_name": "SLE-SDK12-SP1-Updates for ppc64le SAP"
     },
     {
         "channel_label": "sle-sdk12-sp1-debuginfo-updates-ppc64le-sap-sp1",
@@ -26142,7 +26562,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP1-Debuginfo-Updates for ppc64le SAP-SP1"
+        "channel_name": "SLE-SDK12-SP1-Debuginfo-Updates for ppc64le SAP"
     },
     {
         "channel_label": "sle-sdk12-sp1-pool-ppc64le-sap-sp1",
@@ -26157,7 +26577,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP1-Pool for ppc64le SAP-SP1"
+        "channel_name": "SLE-SDK12-SP1-Pool for ppc64le SAP"
     },
     {
         "channel_label": "sle-sdk12-sp1-debuginfo-pool-ppc64le-sap-sp1",
@@ -26172,7 +26592,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP1-Debuginfo-Pool for ppc64le SAP-SP1"
+        "channel_name": "SLE-SDK12-SP1-Debuginfo-Pool for ppc64le SAP"
     },
     {
         "channel_label": "sle-sdk12-sp1-updates-s390x",
@@ -26307,7 +26727,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates x86_64 SAP-SP1"
+        "channel_name": "SLE-Manager-Tools12-Updates for x86_64 SAP SP1"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-x86_64-sap-sp1",
@@ -26322,7 +26742,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates x86_64 SAP-SP1"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for x86_64 SAP SP1"
     },
     {
         "channel_label": "sle-manager-tools12-pool-x86_64-sap-sp1",
@@ -26337,7 +26757,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool x86_64 SAP-SP1"
+        "channel_name": "SLE-Manager-Tools12-Pool for x86_64 SAP SP1"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-x86_64-sap-sp1",
@@ -26352,7 +26772,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool x86_64 SAP-SP1"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for x86_64 SAP SP1"
     },
     {
         "channel_label": "sles12-sp1-updates-x86_64-sap-sp1",
@@ -26367,7 +26787,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP1-Updates for x86_64 SAP-SP1"
+        "channel_name": "SLES12-SP1-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sles12-sp1-debuginfo-updates-x86_64-sap-sp1",
@@ -26382,7 +26802,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP1-Debuginfo-Updates for x86_64 SAP-SP1"
+        "channel_name": "SLES12-SP1-Debuginfo-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sles12-sp1-pool-x86_64-sap-sp1",
@@ -26397,7 +26817,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP1-Pool for x86_64 SAP-SP1"
+        "channel_name": "SLES12-SP1-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sles12-sp1-debuginfo-pool-x86_64-sap-sp1",
@@ -26412,7 +26832,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP1-Debuginfo-Pool for x86_64 SAP-SP1"
+        "channel_name": "SLES12-SP1-Debuginfo-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-ha12-sp1-updates-x86_64-sap-sp1",
@@ -26427,7 +26847,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP1-Updates for x86_64 SAP-SP1"
+        "channel_name": "SLE-HA12-SP1-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-ha12-sp1-debuginfo-updates-x86_64-sap-sp1",
@@ -26442,7 +26862,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP1-Debuginfo-Updates for x86_64 SAP-SP1"
+        "channel_name": "SLE-HA12-SP1-Debuginfo-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-ha12-sp1-pool-x86_64-sap-sp1",
@@ -26457,7 +26877,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP1-Pool for x86_64 SAP-SP1"
+        "channel_name": "SLE-HA12-SP1-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-ha12-sp1-debuginfo-pool-x86_64-sap-sp1",
@@ -26472,7 +26892,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP1-Debuginfo-Pool for x86_64 SAP-SP1"
+        "channel_name": "SLE-HA12-SP1-Debuginfo-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-12-sp1-sap-updates-x86_64",
@@ -26535,7 +26955,7 @@
         "channel_name": "SLE12-SP1-SAP-Debuginfo-Pool for x86_64"
     },
     {
-        "channel_label": "suse-openstack-cloud-6-updates-x86_64",
+        "channel_label": "suse-openstack-cloud-6-updates-x86_64-sp1",
         "parent_channel_label": "sles12-sp1-pool-x86_64",
         "product_id": 1347,
         "repository_id": 1941,
@@ -26547,10 +26967,10 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-6-Updates for x86_64"
+        "channel_name": "SUSE-OpenStack-Cloud-6-Updates for x86_64 SP1"
     },
     {
-        "channel_label": "suse-openstack-cloud-6-debuginfo-updates-x86_64",
+        "channel_label": "suse-openstack-cloud-6-debuginfo-updates-x86_64-sp1",
         "parent_channel_label": "sles12-sp1-pool-x86_64",
         "product_id": 1347,
         "repository_id": 1942,
@@ -26562,10 +26982,10 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-6-Debuginfo-Updates for x86_64"
+        "channel_name": "SUSE-OpenStack-Cloud-6-Debuginfo-Updates for x86_64 SP1"
     },
     {
-        "channel_label": "suse-openstack-cloud-6-pool-x86_64",
+        "channel_label": "suse-openstack-cloud-6-pool-x86_64-sp1",
         "parent_channel_label": "sles12-sp1-pool-x86_64",
         "product_id": 1347,
         "repository_id": 1943,
@@ -26577,10 +26997,10 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-6-Pool for x86_64"
+        "channel_name": "SUSE-OpenStack-Cloud-6-Pool for x86_64 SP1"
     },
     {
-        "channel_label": "suse-openstack-cloud-6-debuginfo-pool-x86_64",
+        "channel_label": "suse-openstack-cloud-6-debuginfo-pool-x86_64-sp1",
         "parent_channel_label": "sles12-sp1-pool-x86_64",
         "product_id": 1347,
         "repository_id": 1944,
@@ -26592,7 +27012,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-6-Debuginfo-Pool for x86_64"
+        "channel_name": "SUSE-OpenStack-Cloud-6-Debuginfo-Pool for x86_64 SP1"
     },
     {
         "channel_label": "suse-openstack-cloud-6-updates-x86_64-sap-sp1",
@@ -26607,7 +27027,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-6-Updates for x86_64 SAP-SP1"
+        "channel_name": "SUSE-OpenStack-Cloud-6-Updates for x86_64 SAP SP1"
     },
     {
         "channel_label": "suse-openstack-cloud-6-debuginfo-updates-x86_64-sap-sp1",
@@ -26622,7 +27042,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-6-Debuginfo-Updates for x86_64 SAP-SP1"
+        "channel_name": "SUSE-OpenStack-Cloud-6-Debuginfo-Updates for x86_64 SAP SP1"
     },
     {
         "channel_label": "suse-openstack-cloud-6-pool-x86_64-sap-sp1",
@@ -26637,7 +27057,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-6-Pool for x86_64 SAP-SP1"
+        "channel_name": "SUSE-OpenStack-Cloud-6-Pool for x86_64 SAP SP1"
     },
     {
         "channel_label": "suse-openstack-cloud-6-debuginfo-pool-x86_64-sap-sp1",
@@ -26652,7 +27072,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-6-Debuginfo-Pool for x86_64 SAP-SP1"
+        "channel_name": "SUSE-OpenStack-Cloud-6-Debuginfo-Pool for x86_64 SAP SP1"
     },
     {
         "channel_label": "suse-manager-server-3.0-updates-s390x",
@@ -26667,7 +27087,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.0-Updates for s390x"
+        "channel_name": "SUSE-Manager-Server-3.0-Updates for s390x SP1"
     },
     {
         "channel_label": "suse-manager-server-3.0-debuginfo-updates-s390x",
@@ -26682,7 +27102,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.0-Debuginfo-Updates for s390x"
+        "channel_name": "SUSE-Manager-Server-3.0-Debuginfo-Updates for s390x SP1"
     },
     {
         "channel_label": "suse-manager-server-3.0-pool-s390x",
@@ -26697,7 +27117,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.0-Pool for s390x"
+        "channel_name": "SUSE-Manager-Server-3.0-Pool for s390x SP1"
     },
     {
         "channel_label": "suse-manager-server-3.0-debuginfo-pool-s390x",
@@ -26712,7 +27132,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.0-Debuginfo-Pool for s390x"
+        "channel_name": "SUSE-Manager-Server-3.0-Debuginfo-Pool for s390x SP1"
     },
     {
         "channel_label": "suse-manager-server-3.0-updates-s390x-sp2",
@@ -26847,7 +27267,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.0-Updates for x86_64"
+        "channel_name": "SUSE-Manager-Server-3.0-Updates for x86_64 SP1"
     },
     {
         "channel_label": "suse-manager-server-3.0-debuginfo-updates-x86_64",
@@ -26862,7 +27282,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.0-Debuginfo-Updates for x86_64"
+        "channel_name": "SUSE-Manager-Server-3.0-Debuginfo-Updates for x86_64 SP1"
     },
     {
         "channel_label": "suse-manager-server-3.0-pool-x86_64",
@@ -26877,7 +27297,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.0-Pool for x86_64"
+        "channel_name": "SUSE-Manager-Server-3.0-Pool for x86_64 SP1"
     },
     {
         "channel_label": "suse-manager-server-3.0-debuginfo-pool-x86_64",
@@ -26892,7 +27312,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.0-Debuginfo-Pool for x86_64"
+        "channel_name": "SUSE-Manager-Server-3.0-Debuginfo-Pool for x86_64 SP1"
     },
     {
         "channel_label": "suse-manager-server-3.0-updates-x86_64-sp2",
@@ -27027,7 +27447,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.0-Updates for x86_64 HPC-SP2"
+        "channel_name": "SUSE-Manager-Server-3.0-Updates for x86_64 HPC SP2"
     },
     {
         "channel_label": "suse-manager-server-3.0-debuginfo-updates-x86_64-hpc-sp2",
@@ -27042,7 +27462,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.0-Debuginfo-Updates for x86_64 HPC-SP2"
+        "channel_name": "SUSE-Manager-Server-3.0-Debuginfo-Updates for x86_64 HPC SP2"
     },
     {
         "channel_label": "suse-manager-server-3.0-pool-x86_64-hpc-sp2",
@@ -27057,7 +27477,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.0-Pool for x86_64 HPC-SP2"
+        "channel_name": "SUSE-Manager-Server-3.0-Pool for x86_64 HPC SP2"
     },
     {
         "channel_label": "suse-manager-server-3.0-debuginfo-pool-x86_64-hpc-sp2",
@@ -27072,7 +27492,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.0-Debuginfo-Pool for x86_64 HPC-SP2"
+        "channel_name": "SUSE-Manager-Server-3.0-Debuginfo-Pool for x86_64 HPC SP2"
     },
     {
         "channel_label": "suse-manager-server-3.0-updates-x86_64-hpc-sp3",
@@ -27087,7 +27507,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.0-Updates for x86_64 HPC-SP3"
+        "channel_name": "SUSE-Manager-Server-3.0-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-manager-server-3.0-debuginfo-updates-x86_64-hpc-sp3",
@@ -27102,7 +27522,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.0-Debuginfo-Updates for x86_64 HPC-SP3"
+        "channel_name": "SUSE-Manager-Server-3.0-Debuginfo-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-manager-server-3.0-pool-x86_64-hpc-sp3",
@@ -27117,7 +27537,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.0-Pool for x86_64 HPC-SP3"
+        "channel_name": "SUSE-Manager-Server-3.0-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-manager-server-3.0-debuginfo-pool-x86_64-hpc-sp3",
@@ -27132,7 +27552,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.0-Debuginfo-Pool for x86_64 HPC-SP3"
+        "channel_name": "SUSE-Manager-Server-3.0-Debuginfo-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-rt12-sp1-updates-x86_64",
@@ -27207,7 +27627,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-RT12-SP1-Updates for x86_64 SAP-SP1"
+        "channel_name": "SLE-RT12-SP1-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-rt12-sp1-debuginfo-updates-x86_64-sap-sp1",
@@ -27222,7 +27642,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-RT12-SP1-Debuginfo-Updates for x86_64 SAP-SP1"
+        "channel_name": "SLE-RT12-SP1-Debuginfo-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-rt12-sp1-pool-x86_64-sap-sp1",
@@ -27237,7 +27657,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-RT12-SP1-Pool for x86_64 SAP-SP1"
+        "channel_name": "SLE-RT12-SP1-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-rt12-sp1-debuginfo-pool-x86_64-sap-sp1",
@@ -27252,7 +27672,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-RT12-SP1-Debuginfo-Pool for x86_64 SAP-SP1"
+        "channel_name": "SLE-RT12-SP1-Debuginfo-Pool for x86_64 SAP"
     },
     {
         "channel_label": "suse-enterprise-storage-2.1-updates-x86_64",
@@ -27267,7 +27687,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-2.1-Updates for x86_64"
+        "channel_name": "SUSE-Enterprise-Storage-2.1-Updates for x86_64 SP1"
     },
     {
         "channel_label": "suse-enterprise-storage-2.1-debuginfo-updates-x86_64",
@@ -27282,7 +27702,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-2.1-Debuginfo-Updates for x86_64"
+        "channel_name": "SUSE-Enterprise-Storage-2.1-Debuginfo-Updates for x86_64 SP1"
     },
     {
         "channel_label": "suse-enterprise-storage-2.1-pool-x86_64",
@@ -27297,7 +27717,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-2.1-Pool for x86_64"
+        "channel_name": "SUSE-Enterprise-Storage-2.1-Pool for x86_64 SP1"
     },
     {
         "channel_label": "suse-enterprise-storage-2.1-debuginfo-pool-x86_64",
@@ -27312,7 +27732,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-2.1-Debuginfo-Pool for x86_64"
+        "channel_name": "SUSE-Enterprise-Storage-2.1-Debuginfo-Pool for x86_64 SP1"
     },
     {
         "channel_label": "suse-enterprise-storage-2.1-updates-x86_64-sap-sp1",
@@ -27327,7 +27747,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-2.1-Updates for x86_64 SAP-SP1"
+        "channel_name": "SUSE-Enterprise-Storage-2.1-Updates for x86_64 SAP SP1"
     },
     {
         "channel_label": "suse-enterprise-storage-2.1-debuginfo-updates-x86_64-sap-sp1",
@@ -27342,7 +27762,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-2.1-Debuginfo-Updates for x86_64 SAP-SP1"
+        "channel_name": "SUSE-Enterprise-Storage-2.1-Debuginfo-Updates for x86_64 SAP SP1"
     },
     {
         "channel_label": "suse-enterprise-storage-2.1-pool-x86_64-sap-sp1",
@@ -27357,7 +27777,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-2.1-Pool for x86_64 SAP-SP1"
+        "channel_name": "SUSE-Enterprise-Storage-2.1-Pool for x86_64 SAP SP1"
     },
     {
         "channel_label": "suse-enterprise-storage-2.1-debuginfo-pool-x86_64-sap-sp1",
@@ -27372,7 +27792,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-2.1-Debuginfo-Pool for x86_64 SAP-SP1"
+        "channel_name": "SUSE-Enterprise-Storage-2.1-Debuginfo-Pool for x86_64 SAP SP1"
     },
     {
         "channel_label": "suse-manager-proxy-3.0-updates-x86_64",
@@ -27387,7 +27807,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.0-Updates for x86_64"
+        "channel_name": "SUSE-Manager-Proxy-3.0-Updates for x86_64 SP1"
     },
     {
         "channel_label": "suse-manager-proxy-3.0-debuginfo-updates-x86_64",
@@ -27402,7 +27822,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.0-Debuginfo-Updates for x86_64"
+        "channel_name": "SUSE-Manager-Proxy-3.0-Debuginfo-Updates for x86_64 SP1"
     },
     {
         "channel_label": "suse-manager-proxy-3.0-pool-x86_64",
@@ -27417,7 +27837,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.0-Pool for x86_64"
+        "channel_name": "SUSE-Manager-Proxy-3.0-Pool for x86_64 SP1"
     },
     {
         "channel_label": "suse-manager-proxy-3.0-debuginfo-pool-x86_64",
@@ -27432,7 +27852,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.0-Debuginfo-Pool for x86_64"
+        "channel_name": "SUSE-Manager-Proxy-3.0-Debuginfo-Pool for x86_64 SP1"
     },
     {
         "channel_label": "suse-manager-proxy-3.0-updates-x86_64-sap-sp1",
@@ -27447,7 +27867,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.0-Updates for x86_64 SAP-SP1"
+        "channel_name": "SUSE-Manager-Proxy-3.0-Updates for x86_64 SAP SP1"
     },
     {
         "channel_label": "suse-manager-proxy-3.0-debuginfo-updates-x86_64-sap-sp1",
@@ -27462,7 +27882,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.0-Debuginfo-Updates for x86_64 SAP-SP1"
+        "channel_name": "SUSE-Manager-Proxy-3.0-Debuginfo-Updates for x86_64 SAP SP1"
     },
     {
         "channel_label": "suse-manager-proxy-3.0-pool-x86_64-sap-sp1",
@@ -27477,7 +27897,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.0-Pool for x86_64 SAP-SP1"
+        "channel_name": "SUSE-Manager-Proxy-3.0-Pool for x86_64 SAP SP1"
     },
     {
         "channel_label": "suse-manager-proxy-3.0-debuginfo-pool-x86_64-sap-sp1",
@@ -27492,7 +27912,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.0-Debuginfo-Pool for x86_64 SAP-SP1"
+        "channel_name": "SUSE-Manager-Proxy-3.0-Debuginfo-Pool for x86_64 SAP SP1"
     },
     {
         "channel_label": "suse-manager-proxy-3.0-updates-x86_64-sp2",
@@ -27567,7 +27987,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.0-Updates for x86_64 SAP-SP2"
+        "channel_name": "SUSE-Manager-Proxy-3.0-Updates for x86_64 SAP SP2"
     },
     {
         "channel_label": "suse-manager-proxy-3.0-debuginfo-updates-x86_64-sap-sp2",
@@ -27582,7 +28002,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.0-Debuginfo-Updates for x86_64 SAP-SP2"
+        "channel_name": "SUSE-Manager-Proxy-3.0-Debuginfo-Updates for x86_64 SAP SP2"
     },
     {
         "channel_label": "suse-manager-proxy-3.0-pool-x86_64-sap-sp2",
@@ -27597,7 +28017,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.0-Pool for x86_64 SAP-SP2"
+        "channel_name": "SUSE-Manager-Proxy-3.0-Pool for x86_64 SAP SP2"
     },
     {
         "channel_label": "suse-manager-proxy-3.0-debuginfo-pool-x86_64-sap-sp2",
@@ -27612,7 +28032,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.0-Debuginfo-Pool for x86_64 SAP-SP2"
+        "channel_name": "SUSE-Manager-Proxy-3.0-Debuginfo-Pool for x86_64 SAP SP2"
     },
     {
         "channel_label": "suse-manager-proxy-3.0-updates-x86_64-sp3",
@@ -27687,7 +28107,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.0-Updates for x86_64 SAP-SP3"
+        "channel_name": "SUSE-Manager-Proxy-3.0-Updates for x86_64 SAP SP3"
     },
     {
         "channel_label": "suse-manager-proxy-3.0-debuginfo-updates-x86_64-sap-sp3",
@@ -27702,7 +28122,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.0-Debuginfo-Updates for x86_64 SAP-SP3"
+        "channel_name": "SUSE-Manager-Proxy-3.0-Debuginfo-Updates for x86_64 SAP SP3"
     },
     {
         "channel_label": "suse-manager-proxy-3.0-pool-x86_64-sap-sp3",
@@ -27717,7 +28137,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.0-Pool for x86_64 SAP-SP3"
+        "channel_name": "SUSE-Manager-Proxy-3.0-Pool for x86_64 SAP SP3"
     },
     {
         "channel_label": "suse-manager-proxy-3.0-debuginfo-pool-x86_64-sap-sp3",
@@ -27732,7 +28152,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.0-Debuginfo-Pool for x86_64 SAP-SP3"
+        "channel_name": "SUSE-Manager-Proxy-3.0-Debuginfo-Pool for x86_64 SAP SP3"
     },
     {
         "channel_label": "suse-manager-proxy-3.0-updates-x86_64-hpc-sp2",
@@ -27747,7 +28167,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.0-Updates for x86_64 HPC-SP2"
+        "channel_name": "SUSE-Manager-Proxy-3.0-Updates for x86_64 HPC SP2"
     },
     {
         "channel_label": "suse-manager-proxy-3.0-debuginfo-updates-x86_64-hpc-sp2",
@@ -27762,7 +28182,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.0-Debuginfo-Updates for x86_64 HPC-SP2"
+        "channel_name": "SUSE-Manager-Proxy-3.0-Debuginfo-Updates for x86_64 HPC SP2"
     },
     {
         "channel_label": "suse-manager-proxy-3.0-pool-x86_64-hpc-sp2",
@@ -27777,7 +28197,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.0-Pool for x86_64 HPC-SP2"
+        "channel_name": "SUSE-Manager-Proxy-3.0-Pool for x86_64 HPC SP2"
     },
     {
         "channel_label": "suse-manager-proxy-3.0-debuginfo-pool-x86_64-hpc-sp2",
@@ -27792,7 +28212,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.0-Debuginfo-Pool for x86_64 HPC-SP2"
+        "channel_name": "SUSE-Manager-Proxy-3.0-Debuginfo-Pool for x86_64 HPC SP2"
     },
     {
         "channel_label": "suse-manager-proxy-3.0-updates-x86_64-hpc-sp3",
@@ -27807,7 +28227,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.0-Updates for x86_64 HPC-SP3"
+        "channel_name": "SUSE-Manager-Proxy-3.0-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-manager-proxy-3.0-debuginfo-updates-x86_64-hpc-sp3",
@@ -27822,7 +28242,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.0-Debuginfo-Updates for x86_64 HPC-SP3"
+        "channel_name": "SUSE-Manager-Proxy-3.0-Debuginfo-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-manager-proxy-3.0-pool-x86_64-hpc-sp3",
@@ -27837,7 +28257,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.0-Pool for x86_64 HPC-SP3"
+        "channel_name": "SUSE-Manager-Proxy-3.0-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-manager-proxy-3.0-debuginfo-pool-x86_64-hpc-sp3",
@@ -27852,7 +28272,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.0-Debuginfo-Pool for x86_64 HPC-SP3"
+        "channel_name": "SUSE-Manager-Proxy-3.0-Debuginfo-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-module-containers12-updates-ppc64le",
@@ -28107,7 +28527,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Updates for ppc64le SAP-SP1"
+        "channel_name": "SLE-Module-Containers12-Updates for ppc64le SAP SP1"
     },
     {
         "channel_label": "sle-module-containers12-debuginfo-updates-ppc64le-sap-sp1",
@@ -28122,7 +28542,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Debuginfo-Updates for ppc64le SAP-SP1"
+        "channel_name": "SLE-Module-Containers12-Debuginfo-Updates for ppc64le SAP SP1"
     },
     {
         "channel_label": "sle-module-containers12-pool-ppc64le-sap-sp1",
@@ -28137,7 +28557,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Pool for ppc64le SAP-SP1"
+        "channel_name": "SLE-Module-Containers12-Pool for ppc64le SAP SP1"
     },
     {
         "channel_label": "sle-module-containers12-debuginfo-pool-ppc64le-sap-sp1",
@@ -28152,7 +28572,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Debuginfo-Pool for ppc64le SAP-SP1"
+        "channel_name": "SLE-Module-Containers12-Debuginfo-Pool for ppc64le SAP SP1"
     },
     {
         "channel_label": "sle-module-containers12-updates-ppc64le-sap-sp2",
@@ -28167,7 +28587,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Updates for ppc64le SAP-SP2"
+        "channel_name": "SLE-Module-Containers12-Updates for ppc64le SAP SP2"
     },
     {
         "channel_label": "sle-module-containers12-debuginfo-updates-ppc64le-sap-sp2",
@@ -28182,7 +28602,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Debuginfo-Updates for ppc64le SAP-SP2"
+        "channel_name": "SLE-Module-Containers12-Debuginfo-Updates for ppc64le SAP SP2"
     },
     {
         "channel_label": "sle-module-containers12-pool-ppc64le-sap-sp2",
@@ -28197,7 +28617,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Pool for ppc64le SAP-SP2"
+        "channel_name": "SLE-Module-Containers12-Pool for ppc64le SAP SP2"
     },
     {
         "channel_label": "sle-module-containers12-debuginfo-pool-ppc64le-sap-sp2",
@@ -28212,7 +28632,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Debuginfo-Pool for ppc64le SAP-SP2"
+        "channel_name": "SLE-Module-Containers12-Debuginfo-Pool for ppc64le SAP SP2"
     },
     {
         "channel_label": "sle-module-containers12-updates-ppc64le-sap-sp3",
@@ -28227,7 +28647,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Updates for ppc64le SAP-SP3"
+        "channel_name": "SLE-Module-Containers12-Updates for ppc64le SAP SP3"
     },
     {
         "channel_label": "sle-module-containers12-debuginfo-updates-ppc64le-sap-sp3",
@@ -28242,7 +28662,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Debuginfo-Updates for ppc64le SAP-SP3"
+        "channel_name": "SLE-Module-Containers12-Debuginfo-Updates for ppc64le SAP SP3"
     },
     {
         "channel_label": "sle-module-containers12-pool-ppc64le-sap-sp3",
@@ -28257,7 +28677,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Pool for ppc64le SAP-SP3"
+        "channel_name": "SLE-Module-Containers12-Pool for ppc64le SAP SP3"
     },
     {
         "channel_label": "sle-module-containers12-debuginfo-pool-ppc64le-sap-sp3",
@@ -28272,7 +28692,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Debuginfo-Pool for ppc64le SAP-SP3"
+        "channel_name": "SLE-Module-Containers12-Debuginfo-Pool for ppc64le SAP SP3"
     },
     {
         "channel_label": "sle-module-containers12-updates-ppc64le-sp4",
@@ -28283,7 +28703,7 @@
         "root_product_id": 1626,
         "update_tag": "SLE-Module-Containers",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Containers/12/ppc64le/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -28298,7 +28718,7 @@
         "root_product_id": 1626,
         "update_tag": "SLE-Module-Containers",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Containers/12/ppc64le/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -28313,7 +28733,7 @@
         "root_product_id": 1626,
         "update_tag": "SLE-Module-Containers",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Containers/12/ppc64le/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -28328,7 +28748,7 @@
         "root_product_id": 1626,
         "update_tag": "SLE-Module-Containers",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Containers/12/ppc64le/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -28343,11 +28763,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-Module-Containers",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Containers/12/ppc64le/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Updates for ppc64le SAP-SP4"
+        "channel_name": "SLE-Module-Containers12-Updates for ppc64le SAP SP4"
     },
     {
         "channel_label": "sle-module-containers12-debuginfo-updates-ppc64le-sap-sp4",
@@ -28358,11 +28778,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-Module-Containers",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Containers/12/ppc64le/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Debuginfo-Updates for ppc64le SAP-SP4"
+        "channel_name": "SLE-Module-Containers12-Debuginfo-Updates for ppc64le SAP SP4"
     },
     {
         "channel_label": "sle-module-containers12-pool-ppc64le-sap-sp4",
@@ -28373,11 +28793,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-Module-Containers",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Containers/12/ppc64le/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Pool for ppc64le SAP-SP4"
+        "channel_name": "SLE-Module-Containers12-Pool for ppc64le SAP SP4"
     },
     {
         "channel_label": "sle-module-containers12-debuginfo-pool-ppc64le-sap-sp4",
@@ -28388,11 +28808,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-Module-Containers",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Containers/12/ppc64le/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Containers12-Debuginfo-Pool for ppc64le SAP-SP4"
+        "channel_name": "SLE-Module-Containers12-Debuginfo-Pool for ppc64le SAP SP4"
     },
     {
         "channel_label": "sle-module-containers12-updates-s390x",
@@ -28643,7 +29063,7 @@
         "root_product_id": 1627,
         "update_tag": "SLE-Module-Containers",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Containers/12/s390x/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -28658,7 +29078,7 @@
         "root_product_id": 1627,
         "update_tag": "SLE-Module-Containers",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Containers/12/s390x/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -28673,7 +29093,7 @@
         "root_product_id": 1627,
         "update_tag": "SLE-Module-Containers",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Containers/12/s390x/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -28688,7 +29108,7 @@
         "root_product_id": 1627,
         "update_tag": "SLE-Module-Containers",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Containers/12/s390x/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -28707,7 +29127,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates ppc64le SP2"
+        "channel_name": "SLE-Manager-Tools12-Updates for ppc64le SP2"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-ppc64le-sp2",
@@ -28722,7 +29142,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates ppc64le SP2"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for ppc64le SP2"
     },
     {
         "channel_label": "sle-manager-tools12-pool-ppc64le-sp2",
@@ -28737,7 +29157,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool ppc64le SP2"
+        "channel_name": "SLE-Manager-Tools12-Pool for ppc64le SP2"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-ppc64le-sp2",
@@ -28752,7 +29172,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool ppc64le SP2"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for ppc64le SP2"
     },
     {
         "channel_label": "sles12-sp2-updates-ppc64le",
@@ -28827,7 +29247,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates s390x SP2"
+        "channel_name": "SLE-Manager-Tools12-Updates for s390x SP2"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-s390x-sp2",
@@ -28842,7 +29262,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates s390x SP2"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for s390x SP2"
     },
     {
         "channel_label": "sle-manager-tools12-pool-s390x-sp2",
@@ -28857,7 +29277,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool s390x SP2"
+        "channel_name": "SLE-Manager-Tools12-Pool for s390x SP2"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-s390x-sp2",
@@ -28872,7 +29292,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool s390x SP2"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for s390x SP2"
     },
     {
         "channel_label": "sles12-sp2-updates-s390x",
@@ -28947,7 +29367,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates x86_64 SP2"
+        "channel_name": "SLE-Manager-Tools12-Updates for x86_64 SP2"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-x86_64-sp2",
@@ -28962,7 +29382,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates x86_64 SP2"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for x86_64 SP2"
     },
     {
         "channel_label": "sle-manager-tools12-pool-x86_64-sp2",
@@ -28977,7 +29397,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool x86_64 SP2"
+        "channel_name": "SLE-Manager-Tools12-Pool for x86_64 SP2"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-x86_64-sp2",
@@ -28992,7 +29412,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool x86_64 SP2"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for x86_64 SP2"
     },
     {
         "channel_label": "sles12-sp2-updates-x86_64",
@@ -29067,7 +29487,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates x86_64 SLED-SP2"
+        "channel_name": "SLE-Manager-Tools12-Updates for x86_64 SLED SP2"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-x86_64-sled-sp2",
@@ -29082,7 +29502,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates x86_64 SLED-SP2"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for x86_64 SLED SP2"
     },
     {
         "channel_label": "sle-manager-tools12-pool-x86_64-sled-sp2",
@@ -29097,7 +29517,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool x86_64 SLED-SP2"
+        "channel_name": "SLE-Manager-Tools12-Pool for x86_64 SLED SP2"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-x86_64-sled-sp2",
@@ -29112,7 +29532,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool x86_64 SLED-SP2"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for x86_64 SLED SP2"
     },
     {
         "channel_label": "sled12-sp2-updates-x86_64",
@@ -29187,7 +29607,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-12-SP2-GA-Desktop-nVidia-Driver"
+        "channel_name": "SLE-12-SP2-GA-Desktop-nVidia-Driver for x86_64"
     },
     {
         "channel_label": "sle-we12-sp2-updates-x86_64",
@@ -29262,7 +29682,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-12-SP2-GA-Desktop-nVidia-Driver WE-SP2"
+        "channel_name": "SLE-12-SP2-GA-Desktop-nVidia-Driver for x86_64 WE"
     },
     {
         "channel_label": "sle-we12-sp2-updates-x86_64-sap-sp2",
@@ -29277,7 +29697,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-WE12-SP2-Updates for x86_64 SAP-SP2"
+        "channel_name": "SLE-WE12-SP2-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-we12-sp2-debuginfo-updates-x86_64-sap-sp2",
@@ -29292,7 +29712,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-WE12-SP2-Debuginfo-Updates for x86_64 SAP-SP2"
+        "channel_name": "SLE-WE12-SP2-Debuginfo-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-we12-sp2-pool-x86_64-sap-sp2",
@@ -29307,7 +29727,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-WE12-SP2-Pool for x86_64 SAP-SP2"
+        "channel_name": "SLE-WE12-SP2-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-we12-sp2-debuginfo-pool-x86_64-sap-sp2",
@@ -29322,7 +29742,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-WE12-SP2-Debuginfo-Pool for x86_64 SAP-SP2"
+        "channel_name": "SLE-WE12-SP2-Debuginfo-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-12-sp2-ga-desktop-nvidia-driver-we-sap-sp2",
@@ -29337,7 +29757,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-12-SP2-GA-Desktop-nVidia-Driver WE-SAP-SP2"
+        "channel_name": "SLE-12-SP2-GA-Desktop-nVidia-Driver for x86_64 WE-SAP"
     },
     {
         "channel_label": "sle-we12-sp2-updates-x86_64-hpc-sp2",
@@ -29352,7 +29772,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-WE12-SP2-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLE-WE12-SP2-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sle-we12-sp2-debuginfo-updates-x86_64-hpc-sp2",
@@ -29367,7 +29787,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-WE12-SP2-Debuginfo-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLE-WE12-SP2-Debuginfo-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sle-we12-sp2-pool-x86_64-hpc-sp2",
@@ -29382,7 +29802,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-WE12-SP2-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLE-WE12-SP2-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sle-we12-sp2-debuginfo-pool-x86_64-hpc-sp2",
@@ -29397,7 +29817,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-WE12-SP2-Debuginfo-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLE-WE12-SP2-Debuginfo-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sle-12-sp2-ga-desktop-nvidia-driver-hpc-sp2",
@@ -29412,7 +29832,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-12-SP2-GA-Desktop-nVidia-Driver for x86_64 HPC-SP2"
+        "channel_name": "SLE-12-SP2-GA-Desktop-nVidia-Driver for x86_64 HPC"
     },
     {
         "channel_label": "sle-ha12-sp2-updates-s390x",
@@ -29547,7 +29967,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP2-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLE-HA12-SP2-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sle-ha12-sp2-debuginfo-updates-x86_64-hpc-sp2",
@@ -29562,7 +29982,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP2-Debuginfo-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLE-HA12-SP2-Debuginfo-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sle-ha12-sp2-pool-x86_64-hpc-sp2",
@@ -29577,7 +29997,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP2-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLE-HA12-SP2-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sle-ha12-sp2-debuginfo-pool-x86_64-hpc-sp2",
@@ -29592,7 +30012,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP2-Debuginfo-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLE-HA12-SP2-Debuginfo-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sle-ha-geo12-sp2-updates-s390x",
@@ -29727,7 +30147,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA-GEO12-SP2-Updates for x86_64 SAP-SP2"
+        "channel_name": "SLE-HA-GEO12-SP2-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-ha-geo12-sp2-debuginfo-updates-x86_64-sap-sp2",
@@ -29742,7 +30162,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA-GEO12-SP2-Debuginfo-Updates for x86_64 SAP-SP2"
+        "channel_name": "SLE-HA-GEO12-SP2-Debuginfo-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-ha-geo12-sp2-pool-x86_64-sap-sp2",
@@ -29757,7 +30177,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA-GEO12-SP2-Pool for x86_64 SAP-SP2"
+        "channel_name": "SLE-HA-GEO12-SP2-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-ha-geo12-sp2-debuginfo-pool-x86_64-sap-sp2",
@@ -29772,7 +30192,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA-GEO12-SP2-Debuginfo-Pool for x86_64 SAP-SP2"
+        "channel_name": "SLE-HA-GEO12-SP2-Debuginfo-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-ha-geo12-sp2-updates-x86_64-hpc-sp2",
@@ -29787,7 +30207,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA-GEO12-SP2-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLE-HA-GEO12-SP2-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sle-ha-geo12-sp2-debuginfo-updates-x86_64-hpc-sp2",
@@ -29802,7 +30222,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA-GEO12-SP2-Debuginfo-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLE-HA-GEO12-SP2-Debuginfo-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sle-ha-geo12-sp2-pool-x86_64-hpc-sp2",
@@ -29817,7 +30237,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA-GEO12-SP2-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLE-HA-GEO12-SP2-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sle-ha-geo12-sp2-debuginfo-pool-x86_64-hpc-sp2",
@@ -29832,7 +30252,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA-GEO12-SP2-Debuginfo-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLE-HA-GEO12-SP2-Debuginfo-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sle-sdk12-sp2-updates-ppc64le",
@@ -29907,7 +30327,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP2-Updates for ppc64le SAP-SP2"
+        "channel_name": "SLE-SDK12-SP2-Updates for ppc64le SAP"
     },
     {
         "channel_label": "sle-sdk12-sp2-debuginfo-updates-ppc64le-sap-sp2",
@@ -29922,7 +30342,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP2-Debuginfo-Updates for ppc64le SAP-SP2"
+        "channel_name": "SLE-SDK12-SP2-Debuginfo-Updates for ppc64le SAP"
     },
     {
         "channel_label": "sle-sdk12-sp2-pool-ppc64le-sap-sp2",
@@ -29937,7 +30357,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP2-Pool for ppc64le SAP-SP2"
+        "channel_name": "SLE-SDK12-SP2-Pool for ppc64le SAP"
     },
     {
         "channel_label": "sle-sdk12-sp2-debuginfo-pool-ppc64le-sap-sp2",
@@ -29952,7 +30372,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP2-Debuginfo-Pool for ppc64le SAP-SP2"
+        "channel_name": "SLE-SDK12-SP2-Debuginfo-Pool for ppc64le SAP"
     },
     {
         "channel_label": "sle-sdk12-sp2-updates-s390x",
@@ -30087,7 +30507,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP2-Updates for x86_64 SLED-SP2"
+        "channel_name": "SLE-SDK12-SP2-Updates for x86_64 SLED"
     },
     {
         "channel_label": "sle-sdk12-sp2-debuginfo-updates-x86_64-sled-sp2",
@@ -30102,7 +30522,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP2-Debuginfo-Updates for x86_64 SLED-SP2"
+        "channel_name": "SLE-SDK12-SP2-Debuginfo-Updates for x86_64 SLED"
     },
     {
         "channel_label": "sle-sdk12-sp2-pool-x86_64-sled-sp2",
@@ -30117,7 +30537,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP2-Pool for x86_64 SLED-SP2"
+        "channel_name": "SLE-SDK12-SP2-Pool for x86_64 SLED"
     },
     {
         "channel_label": "sle-sdk12-sp2-debuginfo-pool-x86_64-sled-sp2",
@@ -30132,7 +30552,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP2-Debuginfo-Pool for x86_64 SLED-SP2"
+        "channel_name": "SLE-SDK12-SP2-Debuginfo-Pool for x86_64 SLED"
     },
     {
         "channel_label": "sle-sdk12-sp2-updates-x86_64-sap-sp2",
@@ -30147,7 +30567,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP2-Updates for x86_64 SAP-SP2"
+        "channel_name": "SLE-SDK12-SP2-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-sdk12-sp2-debuginfo-updates-x86_64-sap-sp2",
@@ -30162,7 +30582,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP2-Debuginfo-Updates for x86_64 SAP-SP2"
+        "channel_name": "SLE-SDK12-SP2-Debuginfo-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-sdk12-sp2-pool-x86_64-sap-sp2",
@@ -30177,7 +30597,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP2-Pool for x86_64 SAP-SP2"
+        "channel_name": "SLE-SDK12-SP2-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-sdk12-sp2-debuginfo-pool-x86_64-sap-sp2",
@@ -30192,7 +30612,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP2-Debuginfo-Pool for x86_64 SAP-SP2"
+        "channel_name": "SLE-SDK12-SP2-Debuginfo-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-sdk12-sp2-updates-x86_64-hpc-sp2",
@@ -30207,7 +30627,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP2-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLE-SDK12-SP2-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sle-sdk12-sp2-debuginfo-updates-x86_64-hpc-sp2",
@@ -30222,7 +30642,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP2-Debuginfo-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLE-SDK12-SP2-Debuginfo-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sle-sdk12-sp2-pool-x86_64-hpc-sp2",
@@ -30237,7 +30657,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP2-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLE-SDK12-SP2-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sle-sdk12-sp2-debuginfo-pool-x86_64-hpc-sp2",
@@ -30252,7 +30672,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP2-Debuginfo-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLE-SDK12-SP2-Debuginfo-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sle-module-certifications12-updates-s390x",
@@ -30567,7 +30987,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Certifications12-Updates for x86_64 SAP-SP1"
+        "channel_name": "SLE-Module-Certifications12-Updates for x86_64 SAP SP1"
     },
     {
         "channel_label": "sle-module-certifications12-debuginfo-updates-x86_64-sap-sp1",
@@ -30582,7 +31002,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Certifications12-Debuginfo-Updates for x86_64 SAP-SP1"
+        "channel_name": "SLE-Module-Certifications12-Debuginfo-Updates for x86_64 SAP SP1"
     },
     {
         "channel_label": "sle-module-certifications12-pool-x86_64-sap-sp1",
@@ -30597,7 +31017,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Certifications12-Pool for x86_64 SAP-SP1"
+        "channel_name": "SLE-Module-Certifications12-Pool for x86_64 SAP SP1"
     },
     {
         "channel_label": "sle-module-certifications12-debuginfo-pool-x86_64-sap-sp1",
@@ -30612,7 +31032,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Certifications12-Debuginfo-Pool for x86_64 SAP-SP1"
+        "channel_name": "SLE-Module-Certifications12-Debuginfo-Pool for x86_64 SAP SP1"
     },
     {
         "channel_label": "suse-enterprise-storage-3-updates-x86_64",
@@ -30627,7 +31047,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-3-Updates for x86_64"
+        "channel_name": "SUSE-Enterprise-Storage-3-Updates for x86_64 SP1"
     },
     {
         "channel_label": "suse-enterprise-storage-3-debuginfo-updates-x86_64",
@@ -30642,7 +31062,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-3-Debuginfo-Updates for x86_64"
+        "channel_name": "SUSE-Enterprise-Storage-3-Debuginfo-Updates for x86_64 SP1"
     },
     {
         "channel_label": "suse-enterprise-storage-3-pool-x86_64",
@@ -30657,7 +31077,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-3-Pool for x86_64"
+        "channel_name": "SUSE-Enterprise-Storage-3-Pool for x86_64 SP1"
     },
     {
         "channel_label": "suse-enterprise-storage-3-debuginfo-pool-x86_64",
@@ -30672,7 +31092,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-3-Debuginfo-Pool for x86_64"
+        "channel_name": "SUSE-Enterprise-Storage-3-Debuginfo-Pool for x86_64 SP1"
     },
     {
         "channel_label": "suse-enterprise-storage-3-updates-x86_64-sap-sp1",
@@ -30687,7 +31107,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-3-Updates for x86_64 SAP-SP1"
+        "channel_name": "SUSE-Enterprise-Storage-3-Updates for x86_64 SAP SP1"
     },
     {
         "channel_label": "suse-enterprise-storage-3-debuginfo-updates-x86_64-sap-sp1",
@@ -30702,7 +31122,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-3-Debuginfo-Updates for x86_64 SAP-SP1"
+        "channel_name": "SUSE-Enterprise-Storage-3-Debuginfo-Updates for x86_64 SAP SP1"
     },
     {
         "channel_label": "suse-enterprise-storage-3-pool-x86_64-sap-sp1",
@@ -30717,7 +31137,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-3-Pool for x86_64 SAP-SP1"
+        "channel_name": "SUSE-Enterprise-Storage-3-Pool for x86_64 SAP SP1"
     },
     {
         "channel_label": "suse-enterprise-storage-3-debuginfo-pool-x86_64-sap-sp1",
@@ -30732,7 +31152,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-3-Debuginfo-Pool for x86_64 SAP-SP1"
+        "channel_name": "SUSE-Enterprise-Storage-3-Debuginfo-Pool for x86_64 SAP SP1"
     },
     {
         "channel_label": "sles12-sp2-updates-aarch64",
@@ -30807,7 +31227,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates aarch64"
+        "channel_name": "SLE-Manager-Tools12-Updates for aarch64 SP2"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-aarch64",
@@ -30822,7 +31242,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates aarch64"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for aarch64 SP2"
     },
     {
         "channel_label": "sle-manager-tools12-pool-aarch64",
@@ -30837,7 +31257,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool aarch64"
+        "channel_name": "SLE-Manager-Tools12-Pool for aarch64 SP2"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-aarch64",
@@ -30852,7 +31272,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool aarch64"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for aarch64 SP2"
     },
     {
         "channel_label": "sle-module-toolchain12-updates-aarch64",
@@ -30867,7 +31287,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Updates for aarch64"
+        "channel_name": "SLE-Module-Toolchain12-Updates for aarch64 SP2"
     },
     {
         "channel_label": "sle-module-toolchain12-debuginfo-updates-aarch64",
@@ -30882,7 +31302,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Updates for aarch64"
+        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Updates for aarch64 SP2"
     },
     {
         "channel_label": "sle-module-toolchain12-pool-aarch64",
@@ -30897,7 +31317,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Pool for aarch64"
+        "channel_name": "SLE-Module-Toolchain12-Pool for aarch64 SP2"
     },
     {
         "channel_label": "sle-module-toolchain12-debuginfo-pool-aarch64",
@@ -30912,7 +31332,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Pool for aarch64"
+        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Pool for aarch64 SP2"
     },
     {
         "channel_label": "sle-module-toolchain12-updates-aarch64-sp3",
@@ -30983,7 +31403,7 @@
         "root_product_id": 1628,
         "update_tag": "SLE-Module-Toolchain",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Toolchain/12/aarch64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -30998,7 +31418,7 @@
         "root_product_id": 1628,
         "update_tag": "SLE-Module-Toolchain",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Toolchain/12/aarch64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -31013,7 +31433,7 @@
         "root_product_id": 1628,
         "update_tag": "SLE-Module-Toolchain",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Toolchain/12/aarch64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -31028,7 +31448,7 @@
         "root_product_id": 1628,
         "update_tag": "SLE-Module-Toolchain",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Toolchain/12/aarch64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -31047,7 +31467,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Updates for aarch64 HPC-SP3"
+        "channel_name": "SLE-Module-Toolchain12-Updates for aarch64 HPC SP3"
     },
     {
         "channel_label": "sle-module-toolchain12-debuginfo-updates-aarch64-hpc-sp3",
@@ -31062,7 +31482,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Updates for aarch64 HPC-SP3"
+        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Updates for aarch64 HPC SP3"
     },
     {
         "channel_label": "sle-module-toolchain12-pool-aarch64-hpc-sp3",
@@ -31077,7 +31497,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Pool for aarch64 HPC-SP3"
+        "channel_name": "SLE-Module-Toolchain12-Pool for aarch64 HPC SP3"
     },
     {
         "channel_label": "sle-module-toolchain12-debuginfo-pool-aarch64-hpc-sp3",
@@ -31092,7 +31512,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Pool for aarch64 HPC-SP3"
+        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Pool for aarch64 HPC SP3"
     },
     {
         "channel_label": "sle-module-toolchain12-updates-aarch64-hpc-sp4",
@@ -31103,11 +31523,11 @@
         "root_product_id": 1758,
         "update_tag": "SLE-Module-Toolchain",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Toolchain/12/aarch64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Updates for aarch64 HPC-SP4"
+        "channel_name": "SLE-Module-Toolchain12-Updates for aarch64 HPC SP4"
     },
     {
         "channel_label": "sle-module-toolchain12-debuginfo-updates-aarch64-hpc-sp4",
@@ -31118,11 +31538,11 @@
         "root_product_id": 1758,
         "update_tag": "SLE-Module-Toolchain",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Toolchain/12/aarch64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Updates for aarch64 HPC-SP4"
+        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Updates for aarch64 HPC SP4"
     },
     {
         "channel_label": "sle-module-toolchain12-pool-aarch64-hpc-sp4",
@@ -31133,11 +31553,11 @@
         "root_product_id": 1758,
         "update_tag": "SLE-Module-Toolchain",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Toolchain/12/aarch64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Pool for aarch64 HPC-SP4"
+        "channel_name": "SLE-Module-Toolchain12-Pool for aarch64 HPC SP4"
     },
     {
         "channel_label": "sle-module-toolchain12-debuginfo-pool-aarch64-hpc-sp4",
@@ -31148,11 +31568,11 @@
         "root_product_id": 1758,
         "update_tag": "SLE-Module-Toolchain",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Toolchain/12/aarch64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Pool for aarch64 HPC-SP4"
+        "channel_name": "SLE-Module-Toolchain12-Debuginfo-Pool for aarch64 HPC SP4"
     },
     {
         "channel_label": "sle-sdk12-sp2-updates-aarch64",
@@ -31317,7 +31737,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-7-Updates for x86_64"
+        "channel_name": "SUSE-OpenStack-Cloud-7-Updates for x86_64 SP2"
     },
     {
         "channel_label": "suse-openstack-cloud-7-debuginfo-updates-x86_64",
@@ -31332,7 +31752,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-7-Debuginfo-Updates for x86_64"
+        "channel_name": "SUSE-OpenStack-Cloud-7-Debuginfo-Updates for x86_64 SP2"
     },
     {
         "channel_label": "suse-openstack-cloud-7-pool-x86_64",
@@ -31347,7 +31767,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-7-Pool for x86_64"
+        "channel_name": "SUSE-OpenStack-Cloud-7-Pool for x86_64 SP2"
     },
     {
         "channel_label": "suse-openstack-cloud-7-debuginfo-pool-x86_64",
@@ -31362,7 +31782,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-7-Debuginfo-Pool for x86_64"
+        "channel_name": "SUSE-OpenStack-Cloud-7-Debuginfo-Pool for x86_64 SP2"
     },
     {
         "channel_label": "suse-openstack-cloud-7-updates-x86_64-sap-sp2",
@@ -31377,7 +31797,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-7-Updates for x86_64 SAP-SP2"
+        "channel_name": "SUSE-OpenStack-Cloud-7-Updates for x86_64 SAP SP2"
     },
     {
         "channel_label": "suse-openstack-cloud-7-debuginfo-updates-x86_64-sap-sp2",
@@ -31392,7 +31812,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-7-Debuginfo-Updates for x86_64 SAP-SP2"
+        "channel_name": "SUSE-OpenStack-Cloud-7-Debuginfo-Updates for x86_64 SAP SP2"
     },
     {
         "channel_label": "suse-openstack-cloud-7-pool-x86_64-sap-sp2",
@@ -31407,7 +31827,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-7-Pool for x86_64 SAP-SP2"
+        "channel_name": "SUSE-OpenStack-Cloud-7-Pool for x86_64 SAP SP2"
     },
     {
         "channel_label": "suse-openstack-cloud-7-debuginfo-pool-x86_64-sap-sp2",
@@ -31422,7 +31842,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-7-Debuginfo-Pool for x86_64 SAP-SP2"
+        "channel_name": "SUSE-OpenStack-Cloud-7-Debuginfo-Pool for x86_64 SAP SP2"
     },
     {
         "channel_label": "suse-openstack-cloud-7-updates-x86_64-hpc-sp2",
@@ -31437,7 +31857,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-7-Updates for x86_64 HPC-SP2"
+        "channel_name": "SUSE-OpenStack-Cloud-7-Updates for x86_64 HPC SP2"
     },
     {
         "channel_label": "suse-openstack-cloud-7-debuginfo-updates-x86_64-hpc-sp2",
@@ -31452,7 +31872,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-7-Debuginfo-Updates for x86_64 HPC-SP2"
+        "channel_name": "SUSE-OpenStack-Cloud-7-Debuginfo-Updates for x86_64 HPC SP2"
     },
     {
         "channel_label": "suse-openstack-cloud-7-pool-x86_64-hpc-sp2",
@@ -31467,7 +31887,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-7-Pool for x86_64 HPC-SP2"
+        "channel_name": "SUSE-OpenStack-Cloud-7-Pool for x86_64 HPC SP2"
     },
     {
         "channel_label": "suse-openstack-cloud-7-debuginfo-pool-x86_64-hpc-sp2",
@@ -31482,7 +31902,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-7-Debuginfo-Pool for x86_64 HPC-SP2"
+        "channel_name": "SUSE-OpenStack-Cloud-7-Debuginfo-Pool for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-manager-tools12-updates-x86_64-sap-sp2",
@@ -31497,7 +31917,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates x86_64 SAP-SP2"
+        "channel_name": "SLE-Manager-Tools12-Updates for x86_64 SAP SP2"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-x86_64-sap-sp2",
@@ -31512,7 +31932,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates x86_64 SAP-SP2"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for x86_64 SAP SP2"
     },
     {
         "channel_label": "sle-manager-tools12-pool-x86_64-sap-sp2",
@@ -31527,7 +31947,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool x86_64 SAP-SP2"
+        "channel_name": "SLE-Manager-Tools12-Pool for x86_64 SAP SP2"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-x86_64-sap-sp2",
@@ -31542,7 +31962,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool x86_64 SAP-SP2"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for x86_64 SAP SP2"
     },
     {
         "channel_label": "sles12-sp2-updates-x86_64-sap-sp2",
@@ -31557,7 +31977,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP2-Updates for x86_64 SAP-SP2"
+        "channel_name": "SLES12-SP2-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sles12-sp2-debuginfo-updates-x86_64-sap-sp2",
@@ -31572,7 +31992,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP2-Debuginfo-Updates for x86_64 SAP-SP2"
+        "channel_name": "SLES12-SP2-Debuginfo-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sles12-sp2-pool-x86_64-sap-sp2",
@@ -31587,7 +32007,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP2-Pool for x86_64 SAP-SP2"
+        "channel_name": "SLES12-SP2-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sles12-sp2-debuginfo-pool-x86_64-sap-sp2",
@@ -31602,7 +32022,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP2-Debuginfo-Pool for x86_64 SAP-SP2"
+        "channel_name": "SLES12-SP2-Debuginfo-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-ha12-sp2-updates-x86_64-sap-sp2",
@@ -31617,7 +32037,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP2-Updates for x86_64 SAP-SP2"
+        "channel_name": "SLE-HA12-SP2-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-ha12-sp2-debuginfo-updates-x86_64-sap-sp2",
@@ -31632,7 +32052,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP2-Debuginfo-Updates for x86_64 SAP-SP2"
+        "channel_name": "SLE-HA12-SP2-Debuginfo-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-ha12-sp2-pool-x86_64-sap-sp2",
@@ -31647,7 +32067,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP2-Pool for x86_64 SAP-SP2"
+        "channel_name": "SLE-HA12-SP2-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-ha12-sp2-debuginfo-pool-x86_64-sap-sp2",
@@ -31662,7 +32082,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP2-Debuginfo-Pool for x86_64 SAP-SP2"
+        "channel_name": "SLE-HA12-SP2-Debuginfo-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-12-sp2-sap-updates-x86_64",
@@ -31737,7 +32157,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-4-Updates for x86_64"
+        "channel_name": "SUSE-Enterprise-Storage-4-Updates for x86_64 SP2"
     },
     {
         "channel_label": "suse-enterprise-storage-4-debuginfo-updates-x86_64",
@@ -31752,7 +32172,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-4-Debuginfo-Updates for x86_64"
+        "channel_name": "SUSE-Enterprise-Storage-4-Debuginfo-Updates for x86_64 SP2"
     },
     {
         "channel_label": "suse-enterprise-storage-4-pool-x86_64",
@@ -31767,7 +32187,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-4-Pool for x86_64"
+        "channel_name": "SUSE-Enterprise-Storage-4-Pool for x86_64 SP2"
     },
     {
         "channel_label": "suse-enterprise-storage-4-debuginfo-pool-x86_64",
@@ -31782,7 +32202,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-4-Debuginfo-Pool for x86_64"
+        "channel_name": "SUSE-Enterprise-Storage-4-Debuginfo-Pool for x86_64 SP2"
     },
     {
         "channel_label": "suse-enterprise-storage-4-updates-x86_64-sap-sp2",
@@ -31797,7 +32217,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-4-Updates for x86_64 SAP-SP2"
+        "channel_name": "SUSE-Enterprise-Storage-4-Updates for x86_64 SAP SP2"
     },
     {
         "channel_label": "suse-enterprise-storage-4-debuginfo-updates-x86_64-sap-sp2",
@@ -31812,7 +32232,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-4-Debuginfo-Updates for x86_64 SAP-SP2"
+        "channel_name": "SUSE-Enterprise-Storage-4-Debuginfo-Updates for x86_64 SAP SP2"
     },
     {
         "channel_label": "suse-enterprise-storage-4-pool-x86_64-sap-sp2",
@@ -31827,7 +32247,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-4-Pool for x86_64 SAP-SP2"
+        "channel_name": "SUSE-Enterprise-Storage-4-Pool for x86_64 SAP SP2"
     },
     {
         "channel_label": "suse-enterprise-storage-4-debuginfo-pool-x86_64-sap-sp2",
@@ -31842,7 +32262,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-4-Debuginfo-Pool for x86_64 SAP-SP2"
+        "channel_name": "SUSE-Enterprise-Storage-4-Debuginfo-Pool for x86_64 SAP SP2"
     },
     {
         "channel_label": "suse-enterprise-storage-4-updates-x86_64-hpc-sp2",
@@ -31857,7 +32277,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-4-Updates for x86_64 HPC-SP2"
+        "channel_name": "SUSE-Enterprise-Storage-4-Updates for x86_64 HPC SP2"
     },
     {
         "channel_label": "suse-enterprise-storage-4-debuginfo-updates-x86_64-hpc-sp2",
@@ -31872,7 +32292,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-4-Debuginfo-Updates for x86_64 HPC-SP2"
+        "channel_name": "SUSE-Enterprise-Storage-4-Debuginfo-Updates for x86_64 HPC SP2"
     },
     {
         "channel_label": "suse-enterprise-storage-4-pool-x86_64-hpc-sp2",
@@ -31887,7 +32307,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-4-Pool for x86_64 HPC-SP2"
+        "channel_name": "SUSE-Enterprise-Storage-4-Pool for x86_64 HPC SP2"
     },
     {
         "channel_label": "suse-enterprise-storage-4-debuginfo-pool-x86_64-hpc-sp2",
@@ -31902,7 +32322,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-4-Debuginfo-Pool for x86_64 HPC-SP2"
+        "channel_name": "SUSE-Enterprise-Storage-4-Debuginfo-Pool for x86_64 HPC SP2"
     },
     {
         "channel_label": "suse-enterprise-storage-4-updates-aarch64-sp2",
@@ -32037,7 +32457,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates aarch64 RPI"
+        "channel_name": "SLE-Manager-Tools12-Updates for aarch64 RPI SP2"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-aarch64-rpi",
@@ -32052,7 +32472,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates aarch64 RPI"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for aarch64 RPI SP2"
     },
     {
         "channel_label": "sle-manager-tools12-pool-aarch64-rpi",
@@ -32067,7 +32487,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool aarch64 RPI"
+        "channel_name": "SLE-Manager-Tools12-Pool for aarch64 RPI SP2"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-aarch64-rpi",
@@ -32082,7 +32502,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool aarch64 RPI"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for aarch64 RPI SP2"
     },
     {
         "channel_label": "sle-ha12-sp2-updates-ppc64le",
@@ -32157,7 +32577,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates x86_64 SP3"
+        "channel_name": "SLE-Manager-Tools12-Updates for x86_64 SP3"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-x86_64-sp3",
@@ -32172,7 +32592,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates x86_64 SP3"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for x86_64 SP3"
     },
     {
         "channel_label": "sle-manager-tools12-pool-x86_64-sp3",
@@ -32187,7 +32607,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool x86_64 SP3"
+        "channel_name": "SLE-Manager-Tools12-Pool for x86_64 SP3"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-x86_64-sp3",
@@ -32202,7 +32622,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool x86_64 SP3"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for x86_64 SP3"
     },
     {
         "channel_label": "sles12-sp3-updates-x86_64",
@@ -32277,7 +32697,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates ppc64le SP3"
+        "channel_name": "SLE-Manager-Tools12-Updates for ppc64le SP3"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-ppc64le-sp3",
@@ -32292,7 +32712,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates ppc64le SP3"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for ppc64le SP3"
     },
     {
         "channel_label": "sle-manager-tools12-pool-ppc64le-sp3",
@@ -32307,7 +32727,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool ppc64le SP3"
+        "channel_name": "SLE-Manager-Tools12-Pool for ppc64le SP3"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-ppc64le-sp3",
@@ -32322,7 +32742,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool ppc64le SP3"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for ppc64le SP3"
     },
     {
         "channel_label": "sles12-sp3-updates-ppc64le",
@@ -32397,7 +32817,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates s390x SP3"
+        "channel_name": "SLE-Manager-Tools12-Updates for s390x SP3"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-s390x-sp3",
@@ -32412,7 +32832,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates s390x SP3"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for s390x SP3"
     },
     {
         "channel_label": "sle-manager-tools12-pool-s390x-sp3",
@@ -32427,7 +32847,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool s390x SP3"
+        "channel_name": "SLE-Manager-Tools12-Pool for s390x SP3"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-s390x-sp3",
@@ -32442,7 +32862,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool s390x SP3"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for s390x SP3"
     },
     {
         "channel_label": "sles12-sp3-updates-s390x",
@@ -32517,7 +32937,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates aarch64 SP3"
+        "channel_name": "SLE-Manager-Tools12-Updates for aarch64 SP3"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-aarch64-sp3",
@@ -32532,7 +32952,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates aarch64 SP3"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for aarch64 SP3"
     },
     {
         "channel_label": "sle-manager-tools12-pool-aarch64-sp3",
@@ -32547,7 +32967,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool aarch64 SP3"
+        "channel_name": "SLE-Manager-Tools12-Pool for aarch64 SP3"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-aarch64-sp3",
@@ -32562,7 +32982,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool aarch64 SP3"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for aarch64 SP3"
     },
     {
         "channel_label": "sles12-sp3-updates-aarch64",
@@ -32637,7 +33057,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates x86_64 SLED-SP3"
+        "channel_name": "SLE-Manager-Tools12-Updates for x86_64 SLED SP3"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-x86_64-sled-sp3",
@@ -32652,7 +33072,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates x86_64 SLED-SP3"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for x86_64 SLED SP3"
     },
     {
         "channel_label": "sle-manager-tools12-pool-x86_64-sled-sp3",
@@ -32667,7 +33087,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool x86_64 SLED-SP3"
+        "channel_name": "SLE-Manager-Tools12-Pool for x86_64 SLED SP3"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-x86_64-sled-sp3",
@@ -32682,7 +33102,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool x86_64 SLED-SP3"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for x86_64 SLED SP3"
     },
     {
         "channel_label": "sled12-sp3-updates-x86_64",
@@ -32742,7 +33162,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-12-SP3-GA-Desktop-nVidia-Driver"
+        "channel_name": "SLE-12-SP3-GA-Desktop-nVidia-Driver for x86_64"
     },
     {
         "channel_label": "sled12-sp3-debuginfo-pool-x86_64",
@@ -32772,7 +33192,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates x86_64 SAP-SP3"
+        "channel_name": "SLE-Manager-Tools12-Updates for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-x86_64-sap-sp3",
@@ -32787,7 +33207,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates x86_64 SAP-SP3"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-manager-tools12-pool-x86_64-sap-sp3",
@@ -32802,7 +33222,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool x86_64 SAP-SP3"
+        "channel_name": "SLE-Manager-Tools12-Pool for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-x86_64-sap-sp3",
@@ -32817,7 +33237,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool x86_64 SAP-SP3"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for x86_64 SAP SP3"
     },
     {
         "channel_label": "sles12-sp3-updates-x86_64-sap-sp3",
@@ -32832,7 +33252,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP3-Updates for x86_64 SAP-SP3"
+        "channel_name": "SLES12-SP3-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sles12-sp3-debuginfo-updates-x86_64-sap-sp3",
@@ -32847,7 +33267,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP3-Debuginfo-Updates for x86_64 SAP-SP3"
+        "channel_name": "SLES12-SP3-Debuginfo-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sles12-sp3-pool-x86_64-sap-sp3",
@@ -32862,7 +33282,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP3-Pool for x86_64 SAP-SP3"
+        "channel_name": "SLES12-SP3-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sles12-sp3-debuginfo-pool-x86_64-sap-sp3",
@@ -32877,7 +33297,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP3-Debuginfo-Pool for x86_64 SAP-SP3"
+        "channel_name": "SLES12-SP3-Debuginfo-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-12-sp3-sap-updates-x86_64",
@@ -32907,7 +33327,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP3-Updates for x86_64 SAP-SP3"
+        "channel_name": "SLE-HA12-SP3-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-12-sp3-sap-debuginfo-updates-x86_64",
@@ -32937,7 +33357,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP3-Debuginfo-Updates for x86_64 SAP-SP3"
+        "channel_name": "SLE-HA12-SP3-Debuginfo-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle12-sp3-sap-pool-x86_64",
@@ -32967,7 +33387,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP3-Pool for x86_64 SAP-SP3"
+        "channel_name": "SLE-HA12-SP3-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle12-sp3-sap-debuginfo-pool-x86_64",
@@ -32997,7 +33417,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP3-Debuginfo-Pool for x86_64 SAP-SP3"
+        "channel_name": "SLE-HA12-SP3-Debuginfo-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-sdk12-sp3-updates-x86_64",
@@ -33072,7 +33492,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP3-Updates for x86_64 SLED-SP3"
+        "channel_name": "SLE-SDK12-SP3-Updates for x86_64 SLED"
     },
     {
         "channel_label": "sle-sdk12-sp3-debuginfo-updates-x86_64-sled-sp3",
@@ -33087,7 +33507,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP3-Debuginfo-Updates for x86_64 SLED-SP3"
+        "channel_name": "SLE-SDK12-SP3-Debuginfo-Updates for x86_64 SLED"
     },
     {
         "channel_label": "sle-sdk12-sp3-pool-x86_64-sled-sp3",
@@ -33102,7 +33522,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP3-Pool for x86_64 SLED-SP3"
+        "channel_name": "SLE-SDK12-SP3-Pool for x86_64 SLED"
     },
     {
         "channel_label": "sle-sdk12-sp3-debuginfo-pool-x86_64-sled-sp3",
@@ -33117,7 +33537,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP3-Debuginfo-Pool for x86_64 SLED-SP3"
+        "channel_name": "SLE-SDK12-SP3-Debuginfo-Pool for x86_64 SLED"
     },
     {
         "channel_label": "sle-sdk12-sp3-updates-x86_64-sap-sp3",
@@ -33132,7 +33552,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP3-Updates for x86_64 SAP-SP3"
+        "channel_name": "SLE-SDK12-SP3-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-sdk12-sp3-debuginfo-updates-x86_64-sap-sp3",
@@ -33147,7 +33567,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP3-Debuginfo-Updates for x86_64 SAP-SP3"
+        "channel_name": "SLE-SDK12-SP3-Debuginfo-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-sdk12-sp3-pool-x86_64-sap-sp3",
@@ -33162,7 +33582,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP3-Pool for x86_64 SAP-SP3"
+        "channel_name": "SLE-SDK12-SP3-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-sdk12-sp3-debuginfo-pool-x86_64-sap-sp3",
@@ -33177,7 +33597,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP3-Debuginfo-Pool for x86_64 SAP-SP3"
+        "channel_name": "SLE-SDK12-SP3-Debuginfo-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-sdk12-sp3-updates-x86_64-hpc-sp3",
@@ -33192,7 +33612,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP3-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLE-SDK12-SP3-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sle-sdk12-sp3-debuginfo-updates-x86_64-hpc-sp3",
@@ -33207,7 +33627,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP3-Debuginfo-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLE-SDK12-SP3-Debuginfo-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sle-sdk12-sp3-pool-x86_64-hpc-sp3",
@@ -33222,7 +33642,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP3-Pool for x86_64 HPC-SP3"
+        "channel_name": "SLE-SDK12-SP3-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sle-sdk12-sp3-debuginfo-pool-x86_64-hpc-sp3",
@@ -33237,7 +33657,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP3-Debuginfo-Pool for x86_64 HPC-SP3"
+        "channel_name": "SLE-SDK12-SP3-Debuginfo-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sle-sdk12-sp3-updates-ppc64le",
@@ -33312,7 +33732,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP3-Updates for ppc64le SAP-SP3"
+        "channel_name": "SLE-SDK12-SP3-Updates for ppc64le SAP"
     },
     {
         "channel_label": "sle-sdk12-sp3-debuginfo-updates-ppc64le-sap-sp3",
@@ -33327,7 +33747,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP3-Debuginfo-Updates for ppc64le SAP-SP3"
+        "channel_name": "SLE-SDK12-SP3-Debuginfo-Updates for ppc64le SAP"
     },
     {
         "channel_label": "sle-sdk12-sp3-pool-ppc64le-sap-sp3",
@@ -33342,7 +33762,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP3-Pool for ppc64le SAP-SP3"
+        "channel_name": "SLE-SDK12-SP3-Pool for ppc64le SAP"
     },
     {
         "channel_label": "sle-sdk12-sp3-debuginfo-pool-ppc64le-sap-sp3",
@@ -33357,7 +33777,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP3-Debuginfo-Pool for ppc64le SAP-SP3"
+        "channel_name": "SLE-SDK12-SP3-Debuginfo-Pool for ppc64le SAP"
     },
     {
         "channel_label": "sle-sdk12-sp3-updates-s390x",
@@ -33492,7 +33912,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP3-Updates for aarch64 HPC-SP3"
+        "channel_name": "SLE-SDK12-SP3-Updates for aarch64 HPC"
     },
     {
         "channel_label": "sle-sdk12-sp3-debuginfo-updates-aarch64-hpc-sp3",
@@ -33507,7 +33927,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP3-Debuginfo-Updates for aarch64 HPC-SP3"
+        "channel_name": "SLE-SDK12-SP3-Debuginfo-Updates for aarch64 HPC"
     },
     {
         "channel_label": "sle-sdk12-sp3-pool-aarch64-hpc-sp3",
@@ -33522,7 +33942,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP3-Pool for aarch64 HPC-SP3"
+        "channel_name": "SLE-SDK12-SP3-Pool for aarch64 HPC"
     },
     {
         "channel_label": "sle-sdk12-sp3-debuginfo-pool-aarch64-hpc-sp3",
@@ -33537,7 +33957,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP3-Debuginfo-Pool for aarch64 HPC-SP3"
+        "channel_name": "SLE-SDK12-SP3-Debuginfo-Pool for aarch64 HPC"
     },
     {
         "channel_label": "sle-12-sp3-ga-desktop-nvidia-driver-we-sp3",
@@ -33552,7 +33972,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-12-SP3-GA-Desktop-nVidia-Driver WE-SP3"
+        "channel_name": "SLE-12-SP3-GA-Desktop-nVidia-Driver for x86_64 WE"
     },
     {
         "channel_label": "sle-we12-sp3-updates-x86_64",
@@ -33627,7 +34047,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-12-SP3-GA-Desktop-nVidia-Driver WE-SAP-SP3"
+        "channel_name": "SLE-12-SP3-GA-Desktop-nVidia-Driver for x86_64 WE-SAP"
     },
     {
         "channel_label": "sle-we12-sp3-updates-x86_64-sap-sp3",
@@ -33642,7 +34062,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-WE12-SP3-Updates for x86_64 SAP-SP3"
+        "channel_name": "SLE-WE12-SP3-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-we12-sp3-debuginfo-updates-x86_64-sap-sp3",
@@ -33657,7 +34077,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-WE12-SP3-Debuginfo-Updates for x86_64 SAP-SP3"
+        "channel_name": "SLE-WE12-SP3-Debuginfo-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-we12-sp3-pool-x86_64-sap-sp3",
@@ -33672,7 +34092,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-WE12-SP3-Pool for x86_64 SAP-SP3"
+        "channel_name": "SLE-WE12-SP3-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-we12-sp3-debuginfo-pool-x86_64-sap-sp3",
@@ -33687,7 +34107,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-WE12-SP3-Debuginfo-Pool for x86_64 SAP-SP3"
+        "channel_name": "SLE-WE12-SP3-Debuginfo-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-12-sp3-ga-desktop-nvidia-driver-hpc-sp3",
@@ -33702,7 +34122,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-12-SP3-GA-Desktop-nVidia-Driver for x86_64 HPC-SP3"
+        "channel_name": "SLE-12-SP3-GA-Desktop-nVidia-Driver for x86_64 HPC"
     },
     {
         "channel_label": "sle-we12-sp3-updates-x86_64-hpc-sp3",
@@ -33717,7 +34137,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-WE12-SP3-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLE-WE12-SP3-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sle-we12-sp3-debuginfo-updates-x86_64-hpc-sp3",
@@ -33732,7 +34152,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-WE12-SP3-Debuginfo-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLE-WE12-SP3-Debuginfo-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sle-we12-sp3-pool-x86_64-hpc-sp3",
@@ -33747,7 +34167,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-WE12-SP3-Pool for x86_64 HPC-SP3"
+        "channel_name": "SLE-WE12-SP3-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sle-we12-sp3-debuginfo-pool-x86_64-hpc-sp3",
@@ -33762,7 +34182,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-WE12-SP3-Debuginfo-Pool for x86_64 HPC-SP3"
+        "channel_name": "SLE-WE12-SP3-Debuginfo-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sle-ha12-sp3-updates-x86_64",
@@ -33837,7 +34257,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP3-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLE-HA12-SP3-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sle-ha12-sp3-debuginfo-updates-x86_64-hpc-sp3",
@@ -33852,7 +34272,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP3-Debuginfo-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLE-HA12-SP3-Debuginfo-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sle-ha12-sp3-pool-x86_64-hpc-sp3",
@@ -33867,7 +34287,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP3-Pool for x86_64 HPC-SP3"
+        "channel_name": "SLE-HA12-SP3-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sle-ha12-sp3-debuginfo-pool-x86_64-hpc-sp3",
@@ -33882,7 +34302,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP3-Debuginfo-Pool for x86_64 HPC-SP3"
+        "channel_name": "SLE-HA12-SP3-Debuginfo-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sle-ha12-sp3-updates-ppc64le",
@@ -34077,7 +34497,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA-GEO12-SP3-Updates for x86_64 SAP-SP3"
+        "channel_name": "SLE-HA-GEO12-SP3-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-ha-geo12-sp3-debuginfo-updates-x86_64-sap-sp3",
@@ -34092,7 +34512,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA-GEO12-SP3-Debuginfo-Updates for x86_64 SAP-SP3"
+        "channel_name": "SLE-HA-GEO12-SP3-Debuginfo-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-ha-geo12-sp3-pool-x86_64-sap-sp3",
@@ -34107,7 +34527,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA-GEO12-SP3-Pool for x86_64 SAP-SP3"
+        "channel_name": "SLE-HA-GEO12-SP3-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-ha-geo12-sp3-debuginfo-pool-x86_64-sap-sp3",
@@ -34122,7 +34542,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA-GEO12-SP3-Debuginfo-Pool for x86_64 SAP-SP3"
+        "channel_name": "SLE-HA-GEO12-SP3-Debuginfo-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-ha-geo12-sp3-updates-x86_64-hpc-sp3",
@@ -34137,7 +34557,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA-GEO12-SP3-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLE-HA-GEO12-SP3-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sle-ha-geo12-sp3-debuginfo-updates-x86_64-hpc-sp3",
@@ -34152,7 +34572,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA-GEO12-SP3-Debuginfo-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLE-HA-GEO12-SP3-Debuginfo-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sle-ha-geo12-sp3-pool-x86_64-hpc-sp3",
@@ -34167,7 +34587,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA-GEO12-SP3-Pool for x86_64 HPC-SP3"
+        "channel_name": "SLE-HA-GEO12-SP3-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sle-ha-geo12-sp3-debuginfo-pool-x86_64-hpc-sp3",
@@ -34182,7 +34602,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA-GEO12-SP3-Debuginfo-Pool for x86_64 HPC-SP3"
+        "channel_name": "SLE-HA-GEO12-SP3-Debuginfo-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sle-ha-geo12-sp3-updates-s390x",
@@ -34257,7 +34677,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates ppc64le SAP-SP1"
+        "channel_name": "SLE-Manager-Tools12-Updates for ppc64le SAP SP1"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-ppc64le-sap-sp1",
@@ -34272,7 +34692,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates ppc64le SAP-SP1"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for ppc64le SAP SP1"
     },
     {
         "channel_label": "sle-manager-tools12-pool-ppc64le-sap-sp1",
@@ -34287,7 +34707,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool ppc64le SAP-SP1"
+        "channel_name": "SLE-Manager-Tools12-Pool for ppc64le SAP SP1"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-ppc64le-sap-sp1",
@@ -34302,7 +34722,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool ppc64le SAP-SP1"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for ppc64le SAP SP1"
     },
     {
         "channel_label": "sles12-sp1-updates-ppc64le-sap-sp1",
@@ -34317,7 +34737,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP1-Updates for ppc64le SAP-SP1"
+        "channel_name": "SLES12-SP1-Updates for ppc64le SAP"
     },
     {
         "channel_label": "sles12-sp1-debuginfo-updates-ppc64le-sap-sp1",
@@ -34332,7 +34752,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP1-Debuginfo-Updates for ppc64le SAP-SP1"
+        "channel_name": "SLES12-SP1-Debuginfo-Updates for ppc64le SAP"
     },
     {
         "channel_label": "sles12-sp1-pool-ppc64le-sap-sp1",
@@ -34347,7 +34767,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP1-Pool for ppc64le SAP-SP1"
+        "channel_name": "SLES12-SP1-Pool for ppc64le SAP"
     },
     {
         "channel_label": "sles12-sp1-debuginfo-pool-ppc64le-sap-sp1",
@@ -34362,7 +34782,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP1-Debuginfo-Pool for ppc64le SAP-SP1"
+        "channel_name": "SLES12-SP1-Debuginfo-Pool for ppc64le SAP"
     },
     {
         "channel_label": "sle-12-sp1-sap-updates-ppc64le",
@@ -34392,7 +34812,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP1-Updates for ppc64le SAP-SP1"
+        "channel_name": "SLE-HA12-SP1-Updates for ppc64le SAP"
     },
     {
         "channel_label": "sle-12-sp1-sap-debuginfo-updates-ppc64le",
@@ -34422,7 +34842,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP1-Debuginfo-Updates for ppc64le SAP-SP1"
+        "channel_name": "SLE-HA12-SP1-Debuginfo-Updates for ppc64le SAP"
     },
     {
         "channel_label": "sle12-sp1-sap-pool-ppc64le",
@@ -34452,7 +34872,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP1-Pool for ppc64le SAP-SP1"
+        "channel_name": "SLE-HA12-SP1-Pool for ppc64le SAP"
     },
     {
         "channel_label": "sle12-sp1-sap-debuginfo-pool-ppc64le",
@@ -34482,7 +34902,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP1-Debuginfo-Pool for ppc64le SAP-SP1"
+        "channel_name": "SLE-HA12-SP1-Debuginfo-Pool for ppc64le SAP"
     },
     {
         "channel_label": "sle-rt12-sp2-updates-x86_64",
@@ -34557,7 +34977,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-RT12-SP2-Updates for x86_64 SAP-SP2"
+        "channel_name": "SLE-RT12-SP2-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-rt12-sp2-debuginfo-updates-x86_64-sap-sp2",
@@ -34572,7 +34992,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-RT12-SP2-Debuginfo-Updates for x86_64 SAP-SP2"
+        "channel_name": "SLE-RT12-SP2-Debuginfo-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-rt12-sp2-pool-x86_64-sap-sp2",
@@ -34587,7 +35007,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-RT12-SP2-Pool for x86_64 SAP-SP2"
+        "channel_name": "SLE-RT12-SP2-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-rt12-sp2-debuginfo-pool-x86_64-sap-sp2",
@@ -34602,7 +35022,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-RT12-SP2-Debuginfo-Pool for x86_64 SAP-SP2"
+        "channel_name": "SLE-RT12-SP2-Debuginfo-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-rt12-sp2-updates-x86_64-hpc-sp2",
@@ -34617,7 +35037,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-RT12-SP2-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLE-RT12-SP2-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sle-rt12-sp2-debuginfo-updates-x86_64-hpc-sp2",
@@ -34632,7 +35052,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-RT12-SP2-Debuginfo-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLE-RT12-SP2-Debuginfo-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sle-rt12-sp2-pool-x86_64-hpc-sp2",
@@ -34647,7 +35067,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-RT12-SP2-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLE-RT12-SP2-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sle-rt12-sp2-debuginfo-pool-x86_64-hpc-sp2",
@@ -34662,7 +35082,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-RT12-SP2-Debuginfo-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLE-RT12-SP2-Debuginfo-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sle-pos12-sp2-updates-x86_64",
@@ -34737,7 +35157,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-POS12-SP2-CLIENT-Updates for x86_64 SP2"
+        "channel_name": "SLE-POS12-SP2-CLIENT-Updates for x86_64"
     },
     {
         "channel_label": "sle-pos12-sp2-client-debuginfo-updates-x86_64",
@@ -34752,7 +35172,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-POS12-SP2-CLIENT-Debuginfo-Updates for x86_64 SP2"
+        "channel_name": "SLE-POS12-SP2-CLIENT-Debuginfo-Updates for x86_64"
     },
     {
         "channel_label": "sle-pos12-sp2-updates-x86_64-sap-sp2",
@@ -34767,7 +35187,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-POS12-SP2-Updates for x86_64 SAP-SP2"
+        "channel_name": "SLE-POS12-SP2-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-pos12-sp2-debuginfo-updates-x86_64-sap-sp2",
@@ -34782,7 +35202,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-POS12-SP2-Debuginfo-Updates for x86_64 SAP-SP2"
+        "channel_name": "SLE-POS12-SP2-Debuginfo-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-pos12-sp2-pool-x86_64-sap-sp2",
@@ -34797,7 +35217,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-POS12-SP2-Pool for x86_64 SAP-SP2"
+        "channel_name": "SLE-POS12-SP2-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-pos12-sp2-debuginfo-pool-x86_64-sap-sp2",
@@ -34812,7 +35232,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-POS12-SP2-Debuginfo-Pool for x86_64 SAP-SP2"
+        "channel_name": "SLE-POS12-SP2-Debuginfo-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-pos12-sp2-client-updates-x86_64-sap-sp2",
@@ -34827,7 +35247,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-POS12-SP2-CLIENT-Updates for x86_64 SAP-SP2"
+        "channel_name": "SLE-POS12-SP2-CLIENT-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-pos12-sp2-client-debuginfo-updates-x86_64-sap-sp2",
@@ -34842,7 +35262,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-POS12-SP2-CLIENT-Debuginfo-Updates for x86_64 SAP-SP2"
+        "channel_name": "SLE-POS12-SP2-CLIENT-Debuginfo-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-pos12-sp2-updates-x86_64-sp3",
@@ -34947,7 +35367,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-POS12-SP2-Updates for x86_64 SAP-SP3"
+        "channel_name": "SLE-POS12-SP2-Updates for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-pos12-sp2-debuginfo-updates-x86_64-sap-sp3",
@@ -34962,7 +35382,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-POS12-SP2-Debuginfo-Updates for x86_64 SAP-SP3"
+        "channel_name": "SLE-POS12-SP2-Debuginfo-Updates for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-pos12-sp2-pool-x86_64-sap-sp3",
@@ -34977,7 +35397,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-POS12-SP2-Pool for x86_64 SAP-SP3"
+        "channel_name": "SLE-POS12-SP2-Pool for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-pos12-sp2-debuginfo-pool-x86_64-sap-sp3",
@@ -34992,7 +35412,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-POS12-SP2-Debuginfo-Pool for x86_64 SAP-SP3"
+        "channel_name": "SLE-POS12-SP2-Debuginfo-Pool for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-pos12-sp2-client-updates-x86_64-sap-sp3",
@@ -35007,7 +35427,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-POS12-SP2-CLIENT-Updates for x86_64 SAP-SP3"
+        "channel_name": "SLE-POS12-SP2-CLIENT-Updates for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-pos12-sp2-client-debuginfo-updates-x86_64-sap-sp3",
@@ -35022,7 +35442,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-POS12-SP2-CLIENT-Debuginfo-Updates for x86_64 SAP-SP3"
+        "channel_name": "SLE-POS12-SP2-CLIENT-Debuginfo-Updates for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-pos12-sp2-updates-x86_64-hpc-sp2",
@@ -35037,7 +35457,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-POS12-SP2-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLE-POS12-SP2-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sle-pos12-sp2-debuginfo-updates-x86_64-hpc-sp2",
@@ -35052,7 +35472,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-POS12-SP2-Debuginfo-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLE-POS12-SP2-Debuginfo-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sle-pos12-sp2-pool-x86_64-hpc-sp2",
@@ -35067,7 +35487,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-POS12-SP2-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLE-POS12-SP2-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sle-pos12-sp2-debuginfo-pool-x86_64-hpc-sp2",
@@ -35082,7 +35502,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-POS12-SP2-Debuginfo-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLE-POS12-SP2-Debuginfo-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sle-pos12-sp2-client-updates-x86_64-hpc-sp2",
@@ -35097,7 +35517,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-POS12-SP2-CLIENT-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLE-POS12-SP2-CLIENT-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sle-pos12-sp2-client-debuginfo-updates-x86_64-hpc-sp2",
@@ -35112,7 +35532,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-POS12-SP2-CLIENT-Debuginfo-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLE-POS12-SP2-CLIENT-Debuginfo-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sle-pos12-sp2-updates-x86_64-hpc-sp3",
@@ -35127,7 +35547,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-POS12-SP2-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLE-POS12-SP2-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-pos12-sp2-debuginfo-updates-x86_64-hpc-sp3",
@@ -35142,7 +35562,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-POS12-SP2-Debuginfo-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLE-POS12-SP2-Debuginfo-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-pos12-sp2-pool-x86_64-hpc-sp3",
@@ -35157,7 +35577,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-POS12-SP2-Pool for x86_64 HPC-SP3"
+        "channel_name": "SLE-POS12-SP2-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-pos12-sp2-debuginfo-pool-x86_64-hpc-sp3",
@@ -35172,7 +35592,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-POS12-SP2-Debuginfo-Pool for x86_64 HPC-SP3"
+        "channel_name": "SLE-POS12-SP2-Debuginfo-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-pos12-sp2-client-updates-x86_64-hpc-sp3",
@@ -35187,7 +35607,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-POS12-SP2-CLIENT-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLE-POS12-SP2-CLIENT-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-pos12-sp2-client-debuginfo-updates-x86_64-hpc-sp3",
@@ -35202,7 +35622,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-POS12-SP2-CLIENT-Debuginfo-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLE-POS12-SP2-CLIENT-Debuginfo-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-pos12-sp2-updates-x86_64-sap-sp4",
@@ -35217,7 +35637,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-POS12-SP2-Updates for x86_64 SAP-SP4"
+        "channel_name": "SLE-POS12-SP2-Updates for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-pos12-sp2-debuginfo-updates-x86_64-sap-sp4",
@@ -35232,7 +35652,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-POS12-SP2-Debuginfo-Updates for x86_64 SAP-SP4"
+        "channel_name": "SLE-POS12-SP2-Debuginfo-Updates for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-pos12-sp2-pool-x86_64-sap-sp4",
@@ -35247,7 +35667,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-POS12-SP2-Pool for x86_64 SAP-SP4"
+        "channel_name": "SLE-POS12-SP2-Pool for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-pos12-sp2-debuginfo-pool-x86_64-sap-sp4",
@@ -35262,7 +35682,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-POS12-SP2-Debuginfo-Pool for x86_64 SAP-SP4"
+        "channel_name": "SLE-POS12-SP2-Debuginfo-Pool for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-pos12-sp2-client-updates-x86_64-sap-sp4",
@@ -35277,7 +35697,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-POS12-SP2-CLIENT-Updates for x86_64 SAP-SP4"
+        "channel_name": "SLE-POS12-SP2-CLIENT-Updates for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-pos12-sp2-client-debuginfo-updates-x86_64-sap-sp4",
@@ -35292,7 +35712,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-POS12-SP2-CLIENT-Debuginfo-Updates for x86_64 SAP-SP4"
+        "channel_name": "SLE-POS12-SP2-CLIENT-Debuginfo-Updates for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-module-hpc12-updates-x86_64",
@@ -35307,7 +35727,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Updates for x86_64"
+        "channel_name": "SLE-Module-HPC12-Updates for x86_64 SP2"
     },
     {
         "channel_label": "sle-module-hpc12-debuginfo-updates-x86_64",
@@ -35322,7 +35742,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Debuginfo-Updates for x86_64"
+        "channel_name": "SLE-Module-HPC12-Debuginfo-Updates for x86_64 SP2"
     },
     {
         "channel_label": "sle-module-hpc12-pool-x86_64",
@@ -35337,7 +35757,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Pool for x86_64"
+        "channel_name": "SLE-Module-HPC12-Pool for x86_64 SP2"
     },
     {
         "channel_label": "sle-module-hpc12-debuginfo-pool-x86_64",
@@ -35352,7 +35772,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Debuginfo-Pool for x86_64"
+        "channel_name": "SLE-Module-HPC12-Debuginfo-Pool for x86_64 SP2"
     },
     {
         "channel_label": "sle-module-hpc12-updates-x86_64-sap-sp2",
@@ -35367,7 +35787,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Updates for x86_64 SAP-SP2"
+        "channel_name": "SLE-Module-HPC12-Updates for x86_64 SAP SP2"
     },
     {
         "channel_label": "sle-module-hpc12-debuginfo-updates-x86_64-sap-sp2",
@@ -35382,7 +35802,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Debuginfo-Updates for x86_64 SAP-SP2"
+        "channel_name": "SLE-Module-HPC12-Debuginfo-Updates for x86_64 SAP SP2"
     },
     {
         "channel_label": "sle-module-hpc12-pool-x86_64-sap-sp2",
@@ -35397,7 +35817,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Pool for x86_64 SAP-SP2"
+        "channel_name": "SLE-Module-HPC12-Pool for x86_64 SAP SP2"
     },
     {
         "channel_label": "sle-module-hpc12-debuginfo-pool-x86_64-sap-sp2",
@@ -35412,7 +35832,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Debuginfo-Pool for x86_64 SAP-SP2"
+        "channel_name": "SLE-Module-HPC12-Debuginfo-Pool for x86_64 SAP SP2"
     },
     {
         "channel_label": "sle-module-hpc12-updates-x86_64-sp3",
@@ -35487,7 +35907,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Updates for x86_64 SAP-SP3"
+        "channel_name": "SLE-Module-HPC12-Updates for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-module-hpc12-debuginfo-updates-x86_64-sap-sp3",
@@ -35502,7 +35922,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Debuginfo-Updates for x86_64 SAP-SP3"
+        "channel_name": "SLE-Module-HPC12-Debuginfo-Updates for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-module-hpc12-pool-x86_64-sap-sp3",
@@ -35517,7 +35937,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Pool for x86_64 SAP-SP3"
+        "channel_name": "SLE-Module-HPC12-Pool for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-module-hpc12-debuginfo-pool-x86_64-sap-sp3",
@@ -35532,7 +35952,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Debuginfo-Pool for x86_64 SAP-SP3"
+        "channel_name": "SLE-Module-HPC12-Debuginfo-Pool for x86_64 SAP SP3"
     },
     {
         "channel_label": "sle-module-hpc12-updates-x86_64-sp4",
@@ -35543,7 +35963,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Module-HPC",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-HPC/12/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -35558,7 +35978,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Module-HPC",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-HPC/12/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -35573,7 +35993,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Module-HPC",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-HPC/12/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -35588,7 +36008,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Module-HPC",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-HPC/12/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -35607,7 +36027,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLE-Module-HPC12-Updates for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-module-hpc12-debuginfo-updates-x86_64-hpc-sp2",
@@ -35622,7 +36042,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Debuginfo-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLE-Module-HPC12-Debuginfo-Updates for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-module-hpc12-pool-x86_64-hpc-sp2",
@@ -35637,7 +36057,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLE-Module-HPC12-Pool for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-module-hpc12-debuginfo-pool-x86_64-hpc-sp2",
@@ -35652,7 +36072,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Debuginfo-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLE-Module-HPC12-Debuginfo-Pool for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-module-hpc12-updates-x86_64-hpc-sp3",
@@ -35667,7 +36087,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLE-Module-HPC12-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-module-hpc12-debuginfo-updates-x86_64-hpc-sp3",
@@ -35682,7 +36102,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Debuginfo-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLE-Module-HPC12-Debuginfo-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-module-hpc12-pool-x86_64-hpc-sp3",
@@ -35697,7 +36117,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Pool for x86_64 HPC-SP3"
+        "channel_name": "SLE-Module-HPC12-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-module-hpc12-debuginfo-pool-x86_64-hpc-sp3",
@@ -35712,7 +36132,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Debuginfo-Pool for x86_64 HPC-SP3"
+        "channel_name": "SLE-Module-HPC12-Debuginfo-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-module-hpc12-updates-x86_64-sap-sp4",
@@ -35723,11 +36143,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-Module-HPC",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-HPC/12/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Updates for x86_64 SAP-SP4"
+        "channel_name": "SLE-Module-HPC12-Updates for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-module-hpc12-debuginfo-updates-x86_64-sap-sp4",
@@ -35738,11 +36158,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-Module-HPC",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-HPC/12/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Debuginfo-Updates for x86_64 SAP-SP4"
+        "channel_name": "SLE-Module-HPC12-Debuginfo-Updates for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-module-hpc12-pool-x86_64-sap-sp4",
@@ -35753,11 +36173,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-Module-HPC",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-HPC/12/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Pool for x86_64 SAP-SP4"
+        "channel_name": "SLE-Module-HPC12-Pool for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-module-hpc12-debuginfo-pool-x86_64-sap-sp4",
@@ -35768,11 +36188,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-Module-HPC",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-HPC/12/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Debuginfo-Pool for x86_64 SAP-SP4"
+        "channel_name": "SLE-Module-HPC12-Debuginfo-Pool for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-module-hpc12-updates-x86_64-hpc-sp4",
@@ -35783,11 +36203,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Module-HPC",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-HPC/12/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Updates for x86_64 HPC-SP4"
+        "channel_name": "SLE-Module-HPC12-Updates for x86_64 HPC SP4"
     },
     {
         "channel_label": "sle-module-hpc12-debuginfo-updates-x86_64-hpc-sp4",
@@ -35798,11 +36218,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Module-HPC",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-HPC/12/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Debuginfo-Updates for x86_64 HPC-SP4"
+        "channel_name": "SLE-Module-HPC12-Debuginfo-Updates for x86_64 HPC SP4"
     },
     {
         "channel_label": "sle-module-hpc12-pool-x86_64-hpc-sp4",
@@ -35813,11 +36233,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Module-HPC",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-HPC/12/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Pool for x86_64 HPC-SP4"
+        "channel_name": "SLE-Module-HPC12-Pool for x86_64 HPC SP4"
     },
     {
         "channel_label": "sle-module-hpc12-debuginfo-pool-x86_64-hpc-sp4",
@@ -35828,11 +36248,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Module-HPC",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-HPC/12/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Debuginfo-Pool for x86_64 HPC-SP4"
+        "channel_name": "SLE-Module-HPC12-Debuginfo-Pool for x86_64 HPC SP4"
     },
     {
         "channel_label": "suse-packagehub-12-x86_64",
@@ -35847,7 +36267,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12 for x86_64"
+        "channel_name": "SUSE-PackageHub-12-Standard-Pool for x86_64"
     },
     {
         "channel_label": "suse-packagehub-12-debuginfo-x86_64",
@@ -35892,7 +36312,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12 for x86_64 SLED"
+        "channel_name": "SUSE-PackageHub-12-Standard-Pool for x86_64 SLED"
     },
     {
         "channel_label": "suse-packagehub-12-debuginfo-x86_64-sled",
@@ -35937,7 +36357,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12 for x86_64 SAP"
+        "channel_name": "SUSE-PackageHub-12-Standard-Pool for x86_64 SAP"
     },
     {
         "channel_label": "suse-packagehub-12-debuginfo-x86_64-sap",
@@ -35982,7 +36402,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12 for s390x"
+        "channel_name": "SUSE-PackageHub-12-Standard-Pool for s390x"
     },
     {
         "channel_label": "suse-packagehub-12-debuginfo-s390x",
@@ -36027,7 +36447,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12 for ppc64le"
+        "channel_name": "SUSE-PackageHub-12-Standard-Pool for ppc64le"
     },
     {
         "channel_label": "suse-packagehub-12-debuginfo-ppc64le",
@@ -36072,7 +36492,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP1 for x86_64"
+        "channel_name": "SUSE-PackageHub-12-SP1-Standard-Pool for x86_64"
     },
     {
         "channel_label": "suse-packagehub-12-sp1-debuginfo-x86_64",
@@ -36117,7 +36537,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP1 for x86_64 SLED-SP1"
+        "channel_name": "SUSE-PackageHub-12-SP1-Standard-Pool for x86_64 SLED"
     },
     {
         "channel_label": "suse-packagehub-12-sp1-debuginfo-x86_64-sled-sp1",
@@ -36132,7 +36552,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP1-Debuginfo for x86_64 SLED-SP1"
+        "channel_name": "SUSE-PackageHub-12-SP1-Debuginfo for x86_64 SLED"
     },
     {
         "channel_label": "suse-packagehub-12-sp1-pool-x86_64-sled-sp1",
@@ -36147,7 +36567,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP1-Pool for x86_64 SLED-SP1"
+        "channel_name": "SUSE-PackageHub-12-SP1-Pool for x86_64 SLED"
     },
     {
         "channel_label": "suse-packagehub-12-sp1-x86_64-sap-sp1",
@@ -36162,7 +36582,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP1 for x86_64 SAP-SP1"
+        "channel_name": "SUSE-PackageHub-12-SP1-Standard-Pool for x86_64 SAP"
     },
     {
         "channel_label": "suse-packagehub-12-sp1-debuginfo-x86_64-sap-sp1",
@@ -36177,7 +36597,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP1-Debuginfo for x86_64 SAP-SP1"
+        "channel_name": "SUSE-PackageHub-12-SP1-Debuginfo for x86_64 SAP"
     },
     {
         "channel_label": "suse-packagehub-12-sp1-pool-x86_64-sap-sp1",
@@ -36192,7 +36612,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP1-Pool for x86_64 SAP-SP1"
+        "channel_name": "SUSE-PackageHub-12-SP1-Pool for x86_64 SAP"
     },
     {
         "channel_label": "suse-packagehub-12-sp1-s390x",
@@ -36207,7 +36627,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP1 for s390x"
+        "channel_name": "SUSE-PackageHub-12-SP1-Standard-Pool for s390x"
     },
     {
         "channel_label": "suse-packagehub-12-sp1-debuginfo-s390x",
@@ -36252,7 +36672,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP1 for ppc64le"
+        "channel_name": "SUSE-PackageHub-12-SP1-Standard-Pool for ppc64le"
     },
     {
         "channel_label": "suse-packagehub-12-sp1-debuginfo-ppc64le",
@@ -36297,7 +36717,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP1 for ppc64le SAP-SP1"
+        "channel_name": "SUSE-PackageHub-12-SP1-Standard-Pool for ppc64le SAP"
     },
     {
         "channel_label": "suse-packagehub-12-sp1-debuginfo-ppc64le-sap-sp1",
@@ -36312,7 +36732,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP1-Debuginfo for ppc64le SAP-SP1"
+        "channel_name": "SUSE-PackageHub-12-SP1-Debuginfo for ppc64le SAP"
     },
     {
         "channel_label": "suse-packagehub-12-sp1-pool-ppc64le-sap-sp1",
@@ -36327,7 +36747,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP1-Pool for ppc64le SAP-SP1"
+        "channel_name": "SUSE-PackageHub-12-SP1-Pool for ppc64le SAP"
     },
     {
         "channel_label": "suse-packagehub-12-sp2-x86_64",
@@ -36342,7 +36762,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP2 for x86_64"
+        "channel_name": "SUSE-PackageHub-12-SP2-Standard-Pool for x86_64"
     },
     {
         "channel_label": "suse-packagehub-12-sp2-debuginfo-x86_64",
@@ -36387,7 +36807,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP2 for x86_64 SLED-SP2"
+        "channel_name": "SUSE-PackageHub-12-SP2-Standard-Pool for x86_64 SLED"
     },
     {
         "channel_label": "suse-packagehub-12-sp2-debuginfo-x86_64-sled-sp2",
@@ -36402,7 +36822,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP2-Debuginfo for x86_64 SLED-SP2"
+        "channel_name": "SUSE-PackageHub-12-SP2-Debuginfo for x86_64 SLED"
     },
     {
         "channel_label": "suse-packagehub-12-sp2-pool-x86_64-sled-sp2",
@@ -36417,7 +36837,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP2-Pool for x86_64 SLED-SP2"
+        "channel_name": "SUSE-PackageHub-12-SP2-Pool for x86_64 SLED"
     },
     {
         "channel_label": "suse-packagehub-12-sp2-x86_64-sap-sp2",
@@ -36432,7 +36852,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP2 for x86_64 SAP-SP2"
+        "channel_name": "SUSE-PackageHub-12-SP2-Standard-Pool for x86_64 SAP"
     },
     {
         "channel_label": "suse-packagehub-12-sp2-debuginfo-x86_64-sap-sp2",
@@ -36447,7 +36867,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP2-Debuginfo for x86_64 SAP-SP2"
+        "channel_name": "SUSE-PackageHub-12-SP2-Debuginfo for x86_64 SAP"
     },
     {
         "channel_label": "suse-packagehub-12-sp2-pool-x86_64-sap-sp2",
@@ -36462,7 +36882,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP2-Pool for x86_64 SAP-SP2"
+        "channel_name": "SUSE-PackageHub-12-SP2-Pool for x86_64 SAP"
     },
     {
         "channel_label": "suse-packagehub-12-sp2-x86_64-hpc-sp2",
@@ -36477,7 +36897,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP2-Standard-Pool for x86_64 HPC-SP2"
+        "channel_name": "SUSE-PackageHub-12-SP2-Standard-Pool for x86_64 HPC"
     },
     {
         "channel_label": "suse-packagehub-12-sp2-debuginfo-x86_64-hpc-sp2",
@@ -36492,7 +36912,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP2-Debuginfo for x86_64 HPC-SP2"
+        "channel_name": "SUSE-PackageHub-12-SP2-Debuginfo for x86_64 HPC"
     },
     {
         "channel_label": "suse-packagehub-12-sp2-pool-x86_64-hpc-sp2",
@@ -36507,7 +36927,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP2-Pool for x86_64 HPC-SP2"
+        "channel_name": "SUSE-PackageHub-12-SP2-Pool for x86_64 HPC"
     },
     {
         "channel_label": "suse-packagehub-12-sp2-s390x",
@@ -36522,7 +36942,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP2 for s390x"
+        "channel_name": "SUSE-PackageHub-12-SP2-Standard-Pool for s390x"
     },
     {
         "channel_label": "suse-packagehub-12-sp2-debuginfo-s390x",
@@ -36567,7 +36987,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP2 for ppc64le"
+        "channel_name": "SUSE-PackageHub-12-SP2-Standard-Pool for ppc64le"
     },
     {
         "channel_label": "suse-packagehub-12-sp2-debuginfo-ppc64le",
@@ -36612,7 +37032,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP2 for ppc64le SAP-SP2"
+        "channel_name": "SUSE-PackageHub-12-SP2-Standard-Pool for ppc64le SAP"
     },
     {
         "channel_label": "suse-packagehub-12-sp2-debuginfo-ppc64le-sap-sp2",
@@ -36627,7 +37047,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP2-Debuginfo for ppc64le SAP-SP2"
+        "channel_name": "SUSE-PackageHub-12-SP2-Debuginfo for ppc64le SAP"
     },
     {
         "channel_label": "suse-packagehub-12-sp2-pool-ppc64le-sap-sp2",
@@ -36642,7 +37062,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP2-Pool for ppc64le SAP-SP2"
+        "channel_name": "SUSE-PackageHub-12-SP2-Pool for ppc64le SAP"
     },
     {
         "channel_label": "suse-packagehub-12-sp2-aarch64",
@@ -36657,7 +37077,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP2 for aarch64"
+        "channel_name": "SUSE-PackageHub-12-SP2-Standard-Pool for aarch64"
     },
     {
         "channel_label": "suse-packagehub-12-sp2-debuginfo-aarch64",
@@ -36762,7 +37182,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "OpenStack-Cloud-Magnum-Orchestration-Updates for x86_64"
+        "channel_name": "OpenStack-Cloud-Magnum-Orchestration-Updates for x86_64 SP2"
     },
     {
         "channel_label": "openstack-cloud-magnum-orchestration-debuginfo-updates-x86_64",
@@ -36777,7 +37197,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "OpenStack-Cloud-Magnum-Orchestration-Debuginfo-Updates for x86_64"
+        "channel_name": "OpenStack-Cloud-Magnum-Orchestration-Debuginfo-Updates for x86_64 SP2"
     },
     {
         "channel_label": "openstack-cloud-magnum-orchestration-pool-x86_64",
@@ -36792,7 +37212,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "OpenStack-Cloud-Magnum-Orchestration-Pool for x86_64"
+        "channel_name": "OpenStack-Cloud-Magnum-Orchestration-Pool for x86_64 SP2"
     },
     {
         "channel_label": "openstack-cloud-magnum-orchestration-debuginfo-pool-x86_64",
@@ -36807,7 +37227,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "OpenStack-Cloud-Magnum-Orchestration-Debuginfo-Pool for x86_64"
+        "channel_name": "OpenStack-Cloud-Magnum-Orchestration-Debuginfo-Pool for x86_64 SP2"
     },
     {
         "channel_label": "openstack-cloud-magnum-orchestration-updates-x86_64-sap-sp2",
@@ -36822,7 +37242,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "OpenStack-Cloud-Magnum-Orchestration-Updates for x86_64 SAP-SP2"
+        "channel_name": "OpenStack-Cloud-Magnum-Orchestration-Updates for x86_64 SAP SP2"
     },
     {
         "channel_label": "openstack-cloud-magnum-orchestration-debuginfo-updates-x86_64-sap-sp2",
@@ -36837,7 +37257,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "OpenStack-Cloud-Magnum-Orchestration-Debuginfo-Updates for x86_64 SAP-SP2"
+        "channel_name": "OpenStack-Cloud-Magnum-Orchestration-Debuginfo-Updates for x86_64 SAP SP2"
     },
     {
         "channel_label": "openstack-cloud-magnum-orchestration-pool-x86_64-sap-sp2",
@@ -36852,7 +37272,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "OpenStack-Cloud-Magnum-Orchestration-Pool for x86_64 SAP-SP2"
+        "channel_name": "OpenStack-Cloud-Magnum-Orchestration-Pool for x86_64 SAP SP2"
     },
     {
         "channel_label": "openstack-cloud-magnum-orchestration-debuginfo-pool-x86_64-sap-sp2",
@@ -36867,7 +37287,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "OpenStack-Cloud-Magnum-Orchestration-Debuginfo-Pool for x86_64 SAP-SP2"
+        "channel_name": "OpenStack-Cloud-Magnum-Orchestration-Debuginfo-Pool for x86_64 SAP SP2"
     },
     {
         "channel_label": "suse-manager-server-3.1-updates-x86_64",
@@ -36882,7 +37302,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.1-Updates for x86_64"
+        "channel_name": "SUSE-Manager-Server-3.1-Updates for x86_64 SP2"
     },
     {
         "channel_label": "suse-manager-server-3.1-debuginfo-updates-x86_64",
@@ -36897,7 +37317,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.1-Debuginfo-Updates for x86_64"
+        "channel_name": "SUSE-Manager-Server-3.1-Debuginfo-Updates for x86_64 SP2"
     },
     {
         "channel_label": "suse-manager-server-3.1-pool-x86_64",
@@ -36912,7 +37332,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.1-Pool for x86_64"
+        "channel_name": "SUSE-Manager-Server-3.1-Pool for x86_64 SP2"
     },
     {
         "channel_label": "suse-manager-server-3.1-debuginfo-pool-x86_64",
@@ -36927,7 +37347,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.1-Debuginfo-Pool for x86_64"
+        "channel_name": "SUSE-Manager-Server-3.1-Debuginfo-Pool for x86_64 SP2"
     },
     {
         "channel_label": "suse-manager-server-3.1-updates-x86_64-sp3",
@@ -37062,7 +37482,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.1-Updates for x86_64 HPC-SP2"
+        "channel_name": "SUSE-Manager-Server-3.1-Updates for x86_64 HPC SP2"
     },
     {
         "channel_label": "suse-manager-server-3.1-debuginfo-updates-x86_64-hpc-sp2",
@@ -37077,7 +37497,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.1-Debuginfo-Updates for x86_64 HPC-SP2"
+        "channel_name": "SUSE-Manager-Server-3.1-Debuginfo-Updates for x86_64 HPC SP2"
     },
     {
         "channel_label": "suse-manager-server-3.1-pool-x86_64-hpc-sp2",
@@ -37092,7 +37512,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.1-Pool for x86_64 HPC-SP2"
+        "channel_name": "SUSE-Manager-Server-3.1-Pool for x86_64 HPC SP2"
     },
     {
         "channel_label": "suse-manager-server-3.1-debuginfo-pool-x86_64-hpc-sp2",
@@ -37107,7 +37527,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.1-Debuginfo-Pool for x86_64 HPC-SP2"
+        "channel_name": "SUSE-Manager-Server-3.1-Debuginfo-Pool for x86_64 HPC SP2"
     },
     {
         "channel_label": "suse-manager-server-3.1-updates-x86_64-hpc-sp3",
@@ -37122,7 +37542,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.1-Updates for x86_64 HPC-SP3"
+        "channel_name": "SUSE-Manager-Server-3.1-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-manager-server-3.1-debuginfo-updates-x86_64-hpc-sp3",
@@ -37137,7 +37557,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.1-Debuginfo-Updates for x86_64 HPC-SP3"
+        "channel_name": "SUSE-Manager-Server-3.1-Debuginfo-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-manager-server-3.1-pool-x86_64-hpc-sp3",
@@ -37152,7 +37572,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.1-Pool for x86_64 HPC-SP3"
+        "channel_name": "SUSE-Manager-Server-3.1-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-manager-server-3.1-debuginfo-pool-x86_64-hpc-sp3",
@@ -37167,7 +37587,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.1-Debuginfo-Pool for x86_64 HPC-SP3"
+        "channel_name": "SUSE-Manager-Server-3.1-Debuginfo-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-manager-server-3.1-updates-x86_64-hpc-sp4",
@@ -37182,7 +37602,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.1-Updates for x86_64 HPC-SP4"
+        "channel_name": "SUSE-Manager-Server-3.1-Updates for x86_64 HPC SP4"
     },
     {
         "channel_label": "suse-manager-server-3.1-debuginfo-updates-x86_64-hpc-sp4",
@@ -37197,7 +37617,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.1-Debuginfo-Updates for x86_64 HPC-SP4"
+        "channel_name": "SUSE-Manager-Server-3.1-Debuginfo-Updates for x86_64 HPC SP4"
     },
     {
         "channel_label": "suse-manager-server-3.1-pool-x86_64-hpc-sp4",
@@ -37212,7 +37632,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.1-Pool for x86_64 HPC-SP4"
+        "channel_name": "SUSE-Manager-Server-3.1-Pool for x86_64 HPC SP4"
     },
     {
         "channel_label": "suse-manager-server-3.1-debuginfo-pool-x86_64-hpc-sp4",
@@ -37227,7 +37647,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.1-Debuginfo-Pool for x86_64 HPC-SP4"
+        "channel_name": "SUSE-Manager-Server-3.1-Debuginfo-Pool for x86_64 HPC SP4"
     },
     {
         "channel_label": "suse-manager-server-3.1-updates-s390x",
@@ -37242,7 +37662,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.1-Updates for s390x"
+        "channel_name": "SUSE-Manager-Server-3.1-Updates for s390x SP2"
     },
     {
         "channel_label": "suse-manager-server-3.1-debuginfo-updates-s390x",
@@ -37257,7 +37677,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.1-Debuginfo-Updates for s390x"
+        "channel_name": "SUSE-Manager-Server-3.1-Debuginfo-Updates for s390x SP2"
     },
     {
         "channel_label": "suse-manager-server-3.1-pool-s390x",
@@ -37272,7 +37692,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.1-Pool for s390x"
+        "channel_name": "SUSE-Manager-Server-3.1-Pool for s390x SP2"
     },
     {
         "channel_label": "suse-manager-server-3.1-debuginfo-pool-s390x",
@@ -37287,7 +37707,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.1-Debuginfo-Pool for s390x"
+        "channel_name": "SUSE-Manager-Server-3.1-Debuginfo-Pool for s390x SP2"
     },
     {
         "channel_label": "suse-manager-server-3.1-updates-s390x-sp3",
@@ -37422,7 +37842,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.1-Updates for x86_64"
+        "channel_name": "SUSE-Manager-Proxy-3.1-Updates for x86_64 SP2"
     },
     {
         "channel_label": "suse-manager-proxy-3.1-debuginfo-updates-x86_64",
@@ -37437,7 +37857,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.1-Debuginfo-Updates for x86_64"
+        "channel_name": "SUSE-Manager-Proxy-3.1-Debuginfo-Updates for x86_64 SP2"
     },
     {
         "channel_label": "suse-manager-proxy-3.1-pool-x86_64",
@@ -37452,7 +37872,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.1-Pool for x86_64"
+        "channel_name": "SUSE-Manager-Proxy-3.1-Pool for x86_64 SP2"
     },
     {
         "channel_label": "suse-manager-proxy-3.1-debuginfo-pool-x86_64",
@@ -37467,7 +37887,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.1-Debuginfo-Pool for x86_64"
+        "channel_name": "SUSE-Manager-Proxy-3.1-Debuginfo-Pool for x86_64 SP2"
     },
     {
         "channel_label": "suse-manager-proxy-3.1-updates-x86_64-sap-sp2",
@@ -37482,7 +37902,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.1-Updates for x86_64 SAP-SP2"
+        "channel_name": "SUSE-Manager-Proxy-3.1-Updates for x86_64 SAP SP2"
     },
     {
         "channel_label": "suse-manager-proxy-3.1-debuginfo-updates-x86_64-sap-sp2",
@@ -37497,7 +37917,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.1-Debuginfo-Updates for x86_64 SAP-SP2"
+        "channel_name": "SUSE-Manager-Proxy-3.1-Debuginfo-Updates for x86_64 SAP SP2"
     },
     {
         "channel_label": "suse-manager-proxy-3.1-pool-x86_64-sap-sp2",
@@ -37512,7 +37932,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.1-Pool for x86_64 SAP-SP2"
+        "channel_name": "SUSE-Manager-Proxy-3.1-Pool for x86_64 SAP SP2"
     },
     {
         "channel_label": "suse-manager-proxy-3.1-debuginfo-pool-x86_64-sap-sp2",
@@ -37527,7 +37947,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.1-Debuginfo-Pool for x86_64 SAP-SP2"
+        "channel_name": "SUSE-Manager-Proxy-3.1-Debuginfo-Pool for x86_64 SAP SP2"
     },
     {
         "channel_label": "suse-manager-proxy-3.1-updates-x86_64-sp3",
@@ -37602,7 +38022,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.1-Updates for x86_64 SAP-SP3"
+        "channel_name": "SUSE-Manager-Proxy-3.1-Updates for x86_64 SAP SP3"
     },
     {
         "channel_label": "suse-manager-proxy-3.1-debuginfo-updates-x86_64-sap-sp3",
@@ -37617,7 +38037,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.1-Debuginfo-Updates for x86_64 SAP-SP3"
+        "channel_name": "SUSE-Manager-Proxy-3.1-Debuginfo-Updates for x86_64 SAP SP3"
     },
     {
         "channel_label": "suse-manager-proxy-3.1-pool-x86_64-sap-sp3",
@@ -37632,7 +38052,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.1-Pool for x86_64 SAP-SP3"
+        "channel_name": "SUSE-Manager-Proxy-3.1-Pool for x86_64 SAP SP3"
     },
     {
         "channel_label": "suse-manager-proxy-3.1-debuginfo-pool-x86_64-sap-sp3",
@@ -37647,7 +38067,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.1-Debuginfo-Pool for x86_64 SAP-SP3"
+        "channel_name": "SUSE-Manager-Proxy-3.1-Debuginfo-Pool for x86_64 SAP SP3"
     },
     {
         "channel_label": "suse-manager-proxy-3.1-updates-x86_64-sp4",
@@ -37722,7 +38142,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.1-Updates for x86_64 HPC-SP2"
+        "channel_name": "SUSE-Manager-Proxy-3.1-Updates for x86_64 HPC SP2"
     },
     {
         "channel_label": "suse-manager-proxy-3.1-debuginfo-updates-x86_64-hpc-sp2",
@@ -37737,7 +38157,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.1-Debuginfo-Updates for x86_64 HPC-SP2"
+        "channel_name": "SUSE-Manager-Proxy-3.1-Debuginfo-Updates for x86_64 HPC SP2"
     },
     {
         "channel_label": "suse-manager-proxy-3.1-pool-x86_64-hpc-sp2",
@@ -37752,7 +38172,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.1-Pool for x86_64 HPC-SP2"
+        "channel_name": "SUSE-Manager-Proxy-3.1-Pool for x86_64 HPC SP2"
     },
     {
         "channel_label": "suse-manager-proxy-3.1-debuginfo-pool-x86_64-hpc-sp2",
@@ -37767,7 +38187,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.1-Debuginfo-Pool for x86_64 HPC-SP2"
+        "channel_name": "SUSE-Manager-Proxy-3.1-Debuginfo-Pool for x86_64 HPC SP2"
     },
     {
         "channel_label": "suse-manager-proxy-3.1-updates-x86_64-hpc-sp3",
@@ -37782,7 +38202,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.1-Updates for x86_64 HPC-SP3"
+        "channel_name": "SUSE-Manager-Proxy-3.1-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-manager-proxy-3.1-debuginfo-updates-x86_64-hpc-sp3",
@@ -37797,7 +38217,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.1-Debuginfo-Updates for x86_64 HPC-SP3"
+        "channel_name": "SUSE-Manager-Proxy-3.1-Debuginfo-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-manager-proxy-3.1-pool-x86_64-hpc-sp3",
@@ -37812,7 +38232,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.1-Pool for x86_64 HPC-SP3"
+        "channel_name": "SUSE-Manager-Proxy-3.1-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-manager-proxy-3.1-debuginfo-pool-x86_64-hpc-sp3",
@@ -37827,7 +38247,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.1-Debuginfo-Pool for x86_64 HPC-SP3"
+        "channel_name": "SUSE-Manager-Proxy-3.1-Debuginfo-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-manager-proxy-3.1-updates-x86_64-hpc-sp4",
@@ -37842,7 +38262,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.1-Updates for x86_64 HPC-SP4"
+        "channel_name": "SUSE-Manager-Proxy-3.1-Updates for x86_64 HPC SP4"
     },
     {
         "channel_label": "suse-manager-proxy-3.1-debuginfo-updates-x86_64-hpc-sp4",
@@ -37857,7 +38277,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.1-Debuginfo-Updates for x86_64 HPC-SP4"
+        "channel_name": "SUSE-Manager-Proxy-3.1-Debuginfo-Updates for x86_64 HPC SP4"
     },
     {
         "channel_label": "suse-manager-proxy-3.1-pool-x86_64-hpc-sp4",
@@ -37872,7 +38292,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.1-Pool for x86_64 HPC-SP4"
+        "channel_name": "SUSE-Manager-Proxy-3.1-Pool for x86_64 HPC SP4"
     },
     {
         "channel_label": "suse-manager-proxy-3.1-debuginfo-pool-x86_64-hpc-sp4",
@@ -37887,7 +38307,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.1-Debuginfo-Pool for x86_64 HPC-SP4"
+        "channel_name": "SUSE-Manager-Proxy-3.1-Debuginfo-Pool for x86_64 HPC SP4"
     },
     {
         "channel_label": "sle-manager-tools12-updates-ppc64le-sap-sp2",
@@ -37902,7 +38322,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates ppc64le SAP-SP2"
+        "channel_name": "SLE-Manager-Tools12-Updates for ppc64le SAP SP2"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-ppc64le-sap-sp2",
@@ -37917,7 +38337,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates ppc64le SAP-SP2"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for ppc64le SAP SP2"
     },
     {
         "channel_label": "sle-manager-tools12-pool-ppc64le-sap-sp2",
@@ -37932,7 +38352,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool ppc64le SAP-SP2"
+        "channel_name": "SLE-Manager-Tools12-Pool for ppc64le SAP SP2"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-ppc64le-sap-sp2",
@@ -37947,7 +38367,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool ppc64le SAP-SP2"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for ppc64le SAP SP2"
     },
     {
         "channel_label": "sles12-sp2-updates-ppc64le-sap-sp2",
@@ -37962,7 +38382,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP2-Updates for ppc64le SAP-SP2"
+        "channel_name": "SLES12-SP2-Updates for ppc64le SAP"
     },
     {
         "channel_label": "sles12-sp2-debuginfo-updates-ppc64le-sap-sp2",
@@ -37977,7 +38397,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP2-Debuginfo-Updates for ppc64le SAP-SP2"
+        "channel_name": "SLES12-SP2-Debuginfo-Updates for ppc64le SAP"
     },
     {
         "channel_label": "sles12-sp2-pool-ppc64le-sap-sp2",
@@ -37992,7 +38412,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP2-Pool for ppc64le SAP-SP2"
+        "channel_name": "SLES12-SP2-Pool for ppc64le SAP"
     },
     {
         "channel_label": "sles12-sp2-debuginfo-pool-ppc64le-sap-sp2",
@@ -38007,7 +38427,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP2-Debuginfo-Pool for ppc64le SAP-SP2"
+        "channel_name": "SLES12-SP2-Debuginfo-Pool for ppc64le SAP"
     },
     {
         "channel_label": "sle-ha12-sp2-updates-ppc64le-sap-sp2",
@@ -38022,7 +38442,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP2-Updates for ppc64le SAP-SP2"
+        "channel_name": "SLE-HA12-SP2-Updates for ppc64le SAP"
     },
     {
         "channel_label": "sle-ha12-sp2-debuginfo-updates-ppc64le-sap-sp2",
@@ -38037,7 +38457,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP2-Debuginfo-Updates for ppc64le SAP-SP2"
+        "channel_name": "SLE-HA12-SP2-Debuginfo-Updates for ppc64le SAP"
     },
     {
         "channel_label": "sle-ha12-sp2-pool-ppc64le-sap-sp2",
@@ -38052,7 +38472,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP2-Pool for ppc64le SAP-SP2"
+        "channel_name": "SLE-HA12-SP2-Pool for ppc64le SAP"
     },
     {
         "channel_label": "sle-ha12-sp2-debuginfo-pool-ppc64le-sap-sp2",
@@ -38067,7 +38487,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP2-Debuginfo-Pool for ppc64le SAP-SP2"
+        "channel_name": "SLE-HA12-SP2-Debuginfo-Pool for ppc64le SAP"
     },
     {
         "channel_label": "sle-12-sp2-sap-updates-ppc64le",
@@ -38142,7 +38562,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Updates for aarch64"
+        "channel_name": "SLE-Module-HPC12-Updates for aarch64 SP2"
     },
     {
         "channel_label": "sle-module-hpc12-debuginfo-updates-aarch64",
@@ -38157,7 +38577,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Debuginfo-Updates for aarch64"
+        "channel_name": "SLE-Module-HPC12-Debuginfo-Updates for aarch64 SP2"
     },
     {
         "channel_label": "sle-module-hpc12-pool-aarch64",
@@ -38172,7 +38592,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Pool for aarch64"
+        "channel_name": "SLE-Module-HPC12-Pool for aarch64 SP2"
     },
     {
         "channel_label": "sle-module-hpc12-debuginfo-pool-aarch64",
@@ -38187,7 +38607,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Debuginfo-Pool for aarch64"
+        "channel_name": "SLE-Module-HPC12-Debuginfo-Pool for aarch64 SP2"
     },
     {
         "channel_label": "sle-module-hpc12-updates-aarch64-sp3",
@@ -38258,7 +38678,7 @@
         "root_product_id": 1628,
         "update_tag": "SLE-Module-HPC",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-HPC/12/aarch64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -38273,7 +38693,7 @@
         "root_product_id": 1628,
         "update_tag": "SLE-Module-HPC",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-HPC/12/aarch64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -38288,7 +38708,7 @@
         "root_product_id": 1628,
         "update_tag": "SLE-Module-HPC",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-HPC/12/aarch64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -38303,7 +38723,7 @@
         "root_product_id": 1628,
         "update_tag": "SLE-Module-HPC",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-HPC/12/aarch64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -38322,7 +38742,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Updates for aarch64 HPC-SP3"
+        "channel_name": "SLE-Module-HPC12-Updates for aarch64 HPC SP3"
     },
     {
         "channel_label": "sle-module-hpc12-debuginfo-updates-aarch64-hpc-sp3",
@@ -38337,7 +38757,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Debuginfo-Updates for aarch64 HPC-SP3"
+        "channel_name": "SLE-Module-HPC12-Debuginfo-Updates for aarch64 HPC SP3"
     },
     {
         "channel_label": "sle-module-hpc12-pool-aarch64-hpc-sp3",
@@ -38352,7 +38772,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Pool for aarch64 HPC-SP3"
+        "channel_name": "SLE-Module-HPC12-Pool for aarch64 HPC SP3"
     },
     {
         "channel_label": "sle-module-hpc12-debuginfo-pool-aarch64-hpc-sp3",
@@ -38367,7 +38787,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Debuginfo-Pool for aarch64 HPC-SP3"
+        "channel_name": "SLE-Module-HPC12-Debuginfo-Pool for aarch64 HPC SP3"
     },
     {
         "channel_label": "sle-module-hpc12-updates-aarch64-hpc-sp4",
@@ -38378,11 +38798,11 @@
         "root_product_id": 1758,
         "update_tag": "SLE-Module-HPC",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-HPC/12/aarch64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Updates for aarch64 HPC-SP4"
+        "channel_name": "SLE-Module-HPC12-Updates for aarch64 HPC SP4"
     },
     {
         "channel_label": "sle-module-hpc12-debuginfo-updates-aarch64-hpc-sp4",
@@ -38393,11 +38813,11 @@
         "root_product_id": 1758,
         "update_tag": "SLE-Module-HPC",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-HPC/12/aarch64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Debuginfo-Updates for aarch64 HPC-SP4"
+        "channel_name": "SLE-Module-HPC12-Debuginfo-Updates for aarch64 HPC SP4"
     },
     {
         "channel_label": "sle-module-hpc12-pool-aarch64-hpc-sp4",
@@ -38408,11 +38828,11 @@
         "root_product_id": 1758,
         "update_tag": "SLE-Module-HPC",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-HPC/12/aarch64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Pool for aarch64 HPC-SP4"
+        "channel_name": "SLE-Module-HPC12-Pool for aarch64 HPC SP4"
     },
     {
         "channel_label": "sle-module-hpc12-debuginfo-pool-aarch64-hpc-sp4",
@@ -38423,131 +38843,11 @@
         "root_product_id": 1758,
         "update_tag": "SLE-Module-HPC",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-HPC/12/aarch64/product_debug/",
-        "release_stage": "beta",
-        "mandatory": false,
-        "signed": true,
-        "recommended": false,
-        "channel_name": "SLE-Module-HPC12-Debuginfo-Pool for aarch64 HPC-SP4"
-    },
-    {
-        "channel_label": "sles12-sp2-bcl-updates-x86_64",
-        "parent_channel_label": "sles12-sp2-pool-x86_64",
-        "product_id": 1523,
-        "repository_id": 2426,
-        "parent_product_id": 1357,
-        "root_product_id": 1357,
-        "update_tag": "SLE-SERVER",
-        "url": "https://updates.suse.com/SUSE/Updates/SLE-SERVER/12-SP2-BCL/x86_64/update/",
-        "release_stage": "released",
-        "mandatory": true,
-        "signed": true,
-        "recommended": false,
-        "channel_name": "SLES12-SP2-BCL-Updates for x86_64 SP2"
-    },
-    {
-        "channel_label": "sles12-sp2-bcl-debuginfo-updates-x86_64",
-        "parent_channel_label": "sles12-sp2-pool-x86_64",
-        "product_id": 1523,
-        "repository_id": 2427,
-        "parent_product_id": 1357,
-        "root_product_id": 1357,
-        "update_tag": "SLE-SERVER",
-        "url": "https://updates.suse.com/SUSE/Updates/SLE-SERVER/12-SP2-BCL/x86_64/update_debug/",
         "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP2-BCL-Debuginfo-Updates for x86_64 SP2"
-    },
-    {
-        "channel_label": "sles12-sp2-bcl-pool-x86_64",
-        "parent_channel_label": "sles12-sp2-pool-x86_64",
-        "product_id": 1523,
-        "repository_id": 2442,
-        "parent_product_id": 1357,
-        "root_product_id": 1357,
-        "update_tag": "SLE-SERVER",
-        "url": "https://updates.suse.com/SUSE/Products/SLE-SERVER/12-SP2-BCL/x86_64/product/",
-        "release_stage": "released",
-        "mandatory": true,
-        "signed": true,
-        "recommended": false,
-        "channel_name": "SLES12-SP2-BCL-Pool for x86_64 SP2"
-    },
-    {
-        "channel_label": "sles12-sp2-bcl-debuginfo-pool-x86_64",
-        "parent_channel_label": "sles12-sp2-pool-x86_64",
-        "product_id": 1523,
-        "repository_id": 2443,
-        "parent_product_id": 1357,
-        "root_product_id": 1357,
-        "update_tag": "SLE-SERVER",
-        "url": "https://updates.suse.com/SUSE/Products/SLE-SERVER/12-SP2-BCL/x86_64/product_debug/",
-        "release_stage": "released",
-        "mandatory": false,
-        "signed": true,
-        "recommended": false,
-        "channel_name": "SLES12-SP2-BCL-Debuginfo-Pool for x86_64 SP2"
-    },
-    {
-        "channel_label": "sles12-sp2-bcl-updates-x86_64-hpc-sp2",
-        "parent_channel_label": "sle12-sp2-hpc-pool-x86_64",
-        "product_id": 1523,
-        "repository_id": 2426,
-        "parent_product_id": 1749,
-        "root_product_id": 1749,
-        "update_tag": "SLE-SERVER",
-        "url": "https://updates.suse.com/SUSE/Updates/SLE-SERVER/12-SP2-BCL/x86_64/update/",
-        "release_stage": "released",
-        "mandatory": true,
-        "signed": true,
-        "recommended": false,
-        "channel_name": "SLES12-SP2-BCL-Updates for x86_64 HPC-SP2"
-    },
-    {
-        "channel_label": "sles12-sp2-bcl-debuginfo-updates-x86_64-hpc-sp2",
-        "parent_channel_label": "sle12-sp2-hpc-pool-x86_64",
-        "product_id": 1523,
-        "repository_id": 2427,
-        "parent_product_id": 1749,
-        "root_product_id": 1749,
-        "update_tag": "SLE-SERVER",
-        "url": "https://updates.suse.com/SUSE/Updates/SLE-SERVER/12-SP2-BCL/x86_64/update_debug/",
-        "release_stage": "released",
-        "mandatory": false,
-        "signed": true,
-        "recommended": false,
-        "channel_name": "SLES12-SP2-BCL-Debuginfo-Updates for x86_64 HPC-SP2"
-    },
-    {
-        "channel_label": "sles12-sp2-bcl-pool-x86_64-hpc-sp2",
-        "parent_channel_label": "sle12-sp2-hpc-pool-x86_64",
-        "product_id": 1523,
-        "repository_id": 2442,
-        "parent_product_id": 1749,
-        "root_product_id": 1749,
-        "update_tag": "SLE-SERVER",
-        "url": "https://updates.suse.com/SUSE/Products/SLE-SERVER/12-SP2-BCL/x86_64/product/",
-        "release_stage": "released",
-        "mandatory": true,
-        "signed": true,
-        "recommended": false,
-        "channel_name": "SLES12-SP2-BCL-Pool for x86_64 HPC-SP2"
-    },
-    {
-        "channel_label": "sles12-sp2-bcl-debuginfo-pool-x86_64-hpc-sp2",
-        "parent_channel_label": "sle12-sp2-hpc-pool-x86_64",
-        "product_id": 1523,
-        "repository_id": 2443,
-        "parent_product_id": 1749,
-        "root_product_id": 1749,
-        "update_tag": "SLE-SERVER",
-        "url": "https://updates.suse.com/SUSE/Products/SLE-SERVER/12-SP2-BCL/x86_64/product_debug/",
-        "release_stage": "released",
-        "mandatory": false,
-        "signed": true,
-        "recommended": false,
-        "channel_name": "SLES12-SP2-BCL-Debuginfo-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLE-Module-HPC12-Debuginfo-Pool for aarch64 HPC SP4"
     },
     {
         "channel_label": "suse-enterprise-storage-5-updates-x86_64",
@@ -38562,7 +38862,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-5-Updates for x86_64"
+        "channel_name": "SUSE-Enterprise-Storage-5-Updates for x86_64 SP3"
     },
     {
         "channel_label": "suse-enterprise-storage-5-debuginfo-updates-x86_64",
@@ -38577,7 +38877,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-5-Debuginfo-Updates for x86_64"
+        "channel_name": "SUSE-Enterprise-Storage-5-Debuginfo-Updates for x86_64 SP3"
     },
     {
         "channel_label": "suse-enterprise-storage-5-pool-x86_64",
@@ -38592,7 +38892,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-5-Pool for x86_64"
+        "channel_name": "SUSE-Enterprise-Storage-5-Pool for x86_64 SP3"
     },
     {
         "channel_label": "suse-enterprise-storage-5-debuginfo-pool-x86_64",
@@ -38607,7 +38907,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-5-Debuginfo-Pool for x86_64"
+        "channel_name": "SUSE-Enterprise-Storage-5-Debuginfo-Pool for x86_64 SP3"
     },
     {
         "channel_label": "suse-enterprise-storage-5-updates-x86_64-sap-sp3",
@@ -38622,7 +38922,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-5-Updates for x86_64 SAP-SP3"
+        "channel_name": "SUSE-Enterprise-Storage-5-Updates for x86_64 SAP SP3"
     },
     {
         "channel_label": "suse-enterprise-storage-5-debuginfo-updates-x86_64-sap-sp3",
@@ -38637,7 +38937,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-5-Debuginfo-Updates for x86_64 SAP-SP3"
+        "channel_name": "SUSE-Enterprise-Storage-5-Debuginfo-Updates for x86_64 SAP SP3"
     },
     {
         "channel_label": "suse-enterprise-storage-5-pool-x86_64-sap-sp3",
@@ -38652,7 +38952,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-5-Pool for x86_64 SAP-SP3"
+        "channel_name": "SUSE-Enterprise-Storage-5-Pool for x86_64 SAP SP3"
     },
     {
         "channel_label": "suse-enterprise-storage-5-debuginfo-pool-x86_64-sap-sp3",
@@ -38667,7 +38967,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-5-Debuginfo-Pool for x86_64 SAP-SP3"
+        "channel_name": "SUSE-Enterprise-Storage-5-Debuginfo-Pool for x86_64 SAP SP3"
     },
     {
         "channel_label": "suse-enterprise-storage-5-updates-x86_64-hpc-sp3",
@@ -38682,7 +38982,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-5-Updates for x86_64 HPC-SP3"
+        "channel_name": "SUSE-Enterprise-Storage-5-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-enterprise-storage-5-debuginfo-updates-x86_64-hpc-sp3",
@@ -38697,7 +38997,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-5-Debuginfo-Updates for x86_64 HPC-SP3"
+        "channel_name": "SUSE-Enterprise-Storage-5-Debuginfo-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-enterprise-storage-5-pool-x86_64-hpc-sp3",
@@ -38712,7 +39012,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-5-Pool for x86_64 HPC-SP3"
+        "channel_name": "SUSE-Enterprise-Storage-5-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-enterprise-storage-5-debuginfo-pool-x86_64-hpc-sp3",
@@ -38727,7 +39027,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-5-Debuginfo-Pool for x86_64 HPC-SP3"
+        "channel_name": "SUSE-Enterprise-Storage-5-Debuginfo-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-enterprise-storage-5-updates-aarch64",
@@ -38742,7 +39042,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-5-Updates for aarch64"
+        "channel_name": "SUSE-Enterprise-Storage-5-Updates for aarch64 SP3"
     },
     {
         "channel_label": "suse-enterprise-storage-5-debuginfo-updates-aarch64",
@@ -38757,7 +39057,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-5-Debuginfo-Updates for aarch64"
+        "channel_name": "SUSE-Enterprise-Storage-5-Debuginfo-Updates for aarch64 SP3"
     },
     {
         "channel_label": "suse-enterprise-storage-5-pool-aarch64",
@@ -38772,7 +39072,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-5-Pool for aarch64"
+        "channel_name": "SUSE-Enterprise-Storage-5-Pool for aarch64 SP3"
     },
     {
         "channel_label": "suse-enterprise-storage-5-debuginfo-pool-aarch64",
@@ -38787,7 +39087,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-5-Debuginfo-Pool for aarch64"
+        "channel_name": "SUSE-Enterprise-Storage-5-Debuginfo-Pool for aarch64 SP3"
     },
     {
         "channel_label": "suse-enterprise-storage-5-updates-aarch64-hpc-sp3",
@@ -38802,7 +39102,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-5-Updates for aarch64 HPC-SP3"
+        "channel_name": "SUSE-Enterprise-Storage-5-Updates for aarch64 HPC SP3"
     },
     {
         "channel_label": "suse-enterprise-storage-5-debuginfo-updates-aarch64-hpc-sp3",
@@ -38817,7 +39117,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-5-Debuginfo-Updates for aarch64 HPC-SP3"
+        "channel_name": "SUSE-Enterprise-Storage-5-Debuginfo-Updates for aarch64 HPC SP3"
     },
     {
         "channel_label": "suse-enterprise-storage-5-pool-aarch64-hpc-sp3",
@@ -38832,7 +39132,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-5-Pool for aarch64 HPC-SP3"
+        "channel_name": "SUSE-Enterprise-Storage-5-Pool for aarch64 HPC SP3"
     },
     {
         "channel_label": "suse-enterprise-storage-5-debuginfo-pool-aarch64-hpc-sp3",
@@ -38847,7 +39147,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-5-Debuginfo-Pool for aarch64 HPC-SP3"
+        "channel_name": "SUSE-Enterprise-Storage-5-Debuginfo-Pool for aarch64 HPC SP3"
     },
     {
         "channel_label": "sle-module-public-cloud12-updates-aarch64",
@@ -38862,7 +39162,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Updates for aarch64"
+        "channel_name": "SLE-Module-Public-Cloud12-Updates for aarch64 SP2"
     },
     {
         "channel_label": "sle-module-public-cloud12-debuginfo-updates-aarch64",
@@ -38877,7 +39177,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Updates for aarch64"
+        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Updates for aarch64 SP2"
     },
     {
         "channel_label": "sle-module-public-cloud12-pool-aarch64",
@@ -38892,7 +39192,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Pool for aarch64"
+        "channel_name": "SLE-Module-Public-Cloud12-Pool for aarch64 SP2"
     },
     {
         "channel_label": "sle-module-public-cloud12-debuginfo-pool-aarch64",
@@ -38907,7 +39207,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Pool for aarch64"
+        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Pool for aarch64 SP2"
     },
     {
         "channel_label": "sle-module-public-cloud12-updates-aarch64-sp3",
@@ -38978,7 +39278,7 @@
         "root_product_id": 1628,
         "update_tag": "SLE-Module-Public-Cloud",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/12/aarch64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -38993,7 +39293,7 @@
         "root_product_id": 1628,
         "update_tag": "SLE-Module-Public-Cloud",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/12/aarch64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -39008,7 +39308,7 @@
         "root_product_id": 1628,
         "update_tag": "SLE-Module-Public-Cloud",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/12/aarch64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -39023,7 +39323,7 @@
         "root_product_id": 1628,
         "update_tag": "SLE-Module-Public-Cloud",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/12/aarch64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -39042,7 +39342,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Updates for aarch64 HPC-SP3"
+        "channel_name": "SLE-Module-Public-Cloud12-Updates for aarch64 HPC SP3"
     },
     {
         "channel_label": "sle-module-public-cloud12-debuginfo-updates-aarch64-hpc-sp3",
@@ -39057,7 +39357,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Updates for aarch64 HPC-SP3"
+        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Updates for aarch64 HPC SP3"
     },
     {
         "channel_label": "sle-module-public-cloud12-pool-aarch64-hpc-sp3",
@@ -39072,7 +39372,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Pool for aarch64 HPC-SP3"
+        "channel_name": "SLE-Module-Public-Cloud12-Pool for aarch64 HPC SP3"
     },
     {
         "channel_label": "sle-module-public-cloud12-debuginfo-pool-aarch64-hpc-sp3",
@@ -39087,7 +39387,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Pool for aarch64 HPC-SP3"
+        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Pool for aarch64 HPC SP3"
     },
     {
         "channel_label": "sle-module-public-cloud12-updates-aarch64-hpc-sp4",
@@ -39098,11 +39398,11 @@
         "root_product_id": 1758,
         "update_tag": "SLE-Module-Public-Cloud",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/12/aarch64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Updates for aarch64 HPC-SP4"
+        "channel_name": "SLE-Module-Public-Cloud12-Updates for aarch64 HPC SP4"
     },
     {
         "channel_label": "sle-module-public-cloud12-debuginfo-updates-aarch64-hpc-sp4",
@@ -39113,11 +39413,11 @@
         "root_product_id": 1758,
         "update_tag": "SLE-Module-Public-Cloud",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/12/aarch64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Updates for aarch64 HPC-SP4"
+        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Updates for aarch64 HPC SP4"
     },
     {
         "channel_label": "sle-module-public-cloud12-pool-aarch64-hpc-sp4",
@@ -39128,11 +39428,11 @@
         "root_product_id": 1758,
         "update_tag": "SLE-Module-Public-Cloud",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/12/aarch64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Pool for aarch64 HPC-SP4"
+        "channel_name": "SLE-Module-Public-Cloud12-Pool for aarch64 HPC SP4"
     },
     {
         "channel_label": "sle-module-public-cloud12-debuginfo-pool-aarch64-hpc-sp4",
@@ -39143,11 +39443,11 @@
         "root_product_id": 1758,
         "update_tag": "SLE-Module-Public-Cloud",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/12/aarch64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Pool for aarch64 HPC-SP4"
+        "channel_name": "SLE-Module-Public-Cloud12-Debuginfo-Pool for aarch64 HPC SP4"
     },
     {
         "channel_label": "suse-packagehub-12-sp3-x86_64",
@@ -39207,7 +39507,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP3 for x86_64 SLED-SP3"
+        "channel_name": "SUSE-PackageHub-12-SP3 for x86_64 SLED"
     },
     {
         "channel_label": "suse-packagehub-12-sp3-debuginfo-x86_64-sled-sp3",
@@ -39222,7 +39522,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP3-Debuginfo for x86_64 SLED-SP3"
+        "channel_name": "SUSE-PackageHub-12-SP3-Debuginfo for x86_64 SLED"
     },
     {
         "channel_label": "suse-packagehub-12-sp3-pool-x86_64-sled-sp3",
@@ -39237,7 +39537,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP3-Pool for x86_64 SLED-SP3"
+        "channel_name": "SUSE-PackageHub-12-SP3-Pool for x86_64 SLED"
     },
     {
         "channel_label": "suse-packagehub-12-sp3-x86_64-sap-sp3",
@@ -39252,7 +39552,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP3 for x86_64 SAP-SP3"
+        "channel_name": "SUSE-PackageHub-12-SP3 for x86_64 SAP"
     },
     {
         "channel_label": "suse-packagehub-12-sp3-debuginfo-x86_64-sap-sp3",
@@ -39267,7 +39567,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP3-Debuginfo for x86_64 SAP-SP3"
+        "channel_name": "SUSE-PackageHub-12-SP3-Debuginfo for x86_64 SAP"
     },
     {
         "channel_label": "suse-packagehub-12-sp3-pool-x86_64-sap-sp3",
@@ -39282,7 +39582,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP3-Pool for x86_64 SAP-SP3"
+        "channel_name": "SUSE-PackageHub-12-SP3-Pool for x86_64 SAP"
     },
     {
         "channel_label": "suse-packagehub-12-sp3-x86_64-hpc-sp3",
@@ -39297,7 +39597,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP3 for x86_64 HPC-SP3"
+        "channel_name": "SUSE-PackageHub-12-SP3 for x86_64 HPC"
     },
     {
         "channel_label": "suse-packagehub-12-sp3-debuginfo-x86_64-hpc-sp3",
@@ -39312,7 +39612,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP3-Debuginfo for x86_64 HPC-SP3"
+        "channel_name": "SUSE-PackageHub-12-SP3-Debuginfo for x86_64 HPC"
     },
     {
         "channel_label": "suse-packagehub-12-sp3-pool-x86_64-hpc-sp3",
@@ -39327,7 +39627,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP3-Pool for x86_64 HPC-SP3"
+        "channel_name": "SUSE-PackageHub-12-SP3-Pool for x86_64 HPC"
     },
     {
         "channel_label": "suse-packagehub-12-sp3-s390x",
@@ -39432,7 +39732,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP3 for ppc64le SAP-SP3"
+        "channel_name": "SUSE-PackageHub-12-SP3 for ppc64le SAP"
     },
     {
         "channel_label": "suse-packagehub-12-sp3-debuginfo-ppc64le-sap-sp3",
@@ -39447,7 +39747,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP3-Debuginfo for ppc64le SAP-SP3"
+        "channel_name": "SUSE-PackageHub-12-SP3-Debuginfo for ppc64le SAP"
     },
     {
         "channel_label": "suse-packagehub-12-sp3-pool-ppc64le-sap-sp3",
@@ -39462,7 +39762,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP3-Pool for ppc64le SAP-SP3"
+        "channel_name": "SUSE-PackageHub-12-SP3-Pool for ppc64le SAP"
     },
     {
         "channel_label": "suse-packagehub-12-sp3-aarch64",
@@ -39522,7 +39822,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP3 for aarch64 HPC-SP3"
+        "channel_name": "SUSE-PackageHub-12-SP3 for aarch64 HPC"
     },
     {
         "channel_label": "suse-packagehub-12-sp3-debuginfo-aarch64-hpc-sp3",
@@ -39537,7 +39837,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP3-Debuginfo for aarch64 HPC-SP3"
+        "channel_name": "SUSE-PackageHub-12-SP3-Debuginfo for aarch64 HPC"
     },
     {
         "channel_label": "suse-packagehub-12-sp3-pool-aarch64-hpc-sp3",
@@ -39552,7 +39852,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP3-Pool for aarch64 HPC-SP3"
+        "channel_name": "SUSE-PackageHub-12-SP3-Pool for aarch64 HPC"
     },
     {
         "channel_label": "sles12-sp1-ltss-updates-x86_64",
@@ -39597,7 +39897,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP1-LTSS-Updates for x86_64 SAP-SP1"
+        "channel_name": "SLES12-SP1-LTSS-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sles12-sp1-ltss-debuginfo-updates-x86_64-sap-sp1",
@@ -39612,7 +39912,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP1-LTSS-Debuginfo-Updates for x86_64 SAP-SP1"
+        "channel_name": "SLES12-SP1-LTSS-Debuginfo-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sles12-sp1-ltss-updates-s390x",
@@ -39717,7 +40017,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Live-Patching12-SP3-Updates for x86_64 SAP-SP3"
+        "channel_name": "SLE-Live-Patching12-SP3-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-live-patching12-sp3-debuginfo-updates-x86_64-sap-sp3",
@@ -39732,7 +40032,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Live-Patching12-SP3-Debuginfo-Updates for x86_64 SAP-SP3"
+        "channel_name": "SLE-Live-Patching12-SP3-Debuginfo-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-live-patching12-sp3-pool-x86_64-sap-sp3",
@@ -39747,7 +40047,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Live-Patching12-SP3-Pool for x86_64 SAP-SP3"
+        "channel_name": "SLE-Live-Patching12-SP3-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-live-patching12-sp3-debuginfo-pool-x86_64-sap-sp3",
@@ -39762,7 +40062,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Live-Patching12-SP3-Debuginfo-Pool for x86_64 SAP-SP3"
+        "channel_name": "SLE-Live-Patching12-SP3-Debuginfo-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-live-patching12-sp3-updates-x86_64-hpc-sp3",
@@ -39777,7 +40077,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Live-Patching12-SP3-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLE-Live-Patching12-SP3-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sle-live-patching12-sp3-debuginfo-updates-x86_64-hpc-sp3",
@@ -39792,7 +40092,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Live-Patching12-SP3-Debuginfo-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLE-Live-Patching12-SP3-Debuginfo-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sle-live-patching12-sp3-pool-x86_64-hpc-sp3",
@@ -39807,7 +40107,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Live-Patching12-SP3-Pool for x86_64 HPC-SP3"
+        "channel_name": "SLE-Live-Patching12-SP3-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sle-live-patching12-sp3-debuginfo-pool-x86_64-hpc-sp3",
@@ -39822,7 +40122,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Live-Patching12-SP3-Debuginfo-Pool for x86_64 HPC-SP3"
+        "channel_name": "SLE-Live-Patching12-SP3-Debuginfo-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sle-live-patching12-sp3-updates-ppc64le",
@@ -39897,7 +40197,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Live-Patching12-SP3-Updates for ppc64le SAP-SP3"
+        "channel_name": "SLE-Live-Patching12-SP3-Updates for ppc64le SAP"
     },
     {
         "channel_label": "sle-live-patching12-sp3-debuginfo-updates-ppc64le-sap-sp3",
@@ -39912,7 +40212,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Live-Patching12-SP3-Debuginfo-Updates for ppc64le SAP-SP3"
+        "channel_name": "SLE-Live-Patching12-SP3-Debuginfo-Updates for ppc64le SAP"
     },
     {
         "channel_label": "sle-live-patching12-sp3-pool-ppc64le-sap-sp3",
@@ -39927,7 +40227,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Live-Patching12-SP3-Pool for ppc64le SAP-SP3"
+        "channel_name": "SLE-Live-Patching12-SP3-Pool for ppc64le SAP"
     },
     {
         "channel_label": "sle-live-patching12-sp3-debuginfo-pool-ppc64le-sap-sp3",
@@ -39942,7 +40242,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Live-Patching12-SP3-Debuginfo-Pool for ppc64le SAP-SP3"
+        "channel_name": "SLE-Live-Patching12-SP3-Debuginfo-Pool for ppc64le SAP"
     },
     {
         "channel_label": "suse-openstack-cloud-continuous-delivery-6-updates-x86_64",
@@ -39957,7 +40257,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-Continuous-Delivery-6-Updates for x86_64"
+        "channel_name": "SUSE-OpenStack-Cloud-Continuous-Delivery-6-Updates for x86_64 SP1"
     },
     {
         "channel_label": "suse-openstack-cloud-continuous-delivery-6-debuginfo-updates-x86_64",
@@ -39972,7 +40272,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-Continuous-Delivery-6-Debuginfo-Updates for x86_64"
+        "channel_name": "SUSE-OpenStack-Cloud-Continuous-Delivery-6-Debuginfo-Updates for x86_64 SP1"
     },
     {
         "channel_label": "suse-openstack-cloud-continuous-delivery-6-pool-x86_64",
@@ -39987,7 +40287,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-Continuous-Delivery-6-Pool for x86_64"
+        "channel_name": "SUSE-OpenStack-Cloud-Continuous-Delivery-6-Pool for x86_64 SP1"
     },
     {
         "channel_label": "suse-openstack-cloud-continuous-delivery-6-debuginfo-pool-x86_64",
@@ -40002,7 +40302,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-Continuous-Delivery-6-Debuginfo-Pool for x86_64"
+        "channel_name": "SUSE-OpenStack-Cloud-Continuous-Delivery-6-Debuginfo-Pool for x86_64 SP1"
     },
     {
         "channel_label": "suse-openstack-cloud-continuous-delivery-6-updates-x86_64-sap-sp1",
@@ -40017,7 +40317,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-Continuous-Delivery-6-Updates for x86_64 SAP-SP1"
+        "channel_name": "SUSE-OpenStack-Cloud-Continuous-Delivery-6-Updates for x86_64 SAP SP1"
     },
     {
         "channel_label": "suse-openstack-cloud-continuous-delivery-6-debuginfo-updates-x86_64-sap-sp1",
@@ -40032,7 +40332,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-Continuous-Delivery-6-Debuginfo-Updates for x86_64 SAP-SP1"
+        "channel_name": "SUSE-OpenStack-Cloud-Continuous-Delivery-6-Debuginfo-Updates for x86_64 SAP SP1"
     },
     {
         "channel_label": "suse-openstack-cloud-continuous-delivery-6-pool-x86_64-sap-sp1",
@@ -40047,7 +40347,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-Continuous-Delivery-6-Pool for x86_64 SAP-SP1"
+        "channel_name": "SUSE-OpenStack-Cloud-Continuous-Delivery-6-Pool for x86_64 SAP SP1"
     },
     {
         "channel_label": "suse-openstack-cloud-continuous-delivery-6-debuginfo-pool-x86_64-sap-sp1",
@@ -40062,7 +40362,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-Continuous-Delivery-6-Debuginfo-Pool for x86_64 SAP-SP1"
+        "channel_name": "SUSE-OpenStack-Cloud-Continuous-Delivery-6-Debuginfo-Pool for x86_64 SAP SP1"
     },
     {
         "channel_label": "sle-module-web-scripting12-updates-aarch64-sp2",
@@ -40137,7 +40437,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Updates for aarch64"
+        "channel_name": "SLE-Module-Web-Scripting12-Updates for aarch64 SP3"
     },
     {
         "channel_label": "sle-module-web-scripting12-debuginfo-updates-aarch64",
@@ -40152,7 +40452,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Updates for aarch64"
+        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Updates for aarch64 SP3"
     },
     {
         "channel_label": "sle-module-web-scripting12-pool-aarch64",
@@ -40167,7 +40467,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Pool for aarch64"
+        "channel_name": "SLE-Module-Web-Scripting12-Pool for aarch64 SP3"
     },
     {
         "channel_label": "sle-module-web-scripting12-debuginfo-pool-aarch64",
@@ -40182,7 +40482,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Pool for aarch64"
+        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Pool for aarch64 SP3"
     },
     {
         "channel_label": "sle-module-web-scripting12-updates-aarch64-sp4",
@@ -40193,7 +40493,7 @@
         "root_product_id": 1628,
         "update_tag": "SLE-Module-Web-Scripting",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/12/aarch64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -40208,7 +40508,7 @@
         "root_product_id": 1628,
         "update_tag": "SLE-Module-Web-Scripting",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/12/aarch64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -40223,7 +40523,7 @@
         "root_product_id": 1628,
         "update_tag": "SLE-Module-Web-Scripting",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/12/aarch64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -40238,7 +40538,7 @@
         "root_product_id": 1628,
         "update_tag": "SLE-Module-Web-Scripting",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/12/aarch64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -40257,7 +40557,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Updates for aarch64 HPC-SP3"
+        "channel_name": "SLE-Module-Web-Scripting12-Updates for aarch64 HPC SP3"
     },
     {
         "channel_label": "sle-module-web-scripting12-debuginfo-updates-aarch64-hpc-sp3",
@@ -40272,7 +40572,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Updates for aarch64 HPC-SP3"
+        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Updates for aarch64 HPC SP3"
     },
     {
         "channel_label": "sle-module-web-scripting12-pool-aarch64-hpc-sp3",
@@ -40287,7 +40587,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Pool for aarch64 HPC-SP3"
+        "channel_name": "SLE-Module-Web-Scripting12-Pool for aarch64 HPC SP3"
     },
     {
         "channel_label": "sle-module-web-scripting12-debuginfo-pool-aarch64-hpc-sp3",
@@ -40302,7 +40602,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Pool for aarch64 HPC-SP3"
+        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Pool for aarch64 HPC SP3"
     },
     {
         "channel_label": "sle-module-web-scripting12-updates-aarch64-hpc-sp4",
@@ -40313,11 +40613,11 @@
         "root_product_id": 1758,
         "update_tag": "SLE-Module-Web-Scripting",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/12/aarch64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Updates for aarch64 HPC-SP4"
+        "channel_name": "SLE-Module-Web-Scripting12-Updates for aarch64 HPC SP4"
     },
     {
         "channel_label": "sle-module-web-scripting12-debuginfo-updates-aarch64-hpc-sp4",
@@ -40328,11 +40628,11 @@
         "root_product_id": 1758,
         "update_tag": "SLE-Module-Web-Scripting",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/12/aarch64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Updates for aarch64 HPC-SP4"
+        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Updates for aarch64 HPC SP4"
     },
     {
         "channel_label": "sle-module-web-scripting12-pool-aarch64-hpc-sp4",
@@ -40343,11 +40643,11 @@
         "root_product_id": 1758,
         "update_tag": "SLE-Module-Web-Scripting",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/12/aarch64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Pool for aarch64 HPC-SP4"
+        "channel_name": "SLE-Module-Web-Scripting12-Pool for aarch64 HPC SP4"
     },
     {
         "channel_label": "sle-module-web-scripting12-debuginfo-pool-aarch64-hpc-sp4",
@@ -40358,11 +40658,11 @@
         "root_product_id": 1758,
         "update_tag": "SLE-Module-Web-Scripting",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/12/aarch64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Pool for aarch64 HPC-SP4"
+        "channel_name": "SLE-Module-Web-Scripting12-Debuginfo-Pool for aarch64 HPC SP4"
     },
     {
         "channel_label": "sle-manager-tools12-updates-ppc64le-sap-sp3",
@@ -40377,7 +40677,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates ppc64le SAP-SP3"
+        "channel_name": "SLE-Manager-Tools12-Updates for ppc64le SAP SP3"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-ppc64le-sap-sp3",
@@ -40392,7 +40692,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates ppc64le SAP-SP3"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for ppc64le SAP SP3"
     },
     {
         "channel_label": "sle-manager-tools12-pool-ppc64le-sap-sp3",
@@ -40407,7 +40707,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool ppc64le SAP-SP3"
+        "channel_name": "SLE-Manager-Tools12-Pool for ppc64le SAP SP3"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-ppc64le-sap-sp3",
@@ -40422,7 +40722,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool ppc64le SAP-SP3"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for ppc64le SAP SP3"
     },
     {
         "channel_label": "sles12-sp3-updates-ppc64le-sap-sp3",
@@ -40437,7 +40737,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP3-Updates for ppc64le SAP-SP3"
+        "channel_name": "SLES12-SP3-Updates for ppc64le SAP"
     },
     {
         "channel_label": "sles12-sp3-debuginfo-updates-ppc64le-sap-sp3",
@@ -40452,7 +40752,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP3-Debuginfo-Updates for ppc64le SAP-SP3"
+        "channel_name": "SLES12-SP3-Debuginfo-Updates for ppc64le SAP"
     },
     {
         "channel_label": "sles12-sp3-pool-ppc64le-sap-sp3",
@@ -40467,7 +40767,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP3-Pool for ppc64le SAP-SP3"
+        "channel_name": "SLES12-SP3-Pool for ppc64le SAP"
     },
     {
         "channel_label": "sles12-sp3-debuginfo-pool-ppc64le-sap-sp3",
@@ -40482,7 +40782,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP3-Debuginfo-Pool for ppc64le SAP-SP3"
+        "channel_name": "SLES12-SP3-Debuginfo-Pool for ppc64le SAP"
     },
     {
         "channel_label": "sle-ha12-sp3-updates-ppc64le-sap-sp3",
@@ -40497,7 +40797,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP3-Updates for ppc64le SAP-SP3"
+        "channel_name": "SLE-HA12-SP3-Updates for ppc64le SAP"
     },
     {
         "channel_label": "sle-ha12-sp3-debuginfo-updates-ppc64le-sap-sp3",
@@ -40512,7 +40812,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP3-Debuginfo-Updates for ppc64le SAP-SP3"
+        "channel_name": "SLE-HA12-SP3-Debuginfo-Updates for ppc64le SAP"
     },
     {
         "channel_label": "sle-ha12-sp3-pool-ppc64le-sap-sp3",
@@ -40527,7 +40827,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP3-Pool for ppc64le SAP-SP3"
+        "channel_name": "SLE-HA12-SP3-Pool for ppc64le SAP"
     },
     {
         "channel_label": "sle-ha12-sp3-debuginfo-pool-ppc64le-sap-sp3",
@@ -40542,7 +40842,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP3-Debuginfo-Pool for ppc64le SAP-SP3"
+        "channel_name": "SLE-HA12-SP3-Debuginfo-Pool for ppc64le SAP"
     },
     {
         "channel_label": "sle-12-sp3-sap-updates-ppc64le",
@@ -40617,7 +40917,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Retail-3.1-Updates for x86_64"
+        "channel_name": "SUSE-Manager-Retail-3.1-Updates for x86_64 SP2"
     },
     {
         "channel_label": "suse-manager-retail-3.1-debuginfo-updates-x86_64",
@@ -40632,7 +40932,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Retail-3.1-Debuginfo-Updates for x86_64"
+        "channel_name": "SUSE-Manager-Retail-3.1-Debuginfo-Updates for x86_64 SP2"
     },
     {
         "channel_label": "suse-manager-retail-3.1-pool-x86_64",
@@ -40647,7 +40947,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Retail-3.1-Pool for x86_64"
+        "channel_name": "SUSE-Manager-Retail-3.1-Pool for x86_64 SP2"
     },
     {
         "channel_label": "suse-manager-retail-3.1-debuginfo-pool-x86_64",
@@ -40662,7 +40962,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Retail-3.1-Debuginfo-Pool for x86_64"
+        "channel_name": "SUSE-Manager-Retail-3.1-Debuginfo-Pool for x86_64 SP2"
     },
     {
         "channel_label": "suse-manager-retail-3.1-updates-x86_64-sp3",
@@ -40737,7 +41037,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Retail-3.1-Updates for x86_64 HPC-SP2"
+        "channel_name": "SUSE-Manager-Retail-3.1-Updates for x86_64 HPC SP2"
     },
     {
         "channel_label": "suse-manager-retail-3.1-debuginfo-updates-x86_64-hpc-sp2",
@@ -40752,7 +41052,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Retail-3.1-Debuginfo-Updates for x86_64 HPC-SP2"
+        "channel_name": "SUSE-Manager-Retail-3.1-Debuginfo-Updates for x86_64 HPC SP2"
     },
     {
         "channel_label": "suse-manager-retail-3.1-pool-x86_64-hpc-sp2",
@@ -40767,7 +41067,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Retail-3.1-Pool for x86_64 HPC-SP2"
+        "channel_name": "SUSE-Manager-Retail-3.1-Pool for x86_64 HPC SP2"
     },
     {
         "channel_label": "suse-manager-retail-3.1-debuginfo-pool-x86_64-hpc-sp2",
@@ -40782,7 +41082,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Retail-3.1-Debuginfo-Pool for x86_64 HPC-SP2"
+        "channel_name": "SUSE-Manager-Retail-3.1-Debuginfo-Pool for x86_64 HPC SP2"
     },
     {
         "channel_label": "suse-manager-retail-3.1-updates-x86_64-hpc-sp3",
@@ -40797,7 +41097,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Retail-3.1-Updates for x86_64 HPC-SP3"
+        "channel_name": "SUSE-Manager-Retail-3.1-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-manager-retail-3.1-debuginfo-updates-x86_64-hpc-sp3",
@@ -40812,7 +41112,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Retail-3.1-Debuginfo-Updates for x86_64 HPC-SP3"
+        "channel_name": "SUSE-Manager-Retail-3.1-Debuginfo-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-manager-retail-3.1-pool-x86_64-hpc-sp3",
@@ -40827,7 +41127,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Retail-3.1-Pool for x86_64 HPC-SP3"
+        "channel_name": "SUSE-Manager-Retail-3.1-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-manager-retail-3.1-debuginfo-pool-x86_64-hpc-sp3",
@@ -40842,7 +41142,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Retail-3.1-Debuginfo-Pool for x86_64 HPC-SP3"
+        "channel_name": "SUSE-Manager-Retail-3.1-Debuginfo-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-product-sles15-updates-x86_64",
@@ -42237,7 +42537,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-15-GA-Desktop-NVIDIA-Driver WE"
+        "channel_name": "SLE-15-GA-Desktop-NVIDIA-Driver for x86_64 WE"
     },
     {
         "channel_label": "sle-product-we15-updates-x86_64-sled",
@@ -42312,7 +42612,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": true,
-        "channel_name": "SLE-15-GA-Desktop-NVIDIA-Driver"
+        "channel_name": "SLE-15-GA-Desktop-NVIDIA-Driver for x86_64"
     },
     {
         "channel_label": "sle-product-we15-updates-x86_64-sap",
@@ -42387,7 +42687,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-15-GA-Desktop-NVIDIA-Driver SAP"
+        "channel_name": "SLE-15-GA-Desktop-NVIDIA-Driver for x86_64 SAP"
     },
     {
         "channel_label": "sle-product-sles15-updates-s390x",
@@ -44442,7 +44742,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-15-GA-Desktop-NVIDIA-Driver"
+        "channel_name": "SLE-15-GA-Desktop-NVIDIA-Driver for x86_64"
     },
     {
         "channel_label": "sle-product-sled15-updates-x86_64",
@@ -44937,7 +45237,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-8-Updates for x86_64"
+        "channel_name": "SUSE-OpenStack-Cloud-8-Updates for x86_64 SP3"
     },
     {
         "channel_label": "suse-openstack-cloud-8-debuginfo-updates-x86_64",
@@ -44952,7 +45252,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-8-Debuginfo-Updates for x86_64"
+        "channel_name": "SUSE-OpenStack-Cloud-8-Debuginfo-Updates for x86_64 SP3"
     },
     {
         "channel_label": "suse-openstack-cloud-8-pool-x86_64",
@@ -44967,7 +45267,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-8-Pool for x86_64"
+        "channel_name": "SUSE-OpenStack-Cloud-8-Pool for x86_64 SP3"
     },
     {
         "channel_label": "suse-openstack-cloud-8-debuginfo-pool-x86_64",
@@ -44982,7 +45282,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-8-Debuginfo-Pool for x86_64"
+        "channel_name": "SUSE-OpenStack-Cloud-8-Debuginfo-Pool for x86_64 SP3"
     },
     {
         "channel_label": "suse-openstack-cloud-8-updates-x86_64-hpc-sp3",
@@ -44997,7 +45297,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-8-Updates for x86_64 HPC-SP3"
+        "channel_name": "SUSE-OpenStack-Cloud-8-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-openstack-cloud-8-debuginfo-updates-x86_64-hpc-sp3",
@@ -45012,7 +45312,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-8-Debuginfo-Updates for x86_64 HPC-SP3"
+        "channel_name": "SUSE-OpenStack-Cloud-8-Debuginfo-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-openstack-cloud-8-pool-x86_64-hpc-sp3",
@@ -45027,7 +45327,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-8-Pool for x86_64 HPC-SP3"
+        "channel_name": "SUSE-OpenStack-Cloud-8-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-openstack-cloud-8-debuginfo-pool-x86_64-hpc-sp3",
@@ -45042,127 +45342,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-8-Debuginfo-Pool for x86_64 HPC-SP3"
-    },
-    {
-        "channel_label": "sles12-sp3-bcl-updates-x86_64",
-        "parent_channel_label": "sles12-sp3-pool-x86_64",
-        "product_id": 1618,
-        "repository_id": 2696,
-        "parent_product_id": 1421,
-        "root_product_id": 1421,
-        "update_tag": "SLE-SERVER",
-        "url": "https://updates.suse.com/SUSE/Updates/SLE-SERVER/12-SP3-BCL/x86_64/update/",
-        "release_stage": "released",
-        "mandatory": true,
-        "signed": true,
-        "recommended": false,
-        "channel_name": "SLES12-SP3-BCL-Updates for x86_64 SP3"
-    },
-    {
-        "channel_label": "sles12-sp3-bcl-debuginfo-updates-x86_64",
-        "parent_channel_label": "sles12-sp3-pool-x86_64",
-        "product_id": 1618,
-        "repository_id": 2697,
-        "parent_product_id": 1421,
-        "root_product_id": 1421,
-        "update_tag": "SLE-SERVER",
-        "url": "https://updates.suse.com/SUSE/Updates/SLE-SERVER/12-SP3-BCL/x86_64/update_debug/",
-        "release_stage": "released",
-        "mandatory": false,
-        "signed": true,
-        "recommended": false,
-        "channel_name": "SLES12-SP3-BCL-Debuginfo-Updates for x86_64 SP3"
-    },
-    {
-        "channel_label": "sles12-sp3-bcl-pool-x86_64",
-        "parent_channel_label": "sles12-sp3-pool-x86_64",
-        "product_id": 1618,
-        "repository_id": 2698,
-        "parent_product_id": 1421,
-        "root_product_id": 1421,
-        "update_tag": "SLE-SERVER",
-        "url": "https://updates.suse.com/SUSE/Products/SLE-SERVER/12-SP3-BCL/x86_64/product/",
-        "release_stage": "released",
-        "mandatory": true,
-        "signed": true,
-        "recommended": false,
-        "channel_name": "SLES12-SP3-BCL-Pool for x86_64 SP3"
-    },
-    {
-        "channel_label": "sles12-sp3-bcl-debuginfo-pool-x86_64",
-        "parent_channel_label": "sles12-sp3-pool-x86_64",
-        "product_id": 1618,
-        "repository_id": 2699,
-        "parent_product_id": 1421,
-        "root_product_id": 1421,
-        "update_tag": "SLE-SERVER",
-        "url": "https://updates.suse.com/SUSE/Products/SLE-SERVER/12-SP3-BCL/x86_64/product_debug/",
-        "release_stage": "released",
-        "mandatory": false,
-        "signed": true,
-        "recommended": false,
-        "channel_name": "SLES12-SP3-BCL-Debuginfo-Pool for x86_64 SP3"
-    },
-    {
-        "channel_label": "sles12-sp3-bcl-updates-x86_64-hpc-sp3",
-        "parent_channel_label": "sle12-sp3-hpc-pool-x86_64",
-        "product_id": 1618,
-        "repository_id": 2696,
-        "parent_product_id": 1751,
-        "root_product_id": 1751,
-        "update_tag": "SLE-SERVER",
-        "url": "https://updates.suse.com/SUSE/Updates/SLE-SERVER/12-SP3-BCL/x86_64/update/",
-        "release_stage": "released",
-        "mandatory": true,
-        "signed": true,
-        "recommended": false,
-        "channel_name": "SLES12-SP3-BCL-Updates for x86_64 HPC-SP3"
-    },
-    {
-        "channel_label": "sles12-sp3-bcl-debuginfo-updates-x86_64-hpc-sp3",
-        "parent_channel_label": "sle12-sp3-hpc-pool-x86_64",
-        "product_id": 1618,
-        "repository_id": 2697,
-        "parent_product_id": 1751,
-        "root_product_id": 1751,
-        "update_tag": "SLE-SERVER",
-        "url": "https://updates.suse.com/SUSE/Updates/SLE-SERVER/12-SP3-BCL/x86_64/update_debug/",
-        "release_stage": "released",
-        "mandatory": false,
-        "signed": true,
-        "recommended": false,
-        "channel_name": "SLES12-SP3-BCL-Debuginfo-Updates for x86_64 HPC-SP3"
-    },
-    {
-        "channel_label": "sles12-sp3-bcl-pool-x86_64-hpc-sp3",
-        "parent_channel_label": "sle12-sp3-hpc-pool-x86_64",
-        "product_id": 1618,
-        "repository_id": 2698,
-        "parent_product_id": 1751,
-        "root_product_id": 1751,
-        "update_tag": "SLE-SERVER",
-        "url": "https://updates.suse.com/SUSE/Products/SLE-SERVER/12-SP3-BCL/x86_64/product/",
-        "release_stage": "released",
-        "mandatory": true,
-        "signed": true,
-        "recommended": false,
-        "channel_name": "SLES12-SP3-BCL-Pool for x86_64 HPC-SP3"
-    },
-    {
-        "channel_label": "sles12-sp3-bcl-debuginfo-pool-x86_64-hpc-sp3",
-        "parent_channel_label": "sle12-sp3-hpc-pool-x86_64",
-        "product_id": 1618,
-        "repository_id": 2699,
-        "parent_product_id": 1751,
-        "root_product_id": 1751,
-        "update_tag": "SLE-SERVER",
-        "url": "https://updates.suse.com/SUSE/Products/SLE-SERVER/12-SP3-BCL/x86_64/product_debug/",
-        "release_stage": "released",
-        "mandatory": false,
-        "signed": true,
-        "recommended": false,
-        "channel_name": "SLES12-SP3-BCL-Debuginfo-Pool for x86_64 HPC-SP3"
+        "channel_name": "SUSE-OpenStack-Cloud-8-Debuginfo-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-rt12-sp3-updates-x86_64",
@@ -45237,7 +45417,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-RT12-SP3-Updates for x86_64 SAP-SP3"
+        "channel_name": "SLE-RT12-SP3-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-rt12-sp3-debuginfo-updates-x86_64-sap-sp3",
@@ -45252,7 +45432,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-RT12-SP3-Debuginfo-Updates for x86_64 SAP-SP3"
+        "channel_name": "SLE-RT12-SP3-Debuginfo-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-rt12-sp3-pool-x86_64-sap-sp3",
@@ -45267,7 +45447,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-RT12-SP3-Pool for x86_64 SAP-SP3"
+        "channel_name": "SLE-RT12-SP3-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-rt12-sp3-debuginfo-pool-x86_64-sap-sp3",
@@ -45282,7 +45462,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-RT12-SP3-Debuginfo-Pool for x86_64 SAP-SP3"
+        "channel_name": "SLE-RT12-SP3-Debuginfo-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-rt12-sp3-updates-x86_64-hpc-sp3",
@@ -45297,7 +45477,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-RT12-SP3-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLE-RT12-SP3-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sle-rt12-sp3-debuginfo-updates-x86_64-hpc-sp3",
@@ -45312,7 +45492,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-RT12-SP3-Debuginfo-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLE-RT12-SP3-Debuginfo-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sle-rt12-sp3-pool-x86_64-hpc-sp3",
@@ -45327,7 +45507,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-RT12-SP3-Pool for x86_64 HPC-SP3"
+        "channel_name": "SLE-RT12-SP3-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sle-rt12-sp3-debuginfo-pool-x86_64-hpc-sp3",
@@ -45342,7 +45522,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-RT12-SP3-Debuginfo-Pool for x86_64 HPC-SP3"
+        "channel_name": "SLE-RT12-SP3-Debuginfo-Pool for x86_64 HPC"
     },
     {
         "channel_label": "suse-manager-server-3.1-updates-ppc64le-sp3",
@@ -45473,11 +45653,11 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Manager-Tools",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/12/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates x86_64 SP4"
+        "channel_name": "SLE-Manager-Tools12-Updates for x86_64 SP4"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-x86_64-sp4",
@@ -45488,11 +45668,11 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Manager-Tools",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/12/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates x86_64 SP4"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for x86_64 SP4"
     },
     {
         "channel_label": "sle-manager-tools12-pool-x86_64-sp4",
@@ -45503,11 +45683,11 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Manager-Tools",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/12/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool x86_64 SP4"
+        "channel_name": "SLE-Manager-Tools12-Pool for x86_64 SP4"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-x86_64-sp4",
@@ -45518,11 +45698,11 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Manager-Tools",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/12/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool x86_64 SP4"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for x86_64 SP4"
     },
     {
         "channel_label": "sles12-sp4-updates-x86_64",
@@ -45533,7 +45713,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-SERVER",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-SERVER/12-SP4/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -45548,7 +45728,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-SERVER",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-SERVER/12-SP4/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -45563,7 +45743,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-SERVER",
         "url": "https://updates.suse.com/SUSE/Products/SLE-SERVER/12-SP4/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -45578,7 +45758,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-SERVER",
         "url": "https://updates.suse.com/SUSE/Products/SLE-SERVER/12-SP4/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -45593,11 +45773,11 @@
         "root_product_id": 1626,
         "update_tag": "SLE-Manager-Tools",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/12/ppc64le/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates ppc64le SP4"
+        "channel_name": "SLE-Manager-Tools12-Updates for ppc64le SP4"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-ppc64le-sp4",
@@ -45608,11 +45788,11 @@
         "root_product_id": 1626,
         "update_tag": "SLE-Manager-Tools",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/12/ppc64le/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates ppc64le SP4"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for ppc64le SP4"
     },
     {
         "channel_label": "sle-manager-tools12-pool-ppc64le-sp4",
@@ -45623,11 +45803,11 @@
         "root_product_id": 1626,
         "update_tag": "SLE-Manager-Tools",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/12/ppc64le/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool ppc64le SP4"
+        "channel_name": "SLE-Manager-Tools12-Pool for ppc64le SP4"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-ppc64le-sp4",
@@ -45638,11 +45818,11 @@
         "root_product_id": 1626,
         "update_tag": "SLE-Manager-Tools",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/12/ppc64le/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool ppc64le SP4"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for ppc64le SP4"
     },
     {
         "channel_label": "sles12-sp4-updates-ppc64le",
@@ -45653,7 +45833,7 @@
         "root_product_id": 1626,
         "update_tag": "SLE-SERVER",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-SERVER/12-SP4/ppc64le/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -45668,7 +45848,7 @@
         "root_product_id": 1626,
         "update_tag": "SLE-SERVER",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-SERVER/12-SP4/ppc64le/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -45683,7 +45863,7 @@
         "root_product_id": 1626,
         "update_tag": "SLE-SERVER",
         "url": "https://updates.suse.com/SUSE/Products/SLE-SERVER/12-SP4/ppc64le/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -45698,7 +45878,7 @@
         "root_product_id": 1626,
         "update_tag": "SLE-SERVER",
         "url": "https://updates.suse.com/SUSE/Products/SLE-SERVER/12-SP4/ppc64le/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -45713,11 +45893,11 @@
         "root_product_id": 1627,
         "update_tag": "SLE-Manager-Tools",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/12/s390x/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates s390x SP4"
+        "channel_name": "SLE-Manager-Tools12-Updates for s390x SP4"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-s390x-sp4",
@@ -45728,11 +45908,11 @@
         "root_product_id": 1627,
         "update_tag": "SLE-Manager-Tools",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/12/s390x/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates s390x SP4"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for s390x SP4"
     },
     {
         "channel_label": "sle-manager-tools12-pool-s390x-sp4",
@@ -45743,11 +45923,11 @@
         "root_product_id": 1627,
         "update_tag": "SLE-Manager-Tools",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/12/s390x/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool s390x SP4"
+        "channel_name": "SLE-Manager-Tools12-Pool for s390x SP4"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-s390x-sp4",
@@ -45758,11 +45938,11 @@
         "root_product_id": 1627,
         "update_tag": "SLE-Manager-Tools",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/12/s390x/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool s390x SP4"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for s390x SP4"
     },
     {
         "channel_label": "sles12-sp4-updates-s390x",
@@ -45773,7 +45953,7 @@
         "root_product_id": 1627,
         "update_tag": "SLE-SERVER",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-SERVER/12-SP4/s390x/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -45788,7 +45968,7 @@
         "root_product_id": 1627,
         "update_tag": "SLE-SERVER",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-SERVER/12-SP4/s390x/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -45803,7 +45983,7 @@
         "root_product_id": 1627,
         "update_tag": "SLE-SERVER",
         "url": "https://updates.suse.com/SUSE/Products/SLE-SERVER/12-SP4/s390x/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -45818,7 +45998,7 @@
         "root_product_id": 1627,
         "update_tag": "SLE-SERVER",
         "url": "https://updates.suse.com/SUSE/Products/SLE-SERVER/12-SP4/s390x/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -45833,11 +46013,11 @@
         "root_product_id": 1628,
         "update_tag": "SLE-Manager-Tools",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/12/aarch64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates aarch64 SP4"
+        "channel_name": "SLE-Manager-Tools12-Updates for aarch64 SP4"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-aarch64-sp4",
@@ -45848,11 +46028,11 @@
         "root_product_id": 1628,
         "update_tag": "SLE-Manager-Tools",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/12/aarch64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates aarch64 SP4"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for aarch64 SP4"
     },
     {
         "channel_label": "sle-manager-tools12-pool-aarch64-sp4",
@@ -45863,11 +46043,11 @@
         "root_product_id": 1628,
         "update_tag": "SLE-Manager-Tools",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/12/aarch64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool aarch64 SP4"
+        "channel_name": "SLE-Manager-Tools12-Pool for aarch64 SP4"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-aarch64-sp4",
@@ -45878,11 +46058,11 @@
         "root_product_id": 1628,
         "update_tag": "SLE-Manager-Tools",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/12/aarch64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool aarch64 SP4"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for aarch64 SP4"
     },
     {
         "channel_label": "sles12-sp4-updates-aarch64",
@@ -45893,7 +46073,7 @@
         "root_product_id": 1628,
         "update_tag": "SLE-SERVER",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-SERVER/12-SP4/aarch64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -45908,7 +46088,7 @@
         "root_product_id": 1628,
         "update_tag": "SLE-SERVER",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-SERVER/12-SP4/aarch64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -45923,7 +46103,7 @@
         "root_product_id": 1628,
         "update_tag": "SLE-SERVER",
         "url": "https://updates.suse.com/SUSE/Products/SLE-SERVER/12-SP4/aarch64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -45938,7 +46118,7 @@
         "root_product_id": 1628,
         "update_tag": "SLE-SERVER",
         "url": "https://updates.suse.com/SUSE/Products/SLE-SERVER/12-SP4/aarch64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -45953,11 +46133,11 @@
         "root_product_id": 1629,
         "update_tag": "SLE-Manager-Tools",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/12/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates x86_64 SLED-SP4"
+        "channel_name": "SLE-Manager-Tools12-Updates for x86_64 SLED SP4"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-x86_64-sled-sp4",
@@ -45968,11 +46148,11 @@
         "root_product_id": 1629,
         "update_tag": "SLE-Manager-Tools",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/12/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates x86_64 SLED-SP4"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for x86_64 SLED SP4"
     },
     {
         "channel_label": "sle-manager-tools12-pool-x86_64-sled-sp4",
@@ -45983,11 +46163,11 @@
         "root_product_id": 1629,
         "update_tag": "SLE-Manager-Tools",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/12/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool x86_64 SLED-SP4"
+        "channel_name": "SLE-Manager-Tools12-Pool for x86_64 SLED SP4"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-x86_64-sled-sp4",
@@ -45998,11 +46178,11 @@
         "root_product_id": 1629,
         "update_tag": "SLE-Manager-Tools",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/12/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool x86_64 SLED-SP4"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for x86_64 SLED SP4"
     },
     {
         "channel_label": "sled12-sp4-updates-x86_64",
@@ -46013,7 +46193,7 @@
         "root_product_id": 1629,
         "update_tag": "SLE-DESKTOP",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-DESKTOP/12-SP4/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -46028,7 +46208,7 @@
         "root_product_id": 1629,
         "update_tag": "SLE-DESKTOP",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-DESKTOP/12-SP4/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -46043,7 +46223,7 @@
         "root_product_id": 1629,
         "update_tag": "SLE-DESKTOP",
         "url": "https://updates.suse.com/SUSE/Products/SLE-DESKTOP/12-SP4/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -46058,7 +46238,7 @@
         "root_product_id": 1629,
         "update_tag": "SLE-DESKTOP",
         "url": "https://updates.suse.com/SUSE/Products/SLE-DESKTOP/12-SP4/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -46073,11 +46253,11 @@
         "root_product_id": 1629,
         "update_tag": null,
         "url": "https://download.nvidia.com/suse/sle12sp4/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-12-SP4-GA-Desktop-nVidia-Driver"
+        "channel_name": "SLE-12-SP4-GA-Desktop-nVidia-Driver for x86_64"
     },
     {
         "channel_label": "sle-sdk12-sp4-updates-x86_64",
@@ -46152,7 +46332,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP4-Updates for x86_64 SLED-SP4"
+        "channel_name": "SLE-SDK12-SP4-Updates for x86_64 SLED"
     },
     {
         "channel_label": "sle-sdk12-sp4-debuginfo-updates-x86_64-sled-sp4",
@@ -46167,7 +46347,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP4-Debuginfo-Updates for x86_64 SLED-SP4"
+        "channel_name": "SLE-SDK12-SP4-Debuginfo-Updates for x86_64 SLED"
     },
     {
         "channel_label": "sle-sdk12-sp4-pool-x86_64-sled-sp4",
@@ -46182,7 +46362,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP4-Pool for x86_64 SLED-SP4"
+        "channel_name": "SLE-SDK12-SP4-Pool for x86_64 SLED"
     },
     {
         "channel_label": "sle-sdk12-sp4-debuginfo-pool-x86_64-sled-sp4",
@@ -46197,7 +46377,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP4-Debuginfo-Pool for x86_64 SLED-SP4"
+        "channel_name": "SLE-SDK12-SP4-Debuginfo-Pool for x86_64 SLED"
     },
     {
         "channel_label": "sle-sdk12-sp4-updates-x86_64-sap-sp4",
@@ -46212,7 +46392,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP4-Updates for x86_64 SAP-SP4"
+        "channel_name": "SLE-SDK12-SP4-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-sdk12-sp4-debuginfo-updates-x86_64-sap-sp4",
@@ -46227,7 +46407,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP4-Debuginfo-Updates for x86_64 SAP-SP4"
+        "channel_name": "SLE-SDK12-SP4-Debuginfo-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-sdk12-sp4-pool-x86_64-sap-sp4",
@@ -46242,7 +46422,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP4-Pool for x86_64 SAP-SP4"
+        "channel_name": "SLE-SDK12-SP4-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-sdk12-sp4-debuginfo-pool-x86_64-sap-sp4",
@@ -46257,7 +46437,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP4-Debuginfo-Pool for x86_64 SAP-SP4"
+        "channel_name": "SLE-SDK12-SP4-Debuginfo-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-sdk12-sp4-updates-x86_64-hpc-sp4",
@@ -46272,7 +46452,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP4-Updates for x86_64 HPC-SP4"
+        "channel_name": "SLE-SDK12-SP4-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sle-sdk12-sp4-debuginfo-updates-x86_64-hpc-sp4",
@@ -46287,7 +46467,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP4-Debuginfo-Updates for x86_64 HPC-SP4"
+        "channel_name": "SLE-SDK12-SP4-Debuginfo-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sle-sdk12-sp4-pool-x86_64-hpc-sp4",
@@ -46302,7 +46482,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP4-Pool for x86_64 HPC-SP4"
+        "channel_name": "SLE-SDK12-SP4-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sle-sdk12-sp4-debuginfo-pool-x86_64-hpc-sp4",
@@ -46317,7 +46497,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP4-Debuginfo-Pool for x86_64 HPC-SP4"
+        "channel_name": "SLE-SDK12-SP4-Debuginfo-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sle-sdk12-sp4-updates-ppc64le",
@@ -46392,7 +46572,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP4-Updates for ppc64le SAP-SP4"
+        "channel_name": "SLE-SDK12-SP4-Updates for ppc64le SAP"
     },
     {
         "channel_label": "sle-sdk12-sp4-debuginfo-updates-ppc64le-sap-sp4",
@@ -46407,7 +46587,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP4-Debuginfo-Updates for ppc64le SAP-SP4"
+        "channel_name": "SLE-SDK12-SP4-Debuginfo-Updates for ppc64le SAP"
     },
     {
         "channel_label": "sle-sdk12-sp4-pool-ppc64le-sap-sp4",
@@ -46422,7 +46602,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP4-Pool for ppc64le SAP-SP4"
+        "channel_name": "SLE-SDK12-SP4-Pool for ppc64le SAP"
     },
     {
         "channel_label": "sle-sdk12-sp4-debuginfo-pool-ppc64le-sap-sp4",
@@ -46437,7 +46617,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP4-Debuginfo-Pool for ppc64le SAP-SP4"
+        "channel_name": "SLE-SDK12-SP4-Debuginfo-Pool for ppc64le SAP"
     },
     {
         "channel_label": "sle-sdk12-sp4-updates-s390x",
@@ -46572,7 +46752,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP4-Updates for aarch64 HPC-SP4"
+        "channel_name": "SLE-SDK12-SP4-Updates for aarch64 HPC"
     },
     {
         "channel_label": "sle-sdk12-sp4-debuginfo-updates-aarch64-hpc-sp4",
@@ -46587,7 +46767,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP4-Debuginfo-Updates for aarch64 HPC-SP4"
+        "channel_name": "SLE-SDK12-SP4-Debuginfo-Updates for aarch64 HPC"
     },
     {
         "channel_label": "sle-sdk12-sp4-pool-aarch64-hpc-sp4",
@@ -46602,7 +46782,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP4-Pool for aarch64 HPC-SP4"
+        "channel_name": "SLE-SDK12-SP4-Pool for aarch64 HPC"
     },
     {
         "channel_label": "sle-sdk12-sp4-debuginfo-pool-aarch64-hpc-sp4",
@@ -46617,7 +46797,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-SDK12-SP4-Debuginfo-Pool for aarch64 HPC-SP4"
+        "channel_name": "SLE-SDK12-SP4-Debuginfo-Pool for aarch64 HPC"
     },
     {
         "channel_label": "sle-ha12-sp4-updates-x86_64",
@@ -46628,7 +46808,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-HA",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-HA/12-SP4/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -46643,7 +46823,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-HA",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-HA/12-SP4/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -46658,7 +46838,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-HA",
         "url": "https://updates.suse.com/SUSE/Products/SLE-HA/12-SP4/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -46673,7 +46853,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-HA",
         "url": "https://updates.suse.com/SUSE/Products/SLE-HA/12-SP4/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -46688,11 +46868,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-HA",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-HA/12-SP4/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP4-Updates for x86_64 HPC-SP4"
+        "channel_name": "SLE-HA12-SP4-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sle-ha12-sp4-debuginfo-updates-x86_64-hpc-sp4",
@@ -46703,11 +46883,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-HA",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-HA/12-SP4/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP4-Debuginfo-Updates for x86_64 HPC-SP4"
+        "channel_name": "SLE-HA12-SP4-Debuginfo-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sle-ha12-sp4-pool-x86_64-hpc-sp4",
@@ -46718,11 +46898,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-HA",
         "url": "https://updates.suse.com/SUSE/Products/SLE-HA/12-SP4/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP4-Pool for x86_64 HPC-SP4"
+        "channel_name": "SLE-HA12-SP4-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sle-ha12-sp4-debuginfo-pool-x86_64-hpc-sp4",
@@ -46733,11 +46913,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-HA",
         "url": "https://updates.suse.com/SUSE/Products/SLE-HA/12-SP4/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP4-Debuginfo-Pool for x86_64 HPC-SP4"
+        "channel_name": "SLE-HA12-SP4-Debuginfo-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sle-ha12-sp4-updates-ppc64le",
@@ -46748,7 +46928,7 @@
         "root_product_id": 1626,
         "update_tag": "SLE-HA",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-HA/12-SP4/ppc64le/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -46763,7 +46943,7 @@
         "root_product_id": 1626,
         "update_tag": "SLE-HA",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-HA/12-SP4/ppc64le/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -46778,7 +46958,7 @@
         "root_product_id": 1626,
         "update_tag": "SLE-HA",
         "url": "https://updates.suse.com/SUSE/Products/SLE-HA/12-SP4/ppc64le/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -46793,7 +46973,7 @@
         "root_product_id": 1626,
         "update_tag": "SLE-HA",
         "url": "https://updates.suse.com/SUSE/Products/SLE-HA/12-SP4/ppc64le/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -46808,7 +46988,7 @@
         "root_product_id": 1627,
         "update_tag": "SLE-HA",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-HA/12-SP4/s390x/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -46823,7 +47003,7 @@
         "root_product_id": 1627,
         "update_tag": "SLE-HA",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-HA/12-SP4/s390x/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -46838,7 +47018,7 @@
         "root_product_id": 1627,
         "update_tag": "SLE-HA",
         "url": "https://updates.suse.com/SUSE/Products/SLE-HA/12-SP4/s390x/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -46853,7 +47033,7 @@
         "root_product_id": 1627,
         "update_tag": "SLE-HA",
         "url": "https://updates.suse.com/SUSE/Products/SLE-HA/12-SP4/s390x/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -46868,7 +47048,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-HA-GEO",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-HA-GEO/12-SP4/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -46883,7 +47063,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-HA-GEO",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-HA-GEO/12-SP4/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -46898,7 +47078,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-HA-GEO",
         "url": "https://updates.suse.com/SUSE/Products/SLE-HA-GEO/12-SP4/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -46913,7 +47093,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-HA-GEO",
         "url": "https://updates.suse.com/SUSE/Products/SLE-HA-GEO/12-SP4/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -46928,11 +47108,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-HA-GEO",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-HA-GEO/12-SP4/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA-GEO12-SP4-Updates for x86_64 SAP-SP4"
+        "channel_name": "SLE-HA-GEO12-SP4-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-ha-geo12-sp4-debuginfo-updates-x86_64-sap-sp4",
@@ -46943,11 +47123,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-HA-GEO",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-HA-GEO/12-SP4/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA-GEO12-SP4-Debuginfo-Updates for x86_64 SAP-SP4"
+        "channel_name": "SLE-HA-GEO12-SP4-Debuginfo-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-ha-geo12-sp4-pool-x86_64-sap-sp4",
@@ -46958,11 +47138,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-HA-GEO",
         "url": "https://updates.suse.com/SUSE/Products/SLE-HA-GEO/12-SP4/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA-GEO12-SP4-Pool for x86_64 SAP-SP4"
+        "channel_name": "SLE-HA-GEO12-SP4-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-ha-geo12-sp4-debuginfo-pool-x86_64-sap-sp4",
@@ -46973,11 +47153,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-HA-GEO",
         "url": "https://updates.suse.com/SUSE/Products/SLE-HA-GEO/12-SP4/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA-GEO12-SP4-Debuginfo-Pool for x86_64 SAP-SP4"
+        "channel_name": "SLE-HA-GEO12-SP4-Debuginfo-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-ha-geo12-sp4-updates-x86_64-hpc-sp4",
@@ -46988,11 +47168,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-HA-GEO",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-HA-GEO/12-SP4/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA-GEO12-SP4-Updates for x86_64 HPC-SP4"
+        "channel_name": "SLE-HA-GEO12-SP4-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sle-ha-geo12-sp4-debuginfo-updates-x86_64-hpc-sp4",
@@ -47003,11 +47183,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-HA-GEO",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-HA-GEO/12-SP4/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA-GEO12-SP4-Debuginfo-Updates for x86_64 HPC-SP4"
+        "channel_name": "SLE-HA-GEO12-SP4-Debuginfo-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sle-ha-geo12-sp4-pool-x86_64-hpc-sp4",
@@ -47018,11 +47198,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-HA-GEO",
         "url": "https://updates.suse.com/SUSE/Products/SLE-HA-GEO/12-SP4/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA-GEO12-SP4-Pool for x86_64 HPC-SP4"
+        "channel_name": "SLE-HA-GEO12-SP4-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sle-ha-geo12-sp4-debuginfo-pool-x86_64-hpc-sp4",
@@ -47033,11 +47213,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-HA-GEO",
         "url": "https://updates.suse.com/SUSE/Products/SLE-HA-GEO/12-SP4/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA-GEO12-SP4-Debuginfo-Pool for x86_64 HPC-SP4"
+        "channel_name": "SLE-HA-GEO12-SP4-Debuginfo-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sle-ha-geo12-sp4-updates-s390x",
@@ -47048,7 +47228,7 @@
         "root_product_id": 1627,
         "update_tag": "SLE-HA-GEO",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-HA-GEO/12-SP4/s390x/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -47063,7 +47243,7 @@
         "root_product_id": 1627,
         "update_tag": "SLE-HA-GEO",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-HA-GEO/12-SP4/s390x/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -47078,7 +47258,7 @@
         "root_product_id": 1627,
         "update_tag": "SLE-HA-GEO",
         "url": "https://updates.suse.com/SUSE/Products/SLE-HA-GEO/12-SP4/s390x/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -47093,7 +47273,7 @@
         "root_product_id": 1627,
         "update_tag": "SLE-HA-GEO",
         "url": "https://updates.suse.com/SUSE/Products/SLE-HA-GEO/12-SP4/s390x/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -47108,7 +47288,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-WE",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-WE/12-SP4/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -47123,7 +47303,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-WE",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-WE/12-SP4/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -47138,7 +47318,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-WE",
         "url": "https://updates.suse.com/SUSE/Products/SLE-WE/12-SP4/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -47153,7 +47333,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-WE",
         "url": "https://updates.suse.com/SUSE/Products/SLE-WE/12-SP4/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -47168,11 +47348,11 @@
         "root_product_id": 1625,
         "update_tag": null,
         "url": "https://download.nvidia.com/suse/sle12sp4/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-12-SP4-GA-Desktop-nVidia-Driver WE-SP4"
+        "channel_name": "SLE-12-SP4-GA-Desktop-nVidia-Driver for x86_64 WE"
     },
     {
         "channel_label": "sle-we12-sp4-updates-x86_64-sap-sp4",
@@ -47183,11 +47363,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-WE",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-WE/12-SP4/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-WE12-SP4-Updates for x86_64 SAP-SP4"
+        "channel_name": "SLE-WE12-SP4-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-we12-sp4-debuginfo-updates-x86_64-sap-sp4",
@@ -47198,11 +47378,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-WE",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-WE/12-SP4/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-WE12-SP4-Debuginfo-Updates for x86_64 SAP-SP4"
+        "channel_name": "SLE-WE12-SP4-Debuginfo-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-we12-sp4-pool-x86_64-sap-sp4",
@@ -47213,11 +47393,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-WE",
         "url": "https://updates.suse.com/SUSE/Products/SLE-WE/12-SP4/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-WE12-SP4-Pool for x86_64 SAP-SP4"
+        "channel_name": "SLE-WE12-SP4-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-we12-sp4-debuginfo-pool-x86_64-sap-sp4",
@@ -47228,11 +47408,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-WE",
         "url": "https://updates.suse.com/SUSE/Products/SLE-WE/12-SP4/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-WE12-SP4-Debuginfo-Pool for x86_64 SAP-SP4"
+        "channel_name": "SLE-WE12-SP4-Debuginfo-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-12-sp4-ga-desktop-nvidia-driver-we-sap-sp4",
@@ -47243,11 +47423,11 @@
         "root_product_id": 1755,
         "update_tag": null,
         "url": "https://download.nvidia.com/suse/sle12sp4/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-12-SP4-GA-Desktop-nVidia-Driver WE-SAP-SP4"
+        "channel_name": "SLE-12-SP4-GA-Desktop-nVidia-Driver for x86_64 WE-SAP"
     },
     {
         "channel_label": "sle-we12-sp4-updates-x86_64-hpc-sp4",
@@ -47258,11 +47438,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-WE",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-WE/12-SP4/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-WE12-SP4-Updates for x86_64 HPC-SP4"
+        "channel_name": "SLE-WE12-SP4-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sle-we12-sp4-debuginfo-updates-x86_64-hpc-sp4",
@@ -47273,11 +47453,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-WE",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-WE/12-SP4/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-WE12-SP4-Debuginfo-Updates for x86_64 HPC-SP4"
+        "channel_name": "SLE-WE12-SP4-Debuginfo-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sle-we12-sp4-pool-x86_64-hpc-sp4",
@@ -47288,11 +47468,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-WE",
         "url": "https://updates.suse.com/SUSE/Products/SLE-WE/12-SP4/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-WE12-SP4-Pool for x86_64 HPC-SP4"
+        "channel_name": "SLE-WE12-SP4-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sle-we12-sp4-debuginfo-pool-x86_64-hpc-sp4",
@@ -47303,11 +47483,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-WE",
         "url": "https://updates.suse.com/SUSE/Products/SLE-WE/12-SP4/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-WE12-SP4-Debuginfo-Pool for x86_64 HPC-SP4"
+        "channel_name": "SLE-WE12-SP4-Debuginfo-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sle-12-sp4-ga-desktop-nvidia-driver-hpc-sp4",
@@ -47318,11 +47498,11 @@
         "root_product_id": 1759,
         "update_tag": null,
         "url": "https://download.nvidia.com/suse/sle12sp4/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-12-SP4-GA-Desktop-nVidia-Driver for x86_64 HPC-SP4"
+        "channel_name": "SLE-12-SP4-GA-Desktop-nVidia-Driver for x86_64 HPC"
     },
     {
         "channel_label": "sle-module-containers15-updates-ppc64le",
@@ -47685,124 +47865,124 @@
         "channel_name": "SLE-Module-Containers15-Debuginfo-Pool for x86_64 HPC"
     },
     {
-        "channel_label": "suse-enterprise-storage-6-updates-aarch64",
-        "parent_channel_label": "sle-product-sles15-pool-aarch64",
+        "channel_label": "suse-enterprise-storage-6-updates-aarch64-sp1",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
         "product_id": 1643,
         "repository_id": 2869,
-        "parent_product_id": 1601,
-        "root_product_id": 1586,
-        "update_tag": "Storage-6",
+        "parent_product_id": 1777,
+        "root_product_id": 1760,
+        "update_tag": null,
         "url": "https://updates.suse.com/SUSE/Updates/Storage/6/aarch64/update/",
         "release_stage": "beta",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-6-Updates for aarch64"
+        "channel_name": "SUSE-Enterprise-Storage-6-Updates for aarch64 SP1"
     },
     {
-        "channel_label": "suse-enterprise-storage-6-debuginfo-updates-aarch64",
-        "parent_channel_label": "sle-product-sles15-pool-aarch64",
+        "channel_label": "suse-enterprise-storage-6-debuginfo-updates-aarch64-sp1",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
         "product_id": 1643,
         "repository_id": 2870,
-        "parent_product_id": 1601,
-        "root_product_id": 1586,
-        "update_tag": "Storage-6",
+        "parent_product_id": 1777,
+        "root_product_id": 1760,
+        "update_tag": null,
         "url": "https://updates.suse.com/SUSE/Updates/Storage/6/aarch64/update_debug/",
         "release_stage": "beta",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-6-Debuginfo-Updates for aarch64"
+        "channel_name": "SUSE-Enterprise-Storage-6-Debuginfo-Updates for aarch64 SP1"
     },
     {
-        "channel_label": "suse-enterprise-storage-6-pool-aarch64",
-        "parent_channel_label": "sle-product-sles15-pool-aarch64",
+        "channel_label": "suse-enterprise-storage-6-pool-aarch64-sp1",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
         "product_id": 1643,
         "repository_id": 2871,
-        "parent_product_id": 1601,
-        "root_product_id": 1586,
-        "update_tag": "Storage-6",
+        "parent_product_id": 1777,
+        "root_product_id": 1760,
+        "update_tag": null,
         "url": "https://updates.suse.com/SUSE/Products/Storage/6/aarch64/product/",
         "release_stage": "beta",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-6-Pool for aarch64"
+        "channel_name": "SUSE-Enterprise-Storage-6-Pool for aarch64 SP1"
     },
     {
-        "channel_label": "suse-enterprise-storage-6-debuginfo-pool-aarch64",
-        "parent_channel_label": "sle-product-sles15-pool-aarch64",
+        "channel_label": "suse-enterprise-storage-6-debuginfo-pool-aarch64-sp1",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
         "product_id": 1643,
         "repository_id": 2872,
-        "parent_product_id": 1601,
-        "root_product_id": 1586,
-        "update_tag": "Storage-6",
+        "parent_product_id": 1777,
+        "root_product_id": 1760,
+        "update_tag": null,
         "url": "https://updates.suse.com/SUSE/Products/Storage/6/aarch64/product_debug/",
         "release_stage": "beta",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-6-Debuginfo-Pool for aarch64"
+        "channel_name": "SUSE-Enterprise-Storage-6-Debuginfo-Pool for aarch64 SP1"
     },
     {
-        "channel_label": "suse-enterprise-storage-6-updates-x86_64",
-        "parent_channel_label": "sle-product-sles15-pool-x86_64",
+        "channel_label": "suse-enterprise-storage-6-updates-x86_64-sp1",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
         "product_id": 1644,
         "repository_id": 2874,
-        "parent_product_id": 1580,
-        "root_product_id": 1575,
-        "update_tag": "Storage-6",
+        "parent_product_id": 1780,
+        "root_product_id": 1763,
+        "update_tag": null,
         "url": "https://updates.suse.com/SUSE/Updates/Storage/6/x86_64/update/",
         "release_stage": "beta",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-6-Updates for x86_64"
+        "channel_name": "SUSE-Enterprise-Storage-6-Updates for x86_64 SP1"
     },
     {
-        "channel_label": "suse-enterprise-storage-6-debuginfo-updates-x86_64",
-        "parent_channel_label": "sle-product-sles15-pool-x86_64",
+        "channel_label": "suse-enterprise-storage-6-debuginfo-updates-x86_64-sp1",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
         "product_id": 1644,
         "repository_id": 2875,
-        "parent_product_id": 1580,
-        "root_product_id": 1575,
-        "update_tag": "Storage-6",
+        "parent_product_id": 1780,
+        "root_product_id": 1763,
+        "update_tag": null,
         "url": "https://updates.suse.com/SUSE/Updates/Storage/6/x86_64/update_debug/",
         "release_stage": "beta",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-6-Debuginfo-Updates for x86_64"
+        "channel_name": "SUSE-Enterprise-Storage-6-Debuginfo-Updates for x86_64 SP1"
     },
     {
-        "channel_label": "suse-enterprise-storage-6-pool-x86_64",
-        "parent_channel_label": "sle-product-sles15-pool-x86_64",
+        "channel_label": "suse-enterprise-storage-6-pool-x86_64-sp1",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
         "product_id": 1644,
         "repository_id": 2876,
-        "parent_product_id": 1580,
-        "root_product_id": 1575,
-        "update_tag": "Storage-6",
+        "parent_product_id": 1780,
+        "root_product_id": 1763,
+        "update_tag": null,
         "url": "https://updates.suse.com/SUSE/Products/Storage/6/x86_64/product/",
         "release_stage": "beta",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-6-Pool for x86_64"
+        "channel_name": "SUSE-Enterprise-Storage-6-Pool for x86_64 SP1"
     },
     {
-        "channel_label": "suse-enterprise-storage-6-debuginfo-pool-x86_64",
-        "parent_channel_label": "sle-product-sles15-pool-x86_64",
+        "channel_label": "suse-enterprise-storage-6-debuginfo-pool-x86_64-sp1",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
         "product_id": 1644,
         "repository_id": 2877,
-        "parent_product_id": 1580,
-        "root_product_id": 1575,
-        "update_tag": "Storage-6",
+        "parent_product_id": 1780,
+        "root_product_id": 1763,
+        "update_tag": null,
         "url": "https://updates.suse.com/SUSE/Products/Storage/6/x86_64/product_debug/",
         "release_stage": "beta",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Enterprise-Storage-6-Debuginfo-Pool for x86_64"
+        "channel_name": "SUSE-Enterprise-Storage-6-Debuginfo-Pool for x86_64 SP1"
     },
     {
         "channel_label": "sle-module-public-cloud15-updates-aarch64",
@@ -48057,7 +48237,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-CAP-Tools-12-Updates for x86_64 SLED-SP1"
+        "channel_name": "SLE-Module-CAP-Tools-12-Updates for x86_64 SLED SP1"
     },
     {
         "channel_label": "sle-module-cap-tools-12-debuginfo-updates-x86_64-sled-sp1",
@@ -48072,7 +48252,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-CAP-Tools-12-Debuginfo-Updates for x86_64 SLED-SP1"
+        "channel_name": "SLE-Module-CAP-Tools-12-Debuginfo-Updates for x86_64 SLED SP1"
     },
     {
         "channel_label": "sle-module-cap-tools-12-pool-x86_64-sled-sp1",
@@ -48087,7 +48267,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-CAP-Tools-12-Pool for x86_64 SLED-SP1"
+        "channel_name": "SLE-Module-CAP-Tools-12-Pool for x86_64 SLED SP1"
     },
     {
         "channel_label": "sle-module-cap-tools-12-debuginfo-pool-x86_64-sled-sp1",
@@ -48102,7 +48282,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-CAP-Tools-12-Debuginfo-Pool for x86_64 SLED-SP1"
+        "channel_name": "SLE-Module-CAP-Tools-12-Debuginfo-Pool for x86_64 SLED SP1"
     },
     {
         "channel_label": "sle-module-cap-tools-12-updates-x86_64-sp2",
@@ -48177,7 +48357,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-CAP-Tools-12-Updates for x86_64 SLED-SP2"
+        "channel_name": "SLE-Module-CAP-Tools-12-Updates for x86_64 SLED SP2"
     },
     {
         "channel_label": "sle-module-cap-tools-12-debuginfo-updates-x86_64-sled-sp2",
@@ -48192,7 +48372,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-CAP-Tools-12-Debuginfo-Updates for x86_64 SLED-SP2"
+        "channel_name": "SLE-Module-CAP-Tools-12-Debuginfo-Updates for x86_64 SLED SP2"
     },
     {
         "channel_label": "sle-module-cap-tools-12-pool-x86_64-sled-sp2",
@@ -48207,7 +48387,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-CAP-Tools-12-Pool for x86_64 SLED-SP2"
+        "channel_name": "SLE-Module-CAP-Tools-12-Pool for x86_64 SLED SP2"
     },
     {
         "channel_label": "sle-module-cap-tools-12-debuginfo-pool-x86_64-sled-sp2",
@@ -48222,7 +48402,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-CAP-Tools-12-Debuginfo-Pool for x86_64 SLED-SP2"
+        "channel_name": "SLE-Module-CAP-Tools-12-Debuginfo-Pool for x86_64 SLED SP2"
     },
     {
         "channel_label": "sle-module-cap-tools-12-updates-x86_64-sp3",
@@ -48297,7 +48477,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-CAP-Tools-12-Updates for x86_64 SLED-SP3"
+        "channel_name": "SLE-Module-CAP-Tools-12-Updates for x86_64 SLED SP3"
     },
     {
         "channel_label": "sle-module-cap-tools-12-debuginfo-updates-x86_64-sled-sp3",
@@ -48312,7 +48492,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-CAP-Tools-12-Debuginfo-Updates for x86_64 SLED-SP3"
+        "channel_name": "SLE-Module-CAP-Tools-12-Debuginfo-Updates for x86_64 SLED SP3"
     },
     {
         "channel_label": "sle-module-cap-tools-12-pool-x86_64-sled-sp3",
@@ -48327,7 +48507,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-CAP-Tools-12-Pool for x86_64 SLED-SP3"
+        "channel_name": "SLE-Module-CAP-Tools-12-Pool for x86_64 SLED SP3"
     },
     {
         "channel_label": "sle-module-cap-tools-12-debuginfo-pool-x86_64-sled-sp3",
@@ -48342,7 +48522,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-CAP-Tools-12-Debuginfo-Pool for x86_64 SLED-SP3"
+        "channel_name": "SLE-Module-CAP-Tools-12-Debuginfo-Pool for x86_64 SLED SP3"
     },
     {
         "channel_label": "sle-module-cap-tools-12-updates-x86_64-sp4",
@@ -48353,7 +48533,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Module-CAP-Tools",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-CAP-Tools/12/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -48368,7 +48548,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Module-CAP-Tools",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-CAP-Tools/12/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -48383,7 +48563,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Module-CAP-Tools",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-CAP-Tools/12/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -48398,7 +48578,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Module-CAP-Tools",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-CAP-Tools/12/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -48413,11 +48593,11 @@
         "root_product_id": 1629,
         "update_tag": "SLE-Module-CAP-Tools",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-CAP-Tools/12/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-CAP-Tools-12-Updates for x86_64 SLED-SP4"
+        "channel_name": "SLE-Module-CAP-Tools-12-Updates for x86_64 SLED SP4"
     },
     {
         "channel_label": "sle-module-cap-tools-12-debuginfo-updates-x86_64-sled-sp4",
@@ -48428,11 +48608,11 @@
         "root_product_id": 1629,
         "update_tag": "SLE-Module-CAP-Tools",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-CAP-Tools/12/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-CAP-Tools-12-Debuginfo-Updates for x86_64 SLED-SP4"
+        "channel_name": "SLE-Module-CAP-Tools-12-Debuginfo-Updates for x86_64 SLED SP4"
     },
     {
         "channel_label": "sle-module-cap-tools-12-pool-x86_64-sled-sp4",
@@ -48443,11 +48623,11 @@
         "root_product_id": 1629,
         "update_tag": "SLE-Module-CAP-Tools",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-CAP-Tools/12/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-CAP-Tools-12-Pool for x86_64 SLED-SP4"
+        "channel_name": "SLE-Module-CAP-Tools-12-Pool for x86_64 SLED SP4"
     },
     {
         "channel_label": "sle-module-cap-tools-12-debuginfo-pool-x86_64-sled-sp4",
@@ -48458,11 +48638,11 @@
         "root_product_id": 1629,
         "update_tag": "SLE-Module-CAP-Tools",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-CAP-Tools/12/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-CAP-Tools-12-Debuginfo-Pool for x86_64 SLED-SP4"
+        "channel_name": "SLE-Module-CAP-Tools-12-Debuginfo-Pool for x86_64 SLED SP4"
     },
     {
         "channel_label": "sle-module-cap-tools-12-updates-x86_64-hpc-sp2",
@@ -48477,7 +48657,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-CAP-Tools-12-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLE-Module-CAP-Tools-12-Updates for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-module-cap-tools-12-debuginfo-updates-x86_64-hpc-sp2",
@@ -48492,7 +48672,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-CAP-Tools-12-Debuginfo-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLE-Module-CAP-Tools-12-Debuginfo-Updates for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-module-cap-tools-12-pool-x86_64-hpc-sp2",
@@ -48507,7 +48687,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-CAP-Tools-12-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLE-Module-CAP-Tools-12-Pool for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-module-cap-tools-12-debuginfo-pool-x86_64-hpc-sp2",
@@ -48522,7 +48702,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-CAP-Tools-12-Debuginfo-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLE-Module-CAP-Tools-12-Debuginfo-Pool for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-module-cap-tools-12-updates-x86_64-hpc-sp3",
@@ -48537,7 +48717,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-CAP-Tools-12-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLE-Module-CAP-Tools-12-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-module-cap-tools-12-debuginfo-updates-x86_64-hpc-sp3",
@@ -48552,7 +48732,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-CAP-Tools-12-Debuginfo-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLE-Module-CAP-Tools-12-Debuginfo-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-module-cap-tools-12-pool-x86_64-hpc-sp3",
@@ -48567,7 +48747,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-CAP-Tools-12-Pool for x86_64 HPC-SP3"
+        "channel_name": "SLE-Module-CAP-Tools-12-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-module-cap-tools-12-debuginfo-pool-x86_64-hpc-sp3",
@@ -48582,7 +48762,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-CAP-Tools-12-Debuginfo-Pool for x86_64 HPC-SP3"
+        "channel_name": "SLE-Module-CAP-Tools-12-Debuginfo-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-module-cap-tools-12-updates-x86_64-hpc-sp4",
@@ -48593,11 +48773,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Module-CAP-Tools",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-CAP-Tools/12/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-CAP-Tools-12-Updates for x86_64 HPC-SP4"
+        "channel_name": "SLE-Module-CAP-Tools-12-Updates for x86_64 HPC SP4"
     },
     {
         "channel_label": "sle-module-cap-tools-12-debuginfo-updates-x86_64-hpc-sp4",
@@ -48608,11 +48788,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Module-CAP-Tools",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-CAP-Tools/12/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-CAP-Tools-12-Debuginfo-Updates for x86_64 HPC-SP4"
+        "channel_name": "SLE-Module-CAP-Tools-12-Debuginfo-Updates for x86_64 HPC SP4"
     },
     {
         "channel_label": "sle-module-cap-tools-12-pool-x86_64-hpc-sp4",
@@ -48623,11 +48803,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Module-CAP-Tools",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-CAP-Tools/12/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-CAP-Tools-12-Pool for x86_64 HPC-SP4"
+        "channel_name": "SLE-Module-CAP-Tools-12-Pool for x86_64 HPC SP4"
     },
     {
         "channel_label": "sle-module-cap-tools-12-debuginfo-pool-x86_64-hpc-sp4",
@@ -48638,11 +48818,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Module-CAP-Tools",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Module-CAP-Tools/12/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Module-CAP-Tools-12-Debuginfo-Pool for x86_64 HPC-SP4"
+        "channel_name": "SLE-Module-CAP-Tools-12-Debuginfo-Pool for x86_64 HPC SP4"
     },
     {
         "channel_label": "sle-manager-tools15-updates-aarch64",
@@ -48765,6 +48945,126 @@
         "channel_name": "SLE-Manager-Tools15-Debuginfo-Pool for aarch64 HPC"
     },
     {
+        "channel_label": "sle-manager-tools15-updates-aarch64-sp1",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1709,
+        "repository_id": 2917,
+        "parent_product_id": 1769,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/15/aarch64/update/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Updates for aarch64 SP1"
+    },
+    {
+        "channel_label": "sle-manager-tools15-debuginfo-updates-aarch64-sp1",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1709,
+        "repository_id": 2918,
+        "parent_product_id": 1769,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/15/aarch64/update_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Debuginfo-Updates for aarch64 SP1"
+    },
+    {
+        "channel_label": "sle-manager-tools15-pool-aarch64-sp1",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1709,
+        "repository_id": 2919,
+        "parent_product_id": 1769,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/aarch64/product/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Pool for aarch64 SP1"
+    },
+    {
+        "channel_label": "sle-manager-tools15-debuginfo-pool-aarch64-sp1",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1709,
+        "repository_id": 2920,
+        "parent_product_id": 1769,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/aarch64/product_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Debuginfo-Pool for aarch64 SP1"
+    },
+    {
+        "channel_label": "sle-manager-tools15-updates-aarch64-hpc-sp1",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1709,
+        "repository_id": 2917,
+        "parent_product_id": 1769,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/15/aarch64/update/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Updates for aarch64 HPC SP1"
+    },
+    {
+        "channel_label": "sle-manager-tools15-debuginfo-updates-aarch64-hpc-sp1",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1709,
+        "repository_id": 2918,
+        "parent_product_id": 1769,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/15/aarch64/update_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Debuginfo-Updates for aarch64 HPC SP1"
+    },
+    {
+        "channel_label": "sle-manager-tools15-pool-aarch64-hpc-sp1",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1709,
+        "repository_id": 2919,
+        "parent_product_id": 1769,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/aarch64/product/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Pool for aarch64 HPC SP1"
+    },
+    {
+        "channel_label": "sle-manager-tools15-debuginfo-pool-aarch64-hpc-sp1",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1709,
+        "repository_id": 2920,
+        "parent_product_id": 1769,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/aarch64/product_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Debuginfo-Pool for aarch64 HPC SP1"
+    },
+    {
         "channel_label": "sle-manager-tools15-updates-ppc64le",
         "parent_channel_label": "sle-product-sles15-pool-ppc64le",
         "product_id": 1710,
@@ -48885,6 +49185,126 @@
         "channel_name": "SLE-Manager-Tools15-Debuginfo-Pool for ppc64le SAP"
     },
     {
+        "channel_label": "sle-manager-tools15-updates-ppc64le-sp1",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1710,
+        "repository_id": 2922,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/15/ppc64le/update/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Updates for ppc64le SP1"
+    },
+    {
+        "channel_label": "sle-manager-tools15-debuginfo-updates-ppc64le-sp1",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1710,
+        "repository_id": 2923,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/15/ppc64le/update_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Debuginfo-Updates for ppc64le SP1"
+    },
+    {
+        "channel_label": "sle-manager-tools15-pool-ppc64le-sp1",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1710,
+        "repository_id": 2924,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/ppc64le/product/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Pool for ppc64le SP1"
+    },
+    {
+        "channel_label": "sle-manager-tools15-debuginfo-pool-ppc64le-sp1",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1710,
+        "repository_id": 2925,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/ppc64le/product_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Debuginfo-Pool for ppc64le SP1"
+    },
+    {
+        "channel_label": "sle-manager-tools15-updates-ppc64le-sap-sp1",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1710,
+        "repository_id": 2922,
+        "parent_product_id": 1770,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/15/ppc64le/update/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Updates for ppc64le SAP SP1"
+    },
+    {
+        "channel_label": "sle-manager-tools15-debuginfo-updates-ppc64le-sap-sp1",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1710,
+        "repository_id": 2923,
+        "parent_product_id": 1770,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/15/ppc64le/update_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Debuginfo-Updates for ppc64le SAP SP1"
+    },
+    {
+        "channel_label": "sle-manager-tools15-pool-ppc64le-sap-sp1",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1710,
+        "repository_id": 2924,
+        "parent_product_id": 1770,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/ppc64le/product/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Pool for ppc64le SAP SP1"
+    },
+    {
+        "channel_label": "sle-manager-tools15-debuginfo-pool-ppc64le-sap-sp1",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1710,
+        "repository_id": 2925,
+        "parent_product_id": 1770,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/ppc64le/product_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Debuginfo-Pool for ppc64le SAP SP1"
+    },
+    {
         "channel_label": "sle-manager-tools15-updates-s390x",
         "parent_channel_label": "sle-product-sles15-pool-s390x",
         "product_id": 1711,
@@ -48943,6 +49363,66 @@
         "signed": true,
         "recommended": true,
         "channel_name": "SLE-Manager-Tools15-Debuginfo-Pool for s390x"
+    },
+    {
+        "channel_label": "sle-manager-tools15-updates-s390x-sp1",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1711,
+        "repository_id": 2927,
+        "parent_product_id": 1771,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/15/s390x/update/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Updates for s390x SP1"
+    },
+    {
+        "channel_label": "sle-manager-tools15-debuginfo-updates-s390x-sp1",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1711,
+        "repository_id": 2928,
+        "parent_product_id": 1771,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/15/s390x/update_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Debuginfo-Updates for s390x SP1"
+    },
+    {
+        "channel_label": "sle-manager-tools15-pool-s390x-sp1",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1711,
+        "repository_id": 2929,
+        "parent_product_id": 1771,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/s390x/product/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Pool for s390x SP1"
+    },
+    {
+        "channel_label": "sle-manager-tools15-debuginfo-pool-s390x-sp1",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1711,
+        "repository_id": 2930,
+        "parent_product_id": 1771,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/s390x/product_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Debuginfo-Pool for s390x SP1"
     },
     {
         "channel_label": "sle-manager-tools15-updates-x86_64",
@@ -49183,6 +49663,306 @@
         "signed": true,
         "recommended": true,
         "channel_name": "SLE-Manager-Tools15-Debuginfo-Pool for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-manager-tools15-updates-x86_64-sp1",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1712,
+        "repository_id": 2932,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Updates for x86_64 SP1"
+    },
+    {
+        "channel_label": "sle-manager-tools15-debuginfo-updates-x86_64-sp1",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1712,
+        "repository_id": 2933,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Debuginfo-Updates for x86_64 SP1"
+    },
+    {
+        "channel_label": "sle-manager-tools15-pool-x86_64-sp1",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1712,
+        "repository_id": 2934,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/x86_64/product/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Pool for x86_64 SP1"
+    },
+    {
+        "channel_label": "sle-manager-tools15-debuginfo-pool-x86_64-sp1",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1712,
+        "repository_id": 2935,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/x86_64/product_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Debuginfo-Pool for x86_64 SP1"
+    },
+    {
+        "channel_label": "sle-manager-tools15-updates-x86_64-sled-sp1",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1712,
+        "repository_id": 2932,
+        "parent_product_id": 1772,
+        "root_product_id": 1764,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Updates for x86_64 SLED SP1"
+    },
+    {
+        "channel_label": "sle-manager-tools15-debuginfo-updates-x86_64-sled-sp1",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1712,
+        "repository_id": 2933,
+        "parent_product_id": 1772,
+        "root_product_id": 1764,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Debuginfo-Updates for x86_64 SLED SP1"
+    },
+    {
+        "channel_label": "sle-manager-tools15-pool-x86_64-sled-sp1",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1712,
+        "repository_id": 2934,
+        "parent_product_id": 1772,
+        "root_product_id": 1764,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/x86_64/product/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Pool for x86_64 SLED SP1"
+    },
+    {
+        "channel_label": "sle-manager-tools15-debuginfo-pool-x86_64-sled-sp1",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1712,
+        "repository_id": 2935,
+        "parent_product_id": 1772,
+        "root_product_id": 1764,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/x86_64/product_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Debuginfo-Pool for x86_64 SLED SP1"
+    },
+    {
+        "channel_label": "sle-manager-tools15-updates-x86_64-sap-sp1",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1712,
+        "repository_id": 2932,
+        "parent_product_id": 1772,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Updates for x86_64 SAP SP1"
+    },
+    {
+        "channel_label": "sle-manager-tools15-debuginfo-updates-x86_64-sap-sp1",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1712,
+        "repository_id": 2933,
+        "parent_product_id": 1772,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Debuginfo-Updates for x86_64 SAP SP1"
+    },
+    {
+        "channel_label": "sle-manager-tools15-pool-x86_64-sap-sp1",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1712,
+        "repository_id": 2934,
+        "parent_product_id": 1772,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/x86_64/product/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Pool for x86_64 SAP SP1"
+    },
+    {
+        "channel_label": "sle-manager-tools15-debuginfo-pool-x86_64-sap-sp1",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1712,
+        "repository_id": 2935,
+        "parent_product_id": 1772,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/x86_64/product_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Debuginfo-Pool for x86_64 SAP SP1"
+    },
+    {
+        "channel_label": "sle-manager-tools15-updates-x86_64-hpc-sp1",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1712,
+        "repository_id": 2932,
+        "parent_product_id": 1772,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Updates for x86_64 HPC SP1"
+    },
+    {
+        "channel_label": "sle-manager-tools15-debuginfo-updates-x86_64-hpc-sp1",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1712,
+        "repository_id": 2933,
+        "parent_product_id": 1772,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Debuginfo-Updates for x86_64 HPC SP1"
+    },
+    {
+        "channel_label": "sle-manager-tools15-pool-x86_64-hpc-sp1",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1712,
+        "repository_id": 2934,
+        "parent_product_id": 1772,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/x86_64/product/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Pool for x86_64 HPC SP1"
+    },
+    {
+        "channel_label": "sle-manager-tools15-debuginfo-pool-x86_64-hpc-sp1",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1712,
+        "repository_id": 2935,
+        "parent_product_id": 1772,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/x86_64/product_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Debuginfo-Pool for x86_64 HPC SP1"
+    },
+    {
+        "channel_label": "sle-manager-tools15-updates-x86_64-rt-sp1",
+        "parent_channel_label": "sle-product-rt-15-sp1-pool-x86_64",
+        "product_id": 1712,
+        "repository_id": 2932,
+        "parent_product_id": 1772,
+        "root_product_id": 1861,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Updates for x86_64 RT SP1"
+    },
+    {
+        "channel_label": "sle-manager-tools15-debuginfo-updates-x86_64-rt-sp1",
+        "parent_channel_label": "sle-product-rt-15-sp1-pool-x86_64",
+        "product_id": 1712,
+        "repository_id": 2933,
+        "parent_product_id": 1772,
+        "root_product_id": 1861,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Debuginfo-Updates for x86_64 RT SP1"
+    },
+    {
+        "channel_label": "sle-manager-tools15-pool-x86_64-rt-sp1",
+        "parent_channel_label": "sle-product-rt-15-sp1-pool-x86_64",
+        "product_id": 1712,
+        "repository_id": 2934,
+        "parent_product_id": 1772,
+        "root_product_id": 1861,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/x86_64/product/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Pool for x86_64 RT SP1"
+    },
+    {
+        "channel_label": "sle-manager-tools15-debuginfo-pool-x86_64-rt-sp1",
+        "parent_channel_label": "sle-product-rt-15-sp1-pool-x86_64",
+        "product_id": 1712,
+        "repository_id": 2935,
+        "parent_product_id": 1772,
+        "root_product_id": 1861,
+        "update_tag": "SLE-Manager-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/x86_64/product_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Manager-Tools15-Debuginfo-Pool for x86_64 RT SP1"
     },
     {
         "channel_label": "suse-caasp-3.0-updates-x86_64",
@@ -49737,7 +50517,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.2-Updates for ppc64le"
+        "channel_name": "SUSE-Manager-Server-3.2-Updates for ppc64le SP3"
     },
     {
         "channel_label": "suse-manager-server-3.2-debuginfo-updates-ppc64le",
@@ -49752,7 +50532,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.2-Debuginfo-Updates for ppc64le"
+        "channel_name": "SUSE-Manager-Server-3.2-Debuginfo-Updates for ppc64le SP3"
     },
     {
         "channel_label": "suse-manager-server-3.2-pool-ppc64le",
@@ -49767,7 +50547,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.2-Pool for ppc64le"
+        "channel_name": "SUSE-Manager-Server-3.2-Pool for ppc64le SP3"
     },
     {
         "channel_label": "suse-manager-server-3.2-debuginfo-pool-ppc64le",
@@ -49782,7 +50562,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.2-Debuginfo-Pool for ppc64le"
+        "channel_name": "SUSE-Manager-Server-3.2-Debuginfo-Pool for ppc64le SP3"
     },
     {
         "channel_label": "suse-manager-server-3.2-updates-ppc64le-sp4",
@@ -49857,7 +50637,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.2-Updates for s390x"
+        "channel_name": "SUSE-Manager-Server-3.2-Updates for s390x SP3"
     },
     {
         "channel_label": "suse-manager-server-3.2-debuginfo-updates-s390x",
@@ -49872,7 +50652,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.2-Debuginfo-Updates for s390x"
+        "channel_name": "SUSE-Manager-Server-3.2-Debuginfo-Updates for s390x SP3"
     },
     {
         "channel_label": "suse-manager-server-3.2-pool-s390x",
@@ -49887,7 +50667,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.2-Pool for s390x"
+        "channel_name": "SUSE-Manager-Server-3.2-Pool for s390x SP3"
     },
     {
         "channel_label": "suse-manager-server-3.2-debuginfo-pool-s390x",
@@ -49902,7 +50682,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.2-Debuginfo-Pool for s390x"
+        "channel_name": "SUSE-Manager-Server-3.2-Debuginfo-Pool for s390x SP3"
     },
     {
         "channel_label": "suse-manager-server-3.2-updates-s390x-sp4",
@@ -49977,7 +50757,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.2-Updates for x86_64"
+        "channel_name": "SUSE-Manager-Server-3.2-Updates for x86_64 SP3"
     },
     {
         "channel_label": "suse-manager-server-3.2-debuginfo-updates-x86_64",
@@ -49992,7 +50772,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.2-Debuginfo-Updates for x86_64"
+        "channel_name": "SUSE-Manager-Server-3.2-Debuginfo-Updates for x86_64 SP3"
     },
     {
         "channel_label": "suse-manager-server-3.2-pool-x86_64",
@@ -50007,7 +50787,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.2-Pool for x86_64"
+        "channel_name": "SUSE-Manager-Server-3.2-Pool for x86_64 SP3"
     },
     {
         "channel_label": "suse-manager-server-3.2-debuginfo-pool-x86_64",
@@ -50022,7 +50802,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.2-Debuginfo-Pool for x86_64"
+        "channel_name": "SUSE-Manager-Server-3.2-Debuginfo-Pool for x86_64 SP3"
     },
     {
         "channel_label": "suse-manager-server-3.2-updates-x86_64-sp4",
@@ -50097,7 +50877,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.2-Updates for x86_64 HPC-SP3"
+        "channel_name": "SUSE-Manager-Server-3.2-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-manager-server-3.2-debuginfo-updates-x86_64-hpc-sp3",
@@ -50112,7 +50892,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.2-Debuginfo-Updates for x86_64 HPC-SP3"
+        "channel_name": "SUSE-Manager-Server-3.2-Debuginfo-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-manager-server-3.2-pool-x86_64-hpc-sp3",
@@ -50127,7 +50907,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.2-Pool for x86_64 HPC-SP3"
+        "channel_name": "SUSE-Manager-Server-3.2-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-manager-server-3.2-debuginfo-pool-x86_64-hpc-sp3",
@@ -50142,7 +50922,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.2-Debuginfo-Pool for x86_64 HPC-SP3"
+        "channel_name": "SUSE-Manager-Server-3.2-Debuginfo-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-manager-server-3.2-updates-x86_64-hpc-sp4",
@@ -50157,7 +50937,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.2-Updates for x86_64 HPC-SP4"
+        "channel_name": "SUSE-Manager-Server-3.2-Updates for x86_64 HPC SP4"
     },
     {
         "channel_label": "suse-manager-server-3.2-debuginfo-updates-x86_64-hpc-sp4",
@@ -50172,7 +50952,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.2-Debuginfo-Updates for x86_64 HPC-SP4"
+        "channel_name": "SUSE-Manager-Server-3.2-Debuginfo-Updates for x86_64 HPC SP4"
     },
     {
         "channel_label": "suse-manager-server-3.2-pool-x86_64-hpc-sp4",
@@ -50187,7 +50967,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.2-Pool for x86_64 HPC-SP4"
+        "channel_name": "SUSE-Manager-Server-3.2-Pool for x86_64 HPC SP4"
     },
     {
         "channel_label": "suse-manager-server-3.2-debuginfo-pool-x86_64-hpc-sp4",
@@ -50202,7 +50982,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Server-3.2-Debuginfo-Pool for x86_64 HPC-SP4"
+        "channel_name": "SUSE-Manager-Server-3.2-Debuginfo-Pool for x86_64 HPC SP4"
     },
     {
         "channel_label": "suse-manager-proxy-3.2-updates-x86_64",
@@ -50217,7 +50997,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.2-Updates for x86_64"
+        "channel_name": "SUSE-Manager-Proxy-3.2-Updates for x86_64 SP3"
     },
     {
         "channel_label": "suse-manager-proxy-3.2-debuginfo-updates-x86_64",
@@ -50232,7 +51012,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.2-Debuginfo-Updates for x86_64"
+        "channel_name": "SUSE-Manager-Proxy-3.2-Debuginfo-Updates for x86_64 SP3"
     },
     {
         "channel_label": "suse-manager-proxy-3.2-pool-x86_64",
@@ -50247,7 +51027,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.2-Pool for x86_64"
+        "channel_name": "SUSE-Manager-Proxy-3.2-Pool for x86_64 SP3"
     },
     {
         "channel_label": "suse-manager-proxy-3.2-debuginfo-pool-x86_64",
@@ -50262,7 +51042,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.2-Debuginfo-Pool for x86_64"
+        "channel_name": "SUSE-Manager-Proxy-3.2-Debuginfo-Pool for x86_64 SP3"
     },
     {
         "channel_label": "suse-manager-proxy-3.2-updates-x86_64-sp4",
@@ -50337,7 +51117,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.2-Updates for x86_64 HPC-SP3"
+        "channel_name": "SUSE-Manager-Proxy-3.2-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-manager-proxy-3.2-debuginfo-updates-x86_64-hpc-sp3",
@@ -50352,7 +51132,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.2-Debuginfo-Updates for x86_64 HPC-SP3"
+        "channel_name": "SUSE-Manager-Proxy-3.2-Debuginfo-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-manager-proxy-3.2-pool-x86_64-hpc-sp3",
@@ -50367,7 +51147,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.2-Pool for x86_64 HPC-SP3"
+        "channel_name": "SUSE-Manager-Proxy-3.2-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-manager-proxy-3.2-debuginfo-pool-x86_64-hpc-sp3",
@@ -50382,7 +51162,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.2-Debuginfo-Pool for x86_64 HPC-SP3"
+        "channel_name": "SUSE-Manager-Proxy-3.2-Debuginfo-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-manager-proxy-3.2-updates-x86_64-hpc-sp4",
@@ -50397,7 +51177,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.2-Updates for x86_64 HPC-SP4"
+        "channel_name": "SUSE-Manager-Proxy-3.2-Updates for x86_64 HPC SP4"
     },
     {
         "channel_label": "suse-manager-proxy-3.2-debuginfo-updates-x86_64-hpc-sp4",
@@ -50412,7 +51192,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.2-Debuginfo-Updates for x86_64 HPC-SP4"
+        "channel_name": "SUSE-Manager-Proxy-3.2-Debuginfo-Updates for x86_64 HPC SP4"
     },
     {
         "channel_label": "suse-manager-proxy-3.2-pool-x86_64-hpc-sp4",
@@ -50427,7 +51207,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.2-Pool for x86_64 HPC-SP4"
+        "channel_name": "SUSE-Manager-Proxy-3.2-Pool for x86_64 HPC SP4"
     },
     {
         "channel_label": "suse-manager-proxy-3.2-debuginfo-pool-x86_64-hpc-sp4",
@@ -50442,7 +51222,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Proxy-3.2-Debuginfo-Pool for x86_64 HPC-SP4"
+        "channel_name": "SUSE-Manager-Proxy-3.2-Debuginfo-Pool for x86_64 HPC SP4"
     },
     {
         "channel_label": "sle-module-sap-applications15-updates-ppc64le",
@@ -50757,7 +51537,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-Crowbar-8-Updates for x86_64"
+        "channel_name": "SUSE-OpenStack-Cloud-Crowbar-8-Updates for x86_64 SP3"
     },
     {
         "channel_label": "suse-openstack-cloud-crowbar-8-debuginfo-updates-x86_64",
@@ -50772,7 +51552,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-Crowbar-8-Debuginfo-Updates for x86_64"
+        "channel_name": "SUSE-OpenStack-Cloud-Crowbar-8-Debuginfo-Updates for x86_64 SP3"
     },
     {
         "channel_label": "suse-openstack-cloud-crowbar-8-pool-x86_64",
@@ -50787,7 +51567,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-Crowbar-8-Pool for x86_64"
+        "channel_name": "SUSE-OpenStack-Cloud-Crowbar-8-Pool for x86_64 SP3"
     },
     {
         "channel_label": "suse-openstack-cloud-crowbar-8-debuginfo-pool-x86_64",
@@ -50802,7 +51582,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-Crowbar-8-Debuginfo-Pool for x86_64"
+        "channel_name": "SUSE-OpenStack-Cloud-Crowbar-8-Debuginfo-Pool for x86_64 SP3"
     },
     {
         "channel_label": "suse-openstack-cloud-crowbar-8-updates-x86_64-hpc-sp3",
@@ -50817,7 +51597,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-Crowbar-8-Updates for x86_64 HPC-SP3"
+        "channel_name": "SUSE-OpenStack-Cloud-Crowbar-8-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-openstack-cloud-crowbar-8-debuginfo-updates-x86_64-hpc-sp3",
@@ -50832,7 +51612,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-Crowbar-8-Debuginfo-Updates for x86_64 HPC-SP3"
+        "channel_name": "SUSE-OpenStack-Cloud-Crowbar-8-Debuginfo-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-openstack-cloud-crowbar-8-pool-x86_64-hpc-sp3",
@@ -50847,7 +51627,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-Crowbar-8-Pool for x86_64 HPC-SP3"
+        "channel_name": "SUSE-OpenStack-Cloud-Crowbar-8-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-openstack-cloud-crowbar-8-debuginfo-pool-x86_64-hpc-sp3",
@@ -50862,7 +51642,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-OpenStack-Cloud-Crowbar-8-Debuginfo-Pool for x86_64 HPC-SP3"
+        "channel_name": "SUSE-OpenStack-Cloud-Crowbar-8-Debuginfo-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "hpe-helion-openstack-8-updates-x86_64-sp3",
@@ -50937,7 +51717,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "HPE-Helion-OpenStack-8-Updates for x86_64 HPC-SP3"
+        "channel_name": "HPE-Helion-OpenStack-8-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "hpe-helion-openstack-8-debuginfo-updates-x86_64-hpc-sp3",
@@ -50952,7 +51732,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "HPE-Helion-OpenStack-8-Debuginfo-Updates for x86_64 HPC-SP3"
+        "channel_name": "HPE-Helion-OpenStack-8-Debuginfo-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "hpe-helion-openstack-8-pool-x86_64-hpc-sp3",
@@ -50967,7 +51747,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "HPE-Helion-OpenStack-8-Pool for x86_64 HPC-SP3"
+        "channel_name": "HPE-Helion-OpenStack-8-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "hpe-helion-openstack-8-debuginfo-pool-x86_64-hpc-sp3",
@@ -50982,7 +51762,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "HPE-Helion-OpenStack-8-Debuginfo-Pool for x86_64 HPC-SP3"
+        "channel_name": "HPE-Helion-OpenStack-8-Debuginfo-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-product-hpc-15-updates-aarch64",
@@ -51567,7 +52347,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP2-LTSS-Updates for ppc64le SAP-SP2"
+        "channel_name": "SLES12-SP2-LTSS-Updates for ppc64le SAP"
     },
     {
         "channel_label": "sles12-sp2-ltss-debuginfo-updates-ppc64le-sap-sp2",
@@ -51582,7 +52362,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP2-LTSS-Debuginfo-Updates for ppc64le SAP-SP2"
+        "channel_name": "SLES12-SP2-LTSS-Debuginfo-Updates for ppc64le SAP"
     },
     {
         "channel_label": "sles12-sp2-ltss-updates-s390x",
@@ -51657,7 +52437,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP2-LTSS-Updates for x86_64 SAP-SP2"
+        "channel_name": "SLES12-SP2-LTSS-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sles12-sp2-ltss-debuginfo-updates-x86_64-sap-sp2",
@@ -51672,7 +52452,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP2-LTSS-Debuginfo-Updates for x86_64 SAP-SP2"
+        "channel_name": "SLES12-SP2-LTSS-Debuginfo-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sles12-sp2-ltss-updates-x86_64-hpc-sp2",
@@ -51687,7 +52467,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP2-LTSS-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLES12-SP2-LTSS-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sles12-sp2-ltss-debuginfo-updates-x86_64-hpc-sp2",
@@ -51702,7 +52482,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP2-LTSS-Debuginfo-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLES12-SP2-LTSS-Debuginfo-Updates for x86_64 HPC"
     },
     {
         "channel_label": "suse-packagehub-15-aarch64",
@@ -51717,7 +52497,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-15 for aarch64"
+        "channel_name": "SUSE-PackageHub-15-Standard-Pool for aarch64"
     },
     {
         "channel_label": "suse-packagehub-15-debuginfo-aarch64",
@@ -51822,7 +52602,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-15 for aarch64 HPC"
+        "channel_name": "SUSE-PackageHub-15-Standard-Pool for aarch64 HPC"
     },
     {
         "channel_label": "suse-packagehub-15-debuginfo-aarch64-hpc",
@@ -51927,7 +52707,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-15 for ppc64le"
+        "channel_name": "SUSE-PackageHub-15-Standard-Pool for ppc64le"
     },
     {
         "channel_label": "suse-packagehub-15-debuginfo-ppc64le",
@@ -52032,7 +52812,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-15 for ppc64le SAP"
+        "channel_name": "SUSE-PackageHub-15-Standard-Pool for ppc64le SAP"
     },
     {
         "channel_label": "suse-packagehub-15-debuginfo-ppc64le-sap",
@@ -52137,7 +52917,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-15 for s390x"
+        "channel_name": "SUSE-PackageHub-15-Standard-Pool for s390x"
     },
     {
         "channel_label": "suse-packagehub-15-debuginfo-s390x",
@@ -52242,7 +53022,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-15 for x86_64"
+        "channel_name": "SUSE-PackageHub-15-Standard-Pool for x86_64"
     },
     {
         "channel_label": "suse-packagehub-15-debuginfo-x86_64",
@@ -52347,7 +53127,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-15 for x86_64 SLED"
+        "channel_name": "SUSE-PackageHub-15-Standard-Pool for x86_64 SLED"
     },
     {
         "channel_label": "suse-packagehub-15-debuginfo-x86_64-sled",
@@ -52452,7 +53232,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-15 for x86_64 SAP"
+        "channel_name": "SUSE-PackageHub-15-Standard-Pool for x86_64 SAP"
     },
     {
         "channel_label": "suse-packagehub-15-debuginfo-x86_64-sap",
@@ -52557,7 +53337,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-15 for x86_64 HPC"
+        "channel_name": "SUSE-PackageHub-15-Standard-Pool for x86_64 HPC"
     },
     {
         "channel_label": "suse-packagehub-15-debuginfo-x86_64-hpc",
@@ -52662,7 +53442,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLE-Manager-Tools12-Updates for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-x86_64-hpc-sp2",
@@ -52677,7 +53457,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-manager-tools12-pool-x86_64-hpc-sp2",
@@ -52692,7 +53472,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLE-Manager-Tools12-Pool for x86_64 HPC SP2"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-x86_64-hpc-sp2",
@@ -52707,7 +53487,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for x86_64 HPC SP2"
     },
     {
         "channel_label": "sles12-sp2-updates-x86_64-hpc-sp2",
@@ -52722,7 +53502,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP2-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLES12-SP2-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sles12-sp2-debuginfo-updates-x86_64-hpc-sp2",
@@ -52737,7 +53517,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP2-Debuginfo-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLES12-SP2-Debuginfo-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sles12-sp2-pool-x86_64-hpc-sp2",
@@ -52752,7 +53532,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP2-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLES12-SP2-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sles12-sp2-debuginfo-pool-x86_64-hpc-sp2",
@@ -52767,7 +53547,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP2-Debuginfo-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLES12-SP2-Debuginfo-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sle-12-sp2-hpc-updates-x86_64",
@@ -52782,7 +53562,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-12-SP2-HPC-Updates for x86_64 HPC"
+        "channel_name": "SLE-12-SP2-HPC-Updates for x86_64"
     },
     {
         "channel_label": "sle-12-sp2-hpc-debuginfo-updates-x86_64",
@@ -52797,7 +53577,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-12-SP2-HPC-Debuginfo-Updates for x86_64 HPC"
+        "channel_name": "SLE-12-SP2-HPC-Debuginfo-Updates for x86_64"
     },
     {
         "channel_label": "sle12-sp2-hpc-pool-x86_64",
@@ -52827,7 +53607,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE12-SP2-HPC-Debuginfo-Pool for x86_64 HPC"
+        "channel_name": "SLE12-SP2-HPC-Debuginfo-Pool for x86_64"
     },
     {
         "channel_label": "sle-manager-tools12-updates-aarch64-hpc-sp3",
@@ -52842,7 +53622,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates for aarch64 HPC-SP3"
+        "channel_name": "SLE-Manager-Tools12-Updates for aarch64 HPC SP3"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-aarch64-hpc-sp3",
@@ -52857,7 +53637,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for aarch64 HPC-SP3"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for aarch64 HPC SP3"
     },
     {
         "channel_label": "sle-manager-tools12-pool-aarch64-hpc-sp3",
@@ -52872,7 +53652,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool for aarch64 HPC-SP3"
+        "channel_name": "SLE-Manager-Tools12-Pool for aarch64 HPC SP3"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-aarch64-hpc-sp3",
@@ -52887,7 +53667,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for aarch64 HPC-SP3"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for aarch64 HPC SP3"
     },
     {
         "channel_label": "sles12-sp3-updates-aarch64-hpc-sp3",
@@ -52902,7 +53682,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP3-Updates for aarch64 HPC-SP3"
+        "channel_name": "SLES12-SP3-Updates for aarch64 HPC"
     },
     {
         "channel_label": "sles12-sp3-debuginfo-updates-aarch64-hpc-sp3",
@@ -52917,7 +53697,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP3-Debuginfo-Updates for aarch64 HPC-SP3"
+        "channel_name": "SLES12-SP3-Debuginfo-Updates for aarch64 HPC"
     },
     {
         "channel_label": "sles12-sp3-pool-aarch64-hpc-sp3",
@@ -52932,7 +53712,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP3-Pool for aarch64 HPC-SP3"
+        "channel_name": "SLES12-SP3-Pool for aarch64 HPC"
     },
     {
         "channel_label": "sles12-sp3-debuginfo-pool-aarch64-hpc-sp3",
@@ -52947,7 +53727,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP3-Debuginfo-Pool for aarch64 HPC-SP3"
+        "channel_name": "SLES12-SP3-Debuginfo-Pool for aarch64 HPC"
     },
     {
         "channel_label": "sles12-sp3-hpc-updates-aarch64",
@@ -52962,7 +53742,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP3-HPC-Updates for aarch64 HPC"
+        "channel_name": "SLES12-SP3-HPC-Updates for aarch64"
     },
     {
         "channel_label": "sle12-sp3-hpc-debuginfo-updates-aarch64",
@@ -52977,7 +53757,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE12-SP3-HPC-Debuginfo-Updates for aarch64 HPC"
+        "channel_name": "SLE12-SP3-HPC-Debuginfo-Updates for aarch64"
     },
     {
         "channel_label": "sle12-sp3-hpc-pool-aarch64",
@@ -53007,7 +53787,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE12-SP3-HPC-Debuginfo-Pool for aarch64 HPC"
+        "channel_name": "SLE12-SP3-HPC-Debuginfo-Pool for aarch64"
     },
     {
         "channel_label": "sle-manager-tools12-updates-x86_64-hpc-sp3",
@@ -53022,7 +53802,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLE-Manager-Tools12-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-x86_64-hpc-sp3",
@@ -53037,7 +53817,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-manager-tools12-pool-x86_64-hpc-sp3",
@@ -53052,7 +53832,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool for x86_64 HPC-SP3"
+        "channel_name": "SLE-Manager-Tools12-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-x86_64-hpc-sp3",
@@ -53067,7 +53847,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for x86_64 HPC-SP3"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "sles12-sp3-updates-x86_64-hpc-sp3",
@@ -53082,7 +53862,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP3-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLES12-SP3-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sles12-sp3-debuginfo-updates-x86_64-hpc-sp3",
@@ -53097,7 +53877,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP3-Debuginfo-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLES12-SP3-Debuginfo-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sles12-sp3-pool-x86_64-hpc-sp3",
@@ -53112,7 +53892,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP3-Pool for x86_64 HPC-SP3"
+        "channel_name": "SLES12-SP3-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sles12-sp3-debuginfo-pool-x86_64-hpc-sp3",
@@ -53127,7 +53907,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP3-Debuginfo-Pool for x86_64 HPC-SP3"
+        "channel_name": "SLES12-SP3-Debuginfo-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sle12-sp3-hpc-updates-x86_64",
@@ -53142,7 +53922,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE12-SP3-HPC-Updates for x86_64 HPC"
+        "channel_name": "SLE12-SP3-HPC-Updates for x86_64"
     },
     {
         "channel_label": "sle12-sp3-hpc-debuginfo-updates-x86_64",
@@ -53157,7 +53937,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE12-SP3-HPC-Debuginfo-Updates for x86_64 HPC"
+        "channel_name": "SLE12-SP3-HPC-Debuginfo-Updates for x86_64"
     },
     {
         "channel_label": "sle12-sp3-hpc-pool-x86_64",
@@ -53187,10 +53967,10 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE12-SP3-HPC-Debuginfo-Pool for x86_64 HPC"
+        "channel_name": "SLE12-SP3-HPC-Debuginfo-Pool for x86_64"
     },
     {
-        "channel_label": "suse-caasp-toolchain-3-updates-x86_64-caasp-3.0",
+        "channel_label": "suse-caasp-toolchain-3-updates-x86_64-3.0",
         "parent_channel_label": "suse-caasp-3.0-pool-x86_64",
         "product_id": 1752,
         "repository_id": 3132,
@@ -53202,10 +53982,10 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-CAASP-Toolchain-3-Updates for x86_64 CAASP-3.0"
+        "channel_name": "SUSE-CAASP-Toolchain-3-Updates for x86_64 3.0"
     },
     {
-        "channel_label": "suse-caasp-toolchain-3-debuginfo-updates-x86_64-caasp-3.0",
+        "channel_label": "suse-caasp-toolchain-3-debuginfo-updates-x86_64-3.0",
         "parent_channel_label": "suse-caasp-3.0-pool-x86_64",
         "product_id": 1752,
         "repository_id": 3133,
@@ -53217,10 +53997,10 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-CAASP-Toolchain-3-Debuginfo-Updates for x86_64 CAASP-3.0"
+        "channel_name": "SUSE-CAASP-Toolchain-3-Debuginfo-Updates for x86_64 3.0"
     },
     {
-        "channel_label": "suse-caasp-toolchain-3-pool-x86_64-caasp-3.0",
+        "channel_label": "suse-caasp-toolchain-3-pool-x86_64-3.0",
         "parent_channel_label": "suse-caasp-3.0-pool-x86_64",
         "product_id": 1752,
         "repository_id": 3134,
@@ -53232,10 +54012,10 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-CAASP-Toolchain-3-Pool for x86_64 CAASP-3.0"
+        "channel_name": "SUSE-CAASP-Toolchain-3-Pool for x86_64 3.0"
     },
     {
-        "channel_label": "suse-caasp-toolchain-3-debuginfo-pool-x86_64-caasp-3.0",
+        "channel_label": "suse-caasp-toolchain-3-debuginfo-pool-x86_64-3.0",
         "parent_channel_label": "suse-caasp-3.0-pool-x86_64",
         "product_id": 1752,
         "repository_id": 3135,
@@ -53247,7 +54027,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-CAASP-Toolchain-3-Debuginfo-Pool for x86_64 CAASP-3.0"
+        "channel_name": "SUSE-CAASP-Toolchain-3-Debuginfo-Pool for x86_64 3.0"
     },
     {
         "channel_label": "sle-manager-tools12-updates-ppc64le-sap-sp4",
@@ -53258,11 +54038,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-Manager-Tools",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/12/ppc64le/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates ppc64le SAP-SP4"
+        "channel_name": "SLE-Manager-Tools12-Updates for ppc64le SAP SP4"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-ppc64le-sap-sp4",
@@ -53273,11 +54053,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-Manager-Tools",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/12/ppc64le/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates ppc64le SAP-SP4"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for ppc64le SAP SP4"
     },
     {
         "channel_label": "sle-manager-tools12-pool-ppc64le-sap-sp4",
@@ -53288,11 +54068,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-Manager-Tools",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/12/ppc64le/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool ppc64le SAP-SP4"
+        "channel_name": "SLE-Manager-Tools12-Pool for ppc64le SAP SP4"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-ppc64le-sap-sp4",
@@ -53303,11 +54083,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-Manager-Tools",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/12/ppc64le/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool ppc64le SAP-SP4"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for ppc64le SAP SP4"
     },
     {
         "channel_label": "sles12-sp4-updates-ppc64le-sap-sp4",
@@ -53318,11 +54098,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-SERVER",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-SERVER/12-SP4/ppc64le/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP4-Updates for ppc64le SAP-SP4"
+        "channel_name": "SLES12-SP4-Updates for ppc64le SAP"
     },
     {
         "channel_label": "sles12-sp4-debuginfo-updates-ppc64le-sap-sp4",
@@ -53333,11 +54113,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-SERVER",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-SERVER/12-SP4/ppc64le/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP4-Debuginfo-Updates for ppc64le SAP-SP4"
+        "channel_name": "SLES12-SP4-Debuginfo-Updates for ppc64le SAP"
     },
     {
         "channel_label": "sles12-sp4-pool-ppc64le-sap-sp4",
@@ -53348,11 +54128,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-SERVER",
         "url": "https://updates.suse.com/SUSE/Products/SLE-SERVER/12-SP4/ppc64le/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP4-Pool for ppc64le SAP-SP4"
+        "channel_name": "SLES12-SP4-Pool for ppc64le SAP"
     },
     {
         "channel_label": "sles12-sp4-debuginfo-pool-ppc64le-sap-sp4",
@@ -53363,11 +54143,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-SERVER",
         "url": "https://updates.suse.com/SUSE/Products/SLE-SERVER/12-SP4/ppc64le/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP4-Debuginfo-Pool for ppc64le SAP-SP4"
+        "channel_name": "SLES12-SP4-Debuginfo-Pool for ppc64le SAP"
     },
     {
         "channel_label": "sle-ha12-sp4-updates-ppc64le-sap-sp4",
@@ -53378,11 +54158,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-HA",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-HA/12-SP4/ppc64le/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP4-Updates for ppc64le SAP-SP4"
+        "channel_name": "SLE-HA12-SP4-Updates for ppc64le SAP"
     },
     {
         "channel_label": "sle-ha12-sp4-debuginfo-updates-ppc64le-sap-sp4",
@@ -53393,11 +54173,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-HA",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-HA/12-SP4/ppc64le/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP4-Debuginfo-Updates for ppc64le SAP-SP4"
+        "channel_name": "SLE-HA12-SP4-Debuginfo-Updates for ppc64le SAP"
     },
     {
         "channel_label": "sle-ha12-sp4-pool-ppc64le-sap-sp4",
@@ -53408,11 +54188,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-HA",
         "url": "https://updates.suse.com/SUSE/Products/SLE-HA/12-SP4/ppc64le/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP4-Pool for ppc64le SAP-SP4"
+        "channel_name": "SLE-HA12-SP4-Pool for ppc64le SAP"
     },
     {
         "channel_label": "sle-ha12-sp4-debuginfo-pool-ppc64le-sap-sp4",
@@ -53423,11 +54203,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-HA",
         "url": "https://updates.suse.com/SUSE/Products/SLE-HA/12-SP4/ppc64le/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP4-Debuginfo-Pool for ppc64le SAP-SP4"
+        "channel_name": "SLE-HA12-SP4-Debuginfo-Pool for ppc64le SAP"
     },
     {
         "channel_label": "sle-12-sp4-sap-updates-ppc64le",
@@ -53438,7 +54218,7 @@
         "root_product_id": 1754,
         "update_tag": "SLE-SAP",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-SAP/12-SP4/ppc64le/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -53453,7 +54233,7 @@
         "root_product_id": 1754,
         "update_tag": "SLE-SAP",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-SAP/12-SP4/ppc64le/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -53468,7 +54248,7 @@
         "root_product_id": 1754,
         "update_tag": "SLE-SAP",
         "url": "https://updates.suse.com/SUSE/Products/SLE-SAP/12-SP4/ppc64le/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -53483,7 +54263,7 @@
         "root_product_id": 1754,
         "update_tag": "SLE-SAP",
         "url": "https://updates.suse.com/SUSE/Products/SLE-SAP/12-SP4/ppc64le/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -53498,11 +54278,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-Manager-Tools",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/12/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates x86_64 SAP-SP4"
+        "channel_name": "SLE-Manager-Tools12-Updates for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-x86_64-sap-sp4",
@@ -53513,11 +54293,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-Manager-Tools",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/12/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates x86_64 SAP-SP4"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-manager-tools12-pool-x86_64-sap-sp4",
@@ -53528,11 +54308,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-Manager-Tools",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/12/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool x86_64 SAP-SP4"
+        "channel_name": "SLE-Manager-Tools12-Pool for x86_64 SAP SP4"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-x86_64-sap-sp4",
@@ -53543,11 +54323,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-Manager-Tools",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/12/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool x86_64 SAP-SP4"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for x86_64 SAP SP4"
     },
     {
         "channel_label": "sles12-sp4-updates-x86_64-sap-sp4",
@@ -53558,11 +54338,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-SERVER",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-SERVER/12-SP4/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP4-Updates for x86_64 SAP-SP4"
+        "channel_name": "SLES12-SP4-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sles12-sp4-debuginfo-updates-x86_64-sap-sp4",
@@ -53573,11 +54353,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-SERVER",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-SERVER/12-SP4/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP4-Debuginfo-Updates for x86_64 SAP-SP4"
+        "channel_name": "SLES12-SP4-Debuginfo-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sles12-sp4-pool-x86_64-sap-sp4",
@@ -53588,11 +54368,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-SERVER",
         "url": "https://updates.suse.com/SUSE/Products/SLE-SERVER/12-SP4/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP4-Pool for x86_64 SAP-SP4"
+        "channel_name": "SLES12-SP4-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sles12-sp4-debuginfo-pool-x86_64-sap-sp4",
@@ -53603,11 +54383,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-SERVER",
         "url": "https://updates.suse.com/SUSE/Products/SLE-SERVER/12-SP4/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP4-Debuginfo-Pool for x86_64 SAP-SP4"
+        "channel_name": "SLES12-SP4-Debuginfo-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-ha12-sp4-updates-x86_64-sap-sp4",
@@ -53618,11 +54398,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-HA",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-HA/12-SP4/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP4-Updates for x86_64 SAP-SP4"
+        "channel_name": "SLE-HA12-SP4-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-ha12-sp4-debuginfo-updates-x86_64-sap-sp4",
@@ -53633,11 +54413,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-HA",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-HA/12-SP4/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP4-Debuginfo-Updates for x86_64 SAP-SP4"
+        "channel_name": "SLE-HA12-SP4-Debuginfo-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-ha12-sp4-pool-x86_64-sap-sp4",
@@ -53648,11 +54428,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-HA",
         "url": "https://updates.suse.com/SUSE/Products/SLE-HA/12-SP4/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP4-Pool for x86_64 SAP-SP4"
+        "channel_name": "SLE-HA12-SP4-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-ha12-sp4-debuginfo-pool-x86_64-sap-sp4",
@@ -53663,11 +54443,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-HA",
         "url": "https://updates.suse.com/SUSE/Products/SLE-HA/12-SP4/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-HA12-SP4-Debuginfo-Pool for x86_64 SAP-SP4"
+        "channel_name": "SLE-HA12-SP4-Debuginfo-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-12-sp4-sap-updates-x86_64",
@@ -53678,7 +54458,7 @@
         "root_product_id": 1755,
         "update_tag": "SLE-SAP",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-SAP/12-SP4/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -53693,7 +54473,7 @@
         "root_product_id": 1755,
         "update_tag": "SLE-SAP",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-SAP/12-SP4/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -53708,7 +54488,7 @@
         "root_product_id": 1755,
         "update_tag": "SLE-SAP",
         "url": "https://updates.suse.com/SUSE/Products/SLE-SAP/12-SP4/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -53723,7 +54503,7 @@
         "root_product_id": 1755,
         "update_tag": "SLE-SAP",
         "url": "https://updates.suse.com/SUSE/Products/SLE-SAP/12-SP4/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -53738,7 +54518,7 @@
         "root_product_id": 1626,
         "update_tag": "SLE-Live-Patching",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Live-Patching/12-SP4/ppc64le/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -53753,7 +54533,7 @@
         "root_product_id": 1626,
         "update_tag": "SLE-Live-Patching",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Live-Patching/12-SP4/ppc64le/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -53768,7 +54548,7 @@
         "root_product_id": 1626,
         "update_tag": "SLE-Live-Patching",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Live-Patching/12-SP4/ppc64le/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -53783,7 +54563,7 @@
         "root_product_id": 1626,
         "update_tag": "SLE-Live-Patching",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Live-Patching/12-SP4/ppc64le/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -53798,11 +54578,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-Live-Patching",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Live-Patching/12-SP4/ppc64le/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Live-Patching12-SP4-Updates for ppc64le SAP-SP4"
+        "channel_name": "SLE-Live-Patching12-SP4-Updates for ppc64le SAP"
     },
     {
         "channel_label": "sle-live-patching12-sp4-debuginfo-updates-ppc64le-sap-sp4",
@@ -53813,11 +54593,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-Live-Patching",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Live-Patching/12-SP4/ppc64le/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Live-Patching12-SP4-Debuginfo-Updates for ppc64le SAP-SP4"
+        "channel_name": "SLE-Live-Patching12-SP4-Debuginfo-Updates for ppc64le SAP"
     },
     {
         "channel_label": "sle-live-patching12-sp4-pool-ppc64le-sap-sp4",
@@ -53828,11 +54608,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-Live-Patching",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Live-Patching/12-SP4/ppc64le/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Live-Patching12-SP4-Pool for ppc64le SAP-SP4"
+        "channel_name": "SLE-Live-Patching12-SP4-Pool for ppc64le SAP"
     },
     {
         "channel_label": "sle-live-patching12-sp4-debuginfo-pool-ppc64le-sap-sp4",
@@ -53843,11 +54623,11 @@
         "root_product_id": 1754,
         "update_tag": "SLE-Live-Patching",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Live-Patching/12-SP4/ppc64le/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Live-Patching12-SP4-Debuginfo-Pool for ppc64le SAP-SP4"
+        "channel_name": "SLE-Live-Patching12-SP4-Debuginfo-Pool for ppc64le SAP"
     },
     {
         "channel_label": "sle-live-patching12-sp4-updates-x86_64",
@@ -53858,7 +54638,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Live-Patching",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Live-Patching/12-SP4/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -53873,7 +54653,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Live-Patching",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Live-Patching/12-SP4/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -53888,7 +54668,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Live-Patching",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Live-Patching/12-SP4/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -53903,7 +54683,7 @@
         "root_product_id": 1625,
         "update_tag": "SLE-Live-Patching",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Live-Patching/12-SP4/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -53918,11 +54698,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-Live-Patching",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Live-Patching/12-SP4/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Live-Patching12-SP4-Updates for x86_64 SAP-SP4"
+        "channel_name": "SLE-Live-Patching12-SP4-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-live-patching12-sp4-debuginfo-updates-x86_64-sap-sp4",
@@ -53933,11 +54713,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-Live-Patching",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Live-Patching/12-SP4/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Live-Patching12-SP4-Debuginfo-Updates for x86_64 SAP-SP4"
+        "channel_name": "SLE-Live-Patching12-SP4-Debuginfo-Updates for x86_64 SAP"
     },
     {
         "channel_label": "sle-live-patching12-sp4-pool-x86_64-sap-sp4",
@@ -53948,11 +54728,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-Live-Patching",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Live-Patching/12-SP4/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Live-Patching12-SP4-Pool for x86_64 SAP-SP4"
+        "channel_name": "SLE-Live-Patching12-SP4-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-live-patching12-sp4-debuginfo-pool-x86_64-sap-sp4",
@@ -53963,11 +54743,11 @@
         "root_product_id": 1755,
         "update_tag": "SLE-Live-Patching",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Live-Patching/12-SP4/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Live-Patching12-SP4-Debuginfo-Pool for x86_64 SAP-SP4"
+        "channel_name": "SLE-Live-Patching12-SP4-Debuginfo-Pool for x86_64 SAP"
     },
     {
         "channel_label": "sle-live-patching12-sp4-updates-x86_64-hpc-sp4",
@@ -53978,11 +54758,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Live-Patching",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Live-Patching/12-SP4/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Live-Patching12-SP4-Updates for x86_64 HPC-SP4"
+        "channel_name": "SLE-Live-Patching12-SP4-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sle-live-patching12-sp4-debuginfo-updates-x86_64-hpc-sp4",
@@ -53993,11 +54773,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Live-Patching",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Live-Patching/12-SP4/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Live-Patching12-SP4-Debuginfo-Updates for x86_64 HPC-SP4"
+        "channel_name": "SLE-Live-Patching12-SP4-Debuginfo-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sle-live-patching12-sp4-pool-x86_64-hpc-sp4",
@@ -54008,11 +54788,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Live-Patching",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Live-Patching/12-SP4/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Live-Patching12-SP4-Pool for x86_64 HPC-SP4"
+        "channel_name": "SLE-Live-Patching12-SP4-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sle-live-patching12-sp4-debuginfo-pool-x86_64-hpc-sp4",
@@ -54023,11 +54803,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Live-Patching",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Live-Patching/12-SP4/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Live-Patching12-SP4-Debuginfo-Pool for x86_64 HPC-SP4"
+        "channel_name": "SLE-Live-Patching12-SP4-Debuginfo-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sle-manager-tools12-updates-aarch64-hpc-sp4",
@@ -54038,11 +54818,11 @@
         "root_product_id": 1758,
         "update_tag": "SLE-Manager-Tools",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/12/aarch64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates aarch64 HPC-SP4"
+        "channel_name": "SLE-Manager-Tools12-Updates for aarch64 HPC SP4"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-aarch64-hpc-sp4",
@@ -54053,11 +54833,11 @@
         "root_product_id": 1758,
         "update_tag": "SLE-Manager-Tools",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/12/aarch64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates aarch64 HPC-SP4"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for aarch64 HPC SP4"
     },
     {
         "channel_label": "sle-manager-tools12-pool-aarch64-hpc-sp4",
@@ -54068,11 +54848,11 @@
         "root_product_id": 1758,
         "update_tag": "SLE-Manager-Tools",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/12/aarch64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool aarch64 HPC-SP4"
+        "channel_name": "SLE-Manager-Tools12-Pool for aarch64 HPC SP4"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-aarch64-hpc-sp4",
@@ -54083,11 +54863,11 @@
         "root_product_id": 1758,
         "update_tag": "SLE-Manager-Tools",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/12/aarch64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool aarch64 HPC-SP4"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for aarch64 HPC SP4"
     },
     {
         "channel_label": "sles12-sp4-updates-aarch64-hpc-sp4",
@@ -54098,11 +54878,11 @@
         "root_product_id": 1758,
         "update_tag": "SLE-SERVER",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-SERVER/12-SP4/aarch64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP4-Updates for aarch64 HPC-SP4"
+        "channel_name": "SLES12-SP4-Updates for aarch64 HPC"
     },
     {
         "channel_label": "sles12-sp4-debuginfo-updates-aarch64-hpc-sp4",
@@ -54113,11 +54893,11 @@
         "root_product_id": 1758,
         "update_tag": "SLE-SERVER",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-SERVER/12-SP4/aarch64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP4-Debuginfo-Updates for aarch64 HPC-SP4"
+        "channel_name": "SLES12-SP4-Debuginfo-Updates for aarch64 HPC"
     },
     {
         "channel_label": "sles12-sp4-pool-aarch64-hpc-sp4",
@@ -54128,11 +54908,11 @@
         "root_product_id": 1758,
         "update_tag": "SLE-SERVER",
         "url": "https://updates.suse.com/SUSE/Products/SLE-SERVER/12-SP4/aarch64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP4-Pool for aarch64 HPC-SP4"
+        "channel_name": "SLES12-SP4-Pool for aarch64 HPC"
     },
     {
         "channel_label": "sles12-sp4-debuginfo-pool-aarch64-hpc-sp4",
@@ -54143,11 +54923,11 @@
         "root_product_id": 1758,
         "update_tag": "SLE-SERVER",
         "url": "https://updates.suse.com/SUSE/Products/SLE-SERVER/12-SP4/aarch64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP4-Debuginfo-Pool for aarch64 HPC-SP4"
+        "channel_name": "SLES12-SP4-Debuginfo-Pool for aarch64 HPC"
     },
     {
         "channel_label": "sle12-sp4-hpc-updates-aarch64",
@@ -54158,7 +54938,7 @@
         "root_product_id": 1758,
         "update_tag": "SLE-HPC",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-HPC/12-SP4/aarch64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -54173,7 +54953,7 @@
         "root_product_id": 1758,
         "update_tag": "SLE-HPC",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-HPC/12-SP4/aarch64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -54188,7 +54968,7 @@
         "root_product_id": 1758,
         "update_tag": "SLE-HPC",
         "url": "https://updates.suse.com/SUSE/Products/SLE-HPC/12-SP4/aarch64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -54203,7 +54983,7 @@
         "root_product_id": 1758,
         "update_tag": "SLE-HPC",
         "url": "https://updates.suse.com/SUSE/Products/SLE-HPC/12-SP4/aarch64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -54218,11 +54998,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Manager-Tools",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/12/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Updates x86_64 HPC-SP4"
+        "channel_name": "SLE-Manager-Tools12-Updates for x86_64 HPC SP4"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-updates-x86_64-hpc-sp4",
@@ -54233,11 +55013,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Manager-Tools",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/12/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates x86_64 HPC-SP4"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Updates for x86_64 HPC SP4"
     },
     {
         "channel_label": "sle-manager-tools12-pool-x86_64-hpc-sp4",
@@ -54248,11 +55028,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Manager-Tools",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/12/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Pool x86_64 HPC-SP4"
+        "channel_name": "SLE-Manager-Tools12-Pool for x86_64 HPC SP4"
     },
     {
         "channel_label": "sle-manager-tools12-debuginfo-pool-x86_64-hpc-sp4",
@@ -54263,11 +55043,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-Manager-Tools",
         "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/12/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool x86_64 HPC-SP4"
+        "channel_name": "SLE-Manager-Tools12-Debuginfo-Pool for x86_64 HPC SP4"
     },
     {
         "channel_label": "sles12-sp4-updates-x86_64-hpc-sp4",
@@ -54278,11 +55058,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-SERVER",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-SERVER/12-SP4/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP4-Updates for x86_64 HPC-SP4"
+        "channel_name": "SLES12-SP4-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sles12-sp4-debuginfo-updates-x86_64-hpc-sp4",
@@ -54293,11 +55073,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-SERVER",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-SERVER/12-SP4/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP4-Debuginfo-Updates for x86_64 HPC-SP4"
+        "channel_name": "SLES12-SP4-Debuginfo-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sles12-sp4-pool-x86_64-hpc-sp4",
@@ -54308,11 +55088,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-SERVER",
         "url": "https://updates.suse.com/SUSE/Products/SLE-SERVER/12-SP4/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP4-Pool for x86_64 HPC-SP4"
+        "channel_name": "SLES12-SP4-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sles12-sp4-debuginfo-pool-x86_64-hpc-sp4",
@@ -54323,11 +55103,11 @@
         "root_product_id": 1759,
         "update_tag": "SLE-SERVER",
         "url": "https://updates.suse.com/SUSE/Products/SLE-SERVER/12-SP4/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP4-Debuginfo-Pool for x86_64 HPC-SP4"
+        "channel_name": "SLES12-SP4-Debuginfo-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sle12-sp4-hpc-updates-x86_64",
@@ -54338,7 +55118,7 @@
         "root_product_id": 1759,
         "update_tag": "SLE-HPC",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-HPC/12-SP4/x86_64/update/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -54353,7 +55133,7 @@
         "root_product_id": 1759,
         "update_tag": "SLE-HPC",
         "url": "https://updates.suse.com/SUSE/Updates/SLE-HPC/12-SP4/x86_64/update_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
@@ -54368,7 +55148,7 @@
         "root_product_id": 1759,
         "update_tag": "SLE-HPC",
         "url": "https://updates.suse.com/SUSE/Products/SLE-HPC/12-SP4/x86_64/product/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": true,
         "signed": true,
         "recommended": false,
@@ -54383,11 +55163,5876 @@
         "root_product_id": 1759,
         "update_tag": "SLE-HPC",
         "url": "https://updates.suse.com/SUSE/Products/SLE-HPC/12-SP4/x86_64/product_debug/",
-        "release_stage": "beta",
+        "release_stage": "released",
         "mandatory": false,
         "signed": true,
         "recommended": false,
         "channel_name": "SLE12-SP4-HPC-Debuginfo-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-product-sles15-sp1-updates-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1760,
+        "repository_id": 3197,
+        "parent_product_id": null,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Product-SLES",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-SLES/15-SP1/aarch64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-SLES15-SP1-Updates for aarch64"
+    },
+    {
+        "channel_label": "sle-product-sles15-sp1-debuginfo-updates-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1760,
+        "repository_id": 3198,
+        "parent_product_id": null,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Product-SLES",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-SLES/15-SP1/aarch64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-SLES15-SP1-Debuginfo-Updates for aarch64"
+    },
+    {
+        "channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "parent_channel_label": null,
+        "product_id": 1760,
+        "repository_id": 3200,
+        "parent_product_id": null,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Product-SLES",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-SLES/15-SP1/aarch64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-SLES15-SP1-Pool for aarch64"
+    },
+    {
+        "channel_label": "sle-product-sles15-sp1-debuginfo-pool-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1760,
+        "repository_id": 3201,
+        "parent_product_id": null,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Product-SLES",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-SLES/15-SP1/aarch64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-SLES15-SP1-Debuginfo-Pool for aarch64"
+    },
+    {
+        "channel_label": "sle-product-sles15-sp1-updates-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1761,
+        "repository_id": 3203,
+        "parent_product_id": null,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Product-SLES",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-SLES/15-SP1/ppc64le/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-SLES15-SP1-Updates for ppc64le"
+    },
+    {
+        "channel_label": "sle-product-sles15-sp1-debuginfo-updates-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1761,
+        "repository_id": 3204,
+        "parent_product_id": null,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Product-SLES",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-SLES/15-SP1/ppc64le/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-SLES15-SP1-Debuginfo-Updates for ppc64le"
+    },
+    {
+        "channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "parent_channel_label": null,
+        "product_id": 1761,
+        "repository_id": 3206,
+        "parent_product_id": null,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Product-SLES",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-SLES/15-SP1/ppc64le/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-SLES15-SP1-Pool for ppc64le"
+    },
+    {
+        "channel_label": "sle-product-sles15-sp1-debuginfo-pool-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1761,
+        "repository_id": 3207,
+        "parent_product_id": null,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Product-SLES",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-SLES/15-SP1/ppc64le/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-SLES15-SP1-Debuginfo-Pool for ppc64le"
+    },
+    {
+        "channel_label": "sle-product-sles15-sp1-updates-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1762,
+        "repository_id": 3209,
+        "parent_product_id": null,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Product-SLES",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-SLES/15-SP1/s390x/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-SLES15-SP1-Updates for s390x"
+    },
+    {
+        "channel_label": "sle-product-sles15-sp1-debuginfo-updates-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1762,
+        "repository_id": 3210,
+        "parent_product_id": null,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Product-SLES",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-SLES/15-SP1/s390x/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-SLES15-SP1-Debuginfo-Updates for s390x"
+    },
+    {
+        "channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "parent_channel_label": null,
+        "product_id": 1762,
+        "repository_id": 3212,
+        "parent_product_id": null,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Product-SLES",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-SLES/15-SP1/s390x/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-SLES15-SP1-Pool for s390x"
+    },
+    {
+        "channel_label": "sle-product-sles15-sp1-debuginfo-pool-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1762,
+        "repository_id": 3213,
+        "parent_product_id": null,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Product-SLES",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-SLES/15-SP1/s390x/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-SLES15-SP1-Debuginfo-Pool for s390x"
+    },
+    {
+        "channel_label": "sle-product-sles15-sp1-updates-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1763,
+        "repository_id": 3215,
+        "parent_product_id": null,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Product-SLES",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-SLES/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-SLES15-SP1-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-product-sles15-sp1-debuginfo-updates-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1763,
+        "repository_id": 3216,
+        "parent_product_id": null,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Product-SLES",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-SLES/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-SLES15-SP1-Debuginfo-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "parent_channel_label": null,
+        "product_id": 1763,
+        "repository_id": 3218,
+        "parent_product_id": null,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Product-SLES",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-SLES/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-SLES15-SP1-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-product-sles15-sp1-debuginfo-pool-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1763,
+        "repository_id": 3219,
+        "parent_product_id": null,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Product-SLES",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-SLES/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-SLES15-SP1-Debuginfo-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-product-sled15-sp1-updates-x86_64",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1764,
+        "repository_id": 3221,
+        "parent_product_id": null,
+        "root_product_id": 1764,
+        "update_tag": "SLE-Product-SLED",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-SLED/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-SLED15-SP1-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-product-sled15-sp1-debuginfo-updates-x86_64",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1764,
+        "repository_id": 3222,
+        "parent_product_id": null,
+        "root_product_id": 1764,
+        "update_tag": "SLE-Product-SLED",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-SLED/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-SLED15-SP1-Debuginfo-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "parent_channel_label": null,
+        "product_id": 1764,
+        "repository_id": 3223,
+        "parent_product_id": null,
+        "root_product_id": 1764,
+        "update_tag": "SLE-Product-SLED",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-SLED/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-SLED15-SP1-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-product-sled15-sp1-debuginfo-pool-x86_64",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1764,
+        "repository_id": 3224,
+        "parent_product_id": null,
+        "root_product_id": 1764,
+        "update_tag": "SLE-Product-SLED",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-SLED/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-SLED15-SP1-Debuginfo-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-product-sles_sap15-sp1-updates-ppc64le",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1765,
+        "repository_id": 3226,
+        "parent_product_id": null,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Product-SLES_SAP",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-SLES_SAP/15-SP1/ppc64le/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-SLES_SAP15-SP1-Updates for ppc64le"
+    },
+    {
+        "channel_label": "sle-product-sles_sap15-sp1-debuginfo-updates-ppc64le",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1765,
+        "repository_id": 3227,
+        "parent_product_id": null,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Product-SLES_SAP",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-SLES_SAP/15-SP1/ppc64le/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-SLES_SAP15-SP1-Debuginfo-Updates for ppc64le"
+    },
+    {
+        "channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "parent_channel_label": null,
+        "product_id": 1765,
+        "repository_id": 3228,
+        "parent_product_id": null,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Product-SLES_SAP",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-SLES_SAP/15-SP1/ppc64le/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-SLES_SAP15-SP1-Pool for ppc64le"
+    },
+    {
+        "channel_label": "sle-product-sles_sap15-sp1-debuginfo-pool-ppc64le",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1765,
+        "repository_id": 3229,
+        "parent_product_id": null,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Product-SLES_SAP",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-SLES_SAP/15-SP1/ppc64le/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-SLES_SAP15-SP1-Debuginfo-Pool for ppc64le"
+    },
+    {
+        "channel_label": "sle-product-sles_sap15-sp1-updates-x86_64",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1766,
+        "repository_id": 3231,
+        "parent_product_id": null,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Product-SLES_SAP",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-SLES_SAP/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-SLES_SAP15-SP1-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-product-sles_sap15-sp1-debuginfo-updates-x86_64",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1766,
+        "repository_id": 3232,
+        "parent_product_id": null,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Product-SLES_SAP",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-SLES_SAP/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-SLES_SAP15-SP1-Debuginfo-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "parent_channel_label": null,
+        "product_id": 1766,
+        "repository_id": 3233,
+        "parent_product_id": null,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Product-SLES_SAP",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-SLES_SAP/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-SLES_SAP15-SP1-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-product-sles_sap15-sp1-debuginfo-pool-x86_64",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1766,
+        "repository_id": 3234,
+        "parent_product_id": null,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Product-SLES_SAP",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-SLES_SAP/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-SLES_SAP15-SP1-Debuginfo-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-product-hpc-15-sp1-updates-aarch64",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1767,
+        "repository_id": 3236,
+        "parent_product_id": null,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Product-HPC",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-HPC/15-SP1/aarch64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-HPC-15-SP1-Updates for aarch64"
+    },
+    {
+        "channel_label": "sle-product-hpc15-sp1-debuginfo-updates-aarch64",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1767,
+        "repository_id": 3237,
+        "parent_product_id": null,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Product-HPC",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-HPC/15-SP1/aarch64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-HPC15-SP1-Debuginfo-Updates for aarch64"
+    },
+    {
+        "channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "parent_channel_label": null,
+        "product_id": 1767,
+        "repository_id": 3238,
+        "parent_product_id": null,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Product-HPC",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-HPC/15-SP1/aarch64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-HPC-15-SP1-Pool for aarch64"
+    },
+    {
+        "channel_label": "sle-product-hpc15-sp1-debuginfo-pool-aarch64",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1767,
+        "repository_id": 3239,
+        "parent_product_id": null,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Product-HPC",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-HPC/15-SP1/aarch64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-HPC15-SP1-Debuginfo-Pool for aarch64"
+    },
+    {
+        "channel_label": "sle-product-hpc-15-sp1-updates-x86_64",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1768,
+        "repository_id": 3241,
+        "parent_product_id": null,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Product-HPC",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-HPC/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-HPC-15-SP1-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-product-hpc15-sp1-debuginfo-updates-x86_64",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1768,
+        "repository_id": 3242,
+        "parent_product_id": null,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Product-HPC",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-HPC/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-HPC15-SP1-Debuginfo-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "parent_channel_label": null,
+        "product_id": 1768,
+        "repository_id": 3243,
+        "parent_product_id": null,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Product-HPC",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-HPC/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-HPC-15-SP1-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-product-hpc15-sp1-debuginfo-pool-x86_64",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1768,
+        "repository_id": 3244,
+        "parent_product_id": null,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Product-HPC",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-HPC/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-HPC15-SP1-Debuginfo-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-updates-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1769,
+        "repository_id": 3246,
+        "parent_product_id": 1760,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15-SP1/aarch64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Updates for aarch64"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-debuginfo-updates-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1769,
+        "repository_id": 3247,
+        "parent_product_id": 1760,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15-SP1/aarch64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Debuginfo-Updates for aarch64"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-pool-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1769,
+        "repository_id": 3248,
+        "parent_product_id": 1760,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15-SP1/aarch64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Pool for aarch64"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-debuginfo-pool-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1769,
+        "repository_id": 3249,
+        "parent_product_id": 1760,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15-SP1/aarch64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Debuginfo-Pool for aarch64"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-updates-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1769,
+        "repository_id": 3246,
+        "parent_product_id": 1767,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15-SP1/aarch64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Updates for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-debuginfo-updates-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1769,
+        "repository_id": 3247,
+        "parent_product_id": 1767,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15-SP1/aarch64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Debuginfo-Updates for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-pool-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1769,
+        "repository_id": 3248,
+        "parent_product_id": 1767,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15-SP1/aarch64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Pool for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-debuginfo-pool-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1769,
+        "repository_id": 3249,
+        "parent_product_id": 1767,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15-SP1/aarch64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Debuginfo-Pool for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-updates-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1770,
+        "repository_id": 3251,
+        "parent_product_id": 1761,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15-SP1/ppc64le/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Updates for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-debuginfo-updates-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1770,
+        "repository_id": 3252,
+        "parent_product_id": 1761,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15-SP1/ppc64le/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Debuginfo-Updates for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-pool-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1770,
+        "repository_id": 3253,
+        "parent_product_id": 1761,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15-SP1/ppc64le/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Pool for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-debuginfo-pool-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1770,
+        "repository_id": 3254,
+        "parent_product_id": 1761,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15-SP1/ppc64le/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Debuginfo-Pool for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-updates-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1770,
+        "repository_id": 3251,
+        "parent_product_id": 1765,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15-SP1/ppc64le/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Updates for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-debuginfo-updates-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1770,
+        "repository_id": 3252,
+        "parent_product_id": 1765,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15-SP1/ppc64le/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Debuginfo-Updates for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-pool-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1770,
+        "repository_id": 3253,
+        "parent_product_id": 1765,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15-SP1/ppc64le/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Pool for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-debuginfo-pool-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1770,
+        "repository_id": 3254,
+        "parent_product_id": 1765,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15-SP1/ppc64le/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Debuginfo-Pool for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-updates-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1771,
+        "repository_id": 3256,
+        "parent_product_id": 1762,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15-SP1/s390x/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Updates for s390x"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-debuginfo-updates-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1771,
+        "repository_id": 3257,
+        "parent_product_id": 1762,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15-SP1/s390x/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Debuginfo-Updates for s390x"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-pool-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1771,
+        "repository_id": 3258,
+        "parent_product_id": 1762,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15-SP1/s390x/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Pool for s390x"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-debuginfo-pool-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1771,
+        "repository_id": 3259,
+        "parent_product_id": 1762,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15-SP1/s390x/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Debuginfo-Pool for s390x"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-updates-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1772,
+        "repository_id": 3261,
+        "parent_product_id": 1763,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-debuginfo-updates-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1772,
+        "repository_id": 3262,
+        "parent_product_id": 1763,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Debuginfo-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-pool-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1772,
+        "repository_id": 3263,
+        "parent_product_id": 1763,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-debuginfo-pool-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1772,
+        "repository_id": 3264,
+        "parent_product_id": 1763,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Debuginfo-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-updates-x86_64-sled",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1772,
+        "repository_id": 3261,
+        "parent_product_id": 1764,
+        "root_product_id": 1764,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Updates for x86_64 SLED"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-debuginfo-updates-x86_64-sled",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1772,
+        "repository_id": 3262,
+        "parent_product_id": 1764,
+        "root_product_id": 1764,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Debuginfo-Updates for x86_64 SLED"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-pool-x86_64-sled",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1772,
+        "repository_id": 3263,
+        "parent_product_id": 1764,
+        "root_product_id": 1764,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Pool for x86_64 SLED"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-debuginfo-pool-x86_64-sled",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1772,
+        "repository_id": 3264,
+        "parent_product_id": 1764,
+        "root_product_id": 1764,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Debuginfo-Pool for x86_64 SLED"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-updates-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1772,
+        "repository_id": 3261,
+        "parent_product_id": 1766,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Updates for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-debuginfo-updates-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1772,
+        "repository_id": 3262,
+        "parent_product_id": 1766,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Debuginfo-Updates for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-pool-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1772,
+        "repository_id": 3263,
+        "parent_product_id": 1766,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Pool for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-debuginfo-pool-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1772,
+        "repository_id": 3264,
+        "parent_product_id": 1766,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Debuginfo-Pool for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-updates-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1772,
+        "repository_id": 3261,
+        "parent_product_id": 1768,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Updates for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-debuginfo-updates-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1772,
+        "repository_id": 3262,
+        "parent_product_id": 1768,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Debuginfo-Updates for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-pool-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1772,
+        "repository_id": 3263,
+        "parent_product_id": 1768,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Pool for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-debuginfo-pool-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1772,
+        "repository_id": 3264,
+        "parent_product_id": 1768,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Debuginfo-Pool for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-updates-x86_64-rt",
+        "parent_channel_label": "sle-product-rt-15-sp1-pool-x86_64",
+        "product_id": 1772,
+        "repository_id": 3261,
+        "parent_product_id": 1861,
+        "root_product_id": 1861,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Updates for x86_64 RT"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-debuginfo-updates-x86_64-rt",
+        "parent_channel_label": "sle-product-rt-15-sp1-pool-x86_64",
+        "product_id": 1772,
+        "repository_id": 3262,
+        "parent_product_id": 1861,
+        "root_product_id": 1861,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Debuginfo-Updates for x86_64 RT"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-pool-x86_64-rt",
+        "parent_channel_label": "sle-product-rt-15-sp1-pool-x86_64",
+        "product_id": 1772,
+        "repository_id": 3263,
+        "parent_product_id": 1861,
+        "root_product_id": 1861,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Pool for x86_64 RT"
+    },
+    {
+        "channel_label": "sle-module-basesystem15-sp1-debuginfo-pool-x86_64-rt",
+        "parent_channel_label": "sle-product-rt-15-sp1-pool-x86_64",
+        "product_id": 1772,
+        "repository_id": 3264,
+        "parent_product_id": 1861,
+        "root_product_id": 1861,
+        "update_tag": "SLE-Module-Basesystem",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Basesystem15-SP1-Debuginfo-Pool for x86_64 RT"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-updates-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1773,
+        "repository_id": 3266,
+        "parent_product_id": 1769,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Desktop-Applications/15-SP1/aarch64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Updates for aarch64"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-debuginfo-updates-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1773,
+        "repository_id": 3267,
+        "parent_product_id": 1769,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Desktop-Applications/15-SP1/aarch64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Debuginfo-Updates for aarch64"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-pool-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1773,
+        "repository_id": 3268,
+        "parent_product_id": 1769,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Desktop-Applications/15-SP1/aarch64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Pool for aarch64"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-debuginfo-pool-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1773,
+        "repository_id": 3269,
+        "parent_product_id": 1769,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Desktop-Applications/15-SP1/aarch64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Debuginfo-Pool for aarch64"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-updates-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1773,
+        "repository_id": 3266,
+        "parent_product_id": 1769,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Desktop-Applications/15-SP1/aarch64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Updates for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-debuginfo-updates-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1773,
+        "repository_id": 3267,
+        "parent_product_id": 1769,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Desktop-Applications/15-SP1/aarch64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Debuginfo-Updates for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-pool-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1773,
+        "repository_id": 3268,
+        "parent_product_id": 1769,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Desktop-Applications/15-SP1/aarch64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Pool for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-debuginfo-pool-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1773,
+        "repository_id": 3269,
+        "parent_product_id": 1769,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Desktop-Applications/15-SP1/aarch64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Debuginfo-Pool for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-updates-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1774,
+        "repository_id": 3271,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Desktop-Applications/15-SP1/ppc64le/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Updates for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-debuginfo-updates-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1774,
+        "repository_id": 3272,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Desktop-Applications/15-SP1/ppc64le/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Debuginfo-Updates for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-pool-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1774,
+        "repository_id": 3273,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Desktop-Applications/15-SP1/ppc64le/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Pool for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-debuginfo-pool-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1774,
+        "repository_id": 3274,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Desktop-Applications/15-SP1/ppc64le/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Debuginfo-Pool for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-updates-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1774,
+        "repository_id": 3271,
+        "parent_product_id": 1770,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Desktop-Applications/15-SP1/ppc64le/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Updates for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-debuginfo-updates-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1774,
+        "repository_id": 3272,
+        "parent_product_id": 1770,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Desktop-Applications/15-SP1/ppc64le/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Debuginfo-Updates for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-pool-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1774,
+        "repository_id": 3273,
+        "parent_product_id": 1770,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Desktop-Applications/15-SP1/ppc64le/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Pool for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-debuginfo-pool-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1774,
+        "repository_id": 3274,
+        "parent_product_id": 1770,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Desktop-Applications/15-SP1/ppc64le/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Debuginfo-Pool for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-updates-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1775,
+        "repository_id": 3276,
+        "parent_product_id": 1771,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Desktop-Applications/15-SP1/s390x/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Updates for s390x"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-debuginfo-updates-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1775,
+        "repository_id": 3277,
+        "parent_product_id": 1771,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Desktop-Applications/15-SP1/s390x/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Debuginfo-Updates for s390x"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-pool-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1775,
+        "repository_id": 3278,
+        "parent_product_id": 1771,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Desktop-Applications/15-SP1/s390x/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Pool for s390x"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-debuginfo-pool-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1775,
+        "repository_id": 3279,
+        "parent_product_id": 1771,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Desktop-Applications/15-SP1/s390x/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Debuginfo-Pool for s390x"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-updates-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1776,
+        "repository_id": 3281,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Desktop-Applications/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-debuginfo-updates-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1776,
+        "repository_id": 3282,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Desktop-Applications/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Debuginfo-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-pool-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1776,
+        "repository_id": 3283,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Desktop-Applications/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-debuginfo-pool-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1776,
+        "repository_id": 3284,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Desktop-Applications/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Debuginfo-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-updates-x86_64-sled",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1776,
+        "repository_id": 3281,
+        "parent_product_id": 1772,
+        "root_product_id": 1764,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Desktop-Applications/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Updates for x86_64 SLED"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-debuginfo-updates-x86_64-sled",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1776,
+        "repository_id": 3282,
+        "parent_product_id": 1772,
+        "root_product_id": 1764,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Desktop-Applications/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Debuginfo-Updates for x86_64 SLED"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-pool-x86_64-sled",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1776,
+        "repository_id": 3283,
+        "parent_product_id": 1772,
+        "root_product_id": 1764,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Desktop-Applications/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Pool for x86_64 SLED"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-debuginfo-pool-x86_64-sled",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1776,
+        "repository_id": 3284,
+        "parent_product_id": 1772,
+        "root_product_id": 1764,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Desktop-Applications/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Debuginfo-Pool for x86_64 SLED"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-updates-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1776,
+        "repository_id": 3281,
+        "parent_product_id": 1772,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Desktop-Applications/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Updates for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-debuginfo-updates-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1776,
+        "repository_id": 3282,
+        "parent_product_id": 1772,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Desktop-Applications/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Debuginfo-Updates for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-pool-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1776,
+        "repository_id": 3283,
+        "parent_product_id": 1772,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Desktop-Applications/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Pool for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-debuginfo-pool-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1776,
+        "repository_id": 3284,
+        "parent_product_id": 1772,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Desktop-Applications/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Debuginfo-Pool for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-updates-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1776,
+        "repository_id": 3281,
+        "parent_product_id": 1772,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Desktop-Applications/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Updates for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-debuginfo-updates-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1776,
+        "repository_id": 3282,
+        "parent_product_id": 1772,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Desktop-Applications/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Debuginfo-Updates for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-pool-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1776,
+        "repository_id": 3283,
+        "parent_product_id": 1772,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Desktop-Applications/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Pool for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-debuginfo-pool-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1776,
+        "repository_id": 3284,
+        "parent_product_id": 1772,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Desktop-Applications/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Debuginfo-Pool for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-updates-x86_64-rt",
+        "parent_channel_label": "sle-product-rt-15-sp1-pool-x86_64",
+        "product_id": 1776,
+        "repository_id": 3281,
+        "parent_product_id": 1772,
+        "root_product_id": 1861,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Desktop-Applications/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Updates for x86_64 RT"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-debuginfo-updates-x86_64-rt",
+        "parent_channel_label": "sle-product-rt-15-sp1-pool-x86_64",
+        "product_id": 1776,
+        "repository_id": 3282,
+        "parent_product_id": 1772,
+        "root_product_id": 1861,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Desktop-Applications/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Debuginfo-Updates for x86_64 RT"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-pool-x86_64-rt",
+        "parent_channel_label": "sle-product-rt-15-sp1-pool-x86_64",
+        "product_id": 1776,
+        "repository_id": 3283,
+        "parent_product_id": 1772,
+        "root_product_id": 1861,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Desktop-Applications/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Pool for x86_64 RT"
+    },
+    {
+        "channel_label": "sle-module-desktop-applications15-sp1-debuginfo-pool-x86_64-rt",
+        "parent_channel_label": "sle-product-rt-15-sp1-pool-x86_64",
+        "product_id": 1776,
+        "repository_id": 3284,
+        "parent_product_id": 1772,
+        "root_product_id": 1861,
+        "update_tag": "SLE-Module-Desktop-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Desktop-Applications/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Desktop-Applications15-SP1-Debuginfo-Pool for x86_64 RT"
+    },
+    {
+        "channel_label": "sle-module-server-applications15-sp1-updates-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1777,
+        "repository_id": 3286,
+        "parent_product_id": 1769,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Server-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Server-Applications/15-SP1/aarch64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Server-Applications15-SP1-Updates for aarch64"
+    },
+    {
+        "channel_label": "sle-module-server-applications15-sp1-debuginfo-updates-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1777,
+        "repository_id": 3287,
+        "parent_product_id": 1769,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Server-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Server-Applications/15-SP1/aarch64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Server-Applications15-SP1-Debuginfo-Updates for aarch64"
+    },
+    {
+        "channel_label": "sle-module-server-applications15-sp1-pool-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1777,
+        "repository_id": 3288,
+        "parent_product_id": 1769,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Server-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Server-Applications/15-SP1/aarch64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Server-Applications15-SP1-Pool for aarch64"
+    },
+    {
+        "channel_label": "sle-module-server-applications15-sp1-debuginfo-pool-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1777,
+        "repository_id": 3289,
+        "parent_product_id": 1769,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Server-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Server-Applications/15-SP1/aarch64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Server-Applications15-SP1-Debuginfo-Pool for aarch64"
+    },
+    {
+        "channel_label": "sle-module-server-applications15-sp1-updates-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1777,
+        "repository_id": 3286,
+        "parent_product_id": 1769,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-Server-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Server-Applications/15-SP1/aarch64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Server-Applications15-SP1-Updates for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-module-server-applications15-sp1-debuginfo-updates-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1777,
+        "repository_id": 3287,
+        "parent_product_id": 1769,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-Server-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Server-Applications/15-SP1/aarch64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Server-Applications15-SP1-Debuginfo-Updates for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-module-server-applications15-sp1-pool-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1777,
+        "repository_id": 3288,
+        "parent_product_id": 1769,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-Server-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Server-Applications/15-SP1/aarch64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Server-Applications15-SP1-Pool for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-module-server-applications15-sp1-debuginfo-pool-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1777,
+        "repository_id": 3289,
+        "parent_product_id": 1769,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-Server-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Server-Applications/15-SP1/aarch64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Server-Applications15-SP1-Debuginfo-Pool for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-module-server-applications15-sp1-updates-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1778,
+        "repository_id": 3291,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Server-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Server-Applications/15-SP1/ppc64le/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Server-Applications15-SP1-Updates for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-server-applications15-sp1-debuginfo-updates-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1778,
+        "repository_id": 3292,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Server-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Server-Applications/15-SP1/ppc64le/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Server-Applications15-SP1-Debuginfo-Updates for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-server-applications15-sp1-pool-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1778,
+        "repository_id": 3293,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Server-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Server-Applications/15-SP1/ppc64le/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Server-Applications15-SP1-Pool for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-server-applications15-sp1-debuginfo-pool-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1778,
+        "repository_id": 3294,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Server-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Server-Applications/15-SP1/ppc64le/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Server-Applications15-SP1-Debuginfo-Pool for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-server-applications15-sp1-updates-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1778,
+        "repository_id": 3291,
+        "parent_product_id": 1770,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Server-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Server-Applications/15-SP1/ppc64le/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Server-Applications15-SP1-Updates for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-server-applications15-sp1-debuginfo-updates-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1778,
+        "repository_id": 3292,
+        "parent_product_id": 1770,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Server-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Server-Applications/15-SP1/ppc64le/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Server-Applications15-SP1-Debuginfo-Updates for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-server-applications15-sp1-pool-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1778,
+        "repository_id": 3293,
+        "parent_product_id": 1770,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Server-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Server-Applications/15-SP1/ppc64le/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Server-Applications15-SP1-Pool for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-server-applications15-sp1-debuginfo-pool-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1778,
+        "repository_id": 3294,
+        "parent_product_id": 1770,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Server-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Server-Applications/15-SP1/ppc64le/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Server-Applications15-SP1-Debuginfo-Pool for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-server-applications15-sp1-updates-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1779,
+        "repository_id": 3296,
+        "parent_product_id": 1771,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Server-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Server-Applications/15-SP1/s390x/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Server-Applications15-SP1-Updates for s390x"
+    },
+    {
+        "channel_label": "sle-module-server-applications15-sp1-debuginfo-updates-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1779,
+        "repository_id": 3297,
+        "parent_product_id": 1771,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Server-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Server-Applications/15-SP1/s390x/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Server-Applications15-SP1-Debuginfo-Updates for s390x"
+    },
+    {
+        "channel_label": "sle-module-server-applications15-sp1-pool-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1779,
+        "repository_id": 3298,
+        "parent_product_id": 1771,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Server-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Server-Applications/15-SP1/s390x/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Server-Applications15-SP1-Pool for s390x"
+    },
+    {
+        "channel_label": "sle-module-server-applications15-sp1-debuginfo-pool-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1779,
+        "repository_id": 3299,
+        "parent_product_id": 1771,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Server-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Server-Applications/15-SP1/s390x/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Server-Applications15-SP1-Debuginfo-Pool for s390x"
+    },
+    {
+        "channel_label": "sle-module-server-applications15-sp1-updates-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1780,
+        "repository_id": 3301,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Server-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Server-Applications/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Server-Applications15-SP1-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-module-server-applications15-sp1-debuginfo-updates-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1780,
+        "repository_id": 3302,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Server-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Server-Applications/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Server-Applications15-SP1-Debuginfo-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-module-server-applications15-sp1-pool-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1780,
+        "repository_id": 3303,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Server-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Server-Applications/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Server-Applications15-SP1-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-module-server-applications15-sp1-debuginfo-pool-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1780,
+        "repository_id": 3304,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Server-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Server-Applications/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Server-Applications15-SP1-Debuginfo-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-module-server-applications15-sp1-updates-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1780,
+        "repository_id": 3301,
+        "parent_product_id": 1772,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Server-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Server-Applications/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Server-Applications15-SP1-Updates for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-server-applications15-sp1-debuginfo-updates-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1780,
+        "repository_id": 3302,
+        "parent_product_id": 1772,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Server-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Server-Applications/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Server-Applications15-SP1-Debuginfo-Updates for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-server-applications15-sp1-pool-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1780,
+        "repository_id": 3303,
+        "parent_product_id": 1772,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Server-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Server-Applications/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Server-Applications15-SP1-Pool for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-server-applications15-sp1-debuginfo-pool-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1780,
+        "repository_id": 3304,
+        "parent_product_id": 1772,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Server-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Server-Applications/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Server-Applications15-SP1-Debuginfo-Pool for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-server-applications15-sp1-updates-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1780,
+        "repository_id": 3301,
+        "parent_product_id": 1772,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Server-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Server-Applications/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Server-Applications15-SP1-Updates for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-server-applications15-sp1-debuginfo-updates-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1780,
+        "repository_id": 3302,
+        "parent_product_id": 1772,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Server-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Server-Applications/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Server-Applications15-SP1-Debuginfo-Updates for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-server-applications15-sp1-pool-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1780,
+        "repository_id": 3303,
+        "parent_product_id": 1772,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Server-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Server-Applications/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Server-Applications15-SP1-Pool for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-server-applications15-sp1-debuginfo-pool-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1780,
+        "repository_id": 3304,
+        "parent_product_id": 1772,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Server-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Server-Applications/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Server-Applications15-SP1-Debuginfo-Pool for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-server-applications15-sp1-updates-x86_64-rt",
+        "parent_channel_label": "sle-product-rt-15-sp1-pool-x86_64",
+        "product_id": 1780,
+        "repository_id": 3301,
+        "parent_product_id": 1772,
+        "root_product_id": 1861,
+        "update_tag": "SLE-Module-Server-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Server-Applications/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Server-Applications15-SP1-Updates for x86_64 RT"
+    },
+    {
+        "channel_label": "sle-module-server-applications15-sp1-debuginfo-updates-x86_64-rt",
+        "parent_channel_label": "sle-product-rt-15-sp1-pool-x86_64",
+        "product_id": 1780,
+        "repository_id": 3302,
+        "parent_product_id": 1772,
+        "root_product_id": 1861,
+        "update_tag": "SLE-Module-Server-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Server-Applications/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Server-Applications15-SP1-Debuginfo-Updates for x86_64 RT"
+    },
+    {
+        "channel_label": "sle-module-server-applications15-sp1-pool-x86_64-rt",
+        "parent_channel_label": "sle-product-rt-15-sp1-pool-x86_64",
+        "product_id": 1780,
+        "repository_id": 3303,
+        "parent_product_id": 1772,
+        "root_product_id": 1861,
+        "update_tag": "SLE-Module-Server-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Server-Applications/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Server-Applications15-SP1-Pool for x86_64 RT"
+    },
+    {
+        "channel_label": "sle-module-server-applications15-sp1-debuginfo-pool-x86_64-rt",
+        "parent_channel_label": "sle-product-rt-15-sp1-pool-x86_64",
+        "product_id": 1780,
+        "repository_id": 3304,
+        "parent_product_id": 1772,
+        "root_product_id": 1861,
+        "update_tag": "SLE-Module-Server-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Server-Applications/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Server-Applications15-SP1-Debuginfo-Pool for x86_64 RT"
+    },
+    {
+        "channel_label": "sle-15-ga-desktop-nvidia-driver-we-sp1",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1781,
+        "repository_id": 2747,
+        "parent_product_id": 1776,
+        "root_product_id": 1763,
+        "update_tag": null,
+        "url": "https://download.nvidia.com/suse/sle15/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-15-GA-Desktop-NVIDIA-Driver for x86_64 WE SP1"
+    },
+    {
+        "channel_label": "sle-product-we15-sp1-updates-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1781,
+        "repository_id": 3306,
+        "parent_product_id": 1776,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Product-WE",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-WE/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-WE15-SP1-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-product-we15-sp1-debuginfo-updates-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1781,
+        "repository_id": 3307,
+        "parent_product_id": 1776,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Product-WE",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-WE/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-WE15-SP1-Debuginfo-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-product-we15-sp1-pool-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1781,
+        "repository_id": 3308,
+        "parent_product_id": 1776,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Product-WE",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-WE/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-WE15-SP1-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-product-we15-sp1-debuginfo-pool-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1781,
+        "repository_id": 3309,
+        "parent_product_id": 1776,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Product-WE",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-WE/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-WE15-SP1-Debuginfo-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-15-ga-desktop-nvidia-driver-sp1",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1781,
+        "repository_id": 2747,
+        "parent_product_id": 1776,
+        "root_product_id": 1764,
+        "update_tag": null,
+        "url": "https://download.nvidia.com/suse/sle15/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-15-GA-Desktop-NVIDIA-Driver for x86_64 SP1"
+    },
+    {
+        "channel_label": "sle-product-we15-sp1-updates-x86_64-sled",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1781,
+        "repository_id": 3306,
+        "parent_product_id": 1776,
+        "root_product_id": 1764,
+        "update_tag": "SLE-Product-WE",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-WE/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Product-WE15-SP1-Updates for x86_64 SLED"
+    },
+    {
+        "channel_label": "sle-product-we15-sp1-debuginfo-updates-x86_64-sled",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1781,
+        "repository_id": 3307,
+        "parent_product_id": 1776,
+        "root_product_id": 1764,
+        "update_tag": "SLE-Product-WE",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-WE/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Product-WE15-SP1-Debuginfo-Updates for x86_64 SLED"
+    },
+    {
+        "channel_label": "sle-product-we15-sp1-pool-x86_64-sled",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1781,
+        "repository_id": 3308,
+        "parent_product_id": 1776,
+        "root_product_id": 1764,
+        "update_tag": "SLE-Product-WE",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-WE/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Product-WE15-SP1-Pool for x86_64 SLED"
+    },
+    {
+        "channel_label": "sle-product-we15-sp1-debuginfo-pool-x86_64-sled",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1781,
+        "repository_id": 3309,
+        "parent_product_id": 1776,
+        "root_product_id": 1764,
+        "update_tag": "SLE-Product-WE",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-WE/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Product-WE15-SP1-Debuginfo-Pool for x86_64 SLED"
+    },
+    {
+        "channel_label": "sle-15-ga-desktop-nvidia-driver-sap-sp1",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1781,
+        "repository_id": 2747,
+        "parent_product_id": 1776,
+        "root_product_id": 1766,
+        "update_tag": null,
+        "url": "https://download.nvidia.com/suse/sle15/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-15-GA-Desktop-NVIDIA-Driver for x86_64 SAP SP1"
+    },
+    {
+        "channel_label": "sle-product-we15-sp1-updates-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1781,
+        "repository_id": 3306,
+        "parent_product_id": 1776,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Product-WE",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-WE/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-WE15-SP1-Updates for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-product-we15-sp1-debuginfo-updates-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1781,
+        "repository_id": 3307,
+        "parent_product_id": 1776,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Product-WE",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-WE/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-WE15-SP1-Debuginfo-Updates for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-product-we15-sp1-pool-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1781,
+        "repository_id": 3308,
+        "parent_product_id": 1776,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Product-WE",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-WE/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-WE15-SP1-Pool for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-product-we15-sp1-debuginfo-pool-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1781,
+        "repository_id": 3309,
+        "parent_product_id": 1776,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Product-WE",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-WE/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-WE15-SP1-Debuginfo-Pool for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-product-ha15-sp1-updates-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1782,
+        "repository_id": 3311,
+        "parent_product_id": 1769,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Product-HA",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-HA/15-SP1/aarch64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-HA15-SP1-Updates for aarch64"
+    },
+    {
+        "channel_label": "sle-product-ha15-sp1-debuginfo-updates-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1782,
+        "repository_id": 3312,
+        "parent_product_id": 1769,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Product-HA",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-HA/15-SP1/aarch64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-HA15-SP1-Debuginfo-Updates for aarch64"
+    },
+    {
+        "channel_label": "sle-product-ha15-sp1-pool-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1782,
+        "repository_id": 3313,
+        "parent_product_id": 1769,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Product-HA",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-HA/15-SP1/aarch64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-HA15-SP1-Pool for aarch64"
+    },
+    {
+        "channel_label": "sle-product-ha15-sp1-debuginfo-pool-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1782,
+        "repository_id": 3314,
+        "parent_product_id": 1769,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Product-HA",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-HA/15-SP1/aarch64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-HA15-SP1-Debuginfo-Pool for aarch64"
+    },
+    {
+        "channel_label": "sle-product-ha15-sp1-updates-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1782,
+        "repository_id": 3311,
+        "parent_product_id": 1769,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Product-HA",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-HA/15-SP1/aarch64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-HA15-SP1-Updates for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-product-ha15-sp1-debuginfo-updates-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1782,
+        "repository_id": 3312,
+        "parent_product_id": 1769,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Product-HA",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-HA/15-SP1/aarch64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-HA15-SP1-Debuginfo-Updates for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-product-ha15-sp1-pool-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1782,
+        "repository_id": 3313,
+        "parent_product_id": 1769,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Product-HA",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-HA/15-SP1/aarch64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-HA15-SP1-Pool for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-product-ha15-sp1-debuginfo-pool-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1782,
+        "repository_id": 3314,
+        "parent_product_id": 1769,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Product-HA",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-HA/15-SP1/aarch64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-HA15-SP1-Debuginfo-Pool for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-product-ha15-sp1-updates-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1783,
+        "repository_id": 3316,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Product-HA",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-HA/15-SP1/ppc64le/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-HA15-SP1-Updates for ppc64le"
+    },
+    {
+        "channel_label": "sle-product-ha15-sp1-debuginfo-updates-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1783,
+        "repository_id": 3317,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Product-HA",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-HA/15-SP1/ppc64le/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-HA15-SP1-Debuginfo-Updates for ppc64le"
+    },
+    {
+        "channel_label": "sle-product-ha15-sp1-pool-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1783,
+        "repository_id": 3318,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Product-HA",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-HA/15-SP1/ppc64le/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-HA15-SP1-Pool for ppc64le"
+    },
+    {
+        "channel_label": "sle-product-ha15-sp1-debuginfo-pool-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1783,
+        "repository_id": 3319,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Product-HA",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-HA/15-SP1/ppc64le/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-HA15-SP1-Debuginfo-Pool for ppc64le"
+    },
+    {
+        "channel_label": "sle-product-ha15-sp1-updates-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1783,
+        "repository_id": 3316,
+        "parent_product_id": 1770,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Product-HA",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-HA/15-SP1/ppc64le/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Product-HA15-SP1-Updates for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-product-ha15-sp1-debuginfo-updates-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1783,
+        "repository_id": 3317,
+        "parent_product_id": 1770,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Product-HA",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-HA/15-SP1/ppc64le/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Product-HA15-SP1-Debuginfo-Updates for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-product-ha15-sp1-pool-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1783,
+        "repository_id": 3318,
+        "parent_product_id": 1770,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Product-HA",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-HA/15-SP1/ppc64le/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Product-HA15-SP1-Pool for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-product-ha15-sp1-debuginfo-pool-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1783,
+        "repository_id": 3319,
+        "parent_product_id": 1770,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Product-HA",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-HA/15-SP1/ppc64le/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Product-HA15-SP1-Debuginfo-Pool for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-product-ha15-sp1-updates-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1784,
+        "repository_id": 3321,
+        "parent_product_id": 1771,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Product-HA",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-HA/15-SP1/s390x/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-HA15-SP1-Updates for s390x"
+    },
+    {
+        "channel_label": "sle-product-ha15-sp1-debuginfo-updates-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1784,
+        "repository_id": 3322,
+        "parent_product_id": 1771,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Product-HA",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-HA/15-SP1/s390x/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-HA15-SP1-Debuginfo-Updates for s390x"
+    },
+    {
+        "channel_label": "sle-product-ha15-sp1-pool-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1784,
+        "repository_id": 3323,
+        "parent_product_id": 1771,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Product-HA",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-HA/15-SP1/s390x/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-HA15-SP1-Pool for s390x"
+    },
+    {
+        "channel_label": "sle-product-ha15-sp1-debuginfo-pool-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1784,
+        "repository_id": 3324,
+        "parent_product_id": 1771,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Product-HA",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-HA/15-SP1/s390x/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-HA15-SP1-Debuginfo-Pool for s390x"
+    },
+    {
+        "channel_label": "sle-product-ha15-sp1-updates-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1785,
+        "repository_id": 3326,
+        "parent_product_id": 1780,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Product-HA",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-HA/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-HA15-SP1-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-product-ha15-sp1-debuginfo-updates-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1785,
+        "repository_id": 3327,
+        "parent_product_id": 1780,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Product-HA",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-HA/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-HA15-SP1-Debuginfo-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-product-ha15-sp1-pool-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1785,
+        "repository_id": 3328,
+        "parent_product_id": 1780,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Product-HA",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-HA/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-HA15-SP1-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-product-ha15-sp1-debuginfo-pool-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1785,
+        "repository_id": 3329,
+        "parent_product_id": 1780,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Product-HA",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-HA/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-HA15-SP1-Debuginfo-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-product-ha15-sp1-updates-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1785,
+        "repository_id": 3326,
+        "parent_product_id": 1780,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Product-HA",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-HA/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Product-HA15-SP1-Updates for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-product-ha15-sp1-debuginfo-updates-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1785,
+        "repository_id": 3327,
+        "parent_product_id": 1780,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Product-HA",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-HA/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Product-HA15-SP1-Debuginfo-Updates for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-product-ha15-sp1-pool-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1785,
+        "repository_id": 3328,
+        "parent_product_id": 1780,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Product-HA",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-HA/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Product-HA15-SP1-Pool for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-product-ha15-sp1-debuginfo-pool-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1785,
+        "repository_id": 3329,
+        "parent_product_id": 1780,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Product-HA",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-HA/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Product-HA15-SP1-Debuginfo-Pool for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-product-ha15-sp1-updates-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1785,
+        "repository_id": 3326,
+        "parent_product_id": 1780,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Product-HA",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-HA/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-HA15-SP1-Updates for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-product-ha15-sp1-debuginfo-updates-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1785,
+        "repository_id": 3327,
+        "parent_product_id": 1780,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Product-HA",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-HA/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-HA15-SP1-Debuginfo-Updates for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-product-ha15-sp1-pool-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1785,
+        "repository_id": 3328,
+        "parent_product_id": 1780,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Product-HA",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-HA/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-HA15-SP1-Pool for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-product-ha15-sp1-debuginfo-pool-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1785,
+        "repository_id": 3329,
+        "parent_product_id": 1780,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Product-HA",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-HA/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-HA15-SP1-Debuginfo-Pool for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-product-ha15-sp1-updates-x86_64-rt-sp1",
+        "parent_channel_label": "sle-product-rt-15-sp1-pool-x86_64",
+        "product_id": 1785,
+        "repository_id": 3326,
+        "parent_product_id": 1780,
+        "root_product_id": 1861,
+        "update_tag": "SLE-Product-HA",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-HA/15-SP1/x86_64/update/",
+        "release_stage": "alpha",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-HA15-SP1-Updates for x86_64 RT-SP1"
+    },
+    {
+        "channel_label": "sle-product-ha15-sp1-debuginfo-updates-x86_64-rt-sp1",
+        "parent_channel_label": "sle-product-rt-15-sp1-pool-x86_64",
+        "product_id": 1785,
+        "repository_id": 3327,
+        "parent_product_id": 1780,
+        "root_product_id": 1861,
+        "update_tag": "SLE-Product-HA",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-HA/15-SP1/x86_64/update_debug/",
+        "release_stage": "alpha",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-HA15-SP1-Debuginfo-Updates for x86_64 RT-SP1"
+    },
+    {
+        "channel_label": "sle-product-ha15-sp1-pool-x86_64-rt-sp1",
+        "parent_channel_label": "sle-product-rt-15-sp1-pool-x86_64",
+        "product_id": 1785,
+        "repository_id": 3328,
+        "parent_product_id": 1780,
+        "root_product_id": 1861,
+        "update_tag": "SLE-Product-HA",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-HA/15-SP1/x86_64/product/",
+        "release_stage": "alpha",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-HA15-SP1-Pool for x86_64 RT-SP1"
+    },
+    {
+        "channel_label": "sle-product-ha15-sp1-debuginfo-pool-x86_64-rt-sp1",
+        "parent_channel_label": "sle-product-rt-15-sp1-pool-x86_64",
+        "product_id": 1785,
+        "repository_id": 3329,
+        "parent_product_id": 1780,
+        "root_product_id": 1861,
+        "update_tag": "SLE-Product-HA",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-HA/15-SP1/x86_64/product_debug/",
+        "release_stage": "alpha",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-HA15-SP1-Debuginfo-Pool for x86_64 RT-SP1"
+    },
+    {
+        "channel_label": "sle-module-sap-applications15-sp1-updates-ppc64le",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1786,
+        "repository_id": 3331,
+        "parent_product_id": 1783,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-SAP-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-SAP-Applications/15-SP1/ppc64le/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-SAP-Applications15-SP1-Updates for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-sap-applications15-sp1-debuginfo-updates-ppc64le",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1786,
+        "repository_id": 3332,
+        "parent_product_id": 1783,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-SAP-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-SAP-Applications/15-SP1/ppc64le/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-SAP-Applications15-SP1-Debuginfo-Updates for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-sap-applications15-sp1-pool-ppc64le",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1786,
+        "repository_id": 3333,
+        "parent_product_id": 1783,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-SAP-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-SAP-Applications/15-SP1/ppc64le/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-SAP-Applications15-SP1-Pool for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-sap-applications15-sp1-debuginfo-pool-ppc64le",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1786,
+        "repository_id": 3334,
+        "parent_product_id": 1783,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-SAP-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-SAP-Applications/15-SP1/ppc64le/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-SAP-Applications15-SP1-Debuginfo-Pool for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-sap-applications15-sp1-updates-x86_64",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1787,
+        "repository_id": 3336,
+        "parent_product_id": 1785,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-SAP-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-SAP-Applications/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-SAP-Applications15-SP1-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-module-sap-applications15-sp1-debuginfo-updates-x86_64",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1787,
+        "repository_id": 3337,
+        "parent_product_id": 1785,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-SAP-Applications",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-SAP-Applications/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-SAP-Applications15-SP1-Debuginfo-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-module-sap-applications15-sp1-pool-x86_64",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1787,
+        "repository_id": 3338,
+        "parent_product_id": 1785,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-SAP-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-SAP-Applications/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-SAP-Applications15-SP1-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-module-sap-applications15-sp1-debuginfo-pool-x86_64",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1787,
+        "repository_id": 3339,
+        "parent_product_id": 1785,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-SAP-Applications",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-SAP-Applications/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-SAP-Applications15-SP1-Debuginfo-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-module-containers15-sp1-updates-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1788,
+        "repository_id": 3341,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Containers",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Containers/15-SP1/ppc64le/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Containers15-SP1-Updates for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-containers15-sp1-debuginfo-updates-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1788,
+        "repository_id": 3342,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Containers",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Containers/15-SP1/ppc64le/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Containers15-SP1-Debuginfo-Updates for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-containers15-sp1-pool-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1788,
+        "repository_id": 3343,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Containers",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Containers/15-SP1/ppc64le/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Containers15-SP1-Pool for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-containers15-sp1-debuginfo-pool-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1788,
+        "repository_id": 3344,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Containers",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Containers/15-SP1/ppc64le/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Containers15-SP1-Debuginfo-Pool for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-containers15-sp1-updates-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1788,
+        "repository_id": 3341,
+        "parent_product_id": 1770,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Containers",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Containers/15-SP1/ppc64le/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Containers15-SP1-Updates for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-containers15-sp1-debuginfo-updates-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1788,
+        "repository_id": 3342,
+        "parent_product_id": 1770,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Containers",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Containers/15-SP1/ppc64le/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Containers15-SP1-Debuginfo-Updates for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-containers15-sp1-pool-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1788,
+        "repository_id": 3343,
+        "parent_product_id": 1770,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Containers",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Containers/15-SP1/ppc64le/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Containers15-SP1-Pool for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-containers15-sp1-debuginfo-pool-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1788,
+        "repository_id": 3344,
+        "parent_product_id": 1770,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Containers",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Containers/15-SP1/ppc64le/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Containers15-SP1-Debuginfo-Pool for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-containers15-sp1-updates-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1789,
+        "repository_id": 3346,
+        "parent_product_id": 1771,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Containers",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Containers/15-SP1/s390x/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Containers15-SP1-Updates for s390x"
+    },
+    {
+        "channel_label": "sle-module-containers15-sp1-debuginfo-updates-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1789,
+        "repository_id": 3347,
+        "parent_product_id": 1771,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Containers",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Containers/15-SP1/s390x/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Containers15-SP1-Debuginfo-Updates for s390x"
+    },
+    {
+        "channel_label": "sle-module-containers15-sp1-pool-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1789,
+        "repository_id": 3348,
+        "parent_product_id": 1771,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Containers",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Containers/15-SP1/s390x/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Containers15-SP1-Pool for s390x"
+    },
+    {
+        "channel_label": "sle-module-containers15-sp1-debuginfo-pool-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1789,
+        "repository_id": 3349,
+        "parent_product_id": 1771,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Containers",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Containers/15-SP1/s390x/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Containers15-SP1-Debuginfo-Pool for s390x"
+    },
+    {
+        "channel_label": "sle-module-containers15-sp1-updates-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1790,
+        "repository_id": 3351,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Containers",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Containers/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Containers15-SP1-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-module-containers15-sp1-debuginfo-updates-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1790,
+        "repository_id": 3352,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Containers",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Containers/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Containers15-SP1-Debuginfo-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-module-containers15-sp1-pool-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1790,
+        "repository_id": 3353,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Containers",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Containers/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Containers15-SP1-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-module-containers15-sp1-debuginfo-pool-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1790,
+        "repository_id": 3354,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Containers",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Containers/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Containers15-SP1-Debuginfo-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-module-containers15-sp1-updates-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1790,
+        "repository_id": 3351,
+        "parent_product_id": 1772,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Containers",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Containers/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Containers15-SP1-Updates for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-containers15-sp1-debuginfo-updates-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1790,
+        "repository_id": 3352,
+        "parent_product_id": 1772,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Containers",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Containers/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Containers15-SP1-Debuginfo-Updates for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-containers15-sp1-pool-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1790,
+        "repository_id": 3353,
+        "parent_product_id": 1772,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Containers",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Containers/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Containers15-SP1-Pool for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-containers15-sp1-debuginfo-pool-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1790,
+        "repository_id": 3354,
+        "parent_product_id": 1772,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Containers",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Containers/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Containers15-SP1-Debuginfo-Pool for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-containers15-sp1-updates-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1790,
+        "repository_id": 3351,
+        "parent_product_id": 1772,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Containers",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Containers/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Containers15-SP1-Updates for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-containers15-sp1-debuginfo-updates-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1790,
+        "repository_id": 3352,
+        "parent_product_id": 1772,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Containers",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Containers/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Containers15-SP1-Debuginfo-Updates for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-containers15-sp1-pool-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1790,
+        "repository_id": 3353,
+        "parent_product_id": 1772,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Containers",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Containers/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Containers15-SP1-Pool for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-containers15-sp1-debuginfo-pool-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1790,
+        "repository_id": 3354,
+        "parent_product_id": 1772,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Containers",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Containers/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Containers15-SP1-Debuginfo-Pool for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-updates-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1791,
+        "repository_id": 3356,
+        "parent_product_id": 1773,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Development-Tools/15-SP1/aarch64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-DevTools15-SP1-Updates for aarch64"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-debuginfo-updates-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1791,
+        "repository_id": 3357,
+        "parent_product_id": 1773,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Development-Tools/15-SP1/aarch64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-DevTools15-SP1-Debuginfo-Updates for aarch64"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-pool-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1791,
+        "repository_id": 3358,
+        "parent_product_id": 1773,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Development-Tools/15-SP1/aarch64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-DevTools15-SP1-Pool for aarch64"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-debuginfo-pool-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1791,
+        "repository_id": 3359,
+        "parent_product_id": 1773,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Development-Tools/15-SP1/aarch64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-DevTools15-SP1-Debuginfo-Pool for aarch64"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-updates-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1791,
+        "repository_id": 3356,
+        "parent_product_id": 1773,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Development-Tools/15-SP1/aarch64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-DevTools15-SP1-Updates for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-debuginfo-updates-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1791,
+        "repository_id": 3357,
+        "parent_product_id": 1773,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Development-Tools/15-SP1/aarch64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-DevTools15-SP1-Debuginfo-Updates for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-pool-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1791,
+        "repository_id": 3358,
+        "parent_product_id": 1773,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Development-Tools/15-SP1/aarch64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-DevTools15-SP1-Pool for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-debuginfo-pool-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1791,
+        "repository_id": 3359,
+        "parent_product_id": 1773,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Development-Tools/15-SP1/aarch64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-DevTools15-SP1-Debuginfo-Pool for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-updates-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1792,
+        "repository_id": 3361,
+        "parent_product_id": 1774,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Development-Tools/15-SP1/ppc64le/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-DevTools15-SP1-Updates for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-debuginfo-updates-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1792,
+        "repository_id": 3362,
+        "parent_product_id": 1774,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Development-Tools/15-SP1/ppc64le/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-DevTools15-SP1-Debuginfo-Updates for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-pool-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1792,
+        "repository_id": 3363,
+        "parent_product_id": 1774,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Development-Tools/15-SP1/ppc64le/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-DevTools15-SP1-Pool for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-debuginfo-pool-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1792,
+        "repository_id": 3364,
+        "parent_product_id": 1774,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Development-Tools/15-SP1/ppc64le/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-DevTools15-SP1-Debuginfo-Pool for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-updates-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1792,
+        "repository_id": 3361,
+        "parent_product_id": 1774,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Development-Tools/15-SP1/ppc64le/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-DevTools15-SP1-Updates for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-debuginfo-updates-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1792,
+        "repository_id": 3362,
+        "parent_product_id": 1774,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Development-Tools/15-SP1/ppc64le/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-DevTools15-SP1-Debuginfo-Updates for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-pool-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1792,
+        "repository_id": 3363,
+        "parent_product_id": 1774,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Development-Tools/15-SP1/ppc64le/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-DevTools15-SP1-Pool for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-debuginfo-pool-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1792,
+        "repository_id": 3364,
+        "parent_product_id": 1774,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Development-Tools/15-SP1/ppc64le/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-DevTools15-SP1-Debuginfo-Pool for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-updates-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1793,
+        "repository_id": 3366,
+        "parent_product_id": 1775,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Development-Tools/15-SP1/s390x/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-DevTools15-SP1-Updates for s390x"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-debuginfo-updates-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1793,
+        "repository_id": 3367,
+        "parent_product_id": 1775,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Development-Tools/15-SP1/s390x/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-DevTools15-SP1-Debuginfo-Updates for s390x"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-pool-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1793,
+        "repository_id": 3368,
+        "parent_product_id": 1775,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Development-Tools/15-SP1/s390x/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-DevTools15-SP1-Pool for s390x"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-debuginfo-pool-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1793,
+        "repository_id": 3369,
+        "parent_product_id": 1775,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Development-Tools/15-SP1/s390x/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-DevTools15-SP1-Debuginfo-Pool for s390x"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-updates-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1794,
+        "repository_id": 3371,
+        "parent_product_id": 1776,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Development-Tools/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-DevTools15-SP1-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-debuginfo-updates-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1794,
+        "repository_id": 3372,
+        "parent_product_id": 1776,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Development-Tools/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-DevTools15-SP1-Debuginfo-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-pool-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1794,
+        "repository_id": 3373,
+        "parent_product_id": 1776,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Development-Tools/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-DevTools15-SP1-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-debuginfo-pool-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1794,
+        "repository_id": 3374,
+        "parent_product_id": 1776,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Development-Tools/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-DevTools15-SP1-Debuginfo-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-updates-x86_64-sled",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1794,
+        "repository_id": 3371,
+        "parent_product_id": 1776,
+        "root_product_id": 1764,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Development-Tools/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-DevTools15-SP1-Updates for x86_64 SLED"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-debuginfo-updates-x86_64-sled",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1794,
+        "repository_id": 3372,
+        "parent_product_id": 1776,
+        "root_product_id": 1764,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Development-Tools/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-DevTools15-SP1-Debuginfo-Updates for x86_64 SLED"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-pool-x86_64-sled",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1794,
+        "repository_id": 3373,
+        "parent_product_id": 1776,
+        "root_product_id": 1764,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Development-Tools/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-DevTools15-SP1-Pool for x86_64 SLED"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-debuginfo-pool-x86_64-sled",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1794,
+        "repository_id": 3374,
+        "parent_product_id": 1776,
+        "root_product_id": 1764,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Development-Tools/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-DevTools15-SP1-Debuginfo-Pool for x86_64 SLED"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-updates-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1794,
+        "repository_id": 3371,
+        "parent_product_id": 1776,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Development-Tools/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-DevTools15-SP1-Updates for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-debuginfo-updates-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1794,
+        "repository_id": 3372,
+        "parent_product_id": 1776,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Development-Tools/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-DevTools15-SP1-Debuginfo-Updates for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-pool-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1794,
+        "repository_id": 3373,
+        "parent_product_id": 1776,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Development-Tools/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-DevTools15-SP1-Pool for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-debuginfo-pool-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1794,
+        "repository_id": 3374,
+        "parent_product_id": 1776,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Development-Tools/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-DevTools15-SP1-Debuginfo-Pool for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-updates-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1794,
+        "repository_id": 3371,
+        "parent_product_id": 1776,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Development-Tools/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-DevTools15-SP1-Updates for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-debuginfo-updates-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1794,
+        "repository_id": 3372,
+        "parent_product_id": 1776,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Development-Tools/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-DevTools15-SP1-Debuginfo-Updates for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-pool-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1794,
+        "repository_id": 3373,
+        "parent_product_id": 1776,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Development-Tools/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-DevTools15-SP1-Pool for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-debuginfo-pool-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1794,
+        "repository_id": 3374,
+        "parent_product_id": 1776,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Development-Tools/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-DevTools15-SP1-Debuginfo-Pool for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-updates-x86_64-rt",
+        "parent_channel_label": "sle-product-rt-15-sp1-pool-x86_64",
+        "product_id": 1794,
+        "repository_id": 3371,
+        "parent_product_id": 1776,
+        "root_product_id": 1861,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Development-Tools/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-DevTools15-SP1-Updates for x86_64 RT"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-debuginfo-updates-x86_64-rt",
+        "parent_channel_label": "sle-product-rt-15-sp1-pool-x86_64",
+        "product_id": 1794,
+        "repository_id": 3372,
+        "parent_product_id": 1776,
+        "root_product_id": 1861,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Development-Tools/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-DevTools15-SP1-Debuginfo-Updates for x86_64 RT"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-pool-x86_64-rt",
+        "parent_channel_label": "sle-product-rt-15-sp1-pool-x86_64",
+        "product_id": 1794,
+        "repository_id": 3373,
+        "parent_product_id": 1776,
+        "root_product_id": 1861,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Development-Tools/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-DevTools15-SP1-Pool for x86_64 RT"
+    },
+    {
+        "channel_label": "sle-module-devtools15-sp1-debuginfo-pool-x86_64-rt",
+        "parent_channel_label": "sle-product-rt-15-sp1-pool-x86_64",
+        "product_id": 1794,
+        "repository_id": 3374,
+        "parent_product_id": 1776,
+        "root_product_id": 1861,
+        "update_tag": "SLE-Module-Development-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Development-Tools/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-DevTools15-SP1-Debuginfo-Pool for x86_64 RT"
+    },
+    {
+        "channel_label": "sle-module-web-scripting15-sp1-updates-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1795,
+        "repository_id": 3376,
+        "parent_product_id": 1777,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/15-SP1/aarch64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Web-Scripting15-SP1-Updates for aarch64"
+    },
+    {
+        "channel_label": "sle-module-web-scripting15-sp1-debuginfo-updates-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1795,
+        "repository_id": 3377,
+        "parent_product_id": 1777,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/15-SP1/aarch64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Web-Scripting15-SP1-Debuginfo-Updates for aarch64"
+    },
+    {
+        "channel_label": "sle-module-web-scripting15-sp1-pool-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1795,
+        "repository_id": 3378,
+        "parent_product_id": 1777,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/15-SP1/aarch64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Web-Scripting15-SP1-Pool for aarch64"
+    },
+    {
+        "channel_label": "sle-module-web-scripting15-sp1-debuginfo-pool-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1795,
+        "repository_id": 3379,
+        "parent_product_id": 1777,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/15-SP1/aarch64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Web-Scripting15-SP1-Debuginfo-Pool for aarch64"
+    },
+    {
+        "channel_label": "sle-module-web-scripting15-sp1-updates-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1795,
+        "repository_id": 3376,
+        "parent_product_id": 1777,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/15-SP1/aarch64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Web-Scripting15-SP1-Updates for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-module-web-scripting15-sp1-debuginfo-updates-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1795,
+        "repository_id": 3377,
+        "parent_product_id": 1777,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/15-SP1/aarch64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Web-Scripting15-SP1-Debuginfo-Updates for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-module-web-scripting15-sp1-pool-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1795,
+        "repository_id": 3378,
+        "parent_product_id": 1777,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/15-SP1/aarch64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Web-Scripting15-SP1-Pool for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-module-web-scripting15-sp1-debuginfo-pool-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1795,
+        "repository_id": 3379,
+        "parent_product_id": 1777,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/15-SP1/aarch64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Web-Scripting15-SP1-Debuginfo-Pool for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-module-web-scripting15-sp1-updates-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1796,
+        "repository_id": 3381,
+        "parent_product_id": 1778,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/15-SP1/ppc64le/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Web-Scripting15-SP1-Updates for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-web-scripting15-sp1-debuginfo-updates-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1796,
+        "repository_id": 3382,
+        "parent_product_id": 1778,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/15-SP1/ppc64le/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Web-Scripting15-SP1-Debuginfo-Updates for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-web-scripting15-sp1-pool-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1796,
+        "repository_id": 3383,
+        "parent_product_id": 1778,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/15-SP1/ppc64le/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Web-Scripting15-SP1-Pool for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-web-scripting15-sp1-debuginfo-pool-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1796,
+        "repository_id": 3384,
+        "parent_product_id": 1778,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/15-SP1/ppc64le/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Web-Scripting15-SP1-Debuginfo-Pool for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-web-scripting15-sp1-updates-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1796,
+        "repository_id": 3381,
+        "parent_product_id": 1778,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/15-SP1/ppc64le/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Web-Scripting15-SP1-Updates for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-web-scripting15-sp1-debuginfo-updates-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1796,
+        "repository_id": 3382,
+        "parent_product_id": 1778,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/15-SP1/ppc64le/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Web-Scripting15-SP1-Debuginfo-Updates for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-web-scripting15-sp1-pool-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1796,
+        "repository_id": 3383,
+        "parent_product_id": 1778,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/15-SP1/ppc64le/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Web-Scripting15-SP1-Pool for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-web-scripting15-sp1-debuginfo-pool-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1796,
+        "repository_id": 3384,
+        "parent_product_id": 1778,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/15-SP1/ppc64le/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Web-Scripting15-SP1-Debuginfo-Pool for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-web-scripting15-sp1-updates-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1797,
+        "repository_id": 3386,
+        "parent_product_id": 1779,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/15-SP1/s390x/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Web-Scripting15-SP1-Updates for s390x"
+    },
+    {
+        "channel_label": "sle-module-web-scripting15-sp1-debuginfo-updates-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1797,
+        "repository_id": 3387,
+        "parent_product_id": 1779,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/15-SP1/s390x/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Web-Scripting15-SP1-Debuginfo-Updates for s390x"
+    },
+    {
+        "channel_label": "sle-module-web-scripting15-sp1-pool-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1797,
+        "repository_id": 3388,
+        "parent_product_id": 1779,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/15-SP1/s390x/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Web-Scripting15-SP1-Pool for s390x"
+    },
+    {
+        "channel_label": "sle-module-web-scripting15-sp1-debuginfo-pool-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1797,
+        "repository_id": 3389,
+        "parent_product_id": 1779,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/15-SP1/s390x/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Web-Scripting15-SP1-Debuginfo-Pool for s390x"
+    },
+    {
+        "channel_label": "sle-module-web-scripting15-sp1-updates-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1798,
+        "repository_id": 3391,
+        "parent_product_id": 1780,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Web-Scripting15-SP1-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-module-web-scripting15-sp1-debuginfo-updates-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1798,
+        "repository_id": 3392,
+        "parent_product_id": 1780,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Web-Scripting15-SP1-Debuginfo-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-module-web-scripting15-sp1-pool-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1798,
+        "repository_id": 3393,
+        "parent_product_id": 1780,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Web-Scripting15-SP1-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-module-web-scripting15-sp1-debuginfo-pool-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1798,
+        "repository_id": 3394,
+        "parent_product_id": 1780,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Web-Scripting15-SP1-Debuginfo-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-module-web-scripting15-sp1-updates-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1798,
+        "repository_id": 3391,
+        "parent_product_id": 1780,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Web-Scripting15-SP1-Updates for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-web-scripting15-sp1-debuginfo-updates-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1798,
+        "repository_id": 3392,
+        "parent_product_id": 1780,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Web-Scripting15-SP1-Debuginfo-Updates for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-web-scripting15-sp1-pool-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1798,
+        "repository_id": 3393,
+        "parent_product_id": 1780,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Web-Scripting15-SP1-Pool for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-web-scripting15-sp1-debuginfo-pool-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1798,
+        "repository_id": 3394,
+        "parent_product_id": 1780,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Web-Scripting15-SP1-Debuginfo-Pool for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-web-scripting15-sp1-updates-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1798,
+        "repository_id": 3391,
+        "parent_product_id": 1780,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Web-Scripting15-SP1-Updates for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-web-scripting15-sp1-debuginfo-updates-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1798,
+        "repository_id": 3392,
+        "parent_product_id": 1780,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Web-Scripting15-SP1-Debuginfo-Updates for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-web-scripting15-sp1-pool-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1798,
+        "repository_id": 3393,
+        "parent_product_id": 1780,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Web-Scripting15-SP1-Pool for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-web-scripting15-sp1-debuginfo-pool-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1798,
+        "repository_id": 3394,
+        "parent_product_id": 1780,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Web-Scripting",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Web-Scripting15-SP1-Debuginfo-Pool for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-hpc15-sp1-updates-aarch64",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1799,
+        "repository_id": 3396,
+        "parent_product_id": 1795,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-HPC",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-HPC/15-SP1/aarch64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-HPC15-SP1-Updates for aarch64"
+    },
+    {
+        "channel_label": "sle-module-hpc15-sp1-debuginfo-updates-aarch64",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1799,
+        "repository_id": 3397,
+        "parent_product_id": 1795,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-HPC",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-HPC/15-SP1/aarch64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-HPC15-SP1-Debuginfo-Updates for aarch64"
+    },
+    {
+        "channel_label": "sle-module-hpc15-sp1-pool-aarch64",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1799,
+        "repository_id": 3398,
+        "parent_product_id": 1795,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-HPC",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-HPC/15-SP1/aarch64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-HPC15-SP1-Pool for aarch64"
+    },
+    {
+        "channel_label": "sle-module-hpc15-sp1-debuginfo-pool-aarch64",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1799,
+        "repository_id": 3399,
+        "parent_product_id": 1795,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-HPC",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-HPC/15-SP1/aarch64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-HPC15-SP1-Debuginfo-Pool for aarch64"
+    },
+    {
+        "channel_label": "sle-module-hpc15-sp1-updates-x86_64",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1800,
+        "repository_id": 3401,
+        "parent_product_id": 1798,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-HPC",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-HPC/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-HPC15-SP1-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-module-hpc15-sp1-debuginfo-updates-x86_64",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1800,
+        "repository_id": 3402,
+        "parent_product_id": 1798,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-HPC",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-HPC/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-HPC15-SP1-Debuginfo-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-module-hpc15-sp1-pool-x86_64",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1800,
+        "repository_id": 3403,
+        "parent_product_id": 1798,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-HPC",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-HPC/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-HPC15-SP1-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-module-hpc15-sp1-debuginfo-pool-x86_64",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1800,
+        "repository_id": 3404,
+        "parent_product_id": 1798,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-HPC",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-HPC/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-HPC15-SP1-Debuginfo-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-module-legacy15-sp1-updates-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1801,
+        "repository_id": 3406,
+        "parent_product_id": 1777,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Legacy",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/15-SP1/aarch64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Legacy15-SP1-Updates for aarch64"
+    },
+    {
+        "channel_label": "sle-module-legacy15-sp1-debuginfo-updates-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1801,
+        "repository_id": 3407,
+        "parent_product_id": 1777,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Legacy",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/15-SP1/aarch64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Legacy15-SP1-Debuginfo-Updates for aarch64"
+    },
+    {
+        "channel_label": "sle-module-legacy15-sp1-pool-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1801,
+        "repository_id": 3408,
+        "parent_product_id": 1777,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Legacy",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/15-SP1/aarch64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Legacy15-SP1-Pool for aarch64"
+    },
+    {
+        "channel_label": "sle-module-legacy15-sp1-debuginfo-pool-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1801,
+        "repository_id": 3409,
+        "parent_product_id": 1777,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Legacy",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/15-SP1/aarch64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Legacy15-SP1-Debuginfo-Pool for aarch64"
+    },
+    {
+        "channel_label": "sle-module-legacy15-sp1-updates-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1801,
+        "repository_id": 3406,
+        "parent_product_id": 1777,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-Legacy",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/15-SP1/aarch64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Legacy15-SP1-Updates for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-module-legacy15-sp1-debuginfo-updates-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1801,
+        "repository_id": 3407,
+        "parent_product_id": 1777,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-Legacy",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/15-SP1/aarch64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Legacy15-SP1-Debuginfo-Updates for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-module-legacy15-sp1-pool-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1801,
+        "repository_id": 3408,
+        "parent_product_id": 1777,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-Legacy",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/15-SP1/aarch64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Legacy15-SP1-Pool for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-module-legacy15-sp1-debuginfo-pool-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1801,
+        "repository_id": 3409,
+        "parent_product_id": 1777,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-Legacy",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/15-SP1/aarch64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Legacy15-SP1-Debuginfo-Pool for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-module-legacy15-sp1-updates-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1802,
+        "repository_id": 3411,
+        "parent_product_id": 1778,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Legacy",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/15-SP1/ppc64le/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Legacy15-SP1-Updates for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-legacy15-sp1-debuginfo-updates-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1802,
+        "repository_id": 3412,
+        "parent_product_id": 1778,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Legacy",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/15-SP1/ppc64le/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Legacy15-SP1-Debuginfo-Updates for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-legacy15-sp1-pool-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1802,
+        "repository_id": 3413,
+        "parent_product_id": 1778,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Legacy",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/15-SP1/ppc64le/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Legacy15-SP1-Pool for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-legacy15-sp1-debuginfo-pool-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1802,
+        "repository_id": 3414,
+        "parent_product_id": 1778,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Legacy",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/15-SP1/ppc64le/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Legacy15-SP1-Debuginfo-Pool for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-legacy15-sp1-updates-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1802,
+        "repository_id": 3411,
+        "parent_product_id": 1778,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Legacy",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/15-SP1/ppc64le/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Legacy15-SP1-Updates for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-legacy15-sp1-debuginfo-updates-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1802,
+        "repository_id": 3412,
+        "parent_product_id": 1778,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Legacy",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/15-SP1/ppc64le/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Legacy15-SP1-Debuginfo-Updates for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-legacy15-sp1-pool-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1802,
+        "repository_id": 3413,
+        "parent_product_id": 1778,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Legacy",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/15-SP1/ppc64le/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Legacy15-SP1-Pool for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-legacy15-sp1-debuginfo-pool-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1802,
+        "repository_id": 3414,
+        "parent_product_id": 1778,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Legacy",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/15-SP1/ppc64le/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Legacy15-SP1-Debuginfo-Pool for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-legacy15-sp1-updates-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1803,
+        "repository_id": 3416,
+        "parent_product_id": 1779,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Legacy",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/15-SP1/s390x/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Legacy15-SP1-Updates for s390x"
+    },
+    {
+        "channel_label": "sle-module-legacy15-sp1-debuginfo-updates-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1803,
+        "repository_id": 3417,
+        "parent_product_id": 1779,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Legacy",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/15-SP1/s390x/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Legacy15-SP1-Debuginfo-Updates for s390x"
+    },
+    {
+        "channel_label": "sle-module-legacy15-sp1-pool-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1803,
+        "repository_id": 3418,
+        "parent_product_id": 1779,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Legacy",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/15-SP1/s390x/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Legacy15-SP1-Pool for s390x"
+    },
+    {
+        "channel_label": "sle-module-legacy15-sp1-debuginfo-pool-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1803,
+        "repository_id": 3419,
+        "parent_product_id": 1779,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Legacy",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/15-SP1/s390x/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Legacy15-SP1-Debuginfo-Pool for s390x"
+    },
+    {
+        "channel_label": "sle-module-legacy15-sp1-updates-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1804,
+        "repository_id": 3421,
+        "parent_product_id": 1780,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Legacy",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Legacy15-SP1-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-module-legacy15-sp1-debuginfo-updates-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1804,
+        "repository_id": 3422,
+        "parent_product_id": 1780,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Legacy",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Legacy15-SP1-Debuginfo-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-module-legacy15-sp1-pool-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1804,
+        "repository_id": 3423,
+        "parent_product_id": 1780,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Legacy",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Legacy15-SP1-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-module-legacy15-sp1-debuginfo-pool-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1804,
+        "repository_id": 3424,
+        "parent_product_id": 1780,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Legacy",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Legacy15-SP1-Debuginfo-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-module-legacy15-sp1-updates-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1804,
+        "repository_id": 3421,
+        "parent_product_id": 1780,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Legacy",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Legacy15-SP1-Updates for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-legacy15-sp1-debuginfo-updates-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1804,
+        "repository_id": 3422,
+        "parent_product_id": 1780,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Legacy",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Legacy15-SP1-Debuginfo-Updates for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-legacy15-sp1-pool-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1804,
+        "repository_id": 3423,
+        "parent_product_id": 1780,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Legacy",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Legacy15-SP1-Pool for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-legacy15-sp1-debuginfo-pool-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1804,
+        "repository_id": 3424,
+        "parent_product_id": 1780,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Legacy",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Legacy15-SP1-Debuginfo-Pool for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-legacy15-sp1-updates-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1804,
+        "repository_id": 3421,
+        "parent_product_id": 1780,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Legacy",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Legacy15-SP1-Updates for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-legacy15-sp1-debuginfo-updates-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1804,
+        "repository_id": 3422,
+        "parent_product_id": 1780,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Legacy",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Legacy15-SP1-Debuginfo-Updates for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-legacy15-sp1-pool-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1804,
+        "repository_id": 3423,
+        "parent_product_id": 1780,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Legacy",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Legacy15-SP1-Pool for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-legacy15-sp1-debuginfo-pool-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1804,
+        "repository_id": 3424,
+        "parent_product_id": 1780,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Legacy",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Legacy15-SP1-Debuginfo-Pool for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-public-cloud15-sp1-updates-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1805,
+        "repository_id": 3426,
+        "parent_product_id": 1777,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Public-Cloud",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/15-SP1/aarch64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Public-Cloud15-SP1-Updates for aarch64"
+    },
+    {
+        "channel_label": "sle-module-public-cloud15-sp1-debuginfo-updates-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1805,
+        "repository_id": 3427,
+        "parent_product_id": 1777,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Public-Cloud",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/15-SP1/aarch64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Public-Cloud15-SP1-Debuginfo-Updates for aarch64"
+    },
+    {
+        "channel_label": "sle-module-public-cloud15-sp1-pool-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1805,
+        "repository_id": 3428,
+        "parent_product_id": 1777,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Public-Cloud",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/15-SP1/aarch64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Public-Cloud15-SP1-Pool for aarch64"
+    },
+    {
+        "channel_label": "sle-module-public-cloud15-sp1-debuginfo-pool-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1805,
+        "repository_id": 3429,
+        "parent_product_id": 1777,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Public-Cloud",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/15-SP1/aarch64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Public-Cloud15-SP1-Debuginfo-Pool for aarch64"
+    },
+    {
+        "channel_label": "sle-module-public-cloud15-sp1-updates-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1805,
+        "repository_id": 3426,
+        "parent_product_id": 1777,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-Public-Cloud",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/15-SP1/aarch64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Public-Cloud15-SP1-Updates for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-module-public-cloud15-sp1-debuginfo-updates-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1805,
+        "repository_id": 3427,
+        "parent_product_id": 1777,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-Public-Cloud",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/15-SP1/aarch64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Public-Cloud15-SP1-Debuginfo-Updates for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-module-public-cloud15-sp1-pool-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1805,
+        "repository_id": 3428,
+        "parent_product_id": 1777,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-Public-Cloud",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/15-SP1/aarch64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Public-Cloud15-SP1-Pool for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-module-public-cloud15-sp1-debuginfo-pool-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1805,
+        "repository_id": 3429,
+        "parent_product_id": 1777,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-Public-Cloud",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/15-SP1/aarch64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Public-Cloud15-SP1-Debuginfo-Pool for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-module-public-cloud15-sp1-updates-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1806,
+        "repository_id": 3431,
+        "parent_product_id": 1778,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Public-Cloud",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/15-SP1/ppc64le/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Public-Cloud15-SP1-Updates for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-public-cloud15-sp1-debuginfo-updates-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1806,
+        "repository_id": 3432,
+        "parent_product_id": 1778,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Public-Cloud",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/15-SP1/ppc64le/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Public-Cloud15-SP1-Debuginfo-Updates for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-public-cloud15-sp1-pool-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1806,
+        "repository_id": 3433,
+        "parent_product_id": 1778,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Public-Cloud",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/15-SP1/ppc64le/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Public-Cloud15-SP1-Pool for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-public-cloud15-sp1-debuginfo-pool-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1806,
+        "repository_id": 3434,
+        "parent_product_id": 1778,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Public-Cloud",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/15-SP1/ppc64le/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Public-Cloud15-SP1-Debuginfo-Pool for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-public-cloud15-sp1-updates-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1806,
+        "repository_id": 3431,
+        "parent_product_id": 1778,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Public-Cloud",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/15-SP1/ppc64le/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Public-Cloud15-SP1-Updates for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-public-cloud15-sp1-debuginfo-updates-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1806,
+        "repository_id": 3432,
+        "parent_product_id": 1778,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Public-Cloud",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/15-SP1/ppc64le/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Public-Cloud15-SP1-Debuginfo-Updates for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-public-cloud15-sp1-pool-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1806,
+        "repository_id": 3433,
+        "parent_product_id": 1778,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Public-Cloud",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/15-SP1/ppc64le/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Public-Cloud15-SP1-Pool for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-public-cloud15-sp1-debuginfo-pool-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1806,
+        "repository_id": 3434,
+        "parent_product_id": 1778,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Public-Cloud",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/15-SP1/ppc64le/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Public-Cloud15-SP1-Debuginfo-Pool for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-public-cloud15-sp1-updates-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1807,
+        "repository_id": 3436,
+        "parent_product_id": 1779,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Public-Cloud",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/15-SP1/s390x/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Public-Cloud15-SP1-Updates for s390x"
+    },
+    {
+        "channel_label": "sle-module-public-cloud15-sp1-debuginfo-updates-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1807,
+        "repository_id": 3437,
+        "parent_product_id": 1779,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Public-Cloud",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/15-SP1/s390x/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Public-Cloud15-SP1-Debuginfo-Updates for s390x"
+    },
+    {
+        "channel_label": "sle-module-public-cloud15-sp1-pool-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1807,
+        "repository_id": 3438,
+        "parent_product_id": 1779,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Public-Cloud",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/15-SP1/s390x/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Public-Cloud15-SP1-Pool for s390x"
+    },
+    {
+        "channel_label": "sle-module-public-cloud15-sp1-debuginfo-pool-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1807,
+        "repository_id": 3439,
+        "parent_product_id": 1779,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Public-Cloud",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/15-SP1/s390x/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Public-Cloud15-SP1-Debuginfo-Pool for s390x"
+    },
+    {
+        "channel_label": "sle-module-public-cloud15-sp1-updates-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1808,
+        "repository_id": 3441,
+        "parent_product_id": 1780,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Public-Cloud",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Public-Cloud15-SP1-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-module-public-cloud15-sp1-debuginfo-updates-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1808,
+        "repository_id": 3442,
+        "parent_product_id": 1780,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Public-Cloud",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Public-Cloud15-SP1-Debuginfo-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-module-public-cloud15-sp1-pool-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1808,
+        "repository_id": 3443,
+        "parent_product_id": 1780,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Public-Cloud",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Public-Cloud15-SP1-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-module-public-cloud15-sp1-debuginfo-pool-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1808,
+        "repository_id": 3444,
+        "parent_product_id": 1780,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Public-Cloud",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Public-Cloud15-SP1-Debuginfo-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-module-public-cloud15-sp1-updates-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1808,
+        "repository_id": 3441,
+        "parent_product_id": 1780,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Public-Cloud",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Public-Cloud15-SP1-Updates for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-public-cloud15-sp1-debuginfo-updates-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1808,
+        "repository_id": 3442,
+        "parent_product_id": 1780,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Public-Cloud",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Public-Cloud15-SP1-Debuginfo-Updates for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-public-cloud15-sp1-pool-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1808,
+        "repository_id": 3443,
+        "parent_product_id": 1780,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Public-Cloud",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Public-Cloud15-SP1-Pool for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-public-cloud15-sp1-debuginfo-pool-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1808,
+        "repository_id": 3444,
+        "parent_product_id": 1780,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Public-Cloud",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Public-Cloud15-SP1-Debuginfo-Pool for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-public-cloud15-sp1-updates-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1808,
+        "repository_id": 3441,
+        "parent_product_id": 1780,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Public-Cloud",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Public-Cloud15-SP1-Updates for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-public-cloud15-sp1-debuginfo-updates-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1808,
+        "repository_id": 3442,
+        "parent_product_id": 1780,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Public-Cloud",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Public-Cloud15-SP1-Debuginfo-Updates for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-public-cloud15-sp1-pool-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1808,
+        "repository_id": 3443,
+        "parent_product_id": 1780,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Public-Cloud",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Public-Cloud15-SP1-Pool for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-public-cloud15-sp1-debuginfo-pool-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1808,
+        "repository_id": 3444,
+        "parent_product_id": 1780,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Public-Cloud",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Public-Cloud15-SP1-Debuginfo-Pool for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-cap-tools15-sp1-updates-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1809,
+        "repository_id": 3446,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-CAP-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-CAP-Tools/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-CAP-Tools15-SP1-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-module-cap-tools15-sp1-debuginfo-updates-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1809,
+        "repository_id": 3447,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-CAP-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-CAP-Tools/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-CAP-Tools15-SP1-Debuginfo-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-module-cap-tools15-sp1-pool-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1809,
+        "repository_id": 3448,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-CAP-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-CAP-Tools/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-CAP-Tools15-SP1-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-module-cap-tools15-sp1-debuginfo-pool-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1809,
+        "repository_id": 3449,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-CAP-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-CAP-Tools/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-CAP-Tools15-SP1-Debuginfo-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-module-cap-tools15-sp1-updates-x86_64-sled",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1809,
+        "repository_id": 3446,
+        "parent_product_id": 1772,
+        "root_product_id": 1764,
+        "update_tag": "SLE-Module-CAP-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-CAP-Tools/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-CAP-Tools15-SP1-Updates for x86_64 SLED"
+    },
+    {
+        "channel_label": "sle-module-cap-tools15-sp1-debuginfo-updates-x86_64-sled",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1809,
+        "repository_id": 3447,
+        "parent_product_id": 1772,
+        "root_product_id": 1764,
+        "update_tag": "SLE-Module-CAP-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-CAP-Tools/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-CAP-Tools15-SP1-Debuginfo-Updates for x86_64 SLED"
+    },
+    {
+        "channel_label": "sle-module-cap-tools15-sp1-pool-x86_64-sled",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1809,
+        "repository_id": 3448,
+        "parent_product_id": 1772,
+        "root_product_id": 1764,
+        "update_tag": "SLE-Module-CAP-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-CAP-Tools/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-CAP-Tools15-SP1-Pool for x86_64 SLED"
+    },
+    {
+        "channel_label": "sle-module-cap-tools15-sp1-debuginfo-pool-x86_64-sled",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1809,
+        "repository_id": 3449,
+        "parent_product_id": 1772,
+        "root_product_id": 1764,
+        "update_tag": "SLE-Module-CAP-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-CAP-Tools/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-CAP-Tools15-SP1-Debuginfo-Pool for x86_64 SLED"
+    },
+    {
+        "channel_label": "sle-module-cap-tools15-sp1-updates-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1809,
+        "repository_id": 3446,
+        "parent_product_id": 1772,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-CAP-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-CAP-Tools/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-CAP-Tools15-SP1-Updates for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-cap-tools15-sp1-debuginfo-updates-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1809,
+        "repository_id": 3447,
+        "parent_product_id": 1772,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-CAP-Tools",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-CAP-Tools/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-CAP-Tools15-SP1-Debuginfo-Updates for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-cap-tools15-sp1-pool-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1809,
+        "repository_id": 3448,
+        "parent_product_id": 1772,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-CAP-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-CAP-Tools/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-CAP-Tools15-SP1-Pool for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-cap-tools15-sp1-debuginfo-pool-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1809,
+        "repository_id": 3449,
+        "parent_product_id": 1772,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-CAP-Tools",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-CAP-Tools/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-CAP-Tools15-SP1-Debuginfo-Pool for x86_64 SAP"
     },
     {
         "channel_label": "suse-packagehub-12-sp4-aarch64",
@@ -54402,7 +61047,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP4-Standard-Pool for aarch64 SP4"
+        "channel_name": "SUSE-PackageHub-12-SP4-Standard-Pool for aarch64"
     },
     {
         "channel_label": "suse-packagehub-12-sp4-debuginfo-aarch64",
@@ -54447,7 +61092,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP4-Standard-Pool for aarch64 HPC-SP4"
+        "channel_name": "SUSE-PackageHub-12-SP4-Standard-Pool for aarch64 HPC"
     },
     {
         "channel_label": "suse-packagehub-12-sp4-debuginfo-aarch64-hpc-sp4",
@@ -54462,7 +61107,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP4-Debuginfo for aarch64 HPC-SP4"
+        "channel_name": "SUSE-PackageHub-12-SP4-Debuginfo for aarch64 HPC"
     },
     {
         "channel_label": "suse-packagehub-12-sp4-pool-aarch64-hpc-sp4",
@@ -54477,7 +61122,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP4-Pool for aarch64 HPC-SP4"
+        "channel_name": "SUSE-PackageHub-12-SP4-Pool for aarch64 HPC"
     },
     {
         "channel_label": "suse-packagehub-12-sp4-ppc64le",
@@ -54492,7 +61137,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP4-Standard-Pool for ppc64le SP4"
+        "channel_name": "SUSE-PackageHub-12-SP4-Standard-Pool for ppc64le"
     },
     {
         "channel_label": "suse-packagehub-12-sp4-debuginfo-ppc64le",
@@ -54537,7 +61182,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP4-Standard-Pool for ppc64le SAP-SP4"
+        "channel_name": "SUSE-PackageHub-12-SP4-Standard-Pool for ppc64le SAP"
     },
     {
         "channel_label": "suse-packagehub-12-sp4-debuginfo-ppc64le-sap-sp4",
@@ -54552,7 +61197,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP4-Debuginfo for ppc64le SAP-SP4"
+        "channel_name": "SUSE-PackageHub-12-SP4-Debuginfo for ppc64le SAP"
     },
     {
         "channel_label": "suse-packagehub-12-sp4-pool-ppc64le-sap-sp4",
@@ -54567,7 +61212,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP4-Pool for ppc64le SAP-SP4"
+        "channel_name": "SUSE-PackageHub-12-SP4-Pool for ppc64le SAP"
     },
     {
         "channel_label": "suse-packagehub-12-sp4-s390x",
@@ -54582,7 +61227,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP4-Standard-Pool for s390x SP4"
+        "channel_name": "SUSE-PackageHub-12-SP4-Standard-Pool for s390x"
     },
     {
         "channel_label": "suse-packagehub-12-sp4-debuginfo-s390x",
@@ -54627,7 +61272,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP4-Standard-Pool for x86_64 SP4"
+        "channel_name": "SUSE-PackageHub-12-SP4-Standard-Pool for x86_64"
     },
     {
         "channel_label": "suse-packagehub-12-sp4-debuginfo-x86_64",
@@ -54672,7 +61317,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP4-Standard-Pool for x86_64 SLED-SP4"
+        "channel_name": "SUSE-PackageHub-12-SP4-Standard-Pool for x86_64 SLED"
     },
     {
         "channel_label": "suse-packagehub-12-sp4-debuginfo-x86_64-sled-sp4",
@@ -54687,7 +61332,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP4-Debuginfo for x86_64 SLED-SP4"
+        "channel_name": "SUSE-PackageHub-12-SP4-Debuginfo for x86_64 SLED"
     },
     {
         "channel_label": "suse-packagehub-12-sp4-pool-x86_64-sled-sp4",
@@ -54702,7 +61347,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP4-Pool for x86_64 SLED-SP4"
+        "channel_name": "SUSE-PackageHub-12-SP4-Pool for x86_64 SLED"
     },
     {
         "channel_label": "suse-packagehub-12-sp4-x86_64-sap-sp4",
@@ -54717,7 +61362,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP4-Standard-Pool for x86_64 SAP-SP4"
+        "channel_name": "SUSE-PackageHub-12-SP4-Standard-Pool for x86_64 SAP"
     },
     {
         "channel_label": "suse-packagehub-12-sp4-debuginfo-x86_64-sap-sp4",
@@ -54732,7 +61377,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP4-Debuginfo for x86_64 SAP-SP4"
+        "channel_name": "SUSE-PackageHub-12-SP4-Debuginfo for x86_64 SAP"
     },
     {
         "channel_label": "suse-packagehub-12-sp4-pool-x86_64-sap-sp4",
@@ -54747,7 +61392,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP4-Pool for x86_64 SAP-SP4"
+        "channel_name": "SUSE-PackageHub-12-SP4-Pool for x86_64 SAP"
     },
     {
         "channel_label": "suse-packagehub-12-sp4-x86_64-hpc-sp4",
@@ -54762,7 +61407,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP4-Standard-Pool for x86_64 HPC-SP4"
+        "channel_name": "SUSE-PackageHub-12-SP4-Standard-Pool for x86_64 HPC"
     },
     {
         "channel_label": "suse-packagehub-12-sp4-debuginfo-x86_64-hpc-sp4",
@@ -54777,7 +61422,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP4-Debuginfo for x86_64 HPC-SP4"
+        "channel_name": "SUSE-PackageHub-12-SP4-Debuginfo for x86_64 HPC"
     },
     {
         "channel_label": "suse-packagehub-12-sp4-pool-x86_64-hpc-sp4",
@@ -54792,7 +61437,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-PackageHub-12-SP4-Pool for x86_64 HPC-SP4"
+        "channel_name": "SUSE-PackageHub-12-SP4-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sles12-sp2-espos-updates-x86_64-hpc-sp2",
@@ -54807,7 +61452,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP2-ESPOS-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLES12-SP2-ESPOS-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sles12-sp2-espos-debuginfo-updates-x86_64-hpc-sp2",
@@ -54822,7 +61467,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP2-ESPOS-Debuginfo-Updates for x86_64 HPC-SP2"
+        "channel_name": "SLES12-SP2-ESPOS-Debuginfo-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sles12-sp2-espos-pool-x86_64-hpc-sp2",
@@ -54837,7 +61482,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP2-ESPOS-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLES12-SP2-ESPOS-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sles12-sp2-espos-debuginfo-pool-x86_64-hpc-sp2",
@@ -54852,7 +61497,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP2-ESPOS-Debuginfo-Pool for x86_64 HPC-SP2"
+        "channel_name": "SLES12-SP2-ESPOS-Debuginfo-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sles12-sp3-espos-updates-aarch64-hpc-sp3",
@@ -54867,7 +61512,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP3-ESPOS-Updates for aarch64 HPC-SP3"
+        "channel_name": "SLES12-SP3-ESPOS-Updates for aarch64 HPC"
     },
     {
         "channel_label": "sles12-sp3-espos-pool-aarch64-hpc-sp3",
@@ -54882,7 +61527,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP3-ESPOS-Pool for aarch64 HPC-SP3"
+        "channel_name": "SLES12-SP3-ESPOS-Pool for aarch64 HPC"
     },
     {
         "channel_label": "sles12-sp3-espos-debuginfo-pool-aarch64-hpc-sp3",
@@ -54897,7 +61542,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP3-ESPOS-Debuginfo-Pool for aarch64 HPC-SP3"
+        "channel_name": "SLES12-SP3-ESPOS-Debuginfo-Pool for aarch64 HPC"
     },
     {
         "channel_label": "sles12-sp3-espos-debuginfo-updates-aarch64-hpc-sp3",
@@ -54912,7 +61557,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP3-ESPOS-Debuginfo-Updates for aarch64 HPC-SP3"
+        "channel_name": "SLES12-SP3-ESPOS-Debuginfo-Updates for aarch64 HPC"
     },
     {
         "channel_label": "sles12-sp3-espos-updates-x86_64-hpc-sp3",
@@ -54927,7 +61572,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP3-ESPOS-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLES12-SP3-ESPOS-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sles12-sp3-espos-debuginfo-updates-x86_64-hpc-sp3",
@@ -54942,7 +61587,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP3-ESPOS-Debuginfo-Updates for x86_64 HPC-SP3"
+        "channel_name": "SLES12-SP3-ESPOS-Debuginfo-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sles12-sp3-espos-pool-x86_64-hpc-sp3",
@@ -54957,7 +61602,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP3-ESPOS-Pool for x86_64 HPC-SP3"
+        "channel_name": "SLES12-SP3-ESPOS-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sles12-sp3-espos-debuginfo-pool-x86_64-hpc-sp3",
@@ -54972,7 +61617,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP3-ESPOS-Debuginfo-Pool for x86_64 HPC-SP3"
+        "channel_name": "SLES12-SP3-ESPOS-Debuginfo-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sles12-sp4-espos-updates-aarch64-hpc-sp4",
@@ -54987,7 +61632,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP4-ESPOS-Updates for aarch64 HPC-SP4"
+        "channel_name": "SLES12-SP4-ESPOS-Updates for aarch64 HPC"
     },
     {
         "channel_label": "sles12-sp4-espos-pool-aarch64-hpc-sp4",
@@ -55002,7 +61647,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP4-ESPOS-Pool for aarch64 HPC-SP4"
+        "channel_name": "SLES12-SP4-ESPOS-Pool for aarch64 HPC"
     },
     {
         "channel_label": "sles12-sp4-espos-debuginfo-pool-aarch64-hpc-sp4",
@@ -55017,7 +61662,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP4-ESPOS-Debuginfo-Pool for aarch64 HPC-SP4"
+        "channel_name": "SLES12-SP4-ESPOS-Debuginfo-Pool for aarch64 HPC"
     },
     {
         "channel_label": "sles12-sp4-espos-debuginfo-updates-aarch64-hpc-sp4",
@@ -55032,7 +61677,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP4-ESPOS-Debuginfo-Updates for aarch64 HPC-SP4"
+        "channel_name": "SLES12-SP4-ESPOS-Debuginfo-Updates for aarch64 HPC"
     },
     {
         "channel_label": "sles12-sp4-espos-updates-x86_64-hpc-sp4",
@@ -55047,7 +61692,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP4-ESPOS-Updates for x86_64 HPC-SP4"
+        "channel_name": "SLES12-SP4-ESPOS-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sles12-sp4-espos-debuginfo-updates-x86_64-hpc-sp4",
@@ -55062,7 +61707,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP4-ESPOS-Debuginfo-Updates for x86_64 HPC-SP4"
+        "channel_name": "SLES12-SP4-ESPOS-Debuginfo-Updates for x86_64 HPC"
     },
     {
         "channel_label": "sles12-sp4-espos-pool-x86_64-hpc-sp4",
@@ -55077,7 +61722,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP4-ESPOS-Pool for x86_64 HPC-SP4"
+        "channel_name": "SLES12-SP4-ESPOS-Pool for x86_64 HPC"
     },
     {
         "channel_label": "sles12-sp4-espos-debuginfo-pool-x86_64-hpc-sp4",
@@ -55092,7 +61737,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SLES12-SP4-ESPOS-Debuginfo-Pool for x86_64 HPC-SP4"
+        "channel_name": "SLES12-SP4-ESPOS-Debuginfo-Pool for x86_64 HPC"
     },
     {
         "channel_label": "suse-caasp-3.1-updates-x86_64",
@@ -55275,6 +61920,246 @@
         "channel_name": "SUSE-OpenStack-Cloud-Crowbar-9-Debuginfo-Pool for x86_64 SP4"
     },
     {
+        "channel_label": "sle-module-transactional-server15-sp1-updates-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1822,
+        "repository_id": 3497,
+        "parent_product_id": 1769,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Transactional-Server",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Transactional-Server/15-SP1/aarch64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Transactional-Server15-SP1-Updates for aarch64"
+    },
+    {
+        "channel_label": "sle-module-transactional-server15-sp1-debuginfo-updates-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1822,
+        "repository_id": 3498,
+        "parent_product_id": 1769,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Transactional-Server",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Transactional-Server/15-SP1/aarch64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Transactional-Server15-SP1-Debuginfo-Updates for aarch64"
+    },
+    {
+        "channel_label": "sle-module-transactional-server15-sp1-pool-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1822,
+        "repository_id": 3499,
+        "parent_product_id": 1769,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Transactional-Server",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Transactional-Server/15-SP1/aarch64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Transactional-Server15-SP1-Pool for aarch64"
+    },
+    {
+        "channel_label": "sle-module-transactional-server15-sp1-debuginfo-pool-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1822,
+        "repository_id": 3500,
+        "parent_product_id": 1769,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Transactional-Server",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Transactional-Server/15-SP1/aarch64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Transactional-Server15-SP1-Debuginfo-Pool for aarch64"
+    },
+    {
+        "channel_label": "sle-module-transactional-server15-sp1-updates-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1823,
+        "repository_id": 3502,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Transactional-Server",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Transactional-Server/15-SP1/ppc64le/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Transactional-Server15-SP1-Updates for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-transactional-server15-sp1-debuginfo-updates-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1823,
+        "repository_id": 3503,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Transactional-Server",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Transactional-Server/15-SP1/ppc64le/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Transactional-Server15-SP1-Debuginfo-Updates for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-transactional-server15-sp1-pool-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1823,
+        "repository_id": 3504,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Transactional-Server",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Transactional-Server/15-SP1/ppc64le/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Transactional-Server15-SP1-Pool for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-transactional-server15-sp1-debuginfo-pool-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1823,
+        "repository_id": 3505,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Transactional-Server",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Transactional-Server/15-SP1/ppc64le/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Transactional-Server15-SP1-Debuginfo-Pool for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-transactional-server15-sp1-updates-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1824,
+        "repository_id": 3507,
+        "parent_product_id": 1771,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Transactional-Server",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Transactional-Server/15-SP1/s390x/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Transactional-Server15-SP1-Updates for s390x"
+    },
+    {
+        "channel_label": "sle-module-transactional-server15-sp1-debuginfo-updates-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1824,
+        "repository_id": 3508,
+        "parent_product_id": 1771,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Transactional-Server",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Transactional-Server/15-SP1/s390x/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Transactional-Server15-SP1-Debuginfo-Updates for s390x"
+    },
+    {
+        "channel_label": "sle-module-transactional-server15-sp1-pool-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1824,
+        "repository_id": 3509,
+        "parent_product_id": 1771,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Transactional-Server",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Transactional-Server/15-SP1/s390x/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Transactional-Server15-SP1-Pool for s390x"
+    },
+    {
+        "channel_label": "sle-module-transactional-server15-sp1-debuginfo-pool-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1824,
+        "repository_id": 3510,
+        "parent_product_id": 1771,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Transactional-Server",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Transactional-Server/15-SP1/s390x/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Transactional-Server15-SP1-Debuginfo-Pool for s390x"
+    },
+    {
+        "channel_label": "sle-module-transactional-server15-sp1-updates-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1825,
+        "repository_id": 3512,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Transactional-Server",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Transactional-Server/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Transactional-Server15-SP1-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-module-transactional-server15-sp1-debuginfo-updates-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1825,
+        "repository_id": 3513,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Transactional-Server",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Transactional-Server/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Transactional-Server15-SP1-Debuginfo-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-module-transactional-server15-sp1-pool-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1825,
+        "repository_id": 3514,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Transactional-Server",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Transactional-Server/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Transactional-Server15-SP1-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-module-transactional-server15-sp1-debuginfo-pool-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1825,
+        "repository_id": 3515,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Transactional-Server",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Transactional-Server/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Transactional-Server15-SP1-Debuginfo-Pool for x86_64"
+    },
+    {
         "channel_label": "suse-manager-retail-branch-server-3.2-updates-x86_64",
         "parent_channel_label": "sles12-sp3-pool-x86_64",
         "product_id": 1826,
@@ -55287,7 +62172,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Retail-Branch-Server-3.2-Updates for x86_64"
+        "channel_name": "SUSE-Manager-Retail-Branch-Server-3.2-Updates for x86_64 SP3"
     },
     {
         "channel_label": "suse-manager-retail-branch-server-3.2-debuginfo-updates-x86_64",
@@ -55302,7 +62187,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Retail-Branch-Server-3.2-Debuginfo-Updates for x86_64"
+        "channel_name": "SUSE-Manager-Retail-Branch-Server-3.2-Debuginfo-Updates for x86_64 SP3"
     },
     {
         "channel_label": "suse-manager-retail-branch-server-3.2-pool-x86_64",
@@ -55317,7 +62202,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Retail-Branch-Server-3.2-Pool for x86_64"
+        "channel_name": "SUSE-Manager-Retail-Branch-Server-3.2-Pool for x86_64 SP3"
     },
     {
         "channel_label": "suse-manager-retail-branch-server-3.2-debuginfo-pool-x86_64",
@@ -55332,7 +62217,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Retail-Branch-Server-3.2-Debuginfo-Pool for x86_64"
+        "channel_name": "SUSE-Manager-Retail-Branch-Server-3.2-Debuginfo-Pool for x86_64 SP3"
     },
     {
         "channel_label": "suse-manager-retail-branch-server-3.2-updates-x86_64-sp4",
@@ -55407,7 +62292,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Retail-Branch-Server-3.2-Updates for x86_64 HPC-SP3"
+        "channel_name": "SUSE-Manager-Retail-Branch-Server-3.2-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-manager-retail-branch-server-3.2-debuginfo-updates-x86_64-hpc-sp3",
@@ -55422,7 +62307,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Retail-Branch-Server-3.2-Debuginfo-Updates for x86_64 HPC-SP3"
+        "channel_name": "SUSE-Manager-Retail-Branch-Server-3.2-Debuginfo-Updates for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-manager-retail-branch-server-3.2-pool-x86_64-hpc-sp3",
@@ -55437,7 +62322,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Retail-Branch-Server-3.2-Pool for x86_64 HPC-SP3"
+        "channel_name": "SUSE-Manager-Retail-Branch-Server-3.2-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-manager-retail-branch-server-3.2-debuginfo-pool-x86_64-hpc-sp3",
@@ -55452,7 +62337,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Retail-Branch-Server-3.2-Debuginfo-Pool for x86_64 HPC-SP3"
+        "channel_name": "SUSE-Manager-Retail-Branch-Server-3.2-Debuginfo-Pool for x86_64 HPC SP3"
     },
     {
         "channel_label": "suse-manager-retail-branch-server-3.2-updates-x86_64-hpc-sp4",
@@ -55467,7 +62352,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Retail-Branch-Server-3.2-Updates for x86_64 HPC-SP4"
+        "channel_name": "SUSE-Manager-Retail-Branch-Server-3.2-Updates for x86_64 HPC SP4"
     },
     {
         "channel_label": "suse-manager-retail-branch-server-3.2-debuginfo-updates-x86_64-hpc-sp4",
@@ -55482,7 +62367,7 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Retail-Branch-Server-3.2-Debuginfo-Updates for x86_64 HPC-SP4"
+        "channel_name": "SUSE-Manager-Retail-Branch-Server-3.2-Debuginfo-Updates for x86_64 HPC SP4"
     },
     {
         "channel_label": "suse-manager-retail-branch-server-3.2-pool-x86_64-hpc-sp4",
@@ -55497,7 +62382,7 @@
         "mandatory": true,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Retail-Branch-Server-3.2-Pool for x86_64 HPC-SP4"
+        "channel_name": "SUSE-Manager-Retail-Branch-Server-3.2-Pool for x86_64 HPC SP4"
     },
     {
         "channel_label": "suse-manager-retail-branch-server-3.2-debuginfo-pool-x86_64-hpc-sp4",
@@ -55512,6 +62397,2031 @@
         "mandatory": false,
         "signed": true,
         "recommended": false,
-        "channel_name": "SUSE-Manager-Retail-Branch-Server-3.2-Debuginfo-Pool for x86_64 HPC-SP4"
+        "channel_name": "SUSE-Manager-Retail-Branch-Server-3.2-Debuginfo-Pool for x86_64 HPC SP4"
+    },
+    {
+        "channel_label": "sle-module-live-patching15-sp1-updates-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1827,
+        "repository_id": 3530,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Live-Patching",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Live-Patching/15-SP1/ppc64le/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Live-Patching15-SP1-Updates for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-live-patching15-sp1-debuginfo-updates-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1827,
+        "repository_id": 3531,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Live-Patching",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Live-Patching/15-SP1/ppc64le/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Live-Patching15-SP1-Debuginfo-Updates for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-live-patching15-sp1-pool-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1827,
+        "repository_id": 3532,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Live-Patching",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Live-Patching/15-SP1/ppc64le/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Live-Patching15-SP1-Pool for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-live-patching15-sp1-debuginfo-pool-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1827,
+        "repository_id": 3533,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Live-Patching",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Live-Patching/15-SP1/ppc64le/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Live-Patching15-SP1-Debuginfo-Pool for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-live-patching15-sp1-updates-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1827,
+        "repository_id": 3530,
+        "parent_product_id": 1770,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Live-Patching",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Live-Patching/15-SP1/ppc64le/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Live-Patching15-SP1-Updates for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-live-patching15-sp1-debuginfo-updates-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1827,
+        "repository_id": 3531,
+        "parent_product_id": 1770,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Live-Patching",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Live-Patching/15-SP1/ppc64le/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Live-Patching15-SP1-Debuginfo-Updates for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-live-patching15-sp1-pool-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1827,
+        "repository_id": 3532,
+        "parent_product_id": 1770,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Live-Patching",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Live-Patching/15-SP1/ppc64le/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Live-Patching15-SP1-Pool for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-live-patching15-sp1-debuginfo-pool-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1827,
+        "repository_id": 3533,
+        "parent_product_id": 1770,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Live-Patching",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Live-Patching/15-SP1/ppc64le/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Live-Patching15-SP1-Debuginfo-Pool for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-live-patching15-sp1-updates-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1828,
+        "repository_id": 3535,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Live-Patching",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Live-Patching/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Live-Patching15-SP1-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-module-live-patching15-sp1-debuginfo-updates-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1828,
+        "repository_id": 3536,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Live-Patching",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Live-Patching/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Live-Patching15-SP1-Debuginfo-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-module-live-patching15-sp1-pool-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1828,
+        "repository_id": 3537,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Live-Patching",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Live-Patching/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Live-Patching15-SP1-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-module-live-patching15-sp1-debuginfo-pool-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1828,
+        "repository_id": 3538,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Live-Patching",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Live-Patching/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Live-Patching15-SP1-Debuginfo-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-module-live-patching15-sp1-updates-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1828,
+        "repository_id": 3535,
+        "parent_product_id": 1772,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Live-Patching",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Live-Patching/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Live-Patching15-SP1-Updates for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-live-patching15-sp1-debuginfo-updates-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1828,
+        "repository_id": 3536,
+        "parent_product_id": 1772,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Live-Patching",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Live-Patching/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Live-Patching15-SP1-Debuginfo-Updates for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-live-patching15-sp1-pool-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1828,
+        "repository_id": 3537,
+        "parent_product_id": 1772,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Live-Patching",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Live-Patching/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Live-Patching15-SP1-Pool for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-live-patching15-sp1-debuginfo-pool-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1828,
+        "repository_id": 3538,
+        "parent_product_id": 1772,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Live-Patching",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Live-Patching/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Live-Patching15-SP1-Debuginfo-Pool for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-live-patching12-updates-ppc64le-sp2",
+        "parent_channel_label": "sles12-sp2-pool-ppc64le",
+        "product_id": 1860,
+        "repository_id": 3563,
+        "parent_product_id": 1355,
+        "root_product_id": 1355,
+        "update_tag": "SLE-Live-Patching",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Live-Patching/12/ppc64le/update/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Live-Patching12-Updates for ppc64le SP2"
+    },
+    {
+        "channel_label": "sle-live-patching12-debuginfo-updates-ppc64le-sp2",
+        "parent_channel_label": "sles12-sp2-pool-ppc64le",
+        "product_id": 1860,
+        "repository_id": 3564,
+        "parent_product_id": 1355,
+        "root_product_id": 1355,
+        "update_tag": "SLE-Live-Patching",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Live-Patching/12/ppc64le/update_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Live-Patching12-Debuginfo-Updates for ppc64le SP2"
+    },
+    {
+        "channel_label": "sle-live-patching12-pool-ppc64le-sp2",
+        "parent_channel_label": "sles12-sp2-pool-ppc64le",
+        "product_id": 1860,
+        "repository_id": 3565,
+        "parent_product_id": 1355,
+        "root_product_id": 1355,
+        "update_tag": "SLE-Live-Patching",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Live-Patching/12/ppc64le/product/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Live-Patching12-Pool for ppc64le SP2"
+    },
+    {
+        "channel_label": "sle-live-patching12-debuginfo-pool-ppc64le-sp2",
+        "parent_channel_label": "sles12-sp2-pool-ppc64le",
+        "product_id": 1860,
+        "repository_id": 3566,
+        "parent_product_id": 1355,
+        "root_product_id": 1355,
+        "update_tag": "SLE-Live-Patching",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Live-Patching/12/ppc64le/product_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Live-Patching12-Debuginfo-Pool for ppc64le SP2"
+    },
+    {
+        "channel_label": "sle-live-patching12-updates-ppc64le-sap-sp2",
+        "parent_channel_label": "sle12-sp2-sap-pool-ppc64le",
+        "product_id": 1860,
+        "repository_id": 3563,
+        "parent_product_id": 1521,
+        "root_product_id": 1521,
+        "update_tag": "SLE-Live-Patching",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Live-Patching/12/ppc64le/update/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Live-Patching12-Updates for ppc64le SAP SP2"
+    },
+    {
+        "channel_label": "sle-live-patching12-debuginfo-updates-ppc64le-sap-sp2",
+        "parent_channel_label": "sle12-sp2-sap-pool-ppc64le",
+        "product_id": 1860,
+        "repository_id": 3564,
+        "parent_product_id": 1521,
+        "root_product_id": 1521,
+        "update_tag": "SLE-Live-Patching",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Live-Patching/12/ppc64le/update_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Live-Patching12-Debuginfo-Updates for ppc64le SAP SP2"
+    },
+    {
+        "channel_label": "sle-live-patching12-pool-ppc64le-sap-sp2",
+        "parent_channel_label": "sle12-sp2-sap-pool-ppc64le",
+        "product_id": 1860,
+        "repository_id": 3565,
+        "parent_product_id": 1521,
+        "root_product_id": 1521,
+        "update_tag": "SLE-Live-Patching",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Live-Patching/12/ppc64le/product/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Live-Patching12-Pool for ppc64le SAP SP2"
+    },
+    {
+        "channel_label": "sle-live-patching12-debuginfo-pool-ppc64le-sap-sp2",
+        "parent_channel_label": "sle12-sp2-sap-pool-ppc64le",
+        "product_id": 1860,
+        "repository_id": 3566,
+        "parent_product_id": 1521,
+        "root_product_id": 1521,
+        "update_tag": "SLE-Live-Patching",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Live-Patching/12/ppc64le/product_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Live-Patching12-Debuginfo-Pool for ppc64le SAP SP2"
+    },
+    {
+        "channel_label": "sle-product-rt-15-sp1-updates-x86_64",
+        "parent_channel_label": "sle-product-rt-15-sp1-pool-x86_64",
+        "product_id": 1861,
+        "repository_id": 3568,
+        "parent_product_id": null,
+        "root_product_id": 1861,
+        "update_tag": "SLE-Product-RT",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-RT/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-RT-15-SP1-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-product-rt15-sp1-debuginfo-updates-x86_64",
+        "parent_channel_label": "sle-product-rt-15-sp1-pool-x86_64",
+        "product_id": 1861,
+        "repository_id": 3569,
+        "parent_product_id": null,
+        "root_product_id": 1861,
+        "update_tag": "SLE-Product-RT",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-RT/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-RT15-SP1-Debuginfo-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-product-rt-15-sp1-pool-x86_64",
+        "parent_channel_label": null,
+        "product_id": 1861,
+        "repository_id": 3570,
+        "parent_product_id": null,
+        "root_product_id": 1861,
+        "update_tag": "SLE-Product-RT",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-RT/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-RT-15-SP1-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-product-rt15-sp1-debuginfo-pool-x86_64",
+        "parent_channel_label": "sle-product-rt-15-sp1-pool-x86_64",
+        "product_id": 1861,
+        "repository_id": 3571,
+        "parent_product_id": null,
+        "root_product_id": 1861,
+        "update_tag": "SLE-Product-RT",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-RT/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Product-RT15-SP1-Debuginfo-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-module-rt15-sp1-updates-x86_64",
+        "parent_channel_label": "sle-product-rt-15-sp1-pool-x86_64",
+        "product_id": 1862,
+        "repository_id": 3573,
+        "parent_product_id": 1780,
+        "root_product_id": 1861,
+        "update_tag": "SLE-Module-RT",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-RT/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-RT15-SP1-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-module-rt15-sp1-debuginfo-updates-x86_64",
+        "parent_channel_label": "sle-product-rt-15-sp1-pool-x86_64",
+        "product_id": 1862,
+        "repository_id": 3574,
+        "parent_product_id": 1780,
+        "root_product_id": 1861,
+        "update_tag": "SLE-Module-RT",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-RT/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-RT15-SP1-Debuginfo-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-module-rt15-sp1-pool-x86_64",
+        "parent_channel_label": "sle-product-rt-15-sp1-pool-x86_64",
+        "product_id": 1862,
+        "repository_id": 3575,
+        "parent_product_id": 1780,
+        "root_product_id": 1861,
+        "update_tag": "SLE-Module-RT",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-RT/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-RT15-SP1-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-module-rt15-sp1-debuginfo-pool-x86_64",
+        "parent_channel_label": "sle-product-rt-15-sp1-pool-x86_64",
+        "product_id": 1862,
+        "repository_id": 3576,
+        "parent_product_id": 1780,
+        "root_product_id": 1861,
+        "update_tag": "SLE-Module-RT",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-RT/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-RT15-SP1-Debuginfo-Pool for x86_64"
+    },
+    {
+        "channel_label": "suse-caasp-4.0-updates-x86_64",
+        "parent_channel_label": "suse-caasp-4.0-pool-x86_64",
+        "product_id": 1863,
+        "repository_id": 3578,
+        "parent_product_id": null,
+        "root_product_id": 1863,
+        "update_tag": null,
+        "url": "https://updates.suse.com/SUSE/Updates/SUSE-CAASP/4.0/x86_64/update/",
+        "release_stage": "alpha",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SUSE-CAASP-4.0-Updates for x86_64"
+    },
+    {
+        "channel_label": "suse-caasp-4.0-debuginfo-updates-x86_64",
+        "parent_channel_label": "suse-caasp-4.0-pool-x86_64",
+        "product_id": 1863,
+        "repository_id": 3579,
+        "parent_product_id": null,
+        "root_product_id": 1863,
+        "update_tag": null,
+        "url": "https://updates.suse.com/SUSE/Updates/SUSE-CAASP/4.0/x86_64/update_debug/",
+        "release_stage": "alpha",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SUSE-CAASP-4.0-Debuginfo-Updates for x86_64"
+    },
+    {
+        "channel_label": "suse-caasp-4.0-pool-x86_64",
+        "parent_channel_label": null,
+        "product_id": 1863,
+        "repository_id": 3580,
+        "parent_product_id": null,
+        "root_product_id": 1863,
+        "update_tag": null,
+        "url": "https://updates.suse.com/SUSE/Products/SUSE-CAASP/4.0/x86_64/product/",
+        "release_stage": "alpha",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SUSE-CAASP-4.0-Pool for x86_64"
+    },
+    {
+        "channel_label": "suse-caasp-4.0-debuginfo-pool-x86_64",
+        "parent_channel_label": "suse-caasp-4.0-pool-x86_64",
+        "product_id": 1863,
+        "repository_id": 3581,
+        "parent_product_id": null,
+        "root_product_id": 1863,
+        "update_tag": null,
+        "url": "https://updates.suse.com/SUSE/Products/SUSE-CAASP/4.0/x86_64/product_debug/",
+        "release_stage": "alpha",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SUSE-CAASP-4.0-Debuginfo-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-module-python2-15-sp1-updates-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1864,
+        "repository_id": 3583,
+        "parent_product_id": 1769,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Python2",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Python2/15-SP1/aarch64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Python2-15-SP1-Updates for aarch64"
+    },
+    {
+        "channel_label": "sle-module-python2-15-sp1-debuginfo-updates-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1864,
+        "repository_id": 3584,
+        "parent_product_id": 1769,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Python2",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Python2/15-SP1/aarch64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Python2-15-SP1-Debuginfo-Updates for aarch64"
+    },
+    {
+        "channel_label": "sle-module-python2-15-sp1-pool-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1864,
+        "repository_id": 3585,
+        "parent_product_id": 1769,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Python2",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Python2/15-SP1/aarch64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Python2-15-SP1-Pool for aarch64"
+    },
+    {
+        "channel_label": "sle-module-python2-15-sp1-debuginfo-pool-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1864,
+        "repository_id": 3586,
+        "parent_product_id": 1769,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Python2",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Python2/15-SP1/aarch64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Python2-15-SP1-Debuginfo-Pool for aarch64"
+    },
+    {
+        "channel_label": "sle-module-python2-15-sp1-updates-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1864,
+        "repository_id": 3583,
+        "parent_product_id": 1769,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-Python2",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Python2/15-SP1/aarch64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Python2-15-SP1-Updates for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-module-python2-15-sp1-debuginfo-updates-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1864,
+        "repository_id": 3584,
+        "parent_product_id": 1769,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-Python2",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Python2/15-SP1/aarch64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Python2-15-SP1-Debuginfo-Updates for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-module-python2-15-sp1-pool-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1864,
+        "repository_id": 3585,
+        "parent_product_id": 1769,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-Python2",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Python2/15-SP1/aarch64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Python2-15-SP1-Pool for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-module-python2-15-sp1-debuginfo-pool-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1864,
+        "repository_id": 3586,
+        "parent_product_id": 1769,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-Python2",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Python2/15-SP1/aarch64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Python2-15-SP1-Debuginfo-Pool for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-module-python2-15-sp1-updates-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1865,
+        "repository_id": 3588,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Python2",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Python2/15-SP1/ppc64le/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Python2-15-SP1-Updates for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-python2-15-sp1-debuginfo-updates-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1865,
+        "repository_id": 3589,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Python2",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Python2/15-SP1/ppc64le/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Python2-15-SP1-Debuginfo-Updates for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-python2-15-sp1-pool-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1865,
+        "repository_id": 3590,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Python2",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Python2/15-SP1/ppc64le/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Python2-15-SP1-Pool for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-python2-15-sp1-debuginfo-pool-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1865,
+        "repository_id": 3591,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Python2",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Python2/15-SP1/ppc64le/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Python2-15-SP1-Debuginfo-Pool for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-python2-15-sp1-updates-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1865,
+        "repository_id": 3588,
+        "parent_product_id": 1770,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Python2",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Python2/15-SP1/ppc64le/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Python2-15-SP1-Updates for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-python2-15-sp1-debuginfo-updates-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1865,
+        "repository_id": 3589,
+        "parent_product_id": 1770,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Python2",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Python2/15-SP1/ppc64le/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Python2-15-SP1-Debuginfo-Updates for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-python2-15-sp1-pool-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1865,
+        "repository_id": 3590,
+        "parent_product_id": 1770,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Python2",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Python2/15-SP1/ppc64le/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Python2-15-SP1-Pool for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-python2-15-sp1-debuginfo-pool-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1865,
+        "repository_id": 3591,
+        "parent_product_id": 1770,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Python2",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Python2/15-SP1/ppc64le/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Python2-15-SP1-Debuginfo-Pool for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-python2-15-sp1-updates-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1866,
+        "repository_id": 3593,
+        "parent_product_id": 1771,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Python2",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Python2/15-SP1/s390x/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Python2-15-SP1-Updates for s390x"
+    },
+    {
+        "channel_label": "sle-module-python2-15-sp1-debuginfo-updates-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1866,
+        "repository_id": 3594,
+        "parent_product_id": 1771,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Python2",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Python2/15-SP1/s390x/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Python2-15-SP1-Debuginfo-Updates for s390x"
+    },
+    {
+        "channel_label": "sle-module-python2-15-sp1-pool-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1866,
+        "repository_id": 3595,
+        "parent_product_id": 1771,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Python2",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Python2/15-SP1/s390x/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Python2-15-SP1-Pool for s390x"
+    },
+    {
+        "channel_label": "sle-module-python2-15-sp1-debuginfo-pool-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1866,
+        "repository_id": 3596,
+        "parent_product_id": 1771,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Python2",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Python2/15-SP1/s390x/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Python2-15-SP1-Debuginfo-Pool for s390x"
+    },
+    {
+        "channel_label": "sle-module-python2-15-sp1-updates-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1867,
+        "repository_id": 3598,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Python2",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Python2/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Python2-15-SP1-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-module-python2-15-sp1-debuginfo-updates-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1867,
+        "repository_id": 3599,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Python2",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Python2/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Python2-15-SP1-Debuginfo-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-module-python2-15-sp1-pool-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1867,
+        "repository_id": 3600,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Python2",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Python2/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Python2-15-SP1-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-module-python2-15-sp1-debuginfo-pool-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1867,
+        "repository_id": 3601,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Python2",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Python2/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Python2-15-SP1-Debuginfo-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-module-python2-15-sp1-updates-x86_64-sled",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1867,
+        "repository_id": 3598,
+        "parent_product_id": 1772,
+        "root_product_id": 1764,
+        "update_tag": "SLE-Module-Python2",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Python2/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Python2-15-SP1-Updates for x86_64 SLED"
+    },
+    {
+        "channel_label": "sle-module-python2-15-sp1-debuginfo-updates-x86_64-sled",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1867,
+        "repository_id": 3599,
+        "parent_product_id": 1772,
+        "root_product_id": 1764,
+        "update_tag": "SLE-Module-Python2",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Python2/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Python2-15-SP1-Debuginfo-Updates for x86_64 SLED"
+    },
+    {
+        "channel_label": "sle-module-python2-15-sp1-pool-x86_64-sled",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1867,
+        "repository_id": 3600,
+        "parent_product_id": 1772,
+        "root_product_id": 1764,
+        "update_tag": "SLE-Module-Python2",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Python2/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Python2-15-SP1-Pool for x86_64 SLED"
+    },
+    {
+        "channel_label": "sle-module-python2-15-sp1-debuginfo-pool-x86_64-sled",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1867,
+        "repository_id": 3601,
+        "parent_product_id": 1772,
+        "root_product_id": 1764,
+        "update_tag": "SLE-Module-Python2",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Python2/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Python2-15-SP1-Debuginfo-Pool for x86_64 SLED"
+    },
+    {
+        "channel_label": "sle-module-python2-15-sp1-updates-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1867,
+        "repository_id": 3598,
+        "parent_product_id": 1772,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Python2",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Python2/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Python2-15-SP1-Updates for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-python2-15-sp1-debuginfo-updates-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1867,
+        "repository_id": 3599,
+        "parent_product_id": 1772,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Python2",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Python2/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Python2-15-SP1-Debuginfo-Updates for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-python2-15-sp1-pool-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1867,
+        "repository_id": 3600,
+        "parent_product_id": 1772,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Python2",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Python2/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Python2-15-SP1-Pool for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-python2-15-sp1-debuginfo-pool-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1867,
+        "repository_id": 3601,
+        "parent_product_id": 1772,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Python2",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Python2/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Python2-15-SP1-Debuginfo-Pool for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-python2-15-sp1-updates-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1867,
+        "repository_id": 3598,
+        "parent_product_id": 1772,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Python2",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Python2/15-SP1/x86_64/update/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Python2-15-SP1-Updates for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-python2-15-sp1-debuginfo-updates-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1867,
+        "repository_id": 3599,
+        "parent_product_id": 1772,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Python2",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Python2/15-SP1/x86_64/update_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Python2-15-SP1-Debuginfo-Updates for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-python2-15-sp1-pool-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1867,
+        "repository_id": 3600,
+        "parent_product_id": 1772,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Python2",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Python2/15-SP1/x86_64/product/",
+        "release_stage": "beta",
+        "mandatory": true,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Python2-15-SP1-Pool for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-python2-15-sp1-debuginfo-pool-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1867,
+        "repository_id": 3601,
+        "parent_product_id": 1772,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Python2",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Python2/15-SP1/x86_64/product_debug/",
+        "release_stage": "beta",
+        "mandatory": false,
+        "signed": true,
+        "recommended": true,
+        "channel_name": "SLE-Module-Python2-15-SP1-Debuginfo-Pool for x86_64 HPC"
+    },
+    {
+        "channel_label": "suse-packagehub-15-sp1-standard-pool-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1868,
+        "repository_id": 3603,
+        "parent_product_id": 1769,
+        "root_product_id": 1760,
+        "update_tag": null,
+        "url": "https://updates.suse.com/SUSE/Backports/SLE-15-SP1_aarch64/standard/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SUSE-PackageHub-15-SP1-Standard-Pool for aarch64"
+    },
+    {
+        "channel_label": "suse-packagehub-15-sp1-debuginfo-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1868,
+        "repository_id": 3604,
+        "parent_product_id": 1769,
+        "root_product_id": 1760,
+        "update_tag": null,
+        "url": "https://updates.suse.com/SUSE/Backports/SLE-15-SP1_aarch64/standard_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SUSE-PackageHub-15-SP1-Debuginfo for aarch64"
+    },
+    {
+        "channel_label": "sle-module-packagehub-subpackages15-sp1-updates-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1868,
+        "repository_id": 3605,
+        "parent_product_id": 1769,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Packagehub-Subpackages",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Packagehub-Subpackages/15-SP1/aarch64/update/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Packagehub-Subpackages15-SP1-Updates for aarch64"
+    },
+    {
+        "channel_label": "sle-module-packagehub-subpackages15-sp1-debuginfo-updates-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1868,
+        "repository_id": 3606,
+        "parent_product_id": 1769,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Packagehub-Subpackages",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Packagehub-Subpackages/15-SP1/aarch64/update_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Packagehub-Subpackages15-SP1-Debuginfo-Updates for aarch64"
+    },
+    {
+        "channel_label": "suse-packagehub-15-sp1-pool-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1868,
+        "repository_id": 3607,
+        "parent_product_id": 1769,
+        "root_product_id": 1760,
+        "update_tag": null,
+        "url": "https://updates.suse.com/SUSE/Backports/SLE-15-SP1_aarch64/product/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SUSE-PackageHub-15-SP1-Pool for aarch64"
+    },
+    {
+        "channel_label": "sle-module-packagehub-subpackages15-sp1-pool-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1868,
+        "repository_id": 3608,
+        "parent_product_id": 1769,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Packagehub-Subpackages",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Packagehub-Subpackages/15-SP1/aarch64/product/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Packagehub-Subpackages15-SP1-Pool for aarch64"
+    },
+    {
+        "channel_label": "sle-module-packagehub-subpackages15-sp1-debuginfo-pool-aarch64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-aarch64",
+        "product_id": 1868,
+        "repository_id": 3609,
+        "parent_product_id": 1769,
+        "root_product_id": 1760,
+        "update_tag": "SLE-Module-Packagehub-Subpackages",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Packagehub-Subpackages/15-SP1/aarch64/product_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Packagehub-Subpackages15-SP1-Debuginfo-Pool for aarch64"
+    },
+    {
+        "channel_label": "suse-packagehub-15-sp1-standard-pool-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1868,
+        "repository_id": 3603,
+        "parent_product_id": 1769,
+        "root_product_id": 1767,
+        "update_tag": null,
+        "url": "https://updates.suse.com/SUSE/Backports/SLE-15-SP1_aarch64/standard/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SUSE-PackageHub-15-SP1-Standard-Pool for aarch64 HPC"
+    },
+    {
+        "channel_label": "suse-packagehub-15-sp1-debuginfo-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1868,
+        "repository_id": 3604,
+        "parent_product_id": 1769,
+        "root_product_id": 1767,
+        "update_tag": null,
+        "url": "https://updates.suse.com/SUSE/Backports/SLE-15-SP1_aarch64/standard_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SUSE-PackageHub-15-SP1-Debuginfo for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-module-packagehub-subpackages15-sp1-updates-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1868,
+        "repository_id": 3605,
+        "parent_product_id": 1769,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-Packagehub-Subpackages",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Packagehub-Subpackages/15-SP1/aarch64/update/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Packagehub-Subpackages15-SP1-Updates for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-module-packagehub-subpackages15-sp1-debuginfo-updates-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1868,
+        "repository_id": 3606,
+        "parent_product_id": 1769,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-Packagehub-Subpackages",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Packagehub-Subpackages/15-SP1/aarch64/update_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Packagehub-Subpackages15-SP1-Debuginfo-Updates for aarch64 HPC"
+    },
+    {
+        "channel_label": "suse-packagehub-15-sp1-pool-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1868,
+        "repository_id": 3607,
+        "parent_product_id": 1769,
+        "root_product_id": 1767,
+        "update_tag": null,
+        "url": "https://updates.suse.com/SUSE/Backports/SLE-15-SP1_aarch64/product/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SUSE-PackageHub-15-SP1-Pool for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-module-packagehub-subpackages15-sp1-pool-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1868,
+        "repository_id": 3608,
+        "parent_product_id": 1769,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-Packagehub-Subpackages",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Packagehub-Subpackages/15-SP1/aarch64/product/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Packagehub-Subpackages15-SP1-Pool for aarch64 HPC"
+    },
+    {
+        "channel_label": "sle-module-packagehub-subpackages15-sp1-debuginfo-pool-aarch64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-aarch64",
+        "product_id": 1868,
+        "repository_id": 3609,
+        "parent_product_id": 1769,
+        "root_product_id": 1767,
+        "update_tag": "SLE-Module-Packagehub-Subpackages",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Packagehub-Subpackages/15-SP1/aarch64/product_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Packagehub-Subpackages15-SP1-Debuginfo-Pool for aarch64 HPC"
+    },
+    {
+        "channel_label": "suse-packagehub-15-sp1-standard-pool-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1869,
+        "repository_id": 3611,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": null,
+        "url": "https://updates.suse.com/SUSE/Backports/SLE-15-SP1_ppc64le/standard/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SUSE-PackageHub-15-SP1-Standard-Pool for ppc64le"
+    },
+    {
+        "channel_label": "suse-packagehub-15-sp1-debuginfo-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1869,
+        "repository_id": 3612,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": null,
+        "url": "https://updates.suse.com/SUSE/Backports/SLE-15-SP1_ppc64le/standard_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SUSE-PackageHub-15-SP1-Debuginfo for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-packagehub-subpackages15-sp1-updates-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1869,
+        "repository_id": 3613,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Packagehub-Subpackages",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Packagehub-Subpackages/15-SP1/ppc64le/update/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Packagehub-Subpackages15-SP1-Updates for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-packagehub-subpackages15-sp1-debuginfo-updates-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1869,
+        "repository_id": 3614,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Packagehub-Subpackages",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Packagehub-Subpackages/15-SP1/ppc64le/update_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Packagehub-Subpackages15-SP1-Debuginfo-Updates for ppc64le"
+    },
+    {
+        "channel_label": "suse-packagehub-15-sp1-pool-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1869,
+        "repository_id": 3615,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": null,
+        "url": "https://updates.suse.com/SUSE/Backports/SLE-15-SP1_ppc64le/product/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SUSE-PackageHub-15-SP1-Pool for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-packagehub-subpackages15-sp1-pool-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1869,
+        "repository_id": 3616,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Packagehub-Subpackages",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Packagehub-Subpackages/15-SP1/ppc64le/product/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Packagehub-Subpackages15-SP1-Pool for ppc64le"
+    },
+    {
+        "channel_label": "sle-module-packagehub-subpackages15-sp1-debuginfo-pool-ppc64le",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-ppc64le",
+        "product_id": 1869,
+        "repository_id": 3617,
+        "parent_product_id": 1770,
+        "root_product_id": 1761,
+        "update_tag": "SLE-Module-Packagehub-Subpackages",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Packagehub-Subpackages/15-SP1/ppc64le/product_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Packagehub-Subpackages15-SP1-Debuginfo-Pool for ppc64le"
+    },
+    {
+        "channel_label": "suse-packagehub-15-sp1-standard-pool-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1869,
+        "repository_id": 3611,
+        "parent_product_id": 1770,
+        "root_product_id": 1765,
+        "update_tag": null,
+        "url": "https://updates.suse.com/SUSE/Backports/SLE-15-SP1_ppc64le/standard/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SUSE-PackageHub-15-SP1-Standard-Pool for ppc64le SAP"
+    },
+    {
+        "channel_label": "suse-packagehub-15-sp1-debuginfo-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1869,
+        "repository_id": 3612,
+        "parent_product_id": 1770,
+        "root_product_id": 1765,
+        "update_tag": null,
+        "url": "https://updates.suse.com/SUSE/Backports/SLE-15-SP1_ppc64le/standard_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SUSE-PackageHub-15-SP1-Debuginfo for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-packagehub-subpackages15-sp1-updates-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1869,
+        "repository_id": 3613,
+        "parent_product_id": 1770,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Packagehub-Subpackages",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Packagehub-Subpackages/15-SP1/ppc64le/update/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Packagehub-Subpackages15-SP1-Updates for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-packagehub-subpackages15-sp1-debuginfo-updates-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1869,
+        "repository_id": 3614,
+        "parent_product_id": 1770,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Packagehub-Subpackages",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Packagehub-Subpackages/15-SP1/ppc64le/update_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Packagehub-Subpackages15-SP1-Debuginfo-Updates for ppc64le SAP"
+    },
+    {
+        "channel_label": "suse-packagehub-15-sp1-pool-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1869,
+        "repository_id": 3615,
+        "parent_product_id": 1770,
+        "root_product_id": 1765,
+        "update_tag": null,
+        "url": "https://updates.suse.com/SUSE/Backports/SLE-15-SP1_ppc64le/product/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SUSE-PackageHub-15-SP1-Pool for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-packagehub-subpackages15-sp1-pool-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1869,
+        "repository_id": 3616,
+        "parent_product_id": 1770,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Packagehub-Subpackages",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Packagehub-Subpackages/15-SP1/ppc64le/product/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Packagehub-Subpackages15-SP1-Pool for ppc64le SAP"
+    },
+    {
+        "channel_label": "sle-module-packagehub-subpackages15-sp1-debuginfo-pool-ppc64le-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-ppc64le",
+        "product_id": 1869,
+        "repository_id": 3617,
+        "parent_product_id": 1770,
+        "root_product_id": 1765,
+        "update_tag": "SLE-Module-Packagehub-Subpackages",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Packagehub-Subpackages/15-SP1/ppc64le/product_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Packagehub-Subpackages15-SP1-Debuginfo-Pool for ppc64le SAP"
+    },
+    {
+        "channel_label": "suse-packagehub-15-sp1-standard-pool-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1870,
+        "repository_id": 3619,
+        "parent_product_id": 1771,
+        "root_product_id": 1762,
+        "update_tag": null,
+        "url": "https://updates.suse.com/SUSE/Backports/SLE-15-SP1_s390x/standard/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SUSE-PackageHub-15-SP1-Standard-Pool for s390x"
+    },
+    {
+        "channel_label": "suse-packagehub-15-sp1-debuginfo-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1870,
+        "repository_id": 3620,
+        "parent_product_id": 1771,
+        "root_product_id": 1762,
+        "update_tag": null,
+        "url": "https://updates.suse.com/SUSE/Backports/SLE-15-SP1_s390x/standard_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SUSE-PackageHub-15-SP1-Debuginfo for s390x"
+    },
+    {
+        "channel_label": "sle-module-packagehub-subpackages15-sp1-updates-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1870,
+        "repository_id": 3621,
+        "parent_product_id": 1771,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Packagehub-Subpackages",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Packagehub-Subpackages/15-SP1/s390x/update/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Packagehub-Subpackages15-SP1-Updates for s390x"
+    },
+    {
+        "channel_label": "sle-module-packagehub-subpackages15-sp1-debuginfo-updates-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1870,
+        "repository_id": 3622,
+        "parent_product_id": 1771,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Packagehub-Subpackages",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Packagehub-Subpackages/15-SP1/s390x/update_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Packagehub-Subpackages15-SP1-Debuginfo-Updates for s390x"
+    },
+    {
+        "channel_label": "suse-packagehub-15-sp1-pool-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1870,
+        "repository_id": 3623,
+        "parent_product_id": 1771,
+        "root_product_id": 1762,
+        "update_tag": null,
+        "url": "https://updates.suse.com/SUSE/Backports/SLE-15-SP1_s390x/product/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SUSE-PackageHub-15-SP1-Pool for s390x"
+    },
+    {
+        "channel_label": "sle-module-packagehub-subpackages15-sp1-pool-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1870,
+        "repository_id": 3624,
+        "parent_product_id": 1771,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Packagehub-Subpackages",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Packagehub-Subpackages/15-SP1/s390x/product/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Packagehub-Subpackages15-SP1-Pool for s390x"
+    },
+    {
+        "channel_label": "sle-module-packagehub-subpackages15-sp1-debuginfo-pool-s390x",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-s390x",
+        "product_id": 1870,
+        "repository_id": 3625,
+        "parent_product_id": 1771,
+        "root_product_id": 1762,
+        "update_tag": "SLE-Module-Packagehub-Subpackages",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Packagehub-Subpackages/15-SP1/s390x/product_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Packagehub-Subpackages15-SP1-Debuginfo-Pool for s390x"
+    },
+    {
+        "channel_label": "suse-packagehub-15-sp1-standard-pool-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1871,
+        "repository_id": 3627,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": null,
+        "url": "https://updates.suse.com/SUSE/Backports/SLE-15-SP1_x86_64/standard/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SUSE-PackageHub-15-SP1-Standard-Pool for x86_64"
+    },
+    {
+        "channel_label": "suse-packagehub-15-sp1-debuginfo-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1871,
+        "repository_id": 3628,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": null,
+        "url": "https://updates.suse.com/SUSE/Backports/SLE-15-SP1_x86_64/standard_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SUSE-PackageHub-15-SP1-Debuginfo for x86_64"
+    },
+    {
+        "channel_label": "sle-module-packagehub-subpackages15-sp1-updates-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1871,
+        "repository_id": 3629,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Packagehub-Subpackages",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Packagehub-Subpackages/15-SP1/x86_64/update/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Packagehub-Subpackages15-SP1-Updates for x86_64"
+    },
+    {
+        "channel_label": "sle-module-packagehub-subpackages15-sp1-debuginfo-updates-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1871,
+        "repository_id": 3630,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Packagehub-Subpackages",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Packagehub-Subpackages/15-SP1/x86_64/update_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Packagehub-Subpackages15-SP1-Debuginfo-Updates for x86_64"
+    },
+    {
+        "channel_label": "suse-packagehub-15-sp1-pool-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1871,
+        "repository_id": 3631,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": null,
+        "url": "https://updates.suse.com/SUSE/Backports/SLE-15-SP1_x86_64/product/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SUSE-PackageHub-15-SP1-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-module-packagehub-subpackages15-sp1-pool-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1871,
+        "repository_id": 3632,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Packagehub-Subpackages",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Packagehub-Subpackages/15-SP1/x86_64/product/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Packagehub-Subpackages15-SP1-Pool for x86_64"
+    },
+    {
+        "channel_label": "sle-module-packagehub-subpackages15-sp1-debuginfo-pool-x86_64",
+        "parent_channel_label": "sle-product-sles15-sp1-pool-x86_64",
+        "product_id": 1871,
+        "repository_id": 3633,
+        "parent_product_id": 1772,
+        "root_product_id": 1763,
+        "update_tag": "SLE-Module-Packagehub-Subpackages",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Packagehub-Subpackages/15-SP1/x86_64/product_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Packagehub-Subpackages15-SP1-Debuginfo-Pool for x86_64"
+    },
+    {
+        "channel_label": "suse-packagehub-15-sp1-standard-pool-x86_64-sled",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1871,
+        "repository_id": 3627,
+        "parent_product_id": 1772,
+        "root_product_id": 1764,
+        "update_tag": null,
+        "url": "https://updates.suse.com/SUSE/Backports/SLE-15-SP1_x86_64/standard/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SUSE-PackageHub-15-SP1-Standard-Pool for x86_64 SLED"
+    },
+    {
+        "channel_label": "suse-packagehub-15-sp1-debuginfo-x86_64-sled",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1871,
+        "repository_id": 3628,
+        "parent_product_id": 1772,
+        "root_product_id": 1764,
+        "update_tag": null,
+        "url": "https://updates.suse.com/SUSE/Backports/SLE-15-SP1_x86_64/standard_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SUSE-PackageHub-15-SP1-Debuginfo for x86_64 SLED"
+    },
+    {
+        "channel_label": "sle-module-packagehub-subpackages15-sp1-updates-x86_64-sled",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1871,
+        "repository_id": 3629,
+        "parent_product_id": 1772,
+        "root_product_id": 1764,
+        "update_tag": "SLE-Module-Packagehub-Subpackages",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Packagehub-Subpackages/15-SP1/x86_64/update/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Packagehub-Subpackages15-SP1-Updates for x86_64 SLED"
+    },
+    {
+        "channel_label": "sle-module-packagehub-subpackages15-sp1-debuginfo-updates-x86_64-sled",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1871,
+        "repository_id": 3630,
+        "parent_product_id": 1772,
+        "root_product_id": 1764,
+        "update_tag": "SLE-Module-Packagehub-Subpackages",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Packagehub-Subpackages/15-SP1/x86_64/update_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Packagehub-Subpackages15-SP1-Debuginfo-Updates for x86_64 SLED"
+    },
+    {
+        "channel_label": "suse-packagehub-15-sp1-pool-x86_64-sled",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1871,
+        "repository_id": 3631,
+        "parent_product_id": 1772,
+        "root_product_id": 1764,
+        "update_tag": null,
+        "url": "https://updates.suse.com/SUSE/Backports/SLE-15-SP1_x86_64/product/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SUSE-PackageHub-15-SP1-Pool for x86_64 SLED"
+    },
+    {
+        "channel_label": "sle-module-packagehub-subpackages15-sp1-pool-x86_64-sled",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1871,
+        "repository_id": 3632,
+        "parent_product_id": 1772,
+        "root_product_id": 1764,
+        "update_tag": "SLE-Module-Packagehub-Subpackages",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Packagehub-Subpackages/15-SP1/x86_64/product/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Packagehub-Subpackages15-SP1-Pool for x86_64 SLED"
+    },
+    {
+        "channel_label": "sle-module-packagehub-subpackages15-sp1-debuginfo-pool-x86_64-sled",
+        "parent_channel_label": "sle-product-sled15-sp1-pool-x86_64",
+        "product_id": 1871,
+        "repository_id": 3633,
+        "parent_product_id": 1772,
+        "root_product_id": 1764,
+        "update_tag": "SLE-Module-Packagehub-Subpackages",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Packagehub-Subpackages/15-SP1/x86_64/product_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Packagehub-Subpackages15-SP1-Debuginfo-Pool for x86_64 SLED"
+    },
+    {
+        "channel_label": "suse-packagehub-15-sp1-standard-pool-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1871,
+        "repository_id": 3627,
+        "parent_product_id": 1772,
+        "root_product_id": 1766,
+        "update_tag": null,
+        "url": "https://updates.suse.com/SUSE/Backports/SLE-15-SP1_x86_64/standard/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SUSE-PackageHub-15-SP1-Standard-Pool for x86_64 SAP"
+    },
+    {
+        "channel_label": "suse-packagehub-15-sp1-debuginfo-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1871,
+        "repository_id": 3628,
+        "parent_product_id": 1772,
+        "root_product_id": 1766,
+        "update_tag": null,
+        "url": "https://updates.suse.com/SUSE/Backports/SLE-15-SP1_x86_64/standard_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SUSE-PackageHub-15-SP1-Debuginfo for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-packagehub-subpackages15-sp1-updates-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1871,
+        "repository_id": 3629,
+        "parent_product_id": 1772,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Packagehub-Subpackages",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Packagehub-Subpackages/15-SP1/x86_64/update/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Packagehub-Subpackages15-SP1-Updates for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-packagehub-subpackages15-sp1-debuginfo-updates-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1871,
+        "repository_id": 3630,
+        "parent_product_id": 1772,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Packagehub-Subpackages",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Packagehub-Subpackages/15-SP1/x86_64/update_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Packagehub-Subpackages15-SP1-Debuginfo-Updates for x86_64 SAP"
+    },
+    {
+        "channel_label": "suse-packagehub-15-sp1-pool-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1871,
+        "repository_id": 3631,
+        "parent_product_id": 1772,
+        "root_product_id": 1766,
+        "update_tag": null,
+        "url": "https://updates.suse.com/SUSE/Backports/SLE-15-SP1_x86_64/product/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SUSE-PackageHub-15-SP1-Pool for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-packagehub-subpackages15-sp1-pool-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1871,
+        "repository_id": 3632,
+        "parent_product_id": 1772,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Packagehub-Subpackages",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Packagehub-Subpackages/15-SP1/x86_64/product/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Packagehub-Subpackages15-SP1-Pool for x86_64 SAP"
+    },
+    {
+        "channel_label": "sle-module-packagehub-subpackages15-sp1-debuginfo-pool-x86_64-sap",
+        "parent_channel_label": "sle-product-sles_sap15-sp1-pool-x86_64",
+        "product_id": 1871,
+        "repository_id": 3633,
+        "parent_product_id": 1772,
+        "root_product_id": 1766,
+        "update_tag": "SLE-Module-Packagehub-Subpackages",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Packagehub-Subpackages/15-SP1/x86_64/product_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Packagehub-Subpackages15-SP1-Debuginfo-Pool for x86_64 SAP"
+    },
+    {
+        "channel_label": "suse-packagehub-15-sp1-standard-pool-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1871,
+        "repository_id": 3627,
+        "parent_product_id": 1772,
+        "root_product_id": 1768,
+        "update_tag": null,
+        "url": "https://updates.suse.com/SUSE/Backports/SLE-15-SP1_x86_64/standard/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SUSE-PackageHub-15-SP1-Standard-Pool for x86_64 HPC"
+    },
+    {
+        "channel_label": "suse-packagehub-15-sp1-debuginfo-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1871,
+        "repository_id": 3628,
+        "parent_product_id": 1772,
+        "root_product_id": 1768,
+        "update_tag": null,
+        "url": "https://updates.suse.com/SUSE/Backports/SLE-15-SP1_x86_64/standard_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SUSE-PackageHub-15-SP1-Debuginfo for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-packagehub-subpackages15-sp1-updates-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1871,
+        "repository_id": 3629,
+        "parent_product_id": 1772,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Packagehub-Subpackages",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Packagehub-Subpackages/15-SP1/x86_64/update/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Packagehub-Subpackages15-SP1-Updates for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-packagehub-subpackages15-sp1-debuginfo-updates-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1871,
+        "repository_id": 3630,
+        "parent_product_id": 1772,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Packagehub-Subpackages",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Packagehub-Subpackages/15-SP1/x86_64/update_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Packagehub-Subpackages15-SP1-Debuginfo-Updates for x86_64 HPC"
+    },
+    {
+        "channel_label": "suse-packagehub-15-sp1-pool-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1871,
+        "repository_id": 3631,
+        "parent_product_id": 1772,
+        "root_product_id": 1768,
+        "update_tag": null,
+        "url": "https://updates.suse.com/SUSE/Backports/SLE-15-SP1_x86_64/product/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SUSE-PackageHub-15-SP1-Pool for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-packagehub-subpackages15-sp1-pool-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1871,
+        "repository_id": 3632,
+        "parent_product_id": 1772,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Packagehub-Subpackages",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Packagehub-Subpackages/15-SP1/x86_64/product/",
+        "release_stage": "released",
+        "mandatory": true,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Packagehub-Subpackages15-SP1-Pool for x86_64 HPC"
+    },
+    {
+        "channel_label": "sle-module-packagehub-subpackages15-sp1-debuginfo-pool-x86_64-hpc",
+        "parent_channel_label": "sle-product-hpc-15-sp1-pool-x86_64",
+        "product_id": 1871,
+        "repository_id": 3633,
+        "parent_product_id": 1772,
+        "root_product_id": 1768,
+        "update_tag": "SLE-Module-Packagehub-Subpackages",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Packagehub-Subpackages/15-SP1/x86_64/product_debug/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLE-Module-Packagehub-Subpackages15-SP1-Debuginfo-Pool for x86_64 HPC"
     }
 ]

--- a/java/code/src/com/redhat/rhn/manager/content/test/smallBase/productsUnscoped.json
+++ b/java/code/src/com/redhat/rhn/manager/content/test/smallBase/productsUnscoped.json
@@ -1192,5 +1192,51 @@
         "installer_updates": false
       }
     ]
+  },
+  {
+    "arch": null,
+    "cpe": null,
+    "description": null,
+    "eula_url": "",
+    "extensions": [],
+    "former_identifier": "RES",
+    "free": false,
+    "friendly_name": "RHEL Expanded Support 7",
+    "id": 1251,
+    "identifier": "RES",
+    "migration_extra": false,
+    "name": "RHEL Expanded Support",
+    "offline_predecessor_ids": [],
+    "online_predecessor_ids": [],
+    "predecessor_ids": [],
+    "product_class": "RES",
+    "product_type": "base",
+    "recommended": false,
+    "release_stage": "released",
+    "release_type": null,
+    "repositories": [
+      {
+        "autorefresh": true,
+        "description": "RES7 for x86_64",
+        "distro_target": "x86_64",
+        "enabled": true,
+        "id": 1736,
+        "installer_updates": false,
+        "name": "RES7",
+        "url": "https://updates.suse.com/repo/$RCE/RES7/x86_64/"
+      },
+      {
+        "autorefresh": true,
+        "description": "RES7 for src",
+        "distro_target": "src",
+        "enabled": true,
+        "id": 1963,
+        "installer_updates": false,
+        "name": "RES7",
+        "url": "https://updates.suse.com/repo/$RCE/RES7/src/"
+      }
+    ],
+    "shortname": null,
+    "version": "7"
   }
 ]

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- fix synchronizing Expanded Support Channel with missing architecture
+  (bsc#1122565)
 - Explicitly require JDK11
 - Update spec file to no longer install tomcat context file in cache directory (bsc#1111308)
 - Fix for duplicate key violation when cloning erratas that have no packages associated (bsc#1111686)


### PR DESCRIPTION
## What does this PR change?

Expanded Support channels do not have an architecture. This result in a Null Pointer Exception.
This patch search for the architecture also in the channel label.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: internal

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/6843

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
