### PR TITLE
Testsuite - package removal moved to scenario

### DIFF
--- a/testsuite/features/core_min_salt_ssh.feature
+++ b/testsuite/features/core_min_salt_ssh.feature
@@ -17,7 +17,11 @@ Feature: Be able to bootstrap a Salt host managed via salt-ssh
     And I navigate to "rhn/systems/Overview.do" page
     And I wait until I see the name of "ssh-minion", refreshing the page
     And I wait until onboarding is completed for "ssh-minion"
-    Then I remove package "sle-manager-tools-release" from highstate
+
+@ssh_minion
+  Scenario: Remove sle-manager-tools-release from state after bootstrap
+    Given I am on the Systems overview page of this "ssh-minion"
+    When I remove package "sle-manager-tools-release" from highstate
 
 @proxy
 @ssh_minion

--- a/testsuite/features/minssh_bootstrap_xmlrpc.feature
+++ b/testsuite/features/minssh_bootstrap_xmlrpc.feature
@@ -24,7 +24,11 @@ Feature: Register a salt-ssh system via XML-RPC
      And I navigate to "rhn/systems/Overview.do" page
      And I wait until I see the name of "ssh-minion", refreshing the page
      And I wait until onboarding is completed for "ssh-minion"
-     Then I remove package "sle-manager-tools-release" from highstate
+
+@ssh_minion
+  Scenario: Remove sle-manager-tools-release from state after bootstrap via XML-RPC
+    Given I am on the Systems overview page of this "ssh-minion"
+    When I remove package "sle-manager-tools-release" from highstate
 
 @ssh_minion
   Scenario: Check contact method of this Salt SSH system


### PR DESCRIPTION
## What does this PR change?

PR moves step containing removal of the package `sle-manager-tools-release` to separate scenario. This ensures this step is always executed.

## Links

https://github.com/SUSE/spacewalk/issues/7267
Port of https://github.com/SUSE/spacewalk/pull/7256

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
