### PR TITLE
Fix invalid XML for firewalld suse-manager-server configuration

### DIFF
--- a/susemanager/etc/firewalld/services/suse-manager-server.xml
+++ b/susemanager/etc/firewalld/services/suse-manager-server.xml
@@ -8,7 +8,7 @@
 	<port protocol="tcp" port="5222"/>
 	<port protocol="tcp" port="5269"/>
         <port protocol="tcp" port="4505"/>
-        <port protocol="tcp" port="4506">
+	<port protocol="tcp" port="4506"/>
 	<port protocol="udp" port="123"/>
 	<port protocol="udp" port="69"/>
 	<module name="nf_conntrack_tftp"/>

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,4 +1,6 @@
+- Fix invalid XML for firewalld suse-manager-server configuration
 - adapt script for migration from 3.2 to 4.0
+
 -------------------------------------------------------------------
 Thu Jan 17 14:46:00 CET 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Fix the XML declaration for port 4506 (was not closed)

As a result firewalld failed to load it:
```
Jan 23 07:31:30 suma40 firewalld[14089]: ERROR: Failed to load service file '/usr/lib/firewalld/services/suse-manager-server.xml': INVALID_SERVICE: not a valid service file: mismatched tag: line 15, column 2
```
And therefore the setup fails:
```
Error: INVALID_SERVICE: 'suse-manager-server' not among existing services
```
## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: Internal fix

- [x] **DONE**

## Test coverage

- No tests: Already covered by sumaform installation

But maybe we should add basic XML validation for our XML files :-)

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/6855

- [x] **DONE**