### PR TITLE
Improve error message when trying to configure a proxy on an machine that is not registered as client

### DIFF
--- a/proxy/installer/configure-proxy.sh
+++ b/proxy/installer/configure-proxy.sh
@@ -342,7 +342,7 @@ SYSTEMID_PATH=$(awk -F '=[[:space:]]*' '/^[[:space:]]*systemIdPath[[:space:]]*=/
 /usr/sbin/fetch-certificate $SYSTEMID_PATH
 
 if [ ! -r $SYSTEMID_PATH ]; then
-    echo ERROR: SUSE Manager Proxy does not appear to be registered
+    echo ERROR: This machine does not appear to be registered with SUSE Manager Server
     exit 2
 fi
 

--- a/proxy/installer/spacewalk-proxy-installer.changes
+++ b/proxy/installer/spacewalk-proxy-installer.changes
@@ -1,3 +1,6 @@
+- Improve error message when trying to configure a proxy on an
+  machine that is not registered as client
+
 -------------------------------------------------------------------
 Wed Jan 16 12:24:15 CET 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

IMHO the current message is missleading. @0rnela was thinking that the script was talking the Proxy Channel not being available at the Server (not registered at SCC), and I had to check the script code to make sure it was talking about client registration.

Maybe we could consider changing the error message to:

```
ERROR: This machine does not appear to be registered with the Server
```

So it works for both Uyuni and SUSE Manager.

Otherwise we'll merge as it is I will open a bug to fix this, but it's unclear to me how the client can easily and cleanly detect if the server is Uyuni or SUSE manager.

## GUI diff

No difference.

## Documentation
- No documentation needed: The message is not at the doc, so no need for updates (the requirement is already documented).

- [x] **DONE**

## Test coverage
- No tests: Just a change at an error messsage text.

## Links

Nothing

- [x] **DONE**