### PR TITLE
Use current ioloop for mgr_events

### DIFF
--- a/susemanager-utils/susemanager-sls/modules/engines/mgr_events.py
+++ b/susemanager-utils/susemanager-sls/modules/engines/mgr_events.py
@@ -73,7 +73,8 @@ import salt.utils.event
 import json
 
 # Import third-party libs
-import tornado.ioloop
+import tornado
+from salt.utils.zeromq import ZMQDefaultLoop
 
 log = logging.getLogger(__name__)
 
@@ -179,7 +180,7 @@ def start(**config):
     '''
     Listen to events and write them to the Postgres database
     '''
-    io_loop = tornado.ioloop.IOLoop()
+    io_loop = ZMQDefaultLoop.current()
     event_bus = salt.utils.event.get_master_event(
             __opts__,
             __opts__['sock_dir'],

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Fix mgr_events to use current ioloop
 - add states for virtual machine actions
 - Added option to read 'pkg_download_point_...' pillar values and use it in repo url
 


### PR DESCRIPTION
## What does this PR change?

Make sure the IOLoop is the current one

## Links
https://www.tornadoweb.org/en/stable/ioloop.html#tornado.ioloop.IOLoop.current