### PR TITLE
Manager suma baseproduct

### DIFF
--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -2,10 +2,10 @@
 
 DISTRIBUTION_ID="$(source /etc/os-release && echo ${ID})"
 case ${DISTRIBUTION_ID} in
-    sles)                    JVM='/usr/lib64/jvm/jre-11-openjdk/bin/java';;
-    opensuse|opensuse-leap)  JVM='/usr/lib64/jvm/jre-11-openjdk/bin/java';;
-    *)                       echo 'Unknown distribution!'
-                             exit 1;;
+    sles|suse-manager-server) JVM='/usr/lib64/jvm/jre-11-openjdk/bin/java';;
+    opensuse|opensuse-leap)   JVM='/usr/lib64/jvm/jre-11-openjdk/bin/java';;
+    *)                        echo 'Unknown distribution!'
+                              exit 1;;
 esac
 
 if [ ! $UID -eq 0 ]; then

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- support new susemanager base product
+
 -------------------------------------------------------------------
 Mon Mar 04 09:57:04 CET 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

SUSE Manager now is a base product so has its own ID string in /etc/os-release. Setup needs to know about this "new distribution".