### PR TITLE
Fix changelog for "spacewalk-backend"

### DIFF
--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- Avoid DB constraint violations caused by extended UTF8 characters on the RPM headers
+- Prevent mgr-inter-sync crash because 'SuseProductRepository' not found (bsc#1129300)
 - Fix invalid mode error when doing spacewalk-repo-sync on Ubuntu
   official repos.
 


### PR DESCRIPTION
## What does this PR change?

This PR simply add two entries into the "spacewalk-backend" changelog (the actual code changes are already merged from: https://github.com/uyuni-project/uyuni/pull/631/) in order to keep consistency.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **changelog entry**

- [x] **DONE**

## Test coverage
- No tests: **changelog entry**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/7286

- [x] **DONE**
