### PR TITLE
 add configurable option to auto deploy new tokens (bsc#1123019)

### DIFF
--- a/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -215,6 +215,10 @@ public class ConfigDefaults {
      */
     public static final String TEMP_TOKEN_LIFETIME = "server.susemanager.temp_token_lifetime";
     public static final String TOKEN_LIFETIME = "server.susemanager.token_lifetime";
+    /**
+     * Controls if refreshed tokens get automatically deployed or not.
+     */
+    public static final String TOKEN_REFRESH_AUTO_DEPLOY = "server.susemanager.token_refresh_auto_deploy";
 
     /**
      * Salt Minions presence ping timeouts in seconds

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- add configurable option to auto deploy new tokens (bsc#1123019)
 - support products with multiple base channels
 - fix ordering of base channels to prevent synchronization errors
   (bsc#1123902)

--- a/susemanager/rhn-conf/rhn_server_susemanager.conf
+++ b/susemanager/rhn-conf/rhn_server_susemanager.conf
@@ -26,3 +26,5 @@ virtpoller.interval = 300
 temp_token_lifetime = 60
 # ~ 1 year
 token_lifetime = 525600
+# automatically deploy tokens once they are refreshed
+token_refresh_auto_deploy = true


### PR DESCRIPTION
## What does this PR change?

This add a configurable option to enable automatic deployment of new generated tokens after the token cleanup job. This option is enabled by default.

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: uses existing and already tested states.



## Links

Fixes #6908 

Relevant branches (GitHub automatic links expected below):
 - Manager-3.2 https://github.com/SUSE/spacewalk/pull/6921
 - Uyuni

- [X] **DONE**

