### PR TITLE
Fix check on mgractionchains job when the module is not there

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/JobReturnEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/JobReturnEventMessageAction.java
@@ -119,7 +119,9 @@ public class JobReturnEventMessageAction implements MessageAction {
             // The Salt reactor triggers a "suma-action-chain" job (mgractionchains.resume) at
             // 'minion/startup/event/'. This means the result might not be a JSON in case of
             // a Salt error when the 'mgractionchains' custom module is not yet deployed.
-            if (jobReturnEvent.getData().getRetcode() == 254 && !jobReturnEvent.getData().isSuccess()) {
+            if (jobReturnEvent.getData().getRetcode() == 1 && !jobReturnEvent.getData().isSuccess() &&
+                    jobReturnEvent.getData().getResult().toString()
+                            .contains("'mgractionchains.resume' is not available")) {
                 return;
             }
 


### PR DESCRIPTION
## What does this PR change?

Fix the custom check for `mgractionchains.resume` function whenever the `module` is not yet installed and the `job` fails and at the moment it also throws a Java exception (here it is the [stacktrace](https://gist.github.com/ncounter/bc312f611fd9594a1750f12c52b0a130)): the `retcode` is changed (it was `245`, now it is `1`).
Now we need a way to differentiate the check in case `mgractionchains.resume` fails because it is not yet installed and when it fails for someother reason. The only custom way to check is to look into the `return` field if it contains the `..is not available` String.

Current `retcode`:
```
salt/job/20190220094718599404/ret/min-sles15sp1.tf.local        {
    "_stamp": "2019-02-20T08:47:37.076619",
    "cmd": "_return",
    "fun": "mgractionchains.resume",
    "fun_args": [],
    "id": "min-sles15sp1.tf.local",
    "jid": "20190220094718599404",
    "metadata": {
        "suma-action-chain": true
    },
    "out": "nested",
    "retcode": 1,
    "return": "'mgractionchains.resume' is not available.",
    "success": false
}
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: nothing to document, it is a code-fix

- [x] **DONE**

## Test coverage
- No tests: the outcome is still a failure, but we do not throw any exception anymore, we just `return` instead, as wished
- Unit tests were already there

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
