### PR TITLE
Log Salt remote commands to separate file for easier auditing

### DIFF
--- a/java/code/src/log4j.properties
+++ b/java/code/src/log4j.properties
@@ -75,3 +75,13 @@ log4j.appender.FrontendLogControllerAppender.layout=org.apache.log4j.PatternLayo
 log4j.appender.FrontendLogControllerAppender.layout.ConversionPattern=%d [%t] %-5p %c - %m%n
 log4j.logger.com.suse.manager.webui.controllers.FrontendLogController=TRACE,FrontendLogControllerAppender
 log4j.additivity.com.suse.manager.webui.controllers.FrontendLogController=false
+
+## Salt remote command logs
+log4j.appender.RemoteCommandsAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.RemoteCommandsAppender.File=/var/log/rhn/rhn_salt_remote_commands.log
+log4j.appender.RemoteCommandsAppender.MaxFileSize=10MB
+log4j.appender.RemoteCommandsAppender.MaxBackupIndex=30
+log4j.appender.RemoteCommandsAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.RemoteCommandsAppender.layout.ConversionPattern=%d [%t] %-5p %c - %m%n
+log4j.logger.com.suse.manager.webui.websocket.RemoteMinionCommands=INFO,RemoteCommandsAppender
+log4j.additivity.com.suse.manager.webui.websocket.RemoteMinionCommands=false

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Log remote commands executed via Salt -> Remote Commands UI to
+  file /var/log/rhn/rhn_salt_remote_commands.log
 - Saving cobbler autoinstall templates with a leading slash.
 - Implement NEVR(A) filtering in Content Lifecycle Management
 - Adjust product tree tag according to the base OS


### PR DESCRIPTION
## What does this PR change?

Logs remote commands executed from Salt->Remote Commands to a separate file for easier auditing.

## GUI diff


![Screenshot-2019-5-6 SUSE Manager - Systems](https://user-images.githubusercontent.com/11468018/57230425-a0c06480-7018-11e9-9d38-6b35695841c1.png)

![Screenshot-2019-5-6 SUSE Manager - Systems(1)](https://user-images.githubusercontent.com/11468018/57230410-969e6600-7018-11e9-90c8-7da215e72761.png)


## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**

## Test coverage
- No tests

## Links

Fixes https://github.com/SUSE/spacewalk/issues/6882



