### PR TITLE
Add "yarn autoclean" and better error handling for .sh scripts (fix spacewalk-web)

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -2,5 +2,6 @@ yarn-path "./susemanager-frontend/susemanager-nodejs-sdk-devel/build/yarn/yarn-1
 --install.cwd susemanager-frontend
 --clean.cwd susemanager-frontend
 --audit.cwd susemanager-frontend
+--autoclean.cwd susemanager-frontend
 --add.cwd susemanager-frontend/susemanager-nodejs-sdk-devel
 --remove.cwd susemanager-frontend/susemanager-nodejs-sdk-devel

--- a/susemanager-frontend/.yarnclean
+++ b/susemanager-frontend/.yarnclean
@@ -1,0 +1,42 @@
+# test directories
+__tests__
+test
+tests
+powered-test
+
+# asset directories
+docs
+doc
+website
+images
+assets
+
+# examples
+example
+examples
+
+# code coverage directories
+coverage
+.nyc_output
+
+# build scripts
+Makefile
+Gulpfile.js
+Gruntfile.js
+
+# configs
+appveyor.yml
+circle.yml
+codeship-services.yml
+codeship-steps.yml
+wercker.yml
+.tern-project
+.gitattributes
+.editorconfig
+.*ignore
+.eslintrc
+.jshintrc
+.flowconfig
+.documentup.json
+.yarn-metadata.json
+.travis.yml

--- a/susemanager-frontend/susemanager-nodejs-sdk-devel/package.json
+++ b/susemanager-frontend/susemanager-nodejs-sdk-devel/package.json
@@ -47,6 +47,6 @@
   },
   "scripts": {
     "clean": "rm -rf node_modules",
-    "postinstall": "test -n \"$NOYARNPOSTINSTALL\" || (rm -f susemanager-nodejs-modules.tar.gz && (tar czf susemanager-nodejs-modules.tar.gz node_modules/))"
+    "zip": "rm -f susemanager-nodejs-modules.tar.gz && (tar czf susemanager-nodejs-modules.tar.gz node_modules/)"
   }
 }

--- a/susemanager-frontend/susemanager-nodejs-sdk-devel/setup.sh
+++ b/susemanager-frontend/susemanager-nodejs-sdk-devel/setup.sh
@@ -1,3 +1,6 @@
+set -euxo pipefail
 (cd susemanager-frontend/susemanager-nodejs-sdk-devel; rm -rf node_modules)
 yarn install --frozen-lockfile
+(cd susemanager-frontend/susemanager-nodejs-sdk-devel; yarn zip)
+yarn autoclean --force
 echo "susemanager-nodejs-modules.tar.gz"

--- a/web/html/src/scripts/docker-javascript-lint.sh
+++ b/web/html/src/scripts/docker-javascript-lint.sh
@@ -1,12 +1,11 @@
 #!/usr/bin/env bash
-set -e
-set -o pipefail
+set -euxo pipefail
 
 zypper --non-interactive install git
 npm install -g flow-bin@0.93.0
 
 cd /manager/web/html/src
 
-NOYARNPOSTINSTALL=1 yarn install
+yarn install
 yarn build
 yarn lint

--- a/web/setup.sh
+++ b/web/setup.sh
@@ -1,3 +1,4 @@
+set -euxo pipefail
 (cd web/html/src; yarn install --frozen-lockfile)
 (cd web/html/src; yarn build)
 echo ""

--- a/web/spacewalk-web.spec
+++ b/web/spacewalk-web.spec
@@ -158,7 +158,7 @@ make -f Makefile.spacewalk-web PERLARGS="INSTALLDIRS=vendor" %{?_smp_mflags}
 %if 0%{?suse_version}
 pushd html/src
 ln -sf %{nodejs_sitelib} .
-node build
+BUILD_VALIDATION=false node build.js
 popd
 %endif
 


### PR DESCRIPTION
## What does this PR change?

Fix module: spacewalk-web 

OBS does some kind of analyzes through all the files to search for unresolved dependencies. Since we are uploading the node_modules folder to OBS without any cleaning all the files were being analyzed, even stuff that doesn't matter (test files, examples, etc). We are now running "yarn autoclean" before uploading it in order to remove all the unneeded files.

Conflicting library commit: https://github.com/browserify/resolve/commit/2321cd4b4e184f9c97f76ea50dd49b9e42927b93#diff-e64f738da7e8c0e8a6cac6fff33241f0 (test files)

I wonder if it's possible to ignore all these validations on obs for the folder "node_modules"

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
