### PR TITLE
Add missing dependency to susemanager-docs_en at spacewalk-java

### DIFF
--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -89,6 +89,7 @@ Requires:       statistics
 Requires:       sudo
 Requires:       tomcat-taglibs-standard
 Requires:       pgjdbc-ng
+Requires:       susemanager-docs_en
 BuildRequires:  apache-commons-lang
 BuildRequires:  apache-commons-lang3
 BuildRequires:  classmate


### PR DESCRIPTION
## What does this PR change?

Add missing dependency to susemanager-docs_en at spacewalk-java, as we depend on it (we have links to the doc at the java code)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: SPEC change.

- [x] **DONE**

## Test coverage
- No tests: SPEC change.

- [x] **DONE**

## Links

- [x] **DONE**