### PR TITLE
Check debian url

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
@@ -1415,6 +1415,24 @@ public class ContentSyncManagerTest extends BaseTestCaseWithUser {
     }
 
     /**
+     * Test debian and repomd url building
+     * @throws Exception
+     */
+    public void testBuildRepoFileUrl() throws Exception {
+        SCCRepository debrepo = new SCCRepository();
+        debrepo.setDistroTarget("amd64");
+        SCCRepository rpmrepo = new SCCRepository();
+        rpmrepo.setDistroTarget("sle-12-x86_64");
+
+        String repourl = "http://localhost/pub/myrepo/";
+        ContentSyncManager csm = new ContentSyncManager();
+
+        assertEquals(repourl + "Release", csm.buildRepoFileUrl(repourl, debrepo));
+        assertEquals(repourl + "repodata/repomd.xml", csm.buildRepoFileUrl(repourl, rpmrepo));
+    }
+
+
+    /**
      * {@inheritDoc}
      */
     @Override

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- adapt check for available repositories to debian style repositories
 - Read and update running kernel release value at each startup of minion (bsc#1122381)
 - Schedule full package refresh only once per action chain if needed(bsc#1126518)
 - Check and schedule package refresh in response to events independently of what originates them (bsc#1126099)


### PR DESCRIPTION
## What does this PR change?

As we now support debian style repos we need to propper test a debian style repository.
For this we look for a `Release` file instead of `repodata/repomd.xml` depending on the
distrotarget value of the repo.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/7257

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
