### PR TITLE
Testsuite - package refresh after zypper operations

### DIFF
--- a/testsuite/features/min_action_chain.feature
+++ b/testsuite/features/min_action_chain.feature
@@ -13,6 +13,10 @@ Feature: Action chain on salt minions
     And I run "zypper -n ref" on "sle-minion"
     And I run "echo '/dev/vda1 / ext4 defaults 0 0' > /etc/fstab" on "sle-minion"
 
+  Scenario: Pre-requisite: refresh package list first on SLE minion
+    When I refresh packages list via spacecmd on "sle-minion"
+    And I wait until refresh package list on "sle-minion" is finished
+
   Scenario: Pre-requisite: wait until downgrade is finished
     Given I am on the Systems overview page of this "sle-minion"
     When I follow "Software" in the content area

--- a/testsuite/features/min_salt_install_package.feature
+++ b/testsuite/features/min_salt_install_package.feature
@@ -8,6 +8,10 @@ Feature: Install a patch on the client via Salt through the UI
     And I run "zypper -n ref" on "sle-minion"
     And I run "zypper -n in --oldpackage virgo-dummy-1.0" on "sle-minion" without error control
 
+  Scenario: Pre-requisite: refresh package list on SLE minion machine
+    When I refresh packages list via spacecmd on "sle-minion"
+    And I wait until refresh package list on "sle-minion" is finished
+
   Scenario: Pre-requisite: ensure the errata cache is computed before patchin Salt minion
     Given I am on the Systems overview page of this "sle-minion"
     When I follow "Software" in the content area

--- a/testsuite/features/min_salt_install_with_staging.feature
+++ b/testsuite/features/min_salt_install_with_staging.feature
@@ -20,12 +20,8 @@ Feature: Install a package on the minion with staging enabled
     And I run "zypper -n rm orion-dummy" on "sle-minion" without error control
 
   Scenario: Pre-requisite: refresh package list on SLE minion 
-    Given I am on the Systems overview page of this "sle-minion"
-    When I follow "Software" in the content area
-    And I click on "Update Package List"
-    And I follow "Events" in the content area
-    And I wait until I do not see "Package List Refresh scheduled by admin" text, refreshing the page
-    Then I wait until event "Package List Refresh scheduled by admin" is completed
+    When I refresh packages list via spacecmd on "sle-minion"
+    And I wait until refresh package list on "sle-minion" is finished
 
   Scenario: Pre-requisite: ensure the errata cache is computed
     Given I am authorized as "admin" with password "admin"

--- a/testsuite/features/min_salt_pkgset_beacon.feature
+++ b/testsuite/features/min_salt_pkgset_beacon.feature
@@ -9,6 +9,10 @@ Feature: System package list is updated if packages are manually installed or re
     And I run "zypper -n ref" on "sle-minion"
     And I run "zypper -n in --oldpackage milkyway-dummy-1.0" on "sle-minion" without error control
 
+  Scenario: Pre-requisite: refresh package list first on SLE minion machine
+    When I refresh packages list via spacecmd on "sle-minion"
+    And I wait until refresh package list on "sle-minion" is finished
+
   Scenario: Pre-requisite: ensure the errata cache is computed
     Given I am on the Systems overview page of this "sle-minion"
     When I follow "Software" in the content area

--- a/testsuite/features/min_salt_software_states.feature
+++ b/testsuite/features/min_salt_software_states.feature
@@ -12,6 +12,10 @@ Feature: Salt package states
     And I run "zypper -n in --oldpackage virgo-dummy-1.0" on "sle-minion" without error control
     And I run "zypper -n in --oldpackage andromeda-dummy-1.0" on "sle-minion" without error control
 
+  Scenario: Pre-requisite: refresh package list on SLES minion
+    When I refresh packages list via spacecmd on "sle-minion"
+    And I wait until refresh package list on "sle-minion" is finished
+
   Scenario: Pre-requisite: ensure the errata cache is computed
     Given I am on the Systems overview page of this "sle-minion"
     When I follow "Software" in the content area

--- a/testsuite/features/minssh_action_chain.feature
+++ b/testsuite/features/minssh_action_chain.feature
@@ -17,11 +17,8 @@ Feature: Salt SSH action chain
 
 @ssh_minion
   Scenario: Pre-requisite: refresh package list
-    Given I am on the Systems overview page of this "ssh-minion"
-    When I follow "Software" in the content area
-    And I click on "Update Package List"
-    And I follow "Events" in the content area
-    And I wait until I do not see "Package List Refresh scheduled by admin" text, refreshing the page
+    When I refresh packages list via spacecmd on "ssh-minion"
+    And I wait until refresh package list on "ssh-minion" is finished
 
 @ssh_minion
   Scenario: Pre-requisite: wait until downgrade is finished

--- a/testsuite/features/minssh_centos_salt_install_package_and_patch.feature
+++ b/testsuite/features/minssh_centos_salt_install_package_and_patch.feature
@@ -11,12 +11,8 @@ Feature: Install a patch on the CentOS SSH minion via Salt through the UI
 
 @centos_minion
   Scenario: Pre-requisite: refresh package list on Centos SSH minion 
-    Given I am on the Systems overview page of this "ceos-ssh-minion"
-    When I follow "Software" in the content area
-    And I click on "Update Package List"
-    And I follow "Events" in the content area
-    And I wait until I do not see "Package List Refresh scheduled by admin" text, refreshing the page
-    Then I wait until event "Package List Refresh scheduled by admin" is completed
+    When I refresh packages list via spacecmd on "ceos-ssh-minion"
+    And I wait until refresh package list on "ceos-ssh-minion" is finished
 
 @centos_minion
   Scenario: Schedule errata refresh to reflect channel assignment on Centos SSH minion 


### PR DESCRIPTION
## What does this PR change?

PR adds scenario with package refresh after zypper operations at the beginning of feature. This change prevents testsuite from failure due to wrong package or package version used. Package refresh scenario in PR is rewritten to use `spacecmd` command to improve stability and performance.

## Links

Issue: https://github.com/SUSE/spacewalk/issues/7271
Port of: https://github.com/SUSE/spacewalk/pull/7311

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test" 
- [ ] Re-run test "backend_unittests_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "java_lint_checkstyle" (Test skipped, there are no changes to test)		 
- [ ] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)		 
- [ ] Re-run test "ruby_rubocop" 
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql" (Test skipped, there are no changes to test)		 
- [ ] Re-run test "susemanager_unittests" (Test skipped, there are no changes to test)
