### PR TITLE
Add automatic trust gpg key of Ubuntu repos

### DIFF
--- a/susemanager-utils/susemanager-sls/pillar_data/gpgkeys.yml
+++ b/susemanager-utils/susemanager-sls/pillar_data/gpgkeys.yml
@@ -8,3 +8,6 @@ gpgkeys:
   res:
     name: gpg-pubkey-0182b964
     file: res-gpg-pubkey-0182b964.key
+  ubuntutools:
+    name: gpg-pubkey-39db7c82
+    file: sle12-gpg-pubkey-39db7c82.key

--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -64,7 +64,7 @@ bootstrap_repo:
 {%- endif %}
 
 {%- if grains['os_family'] == 'RedHat' %}
-trust_suse_manager_tools_gpg_key:
+trust_suse_manager_tools_rhel_gpg_key:
   cmd.run:
 {%- if grains['osmajorrelease']|int == 6 %}
     - name: rpm --import https://{{ salt['pillar.get']('mgr_server') }}/pub/{{ salt['pillar.get']('gpgkeys:res6tools:file') }}
@@ -83,6 +83,10 @@ trust_res_gpg_key:
 
 {%- elif grains['os_family'] == 'Debian' %}
 {%- include 'channels/debiankeyring.sls' %}
+trust_suse_manager_tools_deb_gpg_key:
+  module.run:
+    - name: pkg.add_repo_key
+    - path: https://{{ salt['pillar.get']('mgr_server') }}/pub/{{ salt['pillar.get']('gpgkeys:ubuntutools:file') }}
 {%- endif %}
 
 salt-minion-package:


### PR DESCRIPTION
This PR allows the ubuntu minions to automatically accept the gpg key necessary to install client tools.

Note: The GPG-key in this PR is set to the SLES12 repository key because this key will be used once the feature is released.
For the current development you still need to perform the manual steps described in the documentation:
https://github.com/SUSE/doc-susemanager/blob/develop/adoc/bp_chap_expanded_support.adoc

cherry-pick from https://github.com/SUSE/spacewalk/pull/7161