### PR TITLE
Ivy cleanup and update of dependency versions

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -1,7 +1,7 @@
 <ivy-module version="1.0">
     <info organisation="suse" module="manager" />
     <dependencies>
-        <!-- Webapp dependencies -->
+        <!-- Runtime dependencies -->
         <dependency org="suse" name="antlr" rev="2.7.7" />
         <dependency org="suse" name="asm" rev="3.3.1" />
         <dependency org="suse" name="bcel" rev="5.2" />
@@ -47,6 +47,7 @@
         <dependency org="suse" name="jdom" rev="1.1" />
         <dependency org="suse" name="jose4j" rev="0.5.1" />
         <dependency org="suse" name="log4j" rev="1.2.17" />
+        <dependency org="suse" name="jsch" rev="0.1.54" />
         <dependency org="suse" name="netty-buffer" rev="4.1.8" />
         <dependency org="suse" name="netty-codec" rev="4.1.8" />
         <dependency org="suse" name="netty-common" rev="4.1.8" />
@@ -84,10 +85,7 @@
         <dependency org="suse" name="xerces-j2" rev="2.11.0" />
         <dependency org="suse" name="xerces-j2-xml-apis" rev="2.11.0" />
 
-        <!-- Taskomatic dependencies -->
-        <dependency org="suse" name="jsch" rev="0.1.54" />
-
-        <!-- Tomcat APIs -->
+        <!-- Tomcat jars -->
         <dependency org="suse" name="jasper" rev="9.0.12" />
         <dependency org="suse" name="jasper-el" rev="9.0.12" />
         <dependency org="suse" name="tomcat-el-3.0-api" rev="9.0.12" />
@@ -99,6 +97,7 @@
         <dependency org="suse" name="checkstyle-all" rev="6.11.2" />
         <dependency org="suse" name="hamcrest-core" rev="1.3" />
         <dependency org="suse" name="hamcrest-library" rev="1.3" />
+        <dependency org="suse" name="jacocoant" rev="0.7.7" />
         <dependency org="suse" name="jaxb-api" rev="2.3.0" />
         <dependency org="suse" name="jaxb-core" rev="2.3.0" />
         <dependency org="suse" name="jaxb-impl" rev="2.3.0" />
@@ -112,23 +111,5 @@
         <dependency org="suse" name="objenesis" rev="1.0" />
         <dependency org="suse" name="strutstest" rev="2.1.3" />
         <dependency org="suse" name="websocket-api" rev="1.1" />
-        <!--
-        <dependency org="suse" name="ant" rev="1.9.4" />
-        <dependency org="suse" name="ant-contrib" rev="1.0b2" />
-        <dependency org="suse" name="ant-junit" rev="1.9.4" />
-        <dependency org="suse" name="cglib-nodep" rev="2.2.3" />
-        <dependency org="suse" name="gsbase" rev="2.0.1" />
-        <dependency org="suse" name="jacocoant" rev="0.7.7" />
-        <dependency org="suse" name="jfreechart" rev="1.0.13" />
-        <dependency org="suse" name="oscache" rev="2.2" />
-        <dependency org="suse" name="regexp" rev="1.4" />
-        <dependency org="suse" name="velocity" rev="1.5" />
-        -->
-
-        <!-- Not needed anymore? -->
-        <!--
-        <dependency org="suse" name="asm-attrs" rev="1.5.3" />
-        <dependency org="suse" name="ojdbc7" rev="1.0" />
-        -->
     </dependencies>
 </ivy-module>

--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -99,6 +99,9 @@
         <dependency org="suse" name="checkstyle-all" rev="6.11.2" />
         <dependency org="suse" name="hamcrest-core" rev="1.3" />
         <dependency org="suse" name="hamcrest-library" rev="1.3" />
+        <dependency org="suse" name="jaxb-api" rev="2.3.0" />
+        <dependency org="suse" name="jaxb-core" rev="2.3.0" />
+        <dependency org="suse" name="jaxb-impl" rev="2.3.0" />
         <dependency org="suse" name="junit" rev="3.8.2" />
         <dependency org="suse" name="jmock" rev="2.6.0" />
         <dependency org="suse" name="jmock-junit3" rev="2.6.0" />

--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -1,87 +1,69 @@
 <ivy-module version="1.0">
     <info organisation="suse" module="manager" />
     <dependencies>
-        <dependency org="suse" name="ant" rev="1.9.4" />
-        <dependency org="suse" name="ant-contrib" rev="1.0b2" />
-        <dependency org="suse" name="ant-junit" rev="1.9.4" />
+        <!-- Webapp dependencies -->
         <dependency org="suse" name="antlr" rev="2.7.7" />
-        <dependency org="suse" name="asm" rev="1.5.3" />
-        <dependency org="suse" name="asm-attrs" rev="1.5.3" />
-        <dependency org="suse" name="bcel" rev="5.1" />
+        <dependency org="suse" name="asm" rev="3.3.1" />
+        <dependency org="suse" name="bcel" rev="5.2" />
         <dependency org="suse" name="byte-buddy" rev="1.8.17" />
-        <dependency org="suse" name="c3p0" rev="0.9.5_pre8" />
-        <dependency org="suse" name="cglib" rev="2.1.3" />
-        <dependency org="suse" name="cglib-nodep" rev="2.2.3" />
-        <dependency org="suse" name="checkstyle-all" rev="6.11.2" />
+        <dependency org="suse" name="c3p0" rev="0.9.5.2" />
+        <dependency org="suse" name="cglib" rev="2.2" />
         <dependency org="suse" name="classmate" rev="1.3.4" />
+        <dependency org="suse" name="classpathx-mail-1.3.1-monolithic" rev="1.1.2" />
         <dependency org="suse" name="commons-beanutils" rev="1.9.2" />
         <dependency org="suse" name="commons-cli" rev="1.2" />
-        <dependency org="suse" name="commons-codec" rev="1.8" />
-        <dependency org="suse" name="commons-collections" rev="3.2.1" />
+        <dependency org="suse" name="commons-codec" rev="1.10" />
+        <dependency org="suse" name="commons-collections" rev="3.2.2" />
         <dependency org="suse" name="commons-digester" rev="1.7" />
         <dependency org="suse" name="commons-discovery" rev="0.4" />
         <dependency org="suse" name="commons-el" rev="1.0" />
         <dependency org="suse" name="commons-fileupload" rev="1.1.1" />
-        <dependency org="suse" name="commons-io" rev="1.3.2" />
+        <dependency org="suse" name="commons-io" rev="2.4" />
         <dependency org="suse" name="commons-jexl" rev="2.1.1" />
         <dependency org="suse" name="commons-lang3" rev="3.1" />
-        <dependency org="suse" name="commons-logging" rev="1.1.3" />
+        <dependency org="suse" name="commons-logging" rev="1.2" />
         <dependency org="suse" name="commons-validator" rev="1.1.4" />
         <dependency org="suse" name="concurrent" rev="1.3.4" />
         <dependency org="suse" name="concurrentlinkedhashmap-lru" rev="1.3.1" />
         <dependency org="suse" name="dom4j" rev="1.6.1" />
-        <dependency org="suse" name="dwr" rev="3.0rc2+svn4059" />
+        <dependency org="suse" name="dwr" rev="3.0.2" />
         <dependency org="suse" name="ehcache-core" rev="2.10.1" />
+        <dependency org="suse" name="geronimo-jta-1.1-api" rev="1.1.0" />
         <dependency org="suse" name="google-gson" rev="2.8.2" />
-        <dependency org="suse" name="gsbase" rev="2.0.1" />
-        <dependency org="suse" name="hamcrest-core" rev="1.3" />
-        <dependency org="suse" name="hamcrest-library" rev="1.3" />
         <dependency org="suse" name="hibernate-c3p0" rev="5.3.7" />
         <dependency org="suse" name="hibernate-commons-annotations" rev="5.0.4" />
         <dependency org="suse" name="hibernate-core" rev="5.3.7" />
         <dependency org="suse" name="hibernate-ehcache" rev="5.3.7" />
-        <dependency org="suse" name="httpasyncclient" rev="4.1.3" />
+        <dependency org="suse" name="httpasyncclient" rev="4.1.4" />
         <dependency org="suse" name="httpclient" rev="4.5" />
         <dependency org="suse" name="httpcore" rev="4.4.1" />
-        <dependency org="suse" name="httpcore-nio" rev="4.4.6" />
-        <dependency org="suse" name="jacocoant" rev="0.7.7" />
+        <dependency org="suse" name="httpcore-nio" rev="4.4.1" />
         <dependency org="suse" name="jade4j" rev="1.0.7" />
-        <dependency org="suse" name="jaf" rev="1.0.2" />
+        <dependency org="suse" name="jaf" rev="1.1.1" />
         <dependency org="suse" name="jakarta-persistence-api" rev="2.2.2" />
-        <dependency org="suse" name="jasper" rev="8.0.23" />
-        <dependency org="suse" name="jasper-el" rev="8.0.23" />
         <dependency org="suse" name="javassist" rev="3.20.0" />
-        <dependency org="suse" name="javamail" rev="1.1.1" />
-        <dependency org="suse" name="jcommon" rev="1.0.16" />
-        <dependency org="suse" name="jdom" rev="1.0" />
-        <dependency org="suse" name="jfreechart" rev="1.0.13" />
         <dependency org="suse" name="jboss-logging" rev="3.3.0" />
-        <dependency org="suse" name="jmock" rev="2.6.0" />
-        <dependency org="suse" name="jmock-junit3" rev="2.6.0" />
-        <dependency org="suse" name="jmock-legacy" rev="2.6.0" />
+        <dependency org="suse" name="jcommon" rev="1.0.16" />
+        <dependency org="suse" name="jdom" rev="1.1" />
         <dependency org="suse" name="jose4j" rev="0.5.1" />
-        <dependency org="suse" name="jsch" rev="0.1.54" />
-        <dependency org="suse" name="jta" rev="1.1" />
-        <dependency org="suse" name="junit" rev="3.8.2" />
-        <dependency org="suse" name="log4j" rev="1.2.15" />
-        <dependency org="suse" name="mockobjects" rev="0.09" />
-        <dependency org="suse" name="mockobjects-core" rev="0.09" />
-        <dependency org="suse" name="mockobjects-jdk1.4-j2ee1.3" rev="0.09" />
-        <dependency org="suse" name="objenesis" rev="1.0" />
-        <dependency org="suse" name="ojdbc7" rev="1.0" />
+        <dependency org="suse" name="log4j" rev="1.2.17" />
+        <dependency org="suse" name="netty-buffer" rev="4.1.8" />
+        <dependency org="suse" name="netty-codec" rev="4.1.8" />
+        <dependency org="suse" name="netty-common" rev="4.1.8" />
+        <dependency org="suse" name="netty-handler" rev="4.1.8" />
+        <dependency org="suse" name="netty-resolver" rev="4.1.8" />
+        <dependency org="suse" name="netty-transport" rev="4.1.8" />
         <dependency org="suse" name="oro" rev="2.0.8" />
-        <dependency org="suse" name="oscache" rev="2.2" />
-        <dependency org="suse" name="pgjdbc-ng" rev="0.7" />
+        <dependency org="suse" name="pgjdbc-ng" rev="0.7.1" />
         <dependency org="suse" name="postgresql-jdbc" rev="9.4" />
         <dependency org="suse" name="quartz" rev="2.3.0" />
         <dependency org="suse" name="redstone-xmlrpc" rev="1.1_20071120" />
         <dependency org="suse" name="redstone-xmlrpc-client" rev="1.1_20071120" />
-        <dependency org="suse" name="regexp" rev="1.4" />
-        <dependency org="suse" name="salt-netapi-client" rev="0.15.0" />
+        <dependency org="suse" name="salt-netapi-client" rev="0.15.1" />
         <dependency org="suse" name="simpleclient" rev="0.3.0" />
         <dependency org="suse" name="simpleclient_common" rev="0.3.0" />
-        <dependency org="suse" name="simpleclient_servlet" rev="0.3.0" />
         <dependency org="suse" name="simpleclient_httpserver" rev="0.3.0" />
+        <dependency org="suse" name="simpleclient_servlet" rev="0.3.0" />
         <dependency org="suse" name="simple-core" rev="3.1.3" />
         <dependency org="suse" name="simple-xml" rev="2.6.2" />
         <dependency org="suse" name="sitemesh" rev="2.1" />
@@ -93,19 +75,57 @@
         <dependency org="suse" name="statistics" rev="1.0.2" />
         <dependency org="suse" name="stringtree-json" rev="2.0.9" />
         <dependency org="suse" name="struts" rev="1.2.9" />
-        <dependency org="suse" name="strutstest" rev="2.1.3" />
         <dependency org="suse" name="taglibs-standard-impl" rev="1.2.5" />
         <dependency org="suse" name="taglibs-standard-jstlel" rev="1.2.5" />
         <dependency org="suse" name="taglibs-standard-spec" rev="1.2.5" />
-        <dependency org="suse" name="tanukiwrapper" rev="3.2.3" />
-        <dependency org="suse" name="tomcat-el-3.0-api" rev="8.0.23" />
-        <dependency org="suse" name="tomcat-jsp-2.3-api" rev="8.0.23" />
-        <dependency org="suse" name="tomcat-juli" rev="8.0.23" />
-        <dependency org="suse" name="tomcat-servlet-3.1-api" rev="8.0.23" />
-        <dependency org="suse" name="velocity" rev="1.5" />
+        <dependency org="suse" name="tanukiwrapper" rev="3.5.32" />
+        <dependency org="suse" name="xalan-j2" rev="2.7.2" />
+        <dependency org="suse" name="xalan-j2-serializer" rev="2.7.2" />
+        <dependency org="suse" name="xerces-j2" rev="2.11.0" />
+        <dependency org="suse" name="xerces-j2-xml-apis" rev="2.11.0" />
+
+        <!-- Taskomatic dependencies -->
+        <dependency org="suse" name="jsch" rev="0.1.54" />
+
+        <!-- Tomcat APIs -->
+        <dependency org="suse" name="jasper" rev="9.0.12" />
+        <dependency org="suse" name="jasper-el" rev="9.0.12" />
+        <dependency org="suse" name="tomcat-el-3.0-api" rev="9.0.12" />
+        <dependency org="suse" name="tomcat-jsp-2.3-api" rev="9.0.12" />
+        <dependency org="suse" name="tomcat-juli" rev="9.0.12" />
+        <dependency org="suse" name="tomcat-servlet-4.0-api" rev="9.0.12" />
+
+        <!-- Compilation and testing -->
+        <dependency org="suse" name="checkstyle-all" rev="6.11.2" />
+        <dependency org="suse" name="hamcrest-core" rev="1.3" />
+        <dependency org="suse" name="hamcrest-library" rev="1.3" />
+        <dependency org="suse" name="junit" rev="3.8.2" />
+        <dependency org="suse" name="jmock" rev="2.6.0" />
+        <dependency org="suse" name="jmock-junit3" rev="2.6.0" />
+        <dependency org="suse" name="jmock-legacy" rev="2.6.0" />
+        <dependency org="suse" name="mockobjects" rev="0.09" />
+        <dependency org="suse" name="mockobjects-core" rev="0.09" />
+        <dependency org="suse" name="mockobjects-jdk1.4-j2ee1.3" rev="0.09" />
+        <dependency org="suse" name="objenesis" rev="1.0" />
+        <dependency org="suse" name="strutstest" rev="2.1.3" />
         <dependency org="suse" name="websocket-api" rev="1.1" />
-        <dependency org="suse" name="xalan-j2" rev="2.7.0" />
-        <dependency org="suse" name="xalan-j2-serializer" rev="2.7.0" />
-        <dependency org="suse" name="xerces-j2" rev="2.8.1" />
+        <!--
+        <dependency org="suse" name="ant" rev="1.9.4" />
+        <dependency org="suse" name="ant-contrib" rev="1.0b2" />
+        <dependency org="suse" name="ant-junit" rev="1.9.4" />
+        <dependency org="suse" name="cglib-nodep" rev="2.2.3" />
+        <dependency org="suse" name="gsbase" rev="2.0.1" />
+        <dependency org="suse" name="jacocoant" rev="0.7.7" />
+        <dependency org="suse" name="jfreechart" rev="1.0.13" />
+        <dependency org="suse" name="oscache" rev="2.2" />
+        <dependency org="suse" name="regexp" rev="1.4" />
+        <dependency org="suse" name="velocity" rev="1.5" />
+        -->
+
+        <!-- Not needed anymore? -->
+        <!--
+        <dependency org="suse" name="asm-attrs" rev="1.5.3" />
+        <dependency org="suse" name="ojdbc7" rev="1.0" />
+        -->
     </dependencies>
 </ivy-module>

--- a/java/buildconf/ivy/ivyconf.xml
+++ b/java/buildconf/ivy/ivyconf.xml
@@ -2,7 +2,7 @@
   <settings defaultResolver="default" />
   <resolvers>
     <url name="default">
-      <artifact pattern="http://ramrod.mgr.suse.de/ivy/[artifact]-[revision].[ext]" />
+      <artifact pattern="http://ramrod.mgr.suse.de/ivy/master/[artifact]-[revision].[ext]" />
     </url>
   </resolvers>
 </ivysettings>

--- a/java/code/src/com/redhat/rhn/common/finder/test/JarFinderTest.java
+++ b/java/code/src/com/redhat/rhn/common/finder/test/JarFinderTest.java
@@ -28,12 +28,12 @@ public class JarFinderTest extends TestCase {
     // Sigh.
     // At least make it clear what we're looking for...
 
-    // As of this writing, velocity-1.5.jar
+    // Currently used jarfile: postgresql-jdbc-9.4.jar
     // (previously redstone.xmlrpc could find either redstone-xmlrpc.jar or
     //  redstone-xmlrpc-client.jar, making test-results indeterminate)
-    private static final String TESTJAR = "org.apache.velocity";
-    private static final int NUM_CLASSES_IN_TESTJAR = 246;
-    private static final int NUM_SUBDIRS_IN_TESTJAR = 249;
+    private static final String TESTJAR = "org.postgresql";
+    private static final int NUM_CLASSES_IN_TESTJAR = 248;
+    private static final int NUM_SUBDIRS_IN_TESTJAR = 248;
 
     public void testGetFinder() throws Exception {
         Finder f = FinderFactory.getFinder(TESTJAR);

--- a/java/manager-build.xml
+++ b/java/manager-build.xml
@@ -69,8 +69,8 @@
     <mkdir dir="${build.dir}/java-branding" />
 
     <javac destdir="${build.dir}/java-branding"
-           source="1.8"
-           target="1.8"
+           source="11"
+           target="11"
            includeantruntime="no"
            nowarn="true"
            srcdir="${branding.src.dir}" />
@@ -93,8 +93,8 @@
     <javac destdir="${build.dir}/classes"
            optimize="off"
            debug="on"
-           source="1.8"
-           target="1.8"
+           source="11"
+           target="11"
            deprecation="${deprecation}"
            nowarn="${nowarn}"
            encoding="utf-8"


### PR DESCRIPTION
## What does this PR change?

This is an attempt to update the ivy file and the corresponding jar repository to the latest versions of libraries as we take some of them from `SLE15 SP1`. Some further effort might be needed to bring this to `Leap 15.1`.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed, this is only relevant for developers and CI systems.

- [x] **DONE**

## Test coverage

- No tests needed, this is only relevant for developers and CI systems.

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/7026.

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
