### PR TITLE
temporary disable tests calling cobbler

### DIFF
--- a/testsuite/run_sets/testsuite.yml
+++ b/testsuite/run_sets/testsuite.yml
@@ -70,12 +70,14 @@
 - features/min_salt_install_with_staging.feature
 - features/srv_xmlrpc_activationkey.feature
 - features/allcli_overview_systems_details.feature
-- features/srv_distro_cobbler.feature
+# temporary disable as long as cobbler is broken
+#- features/srv_distro_cobbler.feature
 - features/srv_mainpage.feature
 - features/srv_xmlrpc_user.feature
 - features/srv_salt_download_endpoint.feature
 - features/srv_virtual_host_manager.feature
-- features/trad_baremetal_discovery.feature
+# temporary disable as long as cobbler is broken
+#- features/trad_baremetal_discovery.feature
 - features/trad_action_chain.feature
 - features/min_action_chain.feature
 - features/minssh_action_chain.feature


### PR DESCRIPTION

## What does this PR change?

py3 port of cobbler is not finished so it will always produce errors.
Let's disable it for now and enable them again for Beta 2.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **tempoary change**

- [x] **DONE**

## Test coverage
- hide known errors

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
