### PR TITLE
Spacekwalk web build - Use yarn instead of directly node.js

### DIFF
--- a/web/html/src/package.json
+++ b/web/html/src/package.json
@@ -12,6 +12,7 @@
     "watch": "webpack -d --config build/webpack.config.js --mode development --watch",
     "proxy": "webpack-dev-server -d --mode development --hot --inline --config build/webpack.config.js",
     "build": "node build",
+    "build:novalidate": "BUILD_VALIDATION=false node build",
     "lint": "eslint . -f codeframe"
   },
   "devDependencies": {

--- a/web/setup.sh
+++ b/web/setup.sh
@@ -1,4 +1,4 @@
 set -euxo pipefail
 (cd web/html/src; yarn install --frozen-lockfile)
-(cd web/html/src; BUILD_VALIDATION=false node build.js)
+(cd web/html/src; yarn build:novalidate)
 echo ""


### PR DESCRIPTION
## What does this PR change?

Spacewalk web build - Use yarn instead of directly node.js

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"  
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
