### PR TITLE
YaST2 setup: Improve openSUSE detection

### DIFF
--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -2,10 +2,10 @@
 
 DISTRIBUTION_ID="$(source /etc/os-release && echo ${ID})"
 case ${DISTRIBUTION_ID} in
-    sles)      JVM='/usr/lib64/jvm/jre-11-openjdk/bin/java';;
-    opensuse)  JVM='/usr/lib64/jvm/jre-11-openjdk/bin/java';;
-    *)         echo 'Unknown distribution!'
-               exit 1;;
+    sles)                    JVM='/usr/lib64/jvm/jre-11-openjdk/bin/java';;
+    opensuse|opensuse-leap)  JVM='/usr/lib64/jvm/jre-11-openjdk/bin/java';;
+    *)                       echo 'Unknown distribution!'
+                             exit 1;;
 esac
 
 if [ ! $UID -eq 0 ]; then

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- Fix setup for openSUSE Leap 15.0
 - support migration from 3.2 to 4.0
 - remove SCC setup from YaST SUSE Manager setup
 - Do not show false errors when configuring swapfile during setup


### PR DESCRIPTION
## What does this PR change?

YaST2 setup: Improve openSUSE detection. It seems that `ID` is not `opensuse` as it was for Leap 42.3

I am leaving `opensuse` as well, in case somebody decides to revert that for Leap 15.1 or future versions.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Internal change for setup tools

- [x] **DONE**

## Test coverage
- No tests: Tested by cucumber.

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/6805

- [x] **DONE**