### PR TITLE
Taskotop py3 fix

### DIFF
--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,5 @@
+- fix taskotop crash caused by integer argument expected
+
 -------------------------------------------------------------------
 Wed Feb 27 13:04:42 CET 2019 - jgonzalez@suse.com
 

--- a/utils/taskotop
+++ b/utils/taskotop
@@ -136,7 +136,7 @@ class CursesDisplayBuilder:
     def add_column_value_to_screen(self, screen, value, ypos, xpos, column_width, justify, maxy, maxx):
         if len(value) > column_width:
             value = self.string_of_length(column_width)
-        addxpos = xpos + justify * (column_width - len(value)) / 2
+        addxpos = int(xpos + justify * (column_width - len(value)) / 2)
         # need to skip writing to the last character on the last line
         # so the cursor has a place to exist, even though its not
         # visible


### PR DESCRIPTION
## What does this PR change?

ERROR: Some problems occurred during getting information about tasks: integer argument expected, got float

addxpos turned into a float during calculation.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **manual tested**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
