### PR TITLE
Bootstrap repo sle15 sp1

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -650,6 +650,22 @@ DATA = {
         'PDID' : [1576, 1712], 'PKGLIST' : PKGLIST15 + PKGLIST15_NO_Z,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/0/bootstrap/'
     },
+    'SLE-15-SP1-aarch64' : {
+        'PDID' : [1769, 1709], 'PKGLIST' : PKGLIST15 + PKGLIST15_NO_Z,
+        'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/1/bootstrap/'
+    },
+    'SLE-15-SP1-ppc64le' : {
+        'PDID' : [1770, 1710], 'PKGLIST' : PKGLIST15 + PKGLIST15_NO_Z,
+        'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/1/bootstrap/'
+    },
+    'SLE-15-SP1-s390x' : {
+        'PDID' : [1771, 1711], 'PKGLIST' : PKGLIST15,
+        'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/1/bootstrap/'
+    },
+    'SLE-15-SP1-x86_64' : {
+        'PDID' : [1772, 1712], 'PKGLIST' : PKGLIST15 + PKGLIST15_NO_Z,
+        'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/1/bootstrap/'
+    },
     'openSUSE-Leap-42.3-x86_64' : {
         'BASECHANNEL' : 'opensuse_leap42_3-x86_64', 'PKGLIST' : PKGLIST12 + ONLYOPENSUSE42 + ENHANCE12SP1,
         'DEST' : '/srv/www/htdocs/pub/repositories/opensuse/42/3/bootstrap/'

--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -108,7 +108,6 @@ PKGLIST12 = [
     "python",
     "python-cffi",
     "python-cryptography",
-    "python-setuptools",
     "python-dmidecode",
     "python-ethtool",
     "python-gobject2",
@@ -192,6 +191,7 @@ ENHANCE12SP1 = [
     "python-enum34",
     "python-idna",
     "python-ipaddress",
+    "python-setuptools",
 ]
 
 RES6 = [

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,7 @@
+- move `python-setuptools` package dependency to SLES12 SP1
+  or later
+- add bootstrap repo definition for SLE15 SP1
+
 -------------------------------------------------------------------
 Wed Feb 27 13:14:42 CET 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Add botstrap repo definition for SLE15 SP1 and fix a small issue with SLES12 GA where
python-setuptools is not part of the main distribution.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **not yet possible for bootstrap repo**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
