### PR TITLE
Testsuite - selector for package removal fix

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -901,7 +901,8 @@ And(/^I remove package "([^"]*)" from highstate$/) do |package|
   rows.all('tr').each do |tr|
     next unless tr.text.include?(package)
     puts tr.text
-    tr.find('#sles-release-pkg-state').select('Removed')
+    tr.find("##{package}-pkg-state").select('Removed')
+    next if page.has_css?('#save[disabled]')
     steps %(
       Then I click on "Save"
       And I click on "Apply"


### PR DESCRIPTION
## What does this PR change?

PR changes selector for package to be removed from state page in the testsuite. Also adds check to ensure "save" button is not disabled after this package is set be removed.

## Links

Port of https://github.com/SUSE/spacewalk/pull/7336

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
