### PR TITLE
P1: Make sure the package download url does not have '//' (bsc#1127488)

### DIFF
--- a/backend/satellite_tools/download.py
+++ b/backend/satellite_tools/download.py
@@ -218,7 +218,11 @@ class DownloadThread(Thread):
             ## This also needs a patched urlgrabber AFAIK
             if 'authtoken' in params and params['authtoken']:
                 (scheme, netloc, path, query, _) = urlparse.urlsplit(params['urls'][self.mirror])
-                url = "%s://%s%s/%s?%s" % (scheme,netloc,path,params['relative_path'],query.rstrip('/'))
+                url = urlparse.urlunsplit((
+                    scheme,
+                    netloc,
+                    urlparse.urljoin(path, params['relative_path']),
+                    query.rstrip('/'), ''))
             try:
                 try:
                     fo = PyCurlFileObjectThread(url, params['target_file'], opts, self.curl, self.parent)

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Make sure the package download url does not have '//' (bsc#1127488)
 - Fix bootstrapping SLE15 traditional client (bsc#1128564)
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

This PR fixes the way `reposync` prepares the RPM download URLs when using authentication token (i.a. SCC repositories) to prevent having double slashes in the URL path:

```
https://my.domain.com/repopath//RPMS/foobar-debuginfo-1.0.0.x86_64.rpm?MY_AUTHENTICATION_TOKEN
```

Avoiding double slashes, we prevent possible issues with mirrors/cdn cache.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **bugfix for P1. no test added.**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/salt-board/issues/267
Tracks https://github.com/SUSE/spacewalk/pull/7227

- [x] **DONE**
