### PR TITLE
Removed cobbler's update method call

### DIFF
--- a/java/code/src/org/cobbler/CobblerObject.java
+++ b/java/code/src/org/cobbler/CobblerObject.java
@@ -155,7 +155,6 @@ public abstract class CobblerObject {
      */
     public void save() {
         invokeSave();
-        update();
     }
 
     /**
@@ -459,10 +458,6 @@ public abstract class CobblerObject {
      */
     public void setKernelOptionsPost(Map<String, Object> kernelOptionsPostIn) {
         modify(SET_KERNEL_OPTIONS_POST, kernelOptionsPostIn);
-    }
-
-    protected void update() {
-        client.invokeTokenMethod("update");
     }
 
     protected boolean isBlank(String str) {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Removed cobbler's 'update' method call which is now invalid(bsc#1128917)
 - support ubuntu products and debian architectures in mgr-sync
 - adapt check for available repositories to debian style repositories
 - Add virtual machine display page

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Cobbler version have been updated to >= 3.0
 - Removed cobbler's 'update' method call which is now invalid(bsc#1128917)
 - support ubuntu products and debian architectures in mgr-sync
 - adapt check for available repositories to debian style repositories

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -60,7 +60,7 @@ Requires:       classpathx-mail
 Requires:       apache-commons-beanutils
 Requires:       apache-commons-collections
 Requires:       apache-commons-lang3
-Requires:       cobbler >= 2.0.0
+Requires:       cobbler >= 3.0.0
 Requires:       concurrent
 Requires:       google-gson >= 2.2.4
 Requires:       httpcomponents-client
@@ -415,7 +415,7 @@ Requires:       cglib
 Requires:       bcel
 Requires:       c3p0 >= 0.9.1
 %if 0%{?suse_version}
-Requires:       cobbler >= 2.0.0
+Requires:       cobbler >= 3.0.0
 Requires:       java >= 11
 Requires:       jsch
 Requires:       /sbin/unix2_chkpwd


### PR DESCRIPTION
## What does this PR change?
 'update' method which is not there anymore in cobbler and can be removed altogether. Even in the deprecated version, it was doing nothing but returning simple true.

## Documentation
- No documentation needed: I don' think there is any need to document it

- [ ] **DONE**

## Test coverage
- Unit tests 
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/7250
Tracks # **add downstream PR, if any**

- [ ] **DONE**

