### PR TITLE
Revert "Log out already logged-in user under different name"

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -410,10 +410,6 @@ end
 
 Given(/^I am authorized as "([^"]*)" with password "([^"]*)"$/) do |user, passwd|
   visit Capybara.app_host
-  next if page.has_xpath?("//ul[@class='nav navbar-nav navbar-utility']//*[text()='#{user}']")
-
-  page.find(:xpath, "//a[@href='/rhn/Logout.do']").click if page.has_xpath?("//a[@href='/rhn/Logout.do']")
-
   fill_in 'username', with: user
   fill_in 'password', with: passwd
   click_button 'Sign In'


### PR DESCRIPTION
## What does this PR change?

This PR partially reverts commit d96ed6256fce0ea0f882a21d9b79947e2adefcb6.

This fixes the 20 seconds delay we currently have on the testsuite for each scenario which is making the testsuite to take quite long into complete.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **testsuite change**

- [x] **DONE**

## Test coverage
- No tests: **testsuite change**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/7456

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
