### PR TITLE
Adapt socketserver import, and spec to make osa-dispatcher compatible with python3

### DIFF
--- a/client/tools/mgr-osad/mgr-osad.changes
+++ b/client/tools/mgr-osad/mgr-osad.changes
@@ -1,4 +1,4 @@
-- Fix symbolic link to osa-dispatcher, so it can work with python3
+- Final fixes to make osa-dispatcher compatible with python3
 
 -------------------------------------------------------------------
 Wed Jan 16 12:14:14 CET 2019 - jgonzalez@suse.com

--- a/client/tools/mgr-osad/mgr-osad.spec
+++ b/client/tools/mgr-osad/mgr-osad.spec
@@ -312,6 +312,7 @@ make -f Makefile.osad install PREFIX=$RPM_BUILD_ROOT ROOT=%{rhnroot} INITDIR=%{_
 make -f Makefile.osad install PREFIX=$RPM_BUILD_ROOT ROOT=%{rhnroot} INITDIR=%{_initrddir} \
         PYTHONPATH=%{python3_sitelib} PYTHONVERSION=%{python3_version}
 sed -i 's|#!/usr/bin/python|#!/usr/bin/python3|' $RPM_BUILD_ROOT/usr/sbin/osad-%{python3_version}
+sed -i 's|#!/usr/bin/python|#!/usr/bin/python3|' $RPM_BUILD_ROOT/usr/sbin/osa-dispatcher-%{python3_version}
 %endif
 
 %define default_suffix %{?default_py3:-%{python3_version}}%{!?default_py3:-%{python_version}}

--- a/client/tools/mgr-osad/src/osa_dispatcher.py
+++ b/client/tools/mgr-osad/src/osa_dispatcher.py
@@ -17,7 +17,10 @@ import sys
 import select
 import socket
 import string
-import SocketServer
+try: # python 3
+    import sockerserver
+except ImportError: # python 2
+    import SocketServer
 from random import choice
 from rhn.connections import idn_ascii_to_puny
 from spacewalk.common.rhnLog import initLOG, log_debug, log_error


### PR DESCRIPTION
## What does this PR change?

Adapt socketserver import, and spec to make osa-dispatcher compatible with python3

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: Not present at the documentation.

- [x] **DONE**

## Test coverage

- No tests: Covered by OBS

- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/6855

- [x] **DONE**