### PR TITLE
Add argparse to the embedded diskspace check

### DIFF
--- a/spacewalk/setup/share/embedded_diskspace_check.py
+++ b/spacewalk/setup/share/embedded_diskspace_check.py
@@ -158,7 +158,7 @@ def _humanReadable(n):
     return s
 
 
-def main(needsDict=None):  # pylint: disable=redefined-outer-name
+def check(needsDict=None):  # pylint: disable=redefined-outer-name
     """ determine failed needs if any given needsDict.
         needsDict is by default DEFAULT_NEEDS (see top of module)
     """
@@ -192,9 +192,30 @@ def main(needsDict=None):  # pylint: disable=redefined-outer-name
     return 0
 
 
+def main():
+    """
+    Main app function.
+    """
+    prs = argparse.ArgumentParser(description="Check embedded disk space")
+    prs.add_argument('DEFAULT_NEEDS', nargs='+',
+                     help=('Set default map of failed needs: [directory] [size] ... '
+                           'Example: /var/lig/pgsql/data 12288'))
+    args = prs.parse_args()
+
+    if not len(args.DEFAULT_NEEDS) % 2:
+        needs_dict = {}
+        for directory, size in zip(args.DEFAULT_NEEDS[0::2], args.DEFAULT_NEEDS[1::2]):
+            try:
+                needs_dict[directory] = int(size) * 2 ** 20
+            except ValueError as err:
+                prs.error(err)
+        sys.exit(check(needs_dict) or 0)
+    else:
+        prs.print_help()
+
+
 if __name__ == "__main__":
-    needsDict = {}
-    if sys.argv:
-        for i, dir in enumerate(sys.argv[1::2]):  # pylint: disable=redefined-builtin
-            needsDict[dir] = int(sys.argv[i*2+2]) * 2**20 # in MB
-    sys.exit(main(needsDict) or 0)
+    """
+    Run main function if this script is called directly.
+    """
+    main()

--- a/spacewalk/setup/share/embedded_diskspace_check.py
+++ b/spacewalk/setup/share/embedded_diskspace_check.py
@@ -102,11 +102,9 @@ def paths2freespace(paths):
     paths = _unique(paths)
     pathsd = {} # 1:1
     for path in paths:
-        _statvfs = os.statvfs(path)
-        f_bavail = _statvfs[statvfs.F_BAVAIL] # non-super user space
-        f_bsize = _statvfs[statvfs.F_BSIZE] # respective blocksize
-        # build dict indexed by path
-        pathsd[path] = (six.PY3 and int or long)(f_bavail) * f_bsize
+        vfs = os.statvfs(path)
+        pathsd[path] = (six.PY3 and int or long)(vfs.f_bavail) * vfs.f_bsize
+
     return pathsd
 
 

--- a/spacewalk/setup/share/embedded_diskspace_check.py
+++ b/spacewalk/setup/share/embedded_diskspace_check.py
@@ -8,12 +8,15 @@
     Author: Todd Warner <taw@redhat.com>
 """
 
-from salt.ext import six
+try:
+    from salt.ext import six
+except ImportError:
+    import six
 
 import os
 import sys
 import stat
-import statvfs  # pylint: disable=import-error
+import argparse
 
 # these numbers are for *after* package installation.
 DEFAULT_NEEDS = {'/rhnsat':          12*(2**30),  # 12GB

--- a/spacewalk/setup/share/run_pytest.sh
+++ b/spacewalk/setup/share/run_pytest.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+#
+# This is a temporary solution before all
+# tests are running on docker.
+#
+# Author: bo@suse.de
+#
+
+VENV=".spacewalk-setup-env"
+
+#
+# Setup environment
+#
+function setup_venv () {
+    if [ ! -d $VENV ]; then
+	python3.6 -m venv $VENV
+	source $VENV/bin/activate
+	pip install --upgrade pip
+	pip install six
+	pip install pytest
+    fi
+    echo "NOTE: Virtual setup environment as $VENV"
+}
+
+#
+# Ignore environment
+#
+function git_ignore_venv () {
+    GITIGNORE=$(find -maxdepth 1 -name '.gitignore')
+    if [ "$GITIGNORE" == "" ]; then
+	echo $VENV >> .gitignore
+    else
+	ENV_ADDED=$(grep $VENV .gitignore)
+	if [ "$ENV_ADDED" == "" ]; then
+	    echo $VENV >> .gitignore
+	fi
+    fi
+}
+
+#
+# Activate virtual environment
+#
+function activate_venv () {
+    which deactivate &>/dev/null
+    if [ "$?" == "1" ]; then
+	source $VENV/bin/activate
+    fi
+}
+
+setup_venv;
+git_ignore_venv;
+activate_venv;
+
+HERE=$(cd $(dirname "${BASH_SOURCE[0]}") >/dev/null 2>&1 && pwd)
+export PYTHONPATH="$PYTHONPATH:$HERE:$HERE/tests"
+pytest --disable-warnings --tb=native --color=yes -svv

--- a/spacewalk/setup/share/tests/test_embedded_diskspace_check.py
+++ b/spacewalk/setup/share/tests/test_embedded_diskspace_check.py
@@ -1,0 +1,25 @@
+# coding: utf-8
+"""
+Test embeded diskspace check.
+"""
+
+import embedded_diskspace_check
+from unittest.mock import MagicMock, patch
+
+
+class TestEmbeddedDiskspaceCheck:
+    """
+    Test embedded diskspace check.
+    """
+
+    @patch("sys.exit", MagicMock())
+    @patch("sys.argv", ["dummy", "/tmp", "100000", "/etc", "2000"])
+    def test_cli_arguments(self):
+        """
+        Test command line arguments.
+        """
+        with patch("embedded_diskspace_check.check", MagicMock()) as edcc:
+            embedded_diskspace_check.main()
+        args = edcc.call_args_list[0][0][0]
+        assert args["/tmp"] == 104857600000
+        assert args["/etc"] == 2097152000

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,6 @@
+- Add proper argument parsing to the embedded diskspace check.
+- Fix Python3 porting issues
+
 -------------------------------------------------------------------
 Wed Feb 27 13:03:51 CET 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

- Adds `argparse` for argument parsing
- Adds clear help how to use this check
- Removes `statvfs` deprecated (since 2.6!) module
- Adds unit tests (for this particular PR only ATM)