### PR TITLE
remove zypp-plugin-spacewalk from the proxy when it is a minion

### DIFF
--- a/testsuite/features/core_proxy_register_as_minion_with_gui.feature
+++ b/testsuite/features/core_proxy_register_as_minion_with_gui.feature
@@ -32,6 +32,7 @@ Feature: Setup SUSE Manager proxy
 @proxy
   Scenario: Copy the keys and configure the proxy
     When I copy server's keys to the proxy
+    And I remove package "zypp-plugin-spacewalk" from this "proxy"
     And I configure the proxy
     Then I should see "proxy" in spacewalk
 


### PR DESCRIPTION
## What does this PR change?

On a proxy as minion the package zypp-plugin-spacewalk produces errors.
The package is not needed. I have changed the pattern to only "recommend" it.
It should be possible to remove it without removing the proxy.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- fixes a test

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
