### PR TITLE
Fix spacewalk-utils installation on python3 based operating systems

### DIFF
--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,5 @@
+- Fix package installation on python3 based operating systems
+
 -------------------------------------------------------------------
 Thu Jan 17 14:45:24 CET 2019 - jgonzalez@suse.com
 

--- a/utils/spacewalk-utils.spec
+++ b/utils/spacewalk-utils.spec
@@ -84,7 +84,7 @@ Requires:       rpm-python
 %if 0%{?rhel} == 6
 Requires:       %{pythonX}-argparse
 %endif
-Requires:       rhnlib >= 2.5.20
+Requires:       %{pythonX}-rhnlib >= 2.5.20
 Requires:       rpm
 %if ! 0%{?suse_version}
 Requires:       setup
@@ -92,17 +92,24 @@ Requires:       setup
 Requires:       salt
 Requires:       spacewalk-admin
 Requires:       spacewalk-backend
+%if 0%{?suse_version} >= 1320
+Requires:       python3-spacewalk-backend-libs
+%else
 Requires:       spacewalk-backend-libs
+%endif
 Requires:       spacewalk-backend-tools >= 2.2.27
 Requires:       spacewalk-certs-tools
 Requires:       spacewalk-config
 Requires:       spacewalk-reports
 Requires:       spacewalk-setup
-Requires:       yum-utils
 
 Requires:       %{pythonX}-curses
 Requires:       %{pythonX}-ldap
+%if 0%{?suse_version} >= 1320
+Requires:       python3-PyYAML
+%else
 Requires:       %{pythonX}-yaml
+%endif
 
 %description
 Generic utilities that may be run against a Spacewalk server.


### PR DESCRIPTION
## What does this PR change?

Fix spacewalk-utils installation on python3 based operating systems

Removing `yum-utils` will break `spacewalk-clone-by-date` until we can migrate it to python3.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: SPEC fix

- [x] **DONE**

## Test coverage
- No tests: SPEC fix.

- [x] **DONE**

## Links

- [x] **DONE**