### PR TITLE
Testsuite - pxe boot scenario failure fix

### DIFF
--- a/testsuite/features/proxy_retail_pxeboot.feature
+++ b/testsuite/features/proxy_retail_pxeboot.feature
@@ -217,6 +217,9 @@ Feature: PXE boot a Retail terminal
     And I wait until I see the name of "pxeboot-minion", refreshing the page
     And I follow this "pxeboot-minion" link
     And I wait until event "Apply states [util.syncstates, saltboot] scheduled by (none)" is completed
+    And I follow "Software" in the content area
+    And I follow "Software Channels" in the content area
+    And I wait until radio button "Test-Channel-x86_64" is checked, refreshing the page
     And I wait until event "Package List Refresh scheduled by (none)" is completed
     Then the PXE boot minion should have been reformatted
 

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -802,6 +802,20 @@ And(/^the notification badge and the table should count the same amount of messa
   end
 end
 
+And(/^I wait until radio button "([^"]*)" is checked, refreshing the page$/) do |arg1|
+  begin
+    Timeout.timeout(DEFAULT_TIMEOUT) do
+      loop do
+        break if has_checked_field?(arg1)
+        sleep 1
+        page.evaluate_script 'window.location.reload()'
+      end
+    end
+  rescue Timeout::Error
+    raise "Couldn't find checked radio button #{arg1} in webpage"
+  end
+end
+
 Then(/^I check the first notification message$/) do
   if count_table_items == '0'
     puts "There are no notification messages, nothing to do then"


### PR DESCRIPTION
## What does this PR change?

This PR adds steps to ensure pxe-minion is booted by checking assignment of base channel. It prevents `PXE boot the PXE boot minion` scenario from failure by that.

## Links

Port of https://github.com/SUSE/spacewalk/pull/7036 
