### PR TITLE
Test: fix archived action JUnit test

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/action/test/ActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/action/test/ActionManagerTest.java
@@ -153,6 +153,51 @@ public class ActionManagerTest extends JMockBaseTestCaseWithUser {
         assertNotNull(a2);
     }
 
+    public void testActionsArchivedOnSystemDeleteUser() throws Exception {
+        Server server = ServerTestUtils.createTestSystem(user);
+
+        Action action = ActionFactoryTest.createAction(user, ActionFactory.TYPE_ERRATA);
+        ServerAction serverAction = ServerActionTest.createServerAction(server, action);
+        serverAction.setStatus(ActionFactory.STATUS_COMPLETED);
+
+        action.addServerAction(serverAction);
+        ActionManager.storeAction(action);
+
+        Action result = ActionManager.lookupAction(user, action.getId());
+        assertNotNull(result);
+
+        SystemManager.deleteServer(user, server.getId());
+
+        try {
+            // Regular users cannot see orphan actions
+            ActionManager.lookupAction(user, action.getId());
+            fail("Must throw LookupException.");
+        }
+        catch (LookupException ignored) {
+        }
+    }
+
+    public void testActionsArchivedOnSystemDeleteAdmin() throws Exception {
+        user.addPermanentRole(RoleFactory.ORG_ADMIN);
+        Server server = ServerTestUtils.createTestSystem(user);
+        Action action = ActionFactoryTest.createAction(user, ActionFactory.TYPE_ERRATA);
+        ServerAction serverAction = ServerActionTest.createServerAction(server, action);
+        serverAction.setStatus(ActionFactory.STATUS_COMPLETED);
+
+        action.addServerAction(serverAction);
+        ActionManager.storeAction(action);
+
+        Action result = ActionManager.lookupAction(user, action.getId());
+        assertNotNull(result);
+
+        SystemManager.deleteServer(user, server.getId());
+        // Admins should see orphan actions
+        result = ActionManager.lookupAction(user, action.getId());
+        assertNotNull(result);
+        assertEquals(1, (long) result.getArchived());
+        assertServerActionCount(action, 0);
+    }
+
     public void testFailedActions() throws Exception {
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
         Action parent = ActionFactoryTest.createAction(user, ActionFactory.TYPE_ERRATA);


### PR DESCRIPTION
## What does this PR change?

Fix JUnit test for archived action

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: internal JUnit

- [X] **DONE**

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/7025

- [X] **DONE**
