### PR TITLE
Bugfix: check if errata org is present before comparing values (bsc#1128228)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandler.java
@@ -29,6 +29,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
@@ -922,8 +923,10 @@ public class ErrataHandler extends BaseHandler {
     private Errata lookupErratumByAdvisoryAndOrg(String advisoryName, Org org) throws FaultException {
         List<Errata> erratas = lookupVendorAndUserErrataByAdvisoryAndOrg(advisoryName, org);
 
-       return erratas.stream().filter(e -> e.getOrg().getId() == org.getId())
-                .findFirst().orElse(erratas.stream().findFirst().orElse(null));
+        return erratas.stream()
+                .filter(e -> Optional.ofNullable(e.getOrg()).isPresent() && e.getOrg().getId() == org.getId())
+                .findFirst()
+                .orElse(erratas.stream().findFirst().orElse(null));
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/test/ErrataHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/test/ErrataHandlerTest.java
@@ -151,6 +151,33 @@ public class ErrataHandlerTest extends BaseHandlerTestCase {
         }
     }
 
+    /**
+     * Do not fail in case orgId is null: it means errata is just a vendor one (bsc#1128228)
+     */
+    public void testGetVendorErrataDetails() throws Exception {
+        Errata vendorErrata = ErrataFactoryTest.createTestErrata(user.getOrg().getId());
+        vendorErrata.setOrg(null);
+
+        Map details = handler.getDetails(admin, vendorErrata.getAdvisory());
+        assertNotNull(details);
+    }
+
+    /**
+     * Make sure that if two erratas exist with the same advisoryName,
+     * but one with current user's orgId and one with orgId null (vendor org)
+     * it returns the one with the user org over the vendor one.
+     */
+    public void testGetUserErrataOverVendorErrata() throws Exception {
+        Errata vendorErrata = ErrataFactoryTest.createTestErrata(null);
+        vendorErrata.setOrg(null);
+
+        Errata userErrata = ErrataFactoryTest.createTestErrata(user.getOrg().getId());
+        userErrata.setAdvisoryName(vendorErrata.getAdvisoryName());
+
+        Map details = handler.getDetails(admin, vendorErrata.getAdvisory());
+        assertEquals(details.get("id"), userErrata.getId());
+    }
+
     public void testSetDetailsAdvRelAboveMax() throws Exception {
         // setup
         Errata errata = ErrataFactoryTest.createTestErrata(user.getOrg().getId());

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix errata_details to return details correctly (bsc#128228)
 - prevent an error when onboarding a RES 6 minion (bsc#1124794)
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

`spacecmd errata_details <ERRATA_ADVISORY>` fails in case the `errata` has no `org_id`. This PR fixes the check comparing `org_id` with the current `org` **but first** check if the `org_id` value is present.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [x] **DONE**

## Test coverage
- Unit tests were added https://github.com/uyuni-project/uyuni/pull/687/commits/6207ea47721aae0070fae92b9150e5197b10d383

- [x] **DONE**

## Links

Fixes #
Tracks # https://github.com/SUSE/spacewalk/pull/7258

- [x] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
