### PR TITLE
Use pagination in query that generates repo metadata (bsc#1115776)

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Task_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Task_queries.xml
@@ -488,6 +488,20 @@ where snc.errata_id = :errata_id
    <elaborator name="repomdgenerator_package_elab" />
 </mode>
 
+<mode name="repomdgenerator_channel_package_batch"
+      class="com.redhat.rhn.frontend.dto.PackageDto">
+    <query params="channel_id, limit, offset">
+        SELECT cp.package_id AS id
+        FROM
+        rhnChannelPackage cp
+        WHERE
+        cp.channel_id = :channel_id
+        ORDER by cp.package_id
+        LIMIT :limit OFFSET :offset
+    </query>
+    <elaborator name="repomdgenerator_package_elab" />
+</mode>
+
 <mode name="repomdgenerator_capability_files"
     class="com.redhat.rhn.frontend.dto.PackageCapabilityDto">
    <query params="package_id">

--- a/java/code/src/com/redhat/rhn/manager/task/TaskManager.java
+++ b/java/code/src/com/redhat/rhn/manager/task/TaskManager.java
@@ -55,6 +55,23 @@ public class TaskManager {
     }
 
     /**
+     *  Get the channel package list for a channel
+     * @param channel channel info
+     * @param start index of first element
+     * @param pageSize how many elements to fetch
+     * @return the iterator
+     */
+    public static DataResult<PackageDto> getChannelPackageDtos(Channel channel, long start, int pageSize) {
+        SelectMode m = ModeFactory.getMode(TaskConstants.MODE_NAME,
+                TaskConstants.TASK_QUERY_REPOMD_GENERATOR_CHANNEL_PACKAGES_BATCH);
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("channel_id", channel.getId());
+        params.put("offset", start);
+        params.put("limit", pageSize);
+        return m.execute(params);
+    }
+
+    /**
      * Get capabilities of a certain type for a package
      * @param packageId the package's id
      * @param query the query to execute

--- a/java/code/src/com/redhat/rhn/taskomatic/task/TaskConstants.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/TaskConstants.java
@@ -127,6 +127,9 @@ public class TaskConstants {
     public static final String TASK_QUERY_REPOMD_GENERATOR_CHANNEL_PACKAGES =
         "repomdgenerator_channel_packages";
 
+    public static final String TASK_QUERY_REPOMD_GENERATOR_CHANNEL_PACKAGES_BATCH =
+        "repomdgenerator_channel_package_batch";
+
     public static final String TASK_QUERY_REPOMD_GENERATOR_CAPABILITY_FILES =
         "repomdgenerator_capability_files";
 

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/RpmRepositoryWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/RpmRepositoryWriter.java
@@ -197,9 +197,9 @@ public class RpmRepositoryWriter extends RepositoryWriter {
         // batch the elaboration so we don't have to hold many thousands of
         // packages in memory at once
         final int batchSize = 1000;
-        DataResult<PackageDto> packages = TaskManager.getChannelPackageDtos(channel);
-        for (int i = 0; i < packages.size(); i += batchSize) {
-            DataResult<PackageDto> packageBatch = packages.subList(i, i + batchSize);
+
+        for (long i = 0; i < channel.getPackageCount(); i += batchSize) {
+            DataResult<PackageDto> packageBatch = TaskManager.getChannelPackageDtos(channel, i, batchSize);
             packageBatch.elaborate();
             for (PackageDto pkgDto : packageBatch) {
                 // this is a sanity check
@@ -224,6 +224,7 @@ public class RpmRepositoryWriter extends RepositoryWriter {
                     throw new RepomdRuntimeException(e);
                 }
             }
+            log.info("Processed " + (i + packageBatch.getEnd()) + " packages");
         }
         primary.end();
         filelists.end();

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/test/RpmRepositoryWriterTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/test/RpmRepositoryWriterTest.java
@@ -1,0 +1,183 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.taskomatic.task.repomd.test;
+
+import com.redhat.rhn.common.db.datasource.DataResult;
+import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.channel.ChannelFactory;
+import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
+import com.redhat.rhn.domain.rhnpackage.PackageCapability;
+import com.redhat.rhn.domain.rhnpackage.PackageProvides;
+import com.redhat.rhn.domain.rhnpackage.PackageRequires;
+import com.redhat.rhn.domain.rhnpackage.test.PackageCapabilityTest;
+import com.redhat.rhn.frontend.dto.PackageDto;
+import com.redhat.rhn.manager.rhnpackage.PackageManager;
+import com.redhat.rhn.manager.rhnpackage.test.PackageManagerTest;
+import com.redhat.rhn.manager.task.TaskManager;
+import com.redhat.rhn.taskomatic.task.repomd.RpmRepositoryWriter;
+import com.redhat.rhn.testing.BaseTestCaseWithUser;
+import com.redhat.rhn.testing.TestUtils;
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.GZIPInputStream;
+
+public class RpmRepositoryWriterTest extends BaseTestCaseWithUser {
+
+    private Path mountPointDir;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        mountPointDir = Files.createTempDirectory("rpmrepotest");
+    }
+
+    public void testPagination() throws Exception {
+        Channel channel = ChannelFactoryTest.createTestChannel(user);
+        channel.setChecksumType(ChannelFactory.findChecksumTypeByLabel("sha256"));
+
+        PackageManager.createRepoEntrys(channel.getId());
+
+        for (int i = 0; i < 25; i++) {
+            com.redhat.rhn.domain.rhnpackage.Package pkg = PackageManagerTest.addPackageToChannel("pkgpg" + i, channel);
+        }
+
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().clear();
+
+        DataResult<PackageDto> pkgs = TaskManager.getChannelPackageDtos(channel, 0, 10);
+        assertEquals(10, pkgs.size());
+
+        pkgs = TaskManager.getChannelPackageDtos(channel, 0, 30);
+        assertEquals(25, pkgs.size());
+    }
+
+
+    public void testWriteRepomdFiles() throws Exception {
+        RpmRepositoryWriter writer = new RpmRepositoryWriter("rhn/repodata", mountPointDir.toAbsolutePath().toString());
+
+        Channel channel = ChannelFactoryTest.createTestChannel(user);
+        channel.setChecksumType(ChannelFactory.findChecksumTypeByLabel("sha256"));
+        com.redhat.rhn.domain.rhnpackage.Package pkg1 = PackageManagerTest.addPackageToChannel("pkg1", channel);
+
+        PackageProvides prov1 = new PackageProvides();
+        PackageCapability provCap = PackageCapabilityTest.createTestCapability("capProv1");
+        prov1.setCapability(provCap);
+        prov1.setPack(pkg1);
+        prov1.setSense(0L);
+        pkg1.getProvides().add(prov1);
+
+        PackageRequires req1 = new PackageRequires();
+        PackageCapability reqCap = PackageCapabilityTest.createTestCapability("capReq1");
+        req1.setCapability(reqCap);
+        req1.setPack(pkg1);
+        req1.setSense(0L);
+        pkg1.getRequires().add(req1);
+
+        PackageManager.createRepoEntrys(channel.getId());
+
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().clear();
+
+        writer.writeRepomdFiles(channel);
+
+        String repomdExpected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<repomd xmlns=\"http://linux.duke.edu/metadata/repo\"><data type=\"primary\"><location href=\"repodata/primary.xml.gz\"/>" +
+                "<checksum type=\"sha256\">61d08b336c520bdfade052b808616e5a80e5eec29d82c2e7dbbd58bc7ee93864</checksum>" +
+                "<open-checksum type=\"sha256\">d515cc563a9cf6dfe2f0fbe999bbcec0d495f4c7e1cd09286d7df74c58300e1b</open-checksum><timestamp>1544711985</timestamp>" +
+                "</data><data type=\"filelists\"><location href=\"repodata/filelists.xml.gz\"/>" +
+                "<checksum type=\"sha256\">b6528b97a62a107e9357d406e1d22be971ca55d4332abbc1bb0e9b84c3139d99</checksum>" +
+                "<open-checksum type=\"sha256\">9e1aca5fd324f66bbedd27f6dfc722da83354374a6808010886e93e09795bb30</open-checksum>" +
+                "<timestamp>1544711985</timestamp></data><data type=\"other\"><location href=\"repodata/other.xml.gz\"/>" +
+                "<checksum type=\"sha256\">4fa5ac10cf38edc497f18e41f537e1ef24a2fb4d0b537c96248433ca3a51b975</checksum>" +
+                "<open-checksum type=\"sha256\">a50ffc2416654509bb720263a0ab090c3c53739305e8f637422f81937fabd700</open-checksum>" +
+                "<timestamp>1544711985</timestamp></data><data type=\"susedata\"><location href=\"repodata/susedata.xml.gz\"/>" +
+                "<checksum type=\"sha256\">2818aff4276b64a24abb2e60fc97d152abee478c35a5f4b04015c7704e8b7cfe</checksum>" +
+                "<open-checksum type=\"sha256\">20c9750a06ddcc9b783504433cbc1eaea14c08889770f19274fa3f91bcbbd37f</open-checksum>" +
+                "<timestamp>1544711985</timestamp></data></repomd>";
+        repomdExpected = cleanupRepomd(repomdExpected);
+
+        String primaryXmlExpected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<metadata packages=\"1\" xmlns=\"http://linux.duke.edu/metadata/common\" xmlns:rpm=\"http://linux.duke.edu/metadata/rpm\"><package type=\"rpm\">" +
+                "<name>pkg1</name><arch>noarch</arch><version ver=\"1.0.0\" rel=\"1\" epoch=\"1\"/>" +
+                "<checksum type=\"md5\" pkgid=\"YES\">$1$jrBDaf62$URlwK4AAEVCdcWhcZdcSK1</checksum>" +
+                "<summary>Created by RHN-JAVA unit tests. Please disregard.</summary><description>RHN-JAVA Package Test</description><packager/><url/>" +
+                "<time file=\"1544723761\" build=\"1544723761\"/><size package=\"42\" archive=\"42\" installed=\"42\"/>" +
+                "<location href=\"getPackage/$1$RAiHwOUL$bcHCUHDdGcmVfklrxaRVC1\"/><format><rpm:license>Red Hat - RHN - 2005</rpm:license>" +
+                "<rpm:vendor>Rhn-Java</rpm:vendor><rpm:group>4XwfQEUNzkDr3</rpm:group><rpm:buildhost>foo2</rpm:buildhost>" +
+                "<rpm:sourcerpm>ZL4ke7jOwX6Tz</rpm:sourcerpm><rpm:header-range start=\"-1\" end=\"-1\"/><rpm:provides>" +
+                "<rpm:entry name=\"capProv1\" flags=\"GE\" epoch=\"0\" ver=\"\" rel=\"1.0\"/></rpm:provides><rpm:requires>" +
+                "<rpm:entry name=\"capReq1\" flags=\"GE\" epoch=\"0\" ver=\"\" rel=\"1.0\"/></rpm:requires><rpm:conflicts/>" +
+                "<rpm:obsoletes/><rpm:recommends/><rpm:suggests/><rpm:supplements/><rpm:enhances/></format></package></metadata>";
+
+        primaryXmlExpected = cleanupPrimaryXml(primaryXmlExpected);
+        Path channelDir = mountPointDir.resolve("rhn").resolve("repodata").resolve(channel.getLabel());
+
+
+        File repomdXml = channelDir.resolve("repomd.xml").toFile();
+
+        try (FileInputStream fin = new FileInputStream(repomdXml)) {
+            String xml = TestUtils.readAll(fin);
+
+            assertEquals(repomdExpected, cleanupRepomd(xml));
+
+        }
+        catch (IOException e) {
+            fail(e.getMessage());
+        }
+
+        File primaryXmlGz = channelDir.resolve("primary.xml.gz").toFile();
+
+        try (FileInputStream fin = new FileInputStream(primaryXmlGz); InputStream gzipStream = new GZIPInputStream(fin)) {
+            String primaryXmlStr = TestUtils.readAll(gzipStream);
+
+            primaryXmlStr = cleanupPrimaryXml(primaryXmlStr);
+
+
+            assertEquals(primaryXmlExpected, primaryXmlStr);
+        }
+        catch (IOException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    private String cleanupRepomd(String str) {
+        String ret = str.trim().replaceFirst("<checksum type=\"sha256\">.*</checksum>", "<checksum type=\"sha256\">xxx</checksum>");
+        ret = ret.replaceFirst("<open-checksum type=\"sha256\">.*</open-checksum>", "<open-checksum type=\"sha256\">xxx</open-checksum>");
+        ret = ret.replaceFirst("<timestamp>.*</timestamp>", "<timestamp>123</timestamp>");
+        return ret;
+    }
+
+    private String cleanupPrimaryXml(String str) {
+        String ret = str.trim().replaceFirst(">.*?</checksum>", ">xxx</checksum>");
+        ret = ret.replaceFirst("<time file=\"\\d+\" build=\"\\d+\"/>", "<time file=\"123\" build=\"123\"/>");
+        ret = ret.replaceFirst("<location href=\"getPackage/.*?\"/>", "<location href=\"getPackage/xxx\"/>");
+        ret = ret.replaceFirst("<rpm:sourcerpm>.*?</rpm:sourcerpm>", "<rpm:sourcerpm>xxx</rpm:sourcerpm>");
+        ret = ret.replaceFirst("<rpm:group>.*?</rpm:group>", "<rpm:group>xxx</rpm:group>");
+        return ret;
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        FileUtils.deleteDirectory(mountPointDir.toFile());
+    }
+}

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Improve memory usage when generating repo matadata for channels having
+  a large number of packages (bsc#1115776)
 - Merge unlimited virtualization lifecycle products with the single variant (bsc#1114059)
 - show beta products if a beta subscription is available (bsc#1123189)
 - fix synchronizing Expanded Support Channel with missing architecture


### PR DESCRIPTION
## What does this PR change?

Use pagination in the query that loads the package DTOs when generating repo metadata. This is needed to avoid OutOfMemory with channels having a large number of packages.

## GUI diff

No difference.

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
- No tests: **add explanation**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/6335


