### PR TITLE
Fix spacecmd py3 str

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,5 @@
+- fix python 3 bytes issue when handling config channels
+
 -------------------------------------------------------------------
 Sat Mar 02 00:09:22 CET 2019 - jgonzalez@suse.com
 

--- a/spacecmd/src/lib/configchannel.py
+++ b/spacecmd/src/lib/configchannel.py
@@ -646,7 +646,7 @@ def configfile_getinfo(self, args, options, file_info=None, interactive=False):
                 options.mode = '0644'
 
         logging.debug("base64 encoding contents")
-        contents = base64.b64encode(contents)
+        contents = base64.b64encode(contents.encode('utf8')).decode()
 
         file_info = {'contents': ''.join(contents),
                      'owner': options.owner,
@@ -887,7 +887,7 @@ def do_configchannel_updateinitsls(self, args, update_path=''):
             logging.error('You must provide the file contents')
             return
 
-    contents = base64.b64encode(contents)
+    contents = base64.b64encode(contents.encode('utf8')).decode()
 
     file_info = {'contents': ''.join(contents),
                  'contents_enc64': True


### PR DESCRIPTION
## What does this PR change?

Seems that b64encode() expects and returns a byte object but we have and expect string

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- fixes a test

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
