### PR TITLE
Fix count of disabled repos on Debian (bsc#1128724)

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/channels/disablelocalrepos.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/disablelocalrepos.sls
@@ -16,8 +16,8 @@ disable_repo_{{ repos_disabled.count }}:
     - repo: {{ entry.line }}
     - kwargs:
         disabled: True
-{% endif %}
 {% do repos_disabled.update({'count': repos_disabled.count + 1}) %}
+{% endif %}
 {% endfor %}
 {% else %}
 {% if (repos_disabled.match_str in alias)|string == repos_disabled.matching|string and data.get('enabled', True) %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- Fix Salt error related to remove_traditional_stack when bootstrapping an Ubuntu
+  minion (bsc#1128724)
 - Adapt disablelocalrepos.sls syntax for Salt 2016.10 (rhel6, sle11) (bsc#1127706)
 - util.systeminfo sls has been added to perform different actions at minion startup(bsc#1122381)
 


### PR DESCRIPTION
## What does this PR change?

Fixes wrong value of repos_disabled.count on Ubuntu.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- fix cucumber test

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/7253
Tracks https://github.com/SUSE/spacewalk/pull/7254

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
