### PR TITLE
Testsuite - package refresh instead of list check

### DIFF
--- a/testsuite/features/min_salt_install_with_staging.feature
+++ b/testsuite/features/min_salt_install_with_staging.feature
@@ -19,6 +19,14 @@ Feature: Install a package on the minion with staging enabled
     And I run "zypper -n in --oldpackage virgo-dummy-1.0" on "sle-minion" without error control
     And I run "zypper -n rm orion-dummy" on "sle-minion" without error control
 
+  Scenario: Pre-requisite: refresh package list on SLE minion 
+    Given I am on the Systems overview page of this "sle-minion"
+    When I follow "Software" in the content area
+    And I click on "Update Package List"
+    And I follow "Events" in the content area
+    And I wait until I do not see "Package List Refresh scheduled by admin" text, refreshing the page
+    Then I wait until event "Package List Refresh scheduled by admin" is completed
+
   Scenario: Pre-requisite: ensure the errata cache is computed
     Given I am authorized as "admin" with password "admin"
     When I follow "Admin"


### PR DESCRIPTION
## What does this PR change?

PR adds  scenario `Pre-requisite: refresh package list on SLE minion`.

This change ensures installation of package doesn't fail because of incorrect package version is used (Feature: Install a package on the minion with staging enabled).

## Links

Issue https://github.com/SUSE/spacewalk/issues/7271
Port of https://github.com/SUSE/spacewalk/pull/7283

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
