### PR TITLE
Add support for ULN repositories on new Zypper based reposync

### DIFF
--- a/backend/satellite_tools/repo_plugins/uln_src.py
+++ b/backend/satellite_tools/repo_plugins/uln_src.py
@@ -27,17 +27,15 @@ from spacewalk.satellite_tools.repo_plugins.yum_src import ContentSource as yum_
 from spacewalk.satellite_tools.syncLib import RhnSyncException
 from spacewalk.satellite_tools.ulnauth import ULNAuth
 
-ULNSRC_CONF = '/etc/rhn/spacewalk-repo-sync/uln.conf'
-
 class ContentSource(yum_ContentSource):
 
-    def __init__(self, url, name, insecure=False, interactive=True, yumsrc_conf=ULNSRC_CONF,
+    def __init__(self, url, name, insecure=False, interactive=True, yumsrc_conf=ULNAuth.ULN_CONF_PATH,
                  org=1, channel_label="", no_mirrors=False,
                  ca_cert_file=None, client_cert_file=None, client_key_file=None):
         if url[:6] != "uln://":
             raise RhnSyncException("url format error, url must start with uln://")
         yum_ContentSource.__init__(self, url=url, name=name, insecure=insecure,
-                                   interactive=interactive, yumsrc_conf=ULNSRC_CONF, org=org,
+                                   interactive=interactive, yumsrc_conf=yumsrc_conf, org=org,
                                    channel_label=channel_label, no_mirrors=no_mirrors,
                                    ca_cert_file=ca_cert_file, client_cert_file=client_cert_file,
                                    client_key_file=client_key_file)

--- a/backend/satellite_tools/repo_plugins/uln_src.py
+++ b/backend/satellite_tools/repo_plugins/uln_src.py
@@ -22,55 +22,38 @@ ULN plugin for spacewalk-repo-sync.
 # pylint: disable=E0012, C0413
 import sys
 sys.path.append('/usr/share/rhn')
-from up2date_client.rpcServer import RetryServer, ServerList
 
 from spacewalk.satellite_tools.repo_plugins.yum_src import ContentSource as yum_ContentSource
 from spacewalk.satellite_tools.syncLib import RhnSyncException
+from spacewalk.satellite_tools.ulnauth import ULNAuth
 
 ULNSRC_CONF = '/etc/rhn/spacewalk-repo-sync/uln.conf'
-DEFAULT_UP2DATE_URL = "linux-update.oracle.com"
-
 
 class ContentSource(yum_ContentSource):
 
-    def __init__(self, url, name, insecure=False, interactive=True, yumsrc_conf=ULNSRC_CONF, org=1, channel_label="",
-                 ca_cert_file=None, client_cert_file=None, no_mirrors=False):
+    def __init__(self, url, name, insecure=False, interactive=True, yumsrc_conf=ULNSRC_CONF,
+                 org=1, channel_label="", no_mirrors=False,
+                 ca_cert_file=None, client_cert_file=None, client_key_file=None):
         if url[:6] != "uln://":
             raise RhnSyncException("url format error, url must start with uln://")
-        yum_ContentSource.__init__(self, url, name, insecure, interactive, ULNSRC_CONF, org, channel_label,
-                                   client_cert_file, client_key_file, no_mirrors)
-        self.uln_url = None
-        self.uln_user = None
-        self.uln_pass = None
-        self.key = None
+        yum_ContentSource.__init__(self, url=url, name=name, insecure=insecure,
+                                   interactive=interactive, yumsrc_conf=ULNSRC_CONF, org=org,
+                                   channel_label=channel_label, no_mirrors=no_mirrors,
+                                   ca_cert_file=ca_cert_file, client_cert_file=client_cert_file,
+                                   client_key_file=client_key_file)
+        self.uln_token = None
 
     def _authenticate(self, url):
-        if url.startswith("uln:///"):
-            self.uln_url = "https://" + DEFAULT_UP2DATE_URL
-            label = url[7:]
-        elif url.startswith("uln://"):
-            parts = url[6:].split("/")
-            self.uln_url = "https://" + parts[0]
-            label = parts[1]
-        else:
-            raise RhnSyncException("url format error, url must start with uln://")
-        self.uln_user = self.yumbase.conf.username
-        self.uln_pass = self.yumbase.conf.password
-        self.url = self.uln_url + "/XMLRPC/GET-REQ/" + label
+        self._url_orig = url
+        self._uln_auth = ULNAuth()
+        self.uln_token = self._uln_auth.authenticate(url)
+        self.http_headers = {'X-ULN-Api-User-Key': self.uln_token}
+        hostname, label = self._uln_auth.get_hostname(url)
+        self.url = self._uln_auth.url + "/XMLRPC/GET-REQ/" + label
         print(("The download URL is: " + self.url))
-        if self.proxy_addr:
-            print(("Trying proxy " + self.proxy_addr))
-        slist = ServerList([self.uln_url+"/rpc/api",])
-        s = RetryServer(slist.server(),
-                        refreshCallback=None,
-                        proxy=self.proxy_addr,
-                        username=self.proxy_user,
-                        password=self.proxy_pass,
-                        timeout=5)
-        s.addServerList(slist)
-        self.key = s.auth.login(self.uln_user, self.uln_pass)
+        if self.proxy_url:
+            print(("Trying proxy " + self.proxy_url))
 
     # pylint: disable=arguments-differ
     def setup_repo(self, repo, *args, **kwargs):
-        repo.http_headers = {'X-ULN-Api-User-Key': self.key}
-        yum_ContentSource.setup_repo(self, repo, *args, **kwargs)
+        yum_ContentSource.setup_repo(self, repo, *args, uln_repo=True, **kwargs)

--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -558,7 +558,7 @@ type=rpm-md
         if uln_repo:
            _url = 'plugin:spacewalk-uln-resolver?url={}'.format(self._url_orig)
         else:
-           _url=zypp_repo_url if not mirrorlist else os.path.join(repo.root, 'mirrorlist.txt')
+           _url = zypp_repo_url if not mirrorlist else os.path.join(repo.root, 'mirrorlist.txt')
 
         with open(os.path.join(repo.root, "etc/zypp/repos.d", str(self.channel_label or self.reponame) + ".repo"), "w") as repo_conf_file:
             repo_conf_file.write(repo_cfg.format(

--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -535,7 +535,7 @@ class ContentSource:
             self.error_msg("Could not write the calculated mirrorlist: {}".format(exc))
         return returnlist
 
-    def setup_repo(self, repo):
+    def setup_repo(self, repo, uln_repo=False):
         """
         Setup repository and fetch metadata
         """
@@ -555,11 +555,16 @@ gpgcheck={gpgcheck}
 repo_gpgcheck={gpgcheck}
 type=rpm-md
 '''
+        if uln_repo:
+           _url = 'plugin:spacewalk-uln-resolver?url={}'.format(self._url_orig)
+        else:
+           _url=zypp_repo_url if not mirrorlist else os.path.join(repo.root, 'mirrorlist.txt')
+
         with open(os.path.join(repo.root, "etc/zypp/repos.d", str(self.channel_label or self.reponame) + ".repo"), "w") as repo_conf_file:
             repo_conf_file.write(repo_cfg.format(
                 reponame=self.channel_label or self.reponame,
                 repo_url='baseurl' if not mirrorlist else 'mirrorlist',
-                url=zypp_repo_url if not mirrorlist else os.path.join(repo.root, 'mirrorlist.txt'),
+                url=_url,
                 gpgcheck="0" if self.insecure else "1"
             ))
         zypper_cmd = "zypper"

--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -444,6 +444,8 @@ class ContentSource:
                 if zypper_cfg.has_option(section_name, 'proxy_password'):
                     self.proxy_pass = zypper_cfg.get(section_name, 'proxy_password')
 
+        self._authenticate(url)
+
         # Make sure baseurl ends with / and urljoin will work correctly
         self.urls = [url]
         if self.urls[0][-1] != '/':
@@ -1100,3 +1102,6 @@ type=rpm-md
         self.sslcacert = ca_cert
         self.sslclientcert = client_cert
         self.sslclientkey = client_key
+
+    def _authenticate(self, url):
+        pass

--- a/backend/satellite_tools/spacewalk-uln-resolver
+++ b/backend/satellite_tools/spacewalk-uln-resolver
@@ -11,14 +11,11 @@ import urllib.parse
 sys.path.append("/usr/share/rhn/")
 from spacewalk.satellite_tools.ulnauth import ULNAuth
 
-
 # for testing add the relative path to the load path
 if "spacewalk-uln-resolver" in sys.argv[0]:
     sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '../python'))
 
 from zypp_plugin import Plugin
-
-CONF = "/etc/zypp/zypp.conf"
 
 
 class SpacewalkULNPlugin(Plugin):

--- a/backend/satellite_tools/spacewalk-uln-resolver
+++ b/backend/satellite_tools/spacewalk-uln-resolver
@@ -35,15 +35,16 @@ class SpacewalkULNPlugin(Plugin):
 
         :returns: None
         """
-        url = 'uln:///no-idea-yet'  # get it from uln.conf?
         try:
-            self._uln_auth.authenticate(url)
-            auth_headers = {
+            self._uln_auth.authenticate(headers['url'])
+            self.auth_headers = {
                 "X-ULN-Api-User-Key": self._uln_auth.token
             }
-            self.answer("RESOLVEDURL", auth_headers, self._uln_auth.url)
         except Exception as exc:
             self.answer("ERROR", {}, str(exc))
+        hostname, label = self._uln_auth.get_hostname(headers['url'])
+        url = self._uln_auth.url + "/XMLRPC/GET-REQ/" + label
+        self.answer("RESOLVEDURL", self.auth_headers, url)
 
 plugin = SpacewalkULNPlugin()
 plugin.main()

--- a/backend/satellite_tools/spacewalk-uln-resolver
+++ b/backend/satellite_tools/spacewalk-uln-resolver
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+
+import sys
+import os
+import re
+import logging
+import traceback
+import configparser
+import urllib.parse
+
+sys.path.append("/usr/share/rhn/")
+from spacewalk.satellite_tools.ulnauth import ULNAuth
+
+
+# for testing add the relative path to the load path
+if "spacewalk-uln-resolver" in sys.argv[0]:
+    sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '../python'))
+
+from zypp_plugin import Plugin
+
+CONF = "/etc/zypp/zypp.conf"
+
+
+class SpacewalkULNPlugin(Plugin):
+    """
+    ULN authentication Plugin
+    """
+    def __init__(self):
+        Plugin.__init__(self)
+        self._uln_auth = ULNAuth()
+
+    def RESOLVEURL(self, headers, body):
+        """
+        Resolve URL.
+
+        :returns: None
+        """
+        url = 'uln:///no-idea-yet'  # get it from uln.conf?
+        try:
+            self._uln_auth.authenticate(url)
+            auth_headers = {
+                "X-ULN-Api-User-Key": self._uln_auth.token
+            }
+            self.answer("RESOLVEDURL", auth_headers, self._uln_auth.url)
+        except Exception as exc:
+            self.answer("ERROR", {}, str(exc))
+
+plugin = SpacewalkULNPlugin()
+plugin.main()

--- a/backend/satellite_tools/test/unit/test_uln.py
+++ b/backend/satellite_tools/test/unit/test_uln.py
@@ -33,3 +33,10 @@ class TestULNAuth:
             uln_auth_instance._get_hostname("foo://something/else")
         assert "URL must start with 'uln://'" in str(exc)
 
+    def test_get_hostname_default(self, uln_auth_instance):
+        """
+        Test ULN uri inserts a default hostname, if not specified.
+        """
+        netloc, path  = uln_auth_instance._get_hostname("uln:///suse")
+        assert netloc == ulnauth.ULNAuth.ULN_DEFAULT_HOST
+        assert path == "/suse"

--- a/backend/satellite_tools/test/unit/test_uln.py
+++ b/backend/satellite_tools/test/unit/test_uln.py
@@ -137,7 +137,7 @@ class TestULNAuth:
                 self.uln_auth_instance.get_credentials()
             assert "Credentials were not found in the configuration" in str(exc)
 
-    @patch("ulnauth.get_proxy", MagicMock(return_value=("uln:///suse", "user", "password")))
+    @patch("ulnauth.get_proxy", MagicMock(return_value=("https://my_http_proxy", "user", "password")))
     def test_auth_uln(self):
         """
         Authenticate ULN, getting its token.
@@ -162,7 +162,7 @@ class TestULNAuth:
             assert server_list.call_args_list[0][0] == (['https://linux-update.oracle.com/rpc/api'],)
             rs_call = retry_server.call_args_list[0][1]
             for p_name, p_val in {'refreshCallback': None, 'username': 'user',
-                          'proxy': 'uln:///suse', 'password': 'password', 'timeout': 5}.items():
+                          'proxy': 'https://my_http_proxy', 'password': 'password', 'timeout': 5}.items():
                 assert p_name in rs_call
                 assert rs_call[p_name] == p_val
 

--- a/backend/satellite_tools/test/unit/test_uln.py
+++ b/backend/satellite_tools/test/unit/test_uln.py
@@ -156,7 +156,7 @@ class TestULNAuth:
         uri = "uln:///suse"
         with patch("ulnauth.ServerList", server_list) as srv_lst, patch("ulnauth.RetryServer", retry_server) as rtr_srv:
             uln_auth_instance.get_credentials = MagicMock(return_value=("uln_user", "uln_password",))
-            token = uln_auth_instance.authenticate_uln(uri)
+            token = uln_auth_instance.authenticate(uri)
             assert server_list.call_args_list[0][0] == (['https://linux-update.oracle.com/rpc/api'],)
             rs_call = retry_server.call_args_list[0][1]
             for p_name, p_val in {'refreshCallback': None, 'username': 'user',

--- a/backend/satellite_tools/test/unit/test_uln.py
+++ b/backend/satellite_tools/test/unit/test_uln.py
@@ -4,6 +4,7 @@ Unit tests for the ULN authentication library.
 """
 import sys
 import pytest
+from unittest.mock import MagicMock, patch
 
 try:
     sys.path.insert(0, __file__.split("/test/unit")[0])
@@ -49,3 +50,12 @@ class TestULNAuth:
         assert netloc == "scc.suse.de"
         assert path == "/suse"
 
+    @patch("os.path.exists", MagicMock(return_value=False))
+    @patch("os.access", MagicMock(return_value=False))
+    def test_get_credentials_not_found(self, uln_auth_instance):
+        """
+        Test fetching proper credentials from the ULN configuration.
+        """
+        with pytest.raises(ulnauth.RhnSyncException) as exc:
+            uln_auth_instance._get_credentials()
+        assert "'/etc/rhn/spacewalk-repo-sync/uln.conf' does not exists" in str(exc)

--- a/backend/satellite_tools/test/unit/test_uln.py
+++ b/backend/satellite_tools/test/unit/test_uln.py
@@ -26,6 +26,9 @@ class TestULNAuth:
     Test ULN auth.
     """
     def test_get_hostname_uln(self, uln_auth_instance):
+        """
+        Test ULN uri raises an exception if protocol is not ULN.
+        """
         with pytest.raises(ulnauth.RhnSyncException) as exc:
             uln_auth_instance._get_hostname("foo://something/else")
         assert "URL must start with 'uln://'" in str(exc)

--- a/backend/satellite_tools/test/unit/test_uln.py
+++ b/backend/satellite_tools/test/unit/test_uln.py
@@ -53,17 +53,17 @@ class TestULNAuth:
         """
         Test ULN uri inserts a default hostname, if not specified.
         """
-        netloc, path  = uln_auth_instance.get_hostname("uln:///suse")
-        assert netloc == ulnauth.ULNAuth.ULN_DEFAULT_HOST
-        assert path == "/suse"
+        hostname, path  = self.uln_auth_instance.get_hostname("uln:///suse")
+        assert hostname == "https://{}".format(ulnauth.ULNAuth.ULN_DEFAULT_HOST)
+        assert path == "suse"
 
     def test_get_hostname_custom(self):
         """
         Test ULN uri inserts a custom hostname, if specified.
         """
-        netloc, path  = uln_auth_instance.get_hostname("uln://scc.suse.de/suse")
-        assert netloc == "scc.suse.de"
-        assert path == "/suse"
+        hostname, path  = self.uln_auth_instance.get_hostname("uln://scc.suse.de/suse")
+        assert hostname == "https://scc.suse.de"
+        assert path == "suse"
 
     @patch("os.path.exists", MagicMock(return_value=False))
     @patch("os.access", MagicMock(return_value=False))
@@ -162,7 +162,7 @@ class TestULNAuth:
             assert server_list.call_args_list[0][0] == (['https://linux-update.oracle.com/rpc/api'],)
             rs_call = retry_server.call_args_list[0][1]
             for p_name, p_val in {'refreshCallback': None, 'username': 'user',
-                          'proxy': None, 'password': 'password', 'timeout': 5}.items():
+                          'proxy': 'uln:///suse', 'password': 'password', 'timeout': 5}.items():
                 assert p_name in rs_call
                 assert rs_call[p_name] == p_val
 

--- a/backend/satellite_tools/test/unit/test_uln.py
+++ b/backend/satellite_tools/test/unit/test_uln.py
@@ -1,0 +1,32 @@
+# coding: utf-8
+"""
+Unit tests for the ULN authentication library.
+"""
+import sys
+import pytest
+
+try:
+    sys.path.insert(0, __file__.split("/test/unit")[0])
+    import ulnauth
+except ImportError as ex:
+    ulnauth = None
+
+
+@pytest.fixture
+def uln_auth_instance():
+    """
+    Instantiate ULNAuth.
+    """
+    return ulnauth.ULNAuth()
+
+
+@pytest.mark.skipif(ulnauth is None, reason="'ulnauth' failed to be imported")
+class TestULNAuth:
+    """
+    Test ULN auth.
+    """
+    def test_get_hostname_uln(self, uln_auth_instance):
+        with pytest.raises(ulnauth.RhnSyncException) as exc:
+            uln_auth_instance._get_hostname("foo://something/else")
+        assert "URL must start with 'uln://'" in str(exc)
+

--- a/backend/satellite_tools/test/unit/test_uln.py
+++ b/backend/satellite_tools/test/unit/test_uln.py
@@ -69,3 +69,13 @@ class TestULNAuth:
         with pytest.raises(ulnauth.RhnSyncException) as exc:
             uln_auth_instance._get_credentials()
         assert "Permission denied to '/etc/rhn/spacewalk-repo-sync/uln.conf'" in str(exc)
+
+    @patch("os.path.exists", MagicMock(return_value=True))
+    @patch("os.access", MagicMock(return_value=False))
+    def test_get_credentials_access_denied(self, uln_auth_instance):
+        """
+        Test credentials ULN configuration readable.
+        """
+        with pytest.raises(ulnauth.RhnSyncException) as exc:
+            uln_auth_instance._get_credentials()
+        assert "Permission denied to '/etc/rhn/spacewalk-repo-sync/uln.conf'" in str(exc)

--- a/backend/satellite_tools/test/unit/test_uln.py
+++ b/backend/satellite_tools/test/unit/test_uln.py
@@ -94,3 +94,18 @@ class TestULNAuth:
             username, password = uln_auth_instance._get_credentials()
             assert username == "Darth Vader"
             assert password == "f1ndE4rth"
+
+    @patch("os.path.exists", MagicMock(return_value=True))
+    @patch("os.access", MagicMock(return_value=True))
+    def test_get_credentials_credentials_not_found(self, uln_auth_instance):
+        """
+        Test credentials ULN
+        """
+        class CfgParser(dict):
+            def read(self, path):
+                pass
+
+        with patch("configparser.ConfigParser", CfgParser):
+            with pytest.raises(AssertionError) as exc:
+                uln_auth_instance._get_credentials()
+            assert "Credentials were not found in the configuration" in str(exc)

--- a/backend/satellite_tools/test/unit/test_uln.py
+++ b/backend/satellite_tools/test/unit/test_uln.py
@@ -40,3 +40,12 @@ class TestULNAuth:
         netloc, path  = uln_auth_instance._get_hostname("uln:///suse")
         assert netloc == ulnauth.ULNAuth.ULN_DEFAULT_HOST
         assert path == "/suse"
+
+    def test_get_hostname_custom(self, uln_auth_instance):
+        """
+        Test ULN uri inserts a custom hostname, if specified.
+        """
+        netloc, path  = uln_auth_instance._get_hostname("uln://scc.suse.de/suse")
+        assert netloc == "scc.suse.de"
+        assert path == "/suse"
+

--- a/backend/satellite_tools/test/unit/test_uln.py
+++ b/backend/satellite_tools/test/unit/test_uln.py
@@ -54,8 +54,18 @@ class TestULNAuth:
     @patch("os.access", MagicMock(return_value=False))
     def test_get_credentials_not_found(self, uln_auth_instance):
         """
-        Test fetching proper credentials from the ULN configuration.
+        Test credentials ULN configuration exists.
         """
         with pytest.raises(ulnauth.RhnSyncException) as exc:
             uln_auth_instance._get_credentials()
         assert "'/etc/rhn/spacewalk-repo-sync/uln.conf' does not exists" in str(exc)
+
+    @patch("os.path.exists", MagicMock(return_value=True))
+    @patch("os.access", MagicMock(return_value=False))
+    def test_get_credentials_access_denied(self, uln_auth_instance):
+        """
+        Test credentials ULN configuration readable.
+        """
+        with pytest.raises(ulnauth.RhnSyncException) as exc:
+            uln_auth_instance._get_credentials()
+        assert "Permission denied to '/etc/rhn/spacewalk-repo-sync/uln.conf'" in str(exc)

--- a/backend/satellite_tools/test/unit/test_uln.py
+++ b/backend/satellite_tools/test/unit/test_uln.py
@@ -79,3 +79,18 @@ class TestULNAuth:
         with pytest.raises(ulnauth.RhnSyncException) as exc:
             uln_auth_instance._get_credentials()
         assert "Permission denied to '/etc/rhn/spacewalk-repo-sync/uln.conf'" in str(exc)
+
+    @patch("os.path.exists", MagicMock(return_value=True))
+    @patch("os.access", MagicMock(return_value=True))
+    def test_get_credentials_credentials(self, uln_auth_instance):
+        """
+        Test credentials ULN
+        """
+        class CfgParser(dict):
+            def read(self, path):
+                self["main"] = {"username": "Darth Vader", "password": "f1ndE4rth"}
+
+        with patch("configparser.ConfigParser", CfgParser):
+            username, password = uln_auth_instance._get_credentials()
+            assert username == "Darth Vader"
+            assert password == "f1ndE4rth"

--- a/backend/satellite_tools/test/unit/test_uln.py
+++ b/backend/satellite_tools/test/unit/test_uln.py
@@ -44,14 +44,14 @@ class TestULNAuth:
         Test ULN uri raises an exception if protocol is not ULN.
         """
         with pytest.raises(ulnauth.RhnSyncException) as exc:
-            uln_auth_instance._get_hostname("foo://something/else")
+            uln_auth_instance.get_hostname("foo://something/else")
         assert "URL must start with 'uln://'" in str(exc)
 
     def test_get_hostname_default(self, uln_auth_instance):
         """
         Test ULN uri inserts a default hostname, if not specified.
         """
-        netloc, path  = uln_auth_instance._get_hostname("uln:///suse")
+        netloc, path  = uln_auth_instance.get_hostname("uln:///suse")
         assert netloc == ulnauth.ULNAuth.ULN_DEFAULT_HOST
         assert path == "/suse"
 
@@ -59,7 +59,7 @@ class TestULNAuth:
         """
         Test ULN uri inserts a custom hostname, if specified.
         """
-        netloc, path  = uln_auth_instance._get_hostname("uln://scc.suse.de/suse")
+        netloc, path  = uln_auth_instance.get_hostname("uln://scc.suse.de/suse")
         assert netloc == "scc.suse.de"
         assert path == "/suse"
 
@@ -70,7 +70,7 @@ class TestULNAuth:
         Test credentials ULN configuration exists.
         """
         with pytest.raises(ulnauth.RhnSyncException) as exc:
-            uln_auth_instance._get_credentials()
+            uln_auth_instance.get_credentials()
         assert "'/etc/rhn/spacewalk-repo-sync/uln.conf' does not exists" in str(exc)
 
     @patch("os.path.exists", MagicMock(return_value=True))
@@ -80,7 +80,7 @@ class TestULNAuth:
         Test credentials ULN configuration readable.
         """
         with pytest.raises(ulnauth.RhnSyncException) as exc:
-            uln_auth_instance._get_credentials()
+            uln_auth_instance.get_credentials()
         assert "Permission denied to '/etc/rhn/spacewalk-repo-sync/uln.conf'" in str(exc)
 
     @patch("os.path.exists", MagicMock(return_value=True))
@@ -90,7 +90,7 @@ class TestULNAuth:
         Test credentials ULN configuration readable.
         """
         with pytest.raises(ulnauth.RhnSyncException) as exc:
-            uln_auth_instance._get_credentials()
+            uln_auth_instance.get_credentials()
         assert "Permission denied to '/etc/rhn/spacewalk-repo-sync/uln.conf'" in str(exc)
 
     @patch("os.path.exists", MagicMock(return_value=True))
@@ -101,7 +101,7 @@ class TestULNAuth:
         """
         cfg_parser.cfg = {"username": "Darth Vader", "password": "f1ndE4rth"}
         with patch("configparser.ConfigParser", cfg_parser):
-            username, password = uln_auth_instance._get_credentials()
+            username, password = uln_auth_instance.get_credentials()
             assert username == "Darth Vader"
             assert password == "f1ndE4rth"
 
@@ -113,7 +113,7 @@ class TestULNAuth:
         """
         with patch("configparser.ConfigParser", cfg_parser):
             with pytest.raises(AssertionError) as exc:
-                uln_auth_instance._get_credentials()
+                uln_auth_instance.get_credentials()
             assert "Credentials were not found in the configuration" in str(exc)
 
     @patch("os.path.exists", MagicMock(return_value=True))
@@ -125,12 +125,12 @@ class TestULNAuth:
         cfg_parser.cfg = {"username": "Darth Vader"}
         with patch("configparser.ConfigParser", cfg_parser):
             with pytest.raises(AssertionError) as exc:
-                uln_auth_instance._get_credentials()
+                uln_auth_instance.get_credentials()
             assert "Credentials were not found in the configuration" in str(exc)
 
         cfg_parser.cfg["password"] = "something"
         del cfg_parser.cfg["username"]
         with patch("configparser.ConfigParser", cfg_parser):
             with pytest.raises(AssertionError) as exc:
-                uln_auth_instance._get_credentials()
+                uln_auth_instance.get_credentials()
             assert "Credentials were not found in the configuration" in str(exc)

--- a/backend/satellite_tools/ulnauth.py
+++ b/backend/satellite_tools/ulnauth.py
@@ -61,12 +61,14 @@ class ULNAuth:
         :raises RhnSyncException: if configuration does not contain required sections.
         :returns: ULN token
         """
-        usr, pwd = self._get_credentials()
+        usr, pwd = self.get_credentials()
         px_url, px_usr, px_pwd = get_proxy(url)
-        hostname, label = self._get_hostname(url)
+        hostname, label = self.get_hostname(url)
         self._uln_url = "https://{}/XMLRPC/GET-REQ{}".format(hostname, label)
         server_list = ServerList(["https://{}/rpc/api".format(hostname)])
         retry_server = RetryServer(server_list.server(), refreshCallback=None, proxy=None,
                                    username=px_usr, password=px_pwd, timeout=5)
         retry_server.addServerList(server_list)
         self._uln_token = retry_server.auth.login(usr, pwd)
+
+        return self._uln_token

--- a/backend/satellite_tools/ulnauth.py
+++ b/backend/satellite_tools/ulnauth.py
@@ -57,7 +57,7 @@ class ULNAuth:
 
         return username, password
 
-    def authenticate_uln(self, url):
+    def authenticate(self, url):
         """
         Get ULN token.
 

--- a/backend/satellite_tools/ulnauth.py
+++ b/backend/satellite_tools/ulnauth.py
@@ -10,6 +10,18 @@ from spacewalk.common.suseLib import get_proxy
 from spacewalk.satellite_tools.syncLib import RhnSyncException
 from up2date_client.rpcServer import RetryServer, ServerList
 
+from spacewalk.common.rhnConfig import initCFG
+
+import logging
+log = logging.getLogger(__name__)
+
+
+class ULNTokenException(Exception):
+    """
+    This class represent an exception getting the ULN token
+    """
+    pass
+
 
 class ULNAuth:
     """
@@ -19,6 +31,7 @@ class ULNAuth:
     ULN_DEFAULT_HOST = "linux-update.oracle.com"
 
     def __init__(self):
+        initCFG("server.satellite")
         self._uln_token = None
         self._uln_url = None
 

--- a/backend/satellite_tools/ulnauth.py
+++ b/backend/satellite_tools/ulnauth.py
@@ -5,6 +5,7 @@ Oracle ULN (Unbreakable Linux Network) authentication library.
 import os
 import configparser
 import urllib.parse
+from spacewalk.satellite_tools.syncLib import RhnSyncException
 
 
 class ULNAuth:

--- a/backend/satellite_tools/ulnauth.py
+++ b/backend/satellite_tools/ulnauth.py
@@ -5,7 +5,10 @@ Oracle ULN (Unbreakable Linux Network) authentication library.
 import os
 import configparser
 import urllib.parse
+
+from spacewalk.common.suseLib import get_proxy
 from spacewalk.satellite_tools.syncLib import RhnSyncException
+from up2date_client.rpcServer import RetryServer, ServerList
 
 
 class ULNAuth:

--- a/backend/satellite_tools/ulnauth.py
+++ b/backend/satellite_tools/ulnauth.py
@@ -22,6 +22,20 @@ class ULNAuth:
         self._uln_token = None
         self._uln_url = None
 
+    @property
+    def token(self):
+        """
+        Return ULN token, if authorised.
+        """
+        return self._uln_token
+
+    @property
+    def url(self):
+        """
+        Return ULN URL for the access.
+        """
+        return self._uln_url
+
     def get_hostname(self, url: str) -> tuple:
         """
         Get label from the URL (a hostname).
@@ -75,4 +89,6 @@ class ULNAuth:
             retry_server.addServerList(server_list)
             self._uln_token = retry_server.auth.login(usr, pwd)
 
-        return self._uln_token
+        assert self.token is not None, "Authentication failure: token was not obtained"
+
+        return self.token

--- a/backend/satellite_tools/ulnauth.py
+++ b/backend/satellite_tools/ulnauth.py
@@ -56,10 +56,14 @@ class ULNAuth:
         :raises RhnSyncException: if URL is wrongly formatted.
         :returns: tuple (hostname, label)
         """
-        if not url.startswith("uln://"):
+        if url.startswith("uln:///"):
+            return "https://" + self.ULN_DEFAULT_HOST, url[7:]
+        elif url.startswith("uln://"):
+            parts = url[6:].split("/")
+            return "https://" + parts[0], "/".join(parts[1:])
+        else:
             raise RhnSyncException("URL must start with 'uln://'.")
-        p_url = urllib.parse.urlparse(url)
-        return p_url.netloc or self.ULN_DEFAULT_HOST, p_url.path
+
 
     def get_credentials(self) -> tuple:
         """

--- a/backend/satellite_tools/ulnauth.py
+++ b/backend/satellite_tools/ulnauth.py
@@ -61,14 +61,15 @@ class ULNAuth:
         :raises RhnSyncException: if configuration does not contain required sections.
         :returns: ULN token
         """
-        usr, pwd = self.get_credentials()
-        px_url, px_usr, px_pwd = get_proxy(url)
-        hostname, label = self.get_hostname(url)
-        self._uln_url = "https://{}/XMLRPC/GET-REQ{}".format(hostname, label)
-        server_list = ServerList(["https://{}/rpc/api".format(hostname)])
-        retry_server = RetryServer(server_list.server(), refreshCallback=None, proxy=None,
-                                   username=px_usr, password=px_pwd, timeout=5)
-        retry_server.addServerList(server_list)
-        self._uln_token = retry_server.auth.login(usr, pwd)
+        if self._uln_token is None:
+            usr, pwd = self.get_credentials()
+            px_url, px_usr, px_pwd = get_proxy(url)
+            hostname, label = self.get_hostname(url)
+            self._uln_url = "https://{}/XMLRPC/GET-REQ{}".format(hostname, label)
+            server_list = ServerList(["https://{}/rpc/api".format(hostname)])
+            retry_server = RetryServer(server_list.server(), refreshCallback=None, proxy=None,
+                                       username=px_usr, password=px_pwd, timeout=5)
+            retry_server.addServerList(server_list)
+            self._uln_token = retry_server.auth.login(usr, pwd)
 
         return self._uln_token

--- a/backend/satellite_tools/ulnauth.py
+++ b/backend/satellite_tools/ulnauth.py
@@ -1,0 +1,31 @@
+# coding: utf-8
+"""
+Oracle ULN (Unbreakable Linux Network) authentication library.
+"""
+import urllib.parse
+
+
+class ULNAuth:
+    """
+    ULN Authentication.
+    """
+    ULN_CONF_PATH = "/etc/rhn/spacewalk-repo-sync/uln.conf"
+    ULN_DEFAULT_HOST = "linux-update.oracle.com"
+
+    def __init__(self):
+        self._uln_token = None
+        self._uln_url = None
+
+    def _get_hostname(self, url: str) -> tuple:
+        """
+        Get label from the URL (a hostname).
+
+        :raises RhnSyncException: if URL is wrongly formatted.
+        :returns: tuple (hostname, label)
+        """
+        if not url.startswith("uln://"):
+            RhnSyncException("URL must start with 'uln://'.")
+        p_url = urllib.parse.urlparse(url)
+        return p_url.netloc or self.DEFAULT_ULN_HOST, p_url.path
+
+    

--- a/backend/satellite_tools/ulnauth.py
+++ b/backend/satellite_tools/ulnauth.py
@@ -52,3 +52,20 @@ class ULNAuth:
         assert username is not None and password is not None, "Credentials were not found in the configuration"
 
         return username, password
+
+    def _authenticate_uln(self, url):
+        """
+        Get ULN token.
+
+        :raises RhnSyncException: if configuration does not contain required sections.
+        :returns: ULN token
+        """
+        usr, pwd = self._get_credentials()
+        px_url, px_usr, px_pwd = get_proxy(url)
+        hostname, label = self._get_hostname(url)
+        self._uln_url = "https://{}/XMLRPC/GET-REQ{}".format(hostname, label)
+        server_list = ServerList(["https://{}/rpc/api".format(hostname)])
+        retry_server = RetryServer(server_list.server(), refreshCallback=None, proxy=None,
+                                   username=px_usr, password=px_pwd, timeout=5)
+        retry_server.addServerList(server_list)
+        self._uln_token = retry_server.auth.login(usr, pwd)

--- a/backend/satellite_tools/ulnauth.py
+++ b/backend/satellite_tools/ulnauth.py
@@ -18,7 +18,7 @@ class ULNAuth:
         self._uln_token = None
         self._uln_url = None
 
-    def _get_hostname(self, url: str) -> tuple:
+    def get_hostname(self, url: str) -> tuple:
         """
         Get label from the URL (a hostname).
 
@@ -30,7 +30,7 @@ class ULNAuth:
         p_url = urllib.parse.urlparse(url)
         return p_url.netloc or self.ULN_DEFAULT_HOST, p_url.path
 
-    def _get_credentials(self) -> tuple:
+    def get_credentials(self) -> tuple:
         """
         Get credentials from the uln.conf
 
@@ -53,7 +53,7 @@ class ULNAuth:
 
         return username, password
 
-    def _authenticate_uln(self, url):
+    def authenticate_uln(self, url):
         """
         Get ULN token.
 

--- a/backend/satellite_tools/ulnauth.py
+++ b/backend/satellite_tools/ulnauth.py
@@ -2,6 +2,8 @@
 """
 Oracle ULN (Unbreakable Linux Network) authentication library.
 """
+import os
+import configparser
 import urllib.parse
 
 
@@ -24,8 +26,29 @@ class ULNAuth:
         :returns: tuple (hostname, label)
         """
         if not url.startswith("uln://"):
-            RhnSyncException("URL must start with 'uln://'.")
+            raise RhnSyncException("URL must start with 'uln://'.")
         p_url = urllib.parse.urlparse(url)
-        return p_url.netloc or self.DEFAULT_ULN_HOST, p_url.path
+        return p_url.netloc or self.ULN_DEFAULT_HOST, p_url.path
 
-    
+    def _get_credentials(self) -> tuple:
+        """
+        Get credentials from the uln.conf
+
+        :raises AssertionError: if configuration does not contain required sections.
+        :returns: tuple of username and password
+        """
+        if not os.path.exists(self.ULN_CONF_PATH):
+            raise RhnSyncException("'{}' does not exists".format(self.ULN_CONF_PATH))
+        elif not os.access(self.ULN_CONF_PATH, os.R_OK):
+            raise RhnSyncException("Permission denied to '{}'".format(self.ULN_CONF_PATH))
+
+        config = configparser.ConfigParser()
+        config.read(self.ULN_CONF_PATH)
+        if "main" in config:
+            sct = config["main"]
+            username, password = sct.get("username"), sct.get("password")
+        else:
+            username = password = None
+        assert username is not None and password is not None, "Credentials were not found in the configuration"
+
+        return username, password

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- Add support for ULN repositories on new Zypper based reposync.
+
 -------------------------------------------------------------------
 Wed May 15 17:06:26 CEST 2019 - jgonzalez@suse.com
 

--- a/susemanager-utils/testing/automation/backend-unittest-pgsql.sh
+++ b/susemanager-utils/testing/automation/backend-unittest-pgsql.sh
@@ -9,7 +9,7 @@ if [ ! -e $GITROOT/backend/common/usix.py ]; then
     ln -sf ../../usix/common/usix.py $GITROOT/backend/common/usix.py
 fi
 
-DOCKER_RUN_EXPORT="PYTHONPATH=/manager/client/rhel/rhnlib/:/manager/client/rhel/rhn-client-tools/src"
+DOCKER_RUN_EXPORT="PYTHONPATH=/manager/client/rhel/rhnlib/:/manager/client/rhel/spacewalk-client-tools/src"
 EXIT=0
 docker pull $REGISTRY/$PGSQL_CONTAINER
 docker run --rm=true -e $DOCKER_RUN_EXPORT -v "$GITROOT:/manager" $REGISTRY/$PGSQL_CONTAINER /manager/backend/test/docker-backend-common-tests.sh

--- a/susemanager-utils/testing/docker/master/uyuni-master-pgsql/Dockerfile
+++ b/susemanager-utils/testing/docker/master/uyuni-master-pgsql/Dockerfile
@@ -22,3 +22,4 @@ RUN zypper in -y python3-pip python3-solv python3-salt
 
 RUN pip3 install --upgrade pylint==1.8 astroid==1.6.5
 
+RUN zypper in -y python3-pytest


### PR DESCRIPTION
## What does this PR change?

Implements ULN authentication (reusable in Zypper plugin and RHN plugin)

## Test coverage
- Unit tests were added

## Links
- Fixes: https://github.com/SUSE/salt-board/issues/334
