### PR TITLE
Add missing bsc on "spacewalk-cert-tools" changelog

### DIFF
--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,4 +1,4 @@
-- Fix problem with spacewalk certs tools and Python3
+- Fix problem with spacewalk certs tools and Python3 (bsc#1125282)
 
 -------------------------------------------------------------------
 Wed Jan 16 12:22:08 CET 2019 - jgonzalez@suse.com


### PR DESCRIPTION
## What does this PR change?

This PR simply adds a missing bsc number to an already merged changelog entry for `spacewalk-certs-tools`. This was caused since the fix was created before the actual bug report.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **not needed**

- [x] **DONE**

## Test coverage
- No tests: **not needed**

- [x] **DONE**

## Links

- [x] **DONE**