### PR TITLE
Fix "base64.decodestring" issues and "spacewalk-proxy" to run with Python 3

### DIFF
--- a/backend/server/action_extra_data/scap.py
+++ b/backend/server/action_extra_data/scap.py
@@ -31,7 +31,7 @@ def xccdf_eval(server_id, action_id, data={}):
         return
 
     for item in ('resume', 'errors'):
-        data[item] = decodestring(data[item])
+        data[item] = decodestring(data[item].encode()).decode()
 
     resume = xml.dom.minidom.parseString(data['resume'])
     benchmark = resume.getElementsByTagName('benchmark-resume')[0]

--- a/backend/server/action_extra_data/script.py
+++ b/backend/server/action_extra_data/script.py
@@ -68,7 +68,7 @@ def run(server_id, action_id, data={}):
     # this flag and encoding the results,
     # otherwise xmlrpc isn't very happy on certain characters
     if 'base64enc' in data:
-        output = base64.decodestring(output)
+        output = base64.decodestring(output.encode()).decode()
 
     return_code = data.get('return_code')
     process_end = data.get('process_end')

--- a/backend/server/configFilesHandler.py
+++ b/backend/server/configFilesHandler.py
@@ -319,7 +319,7 @@ class ConfigFilesHandler(rhnHandler):
         file_contents = file.get('file_contents') or ''
 
         if 'enc64' in file and file_contents:
-            file_contents = base64.decodestring(file_contents)
+            file_contents = base64.decodestring(file_contents.encode())
 
         if 'config_file_type_id' not in file:
             log_debug(4, "Client does not support config directories, so set file_type_id to 1")
@@ -340,7 +340,7 @@ class ConfigFilesHandler(rhnHandler):
             # XXX Yes this is iterating over a string
             try:
                 file_contents.decode('UTF-8')
-            except UnicodeDecodeError:
+            except Exception:
                 file['is_binary'] = 'Y'
 
         h = rhnSQL.prepare(self._query_content_lookup)

--- a/proxy/proxy/apacheHandler.py
+++ b/proxy/proxy/apacheHandler.py
@@ -39,7 +39,7 @@ from spacewalk.common import byterange
 
 from rhn import rpclib, connections
 from rhn.UserDictCase import UserDictCase
-from rhnConstants import HEADER_ACTUAL_URI, HEADER_EFFECTIVE_URI, \
+from .rhnConstants import HEADER_ACTUAL_URI, HEADER_EFFECTIVE_URI, \
     HEADER_CHECKSUM, SCHEME_HTTP, SCHEME_HTTPS, URI_PREFIX_KS, \
     URI_PREFIX_KS_CHECKSUM, COMPONENT_BROKER, COMPONENT_REDIRECT
 
@@ -357,11 +357,11 @@ class apacheHandler(rhnApache):
         log_debug(4, "Component", self._component)
 
         if self._component == COMPONENT_BROKER:
-            from broker import rhnBroker
+            from .broker import rhnBroker
             handlerObj = rhnBroker.BrokerHandler(req)
         else:
             # Redirect
-            from redirect import rhnRedirect
+            from .redirect import rhnRedirect
             handlerObj = rhnRedirect.RedirectHandler(req)
 
         try:

--- a/proxy/proxy/apacheHandler.py
+++ b/proxy/proxy/apacheHandler.py
@@ -56,12 +56,12 @@ def getComponentType(req):
     """
 
     # NOTE: X-RHN-Proxy-Auth described in broker/rhnProxyAuth.py
-    if not req.headers_in.has_key('X-RHN-Proxy-Auth'):
+    if 'X-RHN-Proxy-Auth' not in req.headers_in:
         # Request comes from a client, Must be the broker
         return COMPONENT_BROKER
 
     # Might be obsolete if proxy is traditionally registered
-    if req.headers_in.has_key('X-Suse-Auth-Token'):
+    if 'X-Suse-Auth-Token' in req.headers_in:
         return COMPONENT_REDIRECT
 
     # pull server id out of "t:o:k:e:n:hostname1,t:o:k:e:n:hostname2,..."
@@ -200,7 +200,7 @@ class apacheHandler(rhnApache):
         # If we don't get the actual URI in the headers, we'll decline the
         # request.
 
-        if not req.headers_in or not req.headers_in.has_key(HEADER_ACTUAL_URI):
+        if not req.headers_in or HEADER_ACTUAL_URI not in req.headers_in:
             log_error("Kickstart request header did not include '%s'"
                       % HEADER_ACTUAL_URI)
             return apache.DECLINED
@@ -282,7 +282,7 @@ class apacheHandler(rhnApache):
             log_error("HEAD response - No HTTP headers!")
             return (apache.OK, None)
 
-        if not responseHdrs.has_key(HEADER_CHECKSUM):
+        if HEADER_CHECKSUM not in responseHdrs:
             # No checksum was provided.  This could happen if a newer
             # proxy is talking to an older satellite.  To keep things
             # running smoothly, we'll just revert to the BZ 158236
@@ -410,7 +410,7 @@ class apacheHandler(rhnApache):
         response_size = file_size
 
         # Serve up the requested byte range
-        if req.headers_in.has_key("Range"):
+        if "Range" in req.headers_in:
             try:
                 range_start, range_end = \
                     byterange.parse_byteranges(req.headers_in["Range"],
@@ -442,7 +442,7 @@ class apacheHandler(rhnApache):
         if response.name:
             req.headers_out["X-Package-FileName"] = response.name
 
-        xrepcon = req.headers_in.has_key("X-Replace-Content-Active") \
+        xrepcon = "X-Replace-Content-Active" in req.headers_in \
             and rhnFlags.test("Download-Accelerator-Path")
         if xrepcon:
             fpath = rhnFlags.get("Download-Accelerator-Path")
@@ -456,7 +456,7 @@ class apacheHandler(rhnApache):
         # send the headers
         req.send_http_header()
 
-        if req.headers_in.has_key("Range"):
+        if "Range" in req.headers_in:
             # and the file
             read = 0
             while read < response_size:

--- a/proxy/proxy/apacheServer.py
+++ b/proxy/proxy/apacheServer.py
@@ -38,7 +38,7 @@ class HandlerWrap:
         #       req object.
 
         if self.__init:
-            from apacheHandler import getComponentType
+            from .apacheHandler import getComponentType
             # We cannot trust the config files to tell us if we are in the
             # broker or in the redirect because we try to always pass
             # upstream all requests
@@ -73,7 +73,7 @@ class HandlerWrap:
     @staticmethod
     def get_handler_factory(_req):
         """ Handler factory. Redefine in your subclasses if so choose """
-        from apacheHandler import apacheHandler
+        from .apacheHandler import apacheHandler
         return apacheHandler
 
 

--- a/proxy/proxy/broker/rhnBroker.py
+++ b/proxy/proxy/broker/rhnBroker.py
@@ -38,7 +38,7 @@ from spacewalk.common import suseLib
 # local module imports
 from proxy.rhnShared import SharedHandler
 from proxy.rhnConstants import URI_PREFIX_KS_CHECKSUM
-import rhnRepository
+from . import rhnRepository
 import proxy.rhnProxyAuth
 
 
@@ -538,7 +538,7 @@ class BrokerHandler(SharedHandler):
         # "x-rhn-auth"
         prefix = "x-rhn-auth"
         l = len(prefix)
-        tokenKeys = [x for x in headers.keys() if x[:l].lower() == prefix]
+        tokenKeys = [x for x in list(headers.keys()) if x[:l].lower() == prefix]
         for k in tokenKeys:
             if k.lower() == 'x-rhn-auth-channels':
                 # Multivalued header
@@ -705,12 +705,12 @@ class BrokerHandler(SharedHandler):
 def _dictEquals(d1, d2, exceptions=None):
     """ Function that compare two dictionaries, ignoring certain keys """
     exceptions = [x.lower() for x in (exceptions or [])]
-    for k, v in d1.items():
+    for k, v in list(d1.items()):
         if k.lower() in exceptions:
             continue
         if not d2.has_key(k) or d2[k] != v:
             return 0
-    for k, v in d2.items():
+    for k, v in list(d2.items()):
         if k.lower() in exceptions:
             continue
         if not d1.has_key(k) or d1[k] != v:

--- a/proxy/proxy/broker/rhnBroker.py
+++ b/proxy/proxy/broker/rhnBroker.py
@@ -78,7 +78,7 @@ class BrokerHandler(SharedHandler):
         hostname = ''
         # should *always* exist and be my ip address
         my_ip_addr = req.headers_in['SERVER_ADDR']
-        if req.headers_in.has_key('Host'):
+        if 'Host' in req.headers_in:
             # the client has provided a host header
             try:
                 # When a client with python 2.4 (RHEL 5) uses SSL
@@ -161,10 +161,10 @@ class BrokerHandler(SharedHandler):
         #
         # Traditional SLE and RHEL clients uses 'X-RHN-Auth' header, but
         # no auth token is used in order to authenticate.
-        if self.req.headers_in.has_key('X-Mgr-Auth'):
+        if 'X-Mgr-Auth' in self.req.headers_in:
             self.authToken = self.req.headers_in['X-Mgr-Auth']
             del self.req.headers_in['X-Mgr-Auth']
-        elif not self.req.headers_in.has_key('X-RHN-Auth'):
+        elif 'X-RHN-Auth' not in self.req.headers_in:
             self.authToken = effectiveURI_parts.query
 
         if req.method == 'GET':
@@ -240,7 +240,7 @@ class BrokerHandler(SharedHandler):
         else:
             log_debug(5, 'X-RHN-Proxy-Auth is not set')
 
-        if self.req.headers_in.has_key('X-RHN-Proxy-Auth'):
+        if 'X-RHN-Proxy-Auth' in self.req.headers_in:
             tokens = []
             if 'X-RHN-Proxy-Auth' in _oto:
                 tokens = _oto['X-RHN-Proxy-Auth'].split(',')
@@ -305,7 +305,7 @@ class BrokerHandler(SharedHandler):
             # check for proxy authentication blowup.
             respHeaders = self.responseContext.getHeaders()
             if not respHeaders or \
-               not respHeaders.has_key('X-RHN-Proxy-Auth-Error'):
+               'X-RHN-Proxy-Auth-Error' not in respHeaders:
                 # No proxy auth errors
                 # XXX: need to verify that with respHeaders ==
                 #      None that is is correct logic. It should be -taw
@@ -315,7 +315,7 @@ class BrokerHandler(SharedHandler):
 
             # If a proxy other than this one needs to update its auth token
             # pass the error on up to it
-            if (respHeaders.has_key('X-RHN-Proxy-Auth-Origin') and
+            if ('X-RHN-Proxy-Auth-Origin' in respHeaders and
                     respHeaders['X-RHN-Proxy-Auth-Origin'] != self.proxyAuth.hostname):
                 break
 
@@ -413,7 +413,7 @@ class BrokerHandler(SharedHandler):
         log_debug(1)
         # Check if proxy is interested in this action, and execute any
         # action required:
-        if not headers.has_key('X-RHN-Action'):
+        if 'X-RHN-Action' not in headers:
             # Don't know what to do
             return
 
@@ -524,7 +524,7 @@ class BrokerHandler(SharedHandler):
 
         log_debug(1)
         # Get the server ID
-        if not headers.has_key('X-RHN-Server-ID'):
+        if 'X-RHN-Server-ID' not in headers:
             log_debug(3, "Client server ID not found in headers")
             # XXX: no client server ID in headers, should we care?
             #raise rhnFault(1000, _("Client Server ID not found in headers!"))
@@ -563,9 +563,9 @@ class BrokerHandler(SharedHandler):
         log_debug(2, req_type, identifier, funct, params)
 
         # NOTE: X-RHN-Proxy-Auth described in broker/rhnProxyAuth.py
-        if rhnFlags.get('outputTransportOptions').has_key('X-RHN-Proxy-Auth'):
+        if 'X-RHN-Proxy-Auth' in rhnFlags.get('outputTransportOptions'):
             self.cachedClientInfo['X-RHN-Proxy-Auth'] = rhnFlags.get('outputTransportOptions')['X-RHN-Proxy-Auth']
-        if rhnFlags.get('outputTransportOptions').has_key('Host'):
+        if 'Host' in rhnFlags.get('outputTransportOptions'):
             self.cachedClientInfo['Host'] = rhnFlags.get('outputTransportOptions')['Host']
 
         if req_type == 'tinyurl':
@@ -708,12 +708,12 @@ def _dictEquals(d1, d2, exceptions=None):
     for k, v in list(d1.items()):
         if k.lower() in exceptions:
             continue
-        if not d2.has_key(k) or d2[k] != v:
+        if k not in d2 or d2[k] != v:
             return 0
     for k, v in list(d2.items()):
         if k.lower() in exceptions:
             continue
-        if not d1.has_key(k) or d1[k] != v:
+        if k not in d1 or d1[k] != v:
             return 0
     return 1
 

--- a/proxy/proxy/broker/rhnRepository.py
+++ b/proxy/proxy/broker/rhnRepository.py
@@ -44,6 +44,7 @@ from spacewalk.common.rhnException import rhnFault
 from spacewalk.common.rhnConfig import CFG
 from spacewalk.common import rhnRepository
 from spacewalk.common.rhnTranslate import _
+from spacewalk.common.usix import raise_with_tb
 
 ## local imports
 from rhn import rpclib
@@ -143,8 +144,8 @@ class Repository(rhnRepository.Repository):
             retval = server.proxy.package_source_in_channel(
                 pkgFilename, self.channelName, self.clientInfo)
         except xmlrpclib.Fault as e:
-            raise rhnFault(1000,
-                           _("Error retrieving source package: %s") % str(e)), None, sys.exc_info()[2]
+            raise_with_tb(rhnFault(1000,
+                           _("Error retrieving source package: %s") % str(e)), sys.exc_info()[2])
 
         if not retval:
             raise rhnFault(17, _("Invalid SRPM package requested: %s")
@@ -237,8 +238,8 @@ class Repository(rhnRepository.Repository):
             packageList = self._listPackages()
         except xmlrpclib.ProtocolError as e:
             errcode, errmsg = rpclib.reportError(e.headers)
-            raise rhnFault(1000, "SpacewalkProxy error (xmlrpclib.ProtocolError): "
-                           "errode=%s; errmsg=%s" % (errcode, errmsg)), None, sys.exc_info()[2]
+            raise_with_tb(rhnFault(1000, "SpacewalkProxy error (xmlrpclib.ProtocolError): "
+                           "errode=%s; errmsg=%s" % (errcode, errmsg)), sys.exc_info()[2])
 
         # Hash the list
         _hash = {}

--- a/proxy/proxy/rhnAuthCacheClient.py
+++ b/proxy/proxy/rhnAuthCacheClient.py
@@ -34,7 +34,7 @@ from spacewalk.common.rhnTB import Traceback
 from spacewalk.common.rhnException import rhnFault
 from spacewalk.common.rhnTranslate import _
 from spacewalk.common.usix import raise_with_tb
-from rhnAuthProtocol import CommunicationError, send, recv
+from .rhnAuthProtocol import CommunicationError, send, recv
 
 #
 # Protocol description:

--- a/proxy/proxy/rhnProxyAuth.py
+++ b/proxy/proxy/rhnProxyAuth.py
@@ -364,7 +364,7 @@ problems, isn't running, or the token is somehow corrupt.
         satInfo = None
         for key in ('X-RHN-Server-Id', 'X-RHN-Auth-User-Id', 'X-RHN-Auth',
                     'X-RHN-Auth-Server-Time', 'X-RHN-Auth-Expire-Offset'):
-            if token.has_key(key):
+            if key in token:
                 dumbToken[key] = token[key]
         try:
             s = self.__getXmlrpcServer()

--- a/proxy/proxy/rhnProxyAuth.py
+++ b/proxy/proxy/rhnProxyAuth.py
@@ -37,11 +37,12 @@ from spacewalk.common.rhnConfig import CFG
 from spacewalk.common.rhnException import rhnFault
 from spacewalk.common import rhnCache
 from spacewalk.common.rhnTranslate import _
+from spacewalk.common.usix import raise_with_tb
 
 # local imports
 from rhn import rpclib
 from rhn import SSL
-import rhnAuthCacheClient
+from . import rhnAuthCacheClient
 
 
 sys.path.append('/usr/share/rhn')
@@ -92,9 +93,9 @@ class ProxyAuth:
             mtime = os.stat(ProxyAuth.__systemid_filename)[-2]
         except IOError as e:
             log_error("unable to stat %s: %s" % (ProxyAuth.__systemid_filename, repr(e)))
-            raise rhnFault(1000,
+            raise_with_tb(rhnFault(1000,
                       _("SUSE Manager Proxy error (SUSE Manager Proxy systemid has wrong permissions?). "
-                        "Please contact your system administrator.")), None, sys.exc_info()[2]
+                        "Please contact your system administrator.")), sys.exc_info()[2])
 
         if not self.__systemid_mtime:
             ProxyAuth.__systemid_mtime = mtime
@@ -109,9 +110,9 @@ class ProxyAuth:
             ProxyAuth.__systemid = open(ProxyAuth.__systemid_filename, 'r').read()
         except IOError as e:
             log_error("unable to read %s" % ProxyAuth.__systemid_filename)
-            raise rhnFault(1000,
+            raise_with_tb(rhnFault(1000,
                       _("SUSE Manager Proxy error (SUSE Manager Proxy systemid has wrong permissions?). "
-                        "Please contact your system administrator.")), None, sys.exc_info()[2]
+                        "Please contact your system administrator.")), sys.exc_info()[2])
 
         # get serverid
         sysid, _cruft = xmlrpclib.loads(ProxyAuth.__systemid)
@@ -169,9 +170,9 @@ Either the authentication caching daemon is experiencing
 problems, isn't running, or the token is somehow corrupt.
 """) % self.__serverid
             Traceback("ProxyAuth.set_cached_token", extra=text)
-            raise rhnFault(1000,
+            raise_with_tb(rhnFault(1000,
                       _("SUSE Manager Proxy error (auth caching issue). "
-                        "Please contact your system administrator.")), None, sys.exc_info()[2]
+                        "Please contact your system administrator.")), sys.exc_info()[2])
         log_debug(4, "successfully returning")
         return token
 
@@ -305,15 +306,15 @@ problems, isn't running, or the token is somehow corrupt.
                 if e.faultCode == 10000:
                     # reraise it for the users (outage or "important message"
                     # coming through")
-                    raise rhnFault(e.faultCode, e.faultString), None, sys.exc_info()[2]
+                    raise_with_tb(rhnFault(e.faultCode, e.faultString), sys.exc_info()[2])
                 # ok... it's some other fault
                 Traceback("ProxyAuth.login (Fault) - SUSE Manager Proxy not "
                           "able to log in.")
                 # And raise a Proxy Error - the server made its point loud and
                 # clear
-                raise rhnFault(1000,
+                raise_with_tb(rhnFault(1000,
                           _("SUSE Manager Proxy error (during proxy login). "
-                            "Please contact your system administrator.")), None, sys.exc_info()[2]
+                            "Please contact your system administrator.")), sys.exc_info()[2])
             except Exception as e:
                 token = None
                 log_error("Unhandled exception", e)

--- a/proxy/proxy/rhnProxyAuth.py
+++ b/proxy/proxy/rhnProxyAuth.py
@@ -426,7 +426,7 @@ problems, isn't running, or the token is somehow corrupt.
         return serverObj
 
     def __cache_proxy_key(self):
-        return 'p' + str(self.__serverid) + sha1(self.hostname).hexdigest()
+        return 'p' + str(self.__serverid) + sha1(self.hostname.encode()).hexdigest()
 
     def getProxyServerId(self):
         return self.__serverid

--- a/proxy/proxy/rhnShared.py
+++ b/proxy/proxy/rhnShared.py
@@ -409,7 +409,7 @@ class SharedHandler:
         return status, headers, bodyFd
 
     def _getEffectiveURI(self):
-        if self.req.headers_in.has_key(rhnConstants.HEADER_EFFECTIVE_URI):
+        if rhnConstants.HEADER_EFFECTIVE_URI in self.req.headers_in:
             return self.req.headers_in[rhnConstants.HEADER_EFFECTIVE_URI]
 
         return self.req.uri
@@ -423,7 +423,7 @@ class SharedHandler:
 
         # Get the size of the body
         size = 0
-        if headers.has_key(rhnConstants.HEADER_CONTENT_LENGTH):
+        if rhnConstants.HEADER_CONTENT_LENGTH in headers:
             try:
                 size = int(headers[rhnConstants.HEADER_CONTENT_LENGTH])
             except ValueError:

--- a/proxy/proxy/rhnShared.py
+++ b/proxy/proxy/rhnShared.py
@@ -38,10 +38,11 @@ from spacewalk.common.rhnException import rhnFault, rhnException
 from spacewalk.common.rhnLog import log_debug, log_error
 from spacewalk.common import rhnFlags, rhnLib, apache
 from spacewalk.common.rhnTranslate import _
+from spacewalk.common.usix import raise_with_tb
 
 # local imports
-import rhnConstants
-from responseContext import ResponseContext
+from . import rhnConstants
+from .responseContext import ResponseContext
 
 
 class SharedHandler:
@@ -145,9 +146,9 @@ class SharedHandler:
         except socket.error as e:
             log_error("Error opening connection", self.rhnParent, e)
             Traceback(mail=0)
-            raise rhnFault(1000,
+            raise_with_tb(rhnFault(1000,
                            _("SUSE Manager Proxy could not successfully connect its SUSE Manager parent. "
-                             "Please contact your system administrator.")), None, sys.exc_info()[2]
+                             "Please contact your system administrator.")), sys.exc_info()[2])
 
         # At this point the server should be okay
         log_debug(3, "Connected to parent: %s " % self.rhnParent)
@@ -229,13 +230,13 @@ class SharedHandler:
             # Server closed connection on us, no need to mail out
             # XXX: why are we not mailing this out???
             Traceback("SharedHandler._serverCommo", self.req, mail=0)
-            raise rhnFault(1000, _(
-                "SUSE Manager Proxy error: connection with the SUSE Manager server failed")), None, sys.exc_info()[2]
+            raise_with_tb(rhnFault(1000, _(
+                "SUSE Manager Proxy error: connection with the SUSE Manager server failed")), sys.exc_info()[2])
         except socket.error:
             # maybe self.req.read() failed?
             Traceback("SharedHandler._serverCommo", self.req)
-            raise rhnFault(1000, _(
-                "SUSE Manager Proxy error: connection with the SUSE Manager server failed")), None, sys.exc_info()[2]
+            raise_with_tb(rhnFault(1000, _(
+                "SUSE Manager Proxy error: connection with the SUSE Manager server failed")), sys.exc_info()[2])
 
         log_debug(2, "HTTP status code (200 means all is well): %s" % status)
 

--- a/proxy/proxy/rhnShared.py
+++ b/proxy/proxy/rhnShared.py
@@ -23,7 +23,6 @@ except ImportError:
     import urllib
 import socket
 import sys
-from types import ListType, TupleType
 
 # global imports
 from rhn import connections
@@ -38,7 +37,7 @@ from spacewalk.common.rhnException import rhnFault, rhnException
 from spacewalk.common.rhnLog import log_debug, log_error
 from spacewalk.common import rhnFlags, rhnLib, apache
 from spacewalk.common.rhnTranslate import _
-from spacewalk.common.usix import raise_with_tb
+from spacewalk.common.usix import raise_with_tb, ListType, TupleType
 
 # local imports
 from . import rhnConstants
@@ -340,7 +339,7 @@ class SharedHandler:
         # Set the content type
 
         headers = self.responseContext.getHeaders()
-        self.req.content_type = headers.gettype()
+        self.req.content_type = headers.get_content_type()
         self.req.send_http_header()
 
         # Forward the response body back to the client.

--- a/proxy/proxy/spacewalk-proxy.changes
+++ b/proxy/proxy/spacewalk-proxy.changes
@@ -1,3 +1,5 @@
+- Fix issues after when running proxy on Python 3
+
 -------------------------------------------------------------------
 Wed Jan 16 12:23:41 CET 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR addresses few issues related with Python 3:

- Properly fix `base64.decodestring` calls (only accepting bytes in py3) to prevent issues with `rhnpush`.
- Fix `spacewalk-proxy` to successfully process requests and allow access to server channels from clients behind the proxy:

  - Relative imports.
  - Raise exception with traceback.
  - Remove deprecated usage of `has_key` for dict.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **python3 porting**

- [x] **DONE**

## Test coverage
- No tests: **python3 porting**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/salt-board/issues/247

- [x] **DONE**