### PR TITLE
add default TASKO_JAVA_OPTS

### DIFF
--- a/java/conf/default/rhn_taskomatic_daemon.conf
+++ b/java/conf/default/rhn_taskomatic_daemon.conf
@@ -7,5 +7,6 @@ TASKO_LIBRARY_PATH="/usr/lib:/usr/lib64"
 TASKO_RHN_CLASSPATH="/usr/share/rhn/classes"
 TASKO_RHN_JARS="/usr/share/rhn/lib/spacewalk-asm.jar:/usr/share/rhn/lib/rhn.jar:/usr/share/rhn/lib/java-branding.jar"
 TASKO_JARS="/usr/share/spacewalk/taskomatic/*"
+TASKO_JAVA_OPTS="--add-modules java.annotation,com.sun.xml.bind --add-exports java.annotation/javax.annotation.security=ALL-UNNAMED --add-opens java.annotation/javax.annotation.security=ALL-UNNAMED"
 TASKO_INIT_MEMORY=256
 TASKO_MAX_MEMORY=2048

--- a/java/scripts/taskomatic
+++ b/java/scripts/taskomatic
@@ -9,7 +9,7 @@ if [[ $TASKO_MEM_LINE != \#* ]]; then
   TASKO_MAX_MEMORY=$(echo $TASKO_MEM_LINE | sed -r 's/\s+//g' | sed 's/^.*=//');
 fi
 
-TASKO_PARAMS="-Dibm.dst.compatibility=true -Dfile.encoding=UTF-8 -Xms${TASKO_INIT_MEMORY}m -Xmx${TASKO_MAX_MEMORY}m ${TASKO_CRASH_PARAMS}"
+TASKO_PARAMS="-Dibm.dst.compatibility=true -Dfile.encoding=UTF-8 -Xms${TASKO_INIT_MEMORY}m -Xmx${TASKO_MAX_MEMORY}m ${TASKO_CRASH_PARAMS} ${TASKO_JAVA_OPTS}"
 TASKO_CLASSPATH="${TASKO_RHN_CLASSPATH}:${TASKO_RHN_JARS}:${TASKO_JARS}"
 
 # options sourced from /usr/share/rhn/config-defaults/rhn_taskomatic_daemon.conf (do not touch). Add additional options to /etc/rhn/taskomatic.conf


### PR DESCRIPTION
## What does this PR change?

With JDK11 we need some special java opts to make taskomatic start.
This PR add a special TASKO_JAVA_OPTS variable with needed defaults.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **fix service start**

- [x] **DONE**

## Links


- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
