### PR TITLE
Fix: Add `python-setuptools` package dependency to SLES12 bootstrap repo (bsc#1119964)

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -118,6 +118,7 @@ PKGLIST12 = [
     "python-pyasn1",
     "python-pycparser",
     "python-pyOpenSSL",
+    "python-setuptools",
     "python-six",
     "python-xml",
     "python-pyudev",

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- Add `python-setuptools` package dependency to SLES12 bootstrap repo (bsc#1119964)
 - enable and start tftp socket (bsc#1124822)
 - migrate existing rhn.conf; do not allow new database credentials
   during migration


### PR DESCRIPTION
## What does this PR change?

Add `python-setuptools` package dependency to SLES12 bootstrap repository

https://bugzilla.suse.com/show_bug.cgi?id=1119964#c10

- python-cryptography
- python-pyOpenSSL

were already included in the bootstrap repository.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: bootstrap repo is internal

- [X] **DONE**

## Test coverage
- No tests: internal

- [X] **DONE**

## Links

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1119964#c10
Tracks https://github.com/SUSE/spacewalk/pull/6845

- [X] **DONE**
