### PR TITLE
Fix add selected to SSM on System Groups -> systems (bsc#1121856)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/struts/BaseSetHelper.java
+++ b/java/code/src/com/redhat/rhn/frontend/struts/BaseSetHelper.java
@@ -84,7 +84,7 @@ public class BaseSetHelper {
             // itself will have the selected servers cleared
             updateSet(set, listName);
 
-            String[] selected = ListTagHelper.getSelected(listName, request);
+            String[] selected = (String[]) set.toArray(new String[set.size()]);
 
             RequestContext context = new RequestContext(request);
             User user = context.getCurrentUser();

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Fix "Add Selected to SSM" on System Groups -> systems page (bsc#1121856)
+
 -------------------------------------------------------------------
 Fri Feb 08 17:38:56 CET 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

"Add selected to SSM" on "System Groups -> systems" adds all the selected systems instead only the ones selected on the current page

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests:

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/6766
Backport: https://github.com/SUSE/spacewalk/pull/6814

- [x ] **DONE**