### PR TITLE
Configure openJDK 11 as default JVM during setup

### DIFF
--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -2,8 +2,8 @@
 
 DISTRIBUTION_ID="$(source /etc/os-release && echo ${ID})"
 case ${DISTRIBUTION_ID} in
-    sles)      JVM='/usr/lib64/jvm/jre-1.8.0-ibm/bin/java';;
-    opensuse)  JVM='/usr/lib64/jvm/jre-1.8.0-openjdk/bin/java';;
+    sles)      JVM='/usr/lib64/jvm/jre-11-openjdk/bin/java';;
+    opensuse)  JVM='/usr/lib64/jvm/jre-11-openjdk/bin/java';;
     *)         echo 'Unknown distribution!'
                exit 1;;
 esac

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,4 +1,5 @@
 - Fix invalid XML for firewalld suse-manager-server configuration
+- Configure openJDK 11 as default JVM during setup
 - adapt script for migration from 3.2 to 4.0
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Stop using openJDK 8 (openSUSE) and IBM JDK 8 (SUSE), and use openJDK 11 in all cases.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: A search at the [susemanager doc repository](https://github.com/SUSE/doc-susemanager) did not return any references to the Java/JDK version
- [x] **DONE**

## Test coverage
- No tests: Already covered sumaform installation

- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/6855

- [x] **DONE**