### PR TITLE
Ubuntu support fix eth0 ens3

### DIFF
--- a/testsuite/docs/cucumber-steps.md
+++ b/testsuite/docs/cucumber-steps.md
@@ -445,6 +445,11 @@ The check box can be identified by name, id or label text.
   When I wait and check that "sle-client" has rebooted
 ```
 
+* Check the MAC address value 
+
+```cucumber
+  Then the MAC address of "sle-client" should be displayed
+```
 
 <a name="b8" />
 

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -83,15 +83,17 @@ end
 # bare metal
 When(/^I check the ram value$/) do
   get_ram_value = "grep MemTotal /proc/meminfo |awk '{print $2}'"
-  ram_value, _local, _remote, _code = $client.test_and_store_results_together(get_ram_value, 'root', 600)
+  ram_value, _local, _remote, _code = $client.run(get_ram_value, false, 600)
   ram_value = ram_value.gsub(/\s+/, '')
   ram_mb = ram_value.to_i / 1024
   step %(I should see a "#{ram_mb}" text)
 end
 
-When(/^I check the MAC address value$/) do
-  get_mac_address = 'cat /sys/class/net/eth0/address'
-  mac_address, _local, _remote, _code = $client.test_and_store_results_together(get_mac_address, 'root', 600)
+Then(/^the MAC address of "([^"]*)" should be displayed$/) do |host|
+  node = get_target(host)
+  iface = host == 'ubuntu-minion' ? 'ens3' : 'eth0'
+  get_mac_address = "cat /sys/class/net/#{iface}/address"
+  mac_address, _local, _remote, _code = node.run(get_mac_address, false, 600)
   mac_address = mac_address.gsub(/\s+/, '')
   mac_address.downcase!
   step %(I should see a "#{mac_address}" text)
@@ -99,7 +101,7 @@ end
 
 Then(/^I should see the CPU frequency of the client$/) do
   get_cpu_freq = "lscpu  | grep 'CPU MHz'" # | awk '{print $4}'"
-  cpu_freq, _local, _remote, _code = $client.test_and_store_results_together(get_cpu_freq, 'root', 600)
+  cpu_freq, _local, _remote, _code = $client.run(get_cpu_freq, false, 600)
   get_cpu = cpu_freq.gsub(/\s+/, '')
   cpu = get_cpu.split('.')
   cpu = cpu[0].gsub(/[^\d]/, '')

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -426,7 +426,8 @@ end
 
 When(/^I enter the IP address of "([^"]*)" in (.*) field$/) do |host, field|
   node = get_target(host)
-  output, _code = node.run("ip address show dev eth0")
+  iface = host == 'ubuntu-minion' ? 'ens3' : 'eth0'
+  output, return_code = node.run("ip address show dev #{iface}")
   ip = output.split("\n")[2].split[1].split('/')[0]
   fieldids = { 'fifth A address' => 'bind#available_zones#2#records#A#0#1' }
   fill_in fieldids[field], with: ip
@@ -437,7 +438,8 @@ When(/^I enter the MAC address of "([^"]*)" in (.*) field$/) do |host, field|
     mac = $pxeboot_mac
   else
     node = get_target(host)
-    output, _code = node.run("ip link show dev eth1")
+    iface = host == 'ubuntu-minion' ? 'ens4' : 'eth1'
+    output, return_code = node.run("ip link show dev #{iface}")
     mac = output.split("\n")[1].split[1]
   end
   fieldids = { 'first reserved MAC'  => 'dhcpd#hosts#0#hardware',

--- a/testsuite/features/trad_baremetal_discovery.feature
+++ b/testsuite/features/trad_baremetal_discovery.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 SUSE LLC
+# Copyright (c) 2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Bare metal discovery
@@ -48,7 +48,7 @@ Feature: Bare metal discovery
     And I should see a "Number of disks" text
     And I should see a "1" text
     And I should see a "MAC Address(es)" text
-    And I check the MAC address value
+    Then the MAC address of "sle-client" should be displayed
 
   Scenario: Check unprovisioned system details
     Given I am on the Systems page

--- a/testsuite/features/upload_files/01-netcfg.yaml
+++ b/testsuite/features/upload_files/01-netcfg.yaml
@@ -1,0 +1,13 @@
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    ens3:
+      match: {}
+      dhcp4: yes
+    ens4:
+      match: {}
+      dhcp4: yes
+      nameservers:
+      search: [DOMAINS]
+      addresses: [ADDRESSES]


### PR DESCRIPTION
## What does this PR change?

Ubuntu use ens3 and ens4 instead of eth0 and eth1, testsuite fixed.
Task : https://github.com/SUSE/spacewalk/issues/6799