### PR TITLE
Allow custom username for Salt-SSH bootstrap

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/utils/SSHMinionBootstrapper.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/SSHMinionBootstrapper.java
@@ -26,6 +26,7 @@ import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.utils.InputValidator;
 import com.suse.manager.webui.utils.gson.BootstrapParameters;
 import com.suse.manager.webui.utils.gson.BootstrapHostsJson;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 
 import java.util.Arrays;
@@ -132,8 +133,12 @@ public class SSHMinionBootstrapper extends AbstractMinionBootstrapper {
      */
     @Override
     protected BootstrapParameters createBootstrapParams(BootstrapHostsJson input) {
+        String user = input.getUser();
+        if (StringUtils.isEmpty(user)) {
+            user = getSSHUser();
+        }
         return new BootstrapParameters(input.getHost(),
-                Optional.of(SSH_PUSH_PORT), getSSHUser(), input.maybeGetPassword(),
+                Optional.of(SSH_PUSH_PORT), user, input.maybeGetPassword(),
                 input.getActivationKeys(), input.getIgnoreHostKeys(),
                 Optional.ofNullable(input.getProxy()));
     }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add support for custom username when bootstrapping with Salt-SSH
 - Archive orphan actions when a system is deleted and make them visible in the UI (bsc#1118213)
 - Cobbler version have been updated to >= 3.0
 - Removed cobbler's 'update' method call which is now invalid(bsc#1128917)

--- a/testsuite/features/min_ubuntu_salt.feature
+++ b/testsuite/features/min_ubuntu_salt.feature
@@ -62,7 +62,7 @@ Feature: Be able to bootstrap an Ubuntu minion and do some basic operations on i
 #    Then I should see "ubuntu-minion" hostname
 
 @ubuntu_minion
-  Scenario: Re-subscribe the SSH-managed Ubuntu minion to a base channel
+  Scenario: Subscribe the Ubuntu minion to a base channel
     Given I am on the Systems overview page of this "ubuntu-minion"
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area

--- a/web/html/src/manager/bootstrap-minions.js
+++ b/web/html/src/manager/bootstrap-minions.js
@@ -62,7 +62,6 @@ class BootstrapMinions extends React.Component {
     manageWithSSHChanged(event) {
         this.setState({
             manageWithSSH: event.target.checked,
-            user: "",
             port: ""
         });
     }
@@ -165,9 +164,11 @@ class BootstrapMinions extends React.Component {
             <AsyncButton id="clear-btn" defaultType="btn-default pull-right" icon="fa-eraser" text={t("Clear fields")} action={this.clearFields}/>
         ];
 
+        const productName = _IS_UYUNI ? "Uyuni" : "SUSE Manager"
+
         return (
         <TopPanel title={t("Bootstrap Minions")} icon="fa fa-rocket" helpUrl="/rhn/help/reference/en-US/ref.webui.systems.bootstrapping.jsp#ref.webui.systems.bootstrapping">
-            <p>{t('You can add systems to be managed by providing SSH credentials only. SUSE Manager will prepare the system remotely and will perform the registration.')}</p>
+            <p>{t('You can add systems to be managed by providing SSH credentials only. {0} will prepare the system remotely and will perform the registration.', productName)}</p>
             {messages}
             <div className="form-horizontal">
                 <div className="form-group">
@@ -187,7 +188,12 @@ class BootstrapMinions extends React.Component {
                 <div className="form-group">
                     <label className="col-md-3 control-label">User:</label>
                     <div className="col-md-6">
-                        <input name="user" className="form-control" type="text" placeholder="root" value={this.state.user} disabled={this.state.manageWithSSH} onChange={this.userChanged}/>
+                        <input name="user" className="form-control" type="text" placeholder="root" value={this.state.user} onChange={this.userChanged}/>
+                        { this.state.manageWithSSH &&
+                            <div className="help-block">
+                              <i className="fa fa-exclamation-triangle"/>{t("The user will have an effect only during the bootstrap process. Further connections will be made by the user specified in rhn.conf. The default user for the key 'ssh_push_sudo_user' is 'root'. This user is set after {0}'s SSH key is deployed during the bootstrap procedure.", productName)}
+                            </div>
+                        }
                     </div>
                 </div>
                 <div className="form-group">

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Allow username input on bootstrap page when using Salt-SSH
 - Add VNC display for virtual machines on salt minions
 - Fix action scheduler time picker prefill when the server is on  "UTC/GMT" timezone (bsc#1121195)
 


### PR DESCRIPTION
This change allows you to input any username when bootstrapping via Salt-SSH. With this, you can bootstrap minions without having a root password set. The way this works is, it connects to the minion with the provided username, escalates privileges and deposits a ssh-key for the default sudo user.
The default sudo user is determined in the `rhn_web.conf` file as `ssh_push_sudo_user` and by default is empty (which means it falls back to 'root')

Every salt-ssh call after that is handled by this user. This means, if this user is root, the following option has to be set for the ssh server:
`PermitRootLogin prohibit-password`

this is default on Ubuntu systems.

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- Change described in a UI hint (see screenshots)

- [x] **DONE**

## Test coverage
- No tests: So far, only manually tested

- [ ] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/7147

https://github.com/SUSE/spacewalk/issues/6207

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
