### PR TITLE
"man" does not exist on CentOS, use "sed" instead

### DIFF
--- a/testsuite/features/core_srv_create_activationkey.feature
+++ b/testsuite/features/core_srv_create_activationkey.feature
@@ -65,7 +65,7 @@ Feature: Be able to manipulate activation keys
     And I select "Test-Channel-x86_64" from "selectedBaseChannel"
     And I click on "Create Activation Key"
     And I follow "Packages"
-    And I enter "man" as "packages"
+    And I enter "sed" as "packages"
     And I click on "Update Activation Key"
     Then I should see a "Activation key SUSE Test PKG Key x86_64 has been modified." text
     And I should see a "Details" link
@@ -84,7 +84,7 @@ Feature: Be able to manipulate activation keys
     And I select "Test-Channel-i586" from "selectedBaseChannel"
     And I click on "Create Activation Key"
     And I follow "Packages"
-    And I enter "man" as "packages"
+    And I enter "sed" as "packages"
     And I click on "Update Activation Key"
     Then I should see a "Activation key SUSE Test PKG Key i586 has been modified." text
     And I should see a "Details" link

--- a/testsuite/features/trad_mgr_bootstrap.feature
+++ b/testsuite/features/trad_mgr_bootstrap.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2018 SUSE LLC
+# Copyright (c) 2015-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Generate a bootstrap script and use it to register a client
@@ -12,7 +12,7 @@ Feature: Generate a bootstrap script and use it to register a client
     When I fetch "pub/bootstrap/bootstrap-test.sh" to "sle-client"
     And I run "sh ./bootstrap-test.sh" on "sle-client"
     Then I should see "sle-client" in spacewalk
-    And "man" should be installed on "sle-client"
+    And "sed" should be installed on "sle-client"
     And config-actions are enabled
     And remote-commands are enabled
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes a false positive in the test suite when testing CentOS.

