### PR TITLE
Configuration Channels menu was renamed

### DIFF
--- a/testsuite/features/allcli_config_channel.feature
+++ b/testsuite/features/allcli_config_channel.feature
@@ -161,7 +161,7 @@ Feature: Management of configuration of all types of clients in a single channel
     Given I am authorized as "admin" with password "admin"
     When I follow "Home" in the left menu
     And I follow "Configuration" in the left menu
-    And I follow "Configuration Channels" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "Mixed Channel"
     And I follow "Systems" in the content area
     And I check the "ubuntu-minion" client


### PR DESCRIPTION
## What does this PR change?

In Uyuni the menu was a bit renamed. So the Ubuntu port from 3.2 introduced a check for a wrong entry.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- fixes a test

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
