### PR TITLE
Fix swapfile permissions and hide dd transfer statistics

### DIFF
--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -116,10 +116,16 @@ if [ $SWAP -eq 0 ]; then
         if [ $FSTYPE == "btrfs" ]; then
             echo "Will *NOT* create swapfile on btrfs. Make sure you have enough RAM!"
         else
-            dd if=/dev/zero of=/SWAPFILE bs=1M count=2000
+            if [ -f /SWAPFILE ]; then
+                swapoff /SWAPFILE
+            fi
+            dd if=/dev/zero of=/SWAPFILE bs=1M count=2000 status=none
+            chmod 0600 /SWAPFILE
             sync
             mkswap -f /SWAPFILE
-            echo "/SWAPFILE swap swap defaults 0 0" >> /etc/fstab
+            if [ "$(grep -ir '/SWAPFILE swap swap defaults 0 0' /etc/fstab)" == "" ]; then
+                echo "/SWAPFILE swap swap defaults 0 0" >> /etc/fstab
+            fi
             swapon -a
             echo "ok."
         fi

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- Do not show false errors when configuring swapfile during setup
+
 -------------------------------------------------------------------
 Thu Jan 31 09:44:30 CET 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Fix swapfile permissions and hide dd transfer statistics, to avoid stuff at `error_output` at setup.

Bonus: Do not fail on reprovision.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Fix for unwanted comment at `error_output` at setup.

- [x] **DONE**

## Test coverage
- No tests: Fix for unwanted comment at `error_output` at setup.

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/6936

- [x] **DONE**