### PR TITLE
Disable build validation on 2obs for spacewalk-web

### DIFF
--- a/web/setup.sh
+++ b/web/setup.sh
@@ -1,4 +1,4 @@
 set -euxo pipefail
 (cd web/html/src; yarn install --frozen-lockfile)
-(cd web/html/src; yarn build)
+(cd web/html/src; BUILD_VALIDATION=false node build.js)
 echo ""


### PR DESCRIPTION
## What does this PR change?

Disable javascript linting/auditing on the manager-head-2obs job. This check is already being done in the Javascript_linting job

## GUI diff

No difference.
- [ ] **DONE**

## Documentation
- No documentation needed

- [ ] **DONE**

## Test coverage
- No tests

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test" 
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
