### PR TITLE
Fix performance regression in inter-server-sync (bsc#1128781)

### DIFF
--- a/schema/spacewalk/postgres/procs/insert_checksum.sql
+++ b/schema/spacewalk/postgres/procs/insert_checksum.sql
@@ -1,2 +1,29 @@
 -- oracle equivalent source sha1 874b297c5c4a19955e360cfd5dfbd3f7eaa07e3d
--- This file is intentionally left empty.
+
+create or replace function
+insert_checksum(checksum_type_in in varchar, checksum_in in varchar)
+returns numeric
+as
+$$
+declare
+    checksum_id     numeric;
+begin
+    checksum_id := nextval('rhnchecksum_seq');
+
+    insert into rhnChecksum (id, checksum_type_id, checksum)
+      values (
+          checksum_id,
+          (select id from rhnChecksumType where label = checksum_type_in),
+          checksum_in
+      )
+      on conflict do nothing;
+
+    select c.id
+        into strict checksum_id
+        from rhnChecksumView c
+        where c.checksum = checksum_in and
+            c.checksum_type = checksum_type_in;
+
+    return checksum_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/postgres/procs/insert_client_capability.sql
+++ b/schema/spacewalk/postgres/procs/insert_client_capability.sql
@@ -1,2 +1,23 @@
 -- oracle equivalent source sha1 91d69cea4721c434318c724367aad2da26fc580a
--- This file is intentionally left empty.
+
+create or replace function
+insert_client_capability(name_in in varchar)
+returns numeric
+as $$
+declare
+    cap_name_id     numeric;
+begin
+    cap_name_id := nextval('rhn_client_capname_id_seq');
+
+    insert into rhnClientCapabilityName(id, name)
+        values (cap_name_id, name_in)
+        on conflict do nothing;
+
+    select id
+        into strict cap_name_id
+        from rhnclientcapabilityname
+        where name = name_in;
+
+    return cap_name_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/postgres/procs/insert_config_filename.sql
+++ b/schema/spacewalk/postgres/procs/insert_config_filename.sql
@@ -1,2 +1,23 @@
 -- oracle equivalent source sha1 6246cca388a689f557ae46b817b61f647604e261
--- This file is intentionally left empty.
+
+create or replace function
+insert_config_filename(name_in in varchar)
+returns numeric as
+$$
+declare
+    name_id     numeric;
+begin
+    name_id := nextval('rhn_cfname_id_seq');
+
+    insert into rhnConfigFileName (id, path)
+        values (name_id, name_in)
+        on conflict do nothing;
+
+    select id
+        into strict name_id
+        from rhnconfigfilename
+        where path = name_in;
+
+    return name_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/postgres/procs/insert_config_info.sql
+++ b/schema/spacewalk/postgres/procs/insert_config_info.sql
@@ -1,2 +1,34 @@
 -- oracle equivalent source sha1 ac28a1215137bf44831e56f3592afb2ef71a7042
--- This file is intentionally left empty.
+
+create or replace function
+insert_config_info(
+    username_in     in varchar,
+    groupname_in    in varchar,
+    filemode_in     in numeric,
+    selinux_ctx_in  in varchar,
+    symlink_target_id in numeric
+)
+returns numeric
+as
+$$
+declare
+    config_info_id    numeric;
+begin
+    config_info_id := nextval('rhn_confinfo_id_seq');
+
+    insert into rhnConfigInfo (id, username, groupname, filemode, selinux_ctx, symlink_target_filename_id)
+        values (config_info_id, username_in, groupname_in, filemode_in, selinux_ctx_in, symlink_target_id)
+        on conflict do nothing;
+
+    select id
+      into config_info_id
+      from rhnConfigInfo
+      where (username = username_in or (username is null and username_in is null))
+        and (groupname = groupname_in or (groupname is null and groupname_in is null))
+        and (filemode = filemode_in or (filemode is null and filemode_in is null))
+        and (selinux_ctx = selinux_ctx_in or (selinux_ctx is null and selinux_ctx_in is null))
+        and (symlink_target_filename_id = symlink_target_id or (symlink_target_filename_id is null and symlink_target_id is null));
+
+    return config_info_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/postgres/procs/insert_cve.sql
+++ b/schema/spacewalk/postgres/procs/insert_cve.sql
@@ -1,2 +1,23 @@
 -- oracle equivalent source sha1 503d7fcd3467f712f378d98bb0a6195315ff4d5f
--- This file is intentionally left empty.
+
+create or replace function
+insert_cve(name_in in varchar)
+returns numeric
+as $$
+declare
+    name_id     numeric;
+begin
+    name_id := nextval('rhn_cve_id_seq');
+
+    insert into rhnCVE (id, name)
+        values (name_id, name_in)
+        on conflict do nothing;
+
+    select id
+        into strict name_id
+        from rhnCVE
+        where name = name_in;
+
+    return name_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/postgres/procs/insert_evr.sql
+++ b/schema/spacewalk/postgres/procs/insert_evr.sql
@@ -1,2 +1,25 @@
 -- oracle equivalent source sha1 3b34c56a2f9af5419b343fde3245d9bfd6822983
--- This file is intentionally left empty.
+
+create or replace function
+insert_evr(e_in in varchar, v_in in varchar, r_in in varchar)
+returns numeric
+as
+$$
+declare
+    evr_id  numeric;
+begin
+    evr_id := nextval('rhn_pkg_evr_seq');
+
+    insert into rhnPackageEVR(id, epoch, version, release, evr)
+        values (evr_id, e_in, v_in, r_in, evr_t(e_in, v_in, r_in))
+        on conflict do nothing;
+
+    select id
+        into strict evr_id
+        from rhnPackageEVR
+        where ((epoch is null and e_in is null) or (epoch = e_in)) and
+           version = v_in and release = r_in;
+
+    return evr_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/postgres/procs/insert_md_keyword.sql
+++ b/schema/spacewalk/postgres/procs/insert_md_keyword.sql
@@ -1,2 +1,24 @@
 -- oracle equivalent source sha1 c58721f0a618ba2bbe6e4b5c8e9c047e2c1883ae
--- This file is intentionally left empty.
+
+create or replace function
+insert_md_keyword(label_in in varchar)
+returns numeric
+as
+$$
+declare
+    md_keyword_id numeric;
+begin
+    md_keyword_id := nextval('suse_mdkeyword_id_seq');
+
+    insert into suseMdKeyword (id, label)
+        values (md_keyword_id, label_in)
+        on conflict do nothing;
+
+    select id
+        into strict md_keyword_id
+        from suseMdKeyword
+        where label = label_in;
+
+    return md_keyword_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/postgres/procs/insert_package_capability.sql
+++ b/schema/spacewalk/postgres/procs/insert_package_capability.sql
@@ -1,2 +1,31 @@
 -- oracle equivalent source sha1 a397d522dd41720dcd8b77e0a20d999ea5365355
--- This file is intentionally left empty.
+
+create or replace function
+insert_package_capability(name_in in varchar, version_in in varchar default null)
+returns numeric
+as
+$$
+declare
+    name_id numeric;
+begin
+    name_id := nextval('rhn_pkg_capability_id_seq');
+
+    insert into rhnPackageCapability(id, name, version)
+        values (name_id, name_in, version_in)
+        on conflict do nothing;
+
+    if version_in is null then
+        select id
+            into strict name_id
+            from rhnpackagecapability
+            where name = name_in and version is null;
+    else
+        select id
+            into strict name_id
+            from rhnpackagecapability
+            where name = name_in and version = version_in;
+    end if;
+
+    return name_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/postgres/procs/insert_package_delta.sql
+++ b/schema/spacewalk/postgres/procs/insert_package_delta.sql
@@ -1,2 +1,24 @@
 -- oracle equivalent source sha1 4a8214db905b81b0ea4418155a53cc2e8bff4335
--- This file is intentionally left empty.
+
+create or replace function
+insert_package_delta(n_in in varchar)
+returns numeric
+as
+$$
+declare
+    name_id     numeric;
+begin
+    name_id := nextval('rhn_packagedelta_id_seq');
+
+    insert into rhnPackageDelta(id, label)
+        values (name_id, n_in)
+        on conflict do nothing;
+
+    select id
+        into strict name_id
+        from rhnpackagedelta
+        where label = n_in;
+
+    return name_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/postgres/procs/insert_package_group.sql
+++ b/schema/spacewalk/postgres/procs/insert_package_group.sql
@@ -1,2 +1,24 @@
 -- oracle equivalent source sha1 8c8aaa5d2ae7b9933a312c5d7f3aceb5b41a7df7
--- This file is intentionally left empty.
+
+create or replace function
+insert_package_group(name_in in varchar)
+returns numeric
+as
+$$
+declare
+    package_id   numeric;
+begin
+    package_id := nextval('rhn_package_group_id_seq');
+
+    insert into rhnPackageGroup(id, name)
+        values (package_id, name_in)
+        on conflict do nothing;
+
+    select id
+        into strict package_id
+        from rhnPackageGroup
+        where name = name_in;
+
+    return package_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/postgres/procs/insert_package_name.sql
+++ b/schema/spacewalk/postgres/procs/insert_package_name.sql
@@ -1,2 +1,24 @@
 -- oracle equivalent source sha1 865d405e7f5618baa2e444e282fd8800296066f8
--- This file is intentionally left empty.
+
+create or replace function
+insert_package_name(name_in in varchar)
+returns numeric
+as
+$$
+declare
+    name_id     numeric;
+begin
+    name_id := nextval('rhn_pkg_name_seq');
+
+    insert into rhnPackageName(id, name)
+        values (name_id, name_in)
+        on conflict do nothing;
+
+    select id
+        into strict name_id
+        from rhnPackageName
+        where name = name_in;
+
+    return name_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/postgres/procs/insert_package_nevra.sql
+++ b/schema/spacewalk/postgres/procs/insert_package_nevra.sql
@@ -1,2 +1,30 @@
 -- oracle equivalent source sha1 1062cff485519f46e7a53ab703b48a76e90c1a57
 -- This file is intentionally left empty.
+
+create or replace function
+insert_package_nevra(
+        name_id_in in numeric,
+        evr_id_in in numeric,
+        package_arch_id_in in numeric
+) returns numeric
+as
+$$
+declare
+    nevra_id numeric;
+begin
+    nevra_id := nextval('rhn_pkgnevra_id_seq');
+
+    insert into rhnPackageNEVRA(id, name_id, evr_id, package_arch_id)
+        values (nevra_id, name_id_in, evr_id_in, package_arch_id_in)
+        on conflict do nothing;
+
+    select id
+        into strict nevra_id
+        from rhnPackageNEVRA
+        where name_id = name_id_in and evr_id = evr_id_in and
+            (package_arch_id = package_arch_id_in or
+            (package_arch_id is null and package_arch_id_in is null));
+
+    return nevra_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/postgres/procs/insert_source_name.sql
+++ b/schema/spacewalk/postgres/procs/insert_source_name.sql
@@ -1,2 +1,24 @@
 -- oracle equivalent source sha1 961eb765a11aacb9649ca6546c7d71ff06221eab
--- This file is intentionally left empty.
+
+create or replace function
+insert_source_name(name_in in varchar)
+returns numeric
+as
+$$
+declare
+    source_id   numeric;
+begin
+    source_id := nextval('rhn_sourcerpm_id_seq');
+
+    insert into rhnSourceRPM(id, name)
+        values (source_id, name_in)
+        on conflict do nothing;
+
+    select id
+        into strict source_id
+        from rhnSourceRPM
+        where name = name_in;
+
+    return source_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/postgres/procs/insert_tag.sql
+++ b/schema/spacewalk/postgres/procs/insert_tag.sql
@@ -1,2 +1,24 @@
 -- oracle equivalent source sha1 0747be17bb344bff3073e00930025cdd503f6ee2
--- This file is intentionally left empty.
+
+create or replace function
+insert_tag(org_id_in in numeric, tag_name_id_in in numeric)
+returns numeric
+as $$
+declare
+    tag_id  numeric;
+begin
+    tag_id := nextval('rhn_tag_id_seq');
+
+    insert into rhnTag(id, org_id, name_id)
+        values (tag_id, org_id_in, tag_name_id_in)
+        on conflict do nothing;
+
+    select id
+        into strict tag_id
+        from rhnTag
+        where org_id = org_id_in and
+            name_id = tag_name_id_in;
+
+    return tag_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/postgres/procs/insert_tag_name.sql
+++ b/schema/spacewalk/postgres/procs/insert_tag_name.sql
@@ -1,2 +1,24 @@
 -- oracle equivalent source sha1 3a243557dc0c065deb58725a0deb2014574b748a
--- This file is intentionally left empty.
+
+create or replace function
+insert_tag_name(name_in in varchar)
+returns numeric
+as
+$$
+declare
+    name_id numeric;
+begin
+    name_id := nextval('rhn_tagname_id_seq');
+
+    insert into rhnTagName(id, name)
+        values (name_id, name_in)
+        on conflict do nothing;
+
+    select id
+        into strict name_id
+        from rhnTagName
+        where name = name_in;
+
+    return name_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/postgres/procs/insert_transaction_package.sql
+++ b/schema/spacewalk/postgres/procs/insert_transaction_package.sql
@@ -1,2 +1,30 @@
 -- oracle equivalent source sha1 c6072b2270204eee9312f4f43bfc3c0c7eb4dc4e
--- This file is intentionally left empty.
+
+create or replace function
+insert_transaction_package(
+    o_id_in      in numeric,
+    n_id_in      in numeric,
+    e_id_in      in numeric,
+    p_arch_id_in in numeric
+)
+returns numeric
+as
+$$
+declare
+    tp_id       numeric;
+begin
+    tp_id := nextval('rhn_transpack_id_seq');
+
+    insert into rhnTransactionPackage (id, operation, name_id, evr_id, package_arch_id)
+        values (tp_id, o_id_in, n_id_in, e_id_in, p_arch_id_in)
+        on conflict do nothing;
+
+    select id
+        into strict tp_id
+        from rhnTransactionPackage
+     where operation = o_id_in and name_id = n_id_in and evr_id = e_id_in and
+        (package_arch_id = p_arch_id_in or (p_arch_id_in is null and package_arch_id is null));
+
+    return tp_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/postgres/procs/insert_xccdf_benchmark.sql
+++ b/schema/spacewalk/postgres/procs/insert_xccdf_benchmark.sql
@@ -1,2 +1,25 @@
 -- oracle equivalent source sha1 4202a766e12fa3137a822d20683ccabe897631a1
 -- This file is intentionally left empty.
+
+create or replace function
+insert_xccdf_benchmark(identifier_in in varchar, version_in in varchar)
+returns numeric
+as
+$$
+declare
+    benchmark_id numeric;
+begin
+    benchmark_id := nextval('rhn_xccdf_benchmark_id_seq');
+
+    insert into rhnXccdfBenchmark (id, identifier, version)
+        values (benchmark_id, identifier_in, version_in)
+        on conflict do nothing;
+
+    select id
+        into strict benchmark_id
+        from rhnXccdfBenchmark
+        where identifier = identifier_in and version = version_in;
+
+    return benchmark_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/postgres/procs/insert_xccdf_ident.sql
+++ b/schema/spacewalk/postgres/procs/insert_xccdf_ident.sql
@@ -1,2 +1,24 @@
 -- oracle equivalent source sha1 346f0f7fb2cfcff4b50d79095f640bfe64a4cf54
--- This file is intentionally left empty.
+
+create or replace function
+insert_xccdf_ident(ident_sys_id_in in numeric, identifier_in in varchar)
+returns numeric
+as
+$$
+declare
+    xccdf_ident_id numeric;
+begin
+    xccdf_ident_id := nextval('rhn_xccdf_ident_id_seq');
+
+    insert into rhnXccdfIdent (id, identsystem_id, identifier)
+        values (xccdf_ident_id, ident_sys_id_in, identifier_in)
+        on conflict do nothing;
+
+    select id
+        into strict xccdf_ident_id
+        from rhnXccdfIdent
+        where identsystem_id = ident_sys_id_in and identifier = identifier_in;
+
+    return xccdf_ident_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/postgres/procs/insert_xccdf_ident_system.sql
+++ b/schema/spacewalk/postgres/procs/insert_xccdf_ident_system.sql
@@ -1,2 +1,24 @@
 -- oracle equivalent source sha1 ec9ba49c1f25d81a100625db72795bba81976913
--- This file is intentionally left empty.
+
+create or replace function
+insert_xccdf_ident_system(system_in in varchar)
+returns numeric
+as
+$$
+declare
+    ident_sys_id numeric;
+begin
+    ident_sys_id := nextval('rhn_xccdf_identsytem_id_seq');
+
+    insert into rhnXccdfIdentSystem (id, system)
+        values (ident_sys_id, system_in)
+        on conflict do nothing;
+
+    select id
+        into strict ident_sys_id
+        from rhnXccdfIdentSystem
+        where system = system_in;
+
+    return ident_sys_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/postgres/procs/insert_xccdf_profile.sql
+++ b/schema/spacewalk/postgres/procs/insert_xccdf_profile.sql
@@ -1,2 +1,24 @@
 -- oracle equivalent source sha1 6890e6ed27e8fae8e53cc2f6648efe05d6cf5340
--- This file is intentionally left empty.
+
+create or replace function
+insert_xccdf_profile(identifier_in in varchar, title_in in varchar)
+returns numeric
+as
+$$
+declare
+    profile_id numeric;
+begin
+    profile_id := nextval('rhn_xccdf_profile_id_seq');
+
+    insert into rhnXccdfProfile (id, identifier, title)
+        values (profile_id, identifier_in, title_in)
+        on conflict do nothing;
+
+    select id
+        into profile_id
+        from rhnXccdfProfile
+        where identifier = identifier_in and title = title_in;
+
+    return profile_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/postgres/procs/lookup_client_capability.sql
+++ b/schema/spacewalk/postgres/procs/lookup_client_capability.sql
@@ -26,18 +26,12 @@ begin
      where name = name_in;
 
     if not found then
-        cap_name_id := nextval('rhn_client_capname_id_seq');
-
-        insert into rhnClientCapabilityName(id, name)
-            values (cap_name_id, name_in)
-            on conflict do nothing;
-
-        select id
-            into strict cap_name_id
-            from rhnclientcapabilityname
-            where name = name_in;
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_client_capability(name_in);
     end if;
 
     return cap_name_id;
 end;
-$$ language plpgsql;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/postgres/procs/lookup_config_filename.sql
+++ b/schema/spacewalk/postgres/procs/lookup_config_filename.sql
@@ -26,18 +26,12 @@ begin
      where path = name_in;
 
     if not found then
-        name_id := nextval('rhn_cfname_id_seq');
-
-        insert into rhnConfigFileName (id, path)
-            values (name_id, name_in)
-            on conflict do nothing;
-
-        select id
-            into strict name_id
-            from rhnconfigfilename
-            where path = name_in;
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_config_filename(name_in);
     end if;
 
     return name_id;
 end;
-$$ language plpgsql;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/postgres/procs/lookup_cve.sql
+++ b/schema/spacewalk/postgres/procs/lookup_cve.sql
@@ -26,18 +26,12 @@ begin
      where name = name_in;
 
     if not found then
-        name_id := nextval('rhn_cve_id_seq');
-
-        insert into rhnCVE (id, name)
-            values (name_id, name_in)
-            on conflict do nothing;
-
-        select id
-            into strict name_id
-            from rhnCVE
-            where name = name_in;
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_cve(name_in);
     end if;
 
     return name_id;
 end;
-$$ language plpgsql;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/postgres/procs/lookup_md_keyword.sql
+++ b/schema/spacewalk/postgres/procs/lookup_md_keyword.sql
@@ -22,19 +22,14 @@ begin
       into md_keyword_id
       from suseMdKeyword
      where label = label_in;
+
     if not found then
-        md_keyword_id := nextval('suse_mdkeyword_id_seq');
-
-        insert into suseMdKeyword (id, label)
-            values (md_keyword_id, label_in)
-            on conflict do nothing;
-
-        select id
-            into strict md_keyword_id
-            from suseMdKeyword
-            where label = label_in;
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_md_keyword(label_in);
     end if;
 
     return md_keyword_id;
 end;
-$$ language plpgsql;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/postgres/procs/lookup_package_group.sql
+++ b/schema/spacewalk/postgres/procs/lookup_package_group.sql
@@ -27,18 +27,12 @@ begin
      where name = name_in;
 
     if not found then
-        package_id := nextval('rhn_package_group_id_seq');
-
-        insert into rhnPackageGroup(id, name)
-            values (package_id, name_in)
-            on conflict do nothing;
-
-        select id
-            into strict package_id
-            from rhnPackageGroup
-            where name = name_in;
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_package_group(name_in);
     end if;
 
     return package_id;
 end;
-$$ language plpgsql;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/postgres/procs/lookup_package_name.sql
+++ b/schema/spacewalk/postgres/procs/lookup_package_name.sql
@@ -31,18 +31,12 @@ begin
      where name = name_in;
 
     if not found then
-        name_id := nextval('rhn_pkg_name_seq');
-
-        insert into rhnPackageName(id, name)
-            values (name_id, name_in)
-            on conflict do nothing;
-
-        select id
-            into strict name_id
-            from rhnPackageName
-            where name = name_in;
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_package_name(name_in);
     end if;
 
     return name_id;
 end;
-$$ language plpgsql;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/postgres/procs/lookup_source_name.sql
+++ b/schema/spacewalk/postgres/procs/lookup_source_name.sql
@@ -27,18 +27,12 @@ begin
      where name = name_in;
 
     if not found then
-        source_id := nextval('rhn_sourcerpm_id_seq');
-
-        insert into rhnSourceRPM(id, name)
-            values (source_id, name_in)
-            on conflict do nothing;
-
-        select id
-            into strict source_id
-            from rhnSourceRPM
-            where name = name_in;
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_source_name(name_in);
     end if;
 
     return source_id;
 end;
-$$ language plpgsql;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/postgres/procs/lookup_tag.sql
+++ b/schema/spacewalk/postgres/procs/lookup_tag.sql
@@ -30,19 +30,12 @@ begin
            name_id = tag_name_id;
 
     if not found then
-        tag_id := nextval('rhn_tag_id_seq');
-
-        insert into rhnTag(id, org_id, name_id)
-            values (tag_id, org_id_in, tag_name_id)
-            on conflict do nothing;
-
-        select id
-            into strict tag_id
-            from rhnTag
-            where org_id = org_id_in and
-                name_id = lookup_tag_name(name_in);
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_tag(org_id_in, tag_name_id);
     end if;
 
     return tag_id;
 end;
-$$ language plpgsql;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/postgres/procs/lookup_tag_name.sql
+++ b/schema/spacewalk/postgres/procs/lookup_tag_name.sql
@@ -27,18 +27,12 @@ begin
      where name = name_in;
 
     if not found then
-        name_id := nextval('rhn_tagname_id_seq');
-
-        insert into rhnTagName(id, name)
-            values (name_id, name_in)
-            on conflict do nothing;
-
-        select id
-            into strict name_id
-            from rhnTagName
-            where name = name_in;
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_tag_name(name_in);
     end if;
 
     return name_id;
 end;
-$$ language plpgsql;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/postgres/procs/lookup_xccdf_profile.sql
+++ b/schema/spacewalk/postgres/procs/lookup_xccdf_profile.sql
@@ -28,18 +28,12 @@ begin
      where identifier = identifier_in and title = title_in;
 
     if not found then
-        profile_id := nextval('rhn_xccdf_profile_id_seq');
-
-        insert into rhnXccdfProfile (id, identifier, title)
-            values (profile_id, identifier_in, title_in)
-            on conflict do nothing;
-
-        select id
-            into profile_id
-            from rhnXccdfProfile
-            where identifier = identifier_in and title = title_in;
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_xccdf_profile(identifier_in, title_in);
     end if;
 
     return profile_id;
 end;
-$$ language plpgsql;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,5 @@
+- fix performance regression in inter-server-sync (bsc#1128781)
+
 -------------------------------------------------------------------
 Mon Mar 25 17:03:42 CET 2019 - jgonzalez@suse.com
 

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/101-insert_checksum.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/101-insert_checksum.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 101-insert_checksum.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/101-insert_checksum.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/101-insert_checksum.sql.postgresql
@@ -1,0 +1,29 @@
+-- oracle equivalent source sha1 332dff06282e754b71a1691d558af3214bfef2da
+
+create or replace function
+insert_checksum(checksum_type_in in varchar, checksum_in in varchar)
+returns numeric
+as
+$$
+declare
+    checksum_id     numeric;
+begin
+    checksum_id := nextval('rhnchecksum_seq');
+
+    insert into rhnChecksum (id, checksum_type_id, checksum)
+      values (
+          checksum_id,
+          (select id from rhnChecksumType where label = checksum_type_in),
+          checksum_in
+      )
+      on conflict do nothing;
+
+    select c.id
+        into strict checksum_id
+        from rhnChecksumView c
+        where c.checksum = checksum_in and
+            c.checksum_type = checksum_type_in;
+
+    return checksum_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/102-insert_client_capability.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/102-insert_client_capability.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 102-insert_client_capability.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/102-insert_client_capability.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/102-insert_client_capability.sql.postgresql
@@ -1,0 +1,23 @@
+-- oracle equivalent source sha1 f2b491caca6d4c831c063bd6eb6a6f1fe069d083
+
+create or replace function
+insert_client_capability(name_in in varchar)
+returns numeric
+as $$
+declare
+    cap_name_id     numeric;
+begin
+    cap_name_id := nextval('rhn_client_capname_id_seq');
+
+    insert into rhnClientCapabilityName(id, name)
+        values (cap_name_id, name_in)
+        on conflict do nothing;
+
+    select id
+        into strict cap_name_id
+        from rhnclientcapabilityname
+        where name = name_in;
+
+    return cap_name_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/103-insert_config_filename.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/103-insert_config_filename.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 103-insert_config_filename.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/103-insert_config_filename.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/103-insert_config_filename.sql.postgresql
@@ -1,0 +1,23 @@
+-- oracle equivalent source sha1 f1a3c0a7a3e8076009abc9f6a6ca121e9a9cecc0
+
+create or replace function
+insert_config_filename(name_in in varchar)
+returns numeric as
+$$
+declare
+    name_id     numeric;
+begin
+    name_id := nextval('rhn_cfname_id_seq');
+
+    insert into rhnConfigFileName (id, path)
+        values (name_id, name_in)
+        on conflict do nothing;
+
+    select id
+        into strict name_id
+        from rhnconfigfilename
+        where path = name_in;
+
+    return name_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/104-insert_config_info.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/104-insert_config_info.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 104-insert_config_info.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/104-insert_config_info.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/104-insert_config_info.sql.postgresql
@@ -1,0 +1,34 @@
+-- oracle equivalent source sha1 c0296a9f14cc334cc0fd07b3296bced60ba7fb4f
+
+create or replace function
+insert_config_info(
+    username_in     in varchar,
+    groupname_in    in varchar,
+    filemode_in     in numeric,
+    selinux_ctx_in  in varchar,
+    symlink_target_id in numeric
+)
+returns numeric
+as
+$$
+declare
+    config_info_id    numeric;
+begin
+    config_info_id := nextval('rhn_confinfo_id_seq');
+
+    insert into rhnConfigInfo (id, username, groupname, filemode, selinux_ctx, symlink_target_filename_id)
+        values (config_info_id, username_in, groupname_in, filemode_in, selinux_ctx_in, symlink_target_id)
+        on conflict do nothing;
+
+    select id
+      into config_info_id
+      from rhnConfigInfo
+      where (username = username_in or (username is null and username_in is null))
+        and (groupname = groupname_in or (groupname is null and groupname_in is null))
+        and (filemode = filemode_in or (filemode is null and filemode_in is null))
+        and (selinux_ctx = selinux_ctx_in or (selinux_ctx is null and selinux_ctx_in is null))
+        and (symlink_target_filename_id = symlink_target_id or (symlink_target_filename_id is null and symlink_target_id is null));
+
+    return config_info_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/105-insert_cve.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/105-insert_cve.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 105-insert_cve.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/105-insert_cve.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/105-insert_cve.sql.postgresql
@@ -1,0 +1,23 @@
+-- oracle equivalent source sha1 2a98887e4f024f0a92bc1b4fa310e67dcec2cf7c
+
+create or replace function
+insert_cve(name_in in varchar)
+returns numeric
+as $$
+declare
+    name_id     numeric;
+begin
+    name_id := nextval('rhn_cve_id_seq');
+
+    insert into rhnCVE (id, name)
+        values (name_id, name_in)
+        on conflict do nothing;
+
+    select id
+        into strict name_id
+        from rhnCVE
+        where name = name_in;
+
+    return name_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/106-insert_evr.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/106-insert_evr.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 106-insert_evr.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/106-insert_evr.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/106-insert_evr.sql.postgresql
@@ -1,0 +1,25 @@
+-- oracle equivalent source sha1 ffcffb0f08037f894c026baae8071ad2902f38e9
+
+create or replace function
+insert_evr(e_in in varchar, v_in in varchar, r_in in varchar)
+returns numeric
+as
+$$
+declare
+    evr_id  numeric;
+begin
+    evr_id := nextval('rhn_pkg_evr_seq');
+
+    insert into rhnPackageEVR(id, epoch, version, release, evr)
+        values (evr_id, e_in, v_in, r_in, evr_t(e_in, v_in, r_in))
+        on conflict do nothing;
+
+    select id
+        into strict evr_id
+        from rhnPackageEVR
+        where ((epoch is null and e_in is null) or (epoch = e_in)) and
+           version = v_in and release = r_in;
+
+    return evr_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/107-insert_md_keyword.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/107-insert_md_keyword.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 107-insert_md_keyword.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/107-insert_md_keyword.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/107-insert_md_keyword.sql.postgresql
@@ -1,0 +1,24 @@
+-- oracle equivalent source sha1 9b4477d428c6b9b9b57d526609cf7a26b065c8b7
+
+create or replace function
+insert_md_keyword(label_in in varchar)
+returns numeric
+as
+$$
+declare
+    md_keyword_id numeric;
+begin
+    md_keyword_id := nextval('suse_mdkeyword_id_seq');
+
+    insert into suseMdKeyword (id, label)
+        values (md_keyword_id, label_in)
+        on conflict do nothing;
+
+    select id
+        into strict md_keyword_id
+        from suseMdKeyword
+        where label = label_in;
+
+    return md_keyword_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/108-insert_package_capability.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/108-insert_package_capability.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 108-insert_package_capability.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/108-insert_package_capability.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/108-insert_package_capability.sql.postgresql
@@ -1,0 +1,31 @@
+-- oracle equivalent source sha1 af9d3087adc3dc024e959fce3af12a9f595ba2bd
+
+create or replace function
+insert_package_capability(name_in in varchar, version_in in varchar default null)
+returns numeric
+as
+$$
+declare
+    name_id numeric;
+begin
+    name_id := nextval('rhn_pkg_capability_id_seq');
+
+    insert into rhnPackageCapability(id, name, version)
+        values (name_id, name_in, version_in)
+        on conflict do nothing;
+
+    if version_in is null then
+        select id
+            into strict name_id
+            from rhnpackagecapability
+            where name = name_in and version is null;
+    else
+        select id
+            into strict name_id
+            from rhnpackagecapability
+            where name = name_in and version = version_in;
+    end if;
+
+    return name_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/109-insert_package_delta.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/109-insert_package_delta.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 109-insert_package_delta.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/109-insert_package_delta.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/109-insert_package_delta.sql.postgresql
@@ -1,0 +1,24 @@
+-- oracle equivalent source sha1 3002b1726cc0b956c8fc55d73acfd200a9a0e365
+
+create or replace function
+insert_package_delta(n_in in varchar)
+returns numeric
+as
+$$
+declare
+    name_id     numeric;
+begin
+    name_id := nextval('rhn_packagedelta_id_seq');
+
+    insert into rhnPackageDelta(id, label)
+        values (name_id, n_in)
+        on conflict do nothing;
+
+    select id
+        into strict name_id
+        from rhnpackagedelta
+        where label = n_in;
+
+    return name_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/110-insert_package_group.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/110-insert_package_group.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 110-insert_package_group.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/110-insert_package_group.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/110-insert_package_group.sql.postgresql
@@ -1,0 +1,24 @@
+-- oracle equivalent source sha1 978a2f2728867b46e6ba6fd7bb9cf19f17b08b46
+
+create or replace function
+insert_package_group(name_in in varchar)
+returns numeric
+as
+$$
+declare
+    package_id   numeric;
+begin
+    package_id := nextval('rhn_package_group_id_seq');
+
+    insert into rhnPackageGroup(id, name)
+        values (package_id, name_in)
+        on conflict do nothing;
+
+    select id
+        into strict package_id
+        from rhnPackageGroup
+        where name = name_in;
+
+    return package_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/111-insert_package_name.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/111-insert_package_name.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 111-insert_package_name.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/111-insert_package_name.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/111-insert_package_name.sql.postgresql
@@ -1,0 +1,24 @@
+-- oracle equivalent source sha1 63cf9ec1a31f4c751d88acc08d832ec4e4d925ca
+
+create or replace function
+insert_package_name(name_in in varchar)
+returns numeric
+as
+$$
+declare
+    name_id     numeric;
+begin
+    name_id := nextval('rhn_pkg_name_seq');
+
+    insert into rhnPackageName(id, name)
+        values (name_id, name_in)
+        on conflict do nothing;
+
+    select id
+        into strict name_id
+        from rhnPackageName
+        where name = name_in;
+
+    return name_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/112-insert_package_nevra.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/112-insert_package_nevra.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 112-insert_package_nevra.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/112-insert_package_nevra.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/112-insert_package_nevra.sql.postgresql
@@ -1,0 +1,30 @@
+-- oracle equivalent source sha1 f2794675b98155044a14dd41669af2aa258d2b70
+-- This file is intentionally left empty.
+
+create or replace function
+insert_package_nevra(
+        name_id_in in numeric,
+        evr_id_in in numeric,
+        package_arch_id_in in numeric
+) returns numeric
+as
+$$
+declare
+    nevra_id numeric;
+begin
+    nevra_id := nextval('rhn_pkgnevra_id_seq');
+
+    insert into rhnPackageNEVRA(id, name_id, evr_id, package_arch_id)
+        values (nevra_id, name_id_in, evr_id_in, package_arch_id_in)
+        on conflict do nothing;
+
+    select id
+        into strict nevra_id
+        from rhnPackageNEVRA
+        where name_id = name_id_in and evr_id = evr_id_in and
+            (package_arch_id = package_arch_id_in or
+            (package_arch_id is null and package_arch_id_in is null));
+
+    return nevra_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/113-insert_source_name.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/113-insert_source_name.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 113-insert_source_name.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/113-insert_source_name.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/113-insert_source_name.sql.postgresql
@@ -1,0 +1,24 @@
+-- oracle equivalent source sha1 9ef8d613915e4bfc168838df4d135bc2204bdf63
+
+create or replace function
+insert_source_name(name_in in varchar)
+returns numeric
+as
+$$
+declare
+    source_id   numeric;
+begin
+    source_id := nextval('rhn_sourcerpm_id_seq');
+
+    insert into rhnSourceRPM(id, name)
+        values (source_id, name_in)
+        on conflict do nothing;
+
+    select id
+        into strict source_id
+        from rhnSourceRPM
+        where name = name_in;
+
+    return source_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/114-insert_tag.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/114-insert_tag.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 114-insert_tag.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/114-insert_tag.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/114-insert_tag.sql.postgresql
@@ -1,0 +1,24 @@
+-- oracle equivalent source sha1 1bc937c6a7a4323dc72c90dc79ec0ec0e6fdacb0
+
+create or replace function
+insert_tag(org_id_in in numeric, tag_name_id_in in numeric)
+returns numeric
+as $$
+declare
+    tag_id  numeric;
+begin
+    tag_id := nextval('rhn_tag_id_seq');
+
+    insert into rhnTag(id, org_id, name_id)
+        values (tag_id, org_id_in, tag_name_id_in)
+        on conflict do nothing;
+
+    select id
+        into strict tag_id
+        from rhnTag
+        where org_id = org_id_in and
+            name_id = tag_name_id_in;
+
+    return tag_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/115-insert_tag_name.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/115-insert_tag_name.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 115-insert_tag_name.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/115-insert_tag_name.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/115-insert_tag_name.sql.postgresql
@@ -1,0 +1,24 @@
+-- oracle equivalent source sha1 893b032e20a1ced1cddc9cdba9284a7918088475
+
+create or replace function
+insert_tag_name(name_in in varchar)
+returns numeric
+as
+$$
+declare
+    name_id numeric;
+begin
+    name_id := nextval('rhn_tagname_id_seq');
+
+    insert into rhnTagName(id, name)
+        values (name_id, name_in)
+        on conflict do nothing;
+
+    select id
+        into strict name_id
+        from rhnTagName
+        where name = name_in;
+
+    return name_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/116-insert_transaction_package.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/116-insert_transaction_package.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 116-insert_transaction_package.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/116-insert_transaction_package.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/116-insert_transaction_package.sql.postgresql
@@ -1,0 +1,30 @@
+-- oracle equivalent source sha1 bdf8c145129f7a3609bfccc7959260ada2e7f4d5
+
+create or replace function
+insert_transaction_package(
+    o_id_in      in numeric,
+    n_id_in      in numeric,
+    e_id_in      in numeric,
+    p_arch_id_in in numeric
+)
+returns numeric
+as
+$$
+declare
+    tp_id       numeric;
+begin
+    tp_id := nextval('rhn_transpack_id_seq');
+
+    insert into rhnTransactionPackage (id, operation, name_id, evr_id, package_arch_id)
+        values (tp_id, o_id_in, n_id_in, e_id_in, p_arch_id_in)
+        on conflict do nothing;
+
+    select id
+        into strict tp_id
+        from rhnTransactionPackage
+     where operation = o_id_in and name_id = n_id_in and evr_id = e_id_in and
+        (package_arch_id = p_arch_id_in or (p_arch_id_in is null and package_arch_id is null));
+
+    return tp_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/117-insert_xccdf_benchmark.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/117-insert_xccdf_benchmark.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 117-insert_xccdf_benchmark.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/117-insert_xccdf_benchmark.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/117-insert_xccdf_benchmark.sql.postgresql
@@ -1,0 +1,25 @@
+-- oracle equivalent source sha1 c508c688ca4b4aeca39c5c6ebc7bd712c0a0624f
+-- This file is intentionally left empty.
+
+create or replace function
+insert_xccdf_benchmark(identifier_in in varchar, version_in in varchar)
+returns numeric
+as
+$$
+declare
+    benchmark_id numeric;
+begin
+    benchmark_id := nextval('rhn_xccdf_benchmark_id_seq');
+
+    insert into rhnXccdfBenchmark (id, identifier, version)
+        values (benchmark_id, identifier_in, version_in)
+        on conflict do nothing;
+
+    select id
+        into strict benchmark_id
+        from rhnXccdfBenchmark
+        where identifier = identifier_in and version = version_in;
+
+    return benchmark_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/118-insert_xccdf_ident.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/118-insert_xccdf_ident.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 118-insert_xccdf_ident.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/118-insert_xccdf_ident.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/118-insert_xccdf_ident.sql.postgresql
@@ -1,0 +1,24 @@
+-- oracle equivalent source sha1 5bb52739fa5867d1c5ce574d0796d99d255d567c
+
+create or replace function
+insert_xccdf_ident(ident_sys_id_in in numeric, identifier_in in varchar)
+returns numeric
+as
+$$
+declare
+    xccdf_ident_id numeric;
+begin
+    xccdf_ident_id := nextval('rhn_xccdf_ident_id_seq');
+
+    insert into rhnXccdfIdent (id, identsystem_id, identifier)
+        values (xccdf_ident_id, ident_sys_id_in, identifier_in)
+        on conflict do nothing;
+
+    select id
+        into strict xccdf_ident_id
+        from rhnXccdfIdent
+        where identsystem_id = ident_sys_id_in and identifier = identifier_in;
+
+    return xccdf_ident_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/119-insert_xccdf_ident_system.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/119-insert_xccdf_ident_system.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 119-insert_xccdf_ident_system.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/119-insert_xccdf_ident_system.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/119-insert_xccdf_ident_system.sql.postgresql
@@ -1,0 +1,24 @@
+-- oracle equivalent source sha1 1798ee82aca3353cb24b845fd7fb41c7a85492e5
+
+create or replace function
+insert_xccdf_ident_system(system_in in varchar)
+returns numeric
+as
+$$
+declare
+    ident_sys_id numeric;
+begin
+    ident_sys_id := nextval('rhn_xccdf_identsytem_id_seq');
+
+    insert into rhnXccdfIdentSystem (id, system)
+        values (ident_sys_id, system_in)
+        on conflict do nothing;
+
+    select id
+        into strict ident_sys_id
+        from rhnXccdfIdentSystem
+        where system = system_in;
+
+    return ident_sys_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/120-insert_xccdf_profile.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/120-insert_xccdf_profile.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 120-insert_xccdf_profile.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/120-insert_xccdf_profile.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/120-insert_xccdf_profile.sql.postgresql
@@ -1,0 +1,24 @@
+-- oracle equivalent source sha1 de850fee6f7d36c43367bd48d38f52926321709a
+
+create or replace function
+insert_xccdf_profile(identifier_in in varchar, title_in in varchar)
+returns numeric
+as
+$$
+declare
+    profile_id numeric;
+begin
+    profile_id := nextval('rhn_xccdf_profile_id_seq');
+
+    insert into rhnXccdfProfile (id, identifier, title)
+        values (profile_id, identifier_in, title_in)
+        on conflict do nothing;
+
+    select id
+        into profile_id
+        from rhnXccdfProfile
+        where identifier = identifier_in and title = title_in;
+
+    return profile_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/121-lookup_checksum.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/121-lookup_checksum.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 121-lookup_checksum.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/121-lookup_checksum.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/121-lookup_checksum.sql.postgresql
@@ -1,0 +1,76 @@
+-- oracle equivalent source sha1 0225ad19e699e1083cdce364a0a59e2745a7f4ec
+--
+-- Copyright (c) 2010 - 2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+create or replace function
+lookup_checksum(checksum_type_in in varchar, checksum_in in varchar)
+returns numeric
+as
+$$
+declare
+    checksum_id     numeric;
+begin
+    if checksum_in is null then
+        return null;
+    end if;
+
+    select c.id
+      into checksum_id
+      from rhnChecksumView c
+     where c.checksum = checksum_in and
+           c.checksum_type = checksum_type_in;
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_checksum(checksum_type_in, checksum_in);
+    end if;
+
+    return checksum_id;
+end;
+$$ language plpgsql immutable;
+
+-- NOTE: This is intentionally not thread safe! You must lock rhnChecksum
+-- if you are going to use this procedure!
+create or replace function
+lookup_checksum_fast(checksum_type_in in varchar, checksum_in in varchar)
+returns numeric
+as
+$$
+declare
+    checksum_id     numeric;
+begin
+    if checksum_in is null then
+        return null;
+    end if;
+
+    select c.id
+      into checksum_id
+      from rhnChecksumView c
+     where c.checksum = checksum_in and
+           c.checksum_type = checksum_type_in;
+
+    if not found then
+        checksum_id := nextval('rhnchecksum_seq');
+        insert into rhnChecksum (id, checksum_type_id, checksum) values (
+            checksum_id,
+            (select id from rhnChecksumType where label = checksum_type_in),
+            checksum_in);
+    end if;
+
+    return checksum_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/122-lookup_client_capability.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/122-lookup_client_capability.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 122-lookup_client_capability.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/122-lookup_client_capability.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/122-lookup_client_capability.sql.postgresql
@@ -1,0 +1,37 @@
+-- oracle equivalent source sha1 2c0cc0149995c1afcceac8cdf3778befc01e05e0
+--
+-- Copyright (c) 2008--2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+-- 
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation. 
+
+create or replace function
+lookup_client_capability(name_in in varchar)
+returns numeric
+as $$
+declare
+    cap_name_id     numeric;
+begin
+    select id
+      into cap_name_id
+      from rhnclientcapabilityname
+     where name = name_in;
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_client_capability(name_in);
+    end if;
+
+    return cap_name_id;
+end;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/123-lookup_config_filename.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/123-lookup_config_filename.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 123-lookup_config_filename.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/123-lookup_config_filename.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/123-lookup_config_filename.sql.postgresql
@@ -1,0 +1,37 @@
+-- oracle equivalent source sha1 b9e8c5639bae45adbd00c795fc4d04cd01655a2c
+--
+-- Copyright (c) 2008--2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+
+create or replace function
+lookup_config_filename(name_in in varchar)
+returns numeric as
+$$
+declare
+    name_id     numeric;
+begin
+    select id
+      into name_id
+      from rhnconfigfilename
+     where path = name_in;
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_config_filename(name_in);
+    end if;
+
+    return name_id;
+end;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/124-lookup_config_info.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/124-lookup_config_info.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 124-lookup_config_info.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/124-lookup_config_info.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/124-lookup_config_info.sql.postgresql
@@ -1,0 +1,49 @@
+-- oracle equivalent source sha1 1888a3eac85d246d34804ca296db9a62819eac51
+--
+-- Copyright (c) 2008--2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+create or replace function
+lookup_config_info(
+    username_in     in varchar,
+    groupname_in    in varchar,
+    filemode_in     in numeric,
+    selinux_ctx_in  in varchar,
+    symlink_target_id in numeric
+)
+returns numeric
+as
+$$
+declare
+    config_info_id    numeric;
+begin
+    select id
+      into config_info_id
+      from rhnConfigInfo
+      where (username = username_in or (username is null and username_in is null))
+        and (groupname = groupname_in or (groupname is null and groupname_in is null))
+        and (filemode = filemode_in or (filemode is null and filemode_in is null))
+        and (selinux_ctx = selinux_ctx_in or (selinux_ctx is null and selinux_ctx_in is null))
+        and (symlink_target_filename_id = symlink_target_id or (symlink_target_filename_id is null and symlink_target_id is null));
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_config_info(username_in, groupname_in, filemode_in, selinux_ctx_in, symlink_target_id);
+    end if;
+
+    return config_info_id;
+end;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/125-lookup_cve.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/125-lookup_cve.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 125-lookup_cve.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/125-lookup_cve.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/125-lookup_cve.sql.postgresql
@@ -1,0 +1,37 @@
+-- oracle equivalent source sha1 0b23acd7ea9c0a9394848876023fab53c6708545
+--
+-- Copyright (c) 2008--2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+
+create or replace function
+lookup_cve(name_in in varchar)
+returns numeric
+as $$
+declare
+    name_id     numeric;
+begin
+    select id
+      into name_id
+      from rhnCVE
+     where name = name_in;
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_cve(name_in);
+    end if;
+
+    return name_id;
+end;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/126-lookup_evr.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/126-lookup_evr.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 126-lookup_evr.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/126-lookup_evr.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/126-lookup_evr.sql.postgresql
@@ -1,0 +1,40 @@
+-- oracle equivalent source sha1 ef78cdb81a113fe886881179651b9b848698c453
+--
+-- Copyright (c) 2008--2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+
+create or replace function
+lookup_evr(e_in in varchar, v_in in varchar, r_in in varchar)
+returns numeric
+as
+$$
+declare
+    evr_id  numeric;
+begin
+    select id
+      into evr_id
+      from rhnPackageEVR
+     where ((epoch is null and e_in is null) or (epoch = e_in)) and
+           version = v_in and
+           release = r_in;
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_evr(e_in, v_in, r_in);
+    end if;
+
+    return evr_id;
+end;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/127-lookup_md_keyword.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/127-lookup_md_keyword.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 127-lookup_md_keyword.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/127-lookup_md_keyword.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/127-lookup_md_keyword.sql.postgresql
@@ -1,0 +1,35 @@
+-- oracle equivalent source sha1 6f7a55edba8ff32557af08c51aeb74da1d77ff78
+--
+-- Copyright (c) 2012 Novell
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+create or replace function
+lookup_md_keyword(label_in in varchar)
+returns numeric
+as
+$$
+declare
+    md_keyword_id numeric;
+begin
+    select id
+      into md_keyword_id
+      from suseMdKeyword
+     where label = label_in;
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_md_keyword(label_in);
+    end if;
+
+    return md_keyword_id;
+end;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/128-lookup_package_capability.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/128-lookup_package_capability.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 128-lookup_package_capability.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/128-lookup_package_capability.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/128-lookup_package_capability.sql.postgresql
@@ -1,0 +1,80 @@
+-- oracle equivalent source sha1 63aa4b2010dda2391c902d0da5d40fadf76ec628
+--
+-- Copyright (c) 2008--2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+-- 
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation. 
+
+create or replace function
+lookup_package_capability(name_in in varchar, version_in in varchar default null)
+returns numeric
+as
+$$
+declare
+    name_id numeric;
+begin
+    if version_in is null then
+        select id
+          into name_id
+          from rhnpackagecapability
+         where name = name_in and
+               version is null;
+    else
+        select id
+          into name_id
+          from rhnpackagecapability
+         where name = name_in and
+               version = version_in;
+    end if;
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_package_capability(name_in, version_in);
+    end if;
+
+    return name_id;
+end;
+$$ language plpgsql immutable;
+
+-- Note: intentionally not thread-safe! You must aquire a write lock on the
+-- rhnPackageCapability tabel if you are going to use this proc!
+create or replace function lookup_package_capability_fast(name_in in varchar, version_in in varchar default null)
+returns numeric
+as
+$$
+declare
+    name_id numeric;
+begin
+    if version_in is null then
+        select id
+          into name_id
+          from rhnpackagecapability
+         where name = name_in and
+               version is null;
+    else
+        select id
+          into name_id
+          from rhnpackagecapability
+         where name = name_in and
+               version = version_in;
+    end if;
+
+    if not found then
+        name_id := nextval('rhn_pkg_capability_id_seq');
+        insert into rhnPackageCapability(id, name, version) values (
+               name_id, name_in, version_in);
+    end if;
+
+    return name_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/129-lookup_package_delta.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/129-lookup_package_delta.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 129-lookup_package_delta.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/129-lookup_package_delta.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/129-lookup_package_delta.sql.postgresql
@@ -1,0 +1,38 @@
+-- oracle equivalent source sha1 b6dfecd62c143e60f2ed67bedeaebf23013c7fcd
+--
+-- Copyright (c) 2008--2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+-- 
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation. 
+
+create or replace function
+lookup_package_delta(n_in in varchar)
+returns numeric
+as
+$$
+declare
+    name_id     numeric;
+begin
+    select id
+      into name_id
+      from rhnPackageDelta
+     where label = n_in;
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_package_delta(n_in);
+    end if;
+
+    return name_id;
+end;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/130-lookup_package_group.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/130-lookup_package_group.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 130-lookup_package_group.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/130-lookup_package_group.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/130-lookup_package_group.sql.postgresql
@@ -1,0 +1,38 @@
+-- oracle equivalent source sha1 eb1046feed4796e1898cb6365dcac0c192e229bd
+--
+-- Copyright (c) 2008--2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+-- 
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation. 
+
+create or replace function
+lookup_package_group(name_in in varchar)
+returns numeric
+as
+$$
+declare
+    package_id   numeric;
+begin
+    select id
+      into package_id
+      from rhnPackageGroup
+     where name = name_in;
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_package_group(name_in);
+    end if;
+
+    return package_id;
+end;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/131-lookup_package_name.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/131-lookup_package_name.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 131-lookup_package_name.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/131-lookup_package_name.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/131-lookup_package_name.sql.postgresql
@@ -1,0 +1,42 @@
+-- oracle equivalent source sha1 0a62bbccb566b9483e2059f68e8252a9b0730d17
+--
+-- Copyright (c) 2008--2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+-- 
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation. 
+
+create or replace function
+lookup_package_name(name_in in varchar, ignore_null in numeric default 0)
+returns numeric
+as
+$$
+declare
+    name_id     numeric;
+begin
+    if ignore_null = 1 and name_in is null then
+        return null;
+    end if;
+
+    select id
+      into name_id
+      from rhnPackageName
+     where name = name_in;
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_package_name(name_in);
+    end if;
+
+    return name_id;
+end;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/132-lookup_package_nevra.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/132-lookup_package_nevra.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 132-lookup_package_nevra.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/132-lookup_package_nevra.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/132-lookup_package_nevra.sql.postgresql
@@ -1,0 +1,49 @@
+-- oracle equivalent source sha1 5938e8d50de9fafb917955bd4a1b50aeee12cae7
+--
+-- Copyright (c) 2008--2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+-- 
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation. 
+
+create or replace function
+lookup_package_nevra(
+        name_id_in in numeric,
+        evr_id_in in numeric,
+        package_arch_id_in in numeric,
+        ignore_null_name in numeric default 0
+) returns numeric
+as
+$$
+declare
+    nevra_id numeric;
+begin
+    if ignore_null_name = 1 and name_id_in is null then
+        return null;
+    end if;
+
+    select id
+      into nevra_id
+      from rhnPackageNEVRA
+     where name_id = name_id_in and
+           evr_id = evr_id_in and
+           (package_arch_id = package_arch_id_in or
+            (package_arch_id is null and package_arch_id_in is null));
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_package_nevra(name_id_in, evr_id_in, package_arch_id_in);
+    end if;
+
+    return nevra_id;
+end;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/133-lookup_source_name.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/133-lookup_source_name.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 133-lookup_source_name.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/133-lookup_source_name.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/133-lookup_source_name.sql.postgresql
@@ -1,0 +1,38 @@
+-- oracle equivalent source sha1 cc999f2ebd529353b8b7994cbee276e40a4cc396
+--
+-- Copyright (c) 2008--2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+-- 
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation. 
+
+create or replace function
+lookup_source_name(name_in in varchar)
+returns numeric
+as
+$$
+declare
+    source_id   numeric;
+begin
+    select id
+      into source_id
+      from rhnSourceRPM
+     where name = name_in;
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_source_name(name_in);
+    end if;
+
+    return source_id;
+end;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/134-lookup_tag.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/134-lookup_tag.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 134-lookup_tag.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/134-lookup_tag.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/134-lookup_tag.sql.postgresql
@@ -1,0 +1,41 @@
+-- oracle equivalent source sha1 d866228c3de07511d70f723c031efb8c4e25f9a5
+--
+-- Copyright (c) 2008--2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+-- 
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation. 
+
+create or replace function
+lookup_tag(org_id_in in numeric, name_in in varchar)
+returns numeric
+as $$
+declare
+    tag_id  numeric;
+    tag_name_id numeric;
+begin
+    tag_name_id := lookup_tag_name(name_in);
+
+    select id
+      into tag_id
+      from rhnTag
+     where org_id = org_id_in and
+           name_id = tag_name_id;
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_tag(org_id_in, tag_name_id);
+    end if;
+
+    return tag_id;
+end;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/135-lookup_tag_name.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/135-lookup_tag_name.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 135-lookup_tag_name.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/135-lookup_tag_name.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/135-lookup_tag_name.sql.postgresql
@@ -1,0 +1,38 @@
+-- oracle equivalent source sha1 d7587043d8c28a331c33fa9b327c42bbd22ef38f
+--
+-- Copyright (c) 2008--2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+-- 
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation. 
+
+create or replace function
+lookup_tag_name(name_in in varchar)
+returns numeric
+as
+$$
+declare
+    name_id numeric;
+begin
+    select id
+      into name_id
+      from rhnTagName
+     where name = name_in;
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_tag_name(name_in);
+    end if;
+
+    return name_id;
+end;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/136-lookup_transaction_package.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/136-lookup_transaction_package.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 136-lookup_transaction_package.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/136-lookup_transaction_package.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/136-lookup_transaction_package.sql.postgresql
@@ -1,0 +1,67 @@
+-- oracle equivalent source sha1 953793286af21ec441a8b64186acea36e7d6b691
+--
+-- Copyright (c) 2008--2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+-- 
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation. 
+
+create or replace function
+lookup_transaction_package(
+    o_in in varchar,
+    n_in in varchar,
+    e_in in varchar,
+    v_in in varchar,
+    r_in in varchar,
+    a_in in varchar)
+returns numeric
+as
+$$
+declare
+    o_id        numeric;
+    n_id        numeric;
+    e_id        numeric;
+    p_arch_id   numeric;
+    tp_id       numeric;
+begin
+    select id
+      into o_id
+      from rhnTransactionOperation
+     where label = o_in;
+
+    if not found then
+        perform rhn_exception.raise_exception('invalid_transaction_operation');
+    end if;
+
+    n_id := lookup_package_name(n_in);
+    e_id := lookup_evr(e_in, v_in, r_in);
+    p_arch_id := null;
+
+    if a_in is not null then
+        p_arch_id := lookup_package_arch(a_in);
+    end if;
+
+    select id
+      into tp_id
+      from rhnTransactionPackage
+     where operation = o_id and
+           name_id = n_id and
+           evr_id = e_id and
+           (package_arch_id = p_arch_id or (p_arch_id is null and package_arch_id is null));
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_transaction_package(o_id, n_id, e_id, p_arch_id);
+    end if;
+    return tp_id;
+end;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/137-lookup_xccdf_benchmark.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/137-lookup_xccdf_benchmark.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 137-lookup_xccdf_benchmark.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/137-lookup_xccdf_benchmark.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/137-lookup_xccdf_benchmark.sql.postgresql
@@ -1,0 +1,39 @@
+-- oracle equivalent source sha1 9b75cfbbfa0531fdf97dd169d6e8a63abe7c795c
+--
+-- Copyright (c) 2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+create or replace function
+lookup_xccdf_benchmark(identifier_in in varchar, version_in in varchar)
+returns numeric
+as
+$$
+declare
+    benchmark_id numeric;
+begin
+    select id
+      into benchmark_id
+      from rhnXccdfBenchmark
+     where identifier = identifier_in and version = version_in;
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_xccdf_benchmark(identifier_in, version_in);
+    end if;
+
+    return benchmark_id;
+end;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/138-lookup_xccdf_ident.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/138-lookup_xccdf_ident.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 138-lookup_xccdf_ident.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/138-lookup_xccdf_ident.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/138-lookup_xccdf_ident.sql.postgresql
@@ -1,0 +1,48 @@
+-- oracle equivalent source sha1 6f09853b0bd3173b3e1a07d30d0a061c20d47a91
+--
+-- Copyright (c) 2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+
+create or replace function
+lookup_xccdf_ident(system_in in varchar, identifier_in in varchar)
+returns numeric
+as
+$$
+declare
+    xccdf_ident_id numeric;
+    ident_sys_id numeric;
+begin
+    select id
+      into ident_sys_id
+      from rhnXccdfIdentSystem
+     where system = system_in;
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        ident_sys_id := insert_xccdf_ident_system(system_in);
+    end if;
+
+    select id
+      into xccdf_ident_id
+      from rhnXccdfIdent
+     where identsystem_id = ident_sys_id and identifier = identifier_in;
+
+    if not found then
+        return insert_xccdf_ident(ident_sys_id, identifier_in);
+    end if;
+
+    return xccdf_ident_id;
+end;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/139-lookup_xccdf_profile.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/139-lookup_xccdf_profile.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 139-lookup_xccdf_profile.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/139-lookup_xccdf_profile.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.9-to-susemanager-schema-4.0.10/139-lookup_xccdf_profile.sql.postgresql
@@ -1,0 +1,39 @@
+-- oracle equivalent source sha1 905affce9dc1fe13f9ea7c4f8cac1a875b916723
+--
+-- Copyright (c) 2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+create or replace function
+lookup_xccdf_profile(identifier_in in varchar, title_in in varchar)
+returns numeric
+as
+$$
+declare
+    profile_id numeric;
+begin
+    select id
+      into profile_id
+      from rhnXccdfProfile
+     where identifier = identifier_in and title = title_in;
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_xccdf_profile(identifier_in, title_in);
+    end if;
+
+    return profile_id;
+end;
+$$ language plpgsql immutable;


### PR DESCRIPTION
## What does this PR change?

A previous patch removed the `IMMUTABLE` function keyword, which is detrimental to performance as the optimizer will compute the result once per row instead of once per query.

The choice of `IMMUTABLE` is debatable, as per Postgres recommendations `VOLATILE` should be used for any function that alters the database.

https://www.postgresql.org/docs/9.6/xfunc-volatility.html

OTOH, looking exactly at the types of optimizations described, it seems safe to assume `IMMUTABLE` will not cause problems because of the specific nature of these functions - they will never return different values, and they need to be called at least once (in the entire lifetime of the database). We do not really care if that is during the query preparation or query execution.

Indeed `IMMUTABLE` was already there in previous code which did alter the database for many years.

This patch thus assumes it is safe to retain that behavior.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **functions are covered by Cucumber and JUnit tests**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/7262
Tracks https://github.com/SUSE/spacewalk/pull/7413

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
