### PR TITLE
Testsuite - test events during onboarding and after testsuite run

### DIFF
--- a/testsuite/features/core_centos_salt_ssh.feature
+++ b/testsuite/features/core_centos_salt_ssh.feature
@@ -60,3 +60,8 @@ Feature: Bootstrap a SSH-managed CentOS minion and do some basic operations on i
     And  I install package "hwdata m2crypto wget" on this "ceos-client"
     And  I install package "rhn-client-tools rhn-check rhn-setup rhnsd mgr-osad rhncfg-actions" on this "ceos-client"
     And  I install package "spacewalk-oscap scap-security-guide" on this "ceos-client"
+
+@centos_minion
+  Scenario: Check events history for failures on SSH-managed CentOS minion
+    Given I am on the Systems overview page of this "ceos-ssh-minion"
+    Then I check for failed events on history event page

--- a/testsuite/features/core_min_bootstrap.feature
+++ b/testsuite/features/core_min_bootstrap.feature
@@ -165,3 +165,7 @@ Feature: Be able to bootstrap a Salt minion via the GUI
     Given I am on the Systems overview page of this "sle-minion"
     Then I should see a "[Container Build Host]" text
     Then I should see a "[OS Image Build Host]" text
+
+  Scenario: Check events history for failures on SLES minion
+    Given I am on the Systems overview page of this "sle-minion"
+    Then I check for failed events on history event page

--- a/testsuite/features/core_min_salt_ssh.feature
+++ b/testsuite/features/core_min_salt_ssh.feature
@@ -71,3 +71,8 @@ Feature: Be able to bootstrap a Salt host managed via salt-ssh
     Then I should see a "1 package install has been scheduled" text
     When I wait until event "Package Install/Upgrade scheduled by admin" is completed
     Then "hoag-dummy-1.1-2.1" should be installed on "ssh-minion"
+
+@ssh_minion
+  Scenario: Check events history for failures on SSH minion
+    Given I am on the Systems overview page of this "ssh-minion"
+    Then I check for failed events on history event page

--- a/testsuite/features/core_proxy_register_as_minion_with_gui.feature
+++ b/testsuite/features/core_proxy_register_as_minion_with_gui.feature
@@ -42,3 +42,8 @@ Feature: Setup SUSE Manager proxy
     Then I should see "proxy" hostname
     # TODO: uncomment when SCC product becomes available
     # And I wait until I see "$PRODUCT Proxy" text, refreshing the page
+
+@proxy
+  Scenario: Check events history for failures on the proxy
+    Given I am on the Systems overview page of this "proxy"
+    Then I check for failed events on history event page

--- a/testsuite/features/core_ubuntu_salt_ssh.feature
+++ b/testsuite/features/core_ubuntu_salt_ssh.feature
@@ -51,3 +51,8 @@ Feature: Bootstrap a SSH-managed Ubuntu minion and do some basic operations on i
     When I click on "Confirm"
     Then I should see a "Changing the channels has been scheduled." text
     And I wait until event "Subscribe channels scheduled by admin" is completed
+
+@ubuntu_minion
+  Scenario: Check events history for failures on SSH-managed Ubuntu minion
+    Given I am on the Systems overview page of this "ubuntu-minion"
+    Then I check for failed events on history event page

--- a/testsuite/features/min_activationkey.feature
+++ b/testsuite/features/min_activationkey.feature
@@ -162,3 +162,7 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
     Given I am on the Systems overview page of this "sle-minion"
     Then I should see a "[Container Build Host]" text
     Then I should see a "[OS Image Build Host]" text
+
+  Scenario: Check events history for failures on SLES minion with activation key
+    Given I am on the Systems overview page of this "sle-minion"
+    Then I check for failed events on history event page

--- a/testsuite/features/min_bootstrap_xmlrpc.feature
+++ b/testsuite/features/min_bootstrap_xmlrpc.feature
@@ -53,6 +53,10 @@ Feature: Register a Salt minion via XML-RPC API
     Then I should see a "Changing the channels has been scheduled." text
     And I wait until event "Subscribe channels scheduled by admin" is completed
 
+  Scenario: Check events history for failures on SLES minion after XML-RPC bootstrap
+    Given I am on the Systems overview page of this "sle-minion"
+    Then I check for failed events on history event page
+
   Scenario: Bootstrap via XML-RPC a non-existing system
     Given I am logged in via XML-RPC system as user "admin" and password "admin"
     When I call system.bootstrap() on unknown host, I should get an XML-RPC fault with code -1

--- a/testsuite/features/min_centos_salt.feature
+++ b/testsuite/features/min_centos_salt.feature
@@ -107,6 +107,11 @@ Feature: Be able to bootstrap a CentOS minion and do some basic operations on it
     And I should see a "rpm_" link
 
 @centos_minion
+  Scenario: Check events history for failures on CentOS minion
+    Given I am on the Systems overview page of this "ceos-minion"
+    Then I check for failed events on history event page
+
+@centos_minion
   Scenario: Cleanup: delete the CentOS minion
     When I am on the Systems overview page of this "ceos-minion"
     And I follow "Delete System"

--- a/testsuite/features/min_ubuntu_salt.feature
+++ b/testsuite/features/min_ubuntu_salt.feature
@@ -118,6 +118,11 @@ Feature: Be able to bootstrap an Ubuntu minion and do some basic operations on i
     And I should see a "results.xml" link
 
 @ubuntu_minion
+  Scenario: Check events history for failures on Ubuntu minion
+    Given I am on the Systems overview page of this "ubuntu-minion"
+    Then I check for failed events on history event page
+
+@ubuntu_minion
   Scenario: Cleanup: delete the Ubuntu minion
     When I am on the Systems overview page of this "ubuntu-minion"
     And I follow "Delete System"

--- a/testsuite/features/minssh_bootstrap_xmlrpc.feature
+++ b/testsuite/features/minssh_bootstrap_xmlrpc.feature
@@ -45,6 +45,11 @@ Feature: Register a salt-ssh system via XML-RPC
     Then I run spacecmd listevents for "ssh-minion"
 
 @ssh_minion
+  Scenario: Check events history for failures on SSH minion after XML-RPC bootstrap
+    Given I am on the Systems overview page of this "ssh-minion"
+    Then I check for failed events on history event page
+
+@ssh_minion
   Scenario: Cleanup: subscribe SSH minion to base channel
     Given I am on the Systems overview page of this "ssh-minion"
     When I follow "Software" in the content area

--- a/testsuite/features/srv_susemanager_debug.feature
+++ b/testsuite/features/srv_susemanager_debug.feature
@@ -11,3 +11,6 @@ Feature: Debug SUSE Manager after the testsuite has run
 
   Scenario: Check the tomcat logs on server
     Then I check the tomcat logs for errors
+
+  Scenario: Check salt event log for failures on server
+    Then I control that salt event log on server contains no failures

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -94,6 +94,20 @@ Then(/^I control that up2date logs on client under test contains no Traceback er
   raise 'error found, check the client up2date logs' if code.nonzero?
 end
 
+# salt failures log check
+Then(/^I control that salt event log on server contains no failures$/) do
+  # upload salt event parser log
+  file = 'salt_event_parser.py'
+  source = File.dirname(__FILE__) + '/../upload_files/' + file
+  dest = "/tmp/" + file
+  return_code = file_inject($server, source, dest)
+  raise 'File injection failed' unless return_code.zero?
+  # print failures from salt event log
+  output = $server.run("python3 /tmp/#{file}")
+  count_failures = output.to_s.scan(/false/).length
+  raise "\nFound #{count_failures} failures in salt event log:\n#{output.join.to_s}\n" if count_failures.nonzero?
+end
+
 # action chains
 When(/^I check radio button "(.*?)"$/) do |arg1|
   raise unless choose(arg1)
@@ -887,4 +901,22 @@ And(/^I remove package "([^"]*)" from highstate$/) do |package|
       And I click on "Apply"
     )
   end
+end
+
+And(/^I check for failed events on history event page$/) do
+  steps %(
+    When I follow "Events" in the content area
+    And I follow "History" in the content area
+    Then I should see a "System History" text
+  )
+  failings = ""
+  event_table_xpath = "//div[@class='table-responsive']/table/tbody"
+  rows = find(:xpath, event_table_xpath)
+  rows.all('tr').each do |tr|
+    if tr.has_css?('.fa.fa-times-circle-o.fa-1-5x.text-danger')
+      failings << "#{tr.text}\n"
+    end
+  end
+  count_failures = failings.length
+  raise "\nFailures in event history found:\n\n#{failings}" if count_failures.nonzero?
 end

--- a/testsuite/features/upload_files/salt_event_parser.py
+++ b/testsuite/features/upload_files/salt_event_parser.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+import re
+import json
+
+# open salt event log and create correct json from it
+errors = []
+item = [] 
+f = open('/var/log/rhn/salt-event.log', "r")
+for line in f.readlines():
+    item.append(line)
+    if re.search(r"^\}", line):
+        if '\"result\": false' in "".join(item):
+            item[0] = "{"
+            errors.append(item)
+        item = [] 
+f.close()
+
+# parse json and find results ending as failed
+failure_count = 0
+for error in errors:
+    j = json.loads("".join(error))
+    if not "return" in j:
+        break
+    for k in j["return"]:
+        if not j["return"][k]["result"]:
+            failure_count += 1
+            print("\n# Failure", failure_count, ", _stamp:", j['_stamp'], json.dumps(j["return"][k], sort_keys=True, indent=4))


### PR DESCRIPTION
## What does this PR change?

This PR adds check of failed events after bootstrap on history event page to those features:

```
core_centos_salt_ssh.feature
core_min_bootstrap.feature
core_min_salt_ssh.feature
core_proxy_register_as_minion_with_gui.feature
core_ubuntu_salt_ssh.feature
min_activationkey.feature
min_bootstrap_xmlrpc.feature
min_centos_salt.feature
minssh_bootstrap_xmlrpc.feature
min_ubuntu_salt.feature
```
PR also adds check of salt event bus (logfile `/var/log/rhn/salt-event.log`) for failed salt events. Debug output with failed events is printed at the end of testsuite run in `srv_susemanager_debug.feature`.

## Links

Port of https://github.com/SUSE/spacewalk/pull/7169