### PR TITLE
create ubuntu channels with correct architecture and type

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
@@ -33,6 +33,7 @@ import com.redhat.rhn.domain.channel.ChannelFamily;
 import com.redhat.rhn.domain.channel.ChannelFamilyFactory;
 import com.redhat.rhn.domain.channel.ChannelVersion;
 import com.redhat.rhn.domain.channel.ClonedChannel;
+import com.redhat.rhn.domain.channel.ContentSourceType;
 import com.redhat.rhn.domain.channel.DistChannelMap;
 import com.redhat.rhn.domain.channel.InvalidChannelRoleException;
 import com.redhat.rhn.domain.channel.ProductName;
@@ -2817,4 +2818,22 @@ public class ChannelManager extends BaseManager {
                 }));
     }
 
+    /**
+     * Return a compatible Content Source Type for a given Channel Arch
+     * @param cArch the channel architecture
+     * @return content source type
+     */
+    public static ContentSourceType findCompatibleContentSourceType(ChannelArch cArch) {
+        ContentSourceType cType = null;
+        switch (cArch.getArchType().getLabel()) {
+        case "deb":
+            cType = ChannelFactory.lookupContentSourceType("deb");
+            break;
+
+        default:
+            cType = ChannelFactory.lookupContentSourceType("yum");
+            break;
+        }
+        return cType;
+    }
 }

--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -1041,10 +1041,11 @@ public class ContentSyncManager {
      * @param p the SCC product
      * @param product the database product whcih should be updated
      * @param channelFamilyByLabel lookup map for channel family by label
+     * @param packageArchMap lookup map for package archs
      * @return the updated product
      */
     public static SUSEProduct updateProduct(SCCProductJson p, SUSEProduct product,
-            Map<String, ChannelFamily> channelFamilyByLabel) {
+            Map<String, ChannelFamily> channelFamilyByLabel, Map<String, PackageArch> packageArchMap) {
         // it is not guaranteed for this ID to be stable in time, as it
         // depends on IBS
         product.setProductId(p.getId());
@@ -1062,6 +1063,17 @@ public class ContentSyncManager {
         product.setChannelFamily(
                 !StringUtils.isBlank(productClass) ?
                         createOrUpdateChannelFamily(productClass, null, channelFamilyByLabel) : null);
+
+        PackageArch pArch = packageArchMap.computeIfAbsent(p.getArch(), PackageFactory::lookupPackageArchByLabel);
+        if (pArch == null && p.getArch() != null) {
+            // unsupported architecture, skip the product
+            log.error("Unknown architecture '" + p.getArch() +
+                    "'. This may be caused by a missing database migration");
+        }
+        else {
+            product.setArch(pArch);
+        }
+
         return product;
     }
 
@@ -1195,7 +1207,7 @@ public class ContentSyncManager {
                                     // tag for later cleanup all assosicated repositories
                                     productIdsSwitchedToReleased.add(prod.getProductId());
                                 }
-                                updateProduct(productJson, prod, channelFamilyMap);
+                                updateProduct(productJson, prod, channelFamilyMap, packageArchMap);
                                 dbProductsById.put(prod.getProductId(), prod);
                                 return prod;
                             }
@@ -1219,7 +1231,7 @@ public class ContentSyncManager {
                                 return prod;
                             },
                             prod -> {
-                                updateProduct(productJson, prod, channelFamilyMap);
+                                updateProduct(productJson, prod, channelFamilyMap, packageArchMap);
                                 dbProductsById.put(prod.getProductId(), prod);
                                 return prod;
                             }

--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -504,7 +504,7 @@ public class ContentSyncManager {
             source.setMetadataSigned(auth.getRepository().isSigned());
             source.setOrg(null);
             source.setSourceUrl(url);
-            source.setType(ChannelFactory.lookupContentSourceType("yum"));
+            source.setType(ChannelManager.findCompatibleContentSourceType(channel.getChannelArch()));
             ChannelFactory.save(source);
         }
         Set<ContentSource> css = channel.getSources();
@@ -1685,7 +1685,7 @@ public class ContentSyncManager {
                 source.setMetadataSigned(repository.isSigned());
                 source.setOrg(null);
                 source.setSourceUrl(url);
-                source.setType(ChannelFactory.lookupContentSourceType("yum"));
+                source.setType(ChannelManager.findCompatibleContentSourceType(dbChannel.getChannelArch()));
             }
             else {
                 // update the URL as the token might have changed

--- a/java/code/src/com/redhat/rhn/manager/content/MgrSyncUtils.java
+++ b/java/code/src/com/redhat/rhn/manager/content/MgrSyncUtils.java
@@ -49,7 +49,7 @@ public class MgrSyncUtils {
     private static final List<String> OFFICIAL_UPDATE_HOSTS =
             Arrays.asList("updates.suse.com", OFFICIAL_NOVELL_UPDATE_HOST);
     private static final List<String> PRODUCT_ARCHS = Arrays.asList("i586", "ia64", "ppc64le", "ppc64", "ppc",
-            "s390x", "s390", "x86_64", "aarch64");
+            "s390x", "s390", "x86_64", "aarch64", "amd64");
 
     // No instances should be created
     private MgrSyncUtils() {
@@ -125,6 +125,9 @@ public class MgrSyncUtils {
         }
         else if (arch.equals("ppc64")) {
             arch = "ppc";
+        }
+        else if (arch.equals("amd64")) {
+            arch = "amd64-deb";
         }
         return ChannelFactory.findArchByLabel("channel-" + arch);
     }

--- a/java/code/src/com/suse/scc/model/SCCProductJson.java
+++ b/java/code/src/com/suse/scc/model/SCCProductJson.java
@@ -495,6 +495,9 @@ public class SCCProductJson {
      * @return the arch
      */
     public String getArch() {
+        if (arch != null && arch.equals("amd64")) {
+            return arch + "-deb";
+        }
         return arch;
     }
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- support ubuntu products and debian architectures in mgr-sync
 - Change default image download protocol from tftp to ftp
 - Fix apidoc issues
 - Read and update running kernel release value at each startup of minion (bsc#1122381)


### PR DESCRIPTION
## What does this PR change?

When fetching SUSE Manager Tools channel for Ubuntu from SCC we need to create them with the correct channel arch and the repo with the correct ContentSourceType.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Copy the following sentence as a new comment if you don't need changelog entries:

> gitarro no changelog needed !!!

If the test `changelog_test`already run, then add another new comment with the following text:

> gitarro rerun changelog_test !!!
