### PR TITLE
fetch-certificate: allow more time for onboarding

### DIFF
--- a/proxy/installer/fetch-certificate.py
+++ b/proxy/installer/fetch-certificate.py
@@ -6,7 +6,7 @@ import time
 import argparse
 
 
-RETRIES = 3
+RETRIES = 20
 WAIT_RESPONSE = 10
 REQUEST_TAG = 'suse/systemid/generate'
 RESPONSE_TAG = 'suse/systemid/generated'


### PR DESCRIPTION
## What does this PR change?

In automated installs of Proxies (eg. with automatic key acceptance) one wants to run configure-proxy.sh as early as possible, but this might be earlier than the onboarding has finished. configure-proxy.sh calls fetch-certificate.py, which already has a mechanism to wait for registration to finish, waiting at most 30 seconds. This might not be sufficient and this patch raises the limit to 200 seconds.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **already covrered by existing Cucumber tests**

- [x] **DONE**

## Links

Tracks # **add downstream PR, if any**

- [ ] **DONE**
