### PR TITLE
Fix creation of bootstrap repositories for SLE12 (no SP) (bsc#1129765)

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -117,7 +117,6 @@ PKGLIST12 = [
     "python-pyasn1",
     "python-pycparser",
     "python-pyOpenSSL",
-    "python-setuptools",
     "python-six",
     "python-xml",
     "python-pyudev",

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- Fix creation of bootstrap repositories for SLE12 (no SP) by
+  requiring python-setuptools only for SLE12 >= SP1 (bsc#1129765)
 - Allow alternative names for bootstrap packages, to allow
   using old client tools after package renames
 - Feat: create Ubuntu empty repository


### PR DESCRIPTION
## What does this PR change?

Fix creation of bootstrap repositories for SLE12 (no SP) (bsc#1129765)

python-setuptools is only available starting with SLE12 SP1. Keep the package at ENHANCE12SP1 only.

Logs from tests: [log.tar.gz](https://github.com/uyuni-project/uyuni/files/2985968/log.tar.gz)

I can confirm that python-cryptography at SLE12 (no SP) does not require python-setuptools:
```
$ rpm -qpR python-cryptography-0.4-1.23.x86_64.rpm
libc.so.6()(64bit)
libc.so.6(GLIBC_2.2.5)(64bit)
libc.so.6(GLIBC_2.4)(64bit)
libcrypto.so.1.0.0()(64bit)
libpthread.so.0()(64bit)
libpthread.so.0(GLIBC_2.2.5)(64bit)
libpython2.7.so.1.0()(64bit)
libssl.so.1.0.0()(64bit)
python(abi) = 2.7
python-cffi >= 0.8
python-six >= 1.4.1
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(PayloadIsLzma) <= 4.4.6-1
```
So it seems https://bugzilla.suse.com/show_bug.cgi?id=1119964 was about SP3, and not plain SLE12.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Bugfix.

- [x] **DONE**

## Test coverage
- No tests: Not covered by tests. Maybe we'll do it at some point with multiclient testsuite.

- [x] **DONE**

## Links

Issue: https://github.com/SUSE/spacewalk/issues/7337
3.1: https://github.com/SUSE/spacewalk/pull/7365 (@mbologna, please review as well)
3.2: https://github.com/SUSE/spacewalk/pull/7364 (@mbologna, please review as well)

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
