### PR TITLE
ant: fix deploy (add missing file)

### DIFF
--- a/java/manager-build.xml
+++ b/java/manager-build.xml
@@ -146,6 +146,9 @@
       </fileset>
     </copy>
 
+    <mkdir dir="${build.dir}/webapp/META-INF" />
+    <copy file="conf/rhn-tomcat8.xml" tofile="${build.dir}/webapp/META-INF/context.xml" />
+
     <copy todir="${build.dir}/webapp/WEB-INF/lib">
       <fileset file="${build.dir}/rhn.jar" />
       <fileset dir="${lib.dir}">


### PR DESCRIPTION
Fixes `manager-build.xml` deploys.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix only relevant to developers**

- [x] **DONE**

## Test coverage
- No tests: **developer deploy code**

- [x] **DONE**


## Links

Fixes https://github.com/SUSE/spacewalk/issues/6893 (Tomcat throws a NPE in StandardJarScanner after ant deploying)
Tracks # https://github.com/SUSE/spacewalk/pull/6986

- [x] **DONE**
