### PR TITLE
Suppress Python traceback and print only error message

### DIFF
--- a/spacewalk/certs-tools/client_config_update.py
+++ b/spacewalk/certs-tools/client_config_update.py
@@ -215,5 +215,7 @@ def main():
     mapNewSettings(configFilename, readConfigFile(newMappings))
 
 if __name__ == '__main__':
-    sys.exit(main() or 0)
-
+    try:
+        sys.exit(main() or 0)
+    except Exception as err:
+        print(err)

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,5 @@
+- Print error message instead of stacktrace for client_config_update.py
+
 -------------------------------------------------------------------
 Wed Feb 27 13:00:34 CET 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Wrong cli usage no longer prints traceback.



## GUI diff

No difference.

## Links

This is a port of https://github.com/SUSE/spacewalk/pull/6175


## Changelogs

Changelog is provided
