### PR TITLE
Add an explicit requires to netty for spacewalk-java

### DIFF
--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -77,6 +77,7 @@ Requires:       jade4j
 Requires:       javassist
 Requires:       jboss-logging
 Requires:       jose4j
+Requires:       netty
 Requires:       objectweb-asm
 Requires:       /sbin/unix2_chkpwd
 Requires:       prometheus-client-java
@@ -101,6 +102,7 @@ BuildRequires:  java-devel >= 11
 BuildRequires:  javassist
 BuildRequires:  jboss-logging
 BuildRequires:  jsch
+BuildRequires:  netty
 BuildRequires:  objectweb-asm
 BuildRequires:  snakeyaml
 BuildRequires:  statistics


### PR DESCRIPTION
## What does this PR change?

Add an explicit requires to netty for spacewalk-java.

So far it got installed as we required and builrequired pgjdbc-ng, but netty is a dependency on its own for spacewalk-java.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: SPEC internal change.

- [x] **DONE**

## Test coverage
- No tests: SPEC internal change.

- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/7026

- [x] **DONE**