### PR TITLE
new cobbler aligned setter and getter for kernel_options

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/test/CobblerEnableBootstrapCommandTest.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/test/CobblerEnableBootstrapCommandTest.java
@@ -124,7 +124,7 @@ public class CobblerEnableBootstrapCommandTest extends BaseTestCaseWithUser {
         expectedOptions.put("spacewalk_hostname", config.getHostname());
         expectedOptions.put("spacewalk_activationkey", activationKeyToken);
         expectedOptions.put("ROOTFS_FSCK", "0");
-        assertEquals(expectedOptions, newProfile.get("kopts"));
+        assertEquals(expectedOptions, newProfile.get("kernel_options"));
 
         criteria.put("name", SystemRecord.BOOTSTRAP_NAME);
         Map<String, Object> newSystem = CobblerDisableBootstrapCommandTest.invoke(

--- a/java/code/src/org/cobbler/CobblerObject.java
+++ b/java/code/src/org/cobbler/CobblerObject.java
@@ -41,10 +41,10 @@ public abstract class CobblerObject {
     protected static final String OWNERS = "owners";
     protected static final String CTIME = "ctime";
     protected static final String KERNEL_OPTIONS_POST = "kernel_options_post";
-    protected static final String SET_KERNEL_OPTIONS_POST = "kopts_post";
+    protected static final String SET_KERNEL_OPTIONS_POST = "kernel_options_post";
     protected static final String DEPTH = "depth";
     protected static final String KERNEL_OPTIONS = "kernel_options";
-    protected static final String SET_KERNEL_OPTIONS = "kopts";
+    protected static final String SET_KERNEL_OPTIONS = "kernel_options";
     protected static final String NAME = "name";
     protected static final String KS_META = "autoinstall_meta";
     protected static final String SET_KS_META = "autoinstall_meta";


### PR DESCRIPTION
## What does this PR change?

Cobbler 3.0 use now the same names to get and set kernel_options. 
Send the correct keyword when setting kernel options.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- fixed test

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test" 
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests" 		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
