### PR TITLE
Taskomatic: expose necessary Java modules on JDK 9+

### DIFF
--- a/java/conf/default/rhn_taskomatic_daemon.conf
+++ b/java/conf/default/rhn_taskomatic_daemon.conf
@@ -31,6 +31,9 @@ wrapper.java.classpath.5=/usr/share/spacewalk/taskomatic/*.jar
 wrapper.java.additional.1=-Dibm.dst.compatibility=true
 wrapper.java.additional.2=-Dfile.encoding=UTF-8
 
+# Expose necessary modules on JDK 9+
+set.JDK_JAVA_OPTIONS=--add-modules=java.annotation,com.sun.xml.bind --add-exports=java.annotation/javax.annotation.security=ALL-UNNAMED --add-opens=java.annotation/javax.annotation.security=ALL-UNNAMED
+
 # Initial Java Heap Size (in MB)
 wrapper.java.initmemory=256
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Expose necessary Java modules on JDK 9+
 - Add configuration option to limit the number of changelog entries added
   to the repository metadata (FATE#325676)
 - Fix a problem when cloning public child channels with a private base channel (bsc#1124639)


### PR DESCRIPTION
## What does this PR change?

Without these modules, `taskomatic` cannot run, logs look like this:

```
--> Wrapper Started as Daemon
STATUS | wrapper  | 2019/02/26 11:38:44 | Java Service Wrapper Community Edition 64-bit 3.5.32
STATUS | wrapper  | 2019/02/26 11:38:44 |   Copyright (C) 1999-2017 Tanuki Software, Ltd. All Rights Reserved.
STATUS | wrapper  | 2019/02/26 11:38:44 |     http://wrapper.tanukisoftware.com
STATUS | wrapper  | 2019/02/26 11:38:44 | 
STATUS | wrapper  | 2019/02/26 11:38:44 | Launching a JVM...
INFO   | jvm 1    | 2019/02/26 11:38:44 | WrapperManager: Initializing...
INFO   | jvm 1    | 2019/02/26 11:38:46 | Feb 26, 2019 11:38:45 AM com.mchange.v2.log.MLog$1 run
INFO   | jvm 1    | 2019/02/26 11:38:46 | INFO: MLog clients using java 1.4+ standard logging.
INFO   | jvm 1    | 2019/02/26 11:38:46 | Feb 26, 2019 11:38:46 AM com.mchange.v2.c3p0.C3P0Registry banner
INFO   | jvm 1    | 2019/02/26 11:38:46 | INFO: Initializing c3p0-0.9.5.2 [built 12-January-2019 12:00:00 +0000; debug? false; trace: 5]
FATAL  | jvm 1    | 2019/02/26 11:38:46 | javax/xml/bind/JAXBException
FATAL  | jvm 1    | 2019/02/26 11:38:46 | java.lang.NoClassDefFoundError: javax/xml/bind/JAXBException
FATAL  | jvm 1    | 2019/02/26 11:38:46 |       at org.hibernate.boot.spi.XmlMappingBinderAccess.<init>(XmlMappingBinderAccess.java:43)
FATAL  | jvm 1    | 2019/02/26 11:38:46 |       at org.hibernate.boot.MetadataSources.<init>(MetadataSources.java:86)
FATAL  | jvm 1    | 2019/02/26 11:38:46 |       at org.hibernate.cfg.Configuration.<init>(Configuration.java:123)
FATAL  | jvm 1    | 2019/02/26 11:38:46 |       at org.hibernate.cfg.Configuration.<init>(Configuration.java:118)
FATAL  | jvm 1    | 2019/02/26 11:38:46 |       at com.redhat.rhn.common.hibernate.ConnectionManager.createSessionFactory(ConnectionManager.java:160)
FATAL  | jvm 1    | 2019/02/26 11:38:46 |       at com.redhat.rhn.common.hibernate.ConnectionManager.initialize(ConnectionManager.java:136)
FATAL  | jvm 1    | 2019/02/26 11:38:46 |       at com.redhat.rhn.common.hibernate.HibernateFactory.createSessionFactory(HibernateFactory.java:109)
FATAL  | jvm 1    | 2019/02/26 11:38:46 |       at com.redhat.rhn.taskomatic.core.SchedulerKernel.startup(SchedulerKernel.java:146)
FATAL  | jvm 1    | 2019/02/26 11:38:46 |       at com.redhat.rhn.taskomatic.core.TaskomaticDaemon$1.run(TaskomaticDaemon.java:86)
FATAL  | jvm 1    | 2019/02/26 11:38:46 |       at java.base/java.lang.Thread.run(Thread.java:834)
FATAL  | jvm 1    | 2019/02/26 11:38:46 | Caused by: java.lang.ClassNotFoundException: javax.xml.bind.JAXBException
FATAL  | jvm 1    | 2019/02/26 11:38:46 |       at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:583)
FATAL  | jvm 1    | 2019/02/26 11:38:46 |       at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
FATAL  | jvm 1    | 2019/02/26 11:38:46 |       at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
FATAL  | jvm 1    | 2019/02/26 11:38:46 |       ... 10 more
FATAL  | jvm 1    | 2019/02/26 11:38:46 | 
STATUS | wrapper  | 2019/02/26 11:38:49 | <-- Wrapper Stopped
```

## GUI diff

No difference.
- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added --> this fixes the cucumber testsuite actually to run properly

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
