### PR TITLE
Fix removed 'product_url' column for rhnChannelFamily table schema (bsc#1128529)

### DIFF
--- a/backend/server/importlib/backendOracle.py
+++ b/backend/server/importlib/backendOracle.py
@@ -373,7 +373,6 @@ class OracleBackend(Backend):
                   'id': DBint(),
                   'name': DBstring(128),
                   'label': DBstring(128),
-                  'product_url': DBstring(128),
               },
               pk=['label'],
               defaultSeverity=4,

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Fix crash when importing new channel families on 'mgr-inter-sync' (bsc#1129300)
 - Make Zypper to use the spacewalk GPG keyring in reposync (bsc#1128529)
 - Fix: handle non-standard filenames for comps.xml (bsc#1120242)
 - Make reposync use and append token correctly to the URL


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue only happening when new entries for "rhnChannelFamily" need to be created or updated on the database during `mgr-inter-sync` execution:

- Creating entries:
```
07:45:24 Retrieving / parsing channel-families data
Exception reported from xxxxxxx
Time: Tue Mar 19 07:45:25 2019
Exception type <class 'spacewalk.server.rhnSQL.sql_base.SQLStatementPrepareError'>

Exception Handler Information
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/spacewalk/satellite_tools/xmlSource.py", line 146, in process
    self.__parser.parse(self.__stream)
  File "/usr/lib64/python2.7/xml/sax/expatreader.py", line 110, in parse
    xmlreader.IncrementalParser.parse(self, source)
  File "/usr/lib64/python2.7/xml/sax/xmlreader.py", line 123, in parse
    self.feed(buffer)
  File "/usr/lib64/python2.7/xml/sax/expatreader.py", line 213, in feed
    self._parser.Parse(data, isFinal)
  File "/usr/lib64/python2.7/xml/sax/expatreader.py", line 320, in end_element
    self._cont_handler.endElement(name)
  File "/usr/lib/python2.7/site-packages/spacewalk/satellite_tools/xmlSource.py", line 237, in endElement
    self.__container.endElement(name)
  File "/usr/lib/python2.7/site-packages/spacewalk/satellite_tools/xmlSource.py", line 1093, in endElement
    self.endContainerCallback()
  File "/usr/lib/python2.7/site-packages/spacewalk/satellite_tools/sync_handlers.py", line 606, in endContainerCallback
    importer.run()
  File "/usr/lib/python2.7/site-packages/spacewalk/server/importlib/importLib.py", line 764, in run
    self.submit()
  File "/usr/lib/python2.7/site-packages/spacewalk/server/importlib/channelImport.py", line 251, in submit
    self.backend.processChannelFamilies(self.batch)
  File "/usr/lib/python2.7/site-packages/spacewalk/server/importlib/backend.py", line 1020, in processChannelFamilies
    forceVerify=1)
  File "/usr/lib/python2.7/site-packages/spacewalk/server/importlib/backend.py", line 1989, in __processObjectCollection
    return self.__processObjectCollection__(objColl, parentTable, childDict, **kwargs)
  File "/usr/lib/python2.7/site-packages/spacewalk/server/importlib/backend.py", line 2159, in __processObjectCollection__
    return self.__doDML(dml)
  File "/usr/lib/python2.7/site-packages/spacewalk/server/importlib/backend.py", line 2263, in __doDML
    self.__doUpdate(dml.update, dml.tables)
  File "/usr/lib/python2.7/site-packages/spacewalk/server/importlib/backend.py", line 2312, in __doUpdate
    self.__doUpdateTable(tname, dict)
  File "/usr/lib/python2.7/site-packages/spacewalk/server/importlib/backend.py", line 2325, in __doUpdateTable
    updateObj.query(hash)
  File "/usr/lib/python2.7/site-packages/spacewalk/server/importlib/backendLib.py", line 347, in query
    executeStatement(statement, val, self.count)
  File "/usr/lib/python2.7/site-packages/spacewalk/server/importlib/backendLib.py", line 480, in executeStatement
    count += statement.executemany(**tempdict)
  File "/usr/lib/python2.7/site-packages/spacewalk/server/rhnSQL/sql_base.py", line 160, in executemany
    return self._execute_wrapper(self._executemany, *p, **kw)
  File "/usr/lib/python2.7/site-packages/spacewalk/server/rhnSQL/driver_postgresql.py", line 305, in _execute_wrapper
    raise sql_base.SQLStatementPrepareError(self.dbh, e.pgerror, self.sql)
SQLStatementPrepareError: ('ERROR:  column "product_url" of relation "rhnchannelfamily" does not exist\nLINE 1: update rhnChannelFamily set product_url = NULL, id = 1071, n...\n                                    ^\n', <connection object at 0x7f14ddf503f8; dsn: 'password=xxx user=susemanager dbname=susemanager', closed: 0>, 'update rhnChannelFamily set product_url = %(product_url)s, id = %(id)s, name = %(name)s where label = %(label)s')
```

- Updating entries:
```
10:13:02 Retrieving / parsing channel-families data
Exception reported from xxxxxxx
Time: Mon Mar 18 10:13:03 2019
Exception type <class 'spacewalk.common.rhnException.rhnFault'>
Exception Handler Information
Traceback (most recent call last):
 File "/usr/lib/python2.7/site-packages/spacewalk/satellite_tools/xmlSource.py", line 146, in process
   self.__parser.parse(self.__stream)
 File "/usr/lib64/python2.7/xml/sax/expatreader.py", line 110, in parse
   xmlreader.IncrementalParser.parse(self, source)  File "/usr/lib64/python2.7/xml/sax/xmlreader.py", line 123, in parse
   self.feed(buffer)
 File "/usr/lib64/python2.7/xml/sax/expatreader.py", line 213, in feed
   self._parser.Parse(data, isFinal)
 File "/usr/lib64/python2.7/xml/sax/expatreader.py", line 320, in end_element
   self._cont_handler.endElement(name)
 File "/usr/lib/python2.7/site-packages/spacewalk/satellite_tools/xmlSource.py", line 237, in endElement
   self.__container.endElement(name)
 File "/usr/lib/python2.7/site-packages/spacewalk/satellite_tools/xmlSource.py", line 1093, in endElement
   self.endContainerCallback()
 File "/usr/lib/python2.7/site-packages/spacewalk/satellite_tools/sync_handlers.py", line 606, in endContainerCallback
   importer.run()
 File "/usr/lib/python2.7/site-packages/spacewalk/server/importlib/importLib.py", line 764, in run
   self.submit()
 File "/usr/lib/python2.7/site-packages/spacewalk/server/importlib/channelImport.py", line 251, in submit
   self.backend.processChannelFamilies(self.batch)
 File "/usr/lib/python2.7/site-packages/spacewalk/server/importlib/backend.py", line 1020, in processChannelFamilies
   forceVerify=1)
 File "/usr/lib/python2.7/site-packages/spacewalk/server/importlib/backend.py", line 1989, in __processObjectCollection
   return self.__processObjectCollection__(objColl, parentTable, childDict, **kwargs)  File "/usr/lib/python2.7/site-packages/spacewalk/server/importlib/backend.py", line 2159, in __processObjectCollection__
   return self.__doDML(dml)
 File "/usr/lib/python2.7/site-packages/spacewalk/server/importlib/backend.py", line 2264, in __doDML
   self.__doInsert(dml.insert, dml.tables)  File "/usr/lib/python2.7/site-packages/spacewalk/server/importlib/backend.py", line 2274, in __doInsert
   raise_with_tb(rhnFault(54, str(e[1]), explain=0), sys.exc_info()[2])  File "/usr/lib/python2.7/site-packages/spacewalk/server/importlib/backend.py", line 2271, in __doInsert
   self.__doInsertTable(tname, dict)
 File "/usr/lib/python2.7/site-packages/spacewalk/server/importlib/backend.py", line 2286, in __doInsertTable
  insertObj.query(hash)
 File "/usr/lib/python2.7/site-packages/spacewalk/server/importlib/backendLib.py", line 455, in query
   executeStatement(statement, values, chunksize)  File "/usr/lib/python2.7/site-packages/spacewalk/server/importlib/backendLib.py", line 480, in executeStatement
   count += statement.executemany(**tempdict)  File "/usr/lib/python2.7/site-packages/spacewalk/server/rhnSQL/sql_base.py", line 160, in executemany
   return self._execute_wrapper(self._executemany, *p, **kw)  File "/usr/lib/python2.7/site-packages/spacewalk/server/rhnSQL/driver_postgresql.py", line 305, in _execute_wrapper
   raise sql_base.SQLStatementPrepareError(self.dbh, e.pgerror, self.sql)
rhnFault: (54, "<connection object at 0x7fd2bb44d3f8; dsn: 'password=xxx user=susemanager dbname=susemanager', closed: 0>", '\n    Package Upload Failed due to uniqueness constraint violation.\n    Make sure the package does not have any duplicate dependencies or\n    does not already exists on the server\n    ')
```

- Looking at postgresql logs:
```
2019-03-19 17:38:41.898 CET susemanager spacewalk [6406]ERROR:  column "product_url" of relation "rhnchannelfamily" does not exist at character 38
2019-03-19 17:38:41.898 CET susemanager spacewalk [6406]STATEMENT:  insert into rhnChannelFamily (label, product_url, id, name) values (E'CAP-X86-ALPHA', NULL, 1284, E'CAP-X86-ALPHA')
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **mgr-inter-sync is not tests atm**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/salt-board/issues/287
Tracks https://github.com/SUSE/spacewalk/pull/7366

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
