### PR TITLE
Port to Python3: Fix remaining issues on "spacewalk-backend" to run reposync on Python 3

### DIFF
--- a/backend/common/rhnLib.py
+++ b/backend/common/rhnLib.py
@@ -205,7 +205,7 @@ def isSUSE():
 
     cpe_name = ''
     try:
-        lines = open('/etc/os-release', 'rb').readlines()
+        lines = open('/etc/os-release', 'r').readlines()
         for line in lines:
             # Skip empty and comment-only lines
             if re.match(r'[ \t]*(#|$)', line):

--- a/backend/common/stringutils.py
+++ b/backend/common/stringutils.py
@@ -25,6 +25,8 @@ def to_unicode(obj):
 
 def to_string(obj):
     if isinstance(obj, UnicodeType):
-        return obj.encode('utf8')
+        return obj
+    elif isinstance(obj, bytes):
+        return obj.decode('utf8')
     else:
         return obj

--- a/backend/satellite_tools/accounts/satpasswd
+++ b/backend/satellite_tools/accounts/satpasswd
@@ -21,10 +21,10 @@ from spacewalk.server import rhnSQL, rhnUser
 
 
 def print_help():
-    print "Usage: satpasswd [OPTIONS] user\n"
-    print "Options:"
-    print "\t-h, --help\tPrint this help message."
-    print "\t-s, --stdin\tRead the password from standard input."
+    print("Usage: satpasswd [OPTIONS] user\n")
+    print("Options:")
+    print("\t-h, --help\tPrint this help message.")
+    print("\t-s, --stdin\tRead the password from standard input.")
 
 
 def read_passwd(stdin, msg):
@@ -57,22 +57,22 @@ if __name__ == '__main__':
 
     user = rhnUser.search(userIn)
     if not user:
-        print "User %s is not a valid Satellite user." % userIn
+        print("User %s is not a valid Satellite user." % userIn)
         sys.exit(1)
 
     passwordIn = read_passwd(stdin, "Password:")
     passwordCheck = read_passwd(stdin, "Retype password:")
 
     if passwordIn != passwordCheck:
-        print "Sorry, passwords do not match."
+        print("Sorry, passwords do not match.")
         sys.exit(1)
 
     if len(passwordIn) == 0:
-        print "Empty password is not permitted."
+        print("Empty password is not permitted.")
         sys.exit(1)
 
     if len(passwordIn) < CFG.MIN_PASSWD_LEN:
-        print ("User password should be at least %d characters long.") % CFG.MIN_PASSWD_LEN
+        print(("User password should be at least %d characters long.") % CFG.MIN_PASSWD_LEN)
         sys.exit(1)
 
     user.contact['password'] = rhnUser.encrypt_password(passwordIn)

--- a/backend/satellite_tools/contentRemove.py
+++ b/backend/satellite_tools/contentRemove.py
@@ -95,7 +95,7 @@ def __getMinionsByChannel(labels):
     server_list = h.fetchall_dict()
     if not server_list:
         return []
-    server_ids = map(lambda s: s['server_id'], server_list)
+    server_ids = [s['server_id'] for s in server_list]
     return server_ids;
 
 

--- a/backend/satellite_tools/diskImportLib.py
+++ b/backend/satellite_tools/diskImportLib.py
@@ -18,7 +18,7 @@
 
 import os
 
-import xmlSource
+from . import xmlSource
 from spacewalk.common.rhnLib import hash_object_id
 from spacewalk.server.importlib.backendOracle import SQLBackend
 from spacewalk.server.importlib.channelImport import ChannelImport, ChannelFamilyImport

--- a/backend/satellite_tools/disk_dumper/rhn-satellite-exporter
+++ b/backend/satellite_tools/disk_dumper/rhn-satellite-exporter
@@ -14,7 +14,12 @@
 # in this software or its documentation.
 #
 
-import cStringIO
+try:
+    #  python 2
+    import cStringIO
+except ImportError:
+    #  python3
+    import io as cStringIO
 
 import sys
 import os
@@ -29,13 +34,13 @@ from spacewalk.satellite_tools.syncLib import log2stderr, log2email
 from spacewalk.common.rhnTB import Traceback
 
 if os.geteuid() != 0:
-    print "This script must be run as root."
+    print("This script must be run as root.")
     exit()
 
 if __name__ == "__main__":
     try:
         main = iss.ExporterMain()
-    except iss.ISSError, isserror:
+    except iss.ISSError as isserror:
         # I have the tb get generated in the function that the the error occurred in to minimize
         # the amount of extra crap that shows up in it.
         tb = isserror.tb
@@ -43,9 +48,9 @@ if __name__ == "__main__":
         log2stderr(-1, isserror.msg)
         log2stderr(4, isserror.tb)
         sys.exit(-1)
-    except SystemExit, se:
+    except SystemExit as se:
         sys.exit(se.code)
-    except Exception, e:
+    except Exception as e:
         log2stderr(-1, "Unhandled Error: %s" % (e.__class__.__name__,))
         tbout = cStringIO.StringIO()
         Traceback(mail=0, ostream=tbout, with_locals=0)
@@ -55,10 +60,10 @@ if __name__ == "__main__":
     try:
         main.main()
 
-    except SystemExit, se:
+    except SystemExit as se:
         sys.exit(se.code)
 
-    except iss.ISSError, isserror:
+    except iss.ISSError as isserror:
         tb = isserror.tb
         msg = isserror.msg
         iss.handle_error(msg, tb)
@@ -71,7 +76,7 @@ if __name__ == "__main__":
 
         sys.exit(-1)
 
-    except Exception, e:
+    except Exception as e:
         log2stderr(-1, "Unhandled Error: %s" % (e.__class__.__name__,))
         # If we get here we want the traceback, even if it's got some useless junk added to it.
         tbout = cStringIO.StringIO()

--- a/backend/satellite_tools/messages.py
+++ b/backend/satellite_tools/messages.py
@@ -21,7 +21,7 @@
 
 import gettext
 t = gettext.translation('spacewalk-backend-server', fallback=True)
-_ = t.ugettext
+_ = t.gettext
 
 failed_step = _("""
 ERROR: executing step %s. Error is:

--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -557,11 +557,10 @@ type=rpm-md
                     return checksum_elem.get('type')
         return "sha1"
 
+    @staticmethod
     def _fix_encoding(text):
         if text is None:
             return None
-        if isinstance(text, str):
-            return str.encode(text, 'utf-8')
         else:
             return str(text)
 
@@ -618,9 +617,9 @@ type=rpm-md
                 p['version'] = version.get('ver')
                 p['release'] = version.get('rel')
                 p['epoch'] = version.get('epoch')
-                p['vendor'] = _fix_encoding(product.find('vendor').text)
-                p['summary'] = _fix_encoding(product.find('summary').text)
-                p['description'] = _fix_encoding(product.find('description').text)
+                p['vendor'] = self._fix_encoding(product.find('vendor').text)
+                p['summary'] = self._fix_encoding(product.find('summary').text)
+                p['description'] = self._fix_encoding(product.find('description').text)
                 if p['epoch'] == '0':
                     p['epoch'] = None
                 products.append(p)

--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -55,7 +55,7 @@ from spacewalk.satellite_tools.repo_plugins import yum_src
 from spacewalk.server import taskomatic, rhnPackageUpload
 from spacewalk.satellite_tools.satCerts import verify_certificate_dates
 
-from syncLib import log, log2, log2disk, dumpEMAIL_LOG, log2background
+from .syncLib import log, log2, log2disk, dumpEMAIL_LOG, log2background
 
 translation = gettext.translation('spacewalk-backend-server', fallback=True)
 _ = translation.ugettext

--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -55,10 +55,10 @@ from spacewalk.satellite_tools.repo_plugins import yum_src
 from spacewalk.server import taskomatic, rhnPackageUpload
 from spacewalk.satellite_tools.satCerts import verify_certificate_dates
 
-from .syncLib import log, log2, log2disk, dumpEMAIL_LOG, log2background
+from spacewalk.satellite_tools.syncLib import log, log2, log2disk, dumpEMAIL_LOG, log2background
 
 translation = gettext.translation('spacewalk-backend-server', fallback=True)
-_ = translation.ugettext
+_ = translation.gettext
 hostname = socket.gethostname()
 if '.' not in hostname:
     hostname = socket.getfqdn()

--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -1882,11 +1882,11 @@ class RepoSync(object):
             """)
             query.execute(**product)
             row = query.fetchone_dict()
-            if not row or not row.has_key('id'):
+            if not row or 'id' not in row:
                 get_id_q = rhnSQL.prepare("""SELECT sequence_nextval('suse_prod_file_id_seq') as id FROM dual""")
                 get_id_q.execute()
                 row = get_id_q.fetchone_dict() or {}
-                if not row or not row.has_key('id'):
+                if not row or 'id' not in row:
                     print("no id for sequence suse_prod_file_id_seq")
                     continue
 
@@ -1923,7 +1923,7 @@ class RepoSync(object):
 
             query.execute(**params)
             packrow = query.fetchone_dict()
-            if not packrow or not packrow.has_key('id'):
+            if not packrow or 'id' not in packrow:
                 # package not in DB
                 continue
 
@@ -1958,7 +1958,7 @@ class RepoSync(object):
                           arch=package['arch'], pkgid=package['pkgid'],
                           channel_id=int(self.channel['id']))
             row = query.fetchone_dict() or None
-            if not row or not row.has_key('id'):
+            if not row or 'id' not in row:
                 # package not found in DB
                 continue
             pkgid = int(row['id'])
@@ -1996,7 +1996,7 @@ class RepoSync(object):
                     kadd.execute(package_id=pkgid, channel_id=int(self.channel['id']), keyword_id=kwcache[keyword])
                     self.regen = True
 
-            if package.has_key('eula'):
+            if 'eula' in package:
                 eula_id = suseEula.find_or_create_eula(package['eula'])
                 rhnPackage.add_eula_to_package(
                   package_id=pkgid,

--- a/backend/satellite_tools/rhn-satellite-activate
+++ b/backend/satellite_tools/rhn-satellite-activate
@@ -29,7 +29,7 @@ try:
 except KeyboardInterrupt:
     sys.stderr.write("\nUser interrupted process.\n")
     sys.exit(0)
-except ImportError, e:
+except ImportError as e:
     sys.stderr.write("Unable to load module %s\n" % mod_name)
     sys.stderr.write(str(e) + "\n")
     sys.exit(1)

--- a/backend/satellite_tools/rhn-schema-version
+++ b/backend/satellite_tools/rhn-schema-version
@@ -54,11 +54,11 @@ if __name__ == '__main__':
         h.execute()
         row = h.fetchone_dict()
         if row:
-            print row['evrsimple']
+            print(row['evrsimple'])
     except KeyboardInterrupt:
         sys.stderr.write("\nUser interrupted process.\n")
         sys.exit(0)
-    except (rhnSQL.SQLError, rhnSQL.SQLSchemaError, rhnSQL.SQLConnectError), e:
+    except (rhnSQL.SQLError, rhnSQL.SQLSchemaError, rhnSQL.SQLConnectError) as e:
         # really a stub for better exception handling in the future.
         sys.stderr.write("SQL error occurred, traceback follows...\n")
         raise

--- a/backend/satellite_tools/satellite-sync
+++ b/backend/satellite_tools/satellite-sync
@@ -19,7 +19,7 @@
 # For return codes see bottom of this file
 
 if __name__ != '__main__':
-    raise ImportError, "module cannot be imported"
+    raise ImportError("module cannot be imported")
 
 import sys
 
@@ -69,7 +69,7 @@ try:
     from spacewalk.satellite_tools import satsync, syncLib
 except KeyboardInterrupt:
     systemExit(0, "\nUser interrupted process.")
-except ImportError, e:
+except ImportError as e:
     systemExit(2, "Unable to find synchronization tools.\n"
                   "Error: %s" % e)
 
@@ -140,20 +140,20 @@ def main():
     except SystemExit:
         satsync.sendMail()
         raise
-    except socket.error, e:
+    except socket.error as e:
         msg = "\nERROR: a general socket exception occurred:"
         systemExit_exception(3, msg, e)
-    except socket.sslerror, e:
+    except socket.sslerror as e:
         msg = ("""
 ERROR: an SSL error occurred. Recheck your SSL settings. Those settings may
        include URL's, SSL Certificate settings, firewall rules, etc..
        Also, check that your system time has not drifted! Time drift is one
        of the primary reasons for SSL connection failures.""")
         systemExit_exception(4, msg, e)
-    except syncLib.RhnSyncException, e:
+    except syncLib.RhnSyncException as e:
         msg = "\nSYNC ERROR:"
         systemExit_exception(5, msg, e)
-    except Exception, e:
+    except Exception as e:
         msg = "\nSYNC ERROR: unhandled exception occurred:"
         systemExit_exception(6, msg, e)
 
@@ -166,10 +166,10 @@ if __name__ == '__main__':
         sys.exit(abs(main() or 0))
     except KeyboardInterrupt:
         systemExit(0, "\nUser interrupted process.")
-    except SystemExit, e:
+    except SystemExit as e:
         releaseLOCK()
         sys.exit(e.code)
-    except Exception, e:
+    except Exception as e:
         releaseLOCK()
         systemExit_exception(7, "SYNC ERROR: attempting to display as much information as possible:", e)
 

--- a/backend/satellite_tools/satsync.py
+++ b/backend/satellite_tools/satsync.py
@@ -52,18 +52,18 @@ from spacewalk.server.rhnLib import get_package_path
 from spacewalk.common import fileutils
 
 # __rhn sync/import imports__
-import xmlWireSource
-import xmlDiskSource
-from progress_bar import ProgressBar
-from xmlSource import FatalParseException, ParseException
-from diskImportLib import rpmsPath
+from . import xmlWireSource
+from . import xmlDiskSource
+from .progress_bar import ProgressBar
+from .xmlSource import FatalParseException, ParseException
+from .diskImportLib import rpmsPath
 
-from syncLib import log, log2, log2disk, log2stderr, log2email
-from syncLib import RhnSyncException, RpmManip, ReprocessingNeeded
-from syncLib import initEMAIL_LOG, dumpEMAIL_LOG
-from syncLib import FileCreationError, FileManip
+from .syncLib import log, log2, log2disk, log2stderr, log2email
+from .syncLib import RhnSyncException, RpmManip, ReprocessingNeeded
+from .syncLib import initEMAIL_LOG, dumpEMAIL_LOG
+from .syncLib import FileCreationError, FileManip
 
-from SequenceServer import SequenceServer
+from .SequenceServer import SequenceServer
 from spacewalk.server.importlib.errataCache import schedule_errata_cache_update
 
 from spacewalk.server.importlib.importLib import InvalidChannelFamilyError
@@ -71,10 +71,10 @@ from spacewalk.server.importlib.importLib import MissingParentChannelError
 from spacewalk.server.importlib.importLib import get_nevra, get_nevra_dict
 
 from . import satCerts
-import req_channels
-import messages
-import sync_handlers
-import constants
+from . import req_channels
+from . import messages
+from . import sync_handlers
+from . import constants
 
 translation = gettext.translation('spacewalk-backend-server', fallback=True)
 _ = translation.ugettext

--- a/backend/satellite_tools/spacewalk-data-fsck
+++ b/backend/satellite_tools/spacewalk-data-fsck
@@ -44,7 +44,7 @@ def is_sha256_capable():
     mi = ts.dbMatch('Providename', 'spacewalk-schema')
     cmp = -1
     try:
-        h = mi.next()
+        h = next(mi)
         cmp = rpm.labelCompare([h['name'], h['version'], h['release']],
                                [h['name'], '0.8.1', '1'])
     except StopIteration:
@@ -86,7 +86,7 @@ def package_query(options, bind_path=False):
 
 
 def check_db_vs_disk(options):
-    for k in report_msg.keys():
+    for k in list(report_msg.keys()):
         report[k] = 0
     query = package_query(options)
     h = rhnSQL.prepare(query)
@@ -228,7 +228,7 @@ def restore_file_path(file, row):
     cleanup = True
     try:  # 1st, make dirs needed
         os.makedirs(new_path.rsplit('/', 1)[0])
-    except OSError, e:
+    except OSError as e:
         if e.errno != 17:  # something broke up
             log(0, "File path restoration failed: %s" % row['path'])
             return 1
@@ -242,7 +242,7 @@ def restore_file_path(file, row):
         if cleanup == True:
             try:
                 os.removedirs(new_path.rsplit('/', 1)[0])
-            except OSError, e:
+            except OSError as e:
                 if e.errno != 39:
                     log(0, "Could not rollback file path restoration: %s" % row['path'] or '')
                     return 1
@@ -255,7 +255,7 @@ def restore_file_path(file, row):
             if os.path.isfile(backup_path):
                 os.remove(backup_path)
             os.removedirs(backup_path.rsplit('/', 1)[0])
-    except OSError, e:
+    except OSError as e:
         if e.errno == 2:
             log(2, "File %s%s was removed by someone else but transaction has been successfully completed" %
                 (prefix, row['path']))
@@ -299,7 +299,7 @@ def check_disk_checksum(abs_path, checksum_type, db_checksum):
 
 
 def check_disk_vs_db(disk_content=None, db_content=None):
-    for k in report_msg.keys():
+    for k in list(report_msg.keys()):
         report[k] = 0
     query = package_query(options, bind_path=True)
     h = rhnSQL.prepare(query)
@@ -379,7 +379,7 @@ def log(level, *args):
     if not verbose:
         verbose = 0
     if verbose >= level:
-        print (', '.join(map(lambda i: str(i), args)))
+        print((', '.join([str(i) for i in args])))
 
 if __name__ == '__main__':
 

--- a/backend/satellite_tools/spacewalk-fips-tool
+++ b/backend/satellite_tools/spacewalk-fips-tool
@@ -20,7 +20,12 @@ from optparse import OptionParser
 from spacewalk.common import rhn_rpm
 import sys
 import time
-import xmlrpclib
+try:
+    #  python2
+    import xmlrpclib
+except ImportError:
+    #  python3
+    import xmlrpc.client as xmlrpclib # pylint: disable=F0401
 from socket import gethostname
 
 
@@ -56,11 +61,11 @@ def read_username():
     try:
         username = sys.stdin.readline().rstrip('\n')
     except KeyboardInterrupt:
-        print
+        print()
         sys.exit(0)
     if username is None:
         # EOF
-        print
+        print()
         sys.exit(0)
     return username.strip()
 
@@ -120,7 +125,7 @@ if __name__ == '__main__':
     (options, args) = parse_args()
 
     if len(args) == 0:
-        print description
+        print(description)
         sys.exit(1)
 
     if not options.install_packages and not options.update_certificates:
@@ -147,7 +152,7 @@ if __name__ == '__main__':
     scheduled_date = None
     try:
         scheduled_date = xmlrpclib.DateTime(time.strptime(options.date, strftime_format))
-    except ValueError, e:
+    except ValueError as e:
         sys.stderr.write("Error processing the specified date: %s\n" % e)
         sys.exit(1)
 
@@ -160,7 +165,7 @@ if __name__ == '__main__':
 
     try:
         key = client.auth.login(options.username, options.password)
-    except xmlrpclib.Fault, e:
+    except xmlrpclib.Fault as e:
         if hasattr(e, "faultCode") and e.faultCode == 2950:
             sys.stderr.write("Incorrect user name or password\n")
             sys.exit(1)
@@ -182,7 +187,7 @@ if __name__ == '__main__':
                     # Systems which already have spacewalk-client-cert installed are not broken
                     broken_systems.remove(system_id)
                     break
-    except xmlrpclib.Fault, e:
+    except xmlrpclib.Fault as e:
         sys.stderr.write(e.faultString + '\n')
         sys.exit(1)
 
@@ -255,7 +260,7 @@ if __name__ == '__main__':
         for system_id in systems:
             try:
                 action_id = client.system.schedule_certificate_update(key, system_id, scheduled_date)
-            except xmlrpclib.Fault, e:
+            except xmlrpclib.Fault as e:
                 sys.stderr.write("Error scheduling certificate update on %s: %s\n" %
                                  (system_id, e.faultString))
                 sys.exit(1)

--- a/backend/satellite_tools/spacewalk-remove-channel
+++ b/backend/satellite_tools/spacewalk-remove-channel
@@ -105,7 +105,7 @@ def main():
 
     dict_label, dict_parents = __listChannels()
     if options.list:
-        keys = dict_parents.keys()
+        keys = list(dict_parents.keys())
         keys.sort()
         for c in keys:
             print(c)
@@ -134,7 +134,7 @@ def main():
             sys.exit(-1)
 
     child_test_fail = False
-    for channel in channels.keys():
+    for channel in list(channels.keys()):
         if channel not in dict_label:
             print("Unknown channel %s" % channel)
             sys.exit(-1)
@@ -162,17 +162,17 @@ def main():
             raise UserError("Username not specified")
         if not options.password:
             options.password= getpass.getpass()
-        affected_minions =  __getMinionsByChannel(channels.keys())
+        affected_minions =  __getMinionsByChannel(list(channels.keys()))
 
     if not options.skip_channels and not options.just_kickstart_trees:
-        if __serverCheck(channels.keys(), options.unsubscribe):
+        if __serverCheck(list(channels.keys()), options.unsubscribe):
             sys.exit(-1)
 
-        if __kickstartCheck(channels.keys()):
+        if __kickstartCheck(list(channels.keys())):
             sys.exit(-1)
 
     try:
-        delete_channels(channels.keys(), force=options.force,
+        delete_channels(list(channels.keys()), force=options.force,
                                       justdb=options.justdb, skip_packages=options.skip_packages,
                                       skip_channels=options.skip_channels,
                                       skip_kickstart_trees=options.skip_kickstart_trees,
@@ -207,7 +207,7 @@ if __name__ == '__main__':
         sys.stderr.write("\nUser interrupted process.\n")
         releaseLOCK()
         sys.exit(0)
-    except UserError, error:
+    except UserError as error:
         systemExit(-1, "\n%s" % error)
     except SystemExit:
         # Normal exit

--- a/backend/satellite_tools/spacewalk-repo-sync
+++ b/backend/satellite_tools/spacewalk-repo-sync
@@ -16,7 +16,12 @@
 #
 
 import re
-import StringIO
+try:
+    #  python2
+    from StringIO import StringIO
+except ImportError:
+    #  python3
+    from io import StringIO
 import simplejson as json
 import shutil
 import sys
@@ -174,7 +179,7 @@ def main():
 
         # Channels
         if 'channel' in config:
-            for ch,repo in config['channel'].iteritems():
+            for ch,repo in config['channel'].items():
                  if not isinstance(repo, list):
                     systemExit(
                         1,
@@ -214,7 +219,7 @@ def main():
         log(0, "|   Channel Label   |   Repository   |")
         log(0, "======================================")
 
-        for ch,repo in d_ch_repo_sync.items():
+        for ch,repo in list(d_ch_repo_sync.items()):
             if repo:
                 log(0, " %s : %s" % (ch,", ".join(repo)))
             else:
@@ -239,7 +244,7 @@ def main():
 
     total_time = datetime.timedelta()
     ret_code = 0
-    for ch,repo in d_ch_repo_sync.items():
+    for ch,repo in list(d_ch_repo_sync.items()):
 
         log(0, "======================================")
         log(0, "| Channel: %s" % ch)
@@ -281,9 +286,9 @@ if __name__ == '__main__':
         sys.exit(abs(main() or 0))
     except KeyboardInterrupt:
         systemExit(1, "\nProcess has been interrupted.")
-    except SystemExit, e:
+    except SystemExit as e:
         releaseLOCK()
         sys.exit(e.code)
-    except Exception, e:
+    except Exception as e:
         releaseLOCK()
         raise

--- a/backend/satellite_tools/spacewalk-repo-sync
+++ b/backend/satellite_tools/spacewalk-repo-sync
@@ -18,10 +18,10 @@
 import re
 try:
     #  python2
-    from StringIO import StringIO
+    import StringIO as StringIO
 except ImportError:
     #  python3
-    from io import StringIO
+    import io as StringIO
 import simplejson as json
 import shutil
 import sys

--- a/backend/satellite_tools/syncLib.py
+++ b/backend/satellite_tools/syncLib.py
@@ -33,7 +33,7 @@ from spacewalk.common.rhnConfig import CFG
 from spacewalk.common.rhnLog import log_time, log_clean
 from spacewalk.common.fileutils import createPath, setPermsPath
 
-import messages
+from . import messages
 
 EMAIL_LOG = None
 

--- a/backend/satellite_tools/sync_handlers.py
+++ b/backend/satellite_tools/sync_handlers.py
@@ -20,10 +20,10 @@ from spacewalk.common import usix
 from spacewalk.server.importlib import channelImport, packageImport, errataImport, \
     kickstartImport
 from spacewalk.common.usix import raise_with_tb
-import diskImportLib
-import xmlSource
-import syncCache
-import syncLib
+from . import diskImportLib
+from . import xmlSource
+from . import syncCache
+from . import syncLib
 
 DEFAULT_ORG = 1
 

--- a/backend/satellite_tools/update-packages
+++ b/backend/satellite_tools/update-packages
@@ -20,7 +20,7 @@
 
 
 if __name__ != '__main__':
-    raise ImportError, "module cannot be imported"
+    raise ImportError("module cannot be imported")
 
 import sys
 
@@ -67,7 +67,7 @@ try:
     from spacewalk.satellite_tools import updatePackages
 except KeyboardInterrupt:
     systemExit(0, "\nUser interrupted process.")
-except ImportError, e:
+except ImportError as e:
     systemExit(2, "Unable to find update package tool.\n"
                   "Error: %s" % e)
 

--- a/backend/satellite_tools/xmlWireSource.py
+++ b/backend/satellite_tools/xmlWireSource.py
@@ -30,12 +30,12 @@ from spacewalk.common import rhnLib
 from spacewalk.common.rhnConfig import CFG
 
 # local imports
-from syncLib import log, log2, RhnSyncException
+from .syncLib import log, log2, RhnSyncException
 
 from rhn import rpclib
 
 from spacewalk.common.suseLib import get_proxy
-import connection
+from . import connection
 
 class BaseWireSource:
 

--- a/backend/server/auditlog.py
+++ b/backend/server/auditlog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -u
+#!/usr/bin/python3 -u
 # -*- coding: utf-8 -*-
 #
 # Copyright (c) 2010 SUSE LLC

--- a/backend/server/auditlog.py
+++ b/backend/server/auditlog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -u
+#!/usr/bin/python -u
 # -*- coding: utf-8 -*-
 #
 # Copyright (c) 2010 SUSE LLC

--- a/backend/server/importlib/backend.py
+++ b/backend/server/importlib/backend.py
@@ -27,10 +27,10 @@ from spacewalk.common.rhnException import rhnFault
 from spacewalk.common.rhnLog import log_debug
 from spacewalk.common.stringutils import to_string
 from spacewalk.server import rhnSQL, rhnChannel, taskomatic
-from importLib import Diff, Package, IncompletePackage, Erratum, \
+from .importLib import Diff, Package, IncompletePackage, Erratum, \
     AlreadyUploadedError, InvalidPackageError, TransactionError, \
     SourcePackage
-from backendLib import TableCollection, sanitizeValue, TableDelete, \
+from .backendLib import TableCollection, sanitizeValue, TableDelete, \
     TableUpdate, TableLookup, addHash, TableInsert
 
 sequences = {

--- a/backend/server/importlib/backendLib.py
+++ b/backend/server/importlib/backendLib.py
@@ -78,11 +78,13 @@ class Table:
         'fields': DictType,
         'pk': ListType,
         'attribute': str,
+#        'attribute': StringType,
         'map': DictType,
         'nullable': ListType,  # Will become a hash eventually
         'severityHash': DictType,
         'defaultSeverity': IntType,
         'sequenceColumn': str,
+#        'sequenceColumn': StringType,
     }
 
     def __init__(self, name, **kwargs):
@@ -213,7 +215,7 @@ class BaseTableLookup:
         # Now put the queries in self.sqlqueries, keyed on the list of 0/1
         for i in range(len(keys)):
             key = tuple(keys[i])
-            query = string.join(queries[i], ' and ')
+            query = ' and '.join(queries[i])
             self.whereclauses[key] = query
 
     def _selectQueryKey(self, value):

--- a/backend/server/importlib/backendLib.py
+++ b/backend/server/importlib/backendLib.py
@@ -78,13 +78,11 @@ class Table:
         'fields': DictType,
         'pk': ListType,
         'attribute': str,
-#        'attribute': StringType,
         'map': DictType,
         'nullable': ListType,  # Will become a hash eventually
         'severityHash': DictType,
         'defaultSeverity': IntType,
         'sequenceColumn': str,
-#        'sequenceColumn': StringType,
     }
 
     def __init__(self, name, **kwargs):

--- a/backend/server/importlib/backendLib.py
+++ b/backend/server/importlib/backendLib.py
@@ -282,8 +282,7 @@ class TableUpdate(BaseTableLookup):
                 self.blob_fields.append(field)
             else:
                 self.otherfields.append(field)
-        self.updateclause = string.join(
-            ["%s = :%s" % (x, x) for x in self.otherfields], ', ')
+        self.updateclause = ', '.join(["%s = :%s" % (x, x) for x in self.otherfields])
         # key
         self.firstkey = None
         for pk in self.pks:
@@ -361,7 +360,7 @@ class TableUpdate(BaseTableLookup):
     def _update_blobs(self, blobValuesHash):
         # Now update BLOB fields
         template = "select %s from %s where %s for update"
-        blob_fields_string = string.join(self.blob_fields, ", ")
+        blob_fields_string = ", ".join(self.blob_fields)
         for key, val in list(blobValuesHash.items()):
             statement = template % (blob_fields_string, self.table.name,
                                     self.whereclauses[key])
@@ -443,8 +442,8 @@ class TableInsert(TableUpdate):
 
     def _buildQuery(self, key):
         q = self.queryTemplate % (self.table.name,
-                                  string.join(self.insert_fields, ', '),
-                                  string.join(self.insert_values, ', '))
+                                  ', '.join(self.insert_fields),
+                                  ', '.join(self.insert_values))
         return q
 
     def query(self, values):
@@ -497,19 +496,13 @@ def sanitizeValue(value, datatype):
             # and not depend on Oracle converting
             # empty strings to NULLs -- PostgreSQL
             # does not do this
-        elif isinstance(value, UnicodeType):
-            value = UnicodeType.encode(value, 'utf-8')
         if len(value) > datatype.limit:
             value = value[:datatype.limit]
             # ignore incomplete characters created after truncating
-            value = value.decode('utf-8', 'ignore')
-            value = value.encode('utf-8')
         return value
     if isinstance(datatype, DBblob):
         if value is None:
             value = ''
-        if isinstance(value, UnicodeType):
-            value = UnicodeType.encode(value, 'utf-8')
         return str(value)
     if value in [None, '']:
         return None

--- a/backend/server/importlib/backendLib.py
+++ b/backend/server/importlib/backendLib.py
@@ -19,7 +19,12 @@
 import time
 import string
 
-from UserDict import UserDict
+try:
+    #  python 2
+    from UserDict import UserDict
+except ImportError:
+    #  python3
+    from collections import UserDict
 from spacewalk.common.usix import ListType, StringType, DictType, IntType, UnicodeType
 
 # A function that formats a UNIX timestamp to the session's format
@@ -72,12 +77,12 @@ class Table:
     keywords = {
         'fields': DictType,
         'pk': ListType,
-        'attribute': StringType,
+        'attribute': str,
         'map': DictType,
         'nullable': ListType,  # Will become a hash eventually
         'severityHash': DictType,
         'defaultSeverity': IntType,
-        'sequenceColumn': StringType,
+        'sequenceColumn': str,
     }
 
     def __init__(self, name, **kwargs):

--- a/backend/server/importlib/backendOracle.py
+++ b/backend/server/importlib/backendOracle.py
@@ -19,8 +19,8 @@
 #
 
 import sys
-from backend import Backend
-from backendLib import DBint, DBstring, DBdateTime, Table, \
+from .backend import Backend
+from .backendLib import DBint, DBstring, DBdateTime, Table, \
     TableCollection, DBblob
 from spacewalk.server import rhnSQL
 from spacewalk.server.rhnSQL.const import ORACLE, POSTGRESQL

--- a/backend/server/importlib/backend_checker.py
+++ b/backend/server/importlib/backend_checker.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/python
 
 import sys
 from spacewalk.server import rhnSQL

--- a/backend/server/importlib/backend_checker.py
+++ b/backend/server/importlib/backend_checker.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import sys
 from spacewalk.server import rhnSQL

--- a/backend/server/importlib/debPackage.py
+++ b/backend/server/importlib/debPackage.py
@@ -16,10 +16,10 @@
 # Converts headers to the intermediate format
 #
 
-import headerSource
+from . import headerSource
 import time
-from importLib import Channel
-from backendLib import gmtime, localtime
+from .importLib import Channel
+from .backendLib import gmtime, localtime
 from spacewalk.common.usix import IntType, UnicodeType
 from spacewalk.common.stringutils import to_string
 

--- a/backend/server/importlib/errataImport.py
+++ b/backend/server/importlib/errataImport.py
@@ -17,7 +17,7 @@
 #
 
 from spacewalk.common.rhnException import rhnFault
-from importLib import GenericPackageImport
+from .importLib import GenericPackageImport
 from spacewalk.satellite_tools.syncLib import log
 
 

--- a/backend/server/importlib/headerSource.py
+++ b/backend/server/importlib/headerSource.py
@@ -18,9 +18,9 @@
 
 import time
 import string
-from importLib import File, Dependency, ChangeLog, Channel, \
+from .importLib import File, Dependency, ChangeLog, Channel, \
     IncompletePackage, Package, SourcePackage
-from backendLib import gmtime, localtime
+from .backendLib import gmtime, localtime
 from spacewalk.common.usix import ListType, TupleType, IntType, LongType, StringType, UnicodeType
 from spacewalk.common.rhnLog import log_debug
 from spacewalk.common.stringutils import to_string

--- a/backend/server/importlib/headerSource.py
+++ b/backend/server/importlib/headerSource.py
@@ -17,7 +17,6 @@
 #
 
 import time
-import string
 from .importLib import File, Dependency, ChangeLog, Channel, \
     IncompletePackage, Package, SourcePackage
 from .backendLib import gmtime, localtime
@@ -322,8 +321,7 @@ class rpmSourcePackage(SourcePackage, rpmPackage):
 
         # Convert sigchecksum to ASCII
         self['sigchecksum_type'] = 'md5'
-        self['sigchecksum'] = string.join(
-            ["%02x" % ord(x) for x in self['sigchecksum']], '')
+        self['sigchecksum'] = ''.join(["%02x" % ord(x) for x in self['sigchecksum']])
 
 
 class rpmFile(File, ChangeLog):
@@ -356,6 +354,16 @@ class rpmFile(File, ChangeLog):
         if type(self['filedigest']) == StringType:
             self['checksum'] = self['filedigest']
             del(self['filedigest'])
+        if type(self['linkto'] == bytes):
+            self['linkto'] = self['linkto'].decode("utf8")
+        if type(self['lang'] == bytes):
+            self['lang'] = self['lang'].decode("utf8")
+        if type(self['filedigest'] == bytes):
+            self['filedigest'] = self['filedigest'].decode("utf8")
+        if type(self['groupname'] == bytes):
+            self['groupname'] = self['groupname'].decode("utf8")
+        if type(self['username'] == bytes):
+            self['username'] = self['username'].decode("utf8")
 
 
 class rpmProvides(Dependency):

--- a/backend/server/importlib/importLib.py
+++ b/backend/server/importlib/importLib.py
@@ -789,11 +789,10 @@ class Import:
     def _fix_encoding(self, text):
         if text is None:
             return None
-        try:
-            return text.decode('utf8')
-        except UnicodeDecodeError:
-            return text.decode('iso8859-1')
-
+        elif isinstance(text, str):
+            return text
+        elif isinstance(text, bytes):
+            return text.decode("utf8")
 
 # Any package processing import class
 class GenericPackageImport(Import):

--- a/backend/server/importlib/importLib.py
+++ b/backend/server/importlib/importLib.py
@@ -19,13 +19,13 @@
 import os
 import shutil
 from spacewalk.common.usix import IntType, StringType, InstanceType
-from UserDict import UserDict
 try:
     #  python 2
+    from UserDict import UserDict
     from UserList import UserList
 except ImportError:
     #  python3
-    from collections import UserList
+    from collections import UserList, UserDict
 
 from spacewalk.common.checksum import getFileChecksum
 from spacewalk.common.fileutils import createPath

--- a/backend/server/importlib/mpmSource.py
+++ b/backend/server/importlib/mpmSource.py
@@ -16,8 +16,8 @@
 # Converts headers to the intermediate format
 #
 
-import headerSource
-import debPackage
+from . import headerSource
+from . import debPackage
 
 
 class mpmBinaryPackage(headerSource.rpmBinaryPackage):

--- a/backend/server/importlib/packageImport.py
+++ b/backend/server/importlib/packageImport.py
@@ -61,6 +61,7 @@ class ChannelPackageSubscription(GenericPackageImport):
             self._processPackage(package)
 
     def fix(self):
+        #import rpdb; rpdb.set_trace()
         # Look up arches and channels
         self.backend.lookupPackageArches(self.package_arches)
         self.backend.lookupChannels(self.channels)
@@ -255,7 +256,7 @@ class PackageImport(ChannelPackageSubscription):
             for dep in depList:
                 nv = []
                 for f in ('name', 'version'):
-                    nv.append(dep[f])
+                    nv.append(dep[f].decode("utf-8"))
                     del dep[f]
                 nv = tuple(nv)
                 dep['capability'] = nv
@@ -277,6 +278,7 @@ class PackageImport(ChannelPackageSubscription):
         # Uniquify changelog entries
         unique_package_changelog_hash = {}
         unique_package_changelog = []
+        package['changelog'] = self._fix_encoding(package['changelog'])
         for changelog in package['changelog']:
             key = (changelog['name'], changelog['time'], changelog['text'])
             if key not in unique_package_changelog_hash:
@@ -307,6 +309,7 @@ class PackageImport(ChannelPackageSubscription):
                 self.suseEula_data[key] = None
 
     def fix(self):
+        #import rpdb; rpdb.set_trace()
         # If capabilities are available, process them
         if self.capabilities:
             try:

--- a/backend/server/importlib/packageImport.py
+++ b/backend/server/importlib/packageImport.py
@@ -19,10 +19,10 @@
 import rpm
 import sys
 import os.path
-from importLib import GenericPackageImport, IncompletePackage, \
+from .importLib import GenericPackageImport, IncompletePackage, \
     Import, InvalidArchError, InvalidChannelError, \
     IncompatibleArchError
-from mpmSource import mpmBinaryPackage
+from .mpmSource import mpmBinaryPackage
 from spacewalk.common import rhn_pkg
 from spacewalk.common.rhnConfig import CFG
 from spacewalk.server import taskomatic

--- a/backend/server/importlib/packageImport.py
+++ b/backend/server/importlib/packageImport.py
@@ -278,7 +278,6 @@ class PackageImport(ChannelPackageSubscription):
         # Uniquify changelog entries
         unique_package_changelog_hash = {}
         unique_package_changelog = []
-        package['changelog'] = self._fix_encoding(package['changelog'])
         for changelog in package['changelog']:
             key = (self._fix_encoding(changelog['name']), self._fix_encoding(changelog['time']), self._fix_encoding(changelog['text']))
             if key not in unique_package_changelog_hash:

--- a/backend/server/importlib/packageImport.py
+++ b/backend/server/importlib/packageImport.py
@@ -271,6 +271,7 @@ class PackageImport(ChannelPackageSubscription):
             f['capability'] = nv
             if nv not in self.capabilities:
                 self.capabilities[nv] = None
+            f['checksum'] = self._fix_encoding(f['checksum'])
             fchecksumTuple = (f['checksum_type'], f['checksum'])
             if fchecksumTuple not in self.checksums:
                 self.checksums[fchecksumTuple] = None
@@ -280,7 +281,7 @@ class PackageImport(ChannelPackageSubscription):
         unique_package_changelog = []
         package['changelog'] = self._fix_encoding(package['changelog'])
         for changelog in package['changelog']:
-            key = (changelog['name'], changelog['time'], changelog['text'])
+            key = (self._fix_encoding(changelog['name']), self._fix_encoding(changelog['time']), self._fix_encoding(changelog['text']))
             if key not in unique_package_changelog_hash:
                 self.changelog_data[key] = None
                 unique_package_changelog.append(changelog)

--- a/backend/server/importlib/packageImport.py
+++ b/backend/server/importlib/packageImport.py
@@ -61,7 +61,6 @@ class ChannelPackageSubscription(GenericPackageImport):
             self._processPackage(package)
 
     def fix(self):
-        #import rpdb; rpdb.set_trace()
         # Look up arches and channels
         self.backend.lookupPackageArches(self.package_arches)
         self.backend.lookupChannels(self.channels)
@@ -310,7 +309,6 @@ class PackageImport(ChannelPackageSubscription):
                 self.suseEula_data[key] = None
 
     def fix(self):
-        #import rpdb; rpdb.set_trace()
         # If capabilities are available, process them
         if self.capabilities:
             try:

--- a/backend/server/rhnCapability.py
+++ b/backend/server/rhnCapability.py
@@ -15,7 +15,6 @@
 #
 
 import re
-import string
 import sys
 
 # common module
@@ -42,9 +41,9 @@ def set_client_capabilities(capabilities):
             # XXX Just ignoring it, for now
             continue
         dict = mo.groupdict()
-        name = string.strip(dict['name'])
-        version = string.strip(dict['version'])
-        value = string.strip(dict['value'])
+        name = dict['name'].strip()
+        version = dict['version'].strip()
+        value = dict['value'].strip()
 
         caps[name] = {
             'version': version,

--- a/backend/server/rhnChannel.py
+++ b/backend/server/rhnChannel.py
@@ -37,9 +37,9 @@ from spacewalk.common.rhnException import rhnFault, rhnException
 from spacewalk.common.rhnTranslate import _
 
 # local module
-import rhnUser
-import rhnSQL
-import rhnLib
+from . import rhnUser
+from . import rhnSQL
+from . import rhnLib
 
 
 class NoBaseChannelError(Exception):

--- a/backend/server/rhnChannel.py
+++ b/backend/server/rhnChannel.py
@@ -16,7 +16,6 @@
 #
 
 import time
-import string
 import rpm
 import sys
 try:
@@ -994,7 +993,7 @@ def channels_for_release_arch(release, server_arch, org_id=-1, user_id=None):
     if not org_id:
         org_id = -1
 
-    org_id = string.strip(str(org_id))
+    org_id = str(org_id).strip()
     log_debug(3, release, server_arch, org_id)
 
     # Can raise BaseChannelDeniedError or InvalidServerArchError

--- a/backend/server/rhnLib.py
+++ b/backend/server/rhnLib.py
@@ -24,7 +24,7 @@ from spacewalk.common.rhnLog import log_debug
 from spacewalk.common.rhnException import rhnFault
 
 # architecture work
-from rhnMapping import check_package_arch
+from .rhnMapping import check_package_arch
 
 
 def computeSignature(*fields):

--- a/backend/server/rhnPackage.py
+++ b/backend/server/rhnPackage.py
@@ -24,7 +24,7 @@ from spacewalk.common.rhnConfig import CFG
 from spacewalk.common.rhnException import rhnFault
 from spacewalk.common.rhnTranslate import _
 from spacewalk.server import rhnSQL
-from rhnLib import parseRPMFilename
+from .rhnLib import parseRPMFilename
 
 
 #

--- a/backend/server/rhnSQL/driver_postgresql.py
+++ b/backend/server/rhnSQL/driver_postgresql.py
@@ -306,7 +306,7 @@ class Cursor(sql_base.Cursor):
         except KeyError:
             e = sys.exc_info()[1]
             raise sql_base.SQLError("Unable to bound the following variable(s): %s"
-                                    % (string.join(e.args, " ")))
+                                    % (" ".join(e.args)))
         return retval
 
     def _execute_(self, args, kwargs):

--- a/backend/server/rhnSQL/sql_lib.py
+++ b/backend/server/rhnSQL/sql_lib.py
@@ -30,8 +30,8 @@ def build_sql_insert(table, hash_name, items):
     """
     sql = "insert into %s ( %s, %s ) values ( :p0, %s )" % (
         table, hash_name,
-        string.join([a[0] for a in items], ", "),
-        string.join([":p_%s" % a[0] for a in items], ", "))
+        ", ".join([a[0] for a in items]),
+        ", ".join([":p_%s" % a[0] for a in items]))
     pdict = {"p0": None}  # This must be reset after we return from this call
     list(map(pdict.update, [{"p_%s" % a[0]: a[1]} for a in items]))
     return sql, pdict
@@ -43,8 +43,7 @@ def build_sql_update(table, hash_name, items):
     """
     sql = "update %s set %s where %s = :p0" % (
         table,
-        string.join(["%s = :p_%s" % (a, a) for a in [a[0] for a in items]],
-                    ", "),
+        ", ".join(["%s = :p_%s" % (a, a) for a in [a[0] for a in items]]),
         hash_name)
     pdict = {"p0": None}  # This must be reset after we return from this call
     list(map(pdict.update, [{"p_%s" % a[0]: a[1]} for a in items]))

--- a/backend/server/rhnSQL/sql_row.py
+++ b/backend/server/rhnSQL/sql_row.py
@@ -41,7 +41,7 @@ class Row(UserDictCase):
             raise rhnException("Argument db is not a database instance", db)
         self.db = db
         self.table = table
-        self.hashname = string.lower(hashname)
+        self.hashname = hashname.lower()
 
         # and the data dictionary
         self.data = {}
@@ -58,7 +58,7 @@ class Row(UserDictCase):
 
     def __setitem__(self, name, value):
         """ make it work like a dictionary """
-        x = string.lower(name)
+        x = name.lower()
         # forbid setting the value of the hash column because of the
         # ambiguity of the operation (is it a "save as new id" or
         # "load from new id"?). We provide interfaces for load, save
@@ -69,13 +69,13 @@ class Row(UserDictCase):
             self.data[x] = (value, 1)
 
     def __getitem__(self, name):
-        x = string.lower(name)
+        x = name.lower()
         if x in self.data:
             return self.data[x][0]
         raise KeyError("Key %s not found in the Row dictionary" % name)
 
     def get(self, name):
-        x = string.lower(name)
+        x = name.lower()
         if x in self.data:
             return self.data[x][0]
         return None

--- a/backend/server/rhnSQL/sql_table.py
+++ b/backend/server/rhnSQL/sql_table.py
@@ -120,7 +120,7 @@ class Table:
                 clause = "%s = :%s" % (col, col)
             args.append(clause)
         sql = "select * from %s where " % self.__table
-        cursor = self.__db.prepare(sql + string.join(args, " and "))
+        cursor = self.__db.prepare(sql + " and ".join(args))
         cursor.execute(**row)
         rows = cursor.fetchall_dict()
         if rows is None:

--- a/backend/server/rhnServer/__init__.py
+++ b/backend/server/rhnServer/__init__.py
@@ -23,9 +23,9 @@ from spacewalk.common.rhnLog import log_debug, log_error
 from spacewalk.server import rhnUser
 
 # Local imports
-from server_class import Server
-from server_certificate import Certificate
-from server_token import fetch_token, fetch_org_token
+from .server_class import Server
+from .server_certificate import Certificate
+from .server_token import fetch_token, fetch_org_token
 
 
 def get(system_id, load_user=1):

--- a/backend/server/rhnServer/server_certificate.py
+++ b/backend/server/rhnServer/server_certificate.py
@@ -33,8 +33,8 @@ except ImportError:
 from spacewalk.common.rhnLog import log_debug, log_error
 from spacewalk.common.rhnException import rhnFault
 from spacewalk.common.stringutils import to_string
-from server_lib import getServerSecret
-from server_lib import check_entitlement_by_machine_id
+from .server_lib import getServerSecret
+from .server_lib import check_entitlement_by_machine_id
 
 def gen_secret():
     """ Generate a secret """

--- a/backend/server/rhnServer/server_certificate.py
+++ b/backend/server/rhnServer/server_certificate.py
@@ -22,7 +22,6 @@ import hashlib
 import time
 import random
 import socket
-import string
 try:
     #  python 2
     import xmlrpclib
@@ -155,7 +154,7 @@ class Certificate:
     def reload(self, text):
         """ load data from a text certificate passed on by a client """
         log_debug(4)
-        text_id = string.strip(text)
+        text_id = text.strip()
         if not text_id:
             return -1
         # Now decode this certificate

--- a/backend/server/rhnServer/server_class.py
+++ b/backend/server/rhnServer/server_class.py
@@ -27,14 +27,14 @@ from spacewalk.common.rhnException import rhnFault, rhnException
 from spacewalk.common.rhnTranslate import _
 from spacewalk.server import rhnChannel, rhnUser, rhnSQL, rhnLib, rhnAction, \
     rhnVirtualization
-from search_notify import SearchNotify
+from .search_notify import SearchNotify
 
 # Local Modules
-import server_kickstart
-import server_lib
-import server_token
-from server_certificate import Certificate, gen_secret
-from server_wrapper import ServerWrapper
+from . import server_kickstart
+from . import server_lib
+from . import server_token
+from .server_certificate import Certificate, gen_secret
+from .server_wrapper import ServerWrapper
 
 
 class Server(ServerWrapper):

--- a/backend/server/rhnServer/server_hardware.py
+++ b/backend/server/rhnServer/server_hardware.py
@@ -34,7 +34,7 @@ from spacewalk.common import rhnFlags
 from spacewalk.server import rhnSQL, rhnVirtualization, rhnUser
 
 # Local imports
-import server_class
+from . import server_class
 
 def kudzu_mapping(dict=None):
     """ this is a class we use to get the mapping for a kudzu entry """

--- a/backend/server/rhnServer/server_hardware.py
+++ b/backend/server/rhnServer/server_hardware.py
@@ -34,7 +34,7 @@ from spacewalk.common import rhnFlags
 from spacewalk.server import rhnSQL, rhnVirtualization, rhnUser
 
 # Local imports
-from . import server_class
+from .server_class import *
 
 def kudzu_mapping(dict=None):
     """ this is a class we use to get the mapping for a kudzu entry """
@@ -900,7 +900,7 @@ class SystemInformation():
         guestid = guest.getid()
         if not hid:
             # create a new host entry
-            host = server_class.Server(guest.user, hw.get('arch'))
+            host = Server(guest.user, hw.get('arch'))
             host.server["name"] = hw.get('name')
             host.server["os"] = hw.get('os')
             host.server["release"] = hw.get('type')
@@ -925,7 +925,7 @@ class SystemInformation():
             host.reload(hid)
             log_debug(4, "New host created: ", host)
         else:
-            host = server_class.Server(None)
+            host = Server(None)
             host.reload(hid)
             host.checkin(commit=0)
             log_debug(4, "Found host: ", host)

--- a/backend/server/rhnServer/server_hardware.py
+++ b/backend/server/rhnServer/server_hardware.py
@@ -18,7 +18,6 @@
 #
 
 import socket
-import string
 import sys
 import time
 import uuid
@@ -51,7 +50,7 @@ def kudzu_mapping(dict=None):
     # we need to have a bus type to be able to continue
     if not hw_bus:
         return mapping
-    hw_bus = string.lower(hw_bus)
+    hw_bus = hw_bus.lower()
     extra = {}
     if hw_bus == "ddc":
         extra = {
@@ -317,7 +316,7 @@ class Device(GenericDevice):
         try:
             for k in list(self.data.keys()):
                 if type(self.data[k]) == type("") and len(self.data[k]):
-                    self.data[k] = string.strip(self.data[k])
+                    self.data[k] = self.data[k].strip()
                     if not len(self.data[k]):
                         continue
                     if self.data[k][0] == '"' and self.data[k][-1] == '"':

--- a/backend/server/rhnServer/server_packages.py
+++ b/backend/server/rhnServer/server_packages.py
@@ -27,7 +27,7 @@ from spacewalk.common import rhn_rpm
 from spacewalk.common.rhnLog import log_debug
 from spacewalk.common.rhnException import rhnFault
 from spacewalk.server import rhnSQL, rhnAction
-from server_lib import snapshot_server, check_entitlement
+from .server_lib import snapshot_server, check_entitlement
 
 UNCHANGED = 0
 ADDED = 1

--- a/backend/server/rhnServer/server_packages.py
+++ b/backend/server/rhnServer/server_packages.py
@@ -466,7 +466,7 @@ def processPackageKeyAssociations(header, checksum_type, checksum):
         # No package to associate, continue with next
         return
 
-    sigkeys = rhn_rpm.RPM_Header(header).signatures
+    sigkeys = header.signatures
     key_id = None  # _key_ids(sigkeys)[0]
     for sig in sigkeys:
         if sig['signature_type'] in ['gpg', 'pgp']:

--- a/backend/server/rhnServer/server_token.py
+++ b/backend/server/rhnServer/server_token.py
@@ -24,7 +24,7 @@ from spacewalk.common.rhnException import rhnFault, rhnException
 from spacewalk.common.rhnTranslate import _
 from spacewalk.server import rhnSQL, rhnChannel, rhnAction
 
-from server_lib import join_server_group, check_entitlement
+from .server_lib import join_server_group, check_entitlement
 
 VIRT_ENT_LABEL = 'virtualization_host'
 

--- a/backend/server/rhnServer/server_wrapper.py
+++ b/backend/server/rhnServer/server_wrapper.py
@@ -20,10 +20,10 @@
 # the server.Server class inherits this ServerWrapper class
 #
 
-from server_hardware import Hardware
-from server_packages import Packages
-from server_history import History
-from server_suse import SuseData
+from .server_hardware import Hardware
+from .server_packages import Packages
+from .server_history import History
+from .server_suse import SuseData
 
 from rhn.UserDictCase import UserDictCase
 from spacewalk.server import rhnSQL

--- a/backend/server/rhnSession.py
+++ b/backend/server/rhnSession.py
@@ -25,7 +25,7 @@ import sys
 from spacewalk.common.rhnConfig import CFG
 from spacewalk.common.usix import raise_with_tb
 
-import rhnSQL
+from . import rhnSQL
 
 
 class InvalidSessionError(Exception):

--- a/backend/server/rhnUser.py
+++ b/backend/server/rhnUser.py
@@ -26,8 +26,8 @@ from spacewalk.common.rhnConfig import CFG
 from spacewalk.common.rhnException import rhnFault, rhnException
 from spacewalk.common.rhnTranslate import _
 
-import rhnSQL
-import rhnSession
+from . import rhnSQL
+from . import rhnSession
 
 
 class User:

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Add "python-urlgrabber" as a new dependency.
 - Fix Python3 issues on satellite_tools scripts
 
 -------------------------------------------------------------------

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- Fix Python3 issues on satellite_tools scripts
+
 -------------------------------------------------------------------
 Thu Jan 31 09:40:56 CET 2019 - jgonzalez@suse.com
 

--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -452,12 +452,14 @@ Requires:       python3-python-dateutil
 Requires:       python3-gzipstream
 Requires:       python3-rhn-client-tools
 Requires:       python3-solv
+Requires:       python3-urlgrabber
 %else
 Requires:       python-dateutil
 Requires:       python2-gzipstream
 Requires:       python2-rhn-client-tools
 Requires:       python-solv
 Requires:       python-configparser
+Requires:       python2-urlgrabber
 %if 0%{?suse_version}
 Requires:       python-pyliblzma
 %else

--- a/susemanager-utils/testing/docker/master/uyuni-master-pgsql/Dockerfile
+++ b/susemanager-utils/testing/docker/master/uyuni-master-pgsql/Dockerfile
@@ -18,7 +18,7 @@ RUN sh /root/setup-db-postgres.sh
 
 ADD postgresql.conf /var/lib/pgsql/data/postgresql.conf
 
-RUN zypper in -y python3-pip
+RUN zypper in -y python3-pip python3-solv
 
 RUN pip3 install --upgrade pylint==1.8 astroid==1.6.5
 

--- a/usix/common/usix.py
+++ b/usix/common/usix.py
@@ -25,7 +25,7 @@ PY3 = sys.version_info[0] == 3
 if PY3:
     BufferType = memoryview
     UnicodeType = str
-    StringType = bytes
+    StringType = str
     DictType = dict
     IntType = int
     LongType = int

--- a/usix/spacewalk-usix.changes
+++ b/usix/spacewalk-usix.changes
@@ -1,3 +1,5 @@
+- Fix StringType as str on Python 3
+
 -------------------------------------------------------------------
 Fri Oct 26 10:45:34 CEST 2018 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes some issues with Python3 code in `spacewalk-backend`:
- Some of the Python scripts that are not ended with `.py` extension were not ported.
- Encoding issues because `bytes` or `str`.
- Exceptions handling.
- Relative importing.
- Issues with `string` module.

## Test coverage
- No tests: **No new features. Only porting code**
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links
- Track: https://github.com/SUSE/salt-board/issues/64