### PR TITLE
Use product ids for Ubuntu bootstrap data

### DIFF
--- a/susemanager/src/mgr-create-bootstrap-repo
+++ b/susemanager/src/mgr-create-bootstrap-repo
@@ -320,7 +320,7 @@ def create_repo(label, flush, additional=[]):
     if errors:
         for m in messages:
             print(m)
-        if label.startswith('RES') and not options.usecustomchannels:
+        if (label.startswith('RES') or label.lower().startswith('ubuntu'))  and not options.usecustomchannels:
             print("If the installation media was imported into a custom channel, try to run again with --with-custom-channels option")
         suggestions = list([_f for _f in list(suggestions.values()) if _f])
         if suggestions:

--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -762,12 +762,12 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/centos/7/bootstrap/'
     },
     'ubuntu-16.04-amd64' : {
-        'BASECHANNEL' : 'ubuntu-16.04-pool-amd64', 'PKGLIST' : PKGLISTUBUNTU1604,
+        'PDID' : [-2, 1917], 'PKGLIST' : PKGLISTUBUNTU1604,
         'DEST' : '/srv/www/htdocs/pub/repositories/ubuntu/16/4/bootstrap/',
         'TYPE' : 'deb'
     },
     'ubuntu-18.04-amd64' : {
-        'BASECHANNEL' : 'ubuntu-18.04-pool-amd64', 'PKGLIST' : PKGLISTUBUNTU1804,
+        'PDID' : [-1, 1918], 'PKGLIST' : PKGLISTUBUNTU1804,
         'DEST' : '/srv/www/htdocs/pub/repositories/ubuntu/18/4/bootstrap/',
         'TYPE' : 'deb'
     }


### PR DESCRIPTION
## What does this PR change?

Use product ids for Ubuntu bootstrap data use by `mgr-create-bootstrap-data`.

## GUI diff

No difference.

## Documentation
- No documentation needed

## Test coverage
- No tests

## Links

Fixes #

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
