### PR TITLE
Add pylint to the spacecmd

### DIFF
--- a/rel-eng/Makefile.python
+++ b/rel-eng/Makefile.python
@@ -1,0 +1,7 @@
+define update_pip_env
+	rpm -e python3-pylint &>/dev/null
+	pip3 install --upgrade pip
+	pip3 uninstall -y pylint
+	pip3 install pylint==2.3.1
+	mkdir -p reports
+endef

--- a/spacecmd/Makefile.spacecmd
+++ b/spacecmd/Makefile.spacecmd
@@ -1,21 +1,19 @@
+THIS_MAKEFILE := $(realpath $(lastword $(MAKEFILE_LIST)))
+CURRENT_DIR := $(dir $(THIS_MAKEFILE))
+include $(CURRENT_DIR)../rel-eng/Makefile.python
+
 # Docker tests variables
 DOCKER_CONTAINER_BASE = uyuni-master
 DOCKER_REGISTRY       = registry.mgr.suse.de
 DOCKER_RUN_EXPORT     = "PYTHONPATH=/manager/client/rhel/rhnlib/:/manager/client/rhel/rhn-client-tools/src"
 DOCKER_VOLUMES        = -v "$(CURDIR)/../:/manager"
 
-pylint ::
-	pylint --errors-only --disable=W src/
-
-pylint_inside_docker ::
-	rpm -e python3-pylint &>/dev/null
-	pip3 install --upgrade pip
-	pip3 uninstall -y pylint
-	pip3 install pylint==2.3.1
+__pylint ::
+	$(call update_pip_env)
 	pylint --rcfile=spacecmd-pylintrc src/* > reports/pylint.log || :
 
 docker_pylint ::
-	docker run --rm -e $(DOCKER_RUN_EXPORT) $(DOCKER_VOLUMES) $(DOCKER_REGISTRY)/$(DOCKER_CONTAINER_BASE)-pgsql /bin/sh -c "cd /manager/spacecmd; make -f Makefile.spacecmd pylint_inside_docker"
+	docker run --rm -e $(DOCKER_RUN_EXPORT) $(DOCKER_VOLUMES) $(DOCKER_REGISTRY)/$(DOCKER_CONTAINER_BASE)-pgsql /bin/sh -c "cd /manager/spacecmd; make -f Makefile.spacecmd __pylint"
 
 docker_shell ::
 	docker run -t -i --rm -e $(DOCKER_RUN_EXPORT) $(DOCKER_VOLUMES) $(DOCKER_REGISTRY)/$(DOCKER_CONTAINER_BASE)-pgsql /bin/bash

--- a/spacecmd/Makefile.spacecmd
+++ b/spacecmd/Makefile.spacecmd
@@ -1,0 +1,21 @@
+# Docker tests variables
+DOCKER_CONTAINER_BASE = uyuni-master
+DOCKER_REGISTRY       = registry.mgr.suse.de
+DOCKER_RUN_EXPORT     = "PYTHONPATH=/manager/client/rhel/rhnlib/:/manager/client/rhel/rhn-client-tools/src"
+DOCKER_VOLUMES        = -v "$(CURDIR)/../:/manager"
+
+pylint ::
+	pylint --errors-only --disable=W src/
+
+pylint_inside_docker ::
+	rpm -e python3-pylint &>/dev/null
+	pip3 install --upgrade pip
+	pip3 uninstall -y pylint
+	pip3 install pylint==2.3.1
+	pylint --rcfile=spacecmd-pylintrc src/* > reports/pylint.log || :
+
+docker_pylint ::
+	docker run --rm -e $(DOCKER_RUN_EXPORT) $(DOCKER_VOLUMES) $(DOCKER_REGISTRY)/$(DOCKER_CONTAINER_BASE)-pgsql /bin/sh -c "cd /manager/spacecmd; make -f Makefile.spacecmd pylint_inside_docker"
+
+docker_shell ::
+	docker run -t -i --rm -e $(DOCKER_RUN_EXPORT) $(DOCKER_VOLUMES) $(DOCKER_REGISTRY)/$(DOCKER_CONTAINER_BASE)-pgsql /bin/bash

--- a/spacecmd/spacecmd-pylintrc
+++ b/spacecmd/spacecmd-pylintrc
@@ -1,0 +1,188 @@
+# spacewalk pylint configuration
+
+[MASTER]
+
+# Profiled execution.
+profile=no
+
+# Pickle collected data for later comparisons.
+persistent=no
+
+
+[MESSAGES CONTROL]
+
+# Disable the message(s) with the given id(s).
+
+
+disable=I0011,
+	C0302,
+	C0111,
+	R0801,
+	R0902,
+	R0903,
+	R0904,
+	R0912,
+	R0913,
+	R0914,
+	R0915,
+	R0921,
+	R0922,
+	W0142,
+	W0403,
+	W0603,
+	C1001,
+	W0121,
+	useless-else-on-loop,
+	bad-whitespace,
+	unpacking-non-sequence,
+	superfluous-parens,
+	cyclic-import,
+	redefined-variable-type,
+	no-else-return,
+
+        # Uyuni disabled
+	E0203,
+	E0611,
+	E1101,
+	E1102
+
+# list of disabled messages:
+#I0011: 62: Locally disabling R0201
+#C0302:  1: Too many lines in module (2425)
+#C0111:  1: Missing docstring
+#R0902: 19:RequestedChannels: Too many instance attributes (9/7)
+#R0903:  Too few public methods
+#R0904: 26:Transport: Too many public methods (22/20)
+#R0912:171:set_slots_from_cert: Too many branches (59/20)
+#R0913:101:GETServer.__init__: Too many arguments (11/10)
+#R0914:171:set_slots_from_cert: Too many local variables (38/20)
+#R0915:171:set_slots_from_cert: Too many statements (169/50)
+#W0142:228:MPM_Package.write: Used * or ** magic
+#W0403: 28: Relative import 'rhnLog', should be 'backend.common.rhnLog'
+#W0603: 72:initLOG: Using the global statement
+# for pylint-1.0 we also disable
+#C1001: 46, 0: Old-style class defined. (old-style-class)
+#W0121: 33,16: Use raise ErrorClass(args) instead of raise ErrorClass, args. (old-raise-syntax)
+#W:243, 8: Else clause on loop without a break statement (useless-else-on-loop)
+# pylint-1.1 checks
+#C:334, 0: No space allowed after bracket (bad-whitespace)
+#W:162, 8: Attempting to unpack a non-sequence defined at line 6 of (unpacking-non-sequence)
+#C: 37, 0: Unnecessary parens after 'not' keyword (superfluous-parens)
+#C:301, 0: Unnecessary parens after 'if' keyword (superfluous-parens)
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html
+output-format=parseable
+
+# Include message's id in output
+include-ids=yes
+
+# Tells whether to display a full report or only the messages
+reports=yes
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+msg-template="{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}"
+
+[VARIABLES]
+
+# A regular expression matching names used for dummy variables (i.e. not used).
+dummy-variables-rgx=_|dummy
+
+
+[BASIC]
+
+# Regular expression which should only match correct module names
+#module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+module-rgx=([a-zA-Z_][a-zA-Z0-9_]+)$
+
+# Regular expression which should only match correct module level names
+const-rgx=(([a-zA-Z_][a-zA-Z0-9_]*)|(__.*__))$
+
+# Regular expression which should only match correct class names
+class-rgx=[a-zA-Z_][a-zA-Z0-9_]+$
+
+# Regular expression which should only match correct function names
+function-rgx=[a-z_][a-zA-Z0-9_]{,42}$
+
+# Regular expression which should only match correct method names
+method-rgx=[a-z_][a-zA-Z0-9_]{,42}$
+
+# Regular expression which should only match correct instance attribute names
+attr-rgx=[a-z_][a-zA-Z0-9_]{,30}$
+
+# Regular expression which should only match correct argument names
+argument-rgx=[a-z_][a-zA-Z0-9_]{,30}$
+
+# Regular expression which should only match correct variable names
+variable-rgx=[a-z_][a-zA-Z0-9_]{,30}$
+
+# Regular expression which should only match correct list comprehension /
+# generator expression variable names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Regular expression which should only match correct class sttribute names
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,42}|(__.*__))$
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,Run,_
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# List of builtins function names that should not be used, separated by a comma
+bad-functions=apply,input
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=10
+
+# Maximum number of locals for function / method body
+max-locals=20
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of branch for function / method body
+max-branchs=20
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=1
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+
+[CLASSES]
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=120
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=

--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- Add Pylint setup
 - Replace iteritems with items for python2/3 compat (bsc#1129243)
 
 -------------------------------------------------------------------

--- a/usix/Makefile.usix
+++ b/usix/Makefile.usix
@@ -1,26 +1,21 @@
+THIS_MAKEFILE := $(realpath $(lastword $(MAKEFILE_LIST)))
+CURRENT_DIR := $(dir $(THIS_MAKEFILE))
+include $(CURRENT_DIR)../rel-eng/Makefile.python
+
 # Docker tests variables
 DOCKER_CONTAINER_BASE = uyuni-master
 DOCKER_REGISTRY       = registry.mgr.suse.de
-DOCKER_RUN_EXPORT     = "PYTHONPATH=$PYTHONPATH"
+#DOCKER_RUN_EXPORT     = "PYTHONPATH=$PYTHONPATH"
+DOCKER_RUN_EXPORT     := ''
 DOCKER_VOLUMES        = -v "$(CURDIR)/../:/manager"
 
-define update_pip_env
-	rpm -e python3-pylint &>/dev/null
-	pip3 install --upgrade pip
-	pip3 uninstall -y pylint
-	pip3 install pylint==2.3.1
-	mkdir -p reports
-endef
-
-pylint ::
-	pylint --errors-only --disable=W src/
-
-pylint_inside_docker ::
+__pylint ::
 	$(call update_pip_env)
 	pylint --rcfile=usix-pylintrc common/ > reports/pylint.log || :
 
 docker_pylint ::
-	docker run --rm -e $(DOCKER_RUN_EXPORT) $(DOCKER_VOLUMES) $(DOCKER_REGISTRY)/$(DOCKER_CONTAINER_BASE)-pgsql /bin/sh -c "cd /manager/usix; make -f Makefile.usix pylint_inside_docker"
+#	docker run --rm -e $(DOCKER_RUN_EXPORT) $(DOCKER_VOLUMES) $(DOCKER_REGISTRY)/$(DOCKER_CONTAINER_BASE)-pgsql /bin/sh -c "cd /manager/usix; make -f Makefile.usix __pylint"
+	docker run --rm -e $(DOCKER_RUN_EXPORT) $(DOCKER_VOLUMES) $(DOCKER_REGISTRY)/$(DOCKER_CONTAINER_BASE)-pgsql /bin/sh -c "cd /manager/usix; make -f Makefile.usix __pylint"
 
 docker_shell ::
 	docker run -t -i --rm -e $(DOCKER_RUN_EXPORT) $(DOCKER_VOLUMES) $(DOCKER_REGISTRY)/$(DOCKER_CONTAINER_BASE)-pgsql /bin/bash

--- a/usix/Makefile.usix
+++ b/usix/Makefile.usix
@@ -1,0 +1,26 @@
+# Docker tests variables
+DOCKER_CONTAINER_BASE = uyuni-master
+DOCKER_REGISTRY       = registry.mgr.suse.de
+DOCKER_RUN_EXPORT     = "PYTHONPATH=$PYTHONPATH"
+DOCKER_VOLUMES        = -v "$(CURDIR)/../:/manager"
+
+define update_pip_env
+	rpm -e python3-pylint &>/dev/null
+	pip3 install --upgrade pip
+	pip3 uninstall -y pylint
+	pip3 install pylint==2.3.1
+	mkdir -p reports
+endef
+
+pylint ::
+	pylint --errors-only --disable=W src/
+
+pylint_inside_docker ::
+	$(call update_pip_env)
+	pylint --rcfile=usix-pylintrc common/ > reports/pylint.log || :
+
+docker_pylint ::
+	docker run --rm -e $(DOCKER_RUN_EXPORT) $(DOCKER_VOLUMES) $(DOCKER_REGISTRY)/$(DOCKER_CONTAINER_BASE)-pgsql /bin/sh -c "cd /manager/usix; make -f Makefile.usix pylint_inside_docker"
+
+docker_shell ::
+	docker run -t -i --rm -e $(DOCKER_RUN_EXPORT) $(DOCKER_VOLUMES) $(DOCKER_REGISTRY)/$(DOCKER_CONTAINER_BASE)-pgsql /bin/bash

--- a/usix/spacewalk-usix.changes
+++ b/usix/spacewalk-usix.changes
@@ -1,3 +1,5 @@
+- Add PyLint runner and configuration.
+
 -------------------------------------------------------------------
 Sat Mar 02 00:12:10 CET 2019 - jgonzalez@suse.com
 

--- a/usix/usix-pylintrc
+++ b/usix/usix-pylintrc
@@ -1,0 +1,188 @@
+# spacewalk pylint configuration
+
+[MASTER]
+
+# Profiled execution.
+profile=no
+
+# Pickle collected data for later comparisons.
+persistent=no
+
+
+[MESSAGES CONTROL]
+
+# Disable the message(s) with the given id(s).
+
+
+disable=I0011,
+	C0302,
+	C0111,
+	R0801,
+	R0902,
+	R0903,
+	R0904,
+	R0912,
+	R0913,
+	R0914,
+	R0915,
+	R0921,
+	R0922,
+	W0142,
+	W0403,
+	W0603,
+	C1001,
+	W0121,
+	useless-else-on-loop,
+	bad-whitespace,
+	unpacking-non-sequence,
+	superfluous-parens,
+	cyclic-import,
+	redefined-variable-type,
+	no-else-return,
+
+        # Uyuni disabled
+	E0203,
+	E0611,
+	E1101,
+	E1102
+
+# list of disabled messages:
+#I0011: 62: Locally disabling R0201
+#C0302:  1: Too many lines in module (2425)
+#C0111:  1: Missing docstring
+#R0902: 19:RequestedChannels: Too many instance attributes (9/7)
+#R0903:  Too few public methods
+#R0904: 26:Transport: Too many public methods (22/20)
+#R0912:171:set_slots_from_cert: Too many branches (59/20)
+#R0913:101:GETServer.__init__: Too many arguments (11/10)
+#R0914:171:set_slots_from_cert: Too many local variables (38/20)
+#R0915:171:set_slots_from_cert: Too many statements (169/50)
+#W0142:228:MPM_Package.write: Used * or ** magic
+#W0403: 28: Relative import 'rhnLog', should be 'backend.common.rhnLog'
+#W0603: 72:initLOG: Using the global statement
+# for pylint-1.0 we also disable
+#C1001: 46, 0: Old-style class defined. (old-style-class)
+#W0121: 33,16: Use raise ErrorClass(args) instead of raise ErrorClass, args. (old-raise-syntax)
+#W:243, 8: Else clause on loop without a break statement (useless-else-on-loop)
+# pylint-1.1 checks
+#C:334, 0: No space allowed after bracket (bad-whitespace)
+#W:162, 8: Attempting to unpack a non-sequence defined at line 6 of (unpacking-non-sequence)
+#C: 37, 0: Unnecessary parens after 'not' keyword (superfluous-parens)
+#C:301, 0: Unnecessary parens after 'if' keyword (superfluous-parens)
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html
+output-format=parseable
+
+# Include message's id in output
+include-ids=yes
+
+# Tells whether to display a full report or only the messages
+reports=yes
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+msg-template="{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}"
+
+[VARIABLES]
+
+# A regular expression matching names used for dummy variables (i.e. not used).
+dummy-variables-rgx=_|dummy
+
+
+[BASIC]
+
+# Regular expression which should only match correct module names
+#module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+module-rgx=([a-zA-Z_][a-zA-Z0-9_]+)$
+
+# Regular expression which should only match correct module level names
+const-rgx=(([a-zA-Z_][a-zA-Z0-9_]*)|(__.*__))$
+
+# Regular expression which should only match correct class names
+class-rgx=[a-zA-Z_][a-zA-Z0-9_]+$
+
+# Regular expression which should only match correct function names
+function-rgx=[a-z_][a-zA-Z0-9_]{,42}$
+
+# Regular expression which should only match correct method names
+method-rgx=[a-z_][a-zA-Z0-9_]{,42}$
+
+# Regular expression which should only match correct instance attribute names
+attr-rgx=[a-z_][a-zA-Z0-9_]{,30}$
+
+# Regular expression which should only match correct argument names
+argument-rgx=[a-z_][a-zA-Z0-9_]{,30}$
+
+# Regular expression which should only match correct variable names
+variable-rgx=[a-z_][a-zA-Z0-9_]{,30}$
+
+# Regular expression which should only match correct list comprehension /
+# generator expression variable names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Regular expression which should only match correct class sttribute names
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,42}|(__.*__))$
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,Run,_
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# List of builtins function names that should not be used, separated by a comma
+bad-functions=apply,input
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=10
+
+# Maximum number of locals for function / method body
+max-locals=20
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of branch for function / method body
+max-branchs=20
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=1
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+
+[CLASSES]
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=120
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=


### PR DESCRIPTION
## What does this PR change?

Add a runner for the Pylint over spacecmd. Some insights:

- Is using a common image setup. Currently image is a bit too old and contains three (!) pylint installations: one for py2 (1.8), one for py3 (1.8) and one from package (1.7x) and it is used one. Touching to rebuilding it also raises questions what might else be broken. Hence there is one common setup steps that does the following:
  - Removes packaged pylint
  - from pip installs pylint version 2.3.1 to the current python3
  - prepares the `reports` directory if none.

- Refactors Makefile
- Each project has its own `pylintrc` (since codebase differs, thus the restrictions will or may differ too)