### PR TITLE
Content management promote

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/events/AlignSoftwareTargetAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/AlignSoftwareTargetAction.java
@@ -15,12 +15,10 @@
 
 package com.redhat.rhn.frontend.events;
 
-import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.messaging.EventMessage;
 import com.redhat.rhn.common.messaging.MessageAction;
 import com.redhat.rhn.common.security.PermissionException;
-import com.redhat.rhn.domain.contentmgmt.SoftwareEnvironmentTarget;
-import com.redhat.rhn.domain.contentmgmt.SoftwareProjectSource;
+import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.manager.channel.ChannelManager;
 import com.redhat.rhn.manager.user.UserManager;
 import org.apache.log4j.Logger;
@@ -29,7 +27,7 @@ import java.time.Duration;
 import java.time.Instant;
 
 /**
- * Align Errata and Packages of {@link SoftwareEnvironmentTarget} to its corresponding {@link SoftwareProjectSource}
+ * Align Errata and Packages of {@link Channel} to given {@link Channel}
  *
  */
 public class AlignSoftwareTargetAction implements MessageAction {
@@ -39,12 +37,12 @@ public class AlignSoftwareTargetAction implements MessageAction {
     @Override
     public void execute(EventMessage msgIn) {
         AlignSoftwareTargetMsg msg = (AlignSoftwareTargetMsg) msgIn;
-        SoftwareProjectSource source = (SoftwareProjectSource) HibernateFactory.reload(msg.getSource());
-        SoftwareEnvironmentTarget target = (SoftwareEnvironmentTarget) HibernateFactory.reload(msg.getTarget());
+        Channel source = msg.getSource();
+        Channel target = msg.getTarget();
 
-        if (!UserManager.verifyChannelAdmin(msg.getUser(), target.getChannel())) {
+        if (!UserManager.verifyChannelAdmin(msg.getUser(), target)) {
             throw new PermissionException("User " + msg.getUser().getLogin() + " has no permission for channel " +
-                    target.getChannel().getLabel());
+                    target.getLabel());
         }
 
         LOG.info("Asynchronously aligning: " + msg);

--- a/java/code/src/com/redhat/rhn/frontend/events/AlignSoftwareTargetAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/AlignSoftwareTargetAction.java
@@ -19,6 +19,7 @@ import com.redhat.rhn.common.messaging.EventMessage;
 import com.redhat.rhn.common.messaging.MessageAction;
 import com.redhat.rhn.common.security.PermissionException;
 import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.channel.ChannelFactory;
 import com.redhat.rhn.manager.channel.ChannelManager;
 import com.redhat.rhn.manager.user.UserManager;
 import org.apache.log4j.Logger;
@@ -37,8 +38,8 @@ public class AlignSoftwareTargetAction implements MessageAction {
     @Override
     public void execute(EventMessage msgIn) {
         AlignSoftwareTargetMsg msg = (AlignSoftwareTargetMsg) msgIn;
-        Channel source = msg.getSource();
-        Channel target = msg.getTarget();
+        Channel source = ChannelFactory.lookupById(msg.getSource().getId());
+        Channel target = ChannelFactory.lookupById(msg.getTarget().getId());
 
         if (!UserManager.verifyChannelAdmin(msg.getUser(), target)) {
             throw new PermissionException("User " + msg.getUser().getLogin() + " has no permission for channel " +

--- a/java/code/src/com/redhat/rhn/frontend/events/AlignSoftwareTargetMsg.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/AlignSoftwareTargetMsg.java
@@ -17,8 +17,7 @@ package com.redhat.rhn.frontend.events;
 
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.messaging.EventDatabaseMessage;
-import com.redhat.rhn.domain.contentmgmt.SoftwareEnvironmentTarget;
-import com.redhat.rhn.domain.contentmgmt.SoftwareProjectSource;
+import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.user.User;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.hibernate.Transaction;
@@ -28,18 +27,18 @@ import org.hibernate.Transaction;
  */
 public class AlignSoftwareTargetMsg implements EventDatabaseMessage {
 
-    private final SoftwareProjectSource source;
-    private final SoftwareEnvironmentTarget target;
+    private final Channel source;
+    private final Channel target;
     private final User user;
     private final Transaction txn;
 
     /**
      * Standard constructor
-     * @param src the Source
-     * @param tgt the Target
+     * @param src the source Channel
+     * @param tgt the target Channel
      * @param userIn the User
      */
-    public AlignSoftwareTargetMsg(SoftwareProjectSource src, SoftwareEnvironmentTarget tgt, User userIn) {
+    public AlignSoftwareTargetMsg(Channel src, Channel tgt, User userIn) {
         this.source = src;
         this.target = tgt;
         this.user = userIn;
@@ -47,20 +46,20 @@ public class AlignSoftwareTargetMsg implements EventDatabaseMessage {
     }
 
     /**
-     * Gets the source.
+     * Gets the source Channel.
      *
      * @return source
      */
-    public SoftwareProjectSource getSource() {
+    public Channel getSource() {
         return source;
     }
 
     /**
-     * Gets the target.
+     * Gets the target Channel.
      *
      * @return target
      */
-    public SoftwareEnvironmentTarget getTarget() {
+    public Channel getTarget() {
         return target;
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
@@ -445,7 +445,7 @@ public class ContentManagementHandler extends BaseHandler {
      * @return 1 if successful
      *
      * @xmlrpc.doc Build a Project
-     * @xmlrpc.param #param_desc("string", "sessionKey", "Session token, issued at login")
+     * @xmlrpc.param #session_key()
      * @xmlrpc.param #param_desc("string", "projectLabel" "Project label")
      * @xmlrpc.returntype #return_int_success()
      */
@@ -464,7 +464,7 @@ public class ContentManagementHandler extends BaseHandler {
      * @return 1 if successful
      *
      * @xmlrpc.doc Build a Project
-     * @xmlrpc.param #param_desc("string", "sessionKey", "Session token, issued at login")
+     * @xmlrpc.param #session_key()
      * @xmlrpc.param #param_desc("string", "message" "Log message to be assigned to the build")
      * @xmlrpc.param #param_desc("string", "projectLabel" "Project label")
      * @xmlrpc.returntype #return_int_success()
@@ -472,6 +472,26 @@ public class ContentManagementHandler extends BaseHandler {
     public int buildProject(User loggedInUser, String projectLabel, String message) {
         ensureOrgAdmin(loggedInUser);
         ContentManager.buildProject(projectLabel, of(message), true, loggedInUser);
+        return 1;
+    }
+
+    /**
+     * Promote an Environment in a Project
+     *
+     * @param loggedInUser the user
+     * @param projectLabel the Project label
+     * @param envLabel the Environment label
+     * @return 1 if successful
+     *
+     * @xmlrpc.doc Promote an Environment in a Project
+     * @xmlrpc.param #session_key()
+     * @xmlrpc.param #param_desc("string", "projectLabel" "Project label")
+     * @xmlrpc.param #param_desc("string", "envLabel" "Environment label")
+     * @xmlrpc.returntype #return_int_success()
+     */
+    public int promoteProject(User loggedInUser, String projectLabel, String envLabel) {
+        ensureOrgAdmin(loggedInUser);
+        ContentManager.promoteProject(projectLabel, envLabel, loggedInUser);
         return 1;
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
@@ -491,7 +491,7 @@ public class ContentManagementHandler extends BaseHandler {
      */
     public int promoteProject(User loggedInUser, String projectLabel, String envLabel) {
         ensureOrgAdmin(loggedInUser);
-        ContentManager.promoteProject(projectLabel, envLabel, loggedInUser);
+        ContentManager.promoteProject(projectLabel, envLabel, true, loggedInUser);
         return 1;
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
@@ -38,8 +38,6 @@ import com.redhat.rhn.domain.channel.DistChannelMap;
 import com.redhat.rhn.domain.channel.InvalidChannelRoleException;
 import com.redhat.rhn.domain.channel.ProductName;
 import com.redhat.rhn.domain.channel.ReleaseChannelMap;
-import com.redhat.rhn.domain.contentmgmt.SoftwareEnvironmentTarget;
-import com.redhat.rhn.domain.contentmgmt.SoftwareProjectSource;
 import com.redhat.rhn.domain.errata.Errata;
 import com.redhat.rhn.domain.kickstart.KickstartData;
 import com.redhat.rhn.domain.org.Org;
@@ -2739,16 +2737,15 @@ public class ChannelManager extends BaseManager {
     /**
      * Align packages and errata of the target channel to the source one
      *
-     * @param src the source
-     * @param tgt the target
+     * @param src the source Channel
+     * @param tgt the target Channel
      * @param async run this operation asynchronously?
      * @param user the user
      */
-    public static void alignChannels(SoftwareProjectSource src, SoftwareEnvironmentTarget tgt, boolean async,
-            User user) {
-        if (!UserManager.verifyChannelAdmin(user, tgt.getChannel())) {
+    public static void alignChannels(Channel src, Channel tgt, boolean async, User user) {
+        if (!UserManager.verifyChannelAdmin(user, tgt)) {
             throw new PermissionException("User " + user.getLogin() + " has no permission for channel " +
-                    tgt.getChannel().getLabel());
+                    tgt.getLabel());
         }
         AlignSoftwareTargetMsg msg = new AlignSoftwareTargetMsg(src, tgt, user);
         if (async) {
@@ -2761,30 +2758,27 @@ public class ChannelManager extends BaseManager {
 
     /**
      * Synchronously align packages and errata of the target channel to the source one.
-     * This method is potentially time-expensive and should be run asynchronously (e.g. via alignChannels method)
+     * This method is potentially time-expensive and should be run asynchronously (@see alignChannels)
      *
      * @param src the source
      * @param tgt the target
      * @param user the user
      */
-    public static void alignChannelsSync(SoftwareProjectSource src, SoftwareEnvironmentTarget tgt, User user) {
-        Channel tgtChannel = tgt.getChannel();
-        Channel srcChannel = src.getChannel();
-
+    public static void alignChannelsSync(Channel src, Channel tgt, User user) {
         // align packages and the cache (rhnServerNeededCache)
-        alignPackages(srcChannel, tgtChannel);
+        alignPackages(src, tgt);
 
         // align errata and the cache (rhnServerNeededCache)
-        ErrataManager.mergeErrataToChannel(user, srcChannel.getErratas(), tgtChannel, srcChannel, false, false);
-        ErrataManager.truncateErrata(srcChannel, tgtChannel, user);
+        ErrataManager.mergeErrataToChannel(user, src.getErratas(), tgt, src, false, false);
+        ErrataManager.truncateErrata(src, tgt, user);
 
         // update the channel newest packages cache
-        ChannelFactory.refreshNewestPackageCache(tgtChannel, "java::alignPackages");
+        ChannelFactory.refreshNewestPackageCache(tgt, "java::alignPackages");
 
         // now request repo regen
-        tgtChannel.setLastModified(new Date());
-        HibernateFactory.getSession().saveOrUpdate(tgtChannel);
-        ChannelManager.queueChannelChange(tgtChannel.getLabel(), "java::alignChannel", "Channel aligned");
+        tgt.setLastModified(new Date());
+        HibernateFactory.getSession().saveOrUpdate(tgt);
+        ChannelManager.queueChannelChange(tgt.getLabel(), "java::alignChannel", "Channel aligned");
     }
 
     private static void alignPackages(Channel srcChannel, Channel tgtChannel) {

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -459,6 +459,7 @@ public class ContentManager {
         ContentProjectFactory.lookupEnvironmentTargets(env)
                 .flatMap(t -> stream(t.asSoftwareTarget()))
                 .filter(tgt -> !newTargets.contains(tgt.getChannel()))
+                .sorted((c1, c2) -> Boolean.compare(c1.getChannel().isBaseChannel(), c2.getChannel().isBaseChannel()))
                 .forEach(toRemove -> ContentProjectFactory.purgeTarget(toRemove));
 
         // align the contents

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -396,7 +396,7 @@ public class ContentManager {
         ContentEnvironment firstEnv = project.getFirstEnvironmentOpt()
                 .orElseThrow(() -> new ContentManagementException("Cannot publish  project: " + projectLabel +
                         " with no environments."));
-        buildSoftwareSources(project, firstEnv, async, user);
+        buildSoftwareSources(firstEnv, async, user);
         addHistoryEntry(message, user, project);
         firstEnv.increaseVersion();
     }

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
@@ -607,7 +607,7 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
         ContentEnvironment env2 = ContentManager.createEnvironment(cp.getLabel(), of("fst"), "snd", "second env", "desc", user);
 
         System.out.println(ContentProjectFactory.lookupEnvironmentTargets(env2).collect(toList()));
-        ContentManager.promoteProject("cplabel", "fst", user);
+        ContentManager.promoteProject("cplabel", "fst", false, user);
         System.out.println(ContentProjectFactory.lookupEnvironmentTargets(env2).collect(toList()));
     }
 

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
@@ -603,6 +603,12 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
         assertEquals("cplabel-fst-" + newChannel.getLabel(), tgts.get(0).asSoftwareTarget().get().getChannel().getLabel());
         assertEquals(channel.getPackages(), tgtChannel.getPackages());
         assertEquals(channel.getErratas(), tgtChannel.getErratas());
+
+        ContentEnvironment env2 = ContentManager.createEnvironment(cp.getLabel(), of("fst"), "snd", "second env", "desc", user);
+
+        System.out.println(ContentProjectFactory.lookupEnvironmentTargets(env2).collect(toList()));
+        ContentManager.promoteProject("cplabel", "fst", user);
+        System.out.println(ContentProjectFactory.lookupEnvironmentTargets(env2).collect(toList()));
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Implement Content Project promote function
 - Implement Content Project build function
 - Add Countent Project Sources CRUD operations and expose them via XMLRPC
 - Add Content Project and Content Environment CRUD operations and expose them via XMLRPC


### PR DESCRIPTION
## What does this PR change?

This PR adds the "promote" functionality to the Content Project, which allows propagating built sources through the Content Environments.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes #
Tracks https://github.com/SUSE/spacewalk/issues/6518

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
