### PR TITLE
Fix: handle mgr-sync error when no data is loaded

### DIFF
--- a/susemanager/src/mgr_sync/mgr_sync.py
+++ b/susemanager/src/mgr_sync/mgr_sync.py
@@ -351,11 +351,9 @@ class MgrSync(object):  # pylint: disable=too-few-public-methods
             expand=False, filter=None, compact=False,
             no_optionals=no_optionals, show_interactive_numbers=True)
 
-        validator = lambda i: re.search(r"\d+", i) and \
-            int(i) in range(1, len(channels)+1)
         choice = cli_ask(
             msg=("Enter channel number (1-{0})".format(len(channels))),
-            validator=validator)
+            validator=[str(i) for i in list(range(1, len(channels)+1))])
 
         self.log.info("Selecting channel '{0}' from choice '{1}'".format(
             channels[int(choice)-1], choice))
@@ -463,11 +461,9 @@ class MgrSync(object):  # pylint: disable=too-few-public-methods
         if interactive_data is not None and 'num_prod' in interactive_data:
             num_prod = interactive_data['num_prod']
             if num_prod:
-                validator = lambda i: re.search("\d+", i) and \
-                    int(i) in range(1, len(num_prod.keys()) + 1)
                 choice = cli_ask(
                     msg=("Enter product number (1-{0})".format(len(num_prod.keys()))),
-                    validator=validator)
+                    validator=[str(i) for i in list(range(1, len(num_prod.keys()) + 1))])
 
                 self.log.info("Selecting product '{0} {1}' from choice '{2}'".format(
                     num_prod[int(choice)].friendly_name, num_prod[int(choice)].arch,
@@ -589,13 +585,11 @@ class MgrSync(object):  # pylint: disable=too-few-public-methods
         and return the chosen credential.
         """
         saved_credentials = self._fetch_credentials()
-        validator = lambda i: re.search(r"\d+", i) and \
-            int(i) in range(1, len(saved_credentials)+1)
 
         self._list_credentials(True)
         number = cli_ask(
             msg=("Enter credentials number (1-{0})".format(len(saved_credentials))),
-            validator=validator)
+            validator=[str(i) for i in list(range(1, len(saved_credentials)+1))])
 
         self.log.info("Selecting credentials '{0}' from choice '{1}'".format(
             saved_credentials[int(number)-1]['user'], number))

--- a/susemanager/src/mgr_sync/mgr_sync.py
+++ b/susemanager/src/mgr_sync/mgr_sync.py
@@ -481,9 +481,9 @@ class MgrSync(object):  # pylint: disable=too-few-public-methods
                     "nothing to do")
                 return None
         else:
-            self.log.info("Have you run `mgr-sync refresh`?")
-            print("Have you run `mgr-sync refresh`?")
-        
+            self.log.info("Have you run 'mgr-sync refresh'?")
+            print("Have you run 'mgr-sync refresh'?")
+
 
     ##############################
     #                            #

--- a/susemanager/src/mgr_sync/mgr_sync.py
+++ b/susemanager/src/mgr_sync/mgr_sync.py
@@ -476,9 +476,9 @@ class MgrSync(object):  # pylint: disable=too-few-public-methods
                 return num_prod[int(choice)]
             else:
                 self.log.info("All the available products have already been "
-                        "installed, nothing to do")
+                              "installed, nothing to do")
                 print("All the available products have already been installed, "
-                    "nothing to do")
+                      "nothing to do")
                 return None
         else:
             self.log.info("Have you run 'mgr-sync refresh'?")

--- a/susemanager/src/mgr_sync/mgr_sync.py
+++ b/susemanager/src/mgr_sync/mgr_sync.py
@@ -460,25 +460,30 @@ class MgrSync(object):  # pylint: disable=too-few-public-methods
         interactive_data = self._list_products(
             filter=None, expand=False, show_interactive_numbers=True)
 
-        num_prod = interactive_data['num_prod']
-        if num_prod:
-            validator = lambda i: re.search(r"\d+", i) and \
-                int(i) in range(1, len(list(num_prod.keys())) + 1)
-            choice = cli_ask(
-                msg=("Enter product number (1-{0})".format(
-                    len(list(num_prod.keys())))),
-                validator=validator)
+        if interactive_data is not None and 'num_prod' in interactive_data:
+            num_prod = interactive_data['num_prod']
+            if num_prod:
+                validator = lambda i: re.search("\d+", i) and \
+                    int(i) in range(1, len(num_prod.keys()) + 1)
+                choice = cli_ask(
+                    msg=("Enter product number (1-{0})".format(
+                        len(num_prod.keys()))),
+                    validator=validator)
 
-            self.log.info("Selecting product '{0} {1}' from choice '{2}'".format(
-                num_prod[int(choice)].friendly_name, num_prod[int(choice)].arch,
-                choice))
-            return num_prod[int(choice)]
+                self.log.info("Selecting product '{0} {1}' from choice '{2}'".format(
+                    num_prod[int(choice)].friendly_name, num_prod[int(choice)].arch,
+                    choice))
+                return num_prod[int(choice)]
+            else:
+                self.log.info("All the available products have already been "
+                        "installed, nothing to do")
+                print("All the available products have already been installed, "
+                    "nothing to do")
+                return None
         else:
-            self.log.info("All the available products have already been "
-                          "installed, nothing to do")
-            print("All the available products have already been installed, "
-                  "nothing to do")
-            return None
+            self.log.info("Have you run `mgr-sync refresh`?")
+            print("Have you run `mgr-sync refresh`?")
+        
 
     ##############################
     #                            #

--- a/susemanager/src/mgr_sync/mgr_sync.py
+++ b/susemanager/src/mgr_sync/mgr_sync.py
@@ -466,8 +466,7 @@ class MgrSync(object):  # pylint: disable=too-few-public-methods
                 validator = lambda i: re.search("\d+", i) and \
                     int(i) in range(1, len(num_prod.keys()) + 1)
                 choice = cli_ask(
-                    msg=("Enter product number (1-{0})".format(
-                        len(num_prod.keys()))),
+                    msg=("Enter product number (1-{0})".format(len(num_prod.keys()))),
                     validator=validator)
 
                 self.log.info("Selecting product '{0} {1}' from choice '{2}'".format(


### PR DESCRIPTION
## What does this PR change?

When a `mgr-sync` is not executed before adding a product, an exception
arises:

- before patching:
```
    server:~ # mgr-sync add product
    No products found.
    General error: 'NoneType' object has no attribute '__getitem__'
```
- after patching:
```
    server:~ # mgr-sync add product
    No products found.
    Have you run 'mgr-sync refresh'?
```
## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: rewording/hiding an error

- [X] **DONE**

## Test coverage
- No tests: this is internal

- [X] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/6831

- [X] **DONE**

