### PR TITLE
Align the result in cucumber tests with the salt response

### DIFF
--- a/testsuite/features/allcli_config_channel.feature
+++ b/testsuite/features/allcli_config_channel.feature
@@ -198,7 +198,8 @@ Feature: Management of configuration of all types of clients in a single channel
     # bsc#1078764 - CFG-MGMT-SALT: inconsistent UI between traditional clients and Salt minions when comparing files
     # Then I should see a "-COLOR=white" text
     # And I should see a "+COLOR=red" text
-    Then I should see a "-COLOR=white+COLOR=red" text
+    Then I should see a "+COLOR=white" text
+    And I should see a "-COLOR=red" text
 
   Scenario: Check configuration channel and files via XML-RPC
     Given I am logged in via XML-RPC configchannel as user "admin" and password "admin"


### PR DESCRIPTION
## What does this PR change?
Align the result in cucumber tests according to what is coming from salt. In Salt Oxygon, the response was changed but in Fluorine it is back how it was before Oxygon.
## Links

Fixes # https://bugzilla.suse.com/show_bug.cgi?id=1128468
Tracks # **add downstream PR, if any**

- [x] **DONE**

- [x] No changelog needed