### PR TITLE
Testsuite: Fix invalid target errors for "ceos-ssh-minion"

### DIFF
--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -61,6 +61,7 @@ def get_target(host)
     'server' => $server,
     'proxy' => $proxy,
     'ceos-minion' => $ceos_minion,
+    'ceos-ssh-minion' => $ceos_minion,
     'ssh-minion' => $ssh_minion,
     'sle-minion' => $minion,
     'sle-client' => $client,


### PR DESCRIPTION
## What does this PR change?

This PR adds `ceos-ssh-minion` as a defined target in order to prevent all errors get get on the testsuite because `ceos-ssh-minion` is not a valid target:

```cucumber
12:15:59 # Copyright (c) 2016-2019 SUSE LLC
12:15:59 # Licensed under the terms of the MIT license.
12:15:59 #
12:15:59 #  1) bootstrap a new CentOS minion via salt-ssh
12:15:59 #  2) subscribe it to a base channel for testing
12:15:59 Feature: Bootstrap a SSH-managed CentOS minion and do some basic operations on it
12:15:59 
12:16:00   @centos_minion
12:16:00   Scenario: Bootstrap a SSH-managed CentOS minion                             # features/core_centos_salt_ssh.feature:10
12:16:00       This scenario ran at: 2019-02-18 13:15:59 +0100
12:16:00     Given I am authorized                                                     # features/step_definitions/navigation_steps.rb:402
12:16:01     When I go to the bootstrapping page                                       # features/step_definitions/salt_steps.rb:612
12:16:02     Then I should see a "Bootstrap Minions" text                              # features/step_definitions/navigation_steps.rb:480
12:16:02     When I check "manageWithSSH"                                              # features/step_definitions/navigation_steps.rb:138
12:16:02     And I enter the hostname of "ceos-ssh-minion" as "hostname"               # features/step_definitions/salt_steps.rb:697
12:16:02       Invalid target (RuntimeError)
12:16:02       ./features/support/twopence_init.rb:73:in `get_target'
12:16:02       ./features/support/twopence_init.rb:89:in `get_system_name'
12:16:02       ./features/step_definitions/salt_steps.rb:698:in `/^I enter the hostname of "([^"]*)" as "([^"]*)"$/'
12:16:02       features/core_centos_salt_ssh.feature:15:in `And I enter the hostname of "ceos-ssh-minion" as "hostname"'
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **testsuite fix**

- [x] **DONE**

## Test coverage
- No tests: **testsuite fix**

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**