### PR TITLE
Merge unlimited virtualization lifecycle products with the single variant (bsc#1114059)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/product/CachingSUSEProductFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/product/CachingSUSEProductFactory.java
@@ -16,7 +16,6 @@ package com.redhat.rhn.domain.product;
 
 
 import static java.util.Optional.ofNullable;
-import static java.util.stream.Collectors.toList;
 
 import com.redhat.rhn.domain.rhnpackage.PackageArch;
 import com.redhat.rhn.domain.server.InstalledProduct;
@@ -26,9 +25,9 @@ import com.suse.utils.Opt;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Stream;
 
 /**
  * Fetches {@link SUSEProduct} objects caching them for speed.
@@ -63,13 +62,12 @@ public class CachingSUSEProductFactory {
     /**
      * Maps many InstalledProducts to many SUSEProducts
      * @param installedProducts the installed products
-     * @return the SUSE products
+     * @return the SUSE products stream
      */
-    public List<SUSEProduct> map(Collection<InstalledProduct> installedProducts) {
+    public Stream<SUSEProduct> map(Collection<InstalledProduct> installedProducts) {
         return installedProducts.stream()
                 .map(this::lookupCachedSUSEProduct)
                 .filter(Objects::nonNull)
-                .sorted(Comparator.comparing(SUSEProduct::isBase).thenComparing(SUSEProduct::getId))
-                .collect(toList());
+                .sorted(Comparator.comparing(SUSEProduct::isBase).thenComparing(SUSEProduct::getId));
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/product/test/SUSEProductTestUtils.java
+++ b/java/code/src/com/redhat/rhn/domain/product/test/SUSEProductTestUtils.java
@@ -220,6 +220,31 @@ public class SUSEProductTestUtils extends HibernateFactory {
         TestUtils.saveAndFlush(product);
     }
 
+    /**
+     * Create the SUSE Manager Tools product.
+     */
+    public static void createSUMAToolsProduct() {
+        ChannelFamily toolsChannelFamily = ChannelFamilyFactory.lookupByLabel("SLE-M-T", null);
+        if (toolsChannelFamily == null) {
+            toolsChannelFamily = new ChannelFamily();
+            toolsChannelFamily.setLabel("SLE-M-T");
+            toolsChannelFamily.setName("SUSE Manager Tools");
+            TestUtils.saveAndFlush(toolsChannelFamily);
+        }
+
+        SUSEProduct product = new SUSEProduct();
+        product.setName("sle-manager-tools");
+        product.setVersion("12");
+        product.setRelease("0");
+        product.setFriendlyName("SUSE Manager Tools 12");
+        product.setArch(PackageFactory.lookupPackageArchByLabel("x86_64"));
+        product.setProductId(1248L);
+        product.setChannelFamily(toolsChannelFamily);
+        product.setBase(false);
+        product.setReleaseStage(ReleaseStage.released);
+        TestUtils.saveAndFlush(product);
+    }
+
     public static Channel createBaseChannelForBaseProduct(SUSEProduct product, User admin) throws Exception {
         ChannelArch channelArch = ChannelFactory.findArchByLabel("channel-x86_64");
         Channel channel = ChannelTestUtils.createBaseChannel(admin);

--- a/java/code/src/com/redhat/rhn/manager/audit/ImageAuditTarget.java
+++ b/java/code/src/com/redhat/rhn/manager/audit/ImageAuditTarget.java
@@ -23,6 +23,8 @@ import com.redhat.rhn.domain.product.SUSEProduct;
 import java.util.List;
 import java.util.Set;
 
+import static java.util.stream.Collectors.toList;
+
 /**
  * ImageAuditTarget
  */
@@ -50,7 +52,7 @@ public class ImageAuditTarget implements AuditTarget {
 
     @Override
     public List<SUSEProduct> getSUSEProducts() {
-        return productFactory.map(imageInfo.getInstalledProducts());
+        return productFactory.map(imageInfo.getInstalledProducts()).collect(toList());
     }
 
     @Override

--- a/java/code/src/com/redhat/rhn/manager/audit/ServerAuditTarget.java
+++ b/java/code/src/com/redhat/rhn/manager/audit/ServerAuditTarget.java
@@ -23,6 +23,8 @@ import com.redhat.rhn.domain.server.Server;
 import java.util.List;
 import java.util.Set;
 
+import static java.util.stream.Collectors.toList;
+
 /**
  * ServerAuditTarget
  */
@@ -49,7 +51,7 @@ public class ServerAuditTarget implements AuditTarget {
 
     @Override
     public List<SUSEProduct> getSUSEProducts() {
-        return productFactory.map(server.getInstalledProducts());
+        return productFactory.map(server.getInstalledProducts()).collect(toList());
     }
 
     @Override

--- a/java/code/src/com/redhat/rhn/manager/content/test/sccdata_lifecycle_products/organizations_orders.json
+++ b/java/code/src/com/redhat/rhn/manager/content/test/sccdata_lifecycle_products/organizations_orders.json
@@ -1,0 +1,44 @@
+[
+   {
+      "order_number" : 98765432,
+      "order_items" : [
+         {
+            "quantity" : 1,
+            "subscription_id" : 1,
+            "id" : 11,
+            "end_date" : "2017-01-01T00:00:00.000Z",
+            "sku" : "874-005117",
+            "fulfillid" : 555555555,
+            "start_date" : "2013-01-01T00:00:00.000Z"
+         },
+         {
+            "quantity" : 1,
+            "subscription_id" : 2,
+            "id" : 12,
+            "end_date" : "2017-01-01T00:00:00.000Z",
+            "sku" : "874-005118",
+            "fulfillid" : 555555556,
+            "start_date" : "2013-01-01T00:00:00.000Z"
+         },
+         {
+            "quantity" : 1,
+            "subscription_id" : 3,
+            "id" : 13,
+            "end_date" : "2017-01-01T00:00:00.000Z",
+            "sku" : "874-005119",
+            "fulfillid" : 555555557,
+            "start_date" : "2013-01-01T00:00:00.000Z"
+         },
+         {
+            "quantity" : 1,
+            "subscription_id" : 4,
+            "id" : 14,
+            "end_date" : "2017-01-01T00:00:00.000Z",
+            "sku" : "874-005120",
+            "fulfillid" : 555555558,
+            "start_date" : "2013-01-01T00:00:00.000Z"
+         }
+      ]
+   }
+]
+

--- a/java/code/src/com/redhat/rhn/manager/content/test/sccdata_lifecycle_products/organizations_subscriptions.json
+++ b/java/code/src/com/redhat/rhn/manager/content/test/sccdata_lifecycle_products/organizations_subscriptions.json
@@ -1,0 +1,98 @@
+[
+   {
+      "systems" : [
+         {
+            "password" : "secret",
+            "id" : 1245678,
+            "login" : "1234567890945aaa14fa3ba67b1f83b"
+         }
+      ],
+      "id" : 1,
+      "regcode" : "55REGCODE180",
+      "status" : "ACTIVE",
+      "product_classes" : [
+      ],
+      "system_limit" : 1,
+      "type" : "full",
+      "systems_count" : 1,
+      "expires_at" : "2017-12-31T00:00:00.000Z",
+      "virtual_count" : null,
+      "name" : "Mock lifecycle subscription - Management - Single",
+      "starts_at" : "2012-01-01T00:00:00.000Z",
+      "product_ids" : [
+         1076
+      ]
+   },
+   {
+      "systems" : [
+         {
+            "password" : "secret",
+            "id" : 1245678,
+            "login" : "1234567890945aaa14fa3ba67b1f83b"
+         }
+      ],
+      "id" : 2,
+      "regcode" : "55REGCODE181",
+      "status" : "ACTIVE",
+      "product_classes" : [
+      ],
+      "system_limit" : 1,
+      "type" : "full",
+      "systems_count" : 1,
+      "expires_at" : "2017-12-31T00:00:00.000Z",
+      "virtual_count" : null,
+      "name" : "Mock lifecycle subscription - Management - Unlimited Virtualization",
+      "starts_at" : "2012-01-01T00:00:00.000Z",
+      "product_ids" : [
+         1078
+      ]
+   },
+   {
+      "systems" : [
+         {
+            "password" : "secret",
+            "id" : 1245678,
+            "login" : "1234567890945aaa14fa3ba67b1f83b"
+         }
+      ],
+      "id" : 3,
+      "regcode" : "55REGCODE182",
+      "status" : "ACTIVE",
+      "product_classes" : [
+      ],
+      "system_limit" : 1,
+      "type" : "full",
+      "systems_count" : 1,
+      "expires_at" : "2017-12-31T00:00:00.000Z",
+      "virtual_count" : null,
+      "name" : "Mock lifecycle subscription - Provisioning - Single",
+      "starts_at" : "2012-01-01T00:00:00.000Z",
+      "product_ids" : [
+         1097
+      ]
+   },
+   {
+      "systems" : [
+         {
+            "password" : "secret",
+            "id" : 1245678,
+            "login" : "1234567890945aaa14fa3ba67b1f83b"
+         }
+      ],
+      "id" : 4,
+      "regcode" : "55REGCODE183",
+      "status" : "ACTIVE",
+      "product_classes" : [
+      ],
+      "system_limit" : 1,
+      "type" : "full",
+      "systems_count" : 1,
+      "expires_at" : "2017-12-31T00:00:00.000Z",
+      "virtual_count" : null,
+      "name" : "Mock lifecycle subscription - Provisioning - Unlimited Virtualization",
+      "starts_at" : "2012-01-01T00:00:00.000Z",
+      "product_ids" : [
+         1204
+      ]
+   }
+]

--- a/java/code/src/com/suse/manager/matcher/MatcherJsonIO.java
+++ b/java/code/src/com/suse/manager/matcher/MatcherJsonIO.java
@@ -311,9 +311,13 @@ public class MatcherJsonIO {
      * Returns SUSE product ids for a server, including ids for SUSE Manager entitlements.
      * (For systems without a SUSE base product, empty stream is returned as we don't
      * require SUSE Manager entitlements for such systems).
+     * Filters out the products with "SLE-M-T" product class as they are not considered in
+     * subsription matching.
      */
     private Stream<Long> productIdsForServer(Server server, Set<String> entitlements) {
-        List<SUSEProduct> products = productFactory.map(server.getInstalledProducts());
+        List<SUSEProduct> products = productFactory.map(server.getInstalledProducts())
+                .filter(product -> !"SLE-M-T".equals(product.getChannelFamily().getLabel()))
+                .collect(toList());
 
         if (products.stream().noneMatch(SUSEProduct::isBase)) {
             return Stream.empty();

--- a/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
+++ b/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
@@ -185,6 +185,34 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
         assertFalse(guest.getProductIds().contains(PROV_UNLIMITED_VIRT_PROD_ID));
     }
 
+
+    /**
+     * Tests that the SUSE Manager Tools proudct is not reported to the matcher.
+     *
+     * @throws java.lang.Exception if anything goes wrong
+     */
+    public void testFilteringToolsProducts() throws Exception {
+        SUSEProductTestUtils.clearAllProducts();
+        SUSEProductTestUtils.createVendorSUSEProducts();
+        SUSEProductTestUtils.createSUMAToolsProduct();
+        SUSEProductTestUtils.createVendorEntitlementProducts();
+
+        Set<InstalledProduct> installedProducts = new HashSet<>();
+        InstalledProduct instPrd = createInstalledProduct("SLES", "12.1", "0", "x86_64", true);
+        installedProducts.add(instPrd);
+        instPrd = createInstalledProduct("sle-manager-tools", "12", "0", "x86_64", false);
+        installedProducts.add(instPrd);
+
+        Server testSystem = ServerTestUtils.createTestSystem(user);
+        testSystem.setInstalledProducts(installedProducts);
+
+        MatcherJsonIO matcherInput = new MatcherJsonIO();
+        SystemJson system = matcherInput.getJsonSystems(false, AMD64_ARCH).stream()
+                .filter(s -> s.getId().equals(testSystem.getId())).findFirst().get();
+
+        assertFalse(system.getProductIds().contains(instPrd.getSUSEProduct().getProductId()));
+    }
+
     public void testSubscriptionsToJson() throws Exception {
         withSetupContentSyncManager(JARPATH, () -> {
             List<SubscriptionJson> result = new MatcherJsonIO().getJsonSubscriptions();

--- a/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
+++ b/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
@@ -36,6 +36,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static java.util.Collections.singleton;
+
 public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
     private static final String JARPATH = "/com/redhat/rhn/manager/content/test/sccdata/";
     private static final String SUBSCRIPTIONS_JSON = "organizations_subscriptions.json";
@@ -59,20 +61,9 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
         h1.setCpu(createCPU(h1, 8L));
 
         Set<InstalledProduct> installedProducts = new HashSet<>();
-        InstalledProduct instPrd = new InstalledProduct();
-        instPrd.setName("SLES");
-        instPrd.setVersion("12.1");
-        instPrd.setRelease("0");
-        instPrd.setArch(PackageFactory.lookupPackageArchByLabel("x86_64"));
-        instPrd.setBaseproduct(true);
+        InstalledProduct instPrd = createInstalledProduct("SLES", "12.1", "0", "x86_64", true);
         installedProducts.add(instPrd);
-
-        instPrd = new InstalledProduct();
-        instPrd.setName("sle-ha");
-        instPrd.setVersion("12.1");
-        instPrd.setRelease("0");
-        instPrd.setArch(PackageFactory.lookupPackageArchByLabel("x86_64"));
-        instPrd.setBaseproduct(false);
+        instPrd = createInstalledProduct("sle-ha", "12.1", "0", "x86_64", false);
         installedProducts.add(instPrd);
 
         Server g1 = ServerTestUtils.createTestSystem();
@@ -171,14 +162,8 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
 
         Server hostServer = ServerTestUtils.createVirtHostWithGuests(1);
         // let's set some base product to our systems (otherwise lifecycle subscriptions aren't reported)
-        Set<InstalledProduct> installedProducts = new HashSet<>();
-        InstalledProduct instProd = new InstalledProduct();
-        instProd.setName("SLES");
-        instProd.setVersion("12.1");
-        instProd.setRelease("0");
-        instProd.setArch(PackageFactory.lookupPackageArchByLabel("x86_64"));
-        instProd.setBaseproduct(true);
-        installedProducts.add(instProd);
+        InstalledProduct instProd = createInstalledProduct("SLES", "12.1", "0", "x86_64", true);
+        Set<InstalledProduct> installedProducts = singleton(instProd);
         hostServer.setInstalledProducts(installedProducts);
         Server guestServer = hostServer.getGuests().iterator().next().getGuestSystem();
         guestServer.setInstalledProducts(installedProducts);
@@ -350,20 +335,9 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
             ServerFactory.save(h1);
 
             Set<InstalledProduct> installedProducts = new HashSet<>();
-            InstalledProduct instPrd = new InstalledProduct();
-            instPrd.setName("SLES");
-            instPrd.setVersion("12.1");
-            instPrd.setRelease("0");
-            instPrd.setArch(PackageFactory.lookupPackageArchByLabel("x86_64"));
-            instPrd.setBaseproduct(true);
+            InstalledProduct instPrd = createInstalledProduct("SLES", "12.1", "0", "x86_64", true);
             installedProducts.add(instPrd);
-
-            instPrd = new InstalledProduct();
-            instPrd.setName("sle-ha");
-            instPrd.setVersion("12.1");
-            instPrd.setRelease("0");
-            instPrd.setArch(PackageFactory.lookupPackageArchByLabel("x86_64"));
-            instPrd.setBaseproduct(false);
+            instPrd = createInstalledProduct("sle-ha", "12.1", "0", "x86_64", false);
             installedProducts.add(instPrd);
 
             h1.setInstalledProducts(installedProducts);
@@ -411,5 +385,15 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
         cpu.setServer(s);
         cpu.setArch(ServerFactory.lookupCPUArchByName("x86_64"));
         return cpu;
+    }
+
+    private InstalledProduct createInstalledProduct(String name, String version, String release, String archLabel, boolean base) {
+        InstalledProduct instProd = new InstalledProduct();
+        instProd.setName(name);
+        instProd.setVersion(version);
+        instProd.setRelease(release);
+        instProd.setArch(PackageFactory.lookupPackageArchByLabel(archLabel));
+        instProd.setBaseproduct(base);
+        return instProd;
     }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Merge unlimited virtualization lifecycle products with the single variant (bsc#1114059)
 - show beta products if a beta subscription is available (bsc#1123189)
 - fix synchronizing Expanded Support Channel with missing architecture
   (bsc#1122565)


### PR DESCRIPTION
This PR gets rid of useless differentiation between lifecycle products for Unlimited Virtualization and "Single".
The solution is to merge the Unlimited Virtualization products to the Single ones in the subscriptions and systems in the matcher input.

More on the problem: https://github.com/SUSE/spacewalk/pull/6248

 ## GUI diff
 
 - [x] **DONE**
 
 ## Documentation
 - No documentation needed: bugfix
 
 - [x] **DONE**
 
 ## Test coverage
 - Unit tests were added
 
 - [x] **DONE**
 
 ## Links
 
 Fixes https://github.com/SUSE/spacewalk/issues/6248
 Downstream PR: https://github.com/SUSE/spacewalk/pull/6474