### PR TITLE
Event watchdog

### DIFF
--- a/java/code/src/com/suse/manager/reactor/PGEventStream.java
+++ b/java/code/src/com/suse/manager/reactor/PGEventStream.java
@@ -41,8 +41,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Timer;
 import java.util.TimerTask;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 /**
@@ -55,8 +56,12 @@ public class PGEventStream extends AbstractEventStream implements PGNotification
     private static final int THREAD_POOL_SIZE = ConfigDefaults.get().getSaltEventThreadPoolSize();
 
     private PGConnection connection;
-    private final ExecutorService executorService = Executors.newFixedThreadPool(
+    private final ThreadPoolExecutor executorService = new ThreadPoolExecutor(
             THREAD_POOL_SIZE,
+            THREAD_POOL_SIZE,
+            0L,
+            TimeUnit.MILLISECONDS,
+            new LinkedBlockingQueue<Runnable>(),
             new BasicThreadFactory.Builder().namingPattern("salt-event-thread-%d").build()
     );
 

--- a/susemanager-utils/susemanager-sls/modules/engines/mgr_events.py
+++ b/susemanager-utils/susemanager-sls/modules/engines/mgr_events.py
@@ -170,7 +170,7 @@ class Responder:
         if self.tokens > 0 and self.counter > 0:
             log.debug("%s: commit", __name__)
             self.cursor.execute(
-                'NOTIFY {};'.format(self.config['postgres_db']['notify_channel'])
+                "NOTIFY {}, '{}';".format(self.config['postgres_db']['notify_channel'], self.counter)
             )
             self.connection.commit()
             self.counter = 0

--- a/susemanager-utils/susemanager-sls/test/test_engine.py
+++ b/susemanager-utils/susemanager-sls/test/test_engine.py
@@ -142,7 +142,7 @@ def test_postgres_notification(responder):
         responder._insert('salt/minion/1/start', {'value': 1})
         assert responder.counter == 0
         assert responder.tokens == DEFAULT_COMMIT_BURST -1
-        assert responder.cursor.execute.mock_calls[-1:] == [call('NOTIFY suseSaltEvent;')]
+        assert responder.cursor.execute.mock_calls[-1:] == [call("NOTIFY suseSaltEvent, '1';")]
 
 def test_add_token(responder):
     responder.tokens = 0

--- a/susemanager-utils/susemanager-sls/test/test_engine.py
+++ b/susemanager-utils/susemanager-sls/test/test_engine.py
@@ -158,11 +158,11 @@ def test_commit_avoidance_without_tokens(responder):
         with patch.object(responder, 'connection') as mock_connection:
             mock_connection.closed = False
             responder.tokens = 0
-            responder._insert('salt/minion/1/start', {'value': 1})
+            responder._insert('salt/minion/1/start', {'id': 'testminion', 'value': 1})
             assert responder.counter == 1
             assert responder.tokens == 0
             assert responder.connection.commit.call_count == 0
-            assert responder.cursor.execute.mock_calls == [call('INSERT INTO suseSaltEvent (data) VALUES (%s);', ('{"tag": "salt/minion/1/start", "data": {"value": 1}}',))]
+            assert responder.cursor.execute.mock_calls == [call('INSERT INTO suseSaltEvent (minion_id, data) VALUES (%s, %s);', ('testminion', '{"tag": "salt/minion/1/start", "data": {"id": "testminion", "value": 1}}',))]
 
 
 def test_postgres_connect(db_connection, responder):


### PR DESCRIPTION
## What does this PR change?

Under high load `PGEventStream` currently schedules more worker jobs than incoming Salt events. The extra jobs won't do harm as they will just check an empty `suseSaltEvent` table, still it can generate considerable CPU load at the end of normal execution.

This patch changes the way the number of worker jobs is calculated to be much more aligned with reality, and introduces a watchdog check to handle cases in which there are deviations for unexpected reasons.

### Example workload (onboarding of 500 simulated minions, very highly loaded hardware)

Before:

![before](https://user-images.githubusercontent.com/250541/52597622-baa43e00-2e53-11e9-8937-1251ad42b06c.png)

After:

![after](https://user-images.githubusercontent.com/250541/52597625-bd069800-2e53-11e9-9992-4c6c24a88e05.png)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- Unit tests were added for mgr_engine.py
- Other parts covered by Cucumber and PTS

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/7004

- [x] **DONE**