### PR TITLE
Fix: compute scroll offset on window scroll for sticky button bar

### DIFF
--- a/web/html/javascript/spacewalk-essentials.js
+++ b/web/html/javascript/spacewalk-essentials.js
@@ -99,7 +99,7 @@ function sstScrollBehaviorSetup(sst) {
 
   // override the empty function hooked on window.scroll event                                              │
   sstScrollBehavior = function() {
-    var currentScroll = $('section#spacewalk-content').scrollTop();
+    var currentScroll = $(window).scrollTop();
     if (currentScroll >= fixedTop) {
       sst.after(adjustSpaceObject);
       $(sst).addClass('fixed');

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- Fix: compute scroll offset on window scroll for sticky button bar
+
 -------------------------------------------------------------------
 Wed Feb 27 13:11:14 CET 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Fix the sticky button bar on scrolling. Since the split of the scrolling for the nav menu independently from the section, the sticky buttons bar is not getting sticky anymore when the section is scrolled, because the scrolling component is now changed and the offset is computed on the wrong component. This PR fixes this computation and the scroll bar get back to the sticky position when the section scrolls down.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: it's a fix, nothing to document

- [x] **DONE**

## Test coverage
- No tests: it's a css/js style behavior fix
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Downstream: https://github.com/SUSE/spacewalk/issues/7168

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
