### PR TITLE
Fix "reposync" issue after encoding changes on RPM Headers

### DIFF
--- a/backend/server/apacheUploadServer.py
+++ b/backend/server/apacheUploadServer.py
@@ -17,7 +17,7 @@
 import sys
 from spacewalk.common import apache
 
-import rhnSession
+from . import rhnSession
 
 from spacewalk.common import rhnFlags
 from spacewalk.common.rhnLog import log_debug, log_error, log_setreq, initLOG

--- a/backend/server/configFilesHandler.py
+++ b/backend/server/configFilesHandler.py
@@ -528,7 +528,7 @@ def format_file_results(row, server=None):
         contents = interpolator.interpolate(contents)
         if row['checksum_type']:
             checksummer = hashlib.new(row['checksum_type'])
-            checksummer.update(contents)
+            checksummer.update(contents.encode())
             checksum = checksummer.hexdigest()
 
     if contents:

--- a/backend/server/importlib/headerSource.py
+++ b/backend/server/importlib/headerSource.py
@@ -354,16 +354,6 @@ class rpmFile(File, ChangeLog):
         if type(self['filedigest']) == StringType:
             self['checksum'] = self['filedigest']
             del(self['filedigest'])
-        if type(self['linkto'] == bytes):
-            self['linkto'] = self['linkto'].decode("utf8")
-        if type(self['lang'] == bytes):
-            self['lang'] = self['lang'].decode("utf8")
-        if type(self['filedigest'] == bytes):
-            self['filedigest'] = self['filedigest'].decode("utf8")
-        if type(self['groupname'] == bytes):
-            self['groupname'] = self['groupname'].decode("utf8")
-        if type(self['username'] == bytes):
-            self['username'] = self['username'].decode("utf8")
 
 
 class rpmProvides(Dependency):
@@ -500,10 +490,11 @@ class rpmChangeLog(ChangeLog):
         # In changelog, data is either in UTF-8, or in any other
         # undetermined encoding. Assume ISO-Latin-1 if not UTF-8.
         for i in ('text', 'name'):
-            try:
-                self[i] = UnicodeType(self[i], "utf-8")
-            except UnicodeDecodeError:
-                self[i] = UnicodeType(self[i], "iso-8859-1")
+            if type(self[i]) == bytes:
+                try:
+                    self[i] = self[i].encode("utf-8")
+                except:
+                    self[i] = self[i].encode("iso-8859-1")
 
 
 def sanitizeList(l):

--- a/backend/server/rhnSession.py
+++ b/backend/server/rhnSession.py
@@ -70,9 +70,9 @@ class Session:
         secrets = self.get_secrets()
 
         ctx = hashlib.new('sha256')
-        ctx.update(':'.join(secrets[:2] + [str(self.session_id)] + secrets[2:]))
+        ctx.update(':'.join(secrets[:2] + [str(self.session_id)] + secrets[2:]).encode())
 
-        return ''.join(["%02x" % ord(a) for a in ctx.digest()])
+        return ctx.hexdigest()
 
     def get_session(self):
         return "%sx%s" % (self.session_id, self.digest())

--- a/backend/upload_server/handlers/package_push/__init__.py
+++ b/backend/upload_server/handlers/package_push/__init__.py
@@ -18,6 +18,6 @@
 
 __all__ = []
 
-import package_push
+from . import package_push
 
 upload_class = package_push.PackagePush


### PR DESCRIPTION
## What does this PR change?

This PR fixes an error in "reposync" that prevents channels to sync. This regression was introduced by the encoding changes on the RPM Header class made here: https://github.com/uyuni-project/uyuni/pull/581

```
...
2019/02/14 04:41:34 +02:00     3005/3008 : zypper-migration-plugin-0.11.1520597355.bcf74ad-1.38.noarch.rpm
2019/02/14 04:41:34 +02:00     3006/3008 : zypper-1.14.5-1.25.x86_64.rpm
2019/02/14 04:41:34 +02:00     3007/3008 : zsh-5.3.1-1.64.x86_64.rpm
2019/02/14 04:41:39 +02:00     3008/3008 : tftpboot-installation-SLE-15-x86_64-14.373-1.14.noarch.rpm
2019/02/14 04:41:39 +02:00 Importing packages started.
2019/02/14 04:41:39 +02:00
2019/02/14 04:41:39 +02:00   Importing packages to DB:
2019/02/14 04:41:39 +02:00 'str' object has no attribute 'decode'
2019/02/14 04:41:40 +02:00 'str' object has no attribute 'decode'
2019/02/14 04:41:40 +02:00 'str' object has no attribute 'decode'
...
```

After this PR, the channels are able to sync.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **python3 porting**

- [x] **DONE**

## Test coverage
- No tests: **python 3 porting**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/salt-board/issues/247

- [x] **DONE**