### PR TITLE
Adapt Cobbler power management functionality to use new power_system API call (bsc#1128919)

### DIFF
--- a/java/code/src/org/cobbler/SystemRecord.java
+++ b/java/code/src/org/cobbler/SystemRecord.java
@@ -259,7 +259,7 @@ public class SystemRecord extends CobblerObject {
      * @return true if the command was successful
      */
     public boolean powerOn() {
-        return (Integer)client.invokeTokenMethod("power_system", getHandle(), "on") == 0;
+        return (Boolean)client.invokeTokenMethod("power_system", getHandle(), "on");
     }
 
     /**
@@ -269,7 +269,7 @@ public class SystemRecord extends CobblerObject {
      * @return true if the command was successful
      */
     public boolean powerOff() {
-        return (Integer)client.invokeTokenMethod("power_system", getHandle(), "off") == 0;
+        return (Boolean)client.invokeTokenMethod("power_system", getHandle(), "off");
     }
 
     /**
@@ -279,8 +279,8 @@ public class SystemRecord extends CobblerObject {
      * @return true if the command was successful
      */
     public boolean reboot() {
-        return (Integer)
-            client.invokeTokenMethod("power_system", getHandle(), "reboot") == 0;
+        return (Boolean)
+            client.invokeTokenMethod("power_system", getHandle(), "reboot");
     }
 
     /**

--- a/java/code/src/org/cobbler/test/MockConnection.java
+++ b/java/code/src/org/cobbler/test/MockConnection.java
@@ -210,9 +210,9 @@ public class MockConnection extends CobblerConnection {
         if (firstArgumentValid && secondArgumentValid && thirdArgumentValid) {
             powerCommands.add(name + " " + args[1] + " " +
                     systemMap.get(args[0]).get("uid"));
-            return args[1].equals("status") ? true : 0;
+            return true;
         }
-        return 1;
+        return false;
     }
     // images
     else if ("find_image".equals(name)) {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Adapt Cobbler power management functionality to use new power_system API call (bsc#1128919)
 - fix doc generation for content management API
 - Add support for SLES 15 live patches in CVE audit
 - Implement Content Project promote function


### PR DESCRIPTION
## What does this PR change?

Adapt Cobbler power management functionality to use [new power_system API call](https://github.com/cobbler/cobbler/pull/2050) (bsc#1128919)

## GUI diff

No difference.

## Documentation
- No documentation needed

## Test coverage
- No tests: cucumber tests already exist.

## Links

Fixes https://github.com/SUSE/spacewalk/issues/7273

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
