### PR TITLE
fix tftpsync config

### DIFF
--- a/tftpsync/susemanager-tftpsync-recv/configure-tftpsync.sh
+++ b/tftpsync/susemanager-tftpsync-recv/configure-tftpsync.sh
@@ -163,8 +163,8 @@ else
 fi
 
 
-sed -i "s/^[[:space:]]*allow from[[:space:]].*$/    allow from $SUMA_IP/" /etc/apache2/conf.d/susemanager-tftpsync-recv.conf
-sed -i "s/^[[:space:]]*#?Require ip[[:space:]].*$/    Require ip $SUMA_IP/" /etc/apache2/conf.d/susemanager-tftpsync-recv.conf
+sed -i "s/^[[:space:]]*Allow from[[:space:]].*$/        Allow from $SUMA_IP/" /etc/apache2/conf.d/susemanager-tftpsync-recv.conf
+sed -i "s/^[[:space:]#]*Require ip[[:space:]].*$/        Require ip $SUMA_IP/" /etc/apache2/conf.d/susemanager-tftpsync-recv.conf
 
 
 #######################################
@@ -178,12 +178,5 @@ fi
 chown wwwrun:tftp "$TFTPBOOT"
 chmod 750 "$TFTPBOOT"
 systemctl enable tftp.socket
-
-## open firewall for tftp ##
-############################
-
-echo "open tftp service in SUSE firewall..."
-sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_CONFIGURATIONS_EXT tftp
-rcSuSEfirewall2 try-restart
 
 rcapache2 restart


### PR DESCRIPTION
firewall tftp port is part of the general suse manager proxy config

## What does this PR change?

Fix tftpsync configuration

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **should work like before now**

- [x] **DONE**

## Test coverage
- No tests: **was not tested at all**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test" 
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
