### PR TITLE
Manager schema upgrade

### DIFF
--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- add missing schema upgrade paths
 - Add virtual machine creation action
 
 -------------------------------------------------------------------

--- a/schema/spacewalk/upgrade/susemanager-schema-3.1.19-to-susemanager-schema-3.2.0/README
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.1.19-to-susemanager-schema-3.2.0/README
@@ -1,0 +1,2 @@
+-- Schema upgrade scripts.
+-- Intentionally left empty. Please leave this directory empty.

--- a/schema/spacewalk/upgrade/susemanager-schema-3.1.20-to-susemanager-schema-3.2.0/README
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.1.20-to-susemanager-schema-3.2.0/README
@@ -1,0 +1,2 @@
+-- Schema upgrade scripts.
+-- Intentionally left empty. Please leave this directory empty.


### PR DESCRIPTION
## What does this PR change?

add missing schema migration paths. These paths DO exist in Manager-3.2, but are missing in 4.0/uyuni. Once these are present, even a migration from 3.1 to 4.0 works.

Julio, as you added these paths to 3.2, I added you as reviewer.