### PR TITLE
Keep assigned channels on traditional to minion migration (bsc#1122836)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/Server.java
+++ b/java/code/src/com/redhat/rhn/domain/server/Server.java
@@ -1294,7 +1294,11 @@ public class Server extends BaseDomainHelper implements Identifiable {
         return channels;
     }
 
-    protected void setChannels(Set<Channel> chans) {
+    /**
+     * Set channels
+     * @param chans the channels
+     */
+    public void setChannels(Set<Channel> chans) {
         channels = chans;
     }
 

--- a/java/code/src/com/suse/manager/reactor/messaging/ImageDeployedEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/ImageDeployedEventMessageAction.java
@@ -80,6 +80,8 @@ public class ImageDeployedEventMessageAction implements MessageAction {
                     .flatMap(suma -> suma.getOptionalAsString("activation_key"));
             Optional<ActivationKey> activationKey = activationKeyLabel.map(ActivationKeyFactory::lookupByKey);
 
+            // we want to clear assigned channels first
+            m.getChannels().clear();
             RegistrationUtils.subscribeMinionToChannels(saltService, m, grains, activationKey, activationKeyLabel);
             activationKey.ifPresent(ak -> RegistrationUtils.applyActivationKeyProperties(m, ak, grains));
             RegistrationUtils.finishRegistration(m, activationKey, Optional.empty(), false);

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -496,9 +496,6 @@ public class RegisterMinionEventMessageAction implements MessageAction {
                 // remove package profile
                 minion.getPackages().clear();
 
-                // change base channel
-                minion.getChannels().clear();
-
                 // clear config channels
                 minion.setConfigChannels(Collections.emptyList(), minion.getCreator());
 

--- a/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
@@ -233,6 +233,10 @@ public class RegistrationUtils {
                 activationKey,
                 // No ActivationKey
                 () -> {
+                    // if server has a base channel assigned and there is no AK -> don't assign new channels
+                    if (server.getBaseChannel() != null) {
+                        return server.getChannels();
+                    }
                     Set<SUSEProduct> suseProducts = identifyProduct(saltService, server, grains);
                     return findChannelsForProducts(suseProducts, minionId);
                 },
@@ -266,15 +270,7 @@ public class RegistrationUtils {
                 )
         );
 
-        Channel assignedBaseChannel = server.getBaseChannel();
-        if (assignedBaseChannel != null && channelsToAssign.stream()
-                .filter(channel -> channel.isBaseChannel())
-                .anyMatch(baseChannel -> !baseChannel.equals(assignedBaseChannel))) {
-            // if base channel is going to be changed, we reset all current assignments
-            server.getChannels().clear();
-        }
-
-        channelsToAssign.forEach(server::addChannel);
+        server.setChannels(channelsToAssign);
     }
 
     private static Set<Channel> findChannelsForProducts(Set<SUSEProduct> suseProducts, String minionId) {

--- a/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
@@ -61,6 +61,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.partitioningBy;
 import static java.util.stream.Collectors.toSet;
@@ -233,54 +234,14 @@ public class RegistrationUtils {
                 // No ActivationKey
                 () -> {
                     Set<SUSEProduct> suseProducts = identifyProduct(saltService, server, grains);
-                    Map<Boolean, List<SUSEProduct>> baseAndExtProd = suseProducts.stream()
-                            .collect(partitioningBy(SUSEProduct::isBase));
-
-                    Optional<SUSEProduct> baseProductOpt = ofNullable(baseAndExtProd.get(true))
-                            .flatMap(s -> s.stream().findFirst());
-                    List<SUSEProduct> extProducts = baseAndExtProd.get(false);
-
-                    return Opt.fold(
-                            baseProductOpt,
-                            // No ActivationKey and no base product identified
-                            () -> {
-                                LOG.warn("Server " + minionId + " has no identifiable base product" +
-                                        " and will register without base channel assignment");
-                                return Collections.emptySet();
-                            },
-                            baseProduct -> Stream.concat(
-                                    lookupRequiredChannelsForProduct(baseProduct),
-                                    extProducts.stream()
-                                            .flatMap(ext -> recommendedChannelsByBaseProduct(baseProduct, ext))
-                            ).collect(toSet())
-                    );
+                    return findChannelsForProducts(suseProducts, minionId);
                 },
                 ak -> Opt.<Channel, Set<Channel>>fold(
                         ofNullable(ak.getBaseChannel()),
                         // ActivationKey without base channel (SUSE Manager Default)
                         () -> {
                             Set<SUSEProduct> suseProducts = identifyProduct(saltService, server, grains);
-                            Map<Boolean, List<SUSEProduct>> baseAndExtProd = suseProducts.stream()
-                                    .collect(partitioningBy(SUSEProduct::isBase));
-
-                            Optional<SUSEProduct> baseProductOpt = ofNullable(baseAndExtProd.get(true))
-                                    .flatMap(s -> s.stream().findFirst());
-                            List<SUSEProduct> extProducts = baseAndExtProd.get(false);
-
-                            return Opt.fold(
-                                    baseProductOpt,
-                                    // ActivationKey and no base product identified
-                                    () -> {
-                                        LOG.warn("Server " + minionId + " has no identifiable base product" +
-                                                " and will register without base channel assignment");
-                                        return Collections.emptySet();
-                                    },
-                                    baseProduct -> Stream.concat(
-                                            lookupRequiredChannelsForProduct(baseProduct),
-                                            extProducts.stream().flatMap(
-                                                    ext -> recommendedChannelsByBaseProduct(baseProduct, ext))
-                                    ).collect(toSet())
-                            );
+                            return findChannelsForProducts(suseProducts, minionId);
                         },
                         baseChannel -> Opt.fold(
                                 SUSEProductFactory.findProductByChannelLabel(baseChannel.getLabel()),
@@ -314,6 +275,28 @@ public class RegistrationUtils {
         }
 
         channelsToAssign.forEach(server::addChannel);
+    }
+
+    private static Set<Channel> findChannelsForProducts(Set<SUSEProduct> suseProducts, String minionId) {
+        Map<Boolean, List<SUSEProduct>> baseAndExtProd = suseProducts.stream()
+                .collect(partitioningBy(SUSEProduct::isBase));
+        Optional<SUSEProduct> baseProductOpt = ofNullable(baseAndExtProd.get(true))
+                .flatMap(s -> s.stream().findFirst());
+        List<SUSEProduct> extProducts = baseAndExtProd.get(false);
+
+        return Opt.fold(
+                baseProductOpt,
+                () -> {
+                    LOG.warn("Server " + minionId + " has no identifiable base product" +
+                            " and will register without base channel assignment");
+                    return emptySet();
+                },
+                baseProduct -> Stream.concat(
+                        lookupRequiredChannelsForProduct(baseProduct),
+                        extProducts.stream()
+                                .flatMap(ext -> recommendedChannelsByBaseProduct(baseProduct, ext))
+                ).collect(toSet())
+        );
     }
 
     private static Set<SUSEProduct> identifyProduct(SaltService saltService, MinionServer server, ValueMap grains) {
@@ -364,7 +347,7 @@ public class RegistrationUtils {
                 }
             }).collect(toSet());
         }
-        return Collections.emptySet();
+        return emptySet();
     }
 
     private static Stream<Channel> lookupRequiredChannelsForProduct(SUSEProduct sp) {

--- a/java/code/src/com/suse/manager/reactor/messaging/test/ImageDeployedEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/ImageDeployedEventMessageActionTest.java
@@ -115,7 +115,7 @@ public class ImageDeployedEventMessageActionTest extends JMockBaseTestCaseWithUs
     /**
      * Happy path scenario: machine_id grain is present.
      * In this case we test that at the end of the Action, the minion has correct channels
-     * (based on its product) assigned. Old channel assignments will be overriden.
+     * (based on its product) assigned. Old channel assignments will be overridden.
      */
     public void testBaseChannelChanged() throws Exception {
         grains.put("machine_id", testMinion.getMachineId());

--- a/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
@@ -14,11 +14,6 @@
  */
 package com.suse.manager.reactor.test;
 
-import static com.redhat.rhn.testing.ErrataTestUtils.createTestChannelFamily;
-import static com.redhat.rhn.testing.ErrataTestUtils.createTestChannelProduct;
-import static com.redhat.rhn.testing.RhnBaseTestCase.assertContains;
-import static java.util.Collections.singletonMap;
-
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.action.Action;
@@ -57,17 +52,15 @@ import com.redhat.rhn.domain.user.UserFactory;
 import com.redhat.rhn.manager.action.ActionManager;
 import com.redhat.rhn.manager.distupgrade.test.DistUpgradeManagerTest;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
-import com.redhat.rhn.manager.formula.FormulaManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
+import com.redhat.rhn.testing.ChannelTestUtils;
 import com.redhat.rhn.testing.ConfigTestUtils;
 import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
-import com.redhat.rhn.testing.ServerGroupTestUtils;
 import com.redhat.rhn.testing.ServerTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
-
 import com.suse.manager.reactor.messaging.RegisterMinionEventMessage;
 import com.suse.manager.reactor.messaging.RegisterMinionEventMessageAction;
 import com.suse.manager.reactor.utils.test.RhelUtilsTest;
@@ -83,7 +76,6 @@ import com.suse.salt.netapi.datatypes.target.MinionList;
 import com.suse.salt.netapi.parser.JsonParser;
 import com.suse.salt.netapi.results.Result;
 import com.suse.salt.netapi.utils.Xor;
-
 import org.jmock.Expectations;
 import org.jmock.lib.legacy.ClassImposteriser;
 
@@ -103,6 +95,11 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+
+import static com.redhat.rhn.testing.ErrataTestUtils.createTestChannelFamily;
+import static com.redhat.rhn.testing.ErrataTestUtils.createTestChannelProduct;
+import static com.redhat.rhn.testing.RhnBaseTestCase.assertContains;
+import static java.util.Collections.singletonMap;
 
 /**
  * Tests for {@link RegisterMinionEventMessageAction}.
@@ -361,7 +358,6 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         Server server = ServerTestUtils.createTestSystem(otherUser);
         server.setMachineId(MACHINE_ID);
         ServerFactory.save(server);
-        //SystemManager.giveCapability(server.getId(), SystemManager.CAP_SCRIPT_RUN, 1L);
 
         ChannelFamily channelFamily = createTestChannelFamily();
         SUSEProduct product = SUSEProductTestUtils.createTestSUSEProduct(channelFamily);
@@ -373,10 +369,10 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         assertTrue(optMinion.isPresent());
         MinionServer minion = optMinion.get();
 
-        // no base/required channels - e.g. we need an SCC sync
         assertEquals(MINION_ID, minion.getName());
-        assertNull(minion.getBaseChannel());
-        assertTrue(minion.getChannels().isEmpty());
+        // assigned channels are preserved
+        Set<Channel> originalChannels = ((Server) HibernateFactory.reload(server)).getChannels();
+        assertEquals(originalChannels, minion.getChannels());
 
         // Invalid Activation Key should be reported because
         // org of server does not match org of activation key
@@ -1356,6 +1352,153 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                 DEFAULT_CONTACT_METHOD);
     }
 
+    /**
+     * Test that a traditional -> salt migration respects the channels from the Activation Key (and overrides
+     * the channels that have been assigned to the system)
+     *
+     * @throws java.lang.Exception if anything goes wrong
+     */
+    public void testMigrationSystemWithChannelsAndAK() throws Exception {
+        Channel akBaseChannel = ChannelTestUtils.createBaseChannel(user);
+        Channel akChildChannel = ChannelTestUtils.createChildChannel(user, akBaseChannel);
+
+        Channel assignedChannel = ChannelTestUtils.createBaseChannel(user);
+        ServerFactory.findByMachineId(MACHINE_ID).ifPresent(ServerFactory::delete);
+        Server server = ServerTestUtils.createTestSystem(user);
+        server.setMachineId(MACHINE_ID);
+        server.addChannel(assignedChannel);
+        ServerFactory.save(server);
+
+        executeTest((saltServiceMock, key) -> new Expectations() {
+            {
+                allowing(saltServiceMock).getMasterHostname(MINION_ID);
+                will(returnValue(Optional.of(MINION_ID)));
+                allowing(saltServiceMock).getMachineId(MINION_ID);
+                will(returnValue(Optional.of(MACHINE_ID)));
+                allowing(saltServiceMock).syncGrains(with(any(MinionList.class)));
+                allowing(saltServiceMock).syncModules(with(any(MinionList.class)));
+                allowing(saltServiceMock).getGrains(MINION_ID);
+                will(returnValue(getGrains(MINION_ID, null, key)));
+            }
+        }, (DEFAULT_CONTACT_METHOD) -> {
+            ActivationKey key = ActivationKeyTest.createTestActivationKey(user);
+            key.setBaseChannel(akBaseChannel);
+            key.addChannel(akChildChannel);
+            key.setOrg(user.getOrg());
+            ActivationKeyFactory.save(key);
+            return key.getKey();
+        }, (optMinion, machineId, key) -> {
+            assertTrue(optMinion.isPresent());
+            MinionServer minion = optMinion.get();
+            assertEquals(MINION_ID, minion.getName());
+
+            assertNotNull(minion.getBaseChannel());
+            assertEquals(akBaseChannel, minion.getBaseChannel());
+
+            HashSet<Channel> channels = new HashSet<>();
+            channels.add(akBaseChannel);
+            channels.add(akChildChannel);
+            assertEquals(channels, minion.getChannels());
+            assertTrue(minion.getFqdns().isEmpty());
+        }, DEFAULT_CONTACT_METHOD);
+    }
+
+    /**
+     * Test that a traditional -> salt migration respects the channels from the Activation Key (and overrides
+     * the channels that have been assigned to the system)
+     * In this case, the already assigned base channel was same the one in the AK, but the child channels differ.
+     *
+     * @throws java.lang.Exception if anything goes wrong
+     */
+    public void testMigrationSystemWithChannelsAndAKSameBase() throws Exception {
+        Channel akBaseChannel = ChannelTestUtils.createBaseChannel(user);
+        Channel akChildChannel = ChannelTestUtils.createChildChannel(user, akBaseChannel);
+        Channel assignedChildChannel = ChannelTestUtils.createChildChannel(user, akBaseChannel);
+
+        ServerFactory.findByMachineId(MACHINE_ID).ifPresent(ServerFactory::delete);
+        Server server = ServerTestUtils.createTestSystem(user);
+        server.setMachineId(MACHINE_ID);
+        server.addChannel(akBaseChannel);
+        server.addChannel(assignedChildChannel);
+        ServerFactory.save(server);
+
+        executeTest((saltServiceMock, key) -> new Expectations() {
+            {
+                allowing(saltServiceMock).getMasterHostname(MINION_ID);
+                will(returnValue(Optional.of(MINION_ID)));
+                allowing(saltServiceMock).getMachineId(MINION_ID);
+                will(returnValue(Optional.of(MACHINE_ID)));
+                allowing(saltServiceMock).syncGrains(with(any(MinionList.class)));
+                allowing(saltServiceMock).syncModules(with(any(MinionList.class)));
+                allowing(saltServiceMock).getGrains(MINION_ID);
+                will(returnValue(getGrains(MINION_ID, null, key)));
+            }
+        }, (DEFAULT_CONTACT_METHOD) -> {
+            ActivationKey key = ActivationKeyTest.createTestActivationKey(user);
+            key.setBaseChannel(akBaseChannel);
+            key.addChannel(akChildChannel);
+            key.setOrg(user.getOrg());
+            ActivationKeyFactory.save(key);
+            return key.getKey();
+        }, (optMinion, machineId, key) -> {
+            assertTrue(optMinion.isPresent());
+            MinionServer minion = optMinion.get();
+            assertEquals(MINION_ID, minion.getName());
+
+            assertNotNull(minion.getBaseChannel());
+            assertEquals(akBaseChannel, minion.getBaseChannel());
+
+            HashSet<Channel> channels = new HashSet<>();
+            channels.add(akBaseChannel);
+            channels.add(akChildChannel);
+            assertEquals(channels, minion.getChannels());
+            assertTrue(minion.getFqdns().isEmpty());
+        }, DEFAULT_CONTACT_METHOD);
+    }
+
+    /**
+     * Test that a traditional -> salt migration preserves assigned channels when no AK is used
+     *
+     * @throws java.lang.Exception if anything goes wrong
+     */
+    public void testMigrationSystemWithChannelsNoAK() throws Exception {
+        Channel assignedChannel = ChannelTestUtils.createBaseChannel(user);
+        Channel assignedChildChannel = ChannelTestUtils.createChildChannel(user, assignedChannel);
+        ServerFactory.findByMachineId(MACHINE_ID).ifPresent(ServerFactory::delete);
+        Server server = ServerTestUtils.createTestSystem(user);
+        server.setMachineId(MACHINE_ID);
+        server.getChannels().clear();
+        server.addChannel(assignedChannel);
+        server.addChannel(assignedChildChannel);
+        ServerFactory.save(server);
+
+        executeTest((saltServiceMock, key) -> new Expectations() {
+            {
+                allowing(saltServiceMock).getMasterHostname(MINION_ID);
+                will(returnValue(Optional.of(MINION_ID)));
+                allowing(saltServiceMock).getMachineId(MINION_ID);
+                will(returnValue(Optional.of(MACHINE_ID)));
+                allowing(saltServiceMock).syncGrains(with(any(MinionList.class)));
+                allowing(saltServiceMock).syncModules(with(any(MinionList.class)));
+                allowing(saltServiceMock).getGrains(MINION_ID);
+                will(returnValue(getGrains(MINION_ID, null, key)));
+            }
+        }, (DEFAULT_CONTACT_METHOD) -> null,
+        (optMinion, machineId, key) -> {
+            assertTrue(optMinion.isPresent());
+            MinionServer minion = optMinion.get();
+            assertEquals(MINION_ID, minion.getName());
+
+            assertNotNull(minion.getBaseChannel());
+            assertEquals(assignedChannel, minion.getBaseChannel());
+
+            HashSet<Channel> channels = new HashSet<>();
+            channels.add(assignedChannel);
+            channels.add(assignedChildChannel);
+            assertEquals(channels, minion.getChannels());
+            assertTrue(minion.getFqdns().isEmpty());
+        }, DEFAULT_CONTACT_METHOD);
+    }
     private Channel setupBaseAndRequiredChannels(ChannelFamily channelFamily,
             SUSEProduct product)
         throws Exception {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Keep assigned channels on traditional to minion migration (bsc#1122836)
 - Add UI to create virtual machine for salt minions
 - Fix "Add Selected to SSM" on System Groups -> systems page (bsc#1121856)
 


### PR DESCRIPTION
Previously, on traditional -> minion migration, the channels were nulled (and
re-assigned in later phases of the registration based on activation key or
product installed (when no activation key was present)).

This PR changes the behavior: channels assigned to the machine are kept after
the registration. Behavior when an activation key is present is unchanged: AK
always has priority.

For the saltbooted minions, the old behavior (nulling channels) is kept.


No difference.

- [x] **DONE**

- No documentation needed: I checked and it looks like the channels change
behavior during migration is not documented.

- [x] **DONE**

- Unit tests were adjusted

- [x] **DONE**


Tracks https://github.com/SUSE/spacewalk/issues/6884

- [x] **DONE**