### PR TITLE
ChangTime event needs to be fired explicitly 

### DIFF
--- a/testsuite/features/step_definitions/datepicker_steps.rb
+++ b/testsuite/features/step_definitions/datepicker_steps.rb
@@ -90,7 +90,7 @@ end
 When(/^I pick (\d+) minutes from now as schedule time$/) do |arg1|
   action_time = get_future_time(arg1)
   page.execute_script("$('#date_timepicker_widget_input')
-    .timepicker('setTime', '#{action_time}');")
+    .timepicker('setTime', '#{action_time}').trigger('changeTime');")
 end
 
 When(/^I schedule action to (\d+) minutes from now$/) do |minutes|


### PR DESCRIPTION
ChangTime event of datePicker component needs to be fired explicitly in order to change time through javascript. Without this, staging related tests fails.

## Links

Fixes # cucumber tests in testsuit

