### PR TITLE
atftp has been replaced by tftp in uyuni

### DIFF
--- a/testsuite/features/core_first_settings.feature
+++ b/testsuite/features/core_first_settings.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2018 SUSE LLC
+# Copyright (c) 2017-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Very first settings
@@ -57,8 +57,8 @@ Feature: Very first settings
     When I wait until mgr-sync refresh is finished
 
   Scenario: Check services which should run
-    Then service or socket "atftpd" is enabled on "server"
-    And service or socket "atftpd" is active on "server"
+    Then service "apache2" is enabled on "server"
+    And service "apache2" is active on "server"
     And service "auditlog-keeper" is enabled on "server"
     And service "auditlog-keeper" is active on "server"
     And service "cobblerd" is enabled on "server"
@@ -75,8 +75,8 @@ Feature: Very first settings
     And service "salt-master" is active on "server"
     And service "taskomatic" is enabled on "server"
     And service "taskomatic" is active on "server"
-    And service "apache2" is enabled on "server"
-    And service "apache2" is active on "server"
+    And socket "tftp" is enabled on "server"
+    And socket "tftp" is active on "server"
     And service "tomcat" is enabled on "server"
     And service "tomcat" is active on "server"
 

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -334,24 +334,6 @@ Then(/^service "([^"]*)" is active on "([^"]*)"$/) do |service, host|
   raise if output != 'active'
 end
 
-Then(/^service or socket "([^"]*)" is enabled on "([^"]*)"$/) do |name, host|
-  node = get_target(host)
-  output_service, _code_service = node.run("systemctl is-enabled '#{name}'", false)
-  output_service = output_service.split(/\n+/)[-1]
-  output_socket, _code_socket = node.run(" systemctl is-enabled '#{name}.socket'", false)
-  output_socket = output_socket.split(/\n+/)[-1]
-  raise if output_service != 'enabled' and output_socket != 'enabled'
-end
-
-Then(/^service or socket "([^"]*)" is active on "([^"]*)"$/) do |name, host|
-  node = get_target(host)
-  output_service, _code_service = node.run("systemctl is-active '#{name}'", false)
-  output_service = output_service.split(/\n+/)[-1]
-  output_socket, _code_socket = node.run(" systemctl is-active '#{name}.socket'", false)
-  output_socket = output_socket.split(/\n+/)[-1]
-  raise if output_service != 'active' and output_socket != 'active'
-end
-
 Then(/^socket "([^"]*)" is enabled on "([^"]*)"$/) do |service, host|
   node = get_target(host)
   output, _code = node.run("systemctl is-enabled '#{service}.socket'", false)


### PR DESCRIPTION
## What does this PR change?

This PR tests for `tftp` service instead of `atftpd` service or socket on the server.

Please note that it will keep failing, because tftp service is disabled by default. That's expected.

## Links

none, uyuni testsuite only
