### PR TITLE
Remove wrong python3-configparser requirement

### DIFF
--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -452,7 +452,6 @@ Requires:       python3-python-dateutil
 Requires:       python3-gzipstream
 Requires:       python3-rhn-client-tools
 Requires:       python3-solv
-Requires:       python3-configparser
 %else
 Requires:       python-dateutil
 Requires:       python2-gzipstream


### PR DESCRIPTION
## What does this PR change?

This PR removes `python3-configparser` as dependency for `spacewalk-backend` since the `configparser` is now part of the standart Python 3 library. No need to add extra requires.

## Changelogs

gitarro no changelog needed !!!