### PR TITLE
Bring back a step definition test

### DIFF
--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -757,3 +757,13 @@ When(/^I delete a salt "([^"]*)" file with name "([^"]*)" on the server$/) do |t
   return_code = file_delete($server, path)
   raise 'File Deletion failed' unless return_code.zero?
 end
+
+When(/^I install "([^"]*)" to custom formula metadata directory "([^"]*)"$/) do |file, formula|
+  source = File.dirname(__FILE__) + '/../upload_files/' + file
+  dest = "/srv/formula_metadata/" + formula + '/' + file
+
+  $server.run("mkdir -p /srv/formula_metadata/" + formula)
+  return_code = file_inject($server, source, dest)
+  raise 'File injection failed' unless return_code.zero?
+  $server.run("chmod 644 " + dest)
+end


### PR DESCRIPTION
## What does this PR change?

Bring back a missing step definition.
Related refactoring commit#3466b3a7dfabcdc187f4a3f03627be2be47f3c9f

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
