### PR TITLE
Fix removing the environment reference when removing the only environment

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
@@ -229,6 +229,12 @@ public class ContentProjectFactory extends HibernateFactory {
             prev.setNextEnvironment(null);
             save(prev);
         }
+        else {
+            // Only Env - change the project
+            ContentProject project = toRemove.getContentProject();
+            project.setFirstEnvironment(null);
+            save(project);
+        }
         toRemove.setPrevEnvironment(null);
         toRemove.setNextEnvironment(null);
         remove(toRemove);

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentProjectFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentProjectFactoryTest.java
@@ -149,6 +149,23 @@ public class ContentProjectFactoryTest extends BaseTestCaseWithUser {
     }
 
     /**
+     * Test removing a single environment and check that the reference
+     * to the first environment of the project is updated
+     */
+    public void testRemoveSingleEnvironment() {
+        ContentProject cp = new ContentProject("project1", "Project 1", "This is project 1", user.getOrg());
+        ContentProjectFactory.save(cp);
+
+        ContentEnvironment envdev = new ContentEnvironment("dev", "Development", null, cp);
+        ContentProjectFactory.save(envdev);
+        cp.setFirstEnvironment(envdev);
+
+        ContentProjectFactory.removeEnvironment(envdev);
+        assertFalse(ContentProjectFactory.lookupEnvironmentByLabelAndProject("dev", cp).isPresent());
+        assertFalse(cp.getFirstEnvironmentOpt().isPresent());
+    }
+
+    /**
      * Tests saving a ContentProject and listing it from the DB.
      */
     public void testSaveAndList() {


### PR DESCRIPTION
Fix removing the environment reference when removing the only environment

## What does this PR change?

When removing an environment from a project that only contains 1 environment,
the reference to first environment of a  project didn't get updated. This PR
fixes it. 


## GUI diff

No difference.

- [x] **DONE**

## Documentation
Bugfix

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

No links

- [x] **DONE**
