### PR TITLE
Feat: Create empty deb repository

### DIFF
--- a/susemanager/pub/empty-deb/Release
+++ b/susemanager/pub/empty-deb/Release
@@ -1,0 +1,4 @@
+Architectures: amd64
+MD5Sum:
+SHA1:
+SHA256:

--- a/susemanager/pub/empty-deb/Release
+++ b/susemanager/pub/empty-deb/Release
@@ -1,4 +1,7 @@
 Architectures: all
 MD5Sum:
+  d41d8cd98f00b204e9800998ecf8427e 0 Packages
 SHA1:
+  da39a3ee5e6b4b0d3255bfef95601890afd80709 0 Packages
 SHA256:
+  e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 0 Packages

--- a/susemanager/pub/empty-deb/Release
+++ b/susemanager/pub/empty-deb/Release
@@ -1,4 +1,4 @@
-Architectures: amd64
+Architectures: all
 MD5Sum:
 SHA1:
 SHA256:

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- Feat: create Ubuntu empty repository
 -------------------------------------------------------------------
 Tue Mar 05 14:30:39 CET 2019 - jgonzalez@suse.com
 

--- a/susemanager/susemanager.spec
+++ b/susemanager/susemanager.spec
@@ -151,6 +151,9 @@ install -d -m 755 %{buildroot}/srv/www/os-images/
 mkdir -p %{buildroot}/srv/www/htdocs/pub/repositories/
 cp -r pub/empty %{buildroot}/srv/www/htdocs/pub/repositories/
 
+# empty repo for Ubuntu base fake channel
+cp -r pub/empty-deb %{buildroot}/srv/www/htdocs/pub/repositories/
+
 # YaST configuration
 mkdir -p %{buildroot}%{_datadir}/YaST2/clients
 mkdir -p %{buildroot}%{_datadir}/YaST2/scrconf
@@ -278,6 +281,7 @@ fi
 %dir /srv/www/htdocs/pub/repositories
 %dir /srv/www/htdocs/pub/repositories/empty
 %dir /srv/www/htdocs/pub/repositories/empty/repodata
+%dir /srv/www/htdocs/pub/repositories/empty-deb
 %attr(0755,root,www) %dir %{_prefix}/share/rhn/config-defaults
 %config(noreplace) %{_sysconfdir}/logrotate.d/susemanager-tools
 %{_prefix}/share/rhn/config-defaults/rhn_*.conf
@@ -297,5 +301,6 @@ fi
 %{_datadir}/susemanager/mgr_bootstrap_data.py*
 %{_mandir}/man8/mgr-sync.8*
 /srv/www/htdocs/pub/repositories/empty/repodata/*.xml*
-
+/srv/www/htdocs/pub/repositories/empty-deb/Packages
+/srv/www/htdocs/pub/repositories/empty-deb/Release
 %changelog


### PR DESCRIPTION
## What does this PR change?

Create an empty repo upon susemanager package installation

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: internal

- [X] **DONE**

## Test coverage
- No tests: specfile

- [X] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/7280

- [X] **DONE**
