### PR TITLE
Cleanup unused Salt related code from "yum_src" reposync plugin

### DIFF
--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -92,13 +92,13 @@ class ZyppoSync:
             raise
         try:
             # Synchronize new GPG keys that come from the Spacewalk GPG keyring
-            self._synchronize_gpg_keys()
+            self.__synchronize_gpg_keys()
         except Exception as exc:
             msg = "Unable to synchronize Spacewalk GPG keyring: {}".format(exc)
             rhnLog.log_clean(0, msg)
             sys.stderr.write(str(msg) + "\n")
 
-    def _synchronize_gpg_keys(self):
+    def __synchronize_gpg_keys(self):
         """
         This method does update the Zypper RPM database with new keys coming from the Spacewalk GPG keyring
 

--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -70,6 +70,10 @@ RPM_PUBKEY_VERSION_RELEASE_RE = re.compile(r'^gpg-pubkey-([0-9a-fA-F]+)-([0-9a-f
 
 
 class ZyppoSync:
+    """
+    This class prepares a environment for running Zypper inside a dedicated reposync root
+
+    """
     def __init__(self, root=None):
         self._root = root
         if self._root is not None:

--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -99,8 +99,10 @@ class ZyppoSync:
             sys.stderr.write(str(msg) + "\n")
 
     def _synchronize_gpg_keys(self):
-        # We need to import keep reposync zypper RPM database updated according
-        # to the Spacewalk GPG keyring
+        """
+        This method does update the Zypper RPM database with new keys coming from the Spacewalk GPG keyring
+
+        """
         spacewalk_gpg_keys = {}
         zypper_gpg_keys = {}
         with tempfile.NamedTemporaryFile() as f:
@@ -791,7 +793,7 @@ type=rpm-md
 
     def raw_list_packages(self, filters=None):
         """
-        Return a list of available packages.
+        Return a raw list of available packages.
 
         :returns: list
         """


### PR DESCRIPTION
## What does this PR change?

This PR does some cleanup on the `yum_src` plugin from `spacewalk-repo-sync`:

- Remove unnecessary prototype of Salt integration.
- Improve documentation.
- Make `__synchronize_gpg_keys` a private method.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **code refactor**

- [x] **DONE**

## Test coverage
- No tests: **code refactor**

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
