### PR TITLE
We use Head channels instead of 3.2

### DIFF
--- a/testsuite/features/core_centos_salt_ssh.feature
+++ b/testsuite/features/core_centos_salt_ssh.feature
@@ -54,7 +54,7 @@ Feature: Bootstrap a SSH-managed CentOS minion and do some basic operations on i
 @centos_minion
   Scenario: Prepare a SSH-managed CentOS minion 
     Given I am authorized
-    When I enable repository "Devel_Galaxy_Manager_3.2_RES-Manager-Tools-7-x86_64" on this "ceos-client"
+    When I enable repository "Devel_Galaxy_Manager_Head_RES-Manager-Tools-7-x86_64" on this "ceos-client"
     And  I enable repository "SLE-Manager-Tools-RES-7-x86_64" on this "ceos-client"
     And  I enable repository "CentOS-Base" on this "ceos-client"
     And  I install package "hwdata m2crypto wget" on this "ceos-client"

--- a/testsuite/features/trad_centos_client.feature
+++ b/testsuite/features/trad_centos_client.feature
@@ -22,7 +22,7 @@ Feature: Be able to register a CentOS 7 traditional client and do some basic ope
 @centos_minion
   Scenario: Prepare a CentOS 7 traditional client
     Given I am authorized
-    When I enable repository "Devel_Galaxy_Manager_3.2_RES-Manager-Tools-7-x86_64" on this "ceos-client"
+    When I enable repository "Devel_Galaxy_Manager_Head_RES-Manager-Tools-7-x86_64" on this "ceos-client"
     And I enable repository "SLE-Manager-Tools-RES-7-x86_64" on this "ceos-client"
     And I enable repository "CentOS-Base" on this "ceos-client"
     And I install package "hwdata m2crypto wget" on this "ceos-client"


### PR DESCRIPTION
## What does this PR change?

Test failed:

    When I enable repository "Devel_Galaxy_Manager_3.2_RES-Manager-Tools-7-x86_64" on this "ceos-client"

Reason: we have the "Head" repo available and should enable it.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- Cucumber tests fix

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
