### PR TITLE
Tese cases for RES with two base channels

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/channel/test/ChannelFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/test/ChannelFactoryTest.java
@@ -117,9 +117,8 @@ public class ChannelFactoryTest extends RhnBaseTestCase {
         return c;
     }
 
-    public static Channel createTestChannel(User user, String channelLabel) throws Exception {
-        String query = "ChannelArch.findByLabel";
-        ChannelArch arch = (ChannelArch) TestUtils.lookupFromCacheByLabel(channelLabel, query);
+    public static Channel createTestChannel(User user, String channelArch) throws Exception {
+        ChannelArch arch = (ChannelArch) TestUtils.lookupFromCacheByLabel(channelArch, "ChannelArch.findByLabel");
         Channel c = createTestChannel(user.getOrg(), arch, user.getOrg().getPrivateChannelFamily());
         // assume we want the user to have access to this channel once created
         UserManager.addChannelPerm(user, c.getId(), "subscribe");

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add unit tests for base channel assignments when registering RES minions
 - Enable batching mode for salt synchronous calls
 - Do not implicitly set parent channel when cloning (bsc#1130492)
 - Do not report Provisioning installed product to subscription matcher (bsc#1128838)


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/6563

Fixes https://github.com/SUSE/spacewalk/issues/6025

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"  
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 