### PR TITLE
Fix failing unit test on "susemanager-unittests"

### DIFF
--- a/susemanager/src/test/test_mgr_sync/test_refresh_operations.py
+++ b/susemanager/src/test/test_mgr_sync/test_refresh_operations.py
@@ -47,7 +47,7 @@ class RefreshOperationsTest(unittest.TestCase):
 
     def test_refresh_from_mirror(self):
         """ Test the refresh action """
-	mirror_url = "http://smt.suse.de"
+        mirror_url = "http://smt.suse.de"
         options = get_options("refresh --from-mirror {0}".format(mirror_url).split())
         stubbed_xmlrpm_call = MagicMock(return_value=True)
         self.mgr_sync._execute_xmlrpc_method = stubbed_xmlrpm_call


### PR DESCRIPTION
## What does this PR change?

This PR fixes a failing test on `susemanager-unittests`:

```console
======================================================================
ERROR: Failure: TabError (inconsistent use of tabs and spaces in indentation (test_refresh_operations.py, line 50))
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/nose/failure.py", line 39, in runTest
    raise self.exc_val.with_traceback(self.tb)
  File "/usr/lib/python3.6/site-packages/nose/loader.py", line 417, in loadTestsFromName
    addr.filename, addr.module)
  File "/usr/lib/python3.6/site-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/usr/lib/python3.6/site-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/usr/lib64/python3.6/imp.py", line 235, in load_module
    return load_source(name, filename, file)
  File "/usr/lib64/python3.6/imp.py", line 172, in load_source
    module = _load(spec)
  File "<frozen importlib._bootstrap>", line 684, in _load
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 674, in exec_module
  File "<frozen importlib._bootstrap_external>", line 781, in get_code
  File "<frozen importlib._bootstrap_external>", line 741, in source_to_code
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/manager/susemanager/src/test/test_mgr_sync/test_refresh_operations.py", line 50
    mirror_url = "http://smt.suse.de"
                                    ^
TabError: inconsistent use of tabs and spaces in indentation

----------------------------------------------------------------------
Ran 58 tests in 3.449s

FAILED (errors=1)
make: *** [Makefile.susemanager:19: unittest_inside_docker] Error 1
```

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/salt-board/issues/247

- [x] **DONE**