### PR TITLE
Fix GPG and "ISO8859-1" encoding issues with "spacewalk-repo-sync"

### DIFF
--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -456,10 +456,16 @@ class ContentSource:
 enabled=1
 autorefresh=0
 baseurl={baseurl}
+gpgcheck={gpgcheck}
+repo_gpgcheck={gpgcheck}
 type=rpm-md
 '''
         with open(os.path.join(repo.root, "etc/zypp/repos.d", str(self.channel_label or self.reponame) + ".repo"), "w") as repo_conf_file:
-            repo_conf_file.write(repo_cfg.format(reponame=self.channel_label or self.reponame, baseurl=zypp_repo_url))
+            repo_conf_file.write(repo_cfg.format(
+				reponame=self.channel_label or self.reponame,
+				baseurl=zypp_repo_url,
+				gpgcheck="0" if self.insecure else "1"
+			))
         zypper_cmd = "zypper"
         if not self.interactive:
             zypper_cmd = "{} -n".format(zypper_cmd)

--- a/backend/server/importlib/importLib.py
+++ b/backend/server/importlib/importLib.py
@@ -792,7 +792,10 @@ class Import:
         elif isinstance(text, str):
             return text
         elif isinstance(text, bytes):
-            return text.decode("utf8")
+            try:
+                return text.decode("utf8")
+            except:
+                return text.decode("iso8859-1")
 
 # Any package processing import class
 class GenericPackageImport(Import):

--- a/backend/server/importlib/packageImport.py
+++ b/backend/server/importlib/packageImport.py
@@ -255,7 +255,7 @@ class PackageImport(ChannelPackageSubscription):
             for dep in depList:
                 nv = []
                 for f in ('name', 'version'):
-                    nv.append(dep[f].decode("utf-8"))
+                    nv.append(self._fix_encoding(dep[f]))
                     del dep[f]
                 nv = tuple(nv)
                 dep['capability'] = nv

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Fix package import issues when package encoding is ISO8859-1.
 - Fix issues with HTTP proxy and reposync.
 - Solve Python 3 problem and allow traditional registration.
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes two issues related with `spacewalk-repo-sync` (hopefully latest) after Python 3 porting:

- Disable `gpgcheck` and `repo_gpgcheck` if ContentSource is insecure. (Zypper plugin)
- Fix package import crash when bytes encoding is `ISO8859-1` (allow SLE12SP3/4 channels to sync)

```
2019/02/12 10:11:31 +02:00   Importing packages to DB:
2019/02/12 10:13:37 +02:00 6.93 %
2019/02/12 10:15:07 +02:00 20.53 %
2019/02/12 10:16:03 +02:00 'utf-8' codec can't decode byte 0xed in position 23: invalid continuation byte
...
2019/02/12 10:16:59 +02:00 Importing packages finished.
2019/02/12 10:16:59 +02:00
2019/02/12 10:16:59 +02:00   Linking packages to the channel.
2019/02/12 10:17:03 +02:00 Unexpected error: <class 'spacewalk.server.importlib.importLib.InvalidPackageError'>
2019/02/12 10:17:03 +02:00 Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/spacewalk/satellite_tools/reposync.py", line 568, in sync
    ret = self.import_packages(plugin, data['id'], url, is_non_local_repo)
  File "/usr/lib/python3.6/site-packages/spacewalk/satellite_tools/reposync.py", line 1134, in import_packages
    importer.run()
  File "/usr/lib/python3.6/site-packages/spacewalk/server/importlib/importLib.py", line 764, in run
    self.submit()
  File "/usr/lib/python3.6/site-packages/spacewalk/server/importlib/packageImport.py", line 126, in submit
    self.backend.lookupPackages(self.batch, self.checksums)
  File "/usr/lib/python3.6/site-packages/spacewalk/server/importlib/backend.py", line 697, in lookupPackages
    raise_with_tb(not_found[0], not_found[1])
  File "/usr/lib/python3.6/site-packages/spacewalk/common/usix.py", line 69, in raise_with_tb
    raise value
  File "/usr/lib/python3.6/site-packages/spacewalk/server/importlib/backend.py", line 689, in lookupPackages
    self.__lookupObjectCollection([package], 'rhnPackage')
  File "/usr/lib/python3.6/site-packages/spacewalk/server/importlib/backend.py", line 2340, in __lookupObjectCollection
    raise InvalidPackageError(object, "Could not find object %s in table %s" % (object, tableName))
spacewalk.server.importlib.importLib.InvalidPackageError: Could not find object [<<class 'spacewalk.server.importlib.importLib.IncompletePackage'> instance; attributes={'package_id': None, 'name': 'aspell-id', 'epoch': None, 'version': '1.2', 'release': '45.10', 'arch': 'x86_64', 'org_id': None, 'package_size': None, 'last_modified': None, 'md5sum': None, 'channels': {101: 'sles12-sp4-pool-x86_64'}, 'checksum_list': None, 'checksum': '14b49f5c3ff54a62e75cecb7e35d640d55ea6a81d5dfd823a574288a5657a7f5', 'checksum_type': 'sha256', 'checksums': {'sha256': '14b49f5c3ff54a62e75cecb7e35d640d55ea6a81d5dfd823a574288a5657a7f5'}, 'name_id': 6662, 'evr_id': 3400, 'package_arch_id': 120, 'nevra_id': 7309, 'checksum_id': 1002}] in table rhnPackage
```

## Test coverage
- No tests: **No tests needed. This is already covered by cucumber**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/salt-board/issues/247

- [x] **DONE**