### PR TITLE
Migrate nagios plugin to Python 3

### DIFF
--- a/susemanager-utils/nagios-plugin/check_suma_common.py
+++ b/susemanager-utils/nagios-plugin/check_suma_common.py
@@ -19,7 +19,7 @@ from spacewalk.common.rhnConfig import initCFG
 def resultExit(code, msg=None):
     rhnSQL.closeDB()
     if msg:
-        print msg
+        print(msg)
     sys.exit(code)
 
 #############################################################################

--- a/susemanager-utils/nagios-plugin/check_suma_lastevent
+++ b/susemanager-utils/nagios-plugin/check_suma_lastevent
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3 -u
 
 import sys
 from spacewalk.server import rhnSQL

--- a/susemanager-utils/nagios-plugin/check_suma_patches
+++ b/susemanager-utils/nagios-plugin/check_suma_patches
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3 -u
 #
 # Copyright (c) 2013 SUSE LLC
 #

--- a/susemanager-utils/nagios-plugin/susemanager-nagios-plugin.changes
+++ b/susemanager-utils/nagios-plugin/susemanager-nagios-plugin.changes
@@ -1,3 +1,5 @@
+- Use Python 3 to run the plugin.
+
 -------------------------------------------------------------------
 Fri Oct 26 10:50:29 CEST 2018 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Make the `nagios-plugin` use Python 3.

## GUI diff

No difference.

## Documentation
- No documentation needed

## Test coverage
- No tests: tests exist already

## Links

https://github.com/SUSE/spacewalk/issues/7187
