### PR TITLE
Change cobbler template dir

### DIFF
--- a/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -422,7 +422,7 @@ public class ConfigDefaults {
      * @return the dir which has the kickstarts
      */
     public String getKickstartConfigDir() {
-        return Config.get().getString(KICKSTART_COBBLER_DIR, "/var/lib/rhn/kickstarts/");
+        return Config.get().getString(KICKSTART_COBBLER_DIR, "/var/lib/cobbler/templates/");
     }
 
     /**

--- a/java/code/src/org/cobbler/Profile.java
+++ b/java/code/src/org/cobbler/Profile.java
@@ -15,6 +15,9 @@
 
 package org.cobbler;
 
+import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.common.util.StringUtil;
+
 import org.apache.log4j.Logger;
 
 import java.util.Collection;
@@ -207,7 +210,7 @@ public class Profile extends CobblerObject {
      * @return the Kickstart file path
      */
      public String getKickstart() {
-         return (String)dataMap.get(KICKSTART);
+         return getFullAutoinstallPath((String)dataMap.get(KICKSTART));
      }
 
      /**
@@ -299,7 +302,7 @@ public class Profile extends CobblerObject {
       * @param kickstartIn the Kickstart
       */
       public void  setKickstart(String kickstartIn) {
-          modify(KICKSTART, kickstartIn);
+          modify(KICKSTART, getRelativeAutoinstallPath(kickstartIn));
       }
 
       /**
@@ -406,4 +409,22 @@ public class Profile extends CobblerObject {
           }
       }
 
+      private String getFullAutoinstallPath(String pathIn) {
+          String cobblerPath = ConfigDefaults.get().getKickstartConfigDir();
+          if (pathIn.startsWith(cobblerPath)) {
+              return pathIn;
+          }
+          return StringUtil.addPath(cobblerPath, pathIn);
+      }
+
+      private String getRelativeAutoinstallPath(String pathIn) {
+          String cobblerPath = ConfigDefaults.get().getKickstartConfigDir();
+          if (!cobblerPath.endsWith("/")) {
+              cobblerPath += "/";
+          }
+          if (pathIn.startsWith(cobblerPath)) {
+              return pathIn.substring(cobblerPath.length());
+          }
+          return pathIn;
+      }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- change cobblers template directory
 - Remove tanukiwrapper from taskomatic
 - Add error message on sync refresh when there are no scc credentials
 - rename cobbler keyword ksmeta to autoinstall_meta which changed with cobbler 3

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -17,12 +17,12 @@
 #
 
 
-%define cobprofdir      %{_localstatedir}/lib/rhn/kickstarts
-%define cobprofdirup    %{_localstatedir}/lib/rhn/kickstarts/upload
-%define cobprofdirwiz   %{_localstatedir}/lib/rhn/kickstarts/wizard
-%define cobdirsnippets  %{_localstatedir}/lib/rhn/kickstarts/snippets
-%define realcobsnippetsdir  %{_localstatedir}/lib/cobbler/snippets
-%define cobblerdir          %{_localstatedir}/lib/cobbler
+%define cobblerdir      %{_localstatedir}/lib/cobbler
+%define cobprofdir      %{cobblerdir}/templates
+%define cobprofdirup    %{cobprofdir}/upload
+%define cobprofdirwiz   %{cobprofdir}/wizard
+%define cobdirsnippets  %{cobblerdir}/snippets
+%define realcobsnippetsdir  %{cobdirsnippets}/spacewalk
 %define run_checkstyle  1
 
 %if 0%{?fedora} || 0%{?rhel} >= 7
@@ -707,19 +707,18 @@ cp -a build/classes/com/redhat/rhn/common/conf/test/conf $RPM_BUILD_ROOT%{_datad
 install -m 644 conf/log4j.properties.taskomatic $RPM_BUILD_ROOT%{_datadir}/rhn/classes/log4j.properties
 install -m 644 code/src/ehcache.xml $RPM_BUILD_ROOT%{_datadir}/rhn/classes/ehcache.xml
 
-install -m 644 conf/cobbler/snippets/default_motd  $RPM_BUILD_ROOT%{cobdirsnippets}/default_motd
-install -m 644 conf/cobbler/snippets/keep_system_id  $RPM_BUILD_ROOT%{cobdirsnippets}/keep_system_id
-install -m 644 conf/cobbler/snippets/post_reactivation_key  $RPM_BUILD_ROOT%{cobdirsnippets}/post_reactivation_key
-install -m 644 conf/cobbler/snippets/post_delete_system  $RPM_BUILD_ROOT%{cobdirsnippets}/post_delete_system
-install -m 644 conf/cobbler/snippets/redhat_register  $RPM_BUILD_ROOT%{cobdirsnippets}/redhat_register
-install -m 644 conf/cobbler/snippets/sles_register    $RPM_BUILD_ROOT%{cobdirsnippets}/sles_register
-install -m 644 conf/cobbler/snippets/sles_register_script $RPM_BUILD_ROOT%{cobdirsnippets}/sles_register_script
-install -m 644 conf/cobbler/snippets/sles_no_signature_checks $RPM_BUILD_ROOT%{cobdirsnippets}/sles_no_signature_checks
-install -m 644 conf/cobbler/snippets/wait_for_networkmanager_script $RPM_BUILD_ROOT%{cobdirsnippets}/wait_for_networkmanager_script
+install -d -m 755 $RPM_BUILD_ROOT%{realcobsnippetsdir}
+install -m 644 conf/cobbler/snippets/default_motd  $RPM_BUILD_ROOT%{realcobsnippetsdir}/default_motd
+install -m 644 conf/cobbler/snippets/keep_system_id  $RPM_BUILD_ROOT%{realcobsnippetsdir}/keep_system_id
+install -m 644 conf/cobbler/snippets/post_reactivation_key  $RPM_BUILD_ROOT%{realcobsnippetsdir}/post_reactivation_key
+install -m 644 conf/cobbler/snippets/post_delete_system  $RPM_BUILD_ROOT%{realcobsnippetsdir}/post_delete_system
+install -m 644 conf/cobbler/snippets/redhat_register  $RPM_BUILD_ROOT%{realcobsnippetsdir}/redhat_register
+install -m 644 conf/cobbler/snippets/sles_register    $RPM_BUILD_ROOT%{realcobsnippetsdir}/sles_register
+install -m 644 conf/cobbler/snippets/sles_register_script $RPM_BUILD_ROOT%{realcobsnippetsdir}/sles_register_script
+install -m 644 conf/cobbler/snippets/sles_no_signature_checks $RPM_BUILD_ROOT%{realcobsnippetsdir}/sles_no_signature_checks
+install -m 644 conf/cobbler/snippets/wait_for_networkmanager_script $RPM_BUILD_ROOT%{realcobsnippetsdir}/wait_for_networkmanager_script
 
 ln -s -f %{_javadir}/dwr.jar $RPM_BUILD_ROOT%{jardir}/dwr.jar
-install -d -m 755 $RPM_BUILD_ROOT%{realcobsnippetsdir}
-ln -s -f  %{cobdirsnippets} $RPM_BUILD_ROOT%{realcobsnippetsdir}/spacewalk
 %if 0%{?suse_version}
 install -d -m 755 $RPM_BUILD_ROOT%{_datadir}/spacewalk/audit
 install -m 644 conf/audit/auditlog-config.yaml $RPM_BUILD_ROOT%{_datadir}/spacewalk/audit/auditlog-config.yaml


### PR DESCRIPTION
## What does this PR change?

Change cobbler's template directory 

New cobbler require all templates in his own directory and does not
allow other directories anymore.
Additionally it expect the kickstart path relative to the default dir

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- issue was created (GitHub automatic link expected below)

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
