### PR TITLE
Upgraded max length of xccdf ident (bsc#1125492)

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/audit/ScapManager.java
+++ b/java/code/src/com/redhat/rhn/manager/audit/ScapManager.java
@@ -544,10 +544,10 @@ public class ScapManager extends BaseManager {
                             new RuntimeException("no xccdf result type found for label=" +
                                     label)));
             ruleResult.getIdents().add(
-                    getOrCreateIdent("#IDREF#", truncate(rr.getId(), 100, truncated)));
+                    getOrCreateIdent("#IDREF#", truncate(rr.getId(), 255, truncated)));
             if (rr.getIdents() != null) {
                 for (TestResultRuleResultIdent rrIdent : rr.getIdents()) {
-                    String text = truncate(rrIdent.getText(), 100, truncated);
+                    String text = truncate(rrIdent.getText(), 255, truncated);
                     if (StringUtils.isEmpty(text)) {
                         continue;
                     }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- set max length for xccdf rule identifier to 255 to prevent internal server error (bsc#1125492)
 - add configurable option to auto deploy new tokens (bsc#1123019)
 - support products with multiple base channels
 - fix ordering of base channels to prevent synchronization errors


### PR DESCRIPTION
Sets the max length for xccdf rule names to be stored in the database from 100 to 255. This prevents an exception when comparing rules with names larger than 100 characters.
That's because everything above that threshold got truncated. This means, that that two rules could end up with the same ID because their names would differ only after that threshold.

cherry-pick from https://github.com/SUSE/spacewalk/pull/7086