### PR TITLE
Testsuite - failing highstate on SSH minion fix

### DIFF
--- a/testsuite/features/core_min_salt_ssh.feature
+++ b/testsuite/features/core_min_salt_ssh.feature
@@ -17,6 +17,7 @@ Feature: Be able to bootstrap a Salt host managed via salt-ssh
     And I navigate to "rhn/systems/Overview.do" page
     And I wait until I see the name of "ssh-minion", refreshing the page
     And I wait until onboarding is completed for "ssh-minion"
+    Then I remove package "sle-manager-tools-release" from highstate
 
 @proxy
 @ssh_minion

--- a/testsuite/features/minssh_bootstrap_xmlrpc.feature
+++ b/testsuite/features/minssh_bootstrap_xmlrpc.feature
@@ -24,6 +24,7 @@ Feature: Register a salt-ssh system via XML-RPC
      And I navigate to "rhn/systems/Overview.do" page
      And I wait until I see the name of "ssh-minion", refreshing the page
      And I wait until onboarding is completed for "ssh-minion"
+     Then I remove package "sle-manager-tools-release" from highstate
 
 @ssh_minion
   Scenario: Check contact method of this Salt SSH system

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -869,3 +869,22 @@ And(/^I mark as read it via the "([^"]*)" button$/) do |target_button|
     step %(I wait until I see "1 message read status updated successfully." text)
   end
 end
+
+And(/^I remove package "([^"]*)" from highstate$/) do |package|
+  steps %(
+    When I follow "States" in the content area
+    And I follow "Packages" in the content area
+    Then I should see a "Package States" text
+  )
+  event_table_xpath = "//div[@class='table-responsive']/table/tbody"
+  rows = find(:xpath, event_table_xpath)
+  rows.all('tr').each do |tr|
+    next unless tr.text.include?(package)
+    puts tr.text
+    tr.find('#sles-release-pkg-state').select('Removed')
+    steps %(
+      Then I click on "Save"
+      And I click on "Apply"
+    )
+  end
+end

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -96,6 +96,7 @@ When(/^I wait until onboarding is completed for "([^"]*)"$/) do |host|
     And I wait until I see the name of "#{host}", refreshing the page
     And I follow this "#{host}" link
     And I wait until event "Package List Refresh scheduled by (none)" is completed
+    Then I wait until event "Apply states" is completed
   )
 end
 


### PR DESCRIPTION
## What does this PR change?

PR removes package `sle-manager-tools-release` from highstate on SSH minion after its bootstrap.
This ensures applying of hightstate doesn't fail due disabled repo that contains this package.

PR adds step definition for `Then I remove package "sle-manager-tools-release" from highstate`, which is possible to use in general to remove any package from higstate.

PR modifies two features:
- `minssh_bootstrap_xmlrpc.feature`
- `core_min_salt_ssh.feature`

## Links

- related issue https://github.com/SUSE/spacewalk/issues/6969 
- port of https://github.com/SUSE/spacewalk/pull/7190