### PR TITLE
cobbler profile download URL changed

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
@@ -141,6 +141,14 @@ public class DownloadFile extends DownloadAction {
             }
         }
         else if (url.startsWith("/cblr/svc/op/ks/")) {
+            url = url.replaceFirst("ks", "autoinstall");
+            Map<String, Object> params = new HashMap<String, Object>();
+            params.put(TYPE,  DownloadManager.DOWNLOAD_TYPE_COBBLER);
+            params.put(URL_STRING, url);
+            request.setAttribute(PARAMS, params);
+            return super.execute(mapping, formIn, request, response);
+        }
+        else if (url.startsWith("/cblr/svc/op/autoinstall/")) {
             Map<String, Object> params = new HashMap<String, Object>();
             params.put(TYPE,  DownloadManager.DOWNLOAD_TYPE_COBBLER);
             params.put(URL_STRING, url);

--- a/java/code/src/com/redhat/rhn/manager/kickstart/KickstartUrlHelper.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/KickstartUrlHelper.java
@@ -42,7 +42,7 @@ import java.util.Date;
 public class KickstartUrlHelper {
 
     private static Logger log = Logger.getLogger(KickstartUrlHelper.class);
-    public static final String COBBLER_URL_BASE_PATH = "/cblr/svc/op/ks/profile/";
+    public static final String COBBLER_URL_BASE_PATH = "/cblr/svc/op/autoinstall/profile/";
     public static final String KS_DIST = "/ks/dist";
     public static final String KS_CFG = "/ks/cfg";
     public static final String COBBLER_SERVER_VARIABLE = "$http_server";


### PR DESCRIPTION
## What does this PR change?

/cblr/svc/op/ks/profile/ => /cblr/svc/op/autoinstall/profile/
Use new URL and provide a compat handler

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [x] **DONE**

## Test coverage
- No tests: **external service**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
