### PR TITLE
Fix "spacewalk-clone-by-date" and other "spacewalk-utils" scripts

### DIFF
--- a/backend/common/cli.py
+++ b/backend/common/cli.py
@@ -15,6 +15,7 @@
 
 import sys
 import getpass
+import io
 try:
     #  python 2
     import xmlrpclib
@@ -35,7 +36,7 @@ def getUsernamePassword(cmdlineUsername, cmdlinePassword):
     password = cmdlinePassword
 
     # Read the username, if not already specified
-    tty = open("/dev/tty", "r+")
+    tty = io.TextIOWrapper(open("/dev/tty", "r+b", buffering=0))
     while not username:
         tty.write("SUSE Manager username: ")
         try:

--- a/backend/common/spacewalk-cfg-get
+++ b/backend/common/spacewalk-cfg-get
@@ -15,9 +15,9 @@ elif len(sys.argv) == 2:
     comp = ''
     key = sys.argv[1]
 else:
-    print "Usage: spacewalk-cfg-get list COMPONENT"
-    print "       spacewalk-cfg-get get COMPONENT KEY"
-    print "       spacewalk-cfg-get KEY"
+    print("Usage: spacewalk-cfg-get list COMPONENT")
+    print("       spacewalk-cfg-get get COMPONENT KEY")
+    print("       spacewalk-cfg-get KEY")
     sys.exit(1)
 
 cfg = RHNOptions(comp)
@@ -29,6 +29,6 @@ else:
     val = cfg.get(key)
     if isinstance(val, list):
         for i in val:
-            print i
+            print(i)
     elif val != None:
-        print val
+        print(val)

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,6 @@
+- Migrate missing spacewalk-cfg-get script to Python3
+- Improve dependency solving algorithm for spacewalk-repo-sync.
+
 -------------------------------------------------------------------
 Mon Mar 25 16:41:48 CET 2019 - jgonzalez@suse.com
 

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/RpmRepositoryWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/RpmRepositoryWriter.java
@@ -325,8 +325,7 @@ public class RpmRepositoryWriter extends RepositoryWriter {
         renameSolv(prefix, channel.getLastModified().getTime());
     }
 
-    private void generateSolv(Channel channel)
-    {
+    private void generateSolv(Channel channel) {
         String repodir  = mountPoint + File.separator + pathPrefix +
                           File.separator + channel.getLabel() + File.separator;
         String solvout  = repodir + SOLV_FILE;
@@ -339,12 +338,14 @@ public class RpmRepositoryWriter extends RepositoryWriter {
             // Determine the exit value
             int exitVal = pr.waitFor();
             if (exitVal != 0) {
-                log.error("Unable to create the solv file for '"+
+                log.error("Unable to create the solv file for '" +
                           channel.getLabel() + "'");
             }
-        } catch (IOException e) {
+        }
+        catch (IOException e) {
             throw new RuntimeException(e);
-        } catch (InterruptedException e) {
+        }
+        catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
         log.info("Solv file successfully create for '" + channel.getLabel() + "'");

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/RpmRepositoryWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/RpmRepositoryWriter.java
@@ -61,6 +61,8 @@ public class RpmRepositoryWriter extends RepositoryWriter {
     private static final String PRODUCTS_FILE = "products.xml";
     private static final String SUSEDATA_FILE = "susedata.xml.gz.new";
     private static final String NOREPO_FILE = "noyumrepo.txt";
+    private static final String SOLV_FILE = "solv.new";
+    private static final String REPO2SOLV = "/usr/bin/repo2solv.sh";
 
     private static final String GROUP = "groups";
     private static final String MODULES = "modules";
@@ -318,6 +320,34 @@ public class RpmRepositoryWriter extends RepositoryWriter {
         log.info("Repository metadata generation for '" +
                 channel.getLabel() + "' finished in " +
                 (int) (new Date().getTime() - start.getTime()) / 1000 + " seconds");
+
+        generateSolv(channel);
+        renameSolv(prefix, channel.getLastModified().getTime());
+    }
+
+    private void generateSolv(Channel channel)
+    {
+        String repodir  = mountPoint + File.separator + pathPrefix +
+                          File.separator + channel.getLabel() + File.separator;
+        String solvout  = repodir + SOLV_FILE;
+        try {
+            // Execute the command
+            Runtime rt = Runtime.getRuntime();
+            String[] command = {REPO2SOLV, "-o", solvout, repodir};
+            Process pr = rt.exec(command, new String[]{});
+
+            // Determine the exit value
+            int exitVal = pr.waitFor();
+            if (exitVal != 0) {
+                log.error("Unable to create the solv file for '"+
+                          channel.getLabel() + "'");
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        log.info("Solv file successfully create for '" + channel.getLabel() + "'");
     }
 
     /**
@@ -574,4 +604,11 @@ public class RpmRepositoryWriter extends RepositoryWriter {
         repomd.renameTo(new File(prefix + "repomd.xml"));
     }
 
+    private void renameSolv(String prefix, Long lastModified) {
+        File solv = new File(prefix + SOLV_FILE);
+
+        solv.setLastModified(lastModified);
+
+        solv.renameTo(new File(prefix + "solv"));
+    }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Generate solv file when repository metadata is created
 - Fix errata_details to return details correctly (bsc#128228)
 - prevent an error when onboarding a RES 6 minion (bsc#1124794)
 

--- a/spacewalk/certs-tools/rhn_ssl_tool.py
+++ b/spacewalk/certs-tools/rhn_ssl_tool.py
@@ -1328,7 +1328,7 @@ def main():
     """
 
     def writeError(e):
-        sys.stderr.write(bstr('\nERROR: %s\n' % e))
+        sys.stderr.write('\nERROR: %s\n' % e)
 
     ret = 0
     try:

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,5 @@
+- Prevent encoding issues when exceptions are triggered.
+
 -------------------------------------------------------------------
 Wed Feb 27 13:00:34 CET 2019 - jgonzalez@suse.com
 

--- a/utils/apply_errata
+++ b/utils/apply_errata
@@ -37,7 +37,7 @@ except ImportError:
 try:
     import httplib
 except ImportError:
-    import httplib.client as httplib  # pylint: disable=F0401
+    import http.client as httplib  # pylint: disable=F0401
 
 prog = sys.argv[0]
 today = "%d-%d-%d" % (localtime()[2], localtime()[1], localtime()[0])

--- a/utils/cloneByDate.py
+++ b/utils/cloneByDate.py
@@ -732,10 +732,10 @@ class ChannelCloner:
 
     @staticmethod
     def pkg_exists(needed_list, pkg_list):
-        """Given a list of packages in [N, V, E, R, A] format, do any of them
+        """Given a list of packages in [N, EVR, A] format, do any of them
             exist in the pkg_hash with key of N-V-R.A  format"""
         for i in needed_list:
-            key = "%s-%s-%s.%s" % (i[0], i[1], i[3], i[4])
+            key = "%s-%s-.%s" % (i[0], i[1], i[2])
             if key in pkg_list:
                 return pkg_list[key]
         return False

--- a/utils/cloneByDate.py
+++ b/utils/cloneByDate.py
@@ -27,7 +27,6 @@ import datetime
 import re
 
 from salt.ext import six
-from yum.Errors import RepoError
 
 try:
     import xmlrpclib
@@ -51,7 +50,7 @@ except ImportError:
     from common.rhnConfig import CFG, initCFG
     from satellite_tools.progress_bar import ProgressBar
 
-from depsolver import DepSolver
+from .depsolver import DepSolver
 
 
 LOG_LOCATION = '/var/log/rhn/errata-clone.log'
@@ -496,17 +495,16 @@ class ChannelTreeCloner:
         temp_repo_links = []
         repo = None
         for repo in repos:
-            yum_repodata_path = "%s/repodata" % (repo['relative_path'])
-            create_repodata_link(repo['relative_path'], yum_repodata_path)
-            temp_repo_links.append(yum_repodata_path)
+            repodata_path = "%s/repodata" % (repo['relative_path'])
+            create_repodata_link(repo['relative_path'], repodata_path)
+            temp_repo_links.append(repodata_path)
         try:
             try:
                 self.solver = DepSolver(repos)
                 self.__dep_solve(nvrea_list)
                 self.report_depsolve_results()
-                self.solver.cleanup()
-            except RepoError as e:
-                raise UserRepoError(repo["id"], e.value)
+            except Exception as e:
+                raise UserRepoError(repo["id"], e)
         finally:
             # clean up temporary symlinks
             for link in temp_repo_links:
@@ -751,7 +749,7 @@ class ChannelCloner:
         print(msg)
         log_clean(0, "")
         log_clean(0, msg)
-        for e in sorted(self.errata_to_clone):
+        for e in sorted(self.errata_to_clone, key=lambda x: x['advisory_name']):
             log_clean(0, "%s - %s" % (e['advisory_name'], e['synopsis']))
 
         pb = ProgressBar(prompt="", endTag=' - complete',
@@ -1030,10 +1028,10 @@ class UserError(Exception):
 
 class UserRepoError(UserError):
 
-    def __init__(self, label, yum_error=None):
+    def __init__(self, label, error=None):
         msg = ("Unable to read repository information.\n"
                + "Please verify repodata has been generated in "
                + "/var/cache/rhn/repodata/%s." % label)
-        if yum_error:
-            msg += "\nError from yum: %s" % yum_error
+        if error:
+            msg += "\nError: %s" % error
         UserError.__init__(self, msg)

--- a/utils/spacewalk-api
+++ b/utils/spacewalk-api
@@ -17,6 +17,7 @@
 
 from getpass import getpass
 from optparse import Option, OptionParser
+import io
 import re
 import sys
 
@@ -49,7 +50,7 @@ def processCommandline(argv):
         sys.exit(1)
 
     if not options.username and options.login:
-        with open('/dev/tty', 'r+') as tty:
+        with io.TextIOWrapper(open('/dev/tty', 'r+b', buffering=0)) as tty:
             tty.write('Enter username: ')
             try:
                 options.username = tty.readline()

--- a/utils/spacewalk-common-channels
+++ b/utils/spacewalk-common-channels
@@ -68,7 +68,7 @@ class ExtOptionParser(OptionParser):
 def connect(user, password, server):
     server_url = "http://%s/rpc/api" % server
 
-    if options.verbose > 2:
+    if options.verbose and options.verbose > 2:
         client_verbose = options.verbose - 2
     else:
         client_verbose = 0
@@ -89,7 +89,7 @@ def add_channels(channels, section, arch, client):
 
     if config.has_option(section, 'base_channels'):
         base_channels = re.split(SPLIT_PATTERN,
-                                 config.get(section, 'base_channels', 1))
+                                 config.get(section, 'base_channels'), 1)
 
     config.set(section, 'arch', arch)
     config.set(section, 'section', section)

--- a/utils/spacewalk-export
+++ b/utils/spacewalk-export
@@ -29,7 +29,6 @@ import sys
 
 from optparse import OptionParser, OptionGroup
 from os.path import expanduser
-from string import split
 from subprocess import call
 
 home = expanduser("~")
@@ -141,7 +140,7 @@ def setupEntities(options):
     if doAll:
         return entities
 
-    for e in split(options.entities, ','):
+    for e in options.entities.split(','):
         if e in list(entities.keys()):
             entities[e] = True
         else:

--- a/utils/spacewalk-export-channels
+++ b/utils/spacewalk-export-channels
@@ -17,7 +17,6 @@
 #
 
 from optparse import Option, OptionParser
-import commands
 import os
 import shutil
 import stat
@@ -212,15 +211,15 @@ def cp_to_export_dir(pkg_path, dir, options):
 
 def create_repository(repo_dir, options):
     cmd = "createrepo --help | grep 'no-database' | wc -l"
-    (status, output) = commands.getstatusoutput(cmd)
+    (status, output) = subprocess.getstatusoutput(cmd)
     hits = int(output)
     if hits: # 'Our' createrepo understands --no-database
         p = subprocess.Popen(["createrepo", "--no-database", repo_dir], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     else:    # 'Our' createrepo does NOT understand --no-database
         p = subprocess.Popen(["createrepo", repo_dir], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     out, err = p.communicate()
-    split_and_log_to_level(3, 4, out)
-    split_and_log_to_level(2, 4, err)
+    split_and_log_to_level(3, 4, out.decode())
+    split_and_log_to_level(2, 4, err.decode())
 
 
 def pkgs_available_in_repos(pkg, repo_packages):

--- a/utils/spacewalk-manage-channel-lifecycle
+++ b/utils/spacewalk-manage-channel-lifecycle
@@ -26,6 +26,7 @@ import os
 import re
 import sys
 import time
+from salt.ext import six
 from optparse import Option, OptionParser
 from socket import gethostname
 
@@ -472,7 +473,7 @@ if len(phases) < 2:
     sys.exit(1)
 
 # determine if you want to enable XMLRPC debugging
-if options.debug > 1:
+if options.debug and options.debug > 1:
     xmlrpc_debug = True
 else:
     xmlrpc_debug = False

--- a/utils/spacewalk-sync-setup
+++ b/utils/spacewalk-sync-setup
@@ -22,8 +22,6 @@
 import logging
 import os
 import sys
-import string
-from string import lower
 from optparse import OptionParser, OptionGroup
 from os import path, access, R_OK
 from os.path import expanduser
@@ -481,10 +479,10 @@ def apply_slave_template(slave_session, slave_setup_filename):
         moids = slave_setup.options(fqdn)
         # key is either master-org-id, or one of (isDefault, cacert) - skip those
         for moid in moids:  # moid|moname|local_oid
-            if lower(moid) == "isdefault" or lower(moid) == "cacert":
+            if moid.lower() == "isdefault" or moid.lower() == "cacert":
                 continue
             minfo = slave_setup.get(fqdn, moid)
-            elts = string.split(minfo, '|')
+            elts = minfo.split('|')
             orginfo = {}
             orginfo['masterOrgId'] = int(elts[0])
             orginfo['masterOrgName'] = elts[1]
@@ -527,10 +525,10 @@ def describe_slave_template(slave_setup_filename):
 
         moids = slave_setup.options(fqdn)
         for moid in moids:  # moid|moname|local_oid
-            if lower(moid) == "isdefault" or lower(moid) == "cacert":
+            if moid.lower() == "isdefault" or moid.lower() == "cacert":
                 continue
             minfo = slave_setup.get(fqdn, moid)
-            elts = string.split(minfo, '|')
+            elts = minfo.split('|')
             logging.info("  Mapping master OrgId [%s], named [%s], to local OrgId [%s]" %
                          (elts[0], elts[1], elts[2]))
         logging.info("")

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,8 @@
+- Add support on depsolver to use a custom input file and produce YAML output.
+- Fix depsolver to use libsolv instead of yum library.
+- Fix spacewalk-clone-by-date to not depend on yum.
+- Fix issues in spacewalk scripts after migration to Python 3.
+
 -------------------------------------------------------------------
 Mon Mar 25 16:48:23 CET 2019 - jgonzalez@suse.com
 

--- a/utils/taskotop
+++ b/utils/taskotop
@@ -24,11 +24,7 @@ import os.path
 
 from spacewalk.server import rhnSQL
 
-try:
-    # python 2
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
+from io import BytesIO
 
 
 DEFAULT_LOGFILE = './taskotop.log'
@@ -304,12 +300,13 @@ def extract_channel_ids(bytes):
     # represent numbers, we assume they are channel_ids
     # (currently this is the case)
     java_strings = []
-    io = StringIO(bytes)
+    io = BytesIO(bytes)
+
     while True:
         char = io.read(1)
-        if char == "":
+        if char == b"":
             break
-        elif char == "t":
+        elif char == b"t":
             oldpos = io.tell()
             try:
                 length = struct.unpack(">H", io.read(2))[0]
@@ -319,7 +316,7 @@ def extract_channel_ids(bytes):
                 pass # not a real string, ignore
             io.seek(oldpos)
     # of those found, filter the ones looking like a number
-    return [java_string for java_string in java_strings if java_string.isdigit()]
+    return [java_string.decode() for java_string in java_strings if java_string.isdigit()]
 
 # column indexes for ps output
 IX_PID  = 0
@@ -483,7 +480,7 @@ def seconds_to_hms_string(seconds):
     retval += '%02d:' % m
     retval += '%02d' % s
     return retval
-    
+
 def format_elapsed_time(rowdata, data_key, width):
     """Formats the elapsed time for display."""
     end = datetime.datetime.now()
@@ -491,7 +488,7 @@ def format_elapsed_time(rowdata, data_key, width):
         end = rowdata["end_time"]
 
     td = end.replace(tzinfo=None) - rowdata["start_time"].replace(tzinfo=None)
-    seconds = (td.microseconds + (td.seconds + td.days * 24 * 3600) * 10**6) / 10**6
+    seconds = int((td.microseconds + (td.seconds + td.days * 24 * 3600) * 10**6) / 10**6)
     if HUMAN_READABLE:
         return seconds_to_hms_string(seconds)
     return "{0}s".format(seconds)
@@ -674,7 +671,7 @@ if args.showStart:
 if args.hideElapsed:
     SHOW_ELAPSED_TIME = False
     log_debug('ELAPSED column will be hidden')
-    
+
 try:
     curses.wrapper(main)
 except rhnSQL.SQLConnectError:


### PR DESCRIPTION
## What does this PR change?

This PR adds several leftovers (mostly for `spacewalk-utils`) to be include into Beta2:
- Migrate `cloneByDate.py` and `depsolver.py` away from yum.
- Add dependency solving based on libsolv for `depsolver`
- Add support in `depsolver` to collect input parameters from a YAML file and produce YAML output.
- Create `solv` file as part of channel metadata creation job in Taskomatic.
- Improve dependency solving algorithm on `spacewalk-repo-sync`.
- Prevent encoding issue when raising exceptions on `spacewalk-certs-tools`.
- Fix multiple issues related with Python3 migration from `spacewalk-utils` scripts.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **porting to python3**

- [x] **DONE**

## Test coverage
- No tests: **porting to python3**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/salt-board/issues/221

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle" 		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
