### PR TITLE
Implement cache buster for js/css

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/templates/create-project.jade
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/templates/create-project.jade
@@ -5,7 +5,7 @@ include /templates/common.jade
 script(type='text/javascript').
     const csrfToken = "#{csrf_token}";
 
-script(src='/javascript/manager/content-management/create-project/create-project.renderer.bundle.js')
+script(src='/javascript/manager/content-management/create-project/create-project.renderer.bundle.js?cb=#{webVersion}')
 
 script(type='text/javascript').
     pageRenderers.contentManagement.createProject.renderer('content-management-create-project');

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/templates/list-projects.jade
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/templates/list-projects.jade
@@ -5,7 +5,7 @@ include /templates/common.jade
 div#init_data_projects(style="display: none")
     | #{contentProjects}
 
-script(src='/javascript/manager/content-management/list-projects/list-projects.renderer.bundle.js')
+script(src='/javascript/manager/content-management/list-projects/list-projects.renderer.bundle.js?cb=#{webVersion}')
 
 script(type='text/javascript').
     pageRenderers.contentManagement.listProjects.renderer(

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/templates/project.jade
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/templates/project.jade
@@ -8,7 +8,7 @@ script(type='text/javascript').
 div#init_data_project(style="display: none")
     | #{projectToEdit}
 
-script(src='/javascript/manager/content-management/project/project.renderer.bundle.js')
+script(src='/javascript/manager/content-management/project/project.renderer.bundle.js?cb=#{webVersion}')
 
 script(type='text/javascript').
     pageRenderers.contentManagement.project.renderer(

--- a/java/code/src/com/suse/manager/webui/templates/audit/cve.jade
+++ b/java/code/src/com/suse/manager/webui/templates/audit/cve.jade
@@ -6,4 +6,4 @@ script(type='text/javascript').
     const csrfToken = "#{csrf_token}";
 
 +userPreferences
-script(src='/javascript/manager/cveaudit.bundle.js', type='text/javascript')
+script(src='/javascript/manager/cveaudit.bundle.js?cb=#{webVersion}', type='text/javascript')

--- a/java/code/src/com/suse/manager/webui/templates/content_management/build.jade
+++ b/java/code/src/com/suse/manager/webui/templates/content_management/build.jade
@@ -11,4 +11,4 @@ script(type='text/javascript').
     const localTime = "#{h.renderLocalTime()}";
     const actionChains = !{actionChains};
 
-script(src='/javascript/manager/image-build.bundle.js', type='text/javascript')
+script(src='/javascript/manager/image-build.bundle.js?cb=#{webVersion}', type='text/javascript')

--- a/java/code/src/com/suse/manager/webui/templates/content_management/edit-profile.jade
+++ b/java/code/src/com/suse/manager/webui/templates/content_management/edit-profile.jade
@@ -2,7 +2,7 @@ include ../common.jade
 
 #image-profile-edit
 
-script(src='/javascript/validator/validator.min.js', type='text/javascript')
+script(src='/javascript/validator/validator.min.js?cb=#{webVersion}', type='text/javascript')
 
 script(type='text/javascript').
     const csrfToken = "#{csrf_token}";
@@ -11,5 +11,5 @@ script(type='text/javascript').
     const customDataKeys = !{customDataKeys};
     const imageTypesDataFromTheServer = !{imageTypesDataFromTheServer};
 
-script(src='/javascript/manager/image-profile-edit.bundle.js', type='text/javascript')
+script(src='/javascript/manager/image-profile-edit.bundle.js?cb=#{webVersion}', type='text/javascript')
 

--- a/java/code/src/com/suse/manager/webui/templates/content_management/edit-store.jade
+++ b/java/code/src/com/suse/manager/webui/templates/content_management/edit-store.jade
@@ -6,5 +6,5 @@ script(type='text/javascript').
     const csrfToken = "#{csrf_token}";
     const storeId = "#{store_id}"
 
-script(src='/javascript/manager/image-store-edit.bundle.js', type='text/javascript')
+script(src='/javascript/manager/image-store-edit.bundle.js?cb=#{webVersion}', type='text/javascript')
 

--- a/java/code/src/com/suse/manager/webui/templates/content_management/import.jade
+++ b/java/code/src/com/suse/manager/webui/templates/content_management/import.jade
@@ -5,4 +5,4 @@ include ../common.jade
 script(type='text/javascript').
     const csrfToken = "#{csrf_token}";
 
-script(src='/javascript/manager/image-import.bundle.js', type='text/javascript')
+script(src='/javascript/manager/image-import.bundle.js?cb=#{webVersion}', type='text/javascript')

--- a/java/code/src/com/suse/manager/webui/templates/content_management/list-profiles.jade
+++ b/java/code/src/com/suse/manager/webui/templates/content_management/list-profiles.jade
@@ -7,5 +7,5 @@ script(type='text/javascript').
     const isAdmin = #{isAdmin};
 
 +userPreferences
-script(src='/javascript/manager/image-profiles.bundle.js', type='text/javascript')
+script(src='/javascript/manager/image-profiles.bundle.js?cb=#{webVersion}', type='text/javascript')
 

--- a/java/code/src/com/suse/manager/webui/templates/content_management/list-stores.jade
+++ b/java/code/src/com/suse/manager/webui/templates/content_management/list-stores.jade
@@ -7,5 +7,5 @@ script(type='text/javascript').
     const isAdmin = #{is_admin};
 
 +userPreferences
-script(src='/javascript/manager/image-stores.bundle.js', type='text/javascript')
+script(src='/javascript/manager/image-stores.bundle.js?cb=#{webVersion}', type='text/javascript')
 

--- a/java/code/src/com/suse/manager/webui/templates/content_management/view.jade
+++ b/java/code/src/com/suse/manager/webui/templates/content_management/view.jade
@@ -11,4 +11,4 @@ script(type='text/javascript').
     const isRuntimeInfoEnabled = #{isRuntimeInfoEnabled};
 
 +userPreferences
-script(src='/javascript/manager/image-view.bundle.js', type='text/javascript')
+script(src='/javascript/manager/image-view.bundle.js?cb=#{webVersion}', type='text/javascript')

--- a/java/code/src/com/suse/manager/webui/templates/errors/404.jade
+++ b/java/code/src/com/suse/manager/webui/templates/errors/404.jade
@@ -2,7 +2,7 @@ include ../common.jade
 
 #notfoundpage
 
-script(src='/javascript/manager/errors/not-found.bundle.js', type='text/javascript')
+script(src='/javascript/manager/errors/not-found.bundle.js?cb=#{webVersion}', type='text/javascript')
 
 script(type='text/javascript').
     pageRenderers.errors.NotFoundRenderer(

--- a/java/code/src/com/suse/manager/webui/templates/formula_catalog/formula.jade
+++ b/java/code/src/com/suse/manager/webui/templates/formula_catalog/formula.jade
@@ -3,4 +3,4 @@
 script(type="text/javascript").
     var csrfToken = "#{csrf_token}";
     var formulaName = "#{formulaName}";
-script(src='/javascript/manager/org-formula-details.bundle.js')
+script(src='/javascript/manager/org-formula-details.bundle.js?cb=#{webVersion}')

--- a/java/code/src/com/suse/manager/webui/templates/formula_catalog/list.jade
+++ b/java/code/src/com/suse/manager/webui/templates/formula_catalog/list.jade
@@ -14,4 +14,4 @@ else
 #formula-catalog
 
 +userPreferences
-script(src='/javascript/manager/org-formula-catalog.bundle.js')
+script(src='/javascript/manager/org-formula-catalog.bundle.js?cb=#{webVersion}')

--- a/java/code/src/com/suse/manager/webui/templates/groups/custom.jade
+++ b/java/code/src/com/suse/manager/webui/templates/groups/custom.jade
@@ -18,8 +18,8 @@ script(type='text/javascript').
     var csrfToken = "#{csrf_token}";
     var groupId = "#{groupId}";
 
-script(src='/javascript/ace-editor/src-min-noconflict/ace.js')
-script(src='/javascript/ace-editor/src-min-noconflict/ext-modelist.js')
-script(src='/javascript/jquery-ui.js')
+script(src='/javascript/ace-editor/src-min-noconflict/ace.js?cb=#{webVersion}')
+script(src='/javascript/ace-editor/src-min-noconflict/ext-modelist.js?cb=#{webVersion}')
+script(src='/javascript/jquery-ui.js?cb=#{webVersion}')
 
-script(src='/javascript/manager/group-config-channels.bundle.js', type='text/javascript')
+script(src='/javascript/manager/group-config-channels.bundle.js?cb=#{webVersion}', type='text/javascript')

--- a/java/code/src/com/suse/manager/webui/templates/groups/formula.jade
+++ b/java/code/src/com/suse/manager/webui/templates/groups/formula.jade
@@ -20,4 +20,4 @@ script(type='text/javascript').
     var groupId = "#{groupId}";
     var formulaId = #{formula_id};
 
-script(src='/javascript/manager/group-formula.bundle.js', type='text/javascript')
+script(src='/javascript/manager/group-formula.bundle.js?cb=#{webVersion}', type='text/javascript')

--- a/java/code/src/com/suse/manager/webui/templates/groups/formulas.jade
+++ b/java/code/src/com/suse/manager/webui/templates/groups/formulas.jade
@@ -19,4 +19,4 @@ script(type='text/javascript').
     var csrfToken = "#{csrf_token}";
     var groupId = "#{groupId}";
 
-script(src='/javascript/manager/group-formula-selection.bundle.js', type='text/javascript')
+script(src='/javascript/manager/group-formula-selection.bundle.js?cb=#{webVersion}', type='text/javascript')

--- a/java/code/src/com/suse/manager/webui/templates/groups/highstate.jade
+++ b/java/code/src/com/suse/manager/webui/templates/groups/highstate.jade
@@ -21,4 +21,4 @@ script(type='text/javascript').
     const localTime = "#{h.renderLocalTime()}";
     const actionChains = !{actionChains};
 
-script(src='/javascript/manager/highstate.bundle.js', type='text/javascript')
+script(src='/javascript/manager/highstate.bundle.js?cb=#{webVersion}', type='text/javascript')

--- a/java/code/src/com/suse/manager/webui/templates/minion/bootstrap.jade
+++ b/java/code/src/com/suse/manager/webui/templates/minion/bootstrap.jade
@@ -4,4 +4,4 @@ script(type="text/javascript").
     var csrfToken = "#{csrf_token}";
     var availableActivationKeys = !{availableActivationKeys};
     var proxies = !{proxies}
-script(src='/javascript/manager/bootstrap-minions.bundle.js')
+script(src='/javascript/manager/bootstrap-minions.bundle.js?cb=#{webVersion}')

--- a/java/code/src/com/suse/manager/webui/templates/minion/cmd.jade
+++ b/java/code/src/com/suse/manager/webui/templates/minion/cmd.jade
@@ -2,5 +2,5 @@
 
 script(type='text/javascript').
     const csrfToken = "#{csrf_token}";
-script(src='/javascript/manager/remote-commands.bundle.js')
+script(src='/javascript/manager/remote-commands.bundle.js?cb=#{webVersion}')
 

--- a/java/code/src/com/suse/manager/webui/templates/minion/custom.jade
+++ b/java/code/src/com/suse/manager/webui/templates/minion/custom.jade
@@ -6,8 +6,8 @@ script(type='text/javascript').
     var csrfToken = "#{csrf_token}";
     var serverId = "#{server.id}";
 
-script(src='/javascript/ace-editor/src-min-noconflict/ace.js')
-script(src='/javascript/ace-editor/src-min-noconflict/ext-modelist.js')
-script(src='/javascript/jquery-ui.js')
+script(src='/javascript/ace-editor/src-min-noconflict/ace.js?cb=#{webVersion}')
+script(src='/javascript/ace-editor/src-min-noconflict/ext-modelist.js?cb=#{webVersion}')
+script(src='/javascript/jquery-ui.js?cb=#{webVersion}')
 
-script(src='/javascript/manager/minion-config-channels.bundle.js', type='text/javascript')
+script(src='/javascript/manager/minion-config-channels.bundle.js?cb=#{webVersion}', type='text/javascript')

--- a/java/code/src/com/suse/manager/webui/templates/minion/formula.jade
+++ b/java/code/src/com/suse/manager/webui/templates/minion/formula.jade
@@ -7,4 +7,4 @@ script(type='text/javascript').
     var serverId = "#{server.id}";
     var formulaId = #{formula_id};
 
-script(src='/javascript/manager/minion-formula.bundle.js', type='text/javascript')
+script(src='/javascript/manager/minion-formula.bundle.js?cb=#{webVersion}', type='text/javascript')

--- a/java/code/src/com/suse/manager/webui/templates/minion/formulas.jade
+++ b/java/code/src/com/suse/manager/webui/templates/minion/formulas.jade
@@ -6,4 +6,4 @@ script(type='text/javascript').
     var csrfToken = "#{csrf_token}";
     var serverId = "#{server.id}";
 
-script(src='/javascript/manager/minion-formula-selection.bundle.js', type='text/javascript')
+script(src='/javascript/manager/minion-formula-selection.bundle.js?cb=#{webVersion}', type='text/javascript')

--- a/java/code/src/com/suse/manager/webui/templates/minion/highstate.jade
+++ b/java/code/src/com/suse/manager/webui/templates/minion/highstate.jade
@@ -9,4 +9,4 @@ script(type='text/javascript').
     const localTime = "#{h.renderLocalTime()}";
     const actionChains = !{actionChains};
 
-script(src='/javascript/manager/highstate.bundle.js', type='text/javascript')
+script(src='/javascript/manager/highstate.bundle.js?cb=#{webVersion}', type='text/javascript')

--- a/java/code/src/com/suse/manager/webui/templates/minion/list.jade
+++ b/java/code/src/com/suse/manager/webui/templates/minion/list.jade
@@ -6,5 +6,5 @@ script(type='text/javascript').
     const csrfToken = "#{csrf_token}";
     const serverId = "#{serverId}";
 +userPreferences
-script(src='/javascript/manager/key-management.bundle.js', type='text/javascript')
+script(src='/javascript/manager/key-management.bundle.js?cb=#{webVersion}', type='text/javascript')
 

--- a/java/code/src/com/suse/manager/webui/templates/minion/packages.jade
+++ b/java/code/src/com/suse/manager/webui/templates/minion/packages.jade
@@ -5,4 +5,4 @@ include ./minion-header.jade
 script(type='text/javascript').
     const csrfToken = "#{csrf_token}";
     const serverId = "#{server.id}";
-script(src='/javascript/manager/package-states.bundle.js', type='text/javascript')
+script(src='/javascript/manager/package-states.bundle.js?cb=#{webVersion}', type='text/javascript')

--- a/java/code/src/com/suse/manager/webui/templates/notification-messages/list.jade
+++ b/java/code/src/com/suse/manager/webui/templates/notification-messages/list.jade
@@ -2,11 +2,11 @@ include ../common.jade
 
 #notification-messages
 
-script(src='/javascript/momentjs/moment-with-langs.min.js', type='text/javascript')
+script(src='/javascript/momentjs/moment-with-langs.min.js?cb=#{webVersion}', type='text/javascript')
 
 script(type='text/javascript').
     const csrfToken = "#{csrf_token}";
 
 +userPreferences
-script(src='/javascript/manager/notifications/notification-messages.bundle.js')
+script(src='/javascript/manager/notifications/notification-messages.bundle.js?cb=#{webVersion}')
 

--- a/java/code/src/com/suse/manager/webui/templates/org/custom.jade
+++ b/java/code/src/com/suse/manager/webui/templates/org/custom.jade
@@ -14,8 +14,8 @@ script(type='text/javascript').
     var csrfToken = "#{csrf_token}";
     var orgId = "#{orgId}";
 
-script(src='/javascript/ace-editor/src-min-noconflict/ace.js')
-script(src='/javascript/ace-editor/src-min-noconflict/ext-modelist.js')
-script(src='/javascript/jquery-ui.js')
+script(src='/javascript/ace-editor/src-min-noconflict/ace.js?cb=#{webVersion}')
+script(src='/javascript/ace-editor/src-min-noconflict/ext-modelist.js?cb=#{webVersion}')
+script(src='/javascript/jquery-ui.js?cb=#{webVersion}')
 
-script(src='/javascript/manager/org-config-channels.bundle.js', type='text/javascript')
+script(src='/javascript/manager/org-config-channels.bundle.js?cb=#{webVersion}', type='text/javascript')

--- a/java/code/src/com/suse/manager/webui/templates/products/show.jade
+++ b/java/code/src/com/suse/manager/webui/templates/products/show.jade
@@ -8,4 +8,4 @@ script(type='text/javascript').
     const refreshRunning_flag_from_backend = #{refreshRunning};
 
 +userPreferences
-script(src='/javascript/manager/products.bundle.js', type='text/javascript')
+script(src='/javascript/manager/products.bundle.js?cb=#{webVersion}', type='text/javascript')

--- a/java/code/src/com/suse/manager/webui/templates/ssm/highstate.jade
+++ b/java/code/src/com/suse/manager/webui/templates/ssm/highstate.jade
@@ -15,4 +15,4 @@ script(type='text/javascript').
     const localTime = "#{h.renderLocalTime()}";
     const actionChains = !{actionChains};
 
-script(src='/javascript/manager/highstate.bundle.js', type='text/javascript')
+script(src='/javascript/manager/highstate.bundle.js?cb=#{webVersion}', type='text/javascript')

--- a/java/code/src/com/suse/manager/webui/templates/subscription-matching/show.jade
+++ b/java/code/src/com/suse/manager/webui/templates/subscription-matching/show.jade
@@ -5,4 +5,4 @@ include ../common.jade
 script(type='text/javascript').
     const csrfToken = "#{csrf_token}";
 +userPreferences
-script(src='/javascript/manager/subscription-matching.bundle.js', type='text/javascript')
+script(src='/javascript/manager/subscription-matching.bundle.js?cb=#{webVersion}', type='text/javascript')

--- a/java/code/src/com/suse/manager/webui/templates/taskotop/show.jade
+++ b/java/code/src/com/suse/manager/webui/templates/taskotop/show.jade
@@ -5,4 +5,4 @@ script(type='text/javascript').
     const csrfToken = "#{csrf_token}";
 
 +userPreferences
-script(src='/javascript/manager/taskotop.bundle.js', type='text/javascript')
+script(src='/javascript/manager/taskotop.bundle.js?cb=#{webVersion}', type='text/javascript')

--- a/java/code/src/com/suse/manager/webui/templates/virtualhostmanager/list.jade
+++ b/java/code/src/com/suse/manager/webui/templates/virtualhostmanager/list.jade
@@ -5,4 +5,4 @@ script(type='text/javascript').
     const csrfToken = "#{csrf_token}";
 
 +userPreferences
-script(src='/javascript/manager/virtualhostmanager.bundle.js', type='text/javascript')
+script(src='/javascript/manager/virtualhostmanager.bundle.js?cb=#{webVersion}', type='text/javascript')

--- a/java/code/src/com/suse/manager/webui/templates/virtualization/guests/console.jade
+++ b/java/code/src/com/suse/manager/webui/templates/virtualization/guests/console.jade
@@ -1,6 +1,6 @@
 #virtualguests-console(style="height: 100%")
 
-script(src='/javascript/manager/virtualization/guests/console/guests-console.renderer.bundle.js', type='text/javascript')
+script(src='/javascript/manager/virtualization/guests/console/guests-console.renderer.bundle.js?cb=#{webVersion}', type='text/javascript')
 
 script(type='text/javascript').
     pageRenderers.guests.console.guestsConsoleRenderer(

--- a/java/code/src/com/suse/manager/webui/templates/virtualization/guests/create.jade
+++ b/java/code/src/com/suse/manager/webui/templates/virtualization/guests/create.jade
@@ -1,9 +1,9 @@
 include ../../system-common.jade
 #virtualguests-create
 
-script(src='/javascript/momentjs/moment-with-langs.min.js', type='text/javascript')
-script(src='/javascript/validator/validator.min.js', type='text/javascript')
-script(src='/javascript/manager/virtualization/guests/create/guests-create.renderer.bundle.js', type='text/javascript')
+script(src='/javascript/momentjs/moment-with-langs.min.js?cb=#{webVersion}', type='text/javascript')
+script(src='/javascript/validator/validator.min.js?cb=#{webVersion}', type='text/javascript')
+script(src='/javascript/manager/virtualization/guests/create/guests-create.renderer.bundle.js?cb=#{webVersion}', type='text/javascript')
 
 script(type='text/javascript').
     const csrfToken = "#{csrf_token}";

--- a/java/code/src/com/suse/manager/webui/templates/virtualization/guests/edit.jade
+++ b/java/code/src/com/suse/manager/webui/templates/virtualization/guests/edit.jade
@@ -1,9 +1,9 @@
 include ../../system-common.jade
 #virtualguests-edit
 
-script(src='/javascript/momentjs/moment-with-langs.min.js', type='text/javascript')
-script(src='/javascript/validator/validator.min.js', type='text/javascript')
-script(src='/javascript/manager/virtualization/guests/edit/guests-edit.renderer.bundle.js', type='text/javascript')
+script(src='/javascript/momentjs/moment-with-langs.min.js?cb=#{webVersion}', type='text/javascript')
+script(src='/javascript/validator/validator.min.js?cb=#{webVersion}', type='text/javascript')
+script(src='/javascript/manager/virtualization/guests/edit/guests-edit.renderer.bundle.js?cb=#{webVersion}', type='text/javascript')
 
 script(type='text/javascript').
     const csrfToken = "#{csrf_token}";

--- a/java/code/src/com/suse/manager/webui/templates/virtualization/guests/show.jade
+++ b/java/code/src/com/suse/manager/webui/templates/virtualization/guests/show.jade
@@ -1,12 +1,12 @@
 include ../../system-common.jade
 #virtualguests
 
-script(src='/javascript/momentjs/moment-with-langs.min.js', type='text/javascript')
+script(src='/javascript/momentjs/moment-with-langs.min.js?cb=#{webVersion}', type='text/javascript')
 
 script(type='text/javascript').
     const csrfToken = "#{csrf_token}";
 +userPreferences
-script(src='/javascript/manager/virtualization/guests/list/guests-list.renderer.bundle.js', type='text/javascript')
+script(src='/javascript/manager/virtualization/guests/list/guests-list.renderer.bundle.js?cb=#{webVersion}', type='text/javascript')
 script(type='text/javascript').
     pageRenderers.guests.list.renderer(
         'virtualguests',

--- a/java/code/src/com/suse/manager/webui/templates/visualization/hierarchy.jade
+++ b/java/code/src/com/suse/manager/webui/templates/visualization/hierarchy.jade
@@ -1,6 +1,6 @@
 include ../common.jade
 
-script(src='/javascript/d3.js', type='text/javascript')
+script(src='/javascript/d3.js?cb=#{webVersion}', type='text/javascript')
 
 #hierarchy
 
@@ -10,4 +10,4 @@ script(type='text/javascript').
     const title = "#{title}";
     const view = "#{view}";
 
-script(src='/javascript/manager/visualization/hierarchy.bundle.js', type='text/javascript')
+script(src='/javascript/manager/visualization/hierarchy.bundle.js?cb=#{webVersion}', type='text/javascript')

--- a/java/code/src/com/suse/manager/webui/templates/yourorg/custom.jade
+++ b/java/code/src/com/suse/manager/webui/templates/yourorg/custom.jade
@@ -12,8 +12,8 @@ script(type='text/javascript').
     var csrfToken = "#{csrf_token}";
     var orgId = "#{orgId}";
 
-script(src='/javascript/ace-editor/src-min-noconflict/ace.js')
-script(src='/javascript/ace-editor/src-min-noconflict/ext-modelist.js')
-script(src='/javascript/jquery-ui.js')
+script(src='/javascript/ace-editor/src-min-noconflict/ace.js?cb=#{webVersion}')
+script(src='/javascript/ace-editor/src-min-noconflict/ext-modelist.js?cb=#{webVersion}')
+script(src='/javascript/jquery-ui.js?cb=#{webVersion}')
 
-script(src='/javascript/manager/org-config-channels.bundle.js', type='text/javascript')
+script(src='/javascript/manager/org-config-channels.bundle.js?cb=#{webVersion}', type='text/javascript')

--- a/java/code/src/com/suse/manager/webui/utils/SparkApplicationHelper.java
+++ b/java/code/src/com/suse/manager/webui/utils/SparkApplicationHelper.java
@@ -258,6 +258,7 @@ public class SparkApplicationHelper {
         sharedVariables.put("h", ViewHelper.getInstance());
         sharedVariables.put("isDevMode",
                 Config.get().getBoolean("java.development_environment"));
+        sharedVariables.put("webVersion", Config.get().getString("web.version"));
         JadeConfiguration config = jade.configuration();
         config.setSharedVariables(sharedVariables);
 

--- a/java/code/webapp/WEB-INF/decorators/layout_c.jsp
+++ b/java/code/webapp/WEB-INF/decorators/layout_c.jsp
@@ -50,7 +50,7 @@
         </c:if>
         <decorator:body />
       </section>
-      <script src='/javascript/manager/menu.bundle.js'></script>
+      <script src='/javascript/manager/menu.bundle.js?cb=${rhn:getConfig('web.version')}'></script>
     </div>
     <button id="scroll-top"><i class='fa fa-angle-up'></i></button>
   </body>

--- a/java/code/webapp/WEB-INF/decorators/layout_head.jsp
+++ b/java/code/webapp/WEB-INF/decorators/layout_head.jsp
@@ -22,16 +22,19 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-    <!-- import default fonts/icons styles -->
-    <link rel="stylesheet" href="/fonts/font-awesome/css/font-awesome.css" />
+    <c:set var="cb_version" value="${rhn:getConfig('web.version')}" />
+
+
+<!-- import default fonts/icons styles -->
+    <link rel="stylesheet" href="/fonts/font-awesome/css/font-awesome.css?cb=${cb_version}" />
     <!-- import custom fonts/icons styles -->
-    <link rel="stylesheet" href="/fonts/font-spacewalk/css/spacewalk-font.css" />
+    <link rel="stylesheet" href="/fonts/font-spacewalk/css/spacewalk-font.css?cb=${cb_version}" />
 
     <!-- import plugins styles -->
-    <link rel="stylesheet" href="/css/jquery.timepicker.css" />
-    <link rel="stylesheet" href="/css/bootstrap-datepicker.css" />
-    <link rel="stylesheet" href="/javascript/select2/select2.css" />
-    <link rel="stylesheet" href="/javascript/select2/select2-bootstrap.css" />
+    <link rel="stylesheet" href="/css/jquery.timepicker.css?cb=${cb_version}" />
+    <link rel="stylesheet" href="/css/bootstrap-datepicker.css?cb=${cb_version}" />
+    <link rel="stylesheet" href="/javascript/select2/select2.css?cb=${cb_version}" />
+    <link rel="stylesheet" href="/javascript/select2/select2-bootstrap.css?cb=${cb_version}" />
 
     <!-- import spacewalk styles -->
     <rhn:require acl="is(development_environment)">
@@ -40,24 +43,24 @@
       <script src="/javascript/less.js"></script>
     </rhn:require>
     <rhn:require acl="not is(development_environment)">
-      <link rel="stylesheet" href="/css/spacewalk.css" />
+      <link rel="stylesheet" href="/css/spacewalk.css?cb=${cb_version}" />
     </rhn:require>
 
-    <script src="/javascript/loggerhead.js"></script>
-    <script src="/javascript/frontend-log.js"></script>
+    <script src="/javascript/loggerhead.js?cb=${cb_version}"></script>
+    <script src="/javascript/frontend-log.js?cb=${cb_version}"></script>
 
-    <script src="/javascript/jquery.js"></script>
-    <script src="/javascript/bootstrap.js"></script>
-    <script src="/javascript/select2/select2.js"></script>
-    <script src="/javascript/spacewalk-essentials.js"></script>
-    <script src="/javascript/spacewalk-checkall.js"></script>
+    <script src="/javascript/jquery.js?cb=${cb_version}"></script>
+    <script src="/javascript/bootstrap.js?cb=${cb_version}"></script>
+    <script src="/javascript/select2/select2.js?cb=${cb_version}"></script>
+    <script src="/javascript/spacewalk-essentials.js?cb=${cb_version}"></script>
+    <script src="/javascript/spacewalk-checkall.js?cb=${cb_version}"></script>
 
-    <script src="/rhn/dwr/engine.js"></script>
-    <script src="/rhn/dwr/util.js"></script>
-    <script src="/rhn/dwr/interface/DWRItemSelector.js"></script>
-    <script src="/javascript/jquery.timepicker.js"></script>
-    <script src="/javascript/bootstrap-datepicker.js"></script>
+    <script src="/rhn/dwr/engine.js?cb=${cb_version}"></script>
+    <script src="/rhn/dwr/util.js?cb=${cb_version}"></script>
+    <script src="/rhn/dwr/interface/DWRItemSelector.js?cb=${cb_version}"></script>
+    <script src="/javascript/jquery.timepicker.js?cb=${cb_version}"></script>
+    <script src="/javascript/bootstrap-datepicker.js?cb=${cb_version}"></script>
 
-    <script src='/vendors/vendors.bundle.js'></script>
-    <script src='/javascript/manager/polyfill.bundle.js'></script>
-    <script src='/javascript/momentjs/moment-with-langs.min.js' type='text/javascript'></script>
+    <script src='/vendors/vendors.bundle.js?cb=${cb_version}'></script>
+    <script src='/javascript/manager/polyfill.bundle.js?cb=${cb_version}'></script>
+    <script src='/javascript/momentjs/moment-with-langs.min.js?cb=${cb_version}' type='text/javascript'></script>

--- a/java/code/webapp/WEB-INF/includes/header.jsp
+++ b/java/code/webapp/WEB-INF/includes/header.jsp
@@ -53,7 +53,7 @@
   </ul>
   <ul class="nav navbar-nav navbar-primary">
     <li id="notifications">
-      <script src='/javascript/manager/notifications/notifications.bundle.js'></script>
+      <script src='/javascript/manager/notifications/notifications.bundle.js?cb=${rhn:getConfig('web.version')}'></script>
     </li>
     <c:if test="${requestScope.legends != null}">
       <li class="legend">

--- a/java/code/webapp/WEB-INF/pages/activationkeys/configuration/rank.jsp
+++ b/java/code/webapp/WEB-INF/pages/activationkeys/configuration/rank.jsp
@@ -6,7 +6,7 @@
 
 <html>
     <head>
-        <script src="/javascript/rank_options.js" type="text/javascript"></script>
+        <script src="/javascript/rank_options.js?cb=${rhn:getConfig('web.version')}" type="text/javascript"></script>
     </head>
     <body>
         <%@ include file="/WEB-INF/pages/common/fragments/activationkeys/common-header.jspf" %>

--- a/java/code/webapp/WEB-INF/pages/admin/config/restart.jsp
+++ b/java/code/webapp/WEB-INF/pages/admin/config/restart.jsp
@@ -7,7 +7,7 @@
 
 <head>
         <c:if test="${requestScope.restart == 'true'}">
-            <script src="/javascript/restart.js" type="text/javascript"> </script>
+            <script src="/javascript/restart.js?cb=${rhn:getConfig('web.version')}" type="text/javascript"> </script>
         </c:if>
 </head>
 <body  <c:if test="${requestScope.restart == 'true'}">onload="checkConnection(${requestScope.restartDelay})"</c:if> >

--- a/java/code/webapp/WEB-INF/pages/admin/multiorg/orgcreate.jsp
+++ b/java/code/webapp/WEB-INF/pages/admin/multiorg/orgcreate.jsp
@@ -100,7 +100,7 @@
             </div>
 
             <script type="text/javascript" src="/javascript/pwstrength-bootstrap-1.0.2.js"></script>
-            <script type="text/javascript" src="/javascript/spacewalk-pwstrength-handler.js"></script>
+            <script type="text/javascript" src="/javascript/spacewalk-pwstrength-handler.js?cb=${rhn:getConfig('web.version')}"></script>
             <script type="text/javascript">
 function toggleAsterisk() {
   $("[name='password-asterisk']").toggle()

--- a/java/code/webapp/WEB-INF/pages/admin/setup/mirror-credentials.jsp
+++ b/java/code/webapp/WEB-INF/pages/admin/setup/mirror-credentials.jsp
@@ -6,9 +6,9 @@
 
 <html>
     <head>
-        <script type="text/javascript" src="/rhn/dwr/interface/MirrorCredentialsRenderer.js"></script>
-        <script type="text/javascript" src="/javascript/susemanager-setup-wizard.js"></script>
-        <script type="text/javascript" src="/javascript/susemanager-setup-wizard-mirror-credentials.js"></script>
+        <script type="text/javascript" src="/rhn/dwr/interface/MirrorCredentialsRenderer.js?cb=${rhn:getConfig('web.version')}"></script>
+        <script type="text/javascript" src="/javascript/susemanager-setup-wizard.js?cb=${rhn:getConfig('web.version')}"></script>
+        <script type="text/javascript" src="/javascript/susemanager-setup-wizard-mirror-credentials.js?cb=${rhn:getConfig('web.version')}"></script>
     </head>
     <body>
         <!-- MODAL: Edit credentials -->

--- a/java/code/webapp/WEB-INF/pages/admin/setup/proxy-settings.jsp
+++ b/java/code/webapp/WEB-INF/pages/admin/setup/proxy-settings.jsp
@@ -2,9 +2,9 @@
 
 <html>
     <head>
-        <script type="text/javascript" src="/rhn/dwr/interface/ProxySettingsRenderer.js"></script>
-        <script type="text/javascript" src="/javascript/susemanager-setup-wizard.js"></script>
-        <script type="text/javascript" src="/javascript/susemanager-setup-wizard-proxy-settings.js"></script>
+        <script type="text/javascript" src="/rhn/dwr/interface/ProxySettingsRenderer.js?cb=${rhn:getConfig('web.version')}"></script>
+        <script type="text/javascript" src="/javascript/susemanager-setup-wizard.js?cb=${rhn:getConfig('web.version')}"></script>
+        <script type="text/javascript" src="/javascript/susemanager-setup-wizard-proxy-settings.js?cb=${rhn:getConfig('web.version')}"></script>
     </head>
     <body>
         <div class="responsive-wizard">

--- a/java/code/webapp/WEB-INF/pages/channel/all.jsp
+++ b/java/code/webapp/WEB-INF/pages/channel/all.jsp
@@ -6,7 +6,7 @@
 <html>
 
 <head>
-<script src="/javascript/channel_tree.js" type="text/javascript"></script>
+<script src="/javascript/channel_tree.js?cb=${rhn:getConfig('web.version')}" type="text/javascript"></script>
 <script type="text/javascript">
 var filtered = ${requestScope.isFiltered};
 function showFiltered() {

--- a/java/code/webapp/WEB-INF/pages/channel/custom.jsp
+++ b/java/code/webapp/WEB-INF/pages/channel/custom.jsp
@@ -6,7 +6,7 @@
 <html>
 
 <head>
-<script src="/javascript/channel_tree.js" type="text/javascript"></script>
+<script src="/javascript/channel_tree.js?cb=${rhn:getConfig('web.version')}" type="text/javascript"></script>
 <script type="text/javascript">
 var filtered = ${requestScope.isFiltered};
 function showFiltered() {

--- a/java/code/webapp/WEB-INF/pages/channel/packagesearch.jsp
+++ b/java/code/webapp/WEB-INF/pages/channel/packagesearch.jsp
@@ -6,7 +6,7 @@
 
 <html>
     <head>
-        <script type="text/javascript" src="/javascript/highlander.js"></script>
+        <script type="text/javascript" src="/javascript/highlander.js?cb=${rhn:getConfig('web.version')}"></script>
     </head>
     <body>
         <rhn:toolbar base="h1" icon="header-search"

--- a/java/code/webapp/WEB-INF/pages/channel/popular.jsp
+++ b/java/code/webapp/WEB-INF/pages/channel/popular.jsp
@@ -6,7 +6,7 @@
 <html>
 
 <head>
-    <script src="/javascript/channel_tree.js" type="text/javascript"></script>
+    <script src="/javascript/channel_tree.js?cb=${rhn:getConfig('web.version')}" type="text/javascript"></script>
     <script type="text/javascript">
         var filtered = ${requestScope.isFiltered};
         function showFiltered() {

--- a/java/code/webapp/WEB-INF/pages/channel/retired.jsp
+++ b/java/code/webapp/WEB-INF/pages/channel/retired.jsp
@@ -6,7 +6,7 @@
 <html>
 
 <head>
-<script src="/javascript/channel_tree.js" type="text/javascript"></script>
+<script src="/javascript/channel_tree.js?cb=${rhn:getConfig('web.version')}" type="text/javascript"></script>
 <script type="text/javascript">
 var filtered = ${requestScope.isFiltered};
 function showFiltered() {

--- a/java/code/webapp/WEB-INF/pages/channel/shared.jsp
+++ b/java/code/webapp/WEB-INF/pages/channel/shared.jsp
@@ -6,7 +6,7 @@
 <html>
 
 <head>
-<script src="/javascript/channel_tree.js" type="text/javascript"></script>
+<script src="/javascript/channel_tree.js?cb=${rhn:getConfig('web.version')}" type="text/javascript"></script>
 <script type="text/javascript">
 var filtered = ${requestScope.isFiltered};
 function showFiltered() {

--- a/java/code/webapp/WEB-INF/pages/channel/ssm/channelssub.jsp
+++ b/java/code/webapp/WEB-INF/pages/channel/ssm/channelssub.jsp
@@ -19,6 +19,6 @@
         var userPrefPageSize = <%= new com.redhat.rhn.frontend.struts.RequestContext(request).getCurrentUser().getPageSize() %>;
         var actionChains = ${actionChainsJson};
   </script>
-  <script src="/javascript/manager/ssm-subscribe-channels.bundle.js" type="text/javascript"></script>
+  <script src="/javascript/manager/ssm-subscribe-channels.bundle.js?cb=${rhn:getConfig('web.version')}" type="text/javascript"></script>
 </body>
 </html>

--- a/java/code/webapp/WEB-INF/pages/channel/vendor.jsp
+++ b/java/code/webapp/WEB-INF/pages/channel/vendor.jsp
@@ -6,7 +6,7 @@
 <html>
 
 <head>
-<script src="/javascript/channel_tree.js" type="text/javascript"></script>
+<script src="/javascript/channel_tree.js?cb=${rhn:getConfig('web.version')}" type="text/javascript"></script>
 <script type="text/javascript">
 var filtered = ${requestScope.isFiltered};
 function showFiltered() {

--- a/java/code/webapp/WEB-INF/pages/common/fragments/activationkeys/details.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/activationkeys/details.jspf
@@ -77,7 +77,7 @@
                     activationKeyId: '<c:out value="${param.tid}" />'
                 }
         </script>
-        <script src="/javascript/manager/activation-key/activation-key-channels.renderer.bundle.js"></script>
+        <script src="/javascript/manager/activation-key/activation-key-channels.renderer.bundle.js?cb=${rhn:getConfig('web.version')}"></script>
 
         <div class="form-group">
             <label class="col-lg-3 control-label">

--- a/java/code/webapp/WEB-INF/pages/common/fragments/editarea.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/editarea.jspf
@@ -1,7 +1,6 @@
 
-
-<script language="javascript" type="text/javascript" src="/javascript/ace-editor/src-min-noconflict/ace.js?cb=${rhn:getConfig('web.version')}"></script>
-<script language="javascript" type="text/javascript" src="/javascript/ace-editor/src-min-noconflict/ext-modelist.js?cb=${rhn:getConfig('web.version')}"></script>
+<script language="javascript" type="text/javascript" src="/javascript/ace-editor/src-min-noconflict/ace.js"></script>
+<script language="javascript" type="text/javascript" src="/javascript/ace-editor/src-min-noconflict/ext-modelist.js"></script>
 
 <!-- This fragment is obsolete and only includes the editor itself, but
       just add data-editor="language" to the textarea to ge the editor

--- a/java/code/webapp/WEB-INF/pages/common/fragments/editarea.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/editarea.jspf
@@ -1,7 +1,7 @@
 
 
-<script language="javascript" type="text/javascript" src="/javascript/ace-editor/src-min-noconflict/ace.js"></script>
-<script language="javascript" type="text/javascript" src="/javascript/ace-editor/src-min-noconflict/ext-modelist.js"></script>
+<script language="javascript" type="text/javascript" src="/javascript/ace-editor/src-min-noconflict/ace.js?cb=${rhn:getConfig('web.version')}"></script>
+<script language="javascript" type="text/javascript" src="/javascript/ace-editor/src-min-noconflict/ext-modelist.js?cb=${rhn:getConfig('web.version')}"></script>
 
 <!-- This fragment is obsolete and only includes the editor itself, but
       just add data-editor="language" to the textarea to ge the editor

--- a/java/code/webapp/WEB-INF/pages/common/fragments/editareaYaml.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/editareaYaml.jspf
@@ -1,7 +1,5 @@
-
-
-<script language="javascript" type="text/javascript" src="/javascript/ace-editor/src-min-noconflict/ace.js?cb=${rhn:getConfig('web.version')}"></script>
-<script language="javascript" type="text/javascript" src="/javascript/ace-editor/src-min-noconflict/ext-modelist.js?cb=${rhn:getConfig('web.version')}"></script>
+<script language="javascript" type="text/javascript" src="/javascript/ace-editor/src-min-noconflict/ace.js"></script>
+<script language="javascript" type="text/javascript" src="/javascript/ace-editor/src-min-noconflict/ext-modelist.js"></script>
 
 <!-- This fragment is obsolete and only includes the editor itself, but
       just add data-editor="language" to the textarea to ge the editor

--- a/java/code/webapp/WEB-INF/pages/common/fragments/editareaYaml.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/editareaYaml.jspf
@@ -1,7 +1,7 @@
 
 
-<script language="javascript" type="text/javascript" src="/javascript/ace-editor/src-min-noconflict/ace.js"></script>
-<script language="javascript" type="text/javascript" src="/javascript/ace-editor/src-min-noconflict/ext-modelist.js"></script>
+<script language="javascript" type="text/javascript" src="/javascript/ace-editor/src-min-noconflict/ace.js?cb=${rhn:getConfig('web.version')}"></script>
+<script language="javascript" type="text/javascript" src="/javascript/ace-editor/src-min-noconflict/ext-modelist.js?cb=${rhn:getConfig('web.version')}"></script>
 
 <!-- This fragment is obsolete and only includes the editor itself, but
       just add data-editor="language" to the textarea to ge the editor

--- a/java/code/webapp/WEB-INF/pages/common/fragments/kickstartDetailsPage.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/kickstartDetailsPage.jspf
@@ -1,4 +1,5 @@
-<script language="javascript" type="text/javascript" src="/javascript/autoinstallation_textarea_check.js?cb=${rhn:getConfig('web.version')}"></script>
+
+<script language="javascript" type="text/javascript" src="/javascript/autoinstallation_textarea_check.js"></script>
 <script language="javascript" type="text/javascript">
 	checkTheTextarea();
 </script>

--- a/java/code/webapp/WEB-INF/pages/common/fragments/kickstartDetailsPage.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/kickstartDetailsPage.jspf
@@ -1,4 +1,4 @@
-<script language="javascript" type="text/javascript" src="/javascript/autoinstallation_textarea_check.js"></script>
+<script language="javascript" type="text/javascript" src="/javascript/autoinstallation_textarea_check.js?cb=${rhn:getConfig('web.version')}"></script>
 <script language="javascript" type="text/javascript">
 	checkTheTextarea();
 </script>

--- a/java/code/webapp/WEB-INF/pages/common/fragments/schedule-options.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/schedule-options.jspf
@@ -2,7 +2,7 @@
 <%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean" %>
 <%@ taglib uri="http://rhn.redhat.com/rhn" prefix="rhn" %>
 
-<script type="text/javascript" src="/javascript/schedule-options.js"></script>
+<script type="text/javascript" src="/javascript/schedule-options.js?cb=${rhn:getConfig('web.version')}"></script>
 <div class="spacewalk-scheduler">
     <div class="form-horizontal">
         <div class="form-group">

--- a/java/code/webapp/WEB-INF/pages/common/fragments/user/edit_user_table_rows.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/user/edit_user_table_rows.jspf
@@ -69,7 +69,7 @@
 </div>
 
 <script type="text/javascript" src="/javascript/pwstrength-bootstrap-1.0.2.js"></script>
-<script type="text/javascript" src="/javascript/spacewalk-pwstrength-handler.js"></script>
+<script type="text/javascript" src="/javascript/spacewalk-pwstrength-handler.js?cb=${rhn:getConfig('web.version')}"></script>
 <div class="form-group">
     <label class="col-lg-3 control-label"><bean:message key="help.credentials.jsp.passwordstrength"/>:</label>
     <div class="col-lg-6" id="pwstrenghtfield">

--- a/java/code/webapp/WEB-INF/pages/common/fragments/user/edit_user_table_rows.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/user/edit_user_table_rows.jspf
@@ -69,7 +69,7 @@
 </div>
 
 <script type="text/javascript" src="/javascript/pwstrength-bootstrap-1.0.2.js"></script>
-<script type="text/javascript" src="/javascript/spacewalk-pwstrength-handler.js?cb=${rhn:getConfig('web.version')}"></script>
+<script type="text/javascript" src="/javascript/spacewalk-pwstrength-handler.js"></script>
 <div class="form-group">
     <label class="col-lg-3 control-label"><bean:message key="help.credentials.jsp.passwordstrength"/>:</label>
     <div class="col-lg-6" id="pwstrenghtfield">

--- a/java/code/webapp/WEB-INF/pages/common/login.jsp
+++ b/java/code/webapp/WEB-INF/pages/common/login.jsp
@@ -5,7 +5,7 @@
 <html>
 <head>
     <meta name="decorator" content="layout_c" />
-    <script src="/javascript/susemanager-login.js"></script>
+    <script src="/javascript/susemanager-login.js?cb=${rhn:getConfig('web.version')}"></script>
 </head>
 <body>
   <c:if test="${schemaUpgradeRequired == 'true'}">

--- a/java/code/webapp/WEB-INF/pages/common/passwordreset.jsp
+++ b/java/code/webapp/WEB-INF/pages/common/passwordreset.jsp
@@ -6,7 +6,7 @@
 
 <html:html>
 <head>
-<script type="text/javascript" src="/javascript/highlander.js"></script>
+<script type="text/javascript" src="/javascript/highlander.js?cb=${rhn:getConfig('web.version')}"></script>
 </head>
 <body>
 <%@ include file="/WEB-INF/pages/common/fragments/user/user_attribute_sizes.jspf"%>

--- a/java/code/webapp/WEB-INF/pages/common/relogin.jsp
+++ b/java/code/webapp/WEB-INF/pages/common/relogin.jsp
@@ -4,7 +4,7 @@
 <%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean" %>
 <html>
 <head>
-    <script src="/javascript/susemanager-login.js"></script>
+    <script src="/javascript/susemanager-login.js?cb=${rhn:getConfig('web.version')}"></script>
 </head>
 <body>
 

--- a/java/code/webapp/WEB-INF/pages/configuration/sdc/rankchannels.jsp
+++ b/java/code/webapp/WEB-INF/pages/configuration/sdc/rankchannels.jsp
@@ -5,7 +5,7 @@
 <%@ taglib uri="http://rhn.redhat.com/tags/config-managment" prefix="cfg" %>
 <html>
     <head>
-        <script src="/javascript/rank_options.js" type="text/javascript"></script>
+        <script src="/javascript/rank_options.js?cb=${rhn:getConfig('web.version')}" type="text/javascript"></script>
     </head>
     <body>
         <%@ include file="/WEB-INF/pages/common/fragments/systems/system-header.jspf" %>

--- a/java/code/webapp/WEB-INF/pages/configuration/ssm/rankchannels.jsp
+++ b/java/code/webapp/WEB-INF/pages/configuration/ssm/rankchannels.jsp
@@ -6,7 +6,7 @@
 
 <html>
 <head>
-<script src="/javascript/rank_options.js" type="text/javascript"> </script>
+<script src="/javascript/rank_options.js?cb=${rhn:getConfig('web.version')}" type="text/javascript"> </script>
 </head>
 <body>
     <%@ include file="/WEB-INF/pages/common/fragments/ssm/header.jspf" %>

--- a/java/code/webapp/WEB-INF/pages/help/chatindex.jsp
+++ b/java/code/webapp/WEB-INF/pages/help/chatindex.jsp
@@ -6,7 +6,7 @@
 
 <html>
 <head>
-<script type="text/javascript" src="/javascript/highlander.js"></script>
+<script type="text/javascript" src="/javascript/highlander.js?cb=${rhn:getConfig('web.version')}"></script>
 </head>
 <body>
     <h1><rhn:icon type="header-help" title="help.jsp.chat" /> <bean:message key="help.jsp.chat" /></h1>

--- a/java/code/webapp/WEB-INF/pages/help/docsearch.jsp
+++ b/java/code/webapp/WEB-INF/pages/help/docsearch.jsp
@@ -7,7 +7,7 @@
 
 <html>
 <head>
-<script type="text/javascript" src="/javascript/highlander.js"></script>
+<script type="text/javascript" src="/javascript/highlander.js?cb=${rhn:getConfig('web.version')}"></script>
 </head>
 <body>
 <rhn:toolbar base="h1" icon="header-search" imgAlt="docsearch.jsp.imgAlt"

--- a/java/code/webapp/WEB-INF/pages/help/forgotcredentials.jsp
+++ b/java/code/webapp/WEB-INF/pages/help/forgotcredentials.jsp
@@ -7,7 +7,7 @@
 <html:xhtml/>
 <html>
 <head>
-<script type="text/javascript" src="/javascript/highlander.js"></script>
+<script type="text/javascript" src="/javascript/highlander.js?cb=${rhn:getConfig('web.version')}"></script>
 </head>
 <body>
   <rhn:toolbar base="h1" icon="header-search"

--- a/java/code/webapp/WEB-INF/pages/kickstart/cobbler/snippetview.jsp
+++ b/java/code/webapp/WEB-INF/pages/kickstart/cobbler/snippetview.jsp
@@ -4,8 +4,8 @@
 <%@ taglib uri="http://struts.apache.org/tags-html" prefix="html" %>
 
 <head>
-  <script language="javascript" type="text/javascript" src="/javascript/ace-editor/src-min-noconflict/ace.js"></script>
-  <script language="javascript" type="text/javascript" src="/javascript/ace-editor/src-min-noconflict/ext-modelist.js"></script>
+  <script language="javascript" type="text/javascript" src="/javascript/ace-editor/src-min-noconflict/ace.js?cb=${rhn:getConfig('web.version')}"></script>
+  <script language="javascript" type="text/javascript" src="/javascript/ace-editor/src-min-noconflict/ext-modelist.js?cb=${rhn:getConfig('web.version')}"></script>
 </head>
 
 <html:html >

--- a/java/code/webapp/WEB-INF/pages/kickstart/scriptorder.jsp
+++ b/java/code/webapp/WEB-INF/pages/kickstart/scriptorder.jsp
@@ -6,7 +6,7 @@
 <html:xhtml/>
 <html>
 <head>
-<script src="/javascript/rank_options.js" type="text/javascript"></script>
+<script src="/javascript/rank_options.js?cb=${rhn:getConfig('web.version')}" type="text/javascript"></script>
 </head>
 <body>
 <%@ include file="/WEB-INF/pages/common/fragments/kickstart/kickstart-toolbar.jspf" %>

--- a/java/code/webapp/WEB-INF/pages/kickstart/treecreate.jsp
+++ b/java/code/webapp/WEB-INF/pages/kickstart/treecreate.jsp
@@ -4,7 +4,7 @@
 <%@ taglib uri="http://struts.apache.org/tags-html" prefix="html" %>
 
 <html:html>
-<script language="javascript" src="/javascript/refresh.js"></script>
+<script language="javascript" src="/javascript/refresh.js?cb=${rhn:getConfig('web.version')}"></script>
 <head>
     <meta http-equiv="Pragma" content="no-cache" />
 </head>

--- a/java/code/webapp/WEB-INF/pages/kickstart/treeedit.jsp
+++ b/java/code/webapp/WEB-INF/pages/kickstart/treeedit.jsp
@@ -6,7 +6,7 @@
 <html:html >
     <head>
         <meta http-equiv="Pragma" content="no-cache" />
-        <script language="javascript" src="/javascript/refresh.js"></script>
+        <script language="javascript" src="/javascript/refresh.js?cb=${rhn:getConfig('web.version')}"></script>
     </head>
     <body>
         <rhn:toolbar base="h1" icon="header-kickstart"

--- a/java/code/webapp/WEB-INF/pages/multiorg/channels/consumed.jsp
+++ b/java/code/webapp/WEB-INF/pages/multiorg/channels/consumed.jsp
@@ -7,7 +7,7 @@
 <html>
 
 <head>
-<script src="/javascript/channel_tree.js" type="text/javascript"></script>
+<script src="/javascript/channel_tree.js?cb=${rhn:getConfig('web.version')}" type="text/javascript"></script>
 <script type="text/javascript">
 var filtered = ${requestScope.isFiltered};
 function showFiltered() {

--- a/java/code/webapp/WEB-INF/pages/multiorg/channels/provided.jsp
+++ b/java/code/webapp/WEB-INF/pages/multiorg/channels/provided.jsp
@@ -7,7 +7,7 @@
 <html>
 
 <head>
-<script src="/javascript/channel_tree.js" type="text/javascript"></script>
+<script src="/javascript/channel_tree.js?cb=${rhn:getConfig('web.version')}" type="text/javascript"></script>
 <script type="text/javascript">
 var filtered = ${requestScope.isFiltered};
 function showFiltered() {

--- a/java/code/webapp/WEB-INF/pages/schedule/actionchain.jsp
+++ b/java/code/webapp/WEB-INF/pages/schedule/actionchain.jsp
@@ -6,10 +6,10 @@
 
 <html>
 <head>
-    <script type="text/javascript" src="/rhn/dwr/interface/ActionChainEntriesRenderer.js"></script>
-    <script type="text/javascript" src="/rhn/dwr/interface/ActionChainSaveAction.js"></script>
-    <script type="text/javascript" src="/javascript/jquery-ui.js"></script>
-    <script type="text/javascript" src="/javascript/actionchain.js"></script>
+    <script type="text/javascript" src="/rhn/dwr/interface/ActionChainEntriesRenderer.js?cb=${rhn:getConfig('web.version')}"></script>
+    <script type="text/javascript" src="/rhn/dwr/interface/ActionChainSaveAction.js?cb=${rhn:getConfig('web.version')}"></script>
+    <script type="text/javascript" src="/javascript/jquery-ui.js?cb=${rhn:getConfig('web.version')}"></script>
+    <script type="text/javascript" src="/javascript/actionchain.js?cb=${rhn:getConfig('web.version')}"></script>
 </head>
 <body>
     <rhn:toolbar base="h1" icon="header-chain"

--- a/java/code/webapp/WEB-INF/pages/systems/details/kickstart/session_status.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/details/kickstart/session_status.jsp
@@ -12,7 +12,7 @@
             .details td, .details th { white-space: nowrap; }
     </style>
     <c:if test="${not failed and not complete}">
-        <script type="text/javascript" src="/javascript/rememberScroll.js"> </script>
+        <script type="text/javascript" src="/javascript/rememberScroll.js?cb=${rhn:getConfig('web.version')}"> </script>
     </c:if>
 </head>
 <body>

--- a/java/code/webapp/WEB-INF/pages/systems/duplicate/duplicatesystemscompare.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/duplicate/duplicatesystemscompare.jsp
@@ -227,6 +227,6 @@ function getServerIdsToDelete() {
 <c:otherwise><p><bean:message key = "nosystems.message"/></p></c:otherwise>
 </c:choose>
 </rl:listset>
-<script src="/javascript/manager/duplicate-systems-compare-delete.bundle.js" type="text/javascript"></script>
+<script src="/javascript/manager/duplicate-systems-compare-delete.bundle.js?cb=${rhn:getConfig('web.version')}" type="text/javascript"></script>
 </body>
 </html>

--- a/java/code/webapp/WEB-INF/pages/systems/sdc/channels.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/sdc/channels.jsp
@@ -22,7 +22,7 @@
             return ${system.id};
         }
     </script>
-    <script src="/javascript/manager/subscribe-channels.bundle.js" type="text/javascript"></script>
+    <script src="/javascript/manager/subscribe-channels.bundle.js?cb=${rhn:getConfig('web.version')}" type="text/javascript"></script>
 
 </body>
 </html:html>

--- a/java/code/webapp/WEB-INF/pages/systems/sdc/delete_confirm.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/sdc/delete_confirm.jsp
@@ -22,6 +22,6 @@
             return ${sid};
         }
     </script>
-    <script src="/javascript/manager/delete-system-confirm.bundle.js" type="text/javascript"></script>
+    <script src="/javascript/manager/delete-system-confirm.bundle.js?cb=${rhn:getConfig('web.version')}" type="text/javascript"></script>
 </body>
 </html:html>

--- a/java/code/webapp/WEB-INF/pages/systems/spmigration/spmigration-confirm.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/spmigration/spmigration-confirm.jsp
@@ -6,7 +6,7 @@
 <html:html>
 
 <head>
-  <link rel="stylesheet" type="text/css" href="/css/susemanager-sp-migration.css" />
+  <link rel="stylesheet" type="text/css" href="/css/susemanager-sp-migration.css?cb=${rhn:getConfig('web.version')}" />
 </head>
 
 <body>

--- a/java/code/webapp/WEB-INF/pages/systems/spmigration/spmigration-setup.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/spmigration/spmigration-setup.jsp
@@ -6,8 +6,8 @@
 <html:html>
 
 <head>
-<link rel="stylesheet" type="text/css" href="/css/susemanager-sp-migration.css" />
-<script src="/javascript/susemanager-sp-migration.js"></script>
+<link rel="stylesheet" type="text/css" href="/css/susemanager-sp-migration.css?cb=${rhn:getConfig('web.version')}" />
+<script src="/javascript/susemanager-sp-migration.js?cb=${rhn:getConfig('web.version')}"></script>
 </head>
 
 <body>

--- a/java/code/webapp/WEB-INF/pages/systems/spmigration/spmigration-target.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/spmigration/spmigration-target.jsp
@@ -6,8 +6,8 @@
 <html:html>
 
 <head>
-<link rel="stylesheet" type="text/css" href="/css/susemanager-sp-migration.css" />
-<script src="/javascript/susemanager-sp-migration.js"></script>
+<link rel="stylesheet" type="text/css" href="/css/susemanager-sp-migration.css?cb=${rhn:getConfig('web.version')}" />
+<script src="/javascript/susemanager-sp-migration.js?cb=${rhn:getConfig('web.version')}"></script>
 </head>
 
 <body>

--- a/java/code/webapp/WEB-INF/pages/user/create/usercreate.jsp
+++ b/java/code/webapp/WEB-INF/pages/user/create/usercreate.jsp
@@ -51,8 +51,8 @@
                   </div>
                 </div>
               </div>
-              <script type="text/javascript" src="/javascript/pwstrength-bootstrap-1.0.2.js"></script>
-              <script type="text/javascript" src="/javascript/spacewalk-pwstrength-handler.js"></script>
+              <script type="text/javascript" src="/javascript/pwstrength-bootstrap-1.0.2.js?cb=${rhn:getConfig('web.version')}"></script>
+              <script type="text/javascript" src="/javascript/spacewalk-pwstrength-handler.js?cb=${rhn:getConfig('web.version')}"></script>
               <script type="text/javascript">
 function toggleAsterisk() {
   $("[name='password-asterisk']").toggle()

--- a/java/code/webapp/WEB-INF/pages/yourrhn.jsp
+++ b/java/code/webapp/WEB-INF/pages/yourrhn.jsp
@@ -5,26 +5,28 @@
 
 <html>
 <head>
+<c:set var="cb_version" value="${rhn:getConfig('web.version')}" />
+
 <c:if test="${requestScope.inactiveSystems == 'y'}">
-        <script type="text/javascript" src="/rhn/dwr/interface/InactiveSystemsRenderer.js"></script>
+        <script type="text/javascript" src="/rhn/dwr/interface/InactiveSystemsRenderer.js?cb=${cb_version}"></script>
 </c:if>
 <c:if test="${requestScope.tasks == 'y'}">
-        <script type="text/javascript" src="/rhn/dwr/interface/TasksRenderer.js"></script>
+        <script type="text/javascript" src="/rhn/dwr/interface/TasksRenderer.js?cb=${cb_version}"></script>
 </c:if>
 <c:if test="${requestScope.recentlyRegisteredSystems == 'y'}">
-        <script type="text/javascript" src="/rhn/dwr/interface/RecentSystemsRenderer.js"></script>
+        <script type="text/javascript" src="/rhn/dwr/interface/RecentSystemsRenderer.js?cb=${cb_version}"></script>
 </c:if>
 <c:if test="${requestScope.latestErrata == 'y'}">
-        <script type="text/javascript" src="/rhn/dwr/interface/LatestErrataRenderer.js"></script>
+        <script type="text/javascript" src="/rhn/dwr/interface/LatestErrataRenderer.js?cb=${cb_version}"></script>
 </c:if>
 <c:if test="${requestScope.criticalSystems == 'y'}">
-        <script type="text/javascript" src="/rhn/dwr/interface/CriticalSystemsRenderer.js"></script>
+        <script type="text/javascript" src="/rhn/dwr/interface/CriticalSystemsRenderer.js?cb=${cb_version}"></script>
 </c:if>
 <c:if test="${requestScope.pendingActions =='y'}">
-        <script type="text/javascript" src="/rhn/dwr/interface/PendingActionsRenderer.js"></script>
+        <script type="text/javascript" src="/rhn/dwr/interface/PendingActionsRenderer.js?cb=${cb_version}"></script>
 </c:if>
 <c:if test="${requestScope.systemGroupsWidget == 'y'}">
-        <script type="text/javascript" src="/rhn/dwr/interface/SystemGroupsRenderer.js"></script>
+        <script type="text/javascript" src="/rhn/dwr/interface/SystemGroupsRenderer.js?cb=${cb_version}"></script>
 </c:if>
 
 </head>

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Add cache buster for static files (js/css) to fix caching issues after upgrading.
 - Show undetected subscription-matching message object as a string anyway (bsc#1125600)
 
 -------------------------------------------------------------------


### PR DESCRIPTION
Backport of https://github.com/SUSE/spacewalk/pull/7116

Solves the old and annoying problem of broken pages every time a new version is installed.

Implement cache buster for js/css files. It makes sure every time a new version is installed a hard refresh on all the static files will be applied.
