### PR TITLE
Update "jquery-timepicker" depedency for "spacewalk-branding" to 1.11.14 (bsc#1119081)

### DIFF
--- a/branding/spacewalk-branding.changes
+++ b/branding/spacewalk-branding.changes
@@ -1,3 +1,5 @@
+- Update jquery.timepicker dependency to 1.11.14 to allow parsing
+  the new time format from JDK11. (bsc#1119081)
 - Add dropdown number list to jump to a specific table page
 
 -------------------------------------------------------------------

--- a/branding/spacewalk-branding.spec
+++ b/branding/spacewalk-branding.spec
@@ -61,7 +61,7 @@ Requires:       susemanager-getting-started_en-pdf
 Requires:       susemanager-reference_en-pdf
 Requires:       susemanager(bootstrap-datepicker)
 Requires:       susemanager(font-awesome) = 4.4.0
-Requires:       susemanager(jquery-timepicker) = 1.3.2
+Requires:       susemanager(jquery-timepicker) = 1.11.14
 Requires:       susemanager(jquery-ui)
 Requires:       susemanager(momentjs)
 Requires:       susemanager(pwstrength-bootstrap)


### PR DESCRIPTION
## What does this PR change?

This PR fixes `spacewalk-branding` spec to update the required version of `jquery-timepicker` to latest `1.11.14`. This new version successfully parse the new time format from JDK11.

Currently, without this PR, the `spacewalk-branding` installation is broken in our HEAD testsuite due the upgrade of the `jquery-timepicker` package version:

```
14:39:29 module.srv.module.suse_manager.libvirt_domain.domain (remote-exec): Problem: nothing provides susemanager(jquery-timepicker) = 1.3.2 needed by spacewalk-branding-4.0.5-400.2.9.develHead.x86_64
```

/cc @ncounter 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **fix on spec**

- [x] **DONE**

## Links

- [x] **DONE**