### PR TITLE
Remove use of access compat

### DIFF
--- a/backend/apache-conf/zz-spacewalk-server-wsgi.conf
+++ b/backend/apache-conf/zz-spacewalk-server-wsgi.conf
@@ -3,8 +3,13 @@
 </IfModule>
 
 <Directory /usr/share/rhn>
-  Order allow,deny
-  Allow from all
+    <IfVersion <= 2.2>
+        Order allow,deny
+        Allow from all
+    </IfVersion>
+    <IfVersion >= 2.4>
+        Require all granted
+    </IfVersion>
 </Directory>
 
 WSGIPythonPath "/usr/share/rhn"

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- remove apache access_compat module and adapt config files
 - Add support for getting latest versions from RPM packages
   when running "spacewalk-repo-sync" after migration to Zypper.
 - Include packages dependencies on "spacewalk-repo-sync" when using filters

--- a/proxy/proxy/httpd-conf/spacewalk-proxy-wsgi.conf
+++ b/proxy/proxy/httpd-conf/spacewalk-proxy-wsgi.conf
@@ -3,8 +3,13 @@
 #
 
 <Directory /usr/share/rhn>
-  Order allow,deny
-  Allow from all
+    <IfVersion <= 2.2>
+        Order allow,deny
+        Allow from all
+    </IfVersion>
+    <IfVersion >= 2.4>
+        Require all granted
+    </IfVersion>
 </Directory>
 
 WSGIPythonPath "/usr/share/rhn"

--- a/proxy/proxy/httpd-conf/spacewalk-proxy.conf
+++ b/proxy/proxy/httpd-conf/spacewalk-proxy.conf
@@ -13,8 +13,13 @@
 #             expand to in the future
 <Directory "/srv/www/htdocs/pub/*">
     Options Indexes FollowSymLinks
-    Order allow,deny
-    Allow from all
+    <IfVersion <= 2.2>
+        Order allow,deny
+        Allow from all
+    </IfVersion>
+    <IfVersion >= 2.4>
+        Require all granted
+    </IfVersion>
 </Directory>
 
 <LocationMatch "^/pub/*">

--- a/proxy/proxy/spacewalk-proxy.changes
+++ b/proxy/proxy/spacewalk-proxy.changes
@@ -1,3 +1,5 @@
+- remove apache access_compat module and adapt config files
+
 -------------------------------------------------------------------
 Sat Mar 02 00:11:10 CET 2019 - jgonzalez@suse.com
 

--- a/proxy/proxy/spacewalk-proxy.spec
+++ b/proxy/proxy/spacewalk-proxy.spec
@@ -326,7 +326,6 @@ exit 0
 %post common
 %if 0%{?suse_version}
 sysconf_addword /etc/sysconfig/apache2 APACHE_MODULES wsgi
-sysconf_addword /etc/sysconfig/apache2 APACHE_MODULES access_compat
 sysconf_addword /etc/sysconfig/apache2 APACHE_MODULES proxy
 sysconf_addword /etc/sysconfig/apache2 APACHE_MODULES rewrite
 sysconf_addword /etc/sysconfig/apache2 APACHE_MODULES version

--- a/spacewalk/config/etc/httpd/conf.d/os-images.conf
+++ b/spacewalk/config/etc/httpd/conf.d/os-images.conf
@@ -3,7 +3,12 @@ Alias /os-images /srv/www/os-images
 <Directory "/srv/www/os-images">
     SetEnv VIRTUALENV
     Options Indexes
-    Order allow,deny
-    Allow from all
+    <IfVersion <= 2.2>
+        Order allow,deny
+        Allow from all
+    </IfVersion>
+    <IfVersion >= 2.4>
+        Require all granted
+    </IfVersion>
 </Directory>
 

--- a/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-www.conf
+++ b/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-www.conf
@@ -1,8 +1,13 @@
 <Directory "/srv/www/htdocs/*">
     Options Indexes FollowSymLinks
     AllowOverride All
-    Order allow,deny
-    Allow from all
+    <IfVersion <= 2.2>
+        Order allow,deny
+        Allow from all
+    </IfVersion>
+    <IfVersion >= 2.4>
+        Require all granted
+    </IfVersion>
 
     ExpiresActive On
     <FilesMatch "\.(js|css|ico|gif|png|pdf)$">
@@ -69,12 +74,22 @@ XSendFilePath /var/spacewalk/packages
 XSendFilePath /var/spacewalk/rhn/comps
 XSendFilePath /var/cache/rhn/repodata
 <Directory /var/spacewalk/packages>
-  Order allow,deny
-  Allow from all
+    <IfVersion <= 2.2>
+        Order allow,deny
+        Allow from all
+    </IfVersion>
+    <IfVersion >= 2.4>
+        Require all granted
+    </IfVersion>
 </Directory>
 <Directory /var/cache/rhn/repodata>
-  Order allow,deny
-  Allow from all
+    <IfVersion <= 2.2>
+        Order allow,deny
+        Allow from all
+    </IfVersion>
+    <IfVersion >= 2.4>
+        Require all granted
+    </IfVersion>
 </Directory>
 
 RedirectMatch ^/renew/.* http://www.novell.com/center/

--- a/spacewalk/config/spacewalk-config.changes
+++ b/spacewalk/config/spacewalk-config.changes
@@ -1,3 +1,5 @@
+- remove apache access_compat module and adapt config files
+
 -------------------------------------------------------------------
 Sat Mar 02 00:10:15 CET 2019 - jgonzalez@suse.com
 

--- a/spacewalk/config/spacewalk-config.spec
+++ b/spacewalk/config/spacewalk-config.spec
@@ -161,7 +161,6 @@ chmod o-rwx /etc/rhn/rhn.conf* /etc/sysconfig/rhn/backup-* /var/lib/rhn/rhn-sate
 %post
 %if 0%{?suse_version}
 sysconf_addword /etc/sysconfig/apache2 APACHE_MODULES version
-sysconf_addword /etc/sysconfig/apache2 APACHE_MODULES access_compat
 sysconf_addword /etc/sysconfig/apache2 APACHE_MODULES proxy
 sysconf_addword /etc/sysconfig/apache2 APACHE_MODULES proxy_ajp
 sysconf_addword /etc/sysconfig/apache2 APACHE_MODULES proxy_wstunnel


### PR DESCRIPTION
## What does this PR change?

We should not use old style apache configuration format.
Removed configuration of `access_compat` module and adapted the config files

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **work or not**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test" 
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
