### PR TITLE
Include RPM dependencies when using filters with "spacewalk-repo-sync"

### DIFF
--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,7 @@
+- Add support for getting latest versions from RPM packages
+  when running "spacewalk-repo-sync" after migration to Zypper.
+- Include packages dependencies on "spacewalk-repo-sync" when using filters
+  for RPM packages.
 - Allow package filtering (name matching) on spacewalk-repo-sync after
   migrating away from yum.
 - Fix crash when importing new channel families on 'mgr-inter-sync' (bsc#1129300)

--- a/susemanager-utils/testing/docker/master/uyuni-master-pgsql/Dockerfile
+++ b/susemanager-utils/testing/docker/master/uyuni-master-pgsql/Dockerfile
@@ -18,7 +18,7 @@ RUN sh /root/setup-db-postgres.sh
 
 ADD postgresql.conf /var/lib/pgsql/data/postgresql.conf
 
-RUN zypper in -y python3-pip python3-solv
+RUN zypper in -y python3-pip python3-solv python3-salt
 
 RUN pip3 install --upgrade pylint==1.8 astroid==1.6.5
 


### PR DESCRIPTION
## What does this PR change?

This PR calculates the RPM packages dependencies (using pure `libsolv`) when filters are set on a `spacewalk-repo-sync` execution in order to include them into the final list of packagest to be synchronized.

Besides of that, this PR also brings back the support for using `--latest` parameter after migrating to Zypper. When this parameter is set and there are multiple versions for the same package, only the latest "package-evr" is set to be synced.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **this PR is bringing back functionality which was already there before py3 migration**

- [x] **DONE**

## Test coverage
- No tests: **this PR is bringing back functionality which was already there before py3 migration**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/salt-board/issues/221

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
