### PR TITLE
fix metadata regeneration...

### DIFF
--- a/backend/satellite_tools/mgr-sign-metadata-ctl
+++ b/backend/satellite_tools/mgr-sign-metadata-ctl
@@ -31,7 +31,7 @@ function regenerate_metadata {
     echo
     echo "Scheduling repo metadata regeneration..."
     read_spacecmd_user_pass
-    spacecmd -q -u $SPACECMD_USER -p $SPACECMD_PASS "softwarechannel_regenerateyumcache -f *"
+    spacecmd -q -u $SPACECMD_USER -p $SPACECMD_PASS "softwarechannel_regenerateyumcache *"
     RETVAL=$?
     if [ $RETVAL -ne 0 ]; then
         echo "\nERROR queuing repo metadata regeneration. Try executing manually: spacecmd softwarechannel_regenerateyumcache \"*\""


### PR DESCRIPTION
## What does this PR change?

It fixes the metadata regeneration within ```mgr-sign-metadata-ctl```. There is no ```-f``` option or parameter available for ```softwarechannel_regenerateyumcache```. Otherwise, the following error occures

```
uyuni-test:~ # mgr-sign-metadata-ctl regen-metadata
Restarting Tomcat...done.
Restarting Taskomatic...done.

Scheduling repo metadata regeneration...
Server User: my_user
Server Password:
ERROR: unrecognized arguments: -f
uyuni-test:~ #
```


## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: 

- [X] **DONE**

## Test coverage
- No tests: Only manually tested

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
