### PR TITLE
Replace SuSEfirewall by firewalld in proxy tests

### DIFF
--- a/testsuite/features/core_proxy_branch_network.feature
+++ b/testsuite/features/core_proxy_branch_network.feature
@@ -113,11 +113,10 @@ Feature: Setup SUSE Manager for Retail branch network
     Then I should see a "Formula saved!" text
 
 @proxy
-@private_net
-  Scenario: Enable avahi on the branch server
+ @private_net
+  Scenario: Enable repositories for installing branch services
     When I enable repositories before installing branch server
-    And I install package "SuSEfirewall2 expect" on this "proxy"
-    And I open avahi port on the proxy
+    Then I install package "expect" on this "proxy"
 
 @proxy
 @private_net
@@ -131,6 +130,14 @@ Feature: Setup SUSE Manager for Retail branch network
     And service "dhcpd" is active on "proxy"
     And service "named" is enabled on "proxy"
     And service "named" is active on "proxy"
+    And service "firewalld" is enabled on "proxy"
+    And service "firewalld" is active on "proxy"
+
+@proxy
+@private_net
+  Scenario: Enable avahi on the branch server
+    When service "firewalld" is active on "proxy"
+    Then I open avahi port on the proxy
 
 @proxy
 @private_net

--- a/testsuite/features/core_proxy_branch_network.feature
+++ b/testsuite/features/core_proxy_branch_network.feature
@@ -113,10 +113,10 @@ Feature: Setup SUSE Manager for Retail branch network
     Then I should see a "Formula saved!" text
 
 @proxy
- @private_net
+@private_net
   Scenario: Enable repositories for installing branch services
     When I enable repositories before installing branch server
-    Then I install package "expect" on this "proxy"
+    And I install package "expect" on this "proxy"
 
 @proxy
 @private_net
@@ -135,9 +135,10 @@ Feature: Setup SUSE Manager for Retail branch network
 
 @proxy
 @private_net
-  Scenario: Enable avahi on the branch server
-    When service "firewalld" is active on "proxy"
-    Then I open avahi port on the proxy
+  Scenario: Enable avahi and proxy services on the branch server
+    Given service "firewalld" is active on "proxy"
+    And I open avahi port on the proxy
+    And I open proxy ports on the proxy
 
 @proxy
 @private_net

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -624,10 +624,7 @@ And(/^I create the "([^"]*)" bootstrap repository for "([^"]*)" on the server$/)
 end
 
 When(/^I open avahi port on the proxy$/) do
-  sed = 's/FW_DEV_EXT=""/FW_DEV_EXT="eth0"/'
-  $proxy.run("sed -i '#{sed}' /etc/sysconfig/SuSEfirewall2")
-  sed = 's/FW_CONFIGURATIONS_EXT=""/FW_CONFIGURATIONS_EXT="avahi"/'
-  $proxy.run("sed -i '#{sed}' /etc/sysconfig/SuSEfirewall2")
+  $proxy.run('firewall-cmd --add-service=mdns')
 end
 
 When(/^I copy server\'s keys to the proxy$/) do

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -627,6 +627,10 @@ When(/^I open avahi port on the proxy$/) do
   $proxy.run('firewall-cmd --add-service=mdns')
 end
 
+When(/^I open proxy ports on the proxy$/) do
+  $proxy.run('firewall-cmd --add-service=suse-manager-proxy')
+end
+
 When(/^I copy server\'s keys to the proxy$/) do
   ['RHN-ORG-PRIVATE-SSL-KEY', 'RHN-ORG-TRUSTED-SSL-CERT', 'rhn-ca-openssl.cnf'].each do |file|
     return_code = file_extract($server, '/root/ssl-build/' + file, '/tmp/' + file)


### PR DESCRIPTION
## What does this PR change?

Replace deprecated SuSEfirewall2 package by firewalld in proxy testsuite.

## Links

Fixes https://github.com/SUSE/spacewalk/issues/7182

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"  
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
