### PR TITLE
Upgrade node.js from v8 to v10

### DIFF
--- a/susemanager-utils/testing/docker/master/uyuni-master-nodejs/add_packages.sh
+++ b/susemanager-utils/testing/docker/master/uyuni-master-nodejs/add_packages.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Packages for Javascript tests
-zypper --non-interactive in nodejs8 npm8
+zypper --non-interactive in nodejs npm
 
 # Install flow-bin globally
 npm_config_prefix=/usr npm install -g flow-bin@0.82.0

--- a/web/spacewalk-web.spec
+++ b/web/spacewalk-web.spec
@@ -43,7 +43,7 @@ BuildRequires:  perl(ExtUtils::MakeMaker)
 BuildRequires:  apache2
 BuildRequires:  nodejs-packaging
 BuildRequires:  susemanager-nodejs-sdk-devel
-BuildRequires:  nodejs8
+BuildRequires:  nodejs
 
 %endif
 
@@ -61,7 +61,7 @@ BuildArch:      noarch
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  nodejs-packaging
 BuildRequires:  susemanager-nodejs-sdk-devel
-BuildRequires:  nodejs8
+BuildRequires:  nodejs
 
 %description -n susemanager-web-libs
 This package contains Vendor bundles needed for spacewalk-web


### PR DESCRIPTION
## What does this PR change?

Upgrade node.js from v8 to v10. Sle 15 SP1 has now nodejs10 by default

## GUI diff

No difference.

## Documentation
- No documentation needed.

- [x] **DONE**

## Test coverage
- No tests: **add explanation**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
