### PR TITLE
cobbler 3 renamed kickstart variable to autoinstall

### DIFF
--- a/java/code/src/org/cobbler/Profile.java
+++ b/java/code/src/org/cobbler/Profile.java
@@ -37,7 +37,7 @@ public class Profile extends CobblerObject {
     private static Logger log = Logger.getLogger(Profile.class);
 
     private static final String DHCP_TAG = "dhcp_tag";
-    private static final String KICKSTART = "kickstart";
+    private static final String KICKSTART = "autoinstall";
     private static final String VIRT_BRIDGE = "virt_bridge";
     private static final String VIRT_CPUS = "virt_cpus";
     private static final String VIRT_TYPE = "virt_type";


### PR DESCRIPTION
## What does this PR change?

Another rename found.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- fixes a test

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
