### PR TITLE
Use activation key with test repo

### DIFF
--- a/testsuite/features/step_definitions/xmlrpc_common.rb
+++ b/testsuite/features/step_definitions/xmlrpc_common.rb
@@ -23,7 +23,7 @@ end
 When(/^I call system\.bootstrap\(\) on host "([^"]*)" and salt\-ssh "([^"]*)"$/) do |host, salt_ssh_enabled|
   system_name = get_system_name(host)
   salt_ssh = (salt_ssh_enabled == 'enabled')
-  result = systest.bootstrap_system(system_name, '', salt_ssh)
+  result = systest.bootstrap_system(system_name, '1-SUSE-DEV-x86_64', salt_ssh)
   assert(result == 1, 'Bootstrap return code not equal to 1.')
 end
 


### PR DESCRIPTION
## What does this PR change?

Bootstrap with activation key.

This is to prevent using default repo (SLES12 SP3...) which
are only half synced at this point in time.
Using them cause any kind of problems like

  Valid metadata not found at specified URL

or using of packages which are not yet synced.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- fixes Cucumber tests

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test" 
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests" 		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
