### PR TITLE
cobbler validate calls lower() on mac addresses before storing

### DIFF
--- a/testsuite/features/srv_distro_cobbler.feature
+++ b/testsuite/features/srv_distro_cobbler.feature
@@ -151,7 +151,7 @@ Feature: Cobbler and distribution autoinstallation
     Then I wait until file "/srv/tftpboot/pxelinux.cfg/01-00-22-22-77-ee-cc" contains "ks=.*testserver:1" on server
     And the cobbler report contains "testserver.example.com" for system "testserver"
     And the cobbler report contains "1.1.1.1" for system "testserver"
-    And the cobbler report contains "00:22:22:77:EE:CC" for system "testserver"
+    And the cobbler report contains "00:22:22:77:ee:cc" for system "testserver"
 
   Scenario: Cleanup: delete test distro and profiles
     Then I remove kickstart profiles and distros


### PR DESCRIPTION
## What does this PR change?

cobbler store mac addresses in lowercase. Fix matching while providing correct case.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- fixes test

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
