### PR TITLE
Prevent "spacecmd" crashing when stdout is redirected in Python 3 (bsc#1125610)

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,5 @@
+- Prevent spacecmd crashing when piping the output in Python 3 (bsc#1125610)
+
 -------------------------------------------------------------------
 Thu Jan 31 16:34:26 CET 2019 - jgonzalez@suse.com
 

--- a/spacecmd/src/lib/api.py
+++ b/spacecmd/src/lib/api.py
@@ -24,6 +24,7 @@
 # unused argument
 # pylint: disable=W0613
 
+import codecs
 import logging
 import sys
 try:
@@ -77,6 +78,7 @@ def do_api(self, args):
     else:
         output = sys.stdout
 
+    output = codecs.getwriter('utf8')(output.buffer)
     api = getattr(self.client, api_name, None)
 
     if not callable(api):


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue with `spacecmd` only happening when there is a pipe to redirect the `stdout` from the process execution:

```console
suma-head-srv:~ # spacecmd -u admin -p ********** api sync.content.listProducts | grep SLE-Module-Packagehub-Subpackages15-SP1-Debuginfo-Updates
INFO: Spacewalk Username: admin
INFO: Connected to https://suma-head-srv.mgr.suse.de/rpc/api as admin
ERROR: write() argument must be str, not bytes
Traceback (most recent call last):
  File "/usr/bin/spacecmd", line 171, in <module>
    shell.print_result(shell.onecmd(precmd), precmd)
  File "/usr/lib64/python3.6/cmd.py", line 217, in onecmd
    return func(arg)
  File "/usr/lib/python3.6/site-packages/spacecmd/api.py", line 98, in do_api
    json_dump(res, output, indent=2, cls=CustomJsonEncoder)
  File "/usr/lib/python3.6/site-packages/spacecmd/utils.py", line 668, in json_dump
    json.dump(obj, fp, ensure_ascii=False, indent=indent, **kwargs)
  File "/usr/lib64/python3.6/json/__init__.py", line 180, in dump
    fp.write(chunk)
  File "/usr/lib64/python3.6/codecs.py", line 377, in write
    self.stream.write(data)
TypeError: write() argument must be str, not bytes
suma-head-srv:~ # 
```

This is now fixed:
```console
suma-head-srv:~ # spacecmd -u admin -p admin api sync.content.listProducts | grep SLE-Module-Packagehub-Subpackages15-SP1-Debuginfo-Updates
INFO: Spacewalk Username: admin
INFO: Connected to https://suma-head-srv.mgr.suse.de/rpc/api as admin
            "description": "SLE-Module-Packagehub-Subpackages15-SP1-Debuginfo-Updates for sle-15-SP1-aarch64",
            "name": "SLE-Module-Packagehub-Subpackages15-SP1-Debuginfo-Updates for aarch64",
            "description": "SLE-Module-Packagehub-Subpackages15-SP1-Debuginfo-Updates for sle-15-SP1-ppc64le",
            "name": "SLE-Module-Packagehub-Subpackages15-SP1-Debuginfo-Updates for ppc64le",
            "description": "SLE-Module-Packagehub-Subpackages15-SP1-Debuginfo-Updates for sle-15-SP1-x86_64",
            "name": "SLE-Module-Packagehub-Subpackages15-SP1-Debuginfo-Updates for x86_64",
            "description": "SLE-Module-Packagehub-Subpackages15-SP1-Debuginfo-Updates for sle-15-SP1-x86_64",
            "name": "SLE-Module-Packagehub-Subpackages15-SP1-Debuginfo-Updates for x86_64",
            "description": "SLE-Module-Packagehub-Subpackages15-SP1-Debuginfo-Updates for sle-15-SP1-ppc64le",
            "name": "SLE-Module-Packagehub-Subpackages15-SP1-Debuginfo-Updates for ppc64le",
            "description": "SLE-Module-Packagehub-Subpackages15-SP1-Debuginfo-Updates for sle-15-SP1-x86_64",
            "name": "SLE-Module-Packagehub-Subpackages15-SP1-Debuginfo-Updates for x86_64",
            "description": "SLE-Module-Packagehub-Subpackages15-SP1-Debuginfo-Updates for sle-15-SP1-aarch64",
            "name": "SLE-Module-Packagehub-Subpackages15-SP1-Debuginfo-Updates for aarch64",
            "description": "SLE-Module-Packagehub-Subpackages15-SP1-Debuginfo-Updates for sle-15-SP1-x86_64",
            "name": "SLE-Module-Packagehub-Subpackages15-SP1-Debuginfo-Updates for x86_64",
suma-head-srv:~ # 
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **already covered in cucumber**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/salt-board/issues/257

- [x] **DONE**
