### PR TITLE
Manager fix proxy firewall

### DIFF
--- a/proxy/installer/spacewalk-proxy-installer.changes
+++ b/proxy/installer/spacewalk-proxy-installer.changes
@@ -1,3 +1,5 @@
+- fix syntax error in proxy firewall file (bsc#1128885)
+
 -------------------------------------------------------------------
 Sat Mar 02 00:11:37 CET 2019 - jgonzalez@suse.com
 

--- a/proxy/installer/suse-manager-proxy.xml
+++ b/proxy/installer/suse-manager-proxy.xml
@@ -8,7 +8,7 @@
         <port protocol="tcp" port="5222"/>
         <port protocol="tcp" port="5269"/>
         <port protocol="tcp" port="4505"/>
-        <port protocol="tcp" port="4506">
+        <port protocol="tcp" port="4506"/>
         <port protocol="udp" port="123"/>
         <port protocol="udp" port="69"/>
         <module name="nf_conntrack_tftp"/>


### PR DESCRIPTION
## What does this PR change?

The firewall definition file for the SUSE Manager proxy was missing a "/" violating the syntax.