### PR TITLE
track the time a feature needs

### DIFF
--- a/testsuite/features/support/setup_browser.rb
+++ b/testsuite/features/support/setup_browser.rb
@@ -20,6 +20,7 @@ server = ENV['SERVER']
 DEFAULT_TIMEOUT = 250
 $stdout.sync = true
 Capybara.default_wait_time = 10
+STARTTIME = Time.new.to_i
 
 def enable_assertions
   # include assertion globally

--- a/testsuite/features/support/time.rb
+++ b/testsuite/features/support/time.rb
@@ -2,5 +2,11 @@
 
 Before do |_scenario|
   current_time = Time.new
-  puts "This scenario ran at: #{current_time}"
+  @scenario_start_time = current_time.to_i
+  puts "This scenario ran at: #{current_time} - #{@scenario_start_time - STARTTIME} seconds since start"
+end
+
+After do |_scenario|
+  current_epoch = Time.new.to_i
+  puts "This scenario took: #{current_epoch - @scenario_start_time} seconds"
 end


### PR DESCRIPTION
## What does this PR change?

print number of seconds since begining of the test and number of seconds a test took.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- test modification

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
