### PR TITLE
use permanent firewall rules

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -624,11 +624,13 @@ And(/^I create the "([^"]*)" bootstrap repository for "([^"]*)" on the server$/)
 end
 
 When(/^I open avahi port on the proxy$/) do
-  $proxy.run('firewall-cmd --add-service=mdns')
+  $proxy.run('firewall-cmd --permanent --add-service=mdns')
+  $proxy.run('firewall-cmd --state 2>/dev/null && firewall-cmd --reload')
 end
 
 When(/^I open proxy ports on the proxy$/) do
-  $proxy.run('firewall-cmd --add-service=suse-manager-proxy')
+  $proxy.run('firewall-cmd --permanent --add-service=suse-manager-proxy')
+  $proxy.run('firewall-cmd --state 2>/dev/null && firewall-cmd --reload')
 end
 
 When(/^I copy server\'s keys to the proxy$/) do


### PR DESCRIPTION
## What does this PR change?

Firewall rules must be permanent. Otherwise a rule change from a formula reload the firewall and these changes are lost

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- fixes tests

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
