### PR TITLE
Fix multiple issues to allow "mgr-inter-sync" to run successfully

### DIFF
--- a/backend/common/rhnCache.py
+++ b/backend/common/rhnCache.py
@@ -258,17 +258,20 @@ class Cache:
         fd.close()
 
         if sys.version_info[0] >= 3 and isinstance(s, bytes):
-            s = s.decode('latin-1')
 
+            try:
+               s = s.decode('utf8')
+            except:
+               s = s.decode('latin-1')
         return s
 
     def set(self, name, value, modified=None, user='root', group='root',
             mode=int('0755', 8)):
         fd = self.set_file(name, modified, user, group, mode)
 
-        if sys.version_info[0] >= 3:
-            if isinstance(value, str):
-                value = value.encode('latin-1')
+        if sys.version_info[0] >= 3 and isinstance(value, str):
+            value = value.encode('utf8')
+
         fd.write(value)
         fd.close()
 

--- a/backend/common/rhnCache.py
+++ b/backend/common/rhnCache.py
@@ -358,7 +358,7 @@ class CompressedCache:
 
     def get_file(self, name, modified=None):
         compressed_file = self.cache.get_file(name, modified)
-        return ClosingZipFile('r', compressed_file)
+        return ClosingZipFile('rb', compressed_file)
 
     def set_file(self, name, modified=None, user='root', group='root',
                  mode=int('0755', 8)):
@@ -385,10 +385,7 @@ class ObjectCache:
 
     def set(self, name, value, modified=None, user='root', group='root',
             mode=int('0755', 8)):
-        if sys.version_info[0] >= 3:
-            pickled = cPickle.dumps(value, -1).decode('latin-1')
-        else:
-            pickled = cPickle.dumps(value, -1)
+        pickled = cPickle.dumps(value, -1)
         self.cache.set(name, pickled, modified, user, group, mode)
 
     def has_key(self, name, modified=None):

--- a/backend/satellite_exporter/handlers/non_auth_dumper.py
+++ b/backend/satellite_exporter/handlers/non_auth_dumper.py
@@ -567,7 +567,7 @@ class NonAuthenticatedDumper(rhnHandler, dumper.XML_Dumper):
     # Opens the file and sends the stream
     def _send_stream(self, path):
         try:
-            stream = open(path)
+            stream = open(path, mode="rb")
         except IOError:
             e = sys.exc_info()[1]
             if e.errno == 2:

--- a/backend/satellite_tools/SequenceServer.py
+++ b/backend/satellite_tools/SequenceServer.py
@@ -58,8 +58,8 @@ class SequenceServer:
         nevermorethan = nevermorethan or self.NEVER_MORE_THAN
 
         self.seq = seq
-        self.chunksize = min(max(len(seq) / divisor, neverlessthan),
-                             nevermorethan)
+        self.chunksize = int(min(max(len(seq) / divisor, neverlessthan),
+                             nevermorethan))
         self.oneYN = 0
         self.alwaysOneYN = 0
         self.returnedChunksize = 0

--- a/backend/satellite_tools/connection.py
+++ b/backend/satellite_tools/connection.py
@@ -16,7 +16,7 @@
 #
 #
 
-import gzipstream
+import gzip
 
 from rhn import rpclib
 from spacewalk.satellite_tools import constants
@@ -149,8 +149,8 @@ class CompressedStream:
         # gzipstream tries to flush stuff; add a noop function
         self._real_stream.flush = noop
         self.stream = self._real_stream
-        if not isinstance(self._real_stream, gzipstream.GzipStream):
-            self.stream = gzipstream.GzipStream(stream=self._real_stream, mode="r")
+        if not isinstance(self._real_stream, gzip.GzipFile):
+            self.stream = gzip.GzipFile(fileobj=self._real_stream, mode="r")
 
     def close(self):
         if self.stream:

--- a/backend/satellite_tools/disk_dumper/dumper.py
+++ b/backend/satellite_tools/disk_dumper/dumper.py
@@ -32,7 +32,7 @@ from spacewalk.common.rhnException import rhnFault
 from spacewalk.server import rhnSQL
 from spacewalk.satellite_tools import constants
 from spacewalk.satellite_tools.exporter import exportLib, xmlWriter
-from string_buffer import StringBuffer
+from .string_buffer import StringBuffer
 
 
 class XML_Dumper:

--- a/backend/satellite_tools/exporter/exportLib.py
+++ b/backend/satellite_tools/exporter/exportLib.py
@@ -344,7 +344,7 @@ class _ChannelDumper(BaseRowDumper):
             ('rhn-channel-update-tag', 'update_tag'),
         ]
         for k, v in mappings:
-            arr.append(SimpleDumper(self._writer, k, self._row[v]))
+            arr.append(SimpleDumper(self._writer, k, self._row.get(v)))
 
         arr.append(SimpleDumper(self._writer, 'rhn-channel-last-modified',
                                 _dbtime2timestamp(self._row['last_modified'])))
@@ -640,7 +640,7 @@ class ChannelDumper(_ChannelDumper):
             ('rhn-channel-receiving-updates', 'receiving_updates'),
         ]
         for k, v in mappings:
-            arr.append(SimpleDumper(self._writer, k, self._row[v]))
+            arr.append(SimpleDumper(self._writer, k, self._row.get(v)))
 
         #channel_id = self._row['id']
         # Add EUS info
@@ -1031,7 +1031,7 @@ class _ChannelFamilyDumper(BaseRowDumper):
             ('rhn-channel-family-product-url', 'product_url'),
         ]
         for k, v in mappings:
-            arr.append(SimpleDumper(self._writer, k, self._row[v]))
+            arr.append(SimpleDumper(self._writer, k, self._row.get(v)))
 
         return ArrayIterator(arr)
 
@@ -1103,7 +1103,7 @@ class _PackageDumper(BaseRowDumper):
             ('rhn-package-header-end', 'header_end')
         ]
         for k, v in mappings:
-            arr.append(SimpleDumper(self._writer, k, self._row[v]))
+            arr.append(SimpleDumper(self._writer, k, self._row.get(v)))
 
         # checksums
         checksum_arr = [{'type':  self._row['checksum_type'],
@@ -1277,7 +1277,7 @@ class _ChangelogEntryDumper(BaseRowDumper):
             ('rhn-package-changelog-entry-text', 'text'),
         ]
         for k, v in mappings:
-            arr.append(SimpleDumper(self._writer, k, self._row[v]))
+            arr.append(SimpleDumper(self._writer, k, self._row.get(v)))
 
         arr.append(SimpleDumper(self._writer, 'rhn-package-changelog-entry-time',
                                 _dbtime2timestamp(self._row['time'])))
@@ -1306,7 +1306,7 @@ class _SuseProductEntryDumper(BaseRowDumper):
             ('suse-product-file-entry-description', 'description'),
         ]
         for k, v in mappings:
-            arr.append(SimpleDumper(self._writer, k, self._row[v]))
+            arr.append(SimpleDumper(self._writer, k, self._row.get(v)))
         return ArrayIterator(arr)
 
 class _SuseProductFilesDumper(BaseSubelementDumper):
@@ -1324,7 +1324,7 @@ class _SuseEulasEntryDumper(BaseRowDumper):
             ('suse-eula-entry-checksum', 'checksum'),
         ]
         for k, v in mappings:
-            arr.append(SimpleDumper(self._writer, k, self._row[v]))
+            arr.append(SimpleDumper(self._writer, k, self._row.get(v)))
         return ArrayIterator(arr)
 
 class _SuseEulasDumper(BaseSubelementDumper):
@@ -1430,7 +1430,7 @@ class _ErratumDumper(BaseRowDumper):
             ('rhn-erratum-severity', 'severity_id', 127)
         ]
         for k, v, b in mappings:
-            value = self._row[v] if self._row[v] is not None else ""
+            value = self._row.get(v) if self._row.get(v) is not None else ""
             arr.append(SimpleDumper(self._writer, k, value, b))
         arr.append(SimpleDumper(self._writer, 'rhn-erratum-issue-date',
                                 _dbtime2timestamp(self._row['issue_date'])))

--- a/backend/satellite_tools/exporter/exportLib.py
+++ b/backend/satellite_tools/exporter/exportLib.py
@@ -612,15 +612,9 @@ class ChannelsDumper(BaseSubelementDumper):
     subelement_dumper_class = _ChannelDumper
 
     def __init__(self, writer, channels=()):
-        BaseSubelementDumper.__init__(self, writer)
+        super(BaseSubelementDumper, self).__init__(writer)
         self._channels = channels
 
-    def set_iterator(self):
-        if not self._channels:
-            # Nothing to do
-            return
-
-        raise NotImplementedError("To be overridden in a child class")
 
 
 class ChannelDumper(_ChannelDumper):
@@ -882,7 +876,7 @@ class _SuseProductRepositoryDumper(BaseRowDumper):
         return {
             'root-product-id' : self._row['rootid'],
             'product-id' : self._row['pdid'],
-            'repository-id' : self._row['repoid'],
+            'repository-id' : self._row['repo_id'],
             'channel-label': self._row['channel_label'],
             'parent-channel-label': self._row['parent_channel_label'],
             'channel-name': self._row['channel_name'],
@@ -890,12 +884,12 @@ class _SuseProductRepositoryDumper(BaseRowDumper):
             'update-tag': self._row['update_tag']
             }
 
-class SuseProductExtensionDumper(BaseQueryDumper):
+class SuseProductRepositoryDumper(BaseQueryDumper):
     tag_name = 'suse-product-repositories'
     iterator_query = """
     SELECT p1.product_id AS pdid,
            p2.product_id AS rootid,
-           r.scc_id AS repoid,
+           r.scc_id AS repo_id,
            pr.channel_label,
            pr.parent_channel_label,
            pr.channel_name,

--- a/backend/satellite_tools/exporter/xmlWriter.py
+++ b/backend/satellite_tools/exporter/xmlWriter.py
@@ -27,9 +27,9 @@ class XMLWriter:
     """
 
     # We escape &<>'" and chars UTF-8 does not properly escape (everything
-    # other than tab (\x09), newline and carriage return (\x0a and \x0d) and
-    # stuff above ASCII 32)
-    _re = re.compile("(&|<|>|'|\"|[^\x09\x0a\x0d\x20-\xFF])")
+    # other than tab (\x09), newline and carriage return (\x0a and \x0d),
+    # stuff above ASCII 32 and UTF-8 alphanumeric chars in any language)
+    _re = re.compile("(&|<|>|'|\"|[^\x09\x0a\x0d\x20-\xFF\w])")
     _escaped_chars = {
         '&': '&amp;',
         '<': '&lt;',

--- a/backend/satellite_tools/satsync.py
+++ b/backend/satellite_tools/satsync.py
@@ -23,7 +23,6 @@ import os
 import sys
 import stat
 import time
-import exceptions
 import fnmatch
 try:
     #  python 2
@@ -52,32 +51,32 @@ from spacewalk.server.rhnLib import get_package_path
 from spacewalk.common import fileutils
 
 # __rhn sync/import imports__
-from . import xmlWireSource
-from . import xmlDiskSource
-from .progress_bar import ProgressBar
-from .xmlSource import FatalParseException, ParseException
-from .diskImportLib import rpmsPath
+from spacewalk.satellite_tools import xmlWireSource
+from spacewalk.satellite_tools import xmlDiskSource
+from spacewalk.satellite_tools.progress_bar import ProgressBar
+from spacewalk.satellite_tools.xmlSource import FatalParseException, ParseException
+from spacewalk.satellite_tools.diskImportLib import rpmsPath
 
-from .syncLib import log, log2, log2disk, log2stderr, log2email
-from .syncLib import RhnSyncException, RpmManip, ReprocessingNeeded
-from .syncLib import initEMAIL_LOG, dumpEMAIL_LOG
-from .syncLib import FileCreationError, FileManip
+from spacewalk.satellite_tools.syncLib import log, log2, log2disk, log2stderr, log2email
+from spacewalk.satellite_tools.syncLib import RhnSyncException, RpmManip, ReprocessingNeeded
+from spacewalk.satellite_tools.syncLib import initEMAIL_LOG, dumpEMAIL_LOG
+from spacewalk.satellite_tools.syncLib import FileCreationError, FileManip
 
-from .SequenceServer import SequenceServer
+from spacewalk.satellite_tools.SequenceServer import SequenceServer
 from spacewalk.server.importlib.errataCache import schedule_errata_cache_update
 
 from spacewalk.server.importlib.importLib import InvalidChannelFamilyError
 from spacewalk.server.importlib.importLib import MissingParentChannelError
 from spacewalk.server.importlib.importLib import get_nevra, get_nevra_dict
 
-from . import satCerts
-from . import req_channels
-from . import messages
-from . import sync_handlers
-from . import constants
+from spacewalk.satellite_tools import satCerts
+from spacewalk.satellite_tools import req_channels
+from spacewalk.satellite_tools import messages
+from spacewalk.satellite_tools import sync_handlers
+from spacewalk.satellite_tools import constants
 
 translation = gettext.translation('spacewalk-backend-server', fallback=True)
-_ = translation.ugettext
+_ = translation.gettext
 initCFG('server.satellite')
 initLOG(CFG.LOG_FILE, CFG.DEBUG)
 
@@ -599,7 +598,7 @@ class Syncer:
                            e._msg))
             elif isinstance(e, ParseException):
                 msg = (_('ERROR: parser exception occurred: %s') % (e))
-            elif isinstance(e, exceptions.SystemExit):
+            elif isinstance(e, SystemExit):
                 log(-1, _('*** SYSTEM INTERRUPT CALLED ***'), stream=sys.stderr)
                 raise
             else:

--- a/backend/satellite_tools/satsync.py
+++ b/backend/satellite_tools/satsync.py
@@ -306,8 +306,8 @@ class Runner:
     @staticmethod
     def _get_elapsed_time(elapsed):
         elapsed = int(elapsed)
-        hours = elapsed / 60 / 60
-        mins = elapsed / 60 - hours * 60
+        hours = int(elapsed / 60 / 60)
+        mins = int(elapsed / 60) - (hours * 60)
         secs = elapsed - mins * 60 - hours * 60 * 60
 
         delta_list = [[hours, _("hours")], [mins, _("minutes")], [secs, _("seconds")]]
@@ -703,9 +703,9 @@ class Syncer:
             for label in requested_channels:
                 timestamp = self._channel_collection.get_channel_timestamp(label)
                 ch = self._channel_collection.get_channel(label, timestamp)
-                if ch.has_key('comps_last_modified') and ch['comps_last_modified'] is not None:
+                if 'comps_last_modified' in ch and ch['comps_last_modified'] is not None:
                     self._process_comps(importer.backend, label, sync_handlers._to_timestamp(ch['comps_last_modified']))
-                if ch.has_key('modules_last_modified') and ch['modules_last_modified'] is not None:
+                if 'modules_last_modified' in ch and ch['modules_last_modified'] is not None:
                     self._process_modules(importer.backend, label, \
                         sync_handlers._to_timestamp(ch['modules_last_modified']))
 

--- a/backend/satellite_tools/sync_handlers.py
+++ b/backend/satellite_tools/sync_handlers.py
@@ -14,7 +14,6 @@
 #
 
 import sys
-import string  # pylint: disable=W0402
 
 from spacewalk.common import usix
 from spacewalk.server.importlib import channelImport, packageImport, errataImport, \
@@ -238,14 +237,14 @@ def import_channels(channels, orgid=None, master=None):
                 c_obj['org_id'] = org_map[c_obj['org_id']]
             else:
                 c_obj['org_id'] = orgid
-                if c_obj.has_key('trust_list'):
+                if 'trust_list' in c_obj:
                     del(c_obj['trust_list'])
             for family in c_obj['families']:
                 family['label'] = 'private-channel-family-' + \
                     str(c_obj['org_id'])
         # If there's a trust list on the channel, transform the org ids to
         # the local ones
-        if c_obj.has_key('trust_list') and c_obj['trust_list']:
+        if 'trust_list' in c_obj and c_obj['trust_list']:
             trusts = []
             for trust in c_obj['trust_list']:
                 if trust['org_trust_id'] in org_map:
@@ -451,7 +450,7 @@ def _to_timestamp(t):
     # The cache expects YYYYMMDDHH24MISS as format; so just drop the
     # spaces, dashes and columns
     # python 2.4 can't handle t.translate(None, ' -:')
-    last_modified = t.translate(string.maketrans("", ""), ' -:')
+    last_modified = t.translate(' -:')
     return last_modified
 
 # Generic container handler

--- a/backend/satellite_tools/xmlSource.py
+++ b/backend/satellite_tools/xmlSource.py
@@ -117,7 +117,7 @@ class BaseDispatchHandler(ContentHandler, ErrorHandler):
     container_dispatch = {}
 
     def __init__(self):
-        ContentHandler.__init__(self)
+        super(ContentHandler, self).__init__()
         self.rootAttributes = None
         self.__parser = make_parser()
         # Init the parser's handlers
@@ -134,9 +134,8 @@ class BaseDispatchHandler(ContentHandler, ErrorHandler):
         self.__parser.setContentHandler(self)
         self.__parser.setErrorHandler(self)
 
-    @staticmethod
-    def setStream(stream):
-        BaseDispatchHandler.__stream = stream
+    def setStream(self, stream):
+        self.__stream = stream
 
     # Starts processing the data from the XML stream
     def process(self, stream=None):
@@ -858,8 +857,8 @@ class SuseProductRepositoryItem(BaseItem):
     item_class = importLib.SuseProductRepository
     tagMap = {
         'product-id'    : 'product_id',
-        'root-product-id' : 'root_id',
-        'repo-id' : 'repo_id',
+        'root-product-id' : 'rootid',
+        'repository-id' : 'repo_id',
         'channel-label': 'channel_label',
         'parent-channel-label': 'parent_channel_label',
         'channel-name': 'channel_name',

--- a/backend/satellite_tools/xmlWireSource.py
+++ b/backend/satellite_tools/xmlWireSource.py
@@ -30,12 +30,12 @@ from spacewalk.common import rhnLib
 from spacewalk.common.rhnConfig import CFG
 
 # local imports
-from .syncLib import log, log2, RhnSyncException
+from spacewalk.satellite_tools.syncLib import log, log2, RhnSyncException
 
 from rhn import rpclib
 
 from spacewalk.common.suseLib import get_proxy
-from . import connection
+from spacewalk.satellite_tools import connection
 
 class BaseWireSource:
 

--- a/backend/server/importlib/archImport.py
+++ b/backend/server/importlib/archImport.py
@@ -16,7 +16,7 @@
 # Arch import process
 #
 
-from importLib import Import
+from .importLib import Import
 
 
 class ArchImport(Import):

--- a/backend/server/importlib/backend.py
+++ b/backend/server/importlib/backend.py
@@ -1569,7 +1569,7 @@ class Backend:
             SELECT scc_id FROM suseSCCRepository
             """)
         _query_repo.execute()
-        existing_data = ["%s" % (x['sccid']) for x in _query_repo.fetchall_dict() or []]
+        existing_data = ["%s" % (x['sccid']) for x in _query_repo.fetchall_dict() if 'sccid' in x or []]
         toinsert = [[], [], [], [], [], [], [], []]
         todelete = [[]]
         toupdate = [[], [], [], [], [], [], []]
@@ -2544,7 +2544,7 @@ def _buildDatabaseValue(row, fieldsHash):
     # sanitized
     dict = {}
     for f, datatype in list(fieldsHash.items()):
-        dict[f] = sanitizeValue(row[f], datatype)
+        dict[f] = sanitizeValue(row.get(f), datatype)
     return dict
 
 

--- a/backend/server/importlib/backend.py
+++ b/backend/server/importlib/backend.py
@@ -1294,7 +1294,7 @@ class Backend:
                    version = :version,
                    friendly_name = :friendly_name,
                    arch_type_id = :arch_type_id,
-                   release = :release,
+                   release = :release
              WHERE product_id = :product_id
              """)
         _query_product = self.dbmodule.prepare("""
@@ -1306,8 +1306,9 @@ class Backend:
         todelete = [[]]
         toupdate = [[], [], [], [], [], [], []]
         for item in batch:
-            if item['product_id'] in existing_data:
-                existing_data.remove(item['product_id'])
+            ident = "%s" % (item['product_id'])
+            if ident in existing_data:
+                existing_data.remove(ident)
                 toupdate[0].append(item['name'])
                 toupdate[1].append(item['version'])
                 toupdate[2].append(item['friendly_name'])
@@ -1347,7 +1348,7 @@ class Backend:
             """)
         update_pc = self.dbmodule.prepare("""
             UPDATE suseProductChannel
-               SET mandatory = :mand,
+               SET mandatory = :mand
              WHERE product_id = :pid
                AND channel_id = :cid
              """)
@@ -1502,7 +1503,7 @@ class Backend:
             SELECT product_id, root_product_id, repo_id FROM suseProductSCCRepository
             """)
         _query_pr.execute()
-        existing_data = ["%s-%s-%s" % (x['product_pdid'], x['root_pdid'], x['repo_pdid']) for x in _query_pr.fetchall_dict() or []]
+        existing_data = ["%s-%s-%s" % (x['product_id'], x['root_product_id'], x['repo_id']) for x in _query_pr.fetchall_dict() or []]
         toinsert = [[], [], [], [], [], [], [], [], []]
         todelete = [[], [], []]
         toupdate = [[], [], [], [], [], [], [], []]
@@ -1515,9 +1516,9 @@ class Backend:
                 toupdate[2].append(item['channel_name'])
                 toupdate[3].append(item['mandatory'])
                 toupdate[4].append(item['update_tag'])
-                toupdate[5].append(item['product_pdid'])
-                toupdate[6].append(item['root_pdid'])
-                toupdate[7].append(item.get('repo_pdid'))
+                toupdate[5].append(int(item['product_pdid']))
+                toupdate[6].append(int(item['root_pdid']))
+                toupdate[7].append(int(item['repo_pdid']))
                 continue
             toinsert[0].append(self.sequences['suseProductSCCRepository'].next())
             toinsert[1].append(int(item['product_pdid']))
@@ -1558,31 +1559,32 @@ class Backend:
         update_repo = self.dbmodule.prepare("""
             UPDATE suseSCCRepository
                SET name = :name,
-                   autorefresh = :autorefresh
+                   autorefresh = :autorefresh,
                    distro_target = :target,
                    description = :description,
                    url = :url,
-                   signed = :signed,
+                   signed = :signed
              WHERE scc_id = :sccid
              """)
         _query_repo = self.dbmodule.prepare("""
             SELECT scc_id FROM suseSCCRepository
             """)
         _query_repo.execute()
-        existing_data = ["%s" % (x['sccid']) for x in _query_repo.fetchall_dict() if 'sccid' in x or []]
+        existing_data = ["%s" % (x['scc_id']) for x in _query_repo.fetchall_dict() or []]
         toinsert = [[], [], [], [], [], [], [], []]
         todelete = [[]]
         toupdate = [[], [], [], [], [], [], []]
         for item in batch:
-            if item['sccid'] in existing_data:
-                existing_data.remove(item['sccid'])
+            ident = "%s" % item['sccid']
+            if ident in existing_data:
+                existing_data.remove(ident)
                 toupdate[0].append(item['name'])
                 toupdate[1].append(item['autorefresh'])
                 toupdate[2].append(item['distro_target'])
                 toupdate[3].append(item['description'])
                 toupdate[4].append(item['url'])
                 toupdate[5].append(item['signed'])
-                toupdate[6].append(int(item['sccid']))
+                toupdate[6].append(item['sccid'])
                 continue
             toinsert[0].append(self.sequences['suseSCCRepository'].next())
             toinsert[1].append(item['sccid'])

--- a/backend/server/importlib/channelImport.py
+++ b/backend/server/importlib/channelImport.py
@@ -15,7 +15,7 @@
 # Channel import process
 #
 
-from importLib import Import, InvalidArchError, \
+from .importLib import Import, InvalidArchError, \
     InvalidChannelError, InvalidChannelFamilyError, MissingParentChannelError
 from spacewalk.satellite_tools.syncLib import log
 
@@ -315,7 +315,7 @@ if __name__ == '__main__':
     import sys
     from spacewalk.server import rhnSQL
     from backendOracle import OracleBackend
-    from importLib import Collection, ChannelFamily, DistChannelMap
+    from .importLib import Collection, ChannelFamily, DistChannelMap
     backend = OracleBackend()
     if 1:
         batch = Collection()

--- a/backend/server/importlib/contentSourcesImport.py
+++ b/backend/server/importlib/contentSourcesImport.py
@@ -14,7 +14,7 @@
 #
 #
 
-from importLib import Import, Channel
+from .importLib import Import, Channel
 from spacewalk.server.rhnChannel import channel_info
 
 

--- a/backend/server/importlib/importLib.py
+++ b/backend/server/importlib/importLib.py
@@ -215,10 +215,10 @@ class SuseProductExtension(Information):
         'recommended' : StringType
     }
 
-class SuseProductRepositories(Information):
+class SuseProductRepository(Information):
     attributeTypes = {
         'product_id'          : IntType,
-        'root_id'             : IntType,
+        'rootid'              : IntType,
         'repo_id'             : IntType,
         'channel_label'       : StringType,
         'parent_channel_label': StringType,
@@ -227,7 +227,7 @@ class SuseProductRepositories(Information):
         'update_tag'          : StringType
     }
 
-class SCCRepositories(Information):
+class SCCRepository(Information):
     attributeTypes = {
         'sccid'        : IntType,
         'autorefresh'  : StringType,

--- a/backend/server/importlib/kickstartImport.py
+++ b/backend/server/importlib/kickstartImport.py
@@ -16,7 +16,7 @@
 # Package import process
 #
 
-from importLib import KickstartableTree, Import
+from .importLib import KickstartableTree, Import
 
 
 class KickstartableTreeImport(Import):

--- a/backend/server/importlib/orgImport.py
+++ b/backend/server/importlib/orgImport.py
@@ -16,7 +16,7 @@
 # Org import process
 #
 
-from importLib import Import
+from .importLib import Import
 
 # Thanks for this class goes to Alex Martelli:
 # http://stackoverflow.com/questions/1151658/python-hashable-dicts

--- a/backend/server/importlib/productNamesImport.py
+++ b/backend/server/importlib/productNamesImport.py
@@ -15,7 +15,7 @@
 #
 # Product Names Import
 
-from importLib import Import
+from .importLib import Import
 
 
 class ProductNamesImport(Import):

--- a/backend/server/importlib/supportInformationImport.py
+++ b/backend/server/importlib/supportInformationImport.py
@@ -10,7 +10,7 @@
 #
 # Support Information Import
 
-from importLib import GenericPackageImport
+from .importLib import GenericPackageImport
 from spacewalk.satellite_tools import syncCache
 
 class SupportInformationImport(GenericPackageImport):

--- a/backend/server/importlib/suseProductsImport.py
+++ b/backend/server/importlib/suseProductsImport.py
@@ -10,7 +10,7 @@
 #
 # SUSE Products Import
 
-from importLib import GenericPackageImport
+from .importLib import GenericPackageImport
 from spacewalk.satellite_tools import syncCache
 
 class SuseProductsImport(GenericPackageImport):

--- a/backend/server/importlib/suseProductsImport.py
+++ b/backend/server/importlib/suseProductsImport.py
@@ -176,7 +176,8 @@ class SCCRepositoriesImport(GenericPackageImport):
         self._data = []
 
     def preprocess(self):
-        pass
+        for item in self.batch:
+            self._data.append(item)
 
     def fix(self):
         pass

--- a/backend/server/importlib/suseProductsImport.py
+++ b/backend/server/importlib/suseProductsImport.py
@@ -150,9 +150,9 @@ class SuseProductRepositoriesImport(GenericPackageImport):
             if item['product_id'] not in pid_trans:
                 pid_trans[item['product_id']] = self.backend.lookupSuseProductIdByProductId(item['product_id'])
             item['product_pdid'] = pid_trans[item['product_id']]
-            if item['root_id'] not in pid_trans:
-                pid_trans[item['root_id']] = self.backend.lookupSuseProductIdByProductId(item['root_id'])
-            item['root_pdid'] = pid_trans[item['root_id']]
+            if item['rootid'] not in pid_trans:
+                pid_trans[item['rootid']] = self.backend.lookupSuseProductIdByProductId(item['rootid'])
+            item['root_pdid'] = pid_trans[item['rootid']]
             if item['repo_id'] not in rid_trans:
                 rid_trans[item['repo_id']] = self.backend.lookupRepoIdBySCCRepoId(item['repo_id'])
             item['repo_pdid'] = rid_trans[item['repo_id']]

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Fix "mgr-inter-sync" problems after Python 3 migration.
 - mgr-sign-metadata can optionally clear-sign metadata files
 - Added 'mgr-sign-metadata-ctl' for repository metadata signing
 

--- a/client/rhel/rhnlib/rhn/SSL.py
+++ b/client/rhel/rhnlib/rhn/SSL.py
@@ -217,7 +217,7 @@ class SSLSocket:
 
                 # More bytes to read?
                 pending = self._connection.pending()
-                if pending == 0:
+                if pending == 0 and buffer_length == amt:
                     # we're done here
                     break
             except SSL.ZeroReturnError:

--- a/client/rhel/rhnlib/rhnlib.changes
+++ b/client/rhel/rhnlib/rhnlib.changes
@@ -1,3 +1,6 @@
+- Read SSL decoded buffer completely when no pending bytes on the
+  underlying connection.
+
 -------------------------------------------------------------------
 Wed Feb 27 12:58:36 CET 2019 - jgonzalez@suse.com
 

--- a/usix/common/usix.py
+++ b/usix/common/usix.py
@@ -24,7 +24,7 @@ PY3 = sys.version_info[0] == 3
 # Common data types
 if PY3:
     BufferType = bytes
-    UnicodeType = str
+    UnicodeType = bytes
     StringType = str
     DictType = dict
     IntType = int

--- a/usix/spacewalk-usix.changes
+++ b/usix/spacewalk-usix.changes
@@ -1,3 +1,5 @@
+- Fix UnicodeType as bytes on Python 3
+
 -------------------------------------------------------------------
 Wed Feb 27 13:04:18 CET 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes several issues found in order to make `mgr-inter-sync` to run succesfully on Python 3:

- Fix wrong references to unexisting `suseRepositories`, `suseProductRepository` and `suseProductSCCRepositories` tables.
- Fix wrong attributes on XML schema construction during satellite exporter.
- On long SSL frames, read SSL decoded buffer completely even if no pending bytes on the underlying connection (avoid crashing due malformed XML).
- Fix issues with the `CompressedCache` due buffer encoding.
- Relative imports.

Now, with this PR, `mgr-inter-sync` seems to run successfully (including the package downloading):
```console
suma40-head-iss-slave:~ # mgr-inter-sync -c testchannel --email                                                                    
10:42:17 SUSE Manager - live synchronization                                                                                                                                
10:42:17    url: https://suma40-head-iss-master.tf.local                          
10:42:17    debug/output level: 8                                                     
10:42:17    +++ SUSE Manager Server synchronization tool checking in.                      
10:42:18    +++ Entitled SUSE Manager Server validated.                                   
10:42:18    db:  spacewalk/<password>@susemanager                                  
10:42:18 Action list/commandline toggles: ['orgs', 'channel-families', 'arches', 'channels', 'short', 'cloned-channels', 'download-packages', 'rpms', 'packages', 'download-
errata', 'download-kickstarts', 'errata', 'kickstarts', 'supportinfo', 'suse-products', 'scc-repositories', 'suse-product-channels', 'suse-upgrade-paths', 'suse-product-ext
ensions', 'suse-product-repositories', 'suse-subscriptions']                                    
10:42:18                                                                                       
10:42:18 Retrieving / parsing orgs data                                            
10:42:18 orgs data complete                                                       
10:42:18                                                                         
10:42:18 Retrieving / parsing channel-families data                                
10:42:19    parsing family: SUSE (1) Channel Family                               
10:42:19    parsing family: SUSE Linux Enterprise High Availability Extension (PPC)   
10:42:19    parsing family: SUSE Linux Enterprise High Availability Extension (PPC) (ALPHA)
10:42:19    parsing family: SUSE Linux Enterprise High Availability Extension (PPC) (BETA)
10:42:19    parsing family: SUSE Linux Enterprise High Performance Computing (x86)
10:42:19    parsing family: SUSE Linux Enterprise High Performance Computing (x86) (ALPHA)
10:42:19    parsing family: SUSE Linux Enterprise High Performance Computing (x86) (BETA)   
10:42:19    parsing family: SUSE Linux Enterprise Point of Service                                              
...
10:42:19 channel-families data complete                                                   
10:42:19                                                        
10:42:19 Retrieving / parsing product names data                        
10:42:19 product names data complete                                   
10:42:19                                                          
10:42:19 Retrieving / parsing arches data                                 
10:42:19    parsed arch: aarch64                                         
10:42:19    parsed arch: alpha                                
10:42:19    parsed arch: alphaev6                                     
10:42:19    parsed arch: amd64                                       
...
10:42:19 arches data complete
10:42:19
10:42:19 Retrieving / parsing additional arches data
10:42:20 additional arches data complete
10:42:20
10:42:20 Retrieving / parsing channel data
XXX: imported channels: ['sles12-sp3-pool-x86_64']
XXX:   cached channels: ['testchannel', 'sles12-sp3-pool-x86_64', 'sle-manager-tools12-pool-x86_64-sp3', 'sle-manager-tools12-updates-x86_64-sp3', 'sles12-sp3-updates-x86_6
4']
10:42:20    p = previously imported/synced channel
10:42:20    . = channel not yet imported/synced
10:42:20    base-channels:
10:42:20       . testchannel                                14       full import from Wed Feb 27 10:38:28 2019
10:42:20
10:42:20
10:42:20 Syncing Channel testchannel to Org 1
10:42:20 Channel data complete
10:42:20
10:42:20 Retrieving short package metadata (used for indexing)
10:42:20    Retrieving / parsing short package metadata: testchannel (14)
10:42:20 Diffing package metadata (what's missing locally?): testchannel
            ________________________________________
Diffing:    ######################################## - complete
10:42:20
10:42:20 Retrieving / parsing cloned_channels data
10:42:20 cloned_channels data complete
10:42:20
10:42:20 Downloading package metadata
10:42:20    Retrieving / parsing *relevant* package metadata: testchannel (NONE RELEVANT)
10:42:20
10:42:20 Downloading rpm packages
10:42:20    Fetching any missing RPMs: testchannel (NONE MISSING)
10:42:20 Processing rpm packages complete
10:42:20
10:42:20 Importing package metadata
10:42:20    Importing *relevant* package metadata: testchannel (NONE RELEVANT)
10:42:20
10:42:20 Linking packages to channels
10:42:20
10:42:20 Downloading patch data
10:42:20    Retrieving / parsing errata data: testchannel (NONE RELEVANT)
10:42:20 Downloading patch data complete
10:42:20
10:42:20 Downloading kickstartable trees metadata
10:42:20    Retrieving / parsing kickstart data: testchannel (NONE RELEVANT)
10:42:20
10:42:20 Downloading kickstartable trees files
10:42:20    Retrieving / parsing kickstart tree files: testchannel (NONE RELEVANT)
10:42:20
10:42:20 Importing channel patches
10:42:20 Importing 0 patches for channel testchannel.
10:42:20    Importing *relevant* errata: testchannel (NONE RELEVANT)
10:42:20    No new kickstartable tree to import
10:42:20
10:42:20 Retrieving / parsing supportinfo data
10:42:31 supportinfo data complete
10:42:31
10:42:31 Retrieving / parsing suse_products data
10:42:40 suse_products data complete
10:42:40
10:42:40 Retrieving / parsing scc_repositories data
10:42:45 scc_repositories data complete
10:42:45
10:42:45 Retrieving / parsing suse_product_channels data
10:42:45 suse_product_channels data complete
10:42:45
10:42:45 Retrieving / parsing suse_upgrade_paths data
10:42:46 suse_upgrade_paths data complete
10:42:46
10:42:46 Retrieving / parsing suse_product_extensions data
10:42:48 suse_product_extensions data complete
10:42:48
10:42:48 Retrieving / parsing suse_product_repositories data
10:43:05 suse_product_repositories data complete
10:43:05
10:43:05 Retrieving / parsing suse_subscriptions data
10:43:05 suse_subscriptions data complete
    Import complete:
        Begin time: Wed Feb 27 10:42:17 2019
        End time:   Wed Feb 27 10:43:05 2019
        Elapsed:    0 hours, 0 minutes, 47 seconds

+++ sending log as an email +++
suma40-head-iss-slave:~ #
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **python3 porting**

- [x] **DONE**

## Test coverage
- No tests: **python3 porting**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/salt-board/issues/247

- [x] **DONE**