### PR TITLE
Change default image download protocol from tftp to ftp

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -1445,6 +1445,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 Map<String, Map<String, Map<String, Object>>> bootImages = (Map<String, Map<String, Map<String, Object>>>) map.get("boot_images");
                 assertEquals("tftp://tftp/boot/POS_Image_JeOS6-6.0.0/initrd-netboot-suse-SLES12.x86_64-2.1.1.gz", bootImages.get("POS_Image_JeOS6-6.0.0").get("initrd").get("url"));
                 Map<String, Map<String, Map<String, Object>>> images = (Map<String, Map<String, Map<String, Object>>>) map.get("images");
+                assertEquals("ftp://ftp/image/POS_Image_JeOS6.x86_64-6.0.0-build24/POS_Image_JeOS6.x86_64-6.0.0", images.get("POS_Image_JeOS6").get("6.0.0").get("url"));
                 assertEquals(1490026496, images.get("POS_Image_JeOS6").get("6.0.0").get("size"));
                 assertEquals("a64dbc025c748bde968b888db6b7b9e3", images.get("POS_Image_JeOS6").get("6.0.0").get("hash"));
             } catch (FileNotFoundException e) {

--- a/java/code/src/com/suse/manager/webui/services/SaltStateGeneratorService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltStateGeneratorService.java
@@ -263,7 +263,7 @@ public enum SaltStateGeneratorService {
         imagePillarDetails.put("size", image.getSize());
         imagePillarDetails.put("sync", imagePillarDetailsSync);
         imagePillarDetails.put("type", image.getType());
-        imagePillarDetails.put("url", "tftp://tftp/" + localPath + "/" + image.getFilename());
+        imagePillarDetails.put("url", "ftp://ftp/" + localPath + "/" + image.getFilename());
 
         imagePillarBase.put(version, imagePillarDetails);
         imagePillar.put(name, imagePillarBase);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Change default image download protocol from tftp to ftp
 - Fix apidoc issues
 - Read and update running kernel release value at each startup of minion (bsc#1122381)
 - Schedule full package refresh only once per action chain if needed(bsc#1126518)

--- a/testsuite/features/proxy_retail_pxeboot.feature
+++ b/testsuite/features/proxy_retail_pxeboot.feature
@@ -21,6 +21,7 @@ Feature: PXE boot a Retail terminal
 @pxeboot_minion
   Scenario: Install or update PXE formulas on the server
     When I manually install the "tftpd" formula on the server
+    And I manually install the "vsftpd" formula on the server
     And I manually install the "saltboot" formula on the server
     And I manually install the "pxe" formula on the server
     And I wait for "16" seconds
@@ -32,6 +33,7 @@ Feature: PXE boot a Retail terminal
     Given I am on the Systems overview page of this "proxy"
     When I follow "Formulas" in the content area
     And I check the "tftpd" formula
+    And I check the "vsftpd" formula
     And I check the "pxe" formula
     And I click on "Save"
     Then the "tftpd" formula should be checked
@@ -101,6 +103,18 @@ Feature: PXE boot a Retail terminal
     And I follow first "Tftpd" in the content area
     And I enter the local IP address of "proxy" in internal network address field
     And I enter "/srv/saltboot" in TFTP base directory field
+    And I click on "Save Formula"
+    Then I should see a "Formula saved!" text
+
+@proxy
+@private_net
+@pxeboot_minion
+  Scenario: Parametrize vsFTPd on the branch server
+    Given I am on the Systems overview page of this "proxy"
+    When I follow "Formulas" in the content area
+    And I follow first "Vsftpd" in the content area
+    And I enter the local IP address of "proxy" in vsftpd internal network address field
+    And I enter "/srv/saltboot" in FTP server directory field
     And I click on "Save Formula"
     Then I should see a "Formula saved!" text
 

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -321,6 +321,7 @@ When(/^I select "([^"]*)" in (.*) field$/) do |value, box|
   select(value, from: boxids[box])
 end
 
+# rubocop:disable Metrics/BlockLength
 When(/^I enter the local IP address of "([^"]*)" in (.*) field$/) do |host, field|
   fieldids = { 'IP'                       => 'branch_network#ip',
                'domain name server'       => 'dhcpd#domain_name_servers#0',
@@ -337,7 +338,8 @@ When(/^I enter the local IP address of "([^"]*)" in (.*) field$/) do |host, fiel
                'second A address'         => 'bind#available_zones#0#records#A#1#1',
                'third A address'          => 'bind#available_zones#0#records#A#2#1',
                'fourth A address'         => 'bind#available_zones#0#records#A#3#1',
-               'internal network address' => 'tftpd#listen_ip' }
+               'internal network address' => 'tftpd#listen_ip',
+               'vsftpd internal network address' => 'vsftpd_config#listen_address' }
   addresses = { 'network'     => '0',
                 'client'      => '2',
                 'minion'      => '3',
@@ -398,7 +400,8 @@ When(/^I enter "([^"]*)" in (.*) field$/) do |value, field|
                'second partition id'             => 'partitioning#0#partitions#1#$key',
                'second partition size'           => 'partitioning#0#partitions#1#size_MiB',
                'second mount point'              => 'partitioning#0#partitions#1#mountpoint',
-               'second OS image'                 => 'partitioning#0#partitions#1#image' }
+               'second OS image'                 => 'partitioning#0#partitions#1#image',
+               'FTP server directory'            => 'vsftpd_config#anon_root' }
   fill_in fieldids[field], with: value
 end
 # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
## What does this PR change?

Change the default protocol for image downloading to ftp instead of tftp. Tftp was proven no to work reliably with higher number of terminals.

## Documentation
- https://github.com/SUSE/doc-susemanager/pull/329

- [X] **DONE**

## Test coverage
- Unit test updated
- Functionality not changed, covered by existing cucumber tests

- [X] **DONE**

## Links

Fixes #6487 

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
