### PR TITLE
Live patching support for SLES 15

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/audit/CVEAuditManager.java
+++ b/java/code/src/com/redhat/rhn/manager/audit/CVEAuditManager.java
@@ -915,8 +915,8 @@ public class CVEAuditManager {
             // When live patching is available, the original kernel packages ('-default' or '-xen') must be ignored.
             // Keep a list of package names to be ignored.
             Set<String> livePatchedPackages = resultsByPackage.keySet().stream()
-                    .map(p -> Pattern.compile("^kgraft-patch-.*-([^-]*)$").matcher(p)).filter(Matcher::matches)
-                    .map(m -> "kernel-" + m.group(1)).collect(Collectors.toSet());
+                    .map(p -> Pattern.compile("^(?:kgraft-patch|kernel-livepatch)-.*-([^-]*)$").matcher(p))
+                    .filter(Matcher::matches).map(m -> "kernel-" + m.group(1)).collect(Collectors.toSet());
 
             // Loop through affected packages one by one
             for (Map.Entry<String, List<CVEPatchStatus>> packageResults : resultsByPackage.entrySet()) {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add support for SLES 15 live patches in CVE audit
 - Implement Content Project promote function
 - Implement Content Project build function
 - Add Content Project Sources CRUD operations and expose them via XMLRPC

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Update get_kernel_live_version module to support SLES 15 live patches
 - Support register minion using bootstrap repos for 18.04 and 16.04.
 
 -------------------------------------------------------------------


### PR DESCRIPTION
Updates the `get_kernel_live_version` Salt module, and the CVE audit logic to support the new `klp` tool and the live patching packages from SLES 15.

## GUI diff
Before (prior to SLE 15, using `kgraft`):
![livepatch-sles15-before](https://user-images.githubusercontent.com/1103552/55017541-3ec01880-4ff1-11e9-9a7f-c209ed4b98da.png)
After (with SLE 15):
![livepatch-sles15-after](https://user-images.githubusercontent.com/1103552/55017540-3ec01880-4ff1-11e9-80db-a34c01851f03.png)

## Documentation
 - https://github.com/SUSE/doc-susemanager/issues/383
 - https://github.com/SUSE/spacewalk/issues/7425


## Test coverage
- Unit tests were added

## Links

Fixes https://github.com/SUSE/spacewalk/issues/7108

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
