### PR TITLE
Fix initial setting of input values for DateTimePicker (bsc#1126862)

### DIFF
--- a/web/html/javascript/spacewalk-datetimepicker.js
+++ b/web/html/javascript/spacewalk-datetimepicker.js
@@ -54,8 +54,7 @@ function setupDatePicker() {
       input.timepicker('show');
     });
 
-    // compatibility with the forms expected by struts
-    input.on('changeTime', function() {
+    var updateVars = () => {
       var pickerTime = input.timepicker('getTime');
       var am_pm = $('input#' + name + '_am_pm');
       var hour = $('input#' + name + '_hour');
@@ -68,7 +67,10 @@ function setupDatePicker() {
       }
       $('input#' + name + '_minute').val(pickerTime.getMinutes());
       am_pm.val(pickerTime.getHours() >= 12 ? 1 : 0);
-    });
+    };
+
+    // compatibility with the forms expected by struts
+    input.on('changeTime', updateVars);
 
     // set initial time
     var date = new Date();
@@ -81,6 +83,7 @@ function setupDatePicker() {
       date.setMinutes(minute);
     }
     input.timepicker('setTime', date);
+    updateVars();
   });
 }
 

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fix initializing of the datetime picker (bsc#1126862)
 - Sort activation key list on create image profile page (bsc#1122770)
 - Sort activation key list on bootstrap page (bsc#1122770)
 - Add virtual machine creation dialog for salt minions


### PR DESCRIPTION
We need to trigger the initializing of input values because in the recent version of `jquery-datetimepicker`, the `changeTime` event is not triggered on page load or `setTime` call anymore.

Upstream changes:
https://github.com/jonthornton/jquery-timepicker/commit/d0332c4d6478d1cd75c97c3e2859fcdf39ce43a3
https://github.com/jonthornton/jquery-timepicker/commit/3f26316a6f417c77737488d763e9a9055c20d8ae

Tracks https://github.com/SUSE/spacewalk/pull/7152
