### PR TITLE
Fix invalid mode error on syncing debian repos

### DIFF
--- a/backend/common/fileutils.py
+++ b/backend/common/fileutils.py
@@ -24,6 +24,7 @@ import subprocess
 import select
 import stat
 import tempfile
+import io
 from spacewalk.common.checksum import getFileChecksum
 from spacewalk.common.rhnLib import isSUSE
 from spacewalk.common.usix import ListType, TupleType, MaxInt
@@ -489,16 +490,17 @@ class payload:
 
 
 def decompress_open(filename, mode='rt'):
+    #import pdb; pdb.set_trace()
     file_obj = None
     if filename.endswith('.gz'):
-        file_obj = gzip.open(filename, mode)
+        file_obj = gzip.open(filename, 'rb')
     elif filename.endswith('.bz2'):
-        file_obj = bz2.BZ2File(filename, mode)
+        file_obj = bz2.BZ2File(filename, 'rb')
     elif filename.endswith('.xz'):
         try:
             # pylint: disable=F0401,E1101
             import lzma
-            file_obj = lzma.LZMAFile(filename, mode)
+            file_obj = lzma.LZMAFile(filename, 'rb')
         except ImportError: # No LZMA lib - be sad
             # xz uncompresses foo.xml.xz to foo.xml
             # uncompress, keep both, return uncompressed file
@@ -507,4 +509,6 @@ def decompress_open(filename, mode='rt'):
             file_obj = open(uncompressed_path, mode)
     else:
         file_obj = open(filename, mode)
+    if "t" in mode and filename.endswith(('.gz', '.bz2', '.xz')):
+        return io.TextIOWrapper(file_obj)
     return file_obj

--- a/backend/common/fileutils.py
+++ b/backend/common/fileutils.py
@@ -489,8 +489,7 @@ class payload:
         return getattr(self.fileobj, x)
 
 
-def decompress_open(filename, mode='rt'):
-    #import pdb; pdb.set_trace()
+def decompress_open(filename):
     file_obj = None
     if filename.endswith('.gz'):
         file_obj = gzip.open(filename, 'rb')
@@ -506,9 +505,9 @@ def decompress_open(filename, mode='rt'):
             # uncompress, keep both, return uncompressed file
             subprocess.call(['xz', '-d', '-k', filename])
             uncompressed_path = filename.rsplit('.', 1)[0]
-            file_obj = open(uncompressed_path, mode)
+            file_obj = open(uncompressed_path, 'rb')
     else:
-        file_obj = open(filename, mode)
-    if "t" in mode and filename.endswith(('.gz', '.bz2', '.xz')):
+        file_obj = open(filename, 'r')
+    if filename.endswith(('.gz', '.bz2', '.xz')):
         return io.TextIOWrapper(file_obj)
     return file_obj

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,6 @@
+- Fix invalid mode error when doing spacewalk-repo-sync on Ubuntu
+  official repos.
+
 -------------------------------------------------------------------
 Tue Mar 12 11:20:08 CET 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Fix error when syncing debian repos:
```
# /usr/bin/spacewalk-repo-sync --channel ubuntu-18.04-amd64-main --type deb --non-interactive
19:56:33 ======================================
19:56:33 | Channel: ubuntu-18.04-amd64-main
19:56:33 ======================================
19:56:33 Sync of channel started.
19:56:33 Unexpected error: <class 'ValueError'>
19:56:33 Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/spacewalk/satellite_tools/reposync.py", line 568, in sync
    ret = self.import_packages(plugin, data['id'], url, is_non_local_repo)
  File "/usr/lib/python3.6/site-packages/spacewalk/satellite_tools/reposync.py", line 902, in import_packages
    packages = plug.list_packages(filters, self.latest)
  File "/usr/lib/python3.6/site-packages/spacewalk/satellite_tools/repo_plugins/deb_src.py", line 232, in list_packages
    pkglist = self.repo.get_package_list()
  File "/usr/lib/python3.6/site-packages/spacewalk/satellite_tools/repo_plugins/deb_src.py", line 128, in get_package_list
    decompressed = fileutils.decompress_open(filename)
  File "/usr/lib/python3.6/site-packages/spacewalk/common/fileutils.py", line 503, in decompress_open
    file_obj = lzma.LZMAFile(filename, mode)
  File "/usr/lib64/python3.6/lzma.py", line 115, in __init__
    raise ValueError("Invalid mode: {!r}".format(mode))
ValueError: Invalid mode: 'rt'

```

## GUI diff

No difference.

## Documentation
- No documentation needed: bugfix

## Test coverage
- No tests: **add explanation**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/7268


