### PR TITLE
use original value for label and set it uppercase like SCC does

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -1005,7 +1005,7 @@ public class ContentSyncManager {
     public void updateChannelFamilies(Collection<ChannelFamilyJson> channelFamilies)
             throws ContentSyncException {
         log.info("ContentSyncManager.updateChannelFamilies called");
-        List<String> suffixes = Arrays.asList("", "alpha", "beta");
+        List<String> suffixes = Arrays.asList("", "ALPHA", "BETA");
 
         for (ChannelFamilyJson channelFamily : channelFamilies) {
             for (String suffix : suffixes) {
@@ -1694,7 +1694,7 @@ public class ContentSyncManager {
     private ChannelFamily createOrUpdateChannelFamily(String label, String name, String suffix) {
         // to create ALPHA and BETA families
         if (!StringUtils.isBlank(suffix)) {
-            label = label + "-" + suffix.toLowerCase();
+            label = label + "-" + suffix;
             name = name + " (" + suffix.toUpperCase() + ")";
         }
         return createOrUpdateChannelFamily(label, name, new HashMap<>());

--- a/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
@@ -658,7 +658,7 @@ public class ContentSyncManagerTest extends BaseTestCaseWithUser {
             assertNotNull(family.getPublicChannelFamily());
 
             // Check for ALPHA and BETA families
-            String label = cf.getLabel() + "-alpha";
+            String label = cf.getLabel() + "-ALPHA";
             String name = cf.getName() + " (ALPHA)";
             family = ChannelFamilyFactory.lookupByLabel(label, null);
             assertNotNull(family);
@@ -666,7 +666,7 @@ public class ContentSyncManagerTest extends BaseTestCaseWithUser {
             assertEquals(name, family.getName());
             assertNotNull(family.getPublicChannelFamily());
 
-            label = cf.getLabel() + "-beta";
+            label = cf.getLabel() + "-BETA";
             name = cf.getName() + " (BETA)";
             family = ChannelFamilyFactory.lookupByLabel(label, null);
             assertNotNull(family);
@@ -713,7 +713,7 @@ public class ContentSyncManagerTest extends BaseTestCaseWithUser {
             assertNotNull(family.getPublicChannelFamily());
 
             // Check for ALPHA and BETA families
-            String label = cf.getLabel() + "-alpha";
+            String label = cf.getLabel() + "-ALPHA";
             String name = cf.getName() + " (ALPHA)";
             family = ChannelFamilyFactory.lookupByLabel(label, null);
             assertNotNull(family);
@@ -721,7 +721,7 @@ public class ContentSyncManagerTest extends BaseTestCaseWithUser {
             assertEquals(name, family.getName());
             assertNotNull(family.getPublicChannelFamily());
 
-            label = cf.getLabel() + "-beta";
+            label = cf.getLabel() + "-BETA";
             name = cf.getName() + " (BETA)";
             family = ChannelFamilyFactory.lookupByLabel(label, null);
             assertNotNull(family);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- show beta products if a beta subscription is available (bsc#1123189)
 - fix synchronizing Expanded Support Channel with missing architecture
   (bsc#1122565)
 - Explicitly require JDK11

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,4 +1,6 @@
+- remove wrong channel_family labels (bsc#1123189)
 - Remove unused 'remove_servergroup_perm' stored procedure (bsc#1111810)
+
 -------------------------------------------------------------------
 Wed Jan 16 12:28:37 CET 2019 - jgonzalez@suse.com
 

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/005-cleanup-channel_family-labels.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/005-cleanup-channel_family-labels.sql
@@ -1,0 +1,11 @@
+DELETE FROM rhnPublicChannelFamily
+ WHERE channel_family_id IN (
+        SELECT id
+          FROM rhnChannelFamily
+         WHERE label LIKE '%-alpha'
+            OR label LIKE '%-beta'
+);
+
+DELETE FROM rhnChannelFamily
+ WHERE label LIKE '%-alpha'
+    OR label LIKE '%-beta';

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.4-to-susemanager-schema-4.0.5/006-cleanup-channel_family-labels.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.4-to-susemanager-schema-4.0.5/006-cleanup-channel_family-labels.sql
@@ -1,0 +1,11 @@
+DELETE FROM rhnPublicChannelFamily
+ WHERE channel_family_id IN (
+        SELECT id
+          FROM rhnChannelFamily
+         WHERE label LIKE '%-alpha'
+            OR label LIKE '%-beta'
+);
+
+DELETE FROM rhnChannelFamily
+ WHERE label LIKE '%-alpha'
+    OR label LIKE '%-beta';


### PR DESCRIPTION
## What does this PR change?

When creating alpha and beta product classes we do not generate them the same ways as SCC does.
This result in a missmatch and products are not visible.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal bugfix**

- [x] **DONE**

## Test coverage
- Unit tests adapted

- [x] **DONE**

## Links

Fixes #
Tracks https://github.com/SUSE/spacewalk/pull/6892

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
