### PR TITLE
Update ivy configuration for new salt-netapi-client version

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -77,7 +77,7 @@
         <dependency org="suse" name="redstone-xmlrpc" rev="1.1_20071120" />
         <dependency org="suse" name="redstone-xmlrpc-client" rev="1.1_20071120" />
         <dependency org="suse" name="regexp" rev="1.4" />
-        <dependency org="suse" name="salt-netapi-client" rev="0.15.0" />
+        <dependency org="suse" name="salt-netapi-client" rev="0.15.1" />
         <dependency org="suse" name="simpleclient" rev="0.3.0" />
         <dependency org="suse" name="simpleclient_common" rev="0.3.0" />
         <dependency org="suse" name="simpleclient_servlet" rev="0.3.0" />


### PR DESCRIPTION
## What does this PR change?

Update ivy configuration for new salt-netapi-client version (0.15.1)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Changes for development env

- [x] **DONE**

## Test coverage

- No tests:  Changes for development env

- [x] **DONE**

## Links

https://github.com/SUSE/salt-netapi-client/releases/tag/v0.15.1

- [x] **DONE**