### PR TITLE
Include "arch" to distinct between latest packages on "spacewalk-repo-sync"

### DIFF
--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -862,8 +862,9 @@ type=rpm-md
             latest_pkgs = {}
             new_pkgs = []
             for pkg in pkglist:
-               if pkg.name not in latest_pkgs.keys() or LooseVersion(str(pkg.evr)) > LooseVersion(str(latest_pkgs[pkg.name].evr)):
-                  latest_pkgs[pkg.name] = pkg
+               ident = '{}.{}'.format(pkg.name, pkg.arch)
+               if ident not in latest_pkgs.keys() or LooseVersion(str(pkg.evr)) > LooseVersion(str(latest_pkgs[ident].evr)):
+                  latest_pkgs[ident] = pkg
             pkglist = list(latest_pkgs.values())
 
         to_return = []

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Include arch to distinct latest packages on reposync.
 - Migrate missing spacewalk-cfg-get script to Python3
 - Improve dependency solving algorithm for spacewalk-repo-sync.
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue when using the `--latest` parameter on `spacewalk-repo-sync` which is currently not considering the "arch" for collecting the latest version of a package.

This means that i.a. `xulrunner-31.6.0-2.el7_1.x86_64` is basically considered the same as `xulrunner-31.6.0-2.el7_1.i686`, therefore only one of them is included in the final latest package list where both should be included since they're the latest version of this package for each architecture.

With this PR, the `arch` is used together with the package name as a `pkgname.arch` identifier for which latest version is collected.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **python3 migration**

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
