### PR TITLE
Removed more of cobbler's update method call

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerCommand.java
@@ -183,10 +183,6 @@ public abstract class CobblerCommand {
         return makeCobblerName(data.getLabel(), data.getOrg());
     }
 
-    protected void invokeCobblerUpdate() {
-        invokeXMLRPC("update", xmlRpcToken);
-    }
-
     protected CobblerConnection getCobblerConnection() {
         return getCobblerConnection(user);
     }

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroCreateCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroCreateCommand.java
@@ -78,7 +78,6 @@ public class CobblerDistroCreateCommand extends CobblerDistroCommand {
         CobblerDistroHelper.getInstance().createDistroFromTree(
                 CobblerXMLRPCHelper.getConnection(user),
                 tree);
-        invokeCobblerUpdate();
 
         if (tree.doesParaVirt()) {
             CobblerDistroHelper.getInstance().createXenDistroFromTree(

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroDeleteCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroDeleteCommand.java
@@ -79,7 +79,6 @@ public class CobblerDistroDeleteCommand extends CobblerDistroCommand {
             }
         }
 
-        invokeCobblerUpdate();
         return new CobblerSyncCommand(user).store();
 
     }

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroSyncCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroSyncCommand.java
@@ -247,7 +247,6 @@ public class CobblerDistroSyncCommand extends CobblerCommand {
             CobblerDistroHelper.getInstance().createDistroFromTree(
                     CobblerXMLRPCHelper.getAutomatedConnection(),
                     tree);
-            invokeCobblerUpdate();
         }
         else if (tree.doesParaVirt() && xen) {
             log.debug("tree missing in cobbler. " +

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerProfileCreateCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerProfileCreateCommand.java
@@ -105,7 +105,6 @@ public class CobblerProfileCreateCommand extends CobblerProfileCommand {
 
         updateCobblerFields(prof);
 
-        invokeCobblerUpdate();
         ksData.setCobblerId(prof.getUid());
         if (callCobblerSync) {
             return new CobblerSyncCommand(user).store();

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerProfileDeleteCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerProfileDeleteCommand.java
@@ -56,7 +56,6 @@ public class CobblerProfileDeleteCommand extends CobblerProfileCommand {
         if (!profile.remove()) {
             return new ValidatorError("cobbler.profile.remove_failed");
         }
-        invokeCobblerUpdate();
         return new CobblerSyncCommand(user).store();
 
     }


### PR DESCRIPTION
## What does this PR change?

More cobbler update command calls found. That method does not exist anymore. See also:
https://github.com/uyuni-project/uyuni/pull/683

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **enhancement of existing update**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests" 		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
