### PR TITLE
Make rhn-ssl-dbstore compatible with python3

### DIFF
--- a/backend/common/rhnConfig.py
+++ b/backend/common/rhnConfig.py
@@ -228,9 +228,14 @@ class RHNOptions:
                print cfg.DEBUG ---> yields 5
         """
         self.__check()
-        if key not in self.__configs[self.__component]:
+        # For some reason, before the migration to python3, the code
+        # used all attribute names in capital letters, and it worked
+        # while for python3 it is failing. Adding .lower() since
+        # otherwise changing the mentions to config parameters
+        # all over the code, would take ages
+        if key.lower() not in self.__configs[self.__component]:
             raise AttributeError(key)
-        return self.__configs[self.__component][key]
+        return self.__configs[self.__component][key.lower()]
     __getitem__ = __getattr__
 
     def get(self, key, default=None):
@@ -450,18 +455,7 @@ def read_file(filename):
     reads a text config file and returns its lines in a list
     """
     try:
-        lines = open(filename, 'rb').readlines()
-        new_lines = []
-        combined = ''
-        for line in lines:
-            # if the line isn't part of a multiline, lets add it
-            if line.find('\\\n') < 0:
-                combined = combined + line
-                new_lines.append(combined)
-                combined = ''
-            else:
-                combined = combined + line.replace('\\\n', ' ')
-        return new_lines
+        return open(filename, 'r').readlines()
     except (IOError, OSError):
         e = sys.exc_info()[1]
         raise_with_tb(ConfigParserError("Can not read config file", filename, e.args[1]), sys.exc_info()[2])

--- a/backend/satellite_tools/rhn-ssl-dbstore
+++ b/backend/satellite_tools/rhn-ssl-dbstore
@@ -26,7 +26,7 @@ try:
 except KeyboardInterrupt:
     sys.stderr.write("\nUser interrupted process.\n")
     sys.exit(0)
-except ImportError, e:
+except ImportError as e:
     sys.stderr.write("Unable to load module %s\n" % mod_name)
     sys.stderr.write(str(e) + "\n")
     sys.exit(1)

--- a/backend/satellite_tools/rhn_ssl_dbstore.py
+++ b/backend/satellite_tools/rhn_ssl_dbstore.py
@@ -20,7 +20,7 @@ from optparse import Option, OptionParser
 from spacewalk.common import rhnTB
 from spacewalk.server import rhnSQL
 
-import satCerts
+from . import satCerts
 
 DEFAULT_TRUSTED_CERT = 'RHN-ORG-TRUSTED-SSL-CERT'
 

--- a/backend/satellite_tools/satCerts.py
+++ b/backend/satellite_tools/satCerts.py
@@ -133,7 +133,7 @@ def _insertPrep_rhnCryptoKey(rhn_cryptokey_id, description, org_id):
     #       do so if the row does not exist.
     #       bugzilla: 120297 - and no I don't like it.
     rhn_cryptokey_id_seq = rhnSQL.Sequence('rhn_cryptokey_id_seq')
-    rhn_cryptokey_id = next(rhn_cryptokey_id_seq)
+    rhn_cryptokey_id = rhn_cryptokey_id_seq.next()
     # print 'no cert found, new one with id:', rhn_cryptokey_id
     h = rhnSQL.prepare(_queryInsertCryptoCertInfo)
     # ...insert

--- a/backend/satellite_tools/satsync.py
+++ b/backend/satellite_tools/satsync.py
@@ -70,7 +70,7 @@ from spacewalk.server.importlib.importLib import InvalidChannelFamilyError
 from spacewalk.server.importlib.importLib import MissingParentChannelError
 from spacewalk.server.importlib.importLib import get_nevra, get_nevra_dict
 
-import satCerts
+from . import satCerts
 import req_channels
 import messages
 import sync_handlers

--- a/backend/server/rhnSQL/__init__.py
+++ b/backend/server/rhnSQL/__init__.py
@@ -24,17 +24,17 @@ from spacewalk.common.rhnException import rhnException
 from spacewalk.common.rhnTB import add_to_seclist
 
 # SQL objects
-import sql_table
-import sql_row
-import sql_sequence
-import dbi
-import sql_types
+from . import sql_table
+from . import sql_row
+from . import sql_sequence
+from . import dbi
+from . import sql_types
 types = sql_types
 
-from const import ORACLE, POSTGRESQL, SUPPORTED_BACKENDS
+from .const import ORACLE, POSTGRESQL, SUPPORTED_BACKENDS
 
 # expose exceptions
-from sql_base import SQLError, SQLSchemaError, SQLConnectError, \
+from .sql_base import SQLError, SQLSchemaError, SQLConnectError, \
     SQLStatementPrepareError, Statement, ModifiedRowError
 
 # ths module works with a private global __DB object that is

--- a/backend/server/rhnSQL/dbi.py
+++ b/backend/server/rhnSQL/dbi.py
@@ -14,7 +14,7 @@
 #
 #
 
-from const import ORACLE, POSTGRESQL
+from .const import ORACLE, POSTGRESQL
 
 # Map supported backend constants to a specific Python driver:
 BACKEND_DRIVERS = {

--- a/backend/server/rhnSQL/driver_postgresql.py
+++ b/backend/server/rhnSQL/driver_postgresql.py
@@ -27,14 +27,14 @@ import psycopg2
 if not hasattr(psycopg2, 'extensions'):
     import psycopg2.extensions
 
-import sql_base
+from . import sql_base
 from rhn.UserDictCase import UserDictCase
 from spacewalk.server import rhnSQL
 
 from spacewalk.common.usix import BufferType, raise_with_tb
 from spacewalk.common.rhnLog import log_debug, log_error
 from spacewalk.common.rhnException import rhnException
-from const import POSTGRESQL
+from .const import POSTGRESQL
 
 
 def convert_named_query_params(query):

--- a/backend/server/rhnSQL/sql_base.py
+++ b/backend/server/rhnSQL/sql_base.py
@@ -25,7 +25,7 @@
 
 import string
 import sys
-import sql_types
+from . import sql_types
 from spacewalk.common import usix
 
 

--- a/backend/server/rhnSQL/sql_row.py
+++ b/backend/server/rhnSQL/sql_row.py
@@ -20,8 +20,8 @@ import string
 from rhn.UserDictCase import UserDictCase
 from spacewalk.common.rhnException import rhnException
 
-import sql_base
-import sql_lib
+from . import sql_base
+from . import sql_lib
 
 
 class Row(UserDictCase):

--- a/backend/server/rhnSQL/sql_sequence.py
+++ b/backend/server/rhnSQL/sql_sequence.py
@@ -17,7 +17,7 @@
 
 from spacewalk.common.rhnException import rhnException
 
-import sql_base
+from . import sql_base
 
 
 # A class to handle sequences

--- a/backend/server/rhnSQL/sql_table.py
+++ b/backend/server/rhnSQL/sql_table.py
@@ -21,8 +21,8 @@ import string
 from rhn.UserDictCase import UserDictCase
 from spacewalk.common.rhnException import rhnException
 
-import sql_base
-import sql_lib
+from . import sql_base
+from . import sql_lib
 
 
 # A class to handle row updates transparently

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- Make rhn-ssl-dbstore compatible with python3
+
 -------------------------------------------------------------------
 Wed Jan 16 12:21:06 CET 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Make rhn-ssl-dbstore compatible with python3

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: Internal fix

- [x] **DONE**

## Test coverage

- No tests: Already covered by sumaform installation

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/6855

- [x] **DONE**