### PR TITLE
[WIP] Commit successfully downloaded packages

### DIFF
--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -1110,10 +1110,8 @@ class RepoSync(object):
                 try:
                     # importing packages by batch or if the current packages is the last
                     if mpm_bin_batch and (is_last_download_element or len(mpm_bin_batch) % self.import_batch_size == 0):
-                        log(0, "  DO A COMMIT. - {} - {} - {}".format(bool(mpm_bin_batch), is_last_download_element, len(mpm_bin_batch) % self.import_batch_size == 0))
                         self.__process_mpm_bin_batch(mpm_bin_batch, backend, upload_caller, affected_channels)
                     if mpm_src_batch and (is_last_download_element or len(mpm_src_batch) % self.import_batch_size == 0):
-                        log(0, "  DO A SRC COMMIT. - {} - {} - {}".format(bool(mpm_src_batch), is_last_download_element, len(mpm_src_batch) % self.import_batch_size == 0))
                         self.__process_mpm_src_batch(mpm_src_batch, backend, upload_caller)
                     progress_bar_success = True
                 except rhnSQL.SQLError:

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,6 @@
+- Avoid reposync crashing by ensuring import batches are commited
+  even if some packages failed while downloading (bsc#1127488)
+
 -------------------------------------------------------------------
 Mon Mar 04 09:54:01 CET 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue with `spacewalk-repo-sync` that happens in some cases where there are failures while downloading some of the packages from the repository.

During the "Importing packages" step, `reposync` is commiting to the transaction in batches. The way it prepares the batches and commit them has a "bug" which causes that, in case there is a downloading exceptions for the last processed package, the last batch of packages is not actually committed on the present transaction.

This situation produces a crash of `reposync` because it expect some of the packages that were not processed:

```console
2019/03/06 13:30:08 +02:00     2/11 : java-1.8.0-openjdk-src-debug-1.8.0.201.b09-2.el7_6.x86_64.rpm
2019/03/06 13:30:08 +02:00     3/11 : java-1.8.0-openjdk-src-debug-1.8.0.201.b09-2.el7_6.i686.rpm
2019/03/06 13:30:08 +02:00     4/11 : java-1.8.0-openjdk-src-1.8.0.201.b09-2.el7_6.x86_64.rpm
...
2019/03/06 13:30:50 +02:00 ERROR: Download failed: https://updates.suse.com/repo/$RCE/RES7/x86_64//RPMS/qt-debuginfo-4.8.5-13.el7.i686.rpm?XXXXXXXXXXXXXXXXXX - Target file isn't valid. Checksum should be 4a72c7e68e39c6becd987d9e0934d426c5347993 (sha1).. Retrying...                         
2019/03/06 13:31:06 +02:00 ERROR: Download failed: https://updates.suse.com/repo/$RCE/RES7/x86_64//RPMS/qt-debuginfo-4.8.5-13.el7.i686.rpm?XXXXXXXXXXXXXXXXXX - Target file isn't valid. Checksum should be 4a72c7e68e39c6becd987d9e0934d426c5347993 (sha1)..                         
2019/03/06 13:31:06 +02:00     11/11 : qt-debuginfo-4.8.5-13.el7.i686.rpm (failed)
2019/03/06 13:31:07 +02:00 Importing packages started.
2019/03/06 13:31:07 +02:00                                                                                                                                                                                         
2019/03/06 13:31:07 +02:00   Importing packages to DB:
2019/03/06 13:31:07 +02:00 (50, u'checksums did not match 4c171fdedaa1e23e11fec0405883569b47f85dc1 vs 744b30688af3e6f129725b7412cb8ac33a4fafe2', 'Invalid information uploaded to the server')
2019/03/06 13:31:07 +02:00 (50, u'checksums did not match e4781828f8c2a5052d58944634333d316122f388 vs 9f180a4be01825ce8e0762472f5e2bf2cd8f0ec9', 'Invalid information uploaded to the server')
2019/03/06 13:31:07 +02:00 (50, u'checksums did not match 836b32df01ef9d4d2025cdda527c1731fd364c8d vs 9d1b6971e8521e8dfa7611ede67f266a80a9fbab', 'Invalid information uploaded to the server')
2019/03/06 13:31:07 +02:00 (50, u'checksums did not match ea1bab981b1ee889754ba4d4a0d2796db2e8bcea vs 5dd4a7abd726f668c81d3ab52862ab73b794cd47', 'Invalid information uploaded to the server')
2019/03/06 13:31:07 +02:00 (50, u'checksums did not match 4a72c7e68e39c6becd987d9e0934d426c5347993 vs 2949ee276c48dcff41f33d51aa1332d38d70fe78', 'Invalid information uploaded to the server')
2019/03/06 13:31:08 +02:00 (50, u'checksums did not match 87644d09f66701ffda4200ab2b00543d2ccdaa67 vs 281559454b02a00c8d1f5975a32fcedb94494117', 'Invalid information uploaded to the server')
2019/03/06 13:31:08 +02:00 (50, u'checksums did not match e3f181865dc760538cbb0fe880ce96d47b9f3d49 vs 20b1288566b3067988125d1e695eaaa7159004da', 'Invalid information uploaded to the server')
2019/03/06 13:31:08 +02:00 Importing packages finished.
2019/03/06 13:31:08 +02:00       
2019/03/06 13:31:08 +02:00   Linking packages to the channel.
2019/03/06 13:31:08 +02:00 Unexpected error: <class 'spacewalk.server.importlib.importLib.InvalidPackageError'>
2019/03/06 13:31:08 +02:00 Traceback (most recent call last):  
  File "/usr/lib/python2.7/site-packages/spacewalk/satellite_tools/reposync.py", line 544, in sync
    ret = self.import_packages(plugin, data['id'], url)
  File "/usr/lib/python2.7/site-packages/spacewalk/satellite_tools/reposync.py", line 1114, in import_packages
    importer.run()                                                                                                                                                                                                 
  File "/usr/lib/python2.7/site-packages/spacewalk/server/importlib/importLib.py", line 764, in run
    self.submit()                                           
  File "/usr/lib/python2.7/site-packages/spacewalk/server/importlib/packageImport.py", line 128, in submit      
    self.backend.lookupPackages(self.batch, self.checksums)
  File "/usr/lib/python2.7/site-packages/spacewalk/server/importlib/backend.py", line 697, in lookupPackages
    raise_with_tb(not_found[0], not_found[1])                                                                                                                                                                      
  File "/usr/lib/python2.7/site-packages/spacewalk/server/importlib/backend.py", line 689, in lookupPackages
    self.__lookupObjectCollection([package], 'rhnPackage')
  File "/usr/lib/python2.7/site-packages/spacewalk/server/importlib/backend.py", line 2341, in __lookupObjectCollection
    raise InvalidPackageError(object, "Could not find object %s in table %s" % (object, tableName))
InvalidPackageError: Could not find object [<spacewalk.server.importlib.importLib.IncompletePackage instance; attributes={'package_size': None, 'package_arch_id': 104, 'name': u'java-1.8.0-openjdk-src', 'checksum_list': None, 'md5sum': None, 'org_id': None, 'epoch': 1L, 'checksums': {'sha1': 'd9ea8ead4f326515a9a260d60f07b4ec70e18d86'}, 'channels': {141: 'res7-x86_64'}, 'nevra_id': 111157, 'package_id': None, 'last_modified': None, 'name_id': 1468, 'version': u'1.8.0.201.b09', 'checksum': 'd9ea8ead4f326515a9a260d60f07b4ec70e18d86', 'release': u'2.el7_6', 'checksum_type': 'sha1', 'arch': u'i686', 'evr_id': 21151, 'checksum_id': 11514107}] in table rhnPackage

```

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **tests are not included in this PR here in order to speed up the fix for this blocker P1**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/salt-board/issues/267

- [x] **DONE**