### PR TITLE
Make Zypper to use the spacewalk GPG keyring in reposync (bsc#1128529)

### DIFF
--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Make Zypper to use the spacewalk GPG keyring in reposync (bsc#1128529)
 - Fix: handle non-standard filenames for comps.xml (bsc#1120242)
 - Make reposync use and append token correctly to the URL
 - Avoid DB constraint violations caused by extended UTF8 characters on the RPM headers


### PR DESCRIPTION
## What does this PR change?

This PR fixes the issue with GPG keys when syncing repositories using the new Zypper-based plugin for `spacewalk-repo-sync`.

Before this PR, the new RPM database used by Zypper in `reposync` was initialized by loading the GPG keys which are already imported on the SUSE Manager server RPM database. This is wrong.

Now, `reposync` initializes the new RPM database with the GPG keys which are in the spacewalk keyring at `/var/lib/spacewalk/gpgdir/pubring.gpg`.

### UPDATE

- [x] Reposync GPG keys are synchronized with Spacewalk GPG keyring on each run.
- [x] Customer accepted GPG keys are stored into the Reposync RPM database.
- [x] RPM doesn't upgrade already existing keys with newer releases of the same keys. This is fixed on this PR by deleting the old key from the Reposync RPM database before actually importing the new release of the key.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bug fix**

- [x] **DONE**

## Test coverage
- No tests: **reposync is already tested by cucumber**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/salt-board/issues/278

- [x] **DONE**