### PR TITLE
Uyuni limit changelog metadata

### DIFF
--- a/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -186,6 +186,8 @@ public class ConfigDefaults {
     private static final String SYSTEM_CURRENCY_BUG  = "java.sc_bug";
     private static final String SYSTEM_CURRENCY_ENH  = "java.sc_enh";
 
+    public static final String CHANGELOG_ENTRY_LIMIT = "java.max_changelog_entries";
+
     /**
      * Taskomatic defaults
      */

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/OtherXmlWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/OtherXmlWriter.java
@@ -17,6 +17,7 @@
  */
 package com.redhat.rhn.taskomatic.task.repomd;
 
+import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.translation.SqlExceptionTranslator;
 import com.redhat.rhn.domain.channel.Channel;
@@ -127,6 +128,8 @@ public class OtherXmlWriter extends RepomdWriter {
         Long pkgId = pkgDto.getId();
         Collection<PackageChangelogDto> changelogEntries = TaskManager
                 .getPackageChangelogDtos(pkgId);
+        int limit = Config.get().getInt(ConfigDefaults.CHANGELOG_ENTRY_LIMIT, 0);
+        int count = 0;
         for (PackageChangelogDto changelogEntry : changelogEntries) {
             String author = changelogEntry.getAuthor();
             String text = changelogEntry.getText();
@@ -137,6 +140,12 @@ public class OtherXmlWriter extends RepomdWriter {
             tmpHandler.startElement("changelog", attr);
             tmpHandler.addCharacters(sanitize(pkgId, text));
             tmpHandler.endElement("changelog");
+            count++;
+            if (limit > 0 && count >= limit) {
+                // stop adding changelog entries when limit is reached
+                // limit == 0 means add all changelog entries
+                break;
+            }
         }
     }
 

--- a/java/conf/rhn_java.conf
+++ b/java/conf/rhn_java.conf
@@ -193,3 +193,7 @@ java.notifications_type_disabled =
 
 # Maximal number of parallel connections to refresh from SCC
 java.mgr_sync_max_connections = 4
+
+# Maximal number of changelog entries added to repo metadata
+# 0 means unlimited
+java.max_changelog_entries = 0

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Add configuration option to limit the number of changelog entries added
+  to the repository metadata (FATE#325676)
 - Fix a problem when cloning public child channels with a private base channel (bsc#1124639)
 - set max length for xccdf rule identifier to 255 to prevent internal server error (bsc#1125492)
 - add configurable option to auto deploy new tokens (bsc#1123019)


### PR DESCRIPTION
## What does this PR change?

Some packages have a long list of changelog enties. When generating metadata all are taken and added to others.xml . Practically nearly nobody is parsing it and make use of the data but a lot download them.

So it makes sense to just limit the number of entries there to keep the file smaller.

This PR add a new option which define the maximal number of entries added to the metadata.
The default (0) means unlimited and reflect the current behavior.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- [x] **DONE**

## Test coverage

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/7091

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
