### PR TITLE
fix mgr-sync refresh crashes (bsc1125451)

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -1560,28 +1560,33 @@ public class ContentSyncManager {
         String label = dbChannel.getLabel();
         List<SUSEProductSCCRepository> suseProductSCCRepositories = SUSEProductFactory.lookupPSRByChannelLabel(label);
 
-        SUSEProductSCCRepository productrepo = suseProductSCCRepositories.stream().findFirst().get();
-        SUSEProduct product = productrepo.getProduct();
+        Opt.consume(suseProductSCCRepositories.stream().findFirst(),
+                () -> log.error("No product tree entry found for label: '" + label + "'"),
+                productrepo -> {
+                    SUSEProduct product = productrepo.getProduct();
 
-        // update only the fields which are save to be updated
-        dbChannel.setChannelFamily(product.getChannelFamily());
-        dbChannel.setName(productrepo.getChannelName());
-        dbChannel.setSummary(product.getFriendlyName());
-        dbChannel.setDescription(Optional.ofNullable(product.getDescription()).orElse(product.getFriendlyName()));
-        dbChannel.setProduct(MgrSyncUtils.findOrCreateChannelProduct(product));
-        dbChannel.setProductName(MgrSyncUtils.findOrCreateProductName(product.getName()));
-        dbChannel.setUpdateTag(productrepo.getUpdateTag());
-        ChannelFactory.save(dbChannel);
+                    // update only the fields which are save to be updated
+                    dbChannel.setChannelFamily(product.getChannelFamily());
+                    dbChannel.setName(productrepo.getChannelName());
+                    dbChannel.setSummary(product.getFriendlyName());
+                    dbChannel.setDescription(
+                            Optional.ofNullable(product.getDescription())
+                                    .orElse(product.getFriendlyName()));
+                    dbChannel.setProduct(MgrSyncUtils.findOrCreateChannelProduct(product));
+                    dbChannel.setProductName(MgrSyncUtils.findOrCreateProductName(product.getName()));
+                    dbChannel.setUpdateTag(productrepo.getUpdateTag());
+                    ChannelFactory.save(dbChannel);
 
-        // update Mandatory Flag
-        dbChannel.getSuseProductChannels().forEach(pc -> {
-            suseProductSCCRepositories.forEach(pr -> {
-                if (pr.getProduct().equals(pc.getProduct()) && pr.isMandatory() != pc.isMandatory()) {
-                    pc.setMandatory(pr.isMandatory());
-                    SUSEProductFactory.save(pc);
-                }
-            });
-        });
+                    // update Mandatory Flag
+                    dbChannel.getSuseProductChannels().forEach(pc -> {
+                        suseProductSCCRepositories.forEach(pr -> {
+                            if (pr.getProduct().equals(pc.getProduct()) && pr.isMandatory() != pc.isMandatory()) {
+                                pc.setMandatory(pr.isMandatory());
+                                SUSEProductFactory.save(pc);
+                            }
+                        });
+                    });
+                });
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- prevent crash of mgr-sync refresh when channel label could not be found (bsc#1125451)
 - Keep assigned channels on traditional to minion migration (bsc#1122836)
 - Add UI to create virtual machine for salt minions
 - Fix "Add Selected to SSM" on System Groups -> systems page (bsc#1121856)

--- a/susemanager-sync-data/product_tree.json
+++ b/susemanager-sync-data/product_tree.json
@@ -61035,7 +61035,7 @@
         "channel_name": "SLE-Module-CAP-Tools15-SP1-Debuginfo-Pool for x86_64 SAP"
     },
     {
-        "channel_label": "suse-packagehub-12-sp4-aarch64",
+        "channel_label": "suse-packagehub-12-sp4-standard-pool-aarch64",
         "parent_channel_label": "sles12-sp4-pool-aarch64",
         "product_id": 1810,
         "repository_id": 3451,
@@ -61080,7 +61080,7 @@
         "channel_name": "SUSE-PackageHub-12-SP4-Pool for aarch64"
     },
     {
-        "channel_label": "suse-packagehub-12-sp4-aarch64-hpc-sp4",
+        "channel_label": "suse-packagehub-12-sp4-standard-pool-aarch64-hpc-sp4",
         "parent_channel_label": "sle12-sp4-hpc-pool-aarch64",
         "product_id": 1810,
         "repository_id": 3451,
@@ -61125,7 +61125,7 @@
         "channel_name": "SUSE-PackageHub-12-SP4-Pool for aarch64 HPC"
     },
     {
-        "channel_label": "suse-packagehub-12-sp4-ppc64le",
+        "channel_label": "suse-packagehub-12-sp4-standard-pool-ppc64le",
         "parent_channel_label": "sles12-sp4-pool-ppc64le",
         "product_id": 1811,
         "repository_id": 3454,
@@ -61170,7 +61170,7 @@
         "channel_name": "SUSE-PackageHub-12-SP4-Pool for ppc64le"
     },
     {
-        "channel_label": "suse-packagehub-12-sp4-ppc64le-sap-sp4",
+        "channel_label": "suse-packagehub-12-sp4-standard-pool-ppc64le-sap-sp4",
         "parent_channel_label": "sle12-sp4-sap-pool-ppc64le",
         "product_id": 1811,
         "repository_id": 3454,
@@ -61215,7 +61215,7 @@
         "channel_name": "SUSE-PackageHub-12-SP4-Pool for ppc64le SAP"
     },
     {
-        "channel_label": "suse-packagehub-12-sp4-s390x",
+        "channel_label": "suse-packagehub-12-sp4-standard-pool-s390x",
         "parent_channel_label": "sles12-sp4-pool-s390x",
         "product_id": 1812,
         "repository_id": 3457,
@@ -61260,7 +61260,7 @@
         "channel_name": "SUSE-PackageHub-12-SP4-Pool for s390x"
     },
     {
-        "channel_label": "suse-packagehub-12-sp4-x86_64",
+        "channel_label": "suse-packagehub-12-sp4-standard-pool-x86_64",
         "parent_channel_label": "sles12-sp4-pool-x86_64",
         "product_id": 1813,
         "repository_id": 3460,
@@ -61305,7 +61305,7 @@
         "channel_name": "SUSE-PackageHub-12-SP4-Pool for x86_64"
     },
     {
-        "channel_label": "suse-packagehub-12-sp4-x86_64-sled-sp4",
+        "channel_label": "suse-packagehub-12-sp4-standard-pool-x86_64-sled-sp4",
         "parent_channel_label": "sled12-sp4-pool-x86_64",
         "product_id": 1813,
         "repository_id": 3460,
@@ -61350,7 +61350,7 @@
         "channel_name": "SUSE-PackageHub-12-SP4-Pool for x86_64 SLED"
     },
     {
-        "channel_label": "suse-packagehub-12-sp4-x86_64-sap-sp4",
+        "channel_label": "suse-packagehub-12-sp4-standard-pool-x86_64-sap-sp4",
         "parent_channel_label": "sle12-sp4-sap-pool-x86_64",
         "product_id": 1813,
         "repository_id": 3460,
@@ -61395,7 +61395,7 @@
         "channel_name": "SUSE-PackageHub-12-SP4-Pool for x86_64 SAP"
     },
     {
-        "channel_label": "suse-packagehub-12-sp4-x86_64-hpc-sp4",
+        "channel_label": "suse-packagehub-12-sp4-standard-pool-x86_64-hpc-sp4",
         "parent_channel_label": "sle12-sp4-hpc-pool-x86_64",
         "product_id": 1813,
         "repository_id": 3460,

--- a/susemanager-sync-data/product_tree.json
+++ b/susemanager-sync-data/product_tree.json
@@ -26955,7 +26955,7 @@
         "channel_name": "SLE12-SP1-SAP-Debuginfo-Pool for x86_64"
     },
     {
-        "channel_label": "suse-openstack-cloud-6-updates-x86_64-sp1",
+        "channel_label": "suse-openstack-cloud-6-updates-x86_64",
         "parent_channel_label": "sles12-sp1-pool-x86_64",
         "product_id": 1347,
         "repository_id": 1941,
@@ -26970,7 +26970,7 @@
         "channel_name": "SUSE-OpenStack-Cloud-6-Updates for x86_64 SP1"
     },
     {
-        "channel_label": "suse-openstack-cloud-6-debuginfo-updates-x86_64-sp1",
+        "channel_label": "suse-openstack-cloud-6-debuginfo-updates-x86_64",
         "parent_channel_label": "sles12-sp1-pool-x86_64",
         "product_id": 1347,
         "repository_id": 1942,
@@ -26985,7 +26985,7 @@
         "channel_name": "SUSE-OpenStack-Cloud-6-Debuginfo-Updates for x86_64 SP1"
     },
     {
-        "channel_label": "suse-openstack-cloud-6-pool-x86_64-sp1",
+        "channel_label": "suse-openstack-cloud-6-pool-x86_64",
         "parent_channel_label": "sles12-sp1-pool-x86_64",
         "product_id": 1347,
         "repository_id": 1943,
@@ -27000,7 +27000,7 @@
         "channel_name": "SUSE-OpenStack-Cloud-6-Pool for x86_64 SP1"
     },
     {
-        "channel_label": "suse-openstack-cloud-6-debuginfo-pool-x86_64-sp1",
+        "channel_label": "suse-openstack-cloud-6-debuginfo-pool-x86_64",
         "parent_channel_label": "sles12-sp1-pool-x86_64",
         "product_id": 1347,
         "repository_id": 1944,

--- a/susemanager-sync-data/susemanager-sync-data.changes
+++ b/susemanager-sync-data/susemanager-sync-data.changes
@@ -1,3 +1,5 @@
+- fix channel label for suse-openstack-cloud-6 and packagehub-12-sp4-* (bsc#1125451)
+
 -------------------------------------------------------------------
 Wed Jan 16 12:27:30 CET 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Dont crash mgr-sync refresh if we encounter a channel label that is not in the product tree.
Fix channel labels that changed on accident from what we had in channels.xml before