### PR TITLE
Point to the correct log file when tomcat is not able to start

### DIFF
--- a/spacewalk/setup/bin/spacewalk-setup
+++ b/spacewalk/setup/bin/spacewalk-setup
@@ -1283,6 +1283,6 @@ sub wait_for_tomcat {
             return 1;
         }
     }
-    print "Tomcat failed to start properly or the installer ran out of tries.  Please check /var/log/tomcat6/catalina.out or /var/log/tomcat/catalina.\$(date +%Y-%m-%d).log for errors.\n";
+    print "Tomcat failed to start properly or the installer ran out of tries.  Please check /var/log/tomcat/catalina.out or /var/log/tomcat/catalina.\$(date +%Y-%m-%d).log for errors.\n";
     return 0;
 }

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,4 @@
+- Point to the correct log file when tomcat is not able to start
 - Fix distribution detection to work with openSUSE Leap 15 and
   SLE 15
 


### PR DESCRIPTION
## What does this PR change?

Point to the correct log file when tomcat is not able to start

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: Fixing typo.
- [x] **DONE**

## Test coverage
- No tests: Not covered.

- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/6855

- [x] **DONE**