### PR TITLE
Define "usix.BufferType" as bytes for Python 3 and fix piping with "spacecmd"

### DIFF
--- a/backend/server/rhnSQL/driver_postgresql.py
+++ b/backend/server/rhnSQL/driver_postgresql.py
@@ -289,7 +289,7 @@ class Cursor(sql_base.Cursor):
             raise rhnException("Cannot execute empty cursor")
         if self.blob_map:
             for blob_var in list(self.blob_map.keys()):
-                kw[blob_var] = BufferType(kw[blob_var].encode())
+                kw[blob_var] = BufferType(kw[blob_var])
 
         try:
             retval = function(*p, **kw)

--- a/spacecmd/src/bin/spacecmd
+++ b/spacecmd/src/bin/spacecmd
@@ -52,7 +52,7 @@ if __name__ == '__main__':
     # pylint: disable=E1101
 
     if not sys.stdout.isatty():
-        sys.stdout = codecs.getwriter(locale.getpreferredencoding())(sys.stdout)
+        sys.stdout = codecs.getwriter(locale.getpreferredencoding())(sys.stdout.buffer)
 
     usage = '%(prog)s [options] [command]'
     parser = argparse.ArgumentParser(usage=usage)

--- a/spacecmd/src/lib/api.py
+++ b/spacecmd/src/lib/api.py
@@ -78,7 +78,6 @@ def do_api(self, args):
     else:
         output = sys.stdout
 
-    output = codecs.getwriter('utf8')(output.buffer)
     api = getattr(self.client, api_name, None)
 
     if not callable(api):

--- a/usix/common/usix.py
+++ b/usix/common/usix.py
@@ -23,7 +23,7 @@ PY3 = sys.version_info[0] == 3
 # Common data types
 # Common data types
 if PY3:
-    BufferType = memoryview
+    BufferType = bytes
     UnicodeType = str
     StringType = str
     DictType = dict

--- a/usix/spacewalk-usix.changes
+++ b/usix/spacewalk-usix.changes
@@ -1,3 +1,5 @@
+- Fix BufferType as bytes on Python 3
+
 -------------------------------------------------------------------
 Fri Feb 08 17:39:36 CET 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR changes the definition of `usix.BufferType` for Python 3 from `memoryview` to `bytes`. This way we will handle all buffers as `bytes` to avoid issues regardless buffer source encoding:

```console
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/spacewalk/server/apacheRequest.py", line 137, in call_function
    response = func(*params)
  File "/usr/share/rhn/server/handlers/config/rhn_config_management.py", line 279, in client_upload_file
    return self.push_file(config_channel_id, file)
  File "/usr/lib/python3.6/site-packages/spacewalk/server/configFilesHandler.py", line 260, in push_file
    result = self._push_file(config_channel_id, file)
  File "/usr/lib/python3.6/site-packages/spacewalk/server/configFilesHandler.py", line 230, in _push_file
    self._push_contents(file)
  File "/usr/lib/python3.6/site-packages/spacewalk/server/configFilesHandler.py", line 366, in _push_contents
    h.execute(**file)
  File "/usr/lib/python3.6/site-packages/spacewalk/server/rhnSQL/sql_base.py", line 150, in execute
    return self._execute_wrapper(self._execute, *p, **kw)
  File "/usr/lib/python3.6/site-packages/spacewalk/server/rhnSQL/driver_postgresql.py", line 292, in _execute_wrapper
    kw[blob_var] = BufferType(kw[blob_var].encode())
AttributeError: 'bytes' object has no attribute 'encode'

mod_wsgi (pid=9009): Exception occurred processing WSGI script '/usr/share/rhn/wsgi/config.py'.
```

Besides of that, this PR also fixes, in a general way for all possible commands, the crash when piping the stdout from a `spacecmd` execution:

```console
suma-refhead-srv:~ # spacecmd -u admin -p ******* system_listevents suma-refhead-minssh-sles12sp3.mgr.suse.de | grep Salt
INFO: Spacewalk Username: admin
INFO: Connected to https://suma-refhead-srv.mgr.suse.de/rpc/api as admin
ERROR: write() argument must be str, not bytes
suma-refhead-srv:~ # 
```

After this PR:
```console
suma-refhead-srv:~ # spacecmd -u admin -p ******* system_listevents suma-refhead-minssh-sles12sp3.mgr.suse.de | grep Salt
INFO: Spacewalk Username: admin
INFO: Connected to https://suma-refhead-srv.mgr.suse.de/rpc/api as admin
Details:   Salt
suma-refhead-srv:~ # 
```

**NOTE:** No changelog added for `spacewalk-backend` since the changelog already contains a related unreleased entry.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **python3 bugfix**

- [x] **DONE**

## Test coverage
- No tests: **python3 bugfix**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/salt-board/issues/247

- [x] **DONE**