### PR TITLE
Update frequency and age limit for minion-action-cleanup task

### DIFF
--- a/java/code/src/com/suse/manager/webui/utils/MinionActionUtils.java
+++ b/java/code/src/com/suse/manager/webui/utils/MinionActionUtils.java
@@ -178,7 +178,7 @@ public class MinionActionUtils {
             ActionFactory.pendingMinionServerActions().stream().flatMap(a -> {
                     if (a.getEarliestAction().toInstant()
                             .atZone(ZoneId.systemDefault())
-                            .isBefore(now.minus(5, ChronoUnit.MINUTES))) {
+                            .isBefore(now.minus(1, ChronoUnit.HOURS))) {
                         return a.getServerActions()
                                 .stream()
                                 .filter(sa -> sa.getServer().asMinionServer().isPresent() &&

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- minion-action-cleanup Taskomatic task: do not clean actions younger than one hour
 - Add support for custom username when bootstrapping with Salt-SSH
 - Archive orphan actions when a system is deleted and make them visible in the UI (bsc#1118213)
 - Cobbler version have been updated to >= 3.0

--- a/schema/spacewalk/common/data/rhnTaskoSchedule.sql
+++ b/schema/spacewalk/common/data/rhnTaskoSchedule.sql
@@ -83,7 +83,7 @@ INSERT INTO rhnTaskoSchedule (id, job_label, bunch_id, active_from, cron_expr)
 INSERT INTO rhnTaskoSchedule (id, job_label, bunch_id, active_from, cron_expr)
     VALUES (sequence_nextval('rhn_tasko_schedule_id_seq'), 'minion-action-cleanup-default',
         (SELECT id FROM rhnTaskoBunch WHERE name='minion-action-cleanup-bunch'),
-        current_timestamp, '0 0 * * * ?');
+        current_timestamp, '0 0 0 * * ?');
 
 -- Once a day at 4:05:00 AM (beware of 2AM cronjobs)
 

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Set minion-action-cleanup run frequency from hourly to daily at midnight
 - Archive orphan actions when a system is deleted and make them visible in the UI (bsc#1118213)
 
 -------------------------------------------------------------------

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.7-to-susemanager-schema-4.0.8/200-rhnTaskoSchedule-cron-freq.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.7-to-susemanager-schema-4.0.8/200-rhnTaskoSchedule-cron-freq.sql
@@ -1,0 +1,4 @@
+UPDATE rhnTaskoSchedule SET cron_expr = '0 0 0 * * ?'
+    WHERE job_label = 'minion-action-cleanup-default'
+        AND active_till IS NULL
+        AND cron_expr = '0 0 * * * ?';


### PR DESCRIPTION
Sets the default run frequency from 1 hour to **once a day at midnight** (unless it's already modified by the user) and sets the minimum action age from 5 minutes to **1 hour** for canceling.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Doc team has been informed: https://github.com/SUSE/spacewalk/issues/6571#issuecomment-467891149

- [x] **DONE**

## Test coverage
- No tests: There's no test coverage for this feature.

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/7163

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
