### PR TITLE
Allow package filtering (name matching) on "spacewalk-repo-sync"

### DIFF
--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- Allow package filtering (name matching) on spacewalk-repo-sync after
+  migrating away from yum.
 - Fix crash when importing new channel families on 'mgr-inter-sync' (bsc#1129300)
 - Make Zypper to use the spacewalk GPG keyring in reposync (bsc#1128529)
 - Fix: handle non-standard filenames for comps.xml (bsc#1120242)


### PR DESCRIPTION
## What does this PR change?

This PR enables `spacewalk-repo-sync` to use filters, only based on name matching, that were not yet supported after migrating away from "yum":

- Including `samba*` and `libgda*`, excluding `*doc*` and `*krb*`:
```console
suma40-head-srv:~ # spacewalk-repo-sync -c testchannel -u http://xxxxxxxxx/SLES11-Pool/sle-11-x86_64/ --include samba* --include libgda* --exclude *krb* --exclude *doc*
12:11:02 ======================================
12:11:02 | Channel: testchannel
12:11:02 ======================================
12:11:02 Sync of channel started.
Retrieving repository 'testchannel' metadata .........................................................................................................................................................................................[done]
Building repository 'testchannel' cache ..............................................................................................................................................................................................[done]
All repositories have been refreshed.
12:11:08 Repo URL: http://xxxxxxxxx/SLES11-Pool/sle-11-x86_64/
12:11:08     Packages in repo:              2480
12:11:08     Packages passed filter rules:    14
12:11:08     Packages already synced:          0
12:11:08     Packages to sync:                14
12:11:08     New packages to download:        14
12:11:08   Downloading packages:
12:11:08 Downloading total 14 files from 1 queues.
12:11:11     1/14 : libgda-lang-3.1.2-82.29.x86_64.rpm
12:11:12     2/14 : libgda-3_0-sqlite-3.1.2-82.29.x86_64.rpm
12:11:12     3/14 : libgda-3_0-odbc-3.1.2-82.29.x86_64.rpm
12:11:12     4/14 : libgda-3_0-mysql-3.1.2-82.29.x86_64.rpm
12:11:12     5/14 : libgda-3_0-postgres-3.1.2-82.29.x86_64.rpm
12:11:12     6/14 : libgda-3_0-3-3.1.2-82.29.x86_64.rpm
12:11:13     7/14 : samba-winbind-32bit-3.2.7-11.6.x86_64.rpm
12:11:13     8/14 : libgda-3.1.2-82.29.x86_64.rpm
12:11:13     9/14 : samba-client-32bit-3.2.7-11.6.x86_64.rpm
12:11:13     10/14 : libgda-3_0-3.1.2-82.29.x86_64.rpm
12:11:15     11/14 : samba-32bit-3.2.7-11.6.x86_64.rpm
12:11:16     12/14 : samba-winbind-3.2.7-11.6.x86_64.rpm
12:11:19     13/14 : samba-3.2.7-11.6.x86_64.rpm
12:11:26     14/14 : samba-client-3.2.7-11.6.x86_64.rpm
12:11:26 
12:11:26   Importing packages to DB:
               Importing packages:     |##################################################| 100.0% 
12:11:28 
12:11:28   Linking packages to the channel.
12:11:28 
12:11:28   Patches in repo: 0.
12:11:28 Sync completed.
12:11:28 Total time: 0:00:26
```

- Including `samba*` and `libgda*` without any excludes:
```console
suma40-head-srv:~ # spacewalk-repo-sync -c testchannel -u http://xxxxxxxxx/SLES11-Pool/sle-11-x86_64/ --include samba* --include libgda*
12:12:44 ======================================
12:12:44 | Channel: testchannel
12:12:44 ======================================
12:12:44 Sync of channel started.
Retrieving repository 'testchannel' metadata .........................................................................................................................................................................................[done]
Building repository 'testchannel' cache ..............................................................................................................................................................................................[done]
All repositories have been refreshed.
12:12:49 Repo URL: http://xxxxxxxxx/SLES11-Pool/sle-11-x86_64/
12:12:49     Packages in repo:              2480
12:12:49     Packages passed filter rules:    17
12:12:49     Packages already synced:         14
12:12:49     Packages to sync:                 3
12:12:49     New packages to download:         3
12:12:49   Downloading packages:
12:12:49 Downloading total 3 files from 1 queues.
12:12:52     1/3 : libgda-3_0-doc-3.1.2-82.29.x86_64.rpm
12:12:53     2/3 : samba-krb-printing-3.2.7-11.6.x86_64.rpm
12:13:06     3/3 : samba-doc-3.2.7-11.6.noarch.rpm
12:13:07 
12:13:07   Importing packages to DB:
               Importing packages:     |##################################################| 100.0% 
12:13:08 
12:13:08   Linking packages to the channel.
12:13:08 
12:13:08   Patches in repo: 0.
12:13:08 Sync completed.
12:13:08 Total time: 0:00:24
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **No tests for reposync filtering**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/salt-board/issues/221

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
