### PR TITLE
DRY: convenient method to mark a server action as FAILED

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/server/ServerAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/server/ServerAction.java
@@ -16,6 +16,7 @@ package com.redhat.rhn.domain.action.server;
 
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionChild;
+import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.ActionStatus;
 import com.redhat.rhn.domain.server.Server;
 
@@ -223,6 +224,36 @@ public class ServerAction extends ActionChild implements Serializable {
      */
     public void setServerId(Long serverIdIn) {
         this.serverId = serverIdIn;
+    }
+
+    /**
+     * Set this server action to FAILED.
+     * @param message the message to set in the server action
+     */
+    public void fail(String message) {
+        this.fail(-1L, message);
+    }
+
+    /**
+     * Set this server action to FAILED.
+     * @param resultCodeIn the result code set in the server action
+     * @param message the message to set in the server action
+     */
+    public void fail(long resultCodeIn, String message) {
+        this.fail(resultCodeIn, message, new Date());
+    }
+
+    /**
+     * Set this server action to FAILED.
+     * @param resultCodeIn the result code set in the server action
+     * @param message the message to set in the server action
+     * @param completionTimeIn the completionTime to set in the server action
+     */
+    public void fail(long resultCodeIn, String message, Date completionTimeIn) {
+        this.setCompletionTime(completionTimeIn);
+        this.setResultCode(resultCodeIn);
+        this.setStatus(ActionFactory.STATUS_FAILED);
+        this.setResultMsg(message);
     }
 
 }

--- a/java/code/src/com/redhat/rhn/domain/action/server/test/ServerActionTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/server/test/ServerActionTest.java
@@ -25,11 +25,33 @@ import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.testing.RhnBaseTestCase;
 import com.redhat.rhn.testing.UserTestUtils;
 
+import java.util.Date;
+
 /**
  * ServerActionTest
  * @version $Rev$
  */
 public class ServerActionTest extends RhnBaseTestCase {
+
+    public void testFail() {
+        ServerAction sa1 = new ServerAction();
+        sa1.fail(-1L, "Fail_message", new Date());
+        assertEquals(sa1.getResultMsg(), "Fail_message");
+        assertEquals(sa1.getResultCode(), new Long(-1));
+        assertEquals(sa1.getStatus(), ActionFactory.STATUS_FAILED);
+
+        ServerAction sa2 = new ServerAction();
+        sa2.fail(-1L, "Fail_message");
+        assertEquals(sa2.getResultMsg(), "Fail_message");
+        assertEquals(sa2.getResultCode(), new Long(-1));
+        assertEquals(sa2.getStatus(), ActionFactory.STATUS_FAILED);
+
+        ServerAction sa3 = new ServerAction();
+        sa3.fail("Fail_message");
+        assertEquals(sa3.getResultMsg(), "Fail_message");
+        assertEquals(sa3.getResultCode(), new Long(-1));
+        assertEquals(sa3.getStatus(), ActionFactory.STATUS_FAILED);
+    }
 
     public void testEquals() {
         ServerAction sa = new ServerAction();

--- a/java/code/src/com/redhat/rhn/taskomatic/task/RebootActionCleanup.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/RebootActionCleanup.java
@@ -46,6 +46,7 @@ public class RebootActionCleanup extends RhnJavaJob {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void execute(JobExecutionContext arg0In)
         throws JobExecutionException {
         List<Map<String, Long>> failedRebootActions = lookupRebootActionCleanup();
@@ -102,10 +103,7 @@ public class RebootActionCleanup extends RhnJavaJob {
         Action a = ActionFactory.lookupById(actionId);
         ServerAction sa = ActionFactory.getServerActionForServerAndAction(s, a);
         if (sa.getStatus().getName() != "Failed") {
-            sa.setResultCode(-100L);
-            sa.setResultMsg("Prerequisite failed");
-            sa.setCompletionTime(sa.getPickupTime());
-            sa.setStatus(ActionFactory.STATUS_FAILED);
+            sa.fail(-100L, "Prerequisite failed", sa.getPickupTime());
 
             s.asMinionServer()
                     .filter(MinionServerUtils::isSshPushMinion)

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -418,10 +418,7 @@ public class SaltServerActionService {
                     LOG.warn("Failed to schedule action for minion: " +
                             minionServer.getMinionId());
                     if (!isStagingJob) {
-                        serverAction.setCompletionTime(new Date());
-                        serverAction.setResultCode(-1L);
-                        serverAction.setResultMsg("Failed to schedule action.");
-                        serverAction.setStatus(ActionFactory.STATUS_FAILED);
+                        serverAction.fail("Failed to schedule action.");
                         ActionFactory.save(serverAction);
                     }
                 });
@@ -1136,10 +1133,7 @@ public class SaltServerActionService {
             scriptAction.getServerActions().stream()
                     .filter(entry -> minions.contains(entry.getServer()))
                     .forEach(sa -> {
-                        sa.setCompletionTime(new Date());
-                        sa.setResultCode(-1L);
-                        sa.setResultMsg("Error scheduling the action: " + errorMsg);
-                        sa.setStatus(ActionFactory.STATUS_FAILED);
+                        sa.fail("Error scheduling the action: " + errorMsg);
                         ActionFactory.save(sa);
             });
         }
@@ -1662,10 +1656,7 @@ public class SaltServerActionService {
             if (prerequisiteInStatus(sa, ActionFactory.STATUS_FAILED)) {
                 LOG.info("Failing action '" + action.getName() + "' as its prerequisite '" +
                         action.getPrerequisite().getName() + "' failed.");
-                sa.setStatus(STATUS_FAILED);
-                sa.setResultMsg("Prerequisite failed.");
-                sa.setResultCode(-100L);
-                sa.setCompletionTime(new Date());
+                sa.fail(-100L, "Prerequisite failed.");
                 return;
             }
 

--- a/java/code/src/com/suse/manager/webui/utils/MinionActionUtils.java
+++ b/java/code/src/com/suse/manager/webui/utils/MinionActionUtils.java
@@ -134,11 +134,7 @@ public class MinionActionUtils {
                             // If it is a string its likely to be an error because our
                             // actions so far don't have String as a result type
                             if (o.isJsonPrimitive() && o.getAsJsonPrimitive().isString()) {
-                                String error = o.getAsJsonPrimitive().getAsString();
-                                sa.setCompletionTime(new Date());
-                                sa.setResultMsg(error);
-                                sa.setStatus(ActionFactory.STATUS_FAILED);
-                                sa.setResultCode(-1L);
+                                sa.fail(o.getAsJsonPrimitive().getAsString());
                                 return sa;
                             }
                             else {
@@ -149,23 +145,16 @@ public class MinionActionUtils {
                                 return sa;
                             }
                         }).orElseGet(() -> {
-                            sa.setCompletionTime(new Date());
-                            sa.setResultMsg("There was no result.");
-                            sa.setStatus(ActionFactory.STATUS_FAILED);
-                            sa.setResultCode(-1L);
+                            sa.fail("There was no result.");
                             return sa;
                         });
                     }).orElseGet(() -> {
                         if (!sa.getStatus().equals(ActionFactory.STATUS_QUEUED)) {
-                            sa.setCompletionTime(new Date());
-                            if (POSTGRES) {
-                                sa.setResultMsg("No job return event was received.");
+                            String message = "No job return event was received.";
+                            if (!POSTGRES) {
+                                message = "There was no job cache entry.";
                             }
-                            else {
-                                sa.setResultMsg("There was no job cache entry.");
-                            }
-                            sa.setStatus(ActionFactory.STATUS_FAILED);
-                            sa.setResultCode(-1L);
+                            sa.fail(message);
                         }
                         return sa;
                     });


### PR DESCRIPTION
## What does this PR change?

Add convenient method to mark a server action as FAILED

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: small refactoring

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/6955

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
