### PR TITLE
Fix mgr-virtualization package build when using cron

### DIFF
--- a/client/tools/mgr-virtualization/mgr-virtualization.spec
+++ b/client/tools/mgr-virtualization/mgr-virtualization.spec
@@ -207,7 +207,7 @@ sed -i 's,@PYTHON@,python3,; s,@PYTHONPATH@,%{python3_sitelib},;' \
 
 %else
 install -d $RPM_BUILD_ROOT%{cron_dir}
-install -D -m 0644 scripts/rhn-virtualization.cron %{cron_dir}/rhn-virtualization.cron
+install -D -m 0644 scripts/rhn-virtualization.cron $RPM_BUILD_ROOT%{cron_dir}/rhn-virtualization.cron
 sed -i 's,@PYTHON@,python,; s,@PYTHONPATH@,%{python_sitelib},;' \
         $RPM_BUILD_ROOT/%{cron_dir}/rhn-virtualization.cron
 %endif


### PR DESCRIPTION
## What does this PR change?

Fix mgr-virtualization package build when using cron. Otherwise the SPEC tries to install not to the build root, but to the system, and the package fails to build:
https://build.suse.de/package/live_build_log/Devel:Galaxy:Manager:Head:SLE12-SUSE-Manager-Tools/mgr-virtualization/SLE_12/s390x
```
[  161s] + install -D -m 0644 scripts/rhn-virtualization.cron /etc/cron.d/rhn-virtualization.cron
[  161s] install: cannot create regular file '/etc/cron.d/rhn-virtualization.cron': Permission denied
[  161s] error: Bad exit status from /var/tmp/rpm-tmp.I96tox (%install)
```

I did NOT add a changelog entry on purpose, as the previous one should be enough, and in theory this is only a fix for that change:
```
- convert poller to systemd timer (bsc#1115414)
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: SPEC bugfix.

- [x] **DONE**

## Test coverage
- No tests: SPEC bugfix.

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
