### PR TITLE
pkgset beacon: do not fire on first start (bsc#1122896)

### DIFF
--- a/susemanager-utils/susemanager-sls/src/beacons/pkgset.py
+++ b/susemanager-utils/susemanager-sls/src/beacons/pkgset.py
@@ -54,7 +54,9 @@ def beacon(config):
     if os.path.exists(config.get('cookie', '')):
         with open(config.get('cookie')) as ck_file:
             ck_data = ck_file.read().strip()
-            if __context__.get(__virtualname__, "") != ck_data:
+            if __virtualname__ not in __context__:
+                __context__[__virtualname__] = ck_data
+            if __context__[__virtualname__] != ck_data:
                 ret.append({
                     'tag': 'changed'
                 })

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- prevent the pkgset beacon from firing during onboarding (bsc#1122896)
 - Prevent excessive DEBUG logging from mgr_events engine
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

It prevents the `pkgset` beacon from firing during onboarding.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- will be covered in the performance testsuite soon

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/6880

- [x] **DONE**
