### PR TITLE
Fix problems with "mgr-bootstrap" and "mgr-create-bootstrap-repo --with-custom-channels" and Python 3

### DIFF
--- a/backend/common/rhn_rpm.py
+++ b/backend/common/rhn_rpm.py
@@ -337,7 +337,7 @@ def get_package_header(filename=None, file_obj=None, fd=None):
         raise ValueError("No parameters passed")
 
     if filename is not None:
-        f = open(filename, 'rb')
+        f = open(filename, 'r')
     elif file_obj is not None:
         f = file_obj
         f.seek(0, 0)

--- a/backend/common/rhn_rpm.py
+++ b/backend/common/rhn_rpm.py
@@ -86,6 +86,8 @@ class RPM_Header:
         item = self.hdr[name]
         if isinstance(item, bytes):
             item = sstr(item)
+        elif isinstance(item, list):
+            item = [sstr(i) if isinstance(i, bytes) else i for i in item]
         return item
 
     def __setitem__(self, name, item):
@@ -98,6 +100,8 @@ class RPM_Header:
         item = getattr(self.hdr, name)
         if isinstance(item, bytes):
             item = sstr(item)
+        elif isinstance(item, list):
+            item = [sstr(i) if isinstance(i, bytes) else i for i in item]
         return item
 
     def __len__(self):

--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -462,10 +462,10 @@ type=rpm-md
 '''
         with open(os.path.join(repo.root, "etc/zypp/repos.d", str(self.channel_label or self.reponame) + ".repo"), "w") as repo_conf_file:
             repo_conf_file.write(repo_cfg.format(
-				reponame=self.channel_label or self.reponame,
-				baseurl=zypp_repo_url,
-				gpgcheck="0" if self.insecure else "1"
-			))
+                reponame=self.channel_label or self.reponame,
+                baseurl=zypp_repo_url,
+                gpgcheck="0" if self.insecure else "1"
+            ))
         zypper_cmd = "zypper"
         if not self.interactive:
             zypper_cmd = "{} -n".format(zypper_cmd)

--- a/backend/server/action/packages.py
+++ b/backend/server/action/packages.py
@@ -79,7 +79,7 @@ def handle_action(serverId, actionId, packagesIn, dry_run=0):
     multiarch = 0
     if client_caps and 'packages.update' in client_caps:
         cap_info = client_caps['packages.update']
-        if cap_info['version'] > 1:
+        if int(cap_info['version']) > 1:
             multiarch = 1
     if not packagesIn:
         raise InvalidAction("Packages scheduled in action %s for server %s could not be found." %

--- a/backend/server/apacheRequest.py
+++ b/backend/server/apacheRequest.py
@@ -648,7 +648,7 @@ class GetHandler(apacheRequest):
 
             self.req.headers_out["X-RHN-Fault-Code"] = \
                 str(response.faultCode)
-            faultString = base64.encodestring(response.faultString).strip()
+            faultString = base64.encodestring(response.faultString.encode()).decode().strip()
             # Split the faultString into multiple lines
             for line in faultString.split('\n'):
                 self.req.headers_out.add("X-RHN-Fault-String",

--- a/backend/server/apacheUploadServer.py
+++ b/backend/server/apacheUploadServer.py
@@ -128,7 +128,7 @@ class UploadHandler:
     def _error_to_headers(self, headers, error_code, error_string):
         error_string = error_string.strip()
         import base64
-        error_string = base64.encodestring(error_string).strip()
+        error_string = base64.encodestring(error_string.encode()).decode().strip()
         for line in error_string.split('\n'):
             headers.add(self.server.error_header_prefix + '-String', line.strip())
         headers[self.server.error_header_prefix + '-Code'] = str(error_code)

--- a/backend/server/configFilesHandler.py
+++ b/backend/server/configFilesHandler.py
@@ -357,7 +357,7 @@ class ConfigFilesHandler(rhnHandler):
 
         # We have to insert a new file now
         content_seq = rhnSQL.Sequence('rhn_confcontent_id_seq')
-        config_content_id = next(content_seq)
+        config_content_id = content_seq.next()
         file['config_content_id'] = config_content_id
         file['contents'] = file_contents
 
@@ -511,7 +511,7 @@ class ConfigFilesHandler(rhnHandler):
         return CFG.maximum_config_file_size
 
     def new_config_channel_id(self):
-        return next(rhnSQL.Sequence('rhn_confchan_id_seq'))
+        return rhnSQL.Sequence('rhn_confchan_id_seq').next()
 
 
 def format_file_results(row, server=None):

--- a/backend/server/configFilesHandler.py
+++ b/backend/server/configFilesHandler.py
@@ -535,7 +535,7 @@ def format_file_results(row, server=None):
         client_caps = rhnCapability.get_client_capabilities()
         if client_caps and 'configfiles.base64_enc' in client_caps:
             encoding = 'base64'
-            contents = base64.encodestring(contents)
+            contents = base64.encodestring(contents.encode()).decode()
     if row.get('modified', False):
         m_date = xmlrpclib.DateTime(str(row['modified']))
     else:

--- a/backend/server/rhnAction.py
+++ b/backend/server/rhnAction.py
@@ -20,7 +20,7 @@ from spacewalk.server import rhnSQL
 
 def schedule_action(action_type, action_name=None, delta_time=0,
                     scheduler=None, org_id=None, prerequisite=None):
-    action_id = next(rhnSQL.Sequence('rhn_event_id_seq'))
+    action_id = rhnSQL.Sequence('rhn_event_id_seq').next()
 
     at = rhnSQL.Table('rhnActionType', 'label')
     if not at.has_key(action_type):

--- a/backend/server/rhnChannel.py
+++ b/backend/server/rhnChannel.py
@@ -200,7 +200,7 @@ class BaseChannelObject(BaseDatabaseObject):
     def _new_row(self):
         if self._row is None:
             self._row = rhnSQL.Row(self._table_name, 'id')
-            channel_id = next(rhnSQL.Sequence(self._sequence_name))
+            channel_id = rhnSQL.Sequence(self._sequence_name).next()
             self._row.create(channel_id)
 
     def as_dict(self):

--- a/backend/server/rhnLib.py
+++ b/backend/server/rhnLib.py
@@ -31,8 +31,8 @@ def computeSignature(*fields):
     m = hashlib.new('sha256')
     for i in fields:
         # use str(i) since some of the fields may be non-string
-        m.update(str(i))
-    return base64.encodestring(m.digest()).rstrip()
+        m.update(str(i).encode())
+    return base64.encodestring(m.digest()).decode().rstrip()
 
 
 # 'n_n-n-v.v.v-r_r.r:e.ARCH.rpm' ---> [n,v,r,e,a]

--- a/backend/server/rhnSQL/driver_postgresql.py
+++ b/backend/server/rhnSQL/driver_postgresql.py
@@ -289,7 +289,7 @@ class Cursor(sql_base.Cursor):
             raise rhnException("Cannot execute empty cursor")
         if self.blob_map:
             for blob_var in list(self.blob_map.keys()):
-                kw[blob_var] = BufferType(kw[blob_var])
+                kw[blob_var] = BufferType(kw[blob_var].encode())
 
         try:
             retval = function(*p, **kw)

--- a/backend/server/rhnServer/server_kickstart.py
+++ b/backend/server/rhnServer/server_kickstart.py
@@ -191,7 +191,7 @@ def schedule_kickstart_delta(server_id, kickstart_session_id,
         delta_time=0, scheduler=scheduler, org_id=org_id,
     )
 
-    package_delta_id = next(rhnSQL.Sequence('rhn_packagedelta_id_seq'))
+    package_delta_id = rhnSQL.Sequence('rhn_packagedelta_id_seq').next()
 
     h = rhnSQL.prepare(_query_insert_package_delta)
     h.execute(package_delta_id=package_delta_id)

--- a/backend/server/rhnSession.py
+++ b/backend/server/rhnSession.py
@@ -45,7 +45,7 @@ class Session:
 
     def generate(self, duration=None, web_user_id=None):
         # Grabs a session ID
-        self.session_id = next(rhnSQL.Sequence('pxt_id_seq'))
+        self.session_id = rhnSQL.Sequence('pxt_id_seq').next()
         self.duration = int(duration or CFG.SESSION_LIFETIME)
         self.web_user_id(web_user_id)
         return self

--- a/backend/server/rhnUser.py
+++ b/backend/server/rhnUser.py
@@ -600,7 +600,7 @@ def encrypt_password(key, salt=None, method='SHA-256'):
         # add the pid too
         salt = (time.time() % 1) * 1e15 + os.getpid()
         # base64 it and keep only the first n chars
-        salt = base64.encodestring(str(salt))[:pw_params[method][0]]
+        salt = base64.encodestring(str(salt).encode()).decode()[:pw_params[method][0]]
         # slap the magic in front of the salt
         salt = pw_params[method][1] + salt + '$'
     salt = str(salt)

--- a/backend/server/test/attic/rhnActivationKey.py
+++ b/backend/server/test/attic/rhnActivationKey.py
@@ -139,7 +139,7 @@ class ActivationKey:
     def _set(self, name, val):
         if self._row_reg_token is None:
             self._row_reg_token = rhnSQL.Row('rhnRegToken', 'id')
-            token_id = next(rhnSQL.Sequence('rhn_reg_token_seq'))
+            token_id = rhnSQL.Sequence('rhn_reg_token_seq').next()
             self._row_reg_token.create(token_id)
             self._row_reg_token['usage_limit'] = None
 

--- a/backend/server/test/attic/rhnServerGroup.py
+++ b/backend/server/test/attic/rhnServerGroup.py
@@ -63,7 +63,7 @@ class ServerGroup:
     def _set(self, name, val):
         if self._row_server_group is None:
             self._row_server_group = rhnSQL.Row('rhnServerGroup', 'id')
-            server_group_id = next(rhnSQL.Sequence('rhn_server_group_id_seq'))
+            server_group_id = rhnSQL.Sequence('rhn_server_group_id_seq').next()
             self._row_server_group.create(server_group_id)
 
         self._row_server_group[name] = val

--- a/backend/server/test/unit-test/rhnSQL/test_lob.py
+++ b/backend/server/test/unit-test/rhnSQL/test_lob.py
@@ -48,7 +48,7 @@ class ExceptionsTest(unittest.TestCase):
         rhnSQL.commit()
 
     def test_lobs(self):
-        new_id = next(rhnSQL.Sequence('misatestlob_id_seq'))
+        new_id = rhnSQL.Sequence('misatestlob_id_seq').next()
         h = rhnSQL.prepare("""
             insert into misatestlob (id, val) values (:id, empty_blob())
         """)

--- a/spacewalk/certs-tools/rhn_bootstrap.py
+++ b/spacewalk/certs-tools/rhn_bootstrap.py
@@ -39,13 +39,13 @@ from optparse import Option, OptionParser, SUPPRESS_HELP
 ## local imports
 from spacewalk.common import rhn_rpm
 from spacewalk.common.rhnConfig import CFG, initCFG
-from client_config_update import readConfigFile
-from certs.rhn_bootstrap_strings import \
+from .client_config_update import readConfigFile
+from .rhn_bootstrap_strings import \
     getHeader, getConfigFilesSh, getUp2dateScriptsSh, getGPGKeyImportSh, \
     getCorpCACertSh, getRegistrationSh, getUp2dateTheBoxSh, \
     getAllowConfigManagement, getAllowRemoteCommands, \
     getRegistrationStackSh, getRegistrationSaltSh, removeTLSCertificate
-from certs.sslToolConfig import CA_CRT_NAME, CA_CRT_RPM_NAME
+from .sslToolConfig import CA_CRT_NAME, CA_CRT_RPM_NAME
 from spacewalk.common.fileutils import rotateFile, cleanupAbsPath
 from spacewalk.common.checksum  import getFileChecksum
 
@@ -547,7 +547,7 @@ def writeClientConfigOverrides(options):
   '%s'\n""" % _overrides)
 
     if writeYN:
-        fout = open(_overrides, 'wb')
+        fout = open(_overrides, 'w')
         # header
         fout.write("""\
 # RHN Client (rhn_register/up2date) config-overrides file v4.0
@@ -654,7 +654,7 @@ def generateBootstrapScript(options):
         del oldScript
 
     if writeYN:
-        fout = open(_script, 'wb')
+        fout = open(_script, 'w')
         fout.write(newScript)
         fout.close()
         print("""\

--- a/spacewalk/certs-tools/rhn_bootstrap.py
+++ b/spacewalk/certs-tools/rhn_bootstrap.py
@@ -644,7 +644,7 @@ def generateBootstrapScript(options):
     newScript = ''.join(newScript)
 
     if os.path.exists(_script):
-        oldScript = open(_script, 'rb').read()
+        oldScript = open(_script, 'r').read()
         if oldScript == newScript:
             writeYN = 0
         elif os.path.exists(_script):

--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -16,7 +16,6 @@
 # shell script function library for rhn-bootstrap
 #
 
-import string
 import os.path
 
 

--- a/spacewalk/certs-tools/rhn_ssl_tool.py
+++ b/spacewalk/certs-tools/rhn_ssl_tool.py
@@ -42,10 +42,10 @@ import shutil
 import getpass
 
 ## local imports
-from certs.sslToolCli import processCommandline, CertExpTooShortException, \
+from .sslToolCli import processCommandline, CertExpTooShortException, \
         CertExpTooLongException, InvalidCountryCodeException
 
-from certs.sslToolLib import RhnSslToolException, \
+from .sslToolLib import RhnSslToolException, \
         gendir, chdir, getMachineName, fixSerial, TempDir, \
         errnoGeneralError, errnoSuccess
 
@@ -54,7 +54,7 @@ from spacewalk.common.fileutils import rotateFile, rhn_popen, cleanupAbsPath
 from spacewalk.common.rhn_rpm import hdrLabelCompare, sortRPMs, get_package_header, \
         getInstalledHeader
 
-from certs.sslToolConfig import ConfigFile, figureSerial, getOption, CERT_PATH, \
+from .sslToolConfig import ConfigFile, figureSerial, getOption, CERT_PATH, \
         DEFS, MD, CRYPTO, LEGACY_SERVER_RPM_NAME1, LEGACY_SERVER_RPM_NAME2, \
         CA_OPENSSL_CNF_NAME, SERVER_OPENSSL_CNF_NAME, POST_UNINSTALL_SCRIPT, \
         SERVER_RPM_SUMMARY, CA_CERT_RPM_SUMMARY

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,5 @@
+- Fix problem with spacewalk certs tools and Python3
+
 -------------------------------------------------------------------
 Wed Jan 16 12:22:08 CET 2019 - jgonzalez@suse.com
 

--- a/spacewalk/certs-tools/sslToolCli.py
+++ b/spacewalk/certs-tools/sslToolCli.py
@@ -26,11 +26,11 @@ import sys
 from optparse import Option, OptionParser, make_option
 
 ## local imports
-from certs.sslToolLib import daysTil18Jan2038, yearsTil18Jan2038, \
+from .sslToolLib import daysTil18Jan2038, yearsTil18Jan2038, \
                        RhnSslToolException, errnoGeneralError
-from certs.sslToolConfig import figureDEFS_dirs, figureDEFS_CA, figureDEFS_server
-from certs.sslToolConfig import figureDEFS_distinguishing
-from certs.sslToolConfig import DEFS, getOption, reInitDEFS
+from .sslToolConfig import figureDEFS_dirs, figureDEFS_CA, figureDEFS_server
+from .sslToolConfig import figureDEFS_distinguishing
+from .sslToolConfig import DEFS, getOption, reInitDEFS
 
 
 #

--- a/spacewalk/certs-tools/sslToolConfig.py
+++ b/spacewalk/certs-tools/sslToolConfig.py
@@ -28,7 +28,7 @@ import socket
 
 ## local imports
 from spacewalk.common.fileutils import cleanupNormPath, rotateFile, rhn_popen, cleanupAbsPath
-from certs.sslToolLib import getMachineName, daysTil18Jan2038, incSerial, fixSerial
+from .sslToolLib import getMachineName, daysTil18Jan2038, incSerial, fixSerial
 from rhn.i18n import sstr
 
 # defaults where we can see them (NOTE: directory is figured at write time)

--- a/spacewalk/certs-tools/sslToolLib.py
+++ b/spacewalk/certs-tools/sslToolLib.py
@@ -21,7 +21,7 @@ import os
 import sys
 import shutil
 import tempfile
-from certs.timeLib import DAY, now, secs2days, secs2years
+from .timeLib import DAY, now, secs2days, secs2years
 
 class RhnSslToolException(Exception):
     """ general exception class for the tool """

--- a/susemanager/src/mgr-create-bootstrap-repo
+++ b/susemanager/src/mgr-create-bootstrap-repo
@@ -148,7 +148,7 @@ def find_root_channel_labels(pdids):
     :return: list of root channel labels
     """
     h = rhnSQL.Statement( _sql_find_root_channel_label.format(pdids))
-    return map(lambda x: x['label'], rhnSQL.fetchall_dict(h) or [])
+    return [x['label'] for x in rhnSQL.fetchall_dict(h) or []]
 
 def find_custom_parent_channel_labels():
     """
@@ -157,7 +157,7 @@ def find_custom_parent_channel_labels():
     :return: list of custom parent channel labels
     """
     h = rhnSQL.Statement(_sql_find_custom_parent_channel_labels)
-    return map(lambda x: x['label'], rhnSQL.fetchall_dict(h) or [])
+    return [x['label'] for x in rhnSQL.fetchall_dict(h) or []]
 
 
 def list_labels():

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- Fix issue with map() on Python3 when '--with-custom-channels' (bsc#1125272)
 - Fix setup for openSUSE Leap 15.0
 - support migration from 3.2 to 4.0
 - remove SCC setup from YaST SUSE Manager setup


### PR DESCRIPTION
## What does this PR change?

This PR fixes two issues found after Python 3 migration:

- Running `mgr-create-bootstrap-repo --with-custom-channels`:
```
manager02:/var/log/rhn/reposync # mgr-create-bootstrap-repo --with-custom-channels
1. RES6-x86_64
2. RES7-x86_64
3. SLE-15-x86_64
Enter a number of a product label: 3
Traceback (most recent call last):
  File "/usr/sbin/mgr-create-bootstrap-repo", line 353, in <module>
    create_repo(elabel, options.flush, additional=args)
  File "/usr/sbin/mgr-create-bootstrap-repo", line 208, in create_repo
    if len(root_labels) > 1:
TypeError: object of type 'map' has no len()
```

- Running `mgr-bootstrap`:
```
suma-refhead-srv:~ # mgr-bootstrap 
Unable to load module rhn_bootstrap
No module named 'client_config_update'
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **python3 porting**

- [x] **DONE**

## Test coverage
- No tests: **python3 porting**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/salt-board/issues/252

- [x] **DONE**