### PR TITLE
Update commons-lang3 dependency to version 3.4

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -20,7 +20,7 @@
         <dependency org="suse" name="commons-fileupload" rev="1.1.1" />
         <dependency org="suse" name="commons-io" rev="2.4" />
         <dependency org="suse" name="commons-jexl" rev="2.1.1" />
-        <dependency org="suse" name="commons-lang3" rev="3.1" />
+        <dependency org="suse" name="commons-lang3" rev="3.4" />
         <dependency org="suse" name="commons-logging" rev="1.2" />
         <dependency org="suse" name="commons-validator" rev="1.1.4" />
         <dependency org="suse" name="concurrent" rev="1.3.4" />


### PR DESCRIPTION
## What does this PR change?

This patch is updating the `commons-lang3` dependency to version 3.4 in the ivy dependencies list that is used for development purposes.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed.

- [x] **DONE**

## Test coverage

- No tests needed.

- [x] **DONE**

## Links

A part of this downstream issue: https://github.com/SUSE/spacewalk/issues/7026

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
