### PR TITLE
Fix several Python3 issues in "spacewalk-backend"

### DIFF
--- a/backend/satellite_tools/download.py
+++ b/backend/satellite_tools/download.py
@@ -112,6 +112,9 @@ class PyCurlFileObjectThread(PyCurlFileObject):
     def __init__(self, url, filename, opts, curl_cache, parent):
         self.curl_cache = curl_cache
         self.parent = parent
+        (url, parts) = opts.urlparser.parse(url, opts)
+        (scheme, host, path, parm, query, frag) = parts
+        opts.find_proxy(url, scheme)
         PyCurlFileObject.__init__(self, str(url), filename, opts)
 
     def _do_open(self):

--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -401,6 +401,7 @@ class ContentSource:
         # settings on /etc/rhn/spacewalk-repo-sync/zypper.conf
         if CFG.http_proxy:
             self.proxy_url, self.proxy_user, self.proxy_pass = get_proxy(self.url)
+            self.proxy_hostname = self.proxy_url
         elif os.path.isfile(REPOSYNC_ZYPPER_CONF):
             zypper_cfg = configparser.ConfigParser()
             zypper_cfg.read_file(open(REPOSYNC_ZYPPER_CONF))

--- a/backend/server/apacheAuth.py
+++ b/backend/server/apacheAuth.py
@@ -15,7 +15,6 @@
 #
 
 import time
-import string
 import re
 
 from spacewalk.common import rhnFlags
@@ -24,13 +23,13 @@ from spacewalk.common.rhnConfig import CFG
 from spacewalk.common.rhnException import rhnFault
 from spacewalk.common.rhnTranslate import _
 
-from rhnLib import computeSignature
+from .rhnLib import computeSignature
 
 
 def splitProxyAuthToken(token):
     """ given a token:hostname, split it into a token-list, hostname """
 
-    token = string.split(token, ':')
+    token = token.split(':')
     hostname = ''
     if len(token) > 5:
         hostname = token[-1]
@@ -126,7 +125,7 @@ def auth_proxy():
     #     "token1:hostname1,token2:hostname2" the first tuple is the first
     #     proxy hit.
 
-    tokens = string.split(rhnFlags.get('X-RHN-Proxy-Auth'), ',')
+    tokens = rhnFlags.get('X-RHN-Proxy-Auth').split(',')
     tokens = [token for token in tokens if token]
 
     for auth_token in tokens:

--- a/backend/server/apacheHandler.py
+++ b/backend/server/apacheHandler.py
@@ -16,7 +16,6 @@
 import sys
 import os
 import time
-import string
 
 from spacewalk.common import apache, rhnApache, rhnTB, rhnFlags
 from spacewalk.common.rhnException import rhnException, rhnFault
@@ -24,10 +23,10 @@ from spacewalk.common.rhnConfig import CFG, initCFG
 from spacewalk.common.rhnLog import log_debug, log_error, initLOG, log_setreq
 
 # local module imports
-import rhnSQL
+from . import rhnSQL
 
-from apacheRequest import apacheGET, apachePOST, HandlerNotFoundError
-import rhnCapability
+from .apacheRequest import apacheGET, apachePOST, HandlerNotFoundError
+from . import rhnCapability
 
 # a lame timer function for pretty logs
 
@@ -96,7 +95,7 @@ class apacheHandler(apacheSession):
         client_cap_header = 'X-RHN-Client-Capability'
         if client_cap_header in req.headers_in:
             client_caps = req.headers_in[client_cap_header]
-            client_caps = [_f for _f in list(map(string.strip, string.split(client_caps, ","))) if _f]
+            client_caps = [_f.strip() for _f in client_caps.split(',') if _f.strip()]
             rhnCapability.set_client_capabilities(client_caps)
 
         # Enabling the input header flags associated with the redirects/newer clients
@@ -202,7 +201,7 @@ class apacheHandler(apacheSession):
         try:
             ret = self._req_processor.process()
             rhnSQL.rollback()
-        except:
+        except Exception as exc:
             if not CFG.SEND_MESSAGE_TO_ALL:
                 rhnSQL.rollback()
             raise

--- a/backend/server/apacheServer.py
+++ b/backend/server/apacheServer.py
@@ -21,7 +21,7 @@ from spacewalk.common.rhnConfig import CFG, initCFG
 from spacewalk.common.rhnTB import Traceback
 from spacewalk.common.rhnLog import initLOG, log_setreq
 
-from apacheHandler import apacheHandler
+from .apacheHandler import apacheHandler
 apache_server = apacheHandler()
 HeaderParserHandler = apache_server.headerParserHandler
 Handler = apache_server.handler

--- a/backend/server/apacheUploadServer.py
+++ b/backend/server/apacheUploadServer.py
@@ -14,7 +14,6 @@
 #
 #
 
-import string
 import sys
 from spacewalk.common import apache
 
@@ -127,11 +126,11 @@ class UploadHandler:
 
     # Adds an error code and error string to the headers passed in
     def _error_to_headers(self, headers, error_code, error_string):
-        error_string = string.strip(error_string)
+        error_string = error_string.strip()
         import base64
-        error_string = string.strip(base64.encodestring(error_string))
-        for line in map(string.strip, string.split(error_string, '\n')):
-            headers.add(self.server.error_header_prefix + '-String', line)
+        error_string = base64.encodestring(error_string).strip()
+        for line in error_string.split('\n'):
+            headers.add(self.server.error_header_prefix + '-String', line.strip())
         headers[self.server.error_header_prefix + '-Code'] = str(error_code)
 
     def _exception_to_text(self, exception):
@@ -140,8 +139,8 @@ Error Message:
     %s
 Error Class Code: %s
 Error Class Info: %s
-""" % (string.strip(exception.text), exception.code,
-            string.rstrip(exception.arrayText))
+""" % (exception.text.strip(), exception.code,
+            exception.arrayText.rstrip())
 
 # Instantiate external entry points:
 apache_server = UploadHandler()

--- a/backend/server/configFilesHandler.py
+++ b/backend/server/configFilesHandler.py
@@ -40,7 +40,7 @@ from spacewalk.server.rhnHandler import rhnHandler
 from spacewalk.server.config_common.templated_document import ServerTemplatedDocument, var_interp_prep
 
 
-import rhnSession
+from . import rhnSession
 
 # Exceptions
 

--- a/backend/server/config_common/base_templated_document.py
+++ b/backend/server/config_common/base_templated_document.py
@@ -18,7 +18,6 @@
 
 import re
 import sys
-import string
 
 from spacewalk.common.rhnLog import log_error
 
@@ -93,7 +92,7 @@ class TemplatedDocument(BaseTemplatedDocument):
 
     def _repl_func(self, match_object):
         funcname = match_object.groups()[0]
-        funcname = string.strip(funcname)
+        funcname = funcname.strip()
         fname, params, defval = self.parse_func_name(funcname)
         return self.call(fname, params, defval)
 
@@ -112,15 +111,15 @@ class TemplatedDocument(BaseTemplatedDocument):
 
         if fname[-1] == ')':
             # Params are present
-            i = string.rfind(fname, '(')
+            i = fname.rfind('(')
             if i < 0:
                 raise ValueError("Missing (")
 
             params = fname[i + 1:-1]
-            fname = string.strip(fname[:i])
+            fname = fname[:i].strip()
 
             # Parse the params
-            params = list(map(self.unquote, [_f for _f in string.split(params, ',') if _f]))
+            params = list(map(self.unquote, [_f for _f in params.split(',') if _f]))
 
         # Validate the function name
         if not self.funcname_regex.match(fname):
@@ -131,7 +130,7 @@ class TemplatedDocument(BaseTemplatedDocument):
     def null_call(self, fname, params, defval):
         val = fname
         if params:
-            val = "%s(%s)" % (val, string.join(params, ', '))
+            val = "%s(%s)" % (val, ', '.join(params))
         if defval is not None:
             val = "%s = %s" % (val, defval)
         return "%s %s %s" % (self.start_delim, val, self.end_delim)
@@ -167,12 +166,12 @@ class TemplatedDocument(BaseTemplatedDocument):
     def strip(self, s):
         if s is None:
             return None
-        return string.strip(s)
+        return s.strip()
 
     def unquote(self, s):
         if s is None:
             return None
-        s = string.strip(s)
+        s = s.strip()
         if len(s) <= 1:
             # Nothing to unquote
             return s

--- a/backend/server/config_common/templated_document.py
+++ b/backend/server/config_common/templated_document.py
@@ -15,7 +15,7 @@
 #
 #
 
-from base_templated_document import TemplatedDocument
+from .base_templated_document import TemplatedDocument
 
 from spacewalk.common.rhnLog import log_debug
 

--- a/backend/server/handlers/app/__init__.py
+++ b/backend/server/handlers/app/__init__.py
@@ -17,7 +17,7 @@
 
 __all__ = []
 
-import packages
+from . import packages
 
 rpcClasses = {
     "packages": packages.Packages,

--- a/backend/server/handlers/app/packages.py
+++ b/backend/server/handlers/app/packages.py
@@ -18,7 +18,6 @@
 #
 
 import os
-import string
 import sys
 from spacewalk.common.usix import TupleType
 
@@ -365,7 +364,7 @@ class Packages(RPC_Base):
             importer.run()
         except IncompatibleArchError:
             e = sys.exc_info()[1]
-            raise_with_tb(rhnFault(50, string.join(e.args), explain=0), sys.exc_info()[2])
+            raise_with_tb(rhnFault(50, ' '.join(e.args), explain=0), sys.exc_info()[2])
         except InvalidChannelError:
             e = sys.exc_info()[1]
             raise_with_tb(rhnFault(50, str(e), explain=0), sys.exc_info()[2])

--- a/backend/server/handlers/applet/__init__.py
+++ b/backend/server/handlers/applet/__init__.py
@@ -18,7 +18,7 @@
 
 __all__ = []
 
-import applet
+from . import applet
 
 rpcClasses = {
     "applet": applet.Applet,

--- a/backend/server/handlers/applet/applet.py
+++ b/backend/server/handlers/applet/applet.py
@@ -14,7 +14,6 @@
 #
 
 # system module imports
-import string
 try:
     #  python 2
     import xmlrpclib
@@ -169,7 +168,7 @@ class Applet(rhnHandler):
         label_list = [str(a["id"]) for a in channel_list]
         label_list.sort()
         log_debug(4, "label_list", label_list)
-        cache_key = "applet-poll-%s" % string.join(label_list, "-")
+        cache_key = "applet-poll-%s" % "-".join(label_list)
 
         ret = rhnCache.get(cache_key, last_channel_changed_ts)
         if ret:  # we have a good entry with matching timestamp
@@ -193,7 +192,7 @@ class Applet(rhnHandler):
             k = "channel_%s" % v
             qlist.append(":%s" % k)
             qdict[k] = v
-        qlist = string.join(qlist, ", ")
+        qlist = ", ".join(qlist)
 
         # This query is kind of big. One of these days I'm gonna start
         # pulling them out and transforming them into views. We can

--- a/backend/server/handlers/config/__init__.py
+++ b/backend/server/handlers/config/__init__.py
@@ -17,7 +17,7 @@
 
 __all__ = []
 
-import rhn_config_management
+from . import rhn_config_management
 
 rpcClasses = {
     'config': rhn_config_management.ConfigManagement,

--- a/backend/server/handlers/config_mgmt/__init__.py
+++ b/backend/server/handlers/config_mgmt/__init__.py
@@ -17,7 +17,7 @@
 
 __all__ = []
 
-import rhn_config_management
+from . import rhn_config_management
 
 rpcClasses = {
     'config': rhn_config_management.ConfigManagement,

--- a/backend/server/handlers/sat/__init__.py
+++ b/backend/server/handlers/sat/__init__.py
@@ -16,8 +16,8 @@
 
 __all__ = []
 
-import auth
-import cert
+from . import auth
+from . import cert
 
 rpcClasses = {
     'authentication':   auth.Authentication,

--- a/backend/server/handlers/sat/cert.py
+++ b/backend/server/handlers/sat/cert.py
@@ -20,7 +20,7 @@ from spacewalk.common.rhnException import rhnException
 
 # server imports
 from spacewalk.server import rhnSQL
-from auth import Authentication
+from .auth import Authentication
 
 
 class Certificate(Authentication):

--- a/backend/server/handlers/xmlrpc/__init__.py
+++ b/backend/server/handlers/xmlrpc/__init__.py
@@ -18,14 +18,14 @@
 
 __all__ = []
 
-import registration
-import up2date
-import queue
-import errata
-import proxy
-import get_handler
-import abrt
-import scap
+from . import registration
+from . import up2date
+from . import queue
+from . import errata
+from . import proxy
+from . import get_handler
+from . import abrt
+from . import scap
 
 rpcClasses = {
     "registration": registration.Registration,

--- a/backend/server/handlers/xmlrpc/getMethod.py
+++ b/backend/server/handlers/xmlrpc/getMethod.py
@@ -20,8 +20,8 @@
 # hierarchical route to the class/module, and method name.
 #
 
-import os
 import string
+import os
 import sys
 from spacewalk.common.usix import ClassType
 from distutils.sysconfig import get_python_lib
@@ -37,7 +37,7 @@ class GetMethodException(Exception):
 def sanity(methodNameComps):
     """ Verifies if all the components have proper names."""
     # Allowed characters in each string
-    alpha = string.lowercase + string.uppercase
+    alpha = string.ascii_lowercase + string.ascii_uppercase
     allowedChars = alpha + string.digits + '_'
     for comp in methodNameComps:
         if not len(comp):
@@ -57,7 +57,7 @@ def getMethod(methodName, baseClass):
         route/label.
     """
     # First split the method name
-    methodNameComps = ['spacewalk'] + string.split(baseClass, '.') + string.split(methodName, '.')
+    methodNameComps = ['spacewalk'] + baseClass.split('.') + methodName.split('.')
     # Sanity checks
     sanity(methodNameComps)
     # Build the path to the file
@@ -85,7 +85,7 @@ def getMethod(methodName, baseClass):
     # The position of the file
     fIndex = index + 1
     # Now build the module name
-    modulename = string.join(methodNameComps[:fIndex], '.')
+    modulename = '.'.join(methodNameComps[:fIndex])
     # And try to import it
     try:
         actions = __import__(modulename)
@@ -102,7 +102,7 @@ def getMethod(methodName, baseClass):
             if not hasattr(className, comp):
                 # Hmmm... Not there
                 raise GetMethodException("Class %s has no attribute %s" % (
-                    string.join(methodNameComps[:index], '.'), comp))
+                    '.'.join(methodNameComps[:index]), comp))
             className = getattr(className, comp)
             # print type(className)
             continue
@@ -110,11 +110,11 @@ def getMethod(methodName, baseClass):
         # We look for the special __rhnexport__ array
         if not hasattr(className, '__rhnexport__'):
             raise GetMethodException("Class %s is not valid" % \
-                                     string.join(methodNameComps[:index], '.'))
+                                     '.'.join(methodNameComps[:index]))
         export = getattr(className, '__rhnexport__')
         if comp not in export:
             raise GetMethodException("Class %s does not export '%s'" % (
-                string.join(methodNameComps[:index], '.'), comp))
+                '.'.join(methodNameComps[:index]), comp))
         className = getattr(className, comp)
         if type(className) is ClassType:
             # Try to instantiate it
@@ -144,8 +144,7 @@ if __name__ == '__main__':
             method = getMethod(m, 'Actions')
         except GetMethodException:
             e = sys.exc_info()[1]
-            print(("Error getting the method %s: %s" % (m,
-                                                       string.join(map(str, e.args)))))
+            print(("Error getting the method %s: %s" % (m , e.args)))
         else:
             method()
 #-----------------------------------------------------------------------------

--- a/backend/server/handlers/xmlrpc/queue.py
+++ b/backend/server/handlers/xmlrpc/queue.py
@@ -38,7 +38,7 @@ from spacewalk.server import rhnSQL, rhnCapability, rhnAction
 from spacewalk.server.rhnLib import InvalidAction, EmptyAction, ShadowAction
 from spacewalk.server.rhnServer import server_kickstart
 
-import getMethod
+from . import getMethod
 
 
 class Queue(rhnHandler):

--- a/backend/server/handlers/xmlrpc/up2date.py
+++ b/backend/server/handlers/xmlrpc/up2date.py
@@ -17,7 +17,6 @@
 
 # system module import
 import time
-import string
 
 from spacewalk.server.rhnServer import server_lib
 from spacewalk.common.usix import ListType, TupleType, StringType
@@ -111,9 +110,9 @@ class Up2date(rhnHandler):
         transport = rhnFlags.get('outputTransportOptions')
         for k, v in list(loginDict.items()):
             # Special case for channels
-            if string.lower(k) == string.lower('X-RHN-Auth-Channels'):
+            if k.lower() == 'X-RHN-Auth-Channels'.lower():
                 # Concatenate the channel information column-separated
-                transport[k] = [string.join(x, ':') for x in v]
+                transport[k] = [':'.join(x) for x in v]
             else:
                 transport[k] = v
         log_debug(5, "loginDict", loginDict, transport)

--- a/backend/server/repomd/mapper.py
+++ b/backend/server/repomd/mapper.py
@@ -25,7 +25,7 @@ from spacewalk.common.rhnConfig import CFG
 from spacewalk.common.usix import UnicodeType
 from spacewalk.server import rhnSQL
 
-import domain
+from . import domain
 
 
 CACHE_PREFIX = "/var/cache/rhn/"

--- a/backend/server/repomd/repository.py
+++ b/backend/server/repomd/repository.py
@@ -35,9 +35,9 @@ from spacewalk.common import rhnCache
 from spacewalk.common.rhnLog import log_debug
 from spacewalk.common.rhnConfig import CFG
 
-import mapper
-import view
-from domain import RepoMD
+from . import mapper
+from . import view
+from .domain import RepoMD
 from spacewalk.server import rhnChannel
 
 # One meg

--- a/backend/server/rhnCapability.py
+++ b/backend/server/rhnCapability.py
@@ -22,7 +22,7 @@ from spacewalk.common import rhnFlags
 from spacewalk.common.rhnLog import log_debug
 
 # local module
-import rhnSQL
+from . import rhnSQL
 
 # Globally store the parsed capabilities in rhnFlags
 

--- a/backend/server/rhnChannel.py
+++ b/backend/server/rhnChannel.py
@@ -1077,8 +1077,8 @@ def list_packages_source(channel_id):
     if results:
         for r in results:
             r = r['name']
-            if string.find(r, ".rpm") != -1:
-                r = string.replace(r, ".rpm", "")
+            if r.find(".rpm") != -1:
+                r = r.replace(".rpm", "")
                 new_evr = rhnLib.make_evr(r, source=1)
                 new_evr_list = [new_evr['name'], new_evr['version'], new_evr['release'], new_evr['epoch']]
             ret.append(new_evr_list)

--- a/backend/server/rhnDependency.py
+++ b/backend/server/rhnDependency.py
@@ -16,8 +16,8 @@
 
 from spacewalk.common.rhnLog import log_debug, log_error
 from spacewalk.common.rhnException import rhnFault
-import rhnSQL
-import rhnLib
+from . import rhnSQL
+from . import rhnLib
 import rpm
 
 # QUERY PACKAGES

--- a/backend/server/rhnLib.py
+++ b/backend/server/rhnLib.py
@@ -15,7 +15,6 @@
 
 import os
 import hashlib
-import string
 import base64
 import posixpath
 
@@ -57,9 +56,9 @@ def parseRPMFilename(pkgFilename):
 
     # Check that this is a package NAME (with arch.rpm) and strip
     # that crap off.
-    pkg = string.split(pkgFilename, '.')
+    pkg = pkgFilename.split('.')
 
-    dist = string.lower(pkg[-1])
+    dist = pkg[-1].lower()
 
     # 'rpm' at end?
     if dist not in ['rpm', 'deb']:
@@ -72,7 +71,7 @@ def parseRPMFilename(pkgFilename):
     _arch = pkg[-2]
 
     # Nuke that arch.rpm.
-    pkg = string.join(pkg[:-2], '.')
+    pkg = '.'.join(pkg[:-2])
 
     if dist == "deb":
         ret = list(parseDEBName(pkg))

--- a/backend/server/rhnRepository.py
+++ b/backend/server/rhnRepository.py
@@ -31,8 +31,8 @@ from spacewalk.common.rhnLib import rfc822time, timestamp
 
 # local modules imports
 from spacewalk.server import rhnChannel, rhnPackage, taskomatic, rhnSQL
-from rhnServer import server_lib
-from repomd import repository
+from .rhnServer import server_lib
+from .repomd import repository
 
 
 class Repository(rhnRepository.Repository):

--- a/backend/server/rhnSQL/sql_base.py
+++ b/backend/server/rhnSQL/sql_base.py
@@ -23,7 +23,6 @@
 # class.
 #
 
-import string
 import sys
 from . import sql_types
 from spacewalk.common import usix
@@ -60,7 +59,7 @@ class SQLSchemaError(SQLError):
 
     def __init__(self, errno, errmsg, *args):
         self.errno = errno
-        (self.errmsg, errmsg) = string.split(errmsg, '\n', 1)
+        (self.errmsg, errmsg) = errmsg.split('\n', 1)
         SQLError.__init__(self, self.errno, self.errmsg, errmsg, *args)
 
 

--- a/backend/server/rhnServer/satellite_cert.py
+++ b/backend/server/rhnServer/satellite_cert.py
@@ -17,7 +17,6 @@
 # certificate
 #
 
-import string
 import sys
 from xml.dom.minidom import parseString
 from xml.sax import SAXParseException
@@ -48,9 +47,8 @@ class Item:
 
     def __repr__(self):
         return "<%s; %s>" % (self.pretty_name,
-                             string.join(
-                                 ['%s="%s"' % (x, getattr(self, x)) for x in list(self.attributes.values())],
-                                 ', '
+                             ', '.join(
+                                 ['%s="%s"' % (x, getattr(self, x)) for x in list(self.attributes.values())]
                              ))
 
 
@@ -214,4 +212,4 @@ class SatelliteCert:
 
 
 def get_text(node):
-    return string.join([x.data for x in node.childNodes if x.nodeType == x.TEXT_NODE], "")
+    return "".join([x.data for x in node.childNodes if x.nodeType == x.TEXT_NODE])

--- a/backend/server/rhnServer/server_class.py
+++ b/backend/server/rhnServer/server_class.py
@@ -16,7 +16,6 @@
 #
 
 # system modules
-import string
 import sys
 
 from spacewalk.common.usix import raise_with_tb
@@ -278,7 +277,7 @@ class Server(ServerWrapper):
             on your system and has updated your channel subscriptions
             to reflect that.
             Your server has been automatically subscribed to the following
-            channels:\n%s\n""" % (string.join(channel_list, "\n"),)
+            channels:\n%s\n""" % ("\n".join(channel_list),)
         else:
             msg = """*** ERROR: ***
             While trying to subscribe this server to software channels:
@@ -490,7 +489,7 @@ class Server(ServerWrapper):
         if uuid is not None:
             uuid = str(uuid)
         if not uuid:
-            log_debug('Nothing to do')
+            log_debug(3, 'Nothing to do')
             return
 
         uuid = uuid[:uuid_col_length]

--- a/backend/server/rhnServer/server_hardware.py
+++ b/backend/server/rhnServer/server_hardware.py
@@ -525,8 +525,8 @@ class NetIfaceInformation(Device):
 
         columns = list(self.key_mapping.values()) + ['server_id', 'name']
         columns.sort()
-        bind_params = string.join([':' + x for x in columns], ", ")
-        h = rhnSQL.prepare(q % (string.join(columns, ", "), bind_params))
+        bind_params = ", ".join([':' + x for x in columns])
+        h = rhnSQL.prepare(q % (", ".join(columns), bind_params))
         return _dml(h, params)
 
     def _delete(self, params):
@@ -535,7 +535,7 @@ class NetIfaceInformation(Device):
 
         columns = ['server_id', 'name']
         wheres = ['%s = :%s' % (x, x) for x in columns]
-        h = rhnSQL.prepare(q % string.join(wheres, " and "))
+        h = rhnSQL.prepare(q % " and ".join(wheres))
         return _dml(h, params)
 
     def _update(self, params):
@@ -546,12 +546,12 @@ class NetIfaceInformation(Device):
 
         wheres = ['server_id', 'name']
         wheres = ['%s = :%s' % (x, x) for x in wheres]
-        wheres = string.join(wheres, " and ")
+        wheres = " and ".join(wheres)
 
         updates = list(self.key_mapping.values())
         updates.sort()
         updates = ['%s = :%s' % (x, x) for x in updates]
-        updates = string.join(updates, ", ")
+        updates = ", ".join(updates)
 
         h = rhnSQL.prepare(q % (updates, wheres))
         return _dml(h, params)
@@ -692,8 +692,8 @@ class NetIfaceAddress(Device):
 
         columns = list(self.key_mapping.values()) + ['interface_id']
         columns.sort()
-        bind_params = string.join([':' + x for x in columns], ", ")
-        h = rhnSQL.prepare(q % (self.table, string.join(columns, ", "), bind_params))
+        bind_params = ", ".join([':' + x for x in columns])
+        h = rhnSQL.prepare(q % (self.table, ", ".join(columns), bind_params))
         return _dml(h, params)
 
     def _delete(self, params):
@@ -702,7 +702,7 @@ class NetIfaceAddress(Device):
 
         columns = self.unique
         wheres = ['%s = :%s' % (x, x) for x in columns]
-        h = rhnSQL.prepare(q % (self.table, string.join(wheres, " and ")))
+        h = rhnSQL.prepare(q % (self.table, " and ".join(wheres)))
         return _dml(h, params)
 
     def _update(self, params):
@@ -713,12 +713,12 @@ class NetIfaceAddress(Device):
 
         wheres = self.unique
         wheres = ['%s = :%s' % (x, x) for x in wheres]
-        wheres = string.join(wheres, " and ")
+        wheres = " and ".join(wheres)
 
         updates = list(self.key_mapping.values())
         updates.sort()
         updates = ['%s = :%s' % (x, x) for x in updates]
-        updates = string.join(updates, ", ")
+        updates = ", ".join(updates)
 
         h = rhnSQL.prepare(q % (self.table, updates, wheres))
         return _dml(h, params)
@@ -1081,7 +1081,7 @@ class Hardware:
         hw_class = hardware.get("class")
         if hw_class is None:
             return -1
-        hw_class = string.lower(hw_class)
+        hw_class = hw_class.lower()
 
         class_type = None
 

--- a/backend/server/rhnServer/server_lib.py
+++ b/backend/server/rhnServer/server_lib.py
@@ -18,7 +18,6 @@
 import os
 import hashlib
 import time
-import string
 import sys
 
 if sys.version_info[0] == 3:
@@ -89,7 +88,7 @@ def getServerID(server, fields=[]):
     archdb = ""
     archjoin = ""
     # look at the fields
-    fields = list(map(string.lower, fields))
+    fields = [f.lower() for f in fields]
     for k in fields:
         if k == "id":  # already there
             continue
@@ -361,8 +360,8 @@ def generate_random_string(length=20):
 
     devrandom.close()
 
-    result = string.join(result, '')[:length]
-    return string.lower(result)
+    result = ''.join(result)[:length]
+    return result.lower()
 
 if __name__ == '__main__':
     rhnSQL.initDB()

--- a/backend/server/rhnServer/server_packages.py
+++ b/backend/server/rhnServer/server_packages.py
@@ -17,7 +17,6 @@
 # profiles.
 #
 
-import string
 import sys
 import time
 from spacewalk.common.usix import DictType
@@ -48,7 +47,7 @@ class dbPackage:
             return None
         if ('arch' not in pdict) or (pdict['arch'] is None):
             pdict['arch'] = ""
-        if string.lower(str(pdict['epoch'])) == "(none)" or pdict['epoch'] == "" or pdict['epoch'] is None:
+        if str(pdict['epoch']).lower() == "(none)" or pdict['epoch'] == "" or pdict['epoch'] is None:
             pdict['epoch'] = None
         else:
             pdict['epoch'] = str(pdict['epoch'])

--- a/backend/server/rhnServer/server_route.py
+++ b/backend/server/rhnServer/server_route.py
@@ -16,8 +16,6 @@
 # Module for storing client route through proxies
 #
 
-import string
-
 from spacewalk.common import rhnFlags
 from spacewalk.common.rhnLog import log_debug
 from spacewalk.server import rhnSQL, apacheAuth
@@ -51,7 +49,7 @@ def store_client_route(server_id):
     # code block if there *is* routing info in the headers
     # NOTE: X-RHN-Proxy-Auth described in proxy/broker/rhnProxyAuth.py
     if rhnFlags.test('X-RHN-Proxy-Auth'):
-        tokens = string.split(rhnFlags.get('X-RHN-Proxy-Auth'), ',')
+        tokens = rhnFlags.get('X-RHN-Proxy-Auth').split(',')
         tokens = [token for token in tokens if token]
 
         log_debug(4, "route tokens", tokens)

--- a/backend/server/rhnSession.py
+++ b/backend/server/rhnSession.py
@@ -19,7 +19,6 @@
 
 import hashlib
 import time
-import string
 import sys
 
 from spacewalk.common.rhnConfig import CFG
@@ -71,10 +70,9 @@ class Session:
         secrets = self.get_secrets()
 
         ctx = hashlib.new('sha256')
-        ctx.update(string.join(secrets[:2] + [str(self.session_id)] +
-                               secrets[2:], ':'))
+        ctx.update(':'.join(secrets[:2] + [str(self.session_id)] + secrets[2:]))
 
-        return string.join(["%02x" % ord(a) for a in ctx.digest()], '')
+        return ''.join(["%02x" % ord(a) for a in ctx.digest()])
 
     def get_session(self):
         return "%sx%s" % (self.session_id, self.digest())
@@ -85,7 +83,7 @@ class Session:
         return self.uid
 
     def load(self, session):
-        arr = string.split(session, 'x', 1)
+        arr = session.split('x', 1)
         if len(arr) != 2:
             raise InvalidSessionError("Invalid session string")
 

--- a/backend/server/rhnVirtualization.py
+++ b/backend/server/rhnVirtualization.py
@@ -18,7 +18,6 @@
 #
 
 
-import string
 import time
 import sys
 
@@ -475,7 +474,7 @@ class VirtualizationEventHandler:
 
         # Only touch the database if something changed.
         if new_values_array:
-            new_values = string.join(new_values_array, ', ')
+            new_values = ', '.join(new_values_array)
 
             bindings['row_id'] = existing_row['id']
 
@@ -599,7 +598,7 @@ class VirtualizationEventHandler:
 
         # Only touch the database if something changed.
         if new_values_array:
-            new_values = string.join(new_values_array, ', ')
+            new_values = ', '.join(new_values_array)
 
             bindings['row_id'] = existing_row['rvi_id']
 
@@ -657,7 +656,7 @@ class VirtualizationEventHandler:
 
         # Only touch the database if something changed.
         if new_values_array:
-            new_values = string.join(new_values_array, ', ')
+            new_values = ', '.join(new_values_array)
 
             bindings['row_id'] = existing_row['instance_id']
 
@@ -732,7 +731,7 @@ class VirtualizationEventHandler:
         if PropertyType.UUID in properties:
             uuid = properties[PropertyType.UUID]
             if uuid:
-                uuid_as_number = string.atol(uuid, 16)
+                uuid_as_number = int(uuid, 16)
 
                 if uuid_as_number == 0:
                     # If the UUID is a bunch of null bytes, we will convert it

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,6 @@
+- Fix issues with HTTP proxy and reposync.
+- Solve Python 3 problem and allow traditional registration.
+
 -------------------------------------------------------------------
 Fri Feb 08 17:38:16 CET 2019 - jgonzalez@suse.com
 

--- a/backend/wsgi/wsgiRequest.py
+++ b/backend/wsgi/wsgiRequest.py
@@ -58,6 +58,8 @@ class WsgiRequest:
         return repr(self.__dict__)
 
     def write(self, msg):
+        if isinstance(msg, str):
+            msg = msg.encode()
         self.output.append(msg)
 
     def send_http_header(self, status=None):

--- a/client/rhel/rhnlib/rhn/UserDictCase.py
+++ b/client/rhel/rhnlib/rhn/UserDictCase.py
@@ -23,7 +23,7 @@ try: # python2
     from types import StringType
 except ImportError: # python3
     from collections import UserDict
-    StringType = bytes
+    StringType = str
     from functools import reduce
 
 # A dictionary with case insensitive keys

--- a/client/rhel/rhnlib/rhn/transports.py
+++ b/client/rhel/rhnlib/rhn/transports.py
@@ -682,7 +682,7 @@ class BaseOutput:
             encoding_name = self.encodings[self.ENCODE_ZLIB][0]
             self.set_header("Content-Encoding", encoding_name)
             obj = zlib.compressobj(COMPRESS_LEVEL)
-            self.data = obj.compress(data) + obj.flush()
+            self.data = obj.compress(data.encode()) + obj.flush()
         elif self.encoding == self.ENCODE_GPG:
             # XXX: fix me.
             raise NotImplementedError(self.transfer, self.encoding)

--- a/client/rhel/rhnlib/rhnlib.changes
+++ b/client/rhel/rhnlib/rhnlib.changes
@@ -1,3 +1,5 @@
+- Fix encoding issues after porting to Python 3. 
+
 -------------------------------------------------------------------
 Thu Jan 31 09:38:49 CET 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?
This PR fixes multiple issues involved on traditional client registration:

- Remove use of obsolete `string` module methods.
- Fix encoding issues.
- Solve problem with HTTP proxy and "reposync".
- Allow registration of a traditional client.

## Test coverage
- No tests: **Several bugfixing. No specific tests**

- [x] **DONE**

## Links
Tracks # https://github.com/SUSE/salt-board/issues/247

- [x] **DONE**
