### PR TITLE
More access compat fixes

### DIFF
--- a/proxy/installer/cobbler-proxy.conf
+++ b/proxy/installer/cobbler-proxy.conf
@@ -1,6 +1,7 @@
 ProxyPass /cobbler_api $PROTO://$RHN_PARENT/download//cobbler_api
 ProxyPassReverse /cobbler_api $PROTO://$RHN_PARENT/download//cobbler_api
 RewriteRule ^/cblr/svc/op/ks/(.*)$ /download/$0 [P,L]
+RewriteRule ^/cblr/svc/op/autoinstall/(.*)$ /download/$0 [P,L]
 ProxyPass /cblr $PROTO://$RHN_PARENT/cblr
 ProxyPassReverse /cblr $PROTO://$RHN_PARENT/cblr
 ProxyPass /cobbler $PROTO://$RHN_PARENT/cobbler

--- a/proxy/installer/spacewalk-proxy-installer.changes
+++ b/proxy/installer/spacewalk-proxy-installer.changes
@@ -1,3 +1,5 @@
+- redirect new cobbler autoinstall url
+
 -------------------------------------------------------------------
 Tue Mar 12 15:33:51 CET 2019 - jgonzalez@suse.com
 

--- a/tftpsync/susemanager-tftpsync-recv/configure-tftpsync.sh
+++ b/tftpsync/susemanager-tftpsync-recv/configure-tftpsync.sh
@@ -164,6 +164,7 @@ fi
 
 
 sed -i "s/^[[:space:]]*allow from[[:space:]].*$/    allow from $SUMA_IP/" /etc/apache2/conf.d/susemanager-tftpsync-recv.conf
+sed -i "s/^[[:space:]]*#?Require ip[[:space:]].*$/    Require ip $SUMA_IP/" /etc/apache2/conf.d/susemanager-tftpsync-recv.conf
 
 
 #######################################

--- a/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.changes
+++ b/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.changes
@@ -1,3 +1,5 @@
+- provide apache 2.4 compatible configuration
+
 -------------------------------------------------------------------
 Wed Jan 16 12:27:58 CET 2019 - jgonzalez@suse.com
 

--- a/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.conf
+++ b/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.conf
@@ -1,6 +1,11 @@
 <Directory "/srv/www/tftpsync">
-    order allow,deny
-    allow from @@SUMA_IP@@
+    <IfVersion <= 2.2>
+        Order allow,deny
+        Allow from @@SUMA_IP@@
+    </IfVersion>
+    <IfVersion >= 2.4>
+        #Require ip @@SUMA_IP@@
+    </IfVersion>
 </Directory>
 
 WSGIScriptAlias /tftpsync/add /srv/www/tftpsync/add


### PR DESCRIPTION
## What does this PR change?

Found other places where we need to provide an apache 2.4 compatible configuration.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **work or not**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
