### PR TITLE
 Avoid assigning multiple base channels to RES6 minions (bsc#1124794)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/channel/test/ChannelFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/test/ChannelFactoryTest.java
@@ -88,6 +88,17 @@ public class ChannelFactoryTest extends RhnBaseTestCase {
         return c;
     }
 
+    public static Channel createBaseChannel(User user, String channelArchLabel) throws Exception {
+        Channel c = ChannelFactoryTest.createTestChannel(user, channelArchLabel);
+        c.setOrg(user.getOrg());
+
+        ProductName pn = lookupOrCreateProductName(ChannelManager.RHEL_PRODUCT_NAME);
+        c.setProductName(pn);
+
+        ChannelFactory.save(c);
+        return c;
+    }
+
     public static Channel createBaseChannel(User user,
                                 ChannelFamily fam) throws Exception {
         Channel c = createTestChannel(null, fam);

--- a/java/code/src/com/redhat/rhn/manager/content/MgrSyncUtils.java
+++ b/java/code/src/com/redhat/rhn/manager/content/MgrSyncUtils.java
@@ -48,8 +48,8 @@ public class MgrSyncUtils {
     private static final String OFFICIAL_NOVELL_UPDATE_HOST = "nu.novell.com";
     private static final List<String> OFFICIAL_UPDATE_HOSTS =
             Arrays.asList("updates.suse.com", OFFICIAL_NOVELL_UPDATE_HOST);
-    private static final List<String> PRODUCT_ARCHS = Arrays.asList("i586", "ia64", "ppc64le", "ppc64", "ppc",
-            "s390x", "s390", "x86_64", "aarch64", "amd64");
+    private static final List<String> PRODUCT_ARCHS = Arrays.asList("i386", "i486", "i586", "i686", "ia64", "ppc64le",
+            "ppc64", "ppc", "s390x", "s390", "x86_64", "aarch64", "amd64");
 
     // No instances should be created
     private MgrSyncUtils() {

--- a/java/code/src/com/suse/manager/reactor/messaging/test/ImageDeployedEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/ImageDeployedEventMessageActionTest.java
@@ -1,5 +1,7 @@
 package com.suse.manager.reactor.messaging.test;
 
+import static java.util.Arrays.asList;
+
 import com.redhat.rhn.common.messaging.EventMessage;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.channel.Channel;
@@ -11,6 +13,7 @@ import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
 import com.redhat.rhn.domain.product.SUSEProduct;
 import com.redhat.rhn.domain.product.test.SUSEProductTestUtils;
 import com.redhat.rhn.domain.server.MinionServer;
+import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.manager.action.ActionManager;
 import com.redhat.rhn.manager.distupgrade.test.DistUpgradeManagerTest;
@@ -20,6 +23,7 @@ import com.redhat.rhn.testing.ChannelTestUtils;
 import com.redhat.rhn.testing.ErrataTestUtils;
 import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 import com.redhat.rhn.testing.TestUtils;
+
 import com.suse.manager.reactor.messaging.ImageDeployedEventMessage;
 import com.suse.manager.reactor.messaging.ImageDeployedEventMessageAction;
 import com.suse.manager.reactor.utils.ValueMap;
@@ -40,8 +44,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
-import static java.util.Arrays.asList;
 
 /**
  * Test for {@link com.suse.manager.webui.utils.salt.ImageDeployedEvent}
@@ -68,6 +70,7 @@ public class ImageDeployedEventMessageActionTest extends JMockBaseTestCaseWithUs
 
         // setup a minion
         testMinion = MinionServerFactoryTest.createTestMinionServer(user);
+        testMinion.setServerArch(ServerFactory.lookupServerArchByLabel("x86_64-redhat-linux"));
         grains = getGrains();
 
         // setup channels & product
@@ -121,8 +124,10 @@ public class ImageDeployedEventMessageActionTest extends JMockBaseTestCaseWithUs
         grains.put("machine_id", testMinion.getMachineId());
 
         Channel oldBase = ChannelTestUtils.createBaseChannel(user);
+        oldBase.setChannelArch(ChannelFactory.lookupArchByName("x86_64"));
         SystemManager.subscribeServerToChannel(user, testMinion, oldBase);
         Channel oldChild = ChannelTestUtils.createChildChannel(user, oldBase);
+        oldChild.setChannelArch(ChannelFactory.lookupArchByName("x86_64"));
         SystemManager.subscribeServerToChannel(user, testMinion, oldChild);
         System.out.println(testMinion.getChannels());
 
@@ -155,8 +160,8 @@ public class ImageDeployedEventMessageActionTest extends JMockBaseTestCaseWithUs
         Channel baseChannelX8664 = DistUpgradeManagerTest
                 .createTestBaseChannel(channelFamily, channelProduct, channelArch);
         SUSEProductTestUtils.createTestSUSEProductChannel(baseChannelX8664, product, true);
-        Channel channel2 = ChannelFactoryTest.createTestChannel(user);
-        Channel channel3 = ChannelFactoryTest.createTestChannel(user);
+        Channel channel2 = ChannelFactoryTest.createTestChannel(user, "channel-x86_64");
+        Channel channel3 = ChannelFactoryTest.createTestChannel(user, "channel-x86_64");
         channel2.setParentChannel(baseChannelX8664);
         channel3.setParentChannel(baseChannelX8664);
         SUSEProductTestUtils.createTestSUSEProductChannel(channel2, product, true);

--- a/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
@@ -14,6 +14,11 @@
  */
 package com.suse.manager.reactor.test;
 
+import static com.redhat.rhn.testing.ErrataTestUtils.createTestChannelFamily;
+import static com.redhat.rhn.testing.ErrataTestUtils.createTestChannelProduct;
+import static com.redhat.rhn.testing.RhnBaseTestCase.assertContains;
+import static java.util.Collections.singletonMap;
+
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.action.Action;
@@ -61,6 +66,7 @@ import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 import com.redhat.rhn.testing.ServerTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
+
 import com.suse.manager.reactor.messaging.RegisterMinionEventMessage;
 import com.suse.manager.reactor.messaging.RegisterMinionEventMessageAction;
 import com.suse.manager.reactor.utils.test.RhelUtilsTest;
@@ -95,11 +101,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
-
-import static com.redhat.rhn.testing.ErrataTestUtils.createTestChannelFamily;
-import static com.redhat.rhn.testing.ErrataTestUtils.createTestChannelProduct;
-import static com.redhat.rhn.testing.RhnBaseTestCase.assertContains;
-import static java.util.Collections.singletonMap;
 
 /**
  * Tests for {@link RegisterMinionEventMessageAction}.
@@ -164,7 +165,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
             }};
 
     private ActivationKeySupplier ACTIVATION_KEY_SUPPLIER = (contactMethod) -> {
-        Channel baseChannel = ChannelFactoryTest.createBaseChannel(user);
+        Channel baseChannel = ChannelFactoryTest.createBaseChannel(user, "channel-x86_64");
         ActivationKey key = ActivationKeyTest.createTestActivationKey(user);
         key.setBaseChannel(baseChannel);
         key.setOrg(user.getOrg());
@@ -1359,8 +1360,10 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
      * @throws java.lang.Exception if anything goes wrong
      */
     public void testMigrationSystemWithChannelsAndAK() throws Exception {
-        Channel akBaseChannel = ChannelTestUtils.createBaseChannel(user);
-        Channel akChildChannel = ChannelTestUtils.createChildChannel(user, akBaseChannel);
+        Channel akBaseChannel = ChannelFactoryTest.createBaseChannel(user, "channel-x86_64");
+        Channel akChildChannel = ChannelFactoryTest.createTestChannel(user, "channel-x86_64");
+        akChildChannel.setParentChannel(akBaseChannel);
+        TestUtils.saveAndFlush(akChildChannel);
 
         Channel assignedChannel = ChannelTestUtils.createBaseChannel(user);
         ServerFactory.findByMachineId(MACHINE_ID).ifPresent(ServerFactory::delete);
@@ -1411,9 +1414,13 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
      * @throws java.lang.Exception if anything goes wrong
      */
     public void testMigrationSystemWithChannelsAndAKSameBase() throws Exception {
-        Channel akBaseChannel = ChannelTestUtils.createBaseChannel(user);
-        Channel akChildChannel = ChannelTestUtils.createChildChannel(user, akBaseChannel);
-        Channel assignedChildChannel = ChannelTestUtils.createChildChannel(user, akBaseChannel);
+        Channel akBaseChannel = ChannelFactoryTest.createBaseChannel(user, "channel-x86_64");
+        Channel akChildChannel = ChannelFactoryTest.createTestChannel(user, "channel-x86_64");
+        akChildChannel.setParentChannel(akBaseChannel);
+        TestUtils.saveAndFlush(akChildChannel);
+        Channel assignedChildChannel = ChannelFactoryTest.createTestChannel(user, "channel-x86_64");
+        assignedChildChannel.setParentChannel(akBaseChannel);
+        TestUtils.saveAndFlush(assignedChildChannel);
 
         ServerFactory.findByMachineId(MACHINE_ID).ifPresent(ServerFactory::delete);
         Server server = ServerTestUtils.createTestSystem(user);
@@ -1462,8 +1469,11 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
      * @throws java.lang.Exception if anything goes wrong
      */
     public void testMigrationSystemWithChannelsNoAK() throws Exception {
-        Channel assignedChannel = ChannelTestUtils.createBaseChannel(user);
-        Channel assignedChildChannel = ChannelTestUtils.createChildChannel(user, assignedChannel);
+        Channel assignedChannel = ChannelFactoryTest.createBaseChannel(user, "channel-x86_64");
+        Channel assignedChildChannel = ChannelFactoryTest.createTestChannel(user, "channel-x86_64");
+        assignedChildChannel.setParentChannel(assignedChannel);
+        TestUtils.saveAndFlush(assignedChildChannel);
+
         ServerFactory.findByMachineId(MACHINE_ID).ifPresent(ServerFactory::delete);
         Server server = ServerTestUtils.createTestSystem(user);
         server.setMachineId(MACHINE_ID);
@@ -1507,8 +1517,8 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         Channel baseChannelX8664 = DistUpgradeManagerTest
                 .createTestBaseChannel(channelFamily, channelProduct, channelArch);
         SUSEProductTestUtils.createTestSUSEProductChannel(baseChannelX8664, product, true);
-        Channel channel2 = ChannelFactoryTest.createTestChannel(user);
-        Channel channel3 = ChannelFactoryTest.createTestChannel(user);
+        Channel channel2 = ChannelFactoryTest.createTestChannel(user, "channel-x86_64");
+        Channel channel3 = ChannelFactoryTest.createTestChannel(user, "channel-x86_64");
         channel2.setParentChannel(baseChannelX8664);
         channel3.setParentChannel(baseChannelX8664);
         SUSEProductTestUtils.createTestSUSEProductChannel(channel2, product, true);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- prevent an error when onboarding a RES 6 minion (bsc#1124794)
+
 -------------------------------------------------------------------
 Mon Mar 25 16:43:10 CET 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

**add description**

It prevents an error which resulted in a minion having two base channels, which among other things causes an ISE in the System list page.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **unit tests already cover this**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/7015
Tracks https://github.com/SUSE/spacewalk/pull/7003

- [x] **DONE**

