### PR TITLE
Fix issues to allow traditional client registration via proxy with Python 3

### DIFF
--- a/backend/cdn_tools/cdnsync.py
+++ b/backend/cdn_tools/cdnsync.py
@@ -19,7 +19,7 @@ import sys
 import fnmatch
 from datetime import datetime, timedelta
 
-import constants
+from . import constants
 from spacewalk.common.rhnConfig import CFG, initCFG, PRODUCT_NAME
 from spacewalk.common import rhnLog
 from spacewalk.server import rhnSQL
@@ -37,8 +37,8 @@ from spacewalk.satellite_tools.satCerts import get_certificate_info, verify_cert
 from spacewalk.satellite_tools.syncLib import log, log2disk, log2, initEMAIL_LOG, log2email, log2background
 from spacewalk.satellite_tools.repo_plugins import yum_src
 
-from common import CustomChannelSyncError, CountingPackagesError, verify_mappings, human_readable_size
-from repository import CdnRepositoryManager, CdnRepositoryNotFoundError
+from .common import CustomChannelSyncError, CountingPackagesError, verify_mappings, human_readable_size
+from .repository import CdnRepositoryManager, CdnRepositoryNotFoundError
 
 
 class CdnSync(object):

--- a/backend/cdn_tools/common.py
+++ b/backend/cdn_tools/common.py
@@ -13,7 +13,7 @@
 #
 
 from spacewalk.common import fileutils
-import constants
+from . import constants
 
 
 def verify_mappings():

--- a/backend/cdn_tools/manifest.py
+++ b/backend/cdn_tools/manifest.py
@@ -27,7 +27,7 @@ from M2Crypto import X509
 from spacewalk.satellite_tools.syncLib import log2
 from spacewalk.server.rhnServer.satellite_cert import SatelliteCert
 
-import constants
+from . import constants
 
 
 class Manifest(object):

--- a/backend/cdn_tools/repository.py
+++ b/backend/cdn_tools/repository.py
@@ -23,7 +23,7 @@ from spacewalk.satellite_tools.satCerts import verify_certificate_dates
 from spacewalk.satellite_tools.syncLib import log, log2
 from spacewalk.server.importlib.importLib import ContentSource, ContentSourceSsl
 
-import constants
+from . import constants
 
 
 class CdnRepositoryManager(object):

--- a/backend/common/rhnMail.py
+++ b/backend/common/rhnMail.py
@@ -27,7 +27,7 @@ from spacewalk.common.stringutils import to_string
 
 
 def __check_headers(h):
-    if not isinstance(h, type({})) or not hasattr(h, "has_key"):
+    if not isinstance(h, type({})):
         # does not look like a dictionary
         h = {}
     if "Subject" not in h:

--- a/backend/common/rhnRepository.py
+++ b/backend/common/rhnRepository.py
@@ -111,7 +111,7 @@ class Repository(RPC_Base):
             transport_cap = rhnFlags.get('x-rhn-transport-capability')
             if transport_cap:
                 transport_cap_list = transport_cap.split('=')
-                redirectsSupported = transport_cap_list[0] == 'follow-redirects' and transport_cap_list[1] >= 2
+                redirectsSupported = transport_cap_list[0] == 'follow-redirects' and int(transport_cap_list[1]) >= 2
 
         if redirectsSupported:
             log_debug(3, "Client supports redirects.")

--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -546,7 +546,7 @@ type=rpm-md
         """
         if not self.repo.is_configured:
             self.setup_repo(self.repo)
-        return os.path.join(self.repo.root, ZYPP_RAW_CACHE_PATH, self.name, "repodata")
+        return os.path.join(self.repo.root, ZYPP_RAW_CACHE_PATH, self.channel_label or self.reponame, "repodata")
 
     def get_md_checksum_type(self):
         """

--- a/backend/server/action/packages.py
+++ b/backend/server/action/packages.py
@@ -146,7 +146,7 @@ def setLocks(serverId, actionId, dry_run=0):
     client_caps = rhnCapability.get_client_capabilities()
     log_debug(3,"Client Capabilities", client_caps)
     multiarch = 0
-    if not client_caps or not client_caps.has_key('packages.setLocks'):
+    if not client_caps or 'packages.setLocks' not in client_caps:
         raise InvalidAction("Client is not capable of locking packages.")
 
     h = rhnSQL.prepare(_query_action_setLocks)

--- a/backend/server/importlib/backend.py
+++ b/backend/server/importlib/backend.py
@@ -2483,7 +2483,7 @@ class Backend:
             query = "update % set %s where %s" % (
                 table_name,
                 ', '.join(["%s = :s" + (x, x) for x in fields]),
-                ', '.join(["%s = :%s" % (x, x) for x in uq_fields]),
+                ' and '.join(["%s = :%s" % (x, x) for x in uq_fields]),
             )
             h = self.dbmodule.prepare(query)
             h.executemany(**params)

--- a/backend/server/rhnSQL/driver_postgresql.py
+++ b/backend/server/rhnSQL/driver_postgresql.py
@@ -289,7 +289,10 @@ class Cursor(sql_base.Cursor):
             raise rhnException("Cannot execute empty cursor")
         if self.blob_map:
             for blob_var in list(self.blob_map.keys()):
-                kw[blob_var] = BufferType(kw[blob_var])
+                if isinstance(kw[blob_var], str):
+                    kw[blob_var] = BufferType(kw[blob_var].encode())
+                else:
+                    kw[blob_var] = BufferType(kw[blob_var])
 
         try:
             retval = function(*p, **kw)

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Allow errata import from local repositories.
 - Fix "rhnpush" after migration to Python 3.
 - Fix package import issues when package encoding is ISO8859-1.
 - Fix issues with HTTP proxy and reposync.

--- a/backend/wsgi/wsgiRequest.py
+++ b/backend/wsgi/wsgiRequest.py
@@ -140,10 +140,13 @@ class WsgiMPtable:
         self.dict = {}
 
     def add(self, key, value):
-        if key in self.dict:
+        if key in self.dict and value not in self.dict[key]:
             self.dict[key].append(str(value))
         else:
             self.dict[key] = [str(value)]
+
+    def __contains__(self, key):
+        return self.has_key(key)
 
     def __getitem__(self, key):
         if len(self.dict[key]) == 1:
@@ -167,4 +170,4 @@ class WsgiMPtable:
         return list(self.dict.keys())
 
     def __str__(self):
-        return str(list(self.items()))
+        return str(self.items())

--- a/client/rhel/rhnlib/rhn/rpclib.py
+++ b/client/rhel/rhnlib/rhn/rpclib.py
@@ -272,7 +272,7 @@ class Server:
         content_range = headers.get('Content-Range')
         if not content_range:
             return None
-        arr = filter(None, content_range.split())
+        arr = list(filter(None, content_range.split()))
         assert arr[0] == "bytes"
         assert len(arr) == 2
         arr = arr[1].split('/')
@@ -562,7 +562,7 @@ class GETServer(Server):
         if not params or len(params) < 1:
             raise Exception("Required parameter channel not found")
         # Strip the multiple / from the handler
-        h_comps = filter(lambda x: x != '', self._orig_handler.split('/'))
+        h_comps = list(filter(lambda x: x != '', self._orig_handler.split('/')))
         # Set the handler we are going to request
         hndl = h_comps + ["$RHN", params[0], methodname] + list(params[1:])
         self._handler = '/' + '/'.join(hndl)

--- a/client/rhel/rhnlib/rhn/transports.py
+++ b/client/rhel/rhnlib/rhn/transports.py
@@ -699,7 +699,7 @@ class BaseOutput:
             transfer_name = self.transfers[self.TRANSFER_BASE64]
             self.set_header("Content-Transfer-Encoding", transfer_name)
             self.set_header("Content-Type", "text/base64")
-            self.data = base64.encodestring(self.data)
+            self.data = base64.encodestring(self.data).decode()
 
         self.set_header("Content-Length", len(self.data))
 

--- a/proxy/proxy/apacheHandler.py
+++ b/proxy/proxy/apacheHandler.py
@@ -586,7 +586,7 @@ class apacheHandler(rhnApache):
     @staticmethod
     def _response_fault_get(req, response):
         req.headers_out["X-RHN-Fault-Code"] = str(response.faultCode)
-        faultString = base64.encodestring(response.faultString).strip()
+        faultString = base64.encodestring(response.faultString.encode()).decode().strip()
         # Split the faultString into multiple lines
         for line in faultString.split('\n'):
             req.headers_out.add("X-RHN-Fault-String", line.strip())

--- a/proxy/proxy/broker/rhnRepository.py
+++ b/proxy/proxy/broker/rhnRepository.py
@@ -187,7 +187,7 @@ class Repository(rhnRepository.Repository):
         if os.access(filePath, os.R_OK):
             try:
                 # Slurp the file
-                f = open(filePath, "r")
+                f = open(filePath, "rb")
                 data = f.read()
                 f.close()
                 stringObject = cPickle.loads(data)

--- a/proxy/proxy/rhnShared.py
+++ b/proxy/proxy/rhnShared.py
@@ -277,18 +277,8 @@ class SharedHandler:
 
         if hasattr(headerObj, 'getheaders'):
             return headerObj.getheaders(k)
-        # The pain of python 1.5.2
-        headers = headerObj.getallmatchingheaders(k)
-        hname = str(k).lower() + ':'
-        hlen = len(hname)
-        ret = []
-        for header in headers:
-            hn = header[:hlen].lower()
-            if hn != hname:
-                log_debug(1, "Invalid header", header)
-                continue
-            ret.append(header[hlen:].strip())
-        return ret
+
+        return headerObj.get_all(k)
 
     def _clientCommo(self, status=apache.OK):
         """ Handler part 3


### PR DESCRIPTION
## What does this PR change?

This PR fixes few py3 issues and hopefully it will fix the traditional client registration via Proxy:

- Fix "reposync" yum plugin to collect available updates from local filesystem repositories.
- Fix bad handling of HTTP headers for WSGI requests between client <-> proxy <-> server.
- Minor typecasting issues.
- Relative python imports.
- Encoding issues.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **python3**

- [x] **DONE**

## Test coverage
- No tests: **python3 porting**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/salt-board/issues/247

- [x] **DONE**
