### PR TITLE
Replace iteritems with items for python2/3 compat

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,5 @@
+- Replace iteritems with items for python2/3 compat (bsc#1129243)
+
 -------------------------------------------------------------------
 Mon Mar 04 09:53:28 CET 2019 - jgonzalez@suse.com
 

--- a/spacecmd/src/lib/system.py
+++ b/spacecmd/src/lib/system.py
@@ -162,7 +162,7 @@ def do_system_list(self, args, doreturn=False):
         return self.get_system_names()
     else:
         if self.get_system_names():
-            print('\n'.join(sorted(['%s : %s' % (v, k) for k, v in self.get_system_names_ids().iteritems()])))
+            print('\n'.join(sorted(['%s : %s' % (v, k) for k, v in self.get_system_names_ids().items()])))
 
 ####################
 


### PR DESCRIPTION
Co-authored-by: Jochen Breuer <jbreuer@suse.de>

## What does this PR change?

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1129243

## GUI diff

No difference.

## Documentation
- No documentation needed: it's a bug fix

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
