### PR TITLE
ksmeta was renamed in cobbler 3 to autoinstall_meta

### DIFF
--- a/java/code/src/org/cobbler/CobblerObject.java
+++ b/java/code/src/org/cobbler/CobblerObject.java
@@ -46,8 +46,8 @@ public abstract class CobblerObject {
     protected static final String KERNEL_OPTIONS = "kernel_options";
     protected static final String SET_KERNEL_OPTIONS = "kopts";
     protected static final String NAME = "name";
-    protected static final String KS_META = "ks_meta";
-    protected static final String SET_KS_META = "ksmeta";
+    protected static final String KS_META = "autoinstall_meta";
+    protected static final String SET_KS_META = "autoinstall_meta";
     protected static final String PARENT = "parent";
     protected static final String MTIME = "mtime";
     protected static final String MGMT_CLASSES = "mgmt_classes";

--- a/java/code/src/org/cobbler/test/MockConnection.java
+++ b/java/code/src/org/cobbler/test/MockConnection.java
@@ -58,7 +58,7 @@ public class MockConnection extends CobblerConnection {
     static {
         remapKeys.put("kopts", "kernel_options");
         remapKeys.put("kopts_post", "kernel_options_post");
-        remapKeys.put("ksmeta", "ks_meta");
+        remapKeys.put("autoinstall_meta", "autoinstall_meta");
     }
 
     /**
@@ -107,8 +107,8 @@ public class MockConnection extends CobblerConnection {
         return random();
     }
 
-    if (name.startsWith("modify_") && "ksmeta".equals(args[1])) {
-        args[1] = "ks_meta";
+    if (name.startsWith("modify_") && "autoinstall_meta".equals(args[1])) {
+        args[1] = "autoinstall_meta";
     }
 
     //profiles:
@@ -294,7 +294,7 @@ public class MockConnection extends CobblerConnection {
         profile.put("virt_ram", 512);
         profile.put("kernel_options", new HashMap());
         profile.put("kernel_options_post", new HashMap());
-        profile.put("ks_meta", new HashMap());
+        profile.put("autoinstall_meta", new HashMap());
         profile.put("redhat_management_key", "");
         return key;
     }
@@ -311,7 +311,7 @@ public class MockConnection extends CobblerConnection {
         profile.put("interfaces", interfaces);
         systems.add(profile);
         systemMap.put(key, profile);
-        profile.put("ks_meta", new HashMap());
+        profile.put("autoinstall_meta", new HashMap());
         profile.put("redhat_management_key", "");
         return key;
     }
@@ -336,7 +336,7 @@ public class MockConnection extends CobblerConnection {
         distro.put("virt_ram", 512);
         distro.put("kernel_options", new HashMap());
         distro.put("kernel_options_post", new HashMap());
-        distro.put("ks_meta", new HashMap());
+        distro.put("autoinstall_meta", new HashMap());
         distro.put("redhat_management_key", "");
         return key;
     }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- rename cobbler keyword ksmeta to autoinstall_meta which changed with cobbler 3
 - minion-action-cleanup Taskomatic task: do not clean actions younger than one hour
 - Add support for custom username when bootstrapping with Salt-SSH
 - Archive orphan actions when a system is deleted and make them visible in the UI (bsc#1118213)


### PR DESCRIPTION
## What does this PR change?

ks_meta was renamed in cobbler 3 to autoinstall_meta . This change adapt the java code to
use the new name.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- fix cucumber test

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
