### PR TITLE
Give chromium twice as much memory for JavaScript

### DIFF
--- a/testsuite/features/support/setup_browser.rb
+++ b/testsuite/features/support/setup_browser.rb
@@ -30,7 +30,7 @@ end
 # register chromedriver headless mode
 Capybara.register_driver(:headless_chrome) do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: { args: %w[headless disable-gpu window-size=1920,1080, no-sandbox] }
+    chromeOptions: { args: %w[headless disable-gpu window-size=1920,1080, js-flags="--max_old_space_size=1024" no-sandbox] }
   )
 
   Capybara::Selenium::Driver.new(


### PR DESCRIPTION
## What does this PR change?

This is an attempt to fix the chromium crashes. According to the core dump:
```
(gdb) bt
#0  0x0000565331d4d127 in WTF::PartitionsOutOfMemoryUsing512M() ()
Backtrace stopped: Cannot access memory at address 0x7ffe9557dd48
```

## Links

Part of SUSE/spacewalk#6993 task

Tracks 3.1: SUSE/spacewalk#7396   3.2: SUSE/spacewalk#7395

## Changelogs

- [x] No changelog needed
