### PR TITLE
Fix: handle non-standard filenames for comps.xml (bsc#1120242)

### DIFF
--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -714,9 +714,13 @@ class RepoSync(object):
         absdir = os.path.join(CFG.MOUNT_POINT, relativedir)
         if not os.path.exists(absdir):
             os.makedirs(absdir)
+        compressed_suffixes = ['.gz', '.bz', '.xz']
+        if comps_type == 'comps' and not re.match('comps.xml(' + "|".join(compressed_suffixes) + ')*', basename):
+            log(0, "  Renaming non-standard filename %s to %s." % (basename, 'comps' + basename[basename.find('.'):]))
+            basename = 'comps' + basename[basename.find('.'):]
         relativepath = os.path.join(relativedir, basename)
         abspath = os.path.join(absdir, basename)
-        for suffix in ['.gz', '.bz', '.xz']:
+        for suffix in compressed_suffixes:
             if basename.endswith(suffix):
                 abspath = abspath.rstrip(suffix)
                 relativepath = relativepath.rstrip(suffix)

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Fix: handle non-standard filenames for comps.xml (bsc#1120242)
 - Make reposync use and append token correctly to the URL
 - Avoid DB constraint violations caused by extended UTF8 characters on the RPM headers
 - Prevent mgr-inter-sync crash because 'SuseProductRepository' not found (bsc#1129300)


### PR DESCRIPTION
## What does this PR change?

For CentOS repositories, the comps metadata comes in non-standard
filenames (e.g.:
http://mirror.uv.es/mirror/CentOS/7/os/x86_64/repodata/bc140c8149fc43a5248fccff0daeef38182e49f6fe75d9b46db1206dc25a6c1c-c7-x86_64-comps.xml.gz)

The file mirrored from the repository is correctly mirrored in:

/var/cache/rhn/reposync/1/centos/bc140c8149fc43a5248fccff0daeef38182e49f6fe75d9b46db1206dc25a6c1c-c7-x86_64-comps.xml.gz

When this repository is assigned to a channel, the repomd.xml created
is referencing an hardcoded `comps.xml` file:

/var/cache/rhn/repodata/customchan/repomd.xml contains:

<location href="repodata/comps.xml"/><checksum type="sha">e1ce1241f5fb894a42948d512306a779bc40da57</checksum>

`comps.xml` does not exists in that path.

Given that we rely on having `comps.xml` in other parts of the code,
we decided to rename the `comps.xml` file when doing the reposync.
This PR makes sure to use `comps.xml` as filename in case the repository
has a non-standard `comps.xml` filename.

- BEFORE patching:

    - centos repository:

        - remote repomd.xml: http://ftp.fau.de/centos/7/os/x86_64/repodata/repomd.xml

            <location href="repodata/aced7d22b338fdf7c0a71ffcf32614e058f4422c42476d1f4b9e9364d567702f-c7-x86_64-comps.xml"/>

        - SUSE Manager server: /var/cache/rhn/reposync/1/centos

                /var/cache/rhn/reposync/1/centos # ls -l
                    total 30512
                    -rw-r--r-- 1 root root 31059968 Jan 17 14:30 6614b3605d961a4aaec45d74ac4e5e713e517debb3ee454a1c91097955780697-primary.sqlite
                    -rw-r--r-- 1 root root   169676 Nov 25 17:00 bc140c8149fc43a5248fccff0daeef38182e49f6fe75d9b46db1206dc25a6c1c-c7-x86_64-comps.xml.gz
                    -rw-r--r-- 1 root root        0 Jan 17 14:30 cachecookie
                    drwxr-xr-x 2 root root     4096 Jan 17 14:30 gen
                    drwxr-xr-x 2 root root     4096 Jan 17 14:30 packages
                    -rw-r--r-- 1 root root     3736 Nov 25 17:00 repomd.xml

                /var/cache/rhn/reposync/1/centos # grep comps repomd.xml
                    <location href="repodata/aced7d22b338fdf7c0a71ffcf32614e058f4422c42476d1f4b9e9364d567702f-c7-x86_64-comps.xml"/>
                    <location href="repodata/bc140c8149fc43a5248fccff0daeef38182e49f6fe75d9b46db1206dc25a6c1c-c7-x86_64-comps.xml.gz"/>

    - centoschannel, associated to the centos repository:

            /var/cache/rhn/repodata/centoschannel # ls -l 
                total 52284
                -rw-r--r-- 1 root root  8770214 Jan 17 15:12 filelists.xml.gz
                -rw-r--r-- 1 root root 41565889 Jan 17 15:12 other.xml.gz
                -rw-r--r-- 1 root root  3184216 Jan 17 15:12 primary.xml.gz
                -rw-r--r-- 1 root root     1298 Jan 17 15:12 repomd.xml
                -rw-r--r-- 1 root root      134 Jan 17 15:12 susedata.xml.gz
            
            /var/cache/rhn/repodata/centoschannel # grep comps repomd.xml
            <repomd xmlns="http://linux.duke.edu/metadata/repo"><data type="primary"><location href="repodata/primary.xml.gz"/><checksum type="sha">891eb09a11f5baebbcde0445a706f9075e4c5410</checksum><open-checksum type="sha">185d4edcc8ecbd524292af209503ea13ad358e5d</open-checksum><timestamp>1547734366</timestamp></data><data type="filelists"><location href="repodata/filelists.xml.gz"/><checksum type="sha">ec9584c3e26d1ac9241466e8199114006464341c</checksum><open-checksum type="sha">9407a50eb20fca552afb4e3a5eb20c1e388cd6d2</open-checksum><timestamp>1547734366</timestamp></data><data type="other"><location href="repodata/other.xml.gz"/><checksum type="sha">5fc1531550bc8eb5aa8158d229ca9d5a95a0822c</checksum><open-checksum type="sha">fd0c9cc3d5b9837eb0706821cd176df5d3acc1d0</open-checksum><timestamp>1547734366</timestamp></data><data type="susedata"><location href="repodata/susedata.xml.gz"/><checksum type="sha">7d5ef6cf8c9ba03c0c17bee179d4d44df22f5aac</checksum><open-checksum type="sha">5a819bb43057b01884298ca5fd9f3abb9dce0364</open-checksum><timestamp>1547734366</timestamp></data><data type="group"><location href="repodata/comps.xml"/><checksum type="sha">e1ce1241f5fb894a42948d512306a779bc40da57</checksum><timestamp>1547731848</timestamp></data></repomd>

            ^^^ <location href="repodata/comps.xml"/> ^^^

            /var/spacewalk/rhn/comps/centoschannel # ls
            bc140c8149fc43a5248fccff0daeef38182e49f6fe75d9b46db1206dc25a6c1c-c7-x86_64-comps.xml <-- this should be named as it appears in the file above: `comps.xml`
            /var/spacewalk/rhn/comps/centoschannel # sha1sum bc140c8149fc43a5248fccff0daeef38182e49f6fe75d9b46db1206dc25a6c1c-c7-x86_64-comps.xml 
            e1ce1241f5fb894a42948d512306a779bc40da57  bc140c8149fc43a5248fccff0daeef38182e49f6fe75d9b46db1206dc25a6c1c-c7-x86_64-comps.xml

- AFTER patching:

    - centos repository:

        - remote: same as before patching

        - SUSE Manager server: resynced from scratch, same as before patching

    - centoschannelcorrect, associated to the centos repository, same as before patching:

           /var/cache/rhn/repodata/centoschannelcorrect # ls -l
                total 20
                -rw-r--r-- 1 root root  122 Jan 18 11:08 filelists.xml.gz
                -rw-r--r-- 1 root root  120 Jan 18 11:08 other.xml.gz
                -rw-r--r-- 1 root root  129 Jan 18 11:08 primary.xml.gz
                -rw-r--r-- 1 root root 1130 Jan 18 11:08 repomd.xml
                -rw-r--r-- 1 root root  131 Jan 18 11:08 susedata.xml.gz

            
           /var/cache/rhn/repodata/centoschannelcorrect # grep comps repomd.xml 
           <repomd xmlns="http://linux.duke.edu/metadata/repo"><data type="primary"><location href="repodata/primary.xml.gz"/><checksum type="sha">9a3951c82f223991f4bfd8abc9667322e1ab7ecb</checksum><open-checksum type="sha">c84a202b156bf534fb97eef780fedf44116a5ade</open-checksum><timestamp>1547809180</timestamp></data><data type="filelists"><location href="repodata/filelists.xml.gz"/><checksum type="sha">82a6aed2eec4447d78d1f938a4b310f1d72b7ab1</checksum><open-checksum type="sha">c165fc182991282b926804d8a68333ced60909c8</open-checksum><timestamp>1547809180</timestamp></data><data type="other"><location href="repodata/other.xml.gz"/><checksum type="sha">186248eacb8ac0969605aadf6099a0ae3df342dd</checksum><open-checksum type="sha">5832f77b16496c758fb988caec45eb8df5464480</open-checksum><timestamp>1547809180</timestamp></data><data type="susedata"><location href="repodata/susedata.xml.gz"/><checksum type="sha">7d5ef6cf8c9ba03c0c17bee179d4d44df22f5aac</checksum><open-checksum type="sha">5a819bb43057b01884298ca5fd9f3abb9dce0364</open-checksum><timestamp>1547809180</timestamp></data><data type="group"><location href="repodata/comps.xml"/><checksum type="sha">e1ce1241f5fb894a42948d512306a779bc40da57</checksum><timestamp>1547806498</timestamp></data></repomd>

           (same as before patching)

           /var/spacewalk/rhn/comps/centoschannelcorrect # ls
           comps.xml

           /var/spacewalk/rhn/comps/centoschannelcorrect # sha1sum comps.xml 
           e1ce1241f5fb894a42948d512306a779bc40da57  comps.xml








## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: internal modification 

- [X] **DONE**

## Test coverage
- No tests: internal modification

- [X] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/6801

- [X] **DONE**
