### PR TITLE
Fix error 500 when using "rhnpush" after Python 3 migration

### DIFF
--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Fix "rhnpush" after migration to Python 3.
 - Fix package import issues when package encoding is ISO8859-1.
 - Fix issues with HTTP proxy and reposync.
 - Solve Python 3 problem and allow traditional registration.


### PR DESCRIPTION
## What does this PR change?

This PR fixes `rhnpush` after Python 3 migration:

- Before:
```console
suma-refhead-srv:~ # rhnpush -vvv --server=http://suma-refhead-srv.mgr.suse.de/APP -u admin -p admin --nosig -c test_base_channel /root/subscription-tools-1.0-0.noarch.rpm
Connecting to http://suma-refhead-srv.mgr.suse.de/APP
Internal Server Error
suma-refhead-srv:~ #
```

- After:
```console
suma-refhead-srv:~ # rhnpush -vvv --server=http://suma-refhead-srv.mgr.suse.de/APP -u admin -p admin --nosig -c test-channel-x86_64-child-channel /root/subscription-tools-1.0-0.noarch.rpm
Connecting to http://suma-refhead-srv.mgr.suse.de/APP
url is http://suma-refhead-srv.mgr.suse.de/PACKAGE-PUSH
Result codes: 200 OK
Computing checksum and package info. This may take some time ...
Package /root/subscription-tools-1.0-0.noarch.rpm Not Found on SUSE Manager Server -- Uploading
Uploading package /root/subscription-tools-1.0-0.noarch.rpm
Using POST request

suma-refhead-srv:~ # rhnpush -vvv --server=http://suma-refhead-srv.mgr.suse.de/APP -u admin -p admin --nosig -c test-channel-x86_64-child-channel /root/subscription-tools-1.0-0.noarch.rpm
Connecting to http://suma-refhead-srv.mgr.suse.de/APP
url is http://suma-refhead-srv.mgr.suse.de/PACKAGE-PUSH
Result codes: 200 OK
Computing checksum and package info. This may take some time ...
Package /root/subscription-tools-1.0-0.noarch.rpm already exists on the SUSE Manager Server-- Skipping Upload....

```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **python3 porting**

- [x] **DONE**

## Test coverage
- No tests: **python3 porting**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/salt-board/issues/247

- [x] **DONE**