### PR TITLE
fix stripping the token from the filename

### DIFF
--- a/backend/satellite_tools/repo_plugins/deb_src.py
+++ b/backend/satellite_tools/repo_plugins/deb_src.py
@@ -130,8 +130,9 @@ class DebRepo(object):
             filename = self._download(url)
             if filename:
                 if query:
-                    os.rename(filename, filename.strip('?' + query))
-                    filename = filename.strip('?' + query)
+                    newfilename = filename.split('?')[0]
+                    os.rename(filename, newfilename)
+                    filename = newfilename
                 decompressed = fileutils.decompress_open(filename)
                 break
 


### PR DESCRIPTION
## What does this PR change?

Fix stripping the token from filename

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [ ] **DONE**

## Links

Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
