### PR TITLE
Fix nodejs sdk build when a node_module lib have white spaces in a filename

### DIFF
--- a/susemanager-frontend/susemanager-nodejs-sdk-devel/susemanager-nodejs-sdk-devel.spec
+++ b/susemanager-frontend/susemanager-nodejs-sdk-devel/susemanager-nodejs-sdk-devel.spec
@@ -38,7 +38,7 @@ This package contains Node.js software needed by SUSE Manager at build time.
 tar xfv %{S:1}
 
 %build
-find . -type f | xargs sed -i -e 's/#!\/usr\/bin\/env node/#!\/usr\/bin\/node/g'
+find . -type f -exec sed -i -e 's/#!\/usr\/bin\/env node/#!\/usr\/bin\/node/g' {} \;
 
 %install
 mkdir -p %{buildroot}%{nodejs_sitelib}


### PR DESCRIPTION
## What does this PR change?
Fix nodejs sdk build when a node_module lib have white spaces in a filename

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed
- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
