### PR TITLE
provide a early and specific error message when there are no credentials

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -215,13 +215,20 @@ public class ContentSyncManager {
      * from the local file instead of the network.
      * @return List of {@link Credentials}
      */
-    private List<Credentials> filterCredentials() {
+    private List<Credentials> filterCredentials() throws ContentSyncException {
         // if repos are read with "fromdir", no credentials are used. We signal this
         // with one null Credentials object
         if (Config.get().getString(ContentSyncManager.RESOURCE_PATH) != null) {
             return new ArrayList<Credentials>() { { add(null); } };
         }
-        return CredentialsFactory.lookupSCCCredentials();
+
+        List<Credentials> credentials = CredentialsFactory.lookupSCCCredentials();
+        if (credentials.isEmpty()) {
+            throw new ContentSyncException("No SCC credentials found.");
+        }
+        else {
+            return credentials;
+        }
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add error message on sync refresh when there are no scc credentials
 - rename cobbler keyword ksmeta to autoinstall_meta which changed with cobbler 3
 - minion-action-cleanup Taskomatic task: do not clean actions younger than one hour
 - Add support for custom username when bootstrapping with Salt-SSH


### PR DESCRIPTION
## What does this PR change?

This add an exception that gets thrown when there is no scc credentials since all following functions require.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: previous error message was cryptic and would have required documentation. The new error message explains whats needed from the user.
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [x] **DONE**

## Test coverage
- No tests: simple change 
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #7034 

Relevant branches (GitHub automatic links expected below):
 - Manager-3.2
 - Uyuni

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to rerun `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically after re-run it:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
