### PR TITLE
Fix for 'duplicate key' constraint violation when cloning errata

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/errata/ErrataFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/errata/ErrataFactory.java
@@ -408,7 +408,7 @@ public class ErrataFactory extends HibernateFactory {
      */
     private static ErrataFile createPublishedErrataFile(Package pack, Errata errata, Channel chan) {
         ErrataFile publishedFile = ErrataFactory.createPublishedErrataFile(
-                ErrataFactory.lookupErrataFileType("RPM"), pack.getChecksum().getChecksum(), pack.getFilename());
+                ErrataFactory.lookupErrataFileType("RPM"), pack.getChecksum().getChecksum(), pack.getPath());
         publishedFile.addPackage(pack);
         publishedFile.setErrata(errata);
         publishedFile.setModified(new Date());

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/test/ErrataHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/test/ErrataHandlerTest.java
@@ -109,7 +109,7 @@ public class ErrataHandlerTest extends BaseHandlerTestCase {
         assertEquals(publishClonedErrata.getPackages().size(), errata.getPackages().size());
         assertTrue(publishClonedErrata.getPackages().stream()
                 .allMatch(p -> errata.getPackages().stream()
-                        .anyMatch(ep -> ep.getFilename().equals(p.getFilename()))));
+                        .anyMatch(ep -> ep.getPath().equals(p.getPath()))));
 
         // clone a channel with its errata, and the errata's packages are EMPTY
         Errata emptyErrata = ErrataFactoryTest.createTestErrata(admin.getOrg().getId());


### PR DESCRIPTION
## What does this PR change?

Fix for duplicate key violation when cloning channels with spacewalk-clone-by-date, originally fix by https://github.com/uyuni-project/uyuni/pull/495

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bug fixing

- [x] **DONE**

## Test coverage
- Unit tests were updated

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/6973

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
