### PR TITLE
Fix distribution detection for spacewalk-setup and spacewalk-setup-httpd

### DIFF
--- a/spacewalk/setup/bin/spacewalk-setup
+++ b/spacewalk/setup/bin/spacewalk-setup
@@ -1163,8 +1163,24 @@ sub setup_services {
   return 1;
 }
 
+sub is_suse_like {
+  my $filename = '/etc/os-release';
+  if(! -e $filename) {
+    return;
+  }
+  open my $fh, "<", $filename or die "Could not open '$filename': $!\n";
+  while( my $line = <$fh> ) {
+    if ($line =~ m/ID_LIKE=".*suse.*"/) {
+      close $fh;
+      return 1;
+    }
+  }
+  close $fh;
+  return;
+}
+
 sub setup_users_and_groups {
-  if(-e '/etc/SuSE-release')
+  if(is_suse_like)
   {
     # Check to be sure the required users and groups exist.
     my @required_groups = qw/www/;

--- a/spacewalk/setup/bin/spacewalk-setup-httpd
+++ b/spacewalk/setup/bin/spacewalk-setup-httpd
@@ -141,6 +141,22 @@ sub setup_mod_ssl {
         return;
 }
 
+sub is_suse_like {
+  my $filename = '/etc/os-release';
+  if(! -e $filename) {
+    return;
+  }
+  open my $fh, "<", $filename or die "Could not open '$filename': $!\n";
+  while( my $line = <$fh> ) {
+    if ($line =~ m/ID_LIKE=".*suse.*"/) {
+      close $fh;
+      return 1;
+    }
+  }
+  close $fh;
+  return;
+}
+
 # main
 
 my $help;
@@ -163,8 +179,8 @@ if ($help) {
         exit 0;
 }
 
-if(-e '/etc/SuSE-release') {
-    $isSUSE = 1;
+if(is_suse_like) {
+  $isSUSE = 1;
 }
 
 setup_mod_ssl($fips_mode_on);

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,6 @@
+- Fix distribution detection to work with openSUSE Leap 15 and
+  SLE 15
+
 -------------------------------------------------------------------
 Wed Jan 16 12:24:40 CET 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Fix distribution detection for `spacewalk-setup` and `spacewalk-setup-httpd` by looking at `ID_LIKE` at `/etc/os-release`.

We don't look for `/etc/SuSE-release` anymore, as we'll not support SLE/openSUSE < 15

@mbologna, my Perl is really rusty (last time I wrote something was more than 8 years ago, and it was only changes for an oooold from 2000), so I verified this works, but I am not sure the style is up to date. Feel free to correct.

For reference, contents at `/etc/os-release` for:

openSUSE
```
NAME="openSUSE Leap"
VERSION="15.0"
ID="opensuse-leap"
ID_LIKE="suse opensuse"
VERSION_ID="15.0"
PRETTY_NAME="openSUSE Leap 15.0"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:opensuse:leap:15.0"
BUG_REPORT_URL="https://bugs.opensuse.org"
HOME_URL="https://www.opensuse.org/"
```
SUSE:
```
NAME="SLES"
VERSION="15-SP1"
VERSION_ID="15.1"
PRETTY_NAME="SUSE Linux Enterprise Server 15 SP1"
ID="sles"
ID_LIKE="suse"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:suse:sles:15:sp1"
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: Internal fix

- [x] **DONE**

## Test coverage

- No tests: Already covered by sumaform installation

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/6855

- [x] **DONE**