### PR TITLE
Fix python-rpm dependency to allow a python3 proxy

### DIFF
--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- Require the correct dependency for python-rpm to allow the Proxy
+  to work with Python3 only
 - Make rhn-ssl-dbstore compatible with python3
 
 -------------------------------------------------------------------

--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -85,15 +85,16 @@ BuildArch:      noarch
 %endif
 
 Requires:       %{pythonX}
-Requires:       rpm-python
 # /etc/rhn is provided by spacewalk-proxy-common or by spacewalk-config
 Requires:       /etc/rhn
 %if 0%{?build_py3}
 Requires:       python3-%{name}-libs >= %{version}
 Requires:       python3-rhnlib >= 2.5.74
+Requires:       python3-rpm
 %else
 Requires:       python2-rhnlib >= 2.5.74
 Requires:       %{name}-libs >= %{version}
+Requires:       python2-rpm
 %if 0%{?suse_version}
 Requires:       python-pyliblzma
 %else
@@ -124,12 +125,13 @@ BuildRequires:  python2-spacewalk-usix
 BuildRequires:  python3-gzipstream
 BuildRequires:  python3-rhn-client-tools
 BuildRequires:  python3-rhnlib >= 2.5.74
+BuildRequires:  python3-rpm
 %else
 BuildRequires:  python2-gzipstream
 BuildRequires:  python2-rhn-client-tools
 BuildRequires:  python2-rhnlib >= 2.5.74
+BuildRequires:  python2-rpm
 %endif
-BuildRequires:  rpm-python
 BuildRequires:  %{python_prefix}-debian
 
 BuildRequires:  %{m2crypto}
@@ -249,10 +251,11 @@ Group:          Applications/Internet
 Requires:       %{name}-server = %{version}-%{release}
 %if 0%{?build_py3}
 Requires:       python3-spacewalk-usix
+Requires:       python3-rpm
 %else
 Requires:       python2-spacewalk-usix
+Requires:       python2-rpm
 %endif
-Requires:       rpm-python
 Obsoletes:      rhns-server-xmlrpc < 5.3.0
 Obsoletes:      rhns-xmlrpc < 5.3.0
 Provides:       rhns-server-xmlrpc = 1:%{version}-%{release}
@@ -325,10 +328,11 @@ Group:          Applications/Internet
 Requires:       %{name}-xml-export-libs = %{version}-%{release}
 %if 0%{?build_py3}
 Requires:       python3-spacewalk-usix
+Requires:       python3-rpm
 %else
 Requires:       python2-spacewalk-usix
+Requires:       python2-rpm
 %endif
-Requires:       rpm-python
 
 %description iss-export
 %{name} contains the basic code that provides server/backend


### PR DESCRIPTION
## What does this PR change?

Require the correct dependency for python-rpm to allow the Proxy to work with Python3 only

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: A search at the [susemanager doc repository](https://github.com/SUSE/doc-susemanager) did not return any references to the Python
- [x] **DONE**

## Test coverage
- No tests: Already covered sumaform installation

- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/6855

- [x] **DONE**