### PR TITLE
Fix symbolic link to osa-dispatcher, so it can work with python3

### DIFF
--- a/client/tools/mgr-osad/mgr-osad.changes
+++ b/client/tools/mgr-osad/mgr-osad.changes
@@ -1,3 +1,5 @@
+- Fix symbolic link to osa-dispatcher, so it can work with python3
+
 -------------------------------------------------------------------
 Wed Jan 16 12:14:14 CET 2019 - jgonzalez@suse.com
 

--- a/client/tools/mgr-osad/mgr-osad.spec
+++ b/client/tools/mgr-osad/mgr-osad.spec
@@ -317,7 +317,7 @@ sed -i 's|#!/usr/bin/python|#!/usr/bin/python3|' $RPM_BUILD_ROOT/usr/sbin/osad-%
 %define default_suffix %{?default_py3:-%{python3_version}}%{!?default_py3:-%{python_version}}
 ln -s osad%{default_suffix} $RPM_BUILD_ROOT/usr/sbin/osad
 # osa-dispatcher is python2 even on Fedora
-ln -s osa-dispatcher-%{python_version} $RPM_BUILD_ROOT/usr/sbin/osa-dispatcher
+ln -s osa-dispatcher%{default_suffix} $RPM_BUILD_ROOT/usr/sbin/osa-dispatcher
 
 mkdir -p %{buildroot}%{_var}/log/rhn
 touch %{buildroot}%{_var}/log/osad


### PR DESCRIPTION
## What does this PR change?

Fix symbolic link to osa-dispatcher, so it can work with python3

Until now, the link was incorrectly created when python3 was used:
```
[   44s] + ln -s osad-3.6 /home/abuild/rpmbuild/BUILDROOT/mgr-osad-4.0.4-400.1.6.develHead.x86_64/usr/sbin/osad
[   44s] + ln -s osa-dispatcher-2.7 /home/abuild/rpmbuild/BUILDROOT/mgr-osad-4.0.4-400.1.6.develHead.x86_64/usr/sbin/osa-dispatcher
```

Now, the link is created for osad and osa-dispatcher in the same way.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Not part of the documentation

- [x] **DONE**

## Test coverage
- No tests: Tested by cucumber.

- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/6855

- [x] **DONE**