### PR TITLE
Enable/Disable all SLE15-Module repos

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -601,8 +601,14 @@ When(/^I enable repositories before installing branch server$/) do
     puts $proxy.run("zypper mr --enable openSUSE-Leap-#{os_version}-Update")
   else
     arch, _code = $proxy.run('uname -m')
-    puts $proxy.run("zypper mr --enable SLE-#{os_version}-#{arch.strip}-Pool")
-    puts $proxy.run("zypper mr --enable SLE-#{os_version}-#{arch.strip}-Update")
+    # if it is a SLE15, repos are more than one Pool and one Update, they are both for each Module
+    if os_version.include? '15'
+      repos, _code = $proxy.run("zypper lr | grep #{os_version} | cut -d'|' -f2")
+      puts $proxy.run("zypper mr --enable #{repos.gsub(/\s/, ' ')}")
+    else
+      puts $proxy.run("zypper mr --enable SLE-#{os_version}-#{arch.strip}-Pool")
+      puts $proxy.run("zypper mr --enable SLE-#{os_version}-#{arch.strip}-Update")
+    end
   end
 end
 
@@ -615,8 +621,14 @@ When(/^I disable repositories after installing branch server$/) do
     puts $proxy.run("zypper mr --disable openSUSE-Leap-#{os_version}-Update")
   else
     arch, _code = $proxy.run('uname -m')
-    puts $proxy.run("zypper mr --disable SLE-#{os_version}-#{arch.strip}-Pool")
-    puts $proxy.run("zypper mr --disable SLE-#{os_version}-#{arch.strip}-Update")
+    # if it is a SLE15, repos are more than one Pool and one Update, they are both for each Module
+    if os_version.include? '15'
+      repos, _code = $proxy.run("zypper lr | grep #{os_version} | cut -d'|' -f2")
+      puts $proxy.run("zypper mr --disable #{repos.gsub(/\s/, ' ')}")
+    else
+      puts $proxy.run("zypper mr --disable SLE-#{os_version}-#{arch.strip}-Pool")
+      puts $proxy.run("zypper mr --disable SLE-#{os_version}-#{arch.strip}-Update")
+    end
   end
 end
 

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -601,14 +601,9 @@ When(/^I enable repositories before installing branch server$/) do
     puts $proxy.run("zypper mr --enable openSUSE-Leap-#{os_version}-Update")
   else
     arch, _code = $proxy.run('uname -m')
-    # if it is a SLE15, repos are more than one Pool and one Update, they are both for each Module
-    if os_version.include? '15'
-      repos, _code = $proxy.run("zypper lr | grep #{os_version} | cut -d'|' -f2")
-      puts $proxy.run("zypper mr --enable #{repos.gsub(/\s/, ' ')}")
-    else
-      puts $proxy.run("zypper mr --enable SLE-#{os_version}-#{arch.strip}-Pool")
-      puts $proxy.run("zypper mr --enable SLE-#{os_version}-#{arch.strip}-Update")
-    end
+    # take all repos that matche the following pattern "SLE.*#{os_version}-#{arch.strip}.*"
+    repos, _code = $proxy.run("zypper lr | grep SLE.*#{os_version}-#{arch.strip}.* | cut -d'|' -f2")
+    puts $proxy.run("zypper mr --enable #{repos.gsub(/\s/, ' ')}")
   end
 end
 
@@ -621,14 +616,9 @@ When(/^I disable repositories after installing branch server$/) do
     puts $proxy.run("zypper mr --disable openSUSE-Leap-#{os_version}-Update")
   else
     arch, _code = $proxy.run('uname -m')
-    # if it is a SLE15, repos are more than one Pool and one Update, they are both for each Module
-    if os_version.include? '15'
-      repos, _code = $proxy.run("zypper lr | grep #{os_version} | cut -d'|' -f2")
-      puts $proxy.run("zypper mr --disable #{repos.gsub(/\s/, ' ')}")
-    else
-      puts $proxy.run("zypper mr --disable SLE-#{os_version}-#{arch.strip}-Pool")
-      puts $proxy.run("zypper mr --disable SLE-#{os_version}-#{arch.strip}-Update")
-    end
+    # take all repos that matche the following pattern "SLE.*#{os_version}-#{arch.strip}.*"
+    repos, _code = $proxy.run("zypper lr | grep SLE.*#{os_version}-#{arch.strip}.* | cut -d'|' -f2")
+    puts $proxy.run("zypper mr --disable #{repos.gsub(/\s/, ' ')}")
   end
 end
 


### PR DESCRIPTION
## What does this PR change?

In case `proxy` is a SLE15 machine, we need to `enable/disable` all `SLE-Module-...` repos. This PR detect dynamically which are those by listing them first.

This is the current testsuite failure where we try to enable the `SLE-15-SP1-x86_64-Pool` repo but it does not exists because we have instead
```
SLE-Module-Basesystem15-SP1-x86_64-Pool                 
SLE-Module-Basesystem15-SP1-x86_64-Update               
SLE-Module-Python2-SLE-15-SP1-x86_64-Pool               
SLE-Module-Server-Applications-SLE-15-SP1-x86_64-Pool   
SLE-Module-Server-Applications-SLE-15-SP1-x86_64-Update 
SLE-Module-Web-Scripting-SLE-15-SP1-x86_64-Pool         
SLE-Module-Web-Scripting-SLE-15-SP1-x86_64-Update
```

![screenshot from 2019-02-22 14-59-53](https://user-images.githubusercontent.com/7080830/53247022-8f6ee980-36b2-11e9-8d61-4e24345cf101.png)


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: nothing to document

- [x] **DONE**

## Test coverage
- No tests: it's a testsuite fix
- Cucumber tests : this is a PR to fix it

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
