### PR TITLE
Add missing changelog entries for several packages

### DIFF
--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes
@@ -1,3 +1,7 @@
+- Sync with Spacewalk
+- Add ability to work behind http proxies
+- 1666099 - python3 is picky about bytes and string
+
 -------------------------------------------------------------------
 Wed Jan 16 12:22:40 CET 2019 - jgonzalez@suse.com
 

--- a/client/tools/mgr-cfg/mgr-cfg.changes
+++ b/client/tools/mgr-cfg/mgr-cfg.changes
@@ -1,3 +1,7 @@
+- Sync with Spacewalk
+- make filemod more readable
+- 1665858 - diff expects string not bytes
+
 -------------------------------------------------------------------
 Mon Dec 17 14:31:58 CET 2018 - jgonzalez@suse.com
 

--- a/proxy/installer/spacewalk-proxy-installer.changes
+++ b/proxy/installer/spacewalk-proxy-installer.changes
@@ -1,3 +1,5 @@
+- fetch-certificate: allow more time for onboarding
+
 -------------------------------------------------------------------
 Wed Jan 16 12:24:15 CET 2019 - jgonzalez@suse.com
 

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,5 @@
+- enable and start tftp socket (bsc#1124822)
+
 -------------------------------------------------------------------
 Thu Jan 31 09:42:41 CET 2019 - jgonzalez@suse.com
 

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- add configurable option to auto deploy new tokens (bsc#1123019)
 - Add `python-setuptools` package dependency to SLES12 bootstrap repo (bsc#1119964)
 - enable and start tftp socket (bsc#1124822)
 - migrate existing rhn.conf; do not allow new database credentials

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,4 +1,6 @@
 - Fix package installation on python3 based operating systems
+- Sync with Spacewalk
+- Fix typo in spacewalk-manage-channel-lifecycle
 
 -------------------------------------------------------------------
 Thu Jan 17 14:45:24 CET 2019 - jgonzalez@suse.com


### PR DESCRIPTION
## What does this PR change?

Add missing changelog entries for several packages.

Since I fixed the changelogs for you, please review the changes according to this list (authors for the commits):

@moio: spacewalk-proxy-installer (https://github.com/uyuni-project/uyuni/commit/e729fd4eb4f553c0f899254f94e552c70328172c)
@mantel: spacewalk-setup (https://github.com/uyuni-project/uyuni/commit/57ef32c926e477aeda4b5eda40bedb3f261e9057)
@lucidd: susemanager (https://github.com/uyuni-project/uyuni/pull/541/files)
@mcalmer: all other packages (cherrypicking from Spacewalk)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Changelog fixes

- [x] **DONE**

## Test coverage
- No tests: Changelog fixed

- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/6938

- [x] **DONE**