### PR TITLE
Virtual storage pools and volumes

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -475,6 +475,12 @@
           <context context-type="sourcefile">Navigation Menu</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="Storage">
+        <source>Storage</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">Navigation Menu</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="digits">
         <source>0 1 2 3 4 5 6 7 8 9</source>
         <context-group name="ctx">

--- a/java/code/src/com/suse/manager/virtualization/VirtManager.java
+++ b/java/code/src/com/suse/manager/virtualization/VirtManager.java
@@ -19,8 +19,10 @@ import com.google.gson.reflect.TypeToken;
 import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.salt.netapi.calls.LocalCall;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -85,10 +87,10 @@ public class VirtManager {
     }
 
     /**
-     * Query the list of virtual networks defined on a salt minion.
+     * Query the list of virtual storage pools defined on a salt minion.
      *
      * @param minionId the minion to ask about
-     * @return a list of the network names
+     * @return a map associating pool names with their informations as Json elements
      */
     public static Map<String, JsonElement> getPools(String minionId) {
         Map<String, Object> args = new LinkedHashMap<>();
@@ -103,6 +105,22 @@ public class VirtManager {
         return result.entrySet().stream()
                     .filter(entry -> entry.getValue().isJsonObject())
                     .collect(Collectors.toMap(entry -> entry.getKey(), entry -> entry.getValue()));
+    }
+
+    /**
+     * Query the list of virtual storage volumes defined on a salt minion.
+     *
+     * @param minionId the minion to ask about
+     * @return a map associating pool names with the list of volumes it contains mapped by their names
+     */
+    public static Map<String, Map<String, JsonElement>> getVolumes(String minionId) {
+        List<?> args = Arrays.asList(null, null);
+        LocalCall<Map<String, Map<String, JsonElement>>> call =
+                new LocalCall<>("virt.volume_infos", Optional.of(args), Optional.empty(),
+                        new TypeToken<Map<String, Map<String, JsonElement>>>() { });
+
+        Optional<Map<String, Map<String, JsonElement>>> volumes = saltService.callSync(call, minionId);
+        return volumes.orElse(new HashMap<String, Map<String, JsonElement>>());
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/controllers/test/VirtualPoolsControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/VirtualPoolsControllerTest.java
@@ -71,7 +71,6 @@ public class VirtualPoolsControllerTest extends BaseControllerTestCase {
         SystemManager.mockSaltService(saltServiceMock);
 
         host = ServerTestUtils.createVirtHostWithGuests(user, 1, true);
-        host.asMinionServer().get().setMinionId("testminion.local");
     }
 
     public void testData() throws Exception {
@@ -83,6 +82,13 @@ public class VirtualPoolsControllerTest extends BaseControllerTestCase {
                     "/com/suse/manager/webui/controllers/test/virt.pool.info.json",
                     null,
                     new TypeToken<Map<String, JsonElement>>() { }.getType())));
+            oneOf(saltServiceMock).callSync(
+                    with(SaltTestUtils.functionEquals("virt", "volume_infos")),
+                    with(host.asMinionServer().get().getMinionId()));
+            will(returnValue(SaltTestUtils.getSaltResponse(
+                    "/com/suse/manager/webui/controllers/test/virt.volume.info.json",
+                    null,
+                    new TypeToken<Map<String, Map<String, JsonElement>>>() { }.getType())));
         }});
 
         String json = VirtualPoolsController.data(getRequestWithCsrf(

--- a/java/code/src/com/suse/manager/webui/controllers/test/virt.volume.info.json
+++ b/java/code/src/com/suse/manager/webui/controllers/test/virt.volume.info.json
@@ -1,0 +1,22 @@
+{
+    "pool0": {
+        "disk0.qcow2": {
+            "allocation": 298123264,
+            "capacity": 214748364800,
+            "key": "/path/to/pool0/disk0.qcow2",
+            "path": "/path/to/pool0/disk0.qcow2",
+            "type": "file",
+            "used_by": ["vm0"]
+        },
+        "disk1.qcow2": {
+            "allocation": 298123264,
+            "capacity": 214748364800,
+            "key": "/path/to/pool0/disk1.qcow2",
+            "path": "/path/to/pool0/disk1.qcow2",
+            "type": "file",
+            "used_by": []
+        }
+    },
+    "pool1": {
+    }
+}

--- a/java/code/src/com/suse/manager/webui/templates/virtualization/pools/show.jade
+++ b/java/code/src/com/suse/manager/webui/templates/virtualization/pools/show.jade
@@ -1,0 +1,16 @@
+include ../../system-common.jade
+#virtualpools
+
+script(src='/javascript/momentjs/moment-with-langs.min.js', type='text/javascript')
+
+script(type='text/javascript').
+    window.csrfToken = "#{csrf_token}";
+script(src='/javascript/manager/virtualization/pools/list/pools-list.renderer.bundle.js', type='text/javascript')
+script(type='text/javascript').
+    pageRenderers.pools.list.renderer(
+        'virtualpools',
+        {
+            serverId: "#{server.id}",
+            pageSize: "#{pageSize}",
+        }
+    );

--- a/java/code/src/com/suse/manager/webui/utils/gson/VirtualStoragePoolInfoJson.java
+++ b/java/code/src/com/suse/manager/webui/utils/gson/VirtualStoragePoolInfoJson.java
@@ -16,6 +16,8 @@ package com.suse.manager.webui.utils.gson;
 
 import com.google.gson.JsonObject;
 
+import java.util.List;
+
 /**
  * Represents the virtual storage pool informations data to display in the UI.
  * Those data are directly passed over from Salt response.
@@ -32,14 +34,16 @@ public class VirtualStoragePoolInfoJson {
     private Long allocation;
     private Long capacity;
     private Long free;
+    private List<VirtualStorageVolumeInfoJson> volumes;
 
     /**
      * Build up an instance from the data returned from salt virt.pool_info
      *
      * @param nameIn the name of the pool
      * @param values the JSON values returned by salt
+     * @param volumesIn the pool volumes infos
      */
-    public VirtualStoragePoolInfoJson(String nameIn, JsonObject values) {
+    public VirtualStoragePoolInfoJson(String nameIn, JsonObject values, List<VirtualStorageVolumeInfoJson> volumesIn) {
         setName(nameIn);
         setUuid(values.get("uuid").getAsString());
         setAutostart(values.get("autostart").getAsInt() == 1);
@@ -50,6 +54,7 @@ public class VirtualStoragePoolInfoJson {
         setAllocation(values.get("allocation").getAsLong());
         setCapacity(values.get("capacity").getAsLong());
         setFree(values.get("free").getAsLong());
+        volumes = volumesIn;
     }
 
 
@@ -210,5 +215,14 @@ public class VirtualStoragePoolInfoJson {
      */
     public void setFree(Long freeIn) {
         free = freeIn;
+    }
+
+
+
+    /**
+     * @return Returns the volumes infos.
+     */
+    public List<VirtualStorageVolumeInfoJson> getVolumes() {
+        return volumes;
     }
 }

--- a/java/code/src/com/suse/manager/webui/utils/gson/VirtualStorageVolumeInfoJson.java
+++ b/java/code/src/com/suse/manager/webui/utils/gson/VirtualStorageVolumeInfoJson.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.webui.utils.gson;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.reflect.TypeToken;
+
+import java.util.List;
+
+/**
+ * Represents the virtual storage volume informations data to display in the UI.
+ * Those data are directly passed over from Salt response.
+ */
+public class VirtualStorageVolumeInfoJson {
+
+    private String name;
+    private String type;
+    private String key;
+    private String path;
+    private Long capacity;
+    private Long allocation;
+    private List<String> usedBy;
+
+    /**
+     * Build up an instance from the data returned from salt virt.volume_infos
+     *
+     * @param nameIn the name of the volume
+     * @param values the JSON values returned by salt
+     */
+    @SuppressWarnings("serial")
+    public VirtualStorageVolumeInfoJson(String nameIn, JsonObject values) {
+        name = nameIn;
+        type = values.get("type").getAsString();
+        key = values.get("key").getAsString();
+        path = values.get("path").getAsString();
+        allocation = values.get("allocation").getAsLong();
+        capacity = values.get("capacity").getAsLong();
+        usedBy = (new Gson().fromJson(values.get("used_by").getAsJsonArray(),
+                new TypeToken<List<String>>() { }.getType()));
+    }
+
+
+    /**
+     * @return Returns the name.
+     */
+    public String getName() {
+        return name;
+    }
+
+
+    /**
+     * @return Returns the type.
+     */
+    public String getType() {
+        return type;
+    }
+
+
+    /**
+     * @return Returns the key.
+     */
+    public String getKey() {
+        return key;
+    }
+
+
+    /**
+     * @return Returns the path.
+     */
+    public String getPath() {
+        return path;
+    }
+
+
+    /**
+     * @return Returns the capacity.
+     */
+    public Long getCapacity() {
+        return capacity;
+    }
+
+
+    /**
+     * @return Returns the allocation.
+     */
+    public Long getAllocation() {
+        return allocation;
+    }
+
+
+    /**
+     * @return Returns the names of the domains using the volume (not exhaustive).
+     */
+    public List<String> getUsedBy() {
+        return usedBy;
+    }
+}

--- a/java/code/webapp/WEB-INF/nav/system_detail.xml
+++ b/java/code/webapp/WEB-INF/nav/system_detail.xml
@@ -188,6 +188,7 @@
   <rhn-tab name="Virtualization" acl="system_has_virtualization_entitlement() or system_has_foreign_entitlement()">
     <rhn-tab-url>/rhn/manager/systems/details/virtualization/guests/${sid}</rhn-tab-url>
     <rhn-tab name="Guests" url="/rhn/manager/systems/details/virtualization/guests/${sid}"/>
+    <rhn-tab name="Storage" url="/rhn/manager/systems/details/virtualization/storage/${sid}" acl="system_has_salt_entitlement()"/>
     <rhn-tab name="Provisioning" url="/rhn/systems/details/virtualization/ProvisionVirtualizationWizard.do" acl="system_feature(ftr_kickstart) or system_feature(ftr_snapshotting)"/>
     <rhn-tab name="Deployment" url="/rhn/systems/details/virtualization/Deployment.do" acl="not system_is_virtual(); system_has_management_entitlement()"/>
   </rhn-tab>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add page to show virtual storage pools and volumes of a system
 - Migrate login to Spark
 - Use 'SCC organization credentials' instead of 'SCC credentials' in error message (bsc#1149425)
 - implement "regular expression" Filter for Content Lifecycle Management

--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -705,6 +705,12 @@ When I delete test-net1 virtual network on "kvm-server"
 When I delete test-pool1 virtual storage pool on "kvm-server"
 ```
 
+* Managing storage pools
+
+```cucumber
+When I refresh the "test-pool0" storage pool of this "kvm-server"
+```
+
 <a name="c" />
 
 ### Writing new steps

--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -180,6 +180,14 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I close the window
 
 @virthost_kvm
+  Scenario: Show the virtual storage pools and volumes for KVM
+    Given I am on the "Virtualization" page of this "kvm-server"
+    When I refresh the "test-pool0" storage pool of this "kvm-server"
+    When I follow "Storage"
+    And I open the sub-list of the product "test-pool0"
+    Then I wait until I see "test-vm2_system.qcow2" text
+
+@virthost_kvm
   Scenario: delete a running KVM virtual machine
     Given I am on the "Virtualization" page of this "kvm-server"
     When I click on "Delete" in row "test-vm2"

--- a/testsuite/features/secondary/minxen_guests.feature
+++ b/testsuite/features/secondary/minxen_guests.feature
@@ -195,6 +195,13 @@ Feature: Be able to manage XEN virtual machines via the GUI
     And "test-vm3" virtual machine on "xen-server" should have a "test-vm3_system.qcow2" xen disk
 
 @virthost_xen
+  Scenario: Show the virtual storage pools and volumes for Xen
+    Given I am on the "Virtualization" page of this "xen-server"
+    When I follow "Storage"
+    And I open the sub-list of the product "default"
+    Then I wait until I see "test-vm2_system.qcow2" text
+
+@virthost_xen
   Scenario: delete a running Xen virtual machine
     Given I am on the "Virtualization" page of this "xen-server"
     When I click on "Delete" in row "test-vm3"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -989,6 +989,11 @@ When(/^I delete all "([^"]*)" volumes from "([^"]*)" pool on "([^"]*)" without e
   output.each_line { |volume| node.run("virsh vol-delete #{volume} #{pool}", false) }
 end
 
+When(/I refresh the "([^"]*)" storage pool of this "([^"]*)"/) do |pool, host|
+  node = get_target(host)
+  node.run("virsh pool-refresh #{pool}")
+end
+
 When(/^I reduce virtpoller run interval on "([^"]*)"$/) do |host|
   node = get_target(host)
   source = File.dirname(__FILE__) + '/../upload_files/susemanager-virtpoller.conf'

--- a/web/html/src/manager/virtualization/index.js
+++ b/web/html/src/manager/virtualization/index.js
@@ -4,5 +4,6 @@ module.exports = {
     'guests/edit/guests-edit.renderer.js',
     'guests/create/guests-create.renderer.js',
     'guests/console/guests-console.renderer.js',
+    'pools/list/pools-list.renderer.js',
   ],
 };

--- a/web/html/src/manager/virtualization/pools/list/pools-list.js
+++ b/web/html/src/manager/virtualization/pools/list/pools-list.js
@@ -1,0 +1,206 @@
+// @flow
+import * as React from 'react';
+import { Tree } from 'components/tree/tree';
+import type { TreeItem, TreeData } from 'components/tree/tree';
+import { CustomDiv } from 'components/custom-objects';
+import { ProgressBar } from 'components/progressbar';
+import { DataHandler } from 'components/data-handler';
+import { SearchField } from 'components/data-handler';
+import { VirtualizationPoolsListRefreshApi } from '../virtualization-pools-list-refresh-api';
+
+type Props = {
+  serverId: string,
+  refreshInterval: number,
+  pageSize: number,
+};
+
+function poolsInfoToTree(pools: Object) {
+  if (pools == null) {
+    return null;
+  }
+
+  const children = pools.reduce((result, pool) => {
+    const volumes = pool.volumes.map((volume, idx) => ({
+      id: `${pool.uuid}/${idx}`,
+      data: Object.assign({}, volume, { itemType: 'volume' }),
+      children: [],
+    }));
+
+    const poolItem = {
+      id: pool.uuid,
+      data: Object.assign({}, pool, { itemType: 'pool' }),
+      children: volumes.map(volume => volume.id),
+    };
+    return result.concat([poolItem], volumes);
+  }, []);
+
+  const rootNode = {
+    id: 'root',
+    children: children.filter(child => child.data.itemType === 'pool')
+                      .map(child => child.id),
+  };
+
+  return {
+    rootId: 'root',
+    items: [rootNode].concat(children),
+  };
+}
+
+function getPoolsAndVolumes(tree: ?TreeData): Array<TreeItem> {
+  const items = tree != null ? tree.items : [];
+  return items.filter(item => item.data && (item.data.itemType === 'pool' || item.data.itemType === 'volume'));
+}
+
+function searchData (datum, criteria): boolean {
+  if (criteria && datum.data.name) {
+    return (datum.data.name).toLowerCase().includes(criteria.toLowerCase());
+  }
+  return true;
+}
+
+type FilteredTreeProps = {
+  tree: TreeData,
+  data?: Array<TreeItem>,
+  children: React.Node,
+};
+
+function FilteredTree(props: FilteredTreeProps) {
+  const ids = (props.data || []).map(item => item.id).concat(['root']);
+
+  const filteredItems = props.tree.items.filter(item => ids.includes(item.id));
+
+  // Extract the volumes of the filtered pools
+  const filteredPools = filteredItems.filter(item => item.data && item.data.itemType === 'pool');
+  const poolVolumesIds = filteredPools.reduce((acc, item) => acc.concat(item.children), []);
+
+  // Extract the pools containing the filtered volumes
+  const filteredVolumes = filteredItems.filter(item => item.data && item.data.itemType === 'volume');
+  const volumePoolIds = filteredVolumes.map(vol => props.tree.items.filter(item => (item.children || []).includes(vol.id)))
+                                       .reduce((acc, item) => acc.concat(item), [])
+                                       .map(item => item.id);
+
+  const allIds = ids.concat(poolVolumesIds, volumePoolIds);
+
+  const filteredTreeData = {
+    rootId: 'root',
+    items: props.tree.items.filter(item => allIds.includes(item.id)),
+  };
+
+  return React.Children.toArray(props.children)
+      .map(item => React.cloneElement(item, {data: filteredTreeData}));
+}
+
+export function PoolsList(props: Props) {
+  return (
+    <VirtualizationPoolsListRefreshApi
+      serverId={props.serverId}
+      refreshInterval={props.refreshInterval}
+    >
+      {
+        ({
+          pools,
+          refreshError,
+        }) => {
+          function renderPool(pool: Object, renderNameColumn: Function): React.Node {
+            return [
+              <CustomDiv key="name" className="col" width="30" um="%">
+                {renderNameColumn(pool.name)}
+              </CustomDiv>,
+              <CustomDiv key="state" className="col text-center" width="5" um="%">{pool.state}</CustomDiv>,
+              <CustomDiv key="autostart" className="col text-center" width="5" um="%">
+                {
+                  pool.autostart &&
+                  <i className="fa fa-check-square fa-1-5x" title={t(`${pool.name} is started automatically`)}/>
+                }
+              </CustomDiv>,
+              <CustomDiv key="persistent" className="col text-center" width="5" um="%">
+                {
+                  pool.persistent &&
+                  <i className="fa fa-check-square fa-1-5x" title={t(`${pool.name} is persistent`)}/>
+                }
+              </CustomDiv>,
+              <CustomDiv key="target" className="col" width="30" um="%">{pool.targetPath}</CustomDiv>,
+              <CustomDiv key="usage" className="col" width="10" um="%">
+                <ProgressBar
+                  progress={Math.round(100 * pool.allocation / pool.capacity)}
+                  title={t(`${pool.allocation / (1024 * 1024)} GiB / ${pool.capacity / (1024 * 1024)} GiB in use`)}
+                />
+              </CustomDiv>,
+              <CustomDiv key="actions" className="col text-right" width="10" um="%">
+              </CustomDiv>,
+            ];
+          }
+
+          function renderVolume (volume: Object, renderNameColumn: Function): React.Node {
+            return [
+              <CustomDiv key="name" className="col" width="calc((100% + 3em) * 0.3 - 3em)" um="">
+                {renderNameColumn(volume.name)}
+              </CustomDiv>,
+              <CustomDiv key="usedBy" className="col" width="calc((100% + 3em) * 0.45)" um="">{volume.usedBy != null ? volume.usedBy.join(", ") : ''}</CustomDiv>,
+              <CustomDiv key="usage" className="col" width="calc((100% + 3em) * 0.1)" um="">
+                <ProgressBar
+                  progress={Math.min(100, Math.round(100 * volume.allocation / volume.capacity))}
+                  title={t(`${volume.allocation / (1024 * 1024)} GiB / ${volume.capacity / (1024 * 1024)} GiB in use`)}
+                />
+              </CustomDiv>,
+              <CustomDiv key="actions" className="col text-right" width="calc((100% + 3em) * 0.1)" um="">
+                <div className="btn-group">
+                </div>
+              </CustomDiv>,
+            ];
+          }
+
+          function renderItem (item: TreeItem, renderNameColumn: Function): React.Node {
+            const itemRenderers = {
+              pool: renderPool,
+              volume: renderVolume,
+            };
+            if (item.data != null) {
+              return itemRenderers[item.data.itemType](item.data, renderNameColumn);
+            } else {
+              return null;
+            }
+          }
+
+          const tree = poolsInfoToTree(pools);
+          const header = [
+            <CustomDiv key="name" className="col col-class-calc-width" width="30" um="%">{t('Name')}</CustomDiv>,
+            <CustomDiv key="state" className="col text-center" width="5" um="%">{t('State')}</CustomDiv>,
+            <CustomDiv key="autostart" className="col text-center" width="5" um="%">{t('Autostart')}</CustomDiv>,
+            <CustomDiv key="persistent" className="col text-center" width="5" um="%">{t('Persistent')}</CustomDiv>,
+            <CustomDiv key="target" className="col" width="30" um="%">{t('Location')}</CustomDiv>,
+            <CustomDiv key="usage" className="col" width="10" um="%">{t('Usage')}</CustomDiv>,
+            <CustomDiv key="actions" className="col text-right" width="10" um="%">{t('Actions')}</CustomDiv>,
+          ];
+
+          return (
+            <DataHandler
+              data={getPoolsAndVolumes(tree)}
+              identifier={(raw) => raw.id}
+              initialItemsPerPage={props.pageSize}
+              loading={tree == null}
+              additionalFilters={[]}
+              searchField={
+                  <SearchField filter={searchData}
+                      criteria={''}
+                      placeholder={t('Filter by pool or volume name')}
+                      name='pool-name-filter'
+                  />
+              }
+            >
+            {
+              tree != null &&
+              <FilteredTree tree={tree}>
+                <Tree
+                  header={header}
+                  renderItem={renderItem}
+                />
+              </FilteredTree>
+            }
+            </DataHandler>
+          );
+        }
+      }
+    </VirtualizationPoolsListRefreshApi>
+  );
+}

--- a/web/html/src/manager/virtualization/pools/list/pools-list.renderer.js
+++ b/web/html/src/manager/virtualization/pools/list/pools-list.renderer.js
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { PoolsList } from './pools-list';
+import SpaRenderer from "core/spa/spa-renderer";
+
+window.pageRenderers = window.pageRenderers || {};
+window.pageRenderers.pools = window.pageRenderers.pools || {};
+window.pageRenderers.pools.list = window.pageRenderers.pools.list || {};
+window.pageRenderers.pools.list.renderer = (id, { serverId, pageSize }) => {
+  SpaRenderer.renderNavigationReact(
+    <PoolsList
+      refreshInterval={5 * 1000}
+      pageSize={pageSize}
+      serverId={serverId}
+    />,
+    document.getElementById(id),
+  );
+};

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Show virtual storage volumes and pools on salt minions
 - Migrate login to Spark
 - Add UI message when salt-formulas system folders are unreachable (bsc#1142309)
 - implement "regular expression" Filter for Content Lifecycle Management


### PR DESCRIPTION
## What does this PR change?

Add a UI to manage virtual storage pools and volumes.

## GUI diff

**Before**: No page to show the list of virtual storage pools and volumes

**After**: a new `Storage` page is introduced in the system `Virtualization` tab to list the storage pools and volumes.

![suma-pools](https://user-images.githubusercontent.com/397931/60948630-a88bd600-a2f3-11e9-91c2-6a9ec550070a.png)

- [X] **DONE**

## Documentation
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- Unit tests were added
- Cucumber tests were added

- [X] **DONE**

## Links

- [X] **DONE**