### PR TITLE
Fixed typo in command help message

### DIFF
--- a/backend/satellite_tools/spacewalk-repo-sync
+++ b/backend/satellite_tools/spacewalk-repo-sync
@@ -76,7 +76,7 @@ def main():
 
     parser = OptionParser()
     parser.add_option('-l', '--list', action='store_true', dest='list',
-                      help='List the custom channels with the assosiated repositories.')
+                      help='List the custom channels with the associated repositories.')
     parser.add_option('-s', '--show-packages', action='store_true', dest='show_packages',
                       help='List all packages in a specified channel.')
     parser.add_option('-u', '--url', action='append', dest='url',


### PR DESCRIPTION
## What does this PR change?

This just fixes a typo in command help output.

