### PR TITLE
Fix potentially problematic comments at SPEC files

### DIFF
--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -104,9 +104,9 @@ Requires:       python-pyliblzma
 %else
 %if 0%{?rhel}
 Requires:       pyliblzma
-%endif # %if 0%{?rhel}
-%endif # 0%{?suse_version}
-%endif # 0%{?build_py3}
+%endif # if 0{?rhel}
+%endif # 0{?suse_version}
+%endif # 0{?build_py3}
 # for Debian support
 Requires:       %{python_prefix}-debian
 %if 0%{?pylint_check}
@@ -465,9 +465,9 @@ Requires:       python-pyliblzma
 %else
 %if 0%{?fedora} || 0%{?rhel} > 6
 Requires:       pyliblzma
-%endif # 0%{?fedora} || 0%{?rhel} > 6
-%endif # 0%{?suse_version}
-%endif # 0%{?build_py3}
+%endif # 0{?fedora} || 0{?rhel} > 6
+%endif # 0{?suse_version}
+%endif # 0{?build_py3}
 Requires:       spacewalk-admin >= 0.1.1-0
 Requires:       spacewalk-certs-tools
 %if 0%{?suse_version}

--- a/client/rhel/rhnlib/rhnlib.spec
+++ b/client/rhel/rhnlib/rhnlib.spec
@@ -77,12 +77,12 @@ BuildRequires:  python-devel
 Requires:       python-pyOpenSSL
 %else
 Requires:       python-openssl
-%endif # 0%{?suse_version} > 1200
+%endif # 0{?suse_version} > 1200
 %else
 Requires:       pyOpenSSL
-%endif # 0%{?suse_version}
-%endif # 0%{?fedora} >= 28 || 0%{?rhel} >= 8
-%endif # %{_vendor} != "debbuild"
+%endif # 0{?suse_version}
+%endif # 0{?fedora} >= 28 || 0{?rhel} >= 8
+%endif # {_vendor} != "debbuild"
 
 %if %{_vendor} == "debbuild"
 BuildRequires: python-dev

--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.spec
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.spec
@@ -104,9 +104,9 @@ Requires:       zypper
 Requires:       dnf
 %else
 Requires:       yum
-%endif # 0%{?fedora}
-%endif # 0%{?suse_version}
-%endif # %{_vendor} != "debbuild"
+%endif # 0{?fedora}
+%endif # 0{?suse_version}
+%endif # {_vendor} != "debbuild"
 
 %if %{_vendor} == "debbuild"
 Requires: apt
@@ -189,9 +189,9 @@ Requires:       python-gudev
 Requires:       python-hwdata
 %else
 Requires:       hal >= 0.5.8.1-52
-%endif # 0%{?rhel} > 5
-%endif # 0%{?suse_version} >= 1140
-%endif # 0%{?fedora}
+%endif # 0{?rhel} > 5
+%endif # 0{?suse_version} >= 1140
+%endif # 0{?fedora}
 
 %if 0%{?rhel} == 5
 Requires:       newt
@@ -206,7 +206,7 @@ Requires:       dbus-1-python
 Requires:       python-newt
 %else
 Requires:       dbus-python
-%endif # 0%{?suse_version}
+%endif # 0{?suse_version}
 Requires:       logrotate
 Requires:       suseRegisterInfo
 
@@ -215,7 +215,7 @@ Requires:       suseRegisterInfo
 BuildRequires:  python-coverage
 BuildRequires:  rpm-python
 %endif
-%endif #%if %{_vendor} != "debbuild"
+%endif # if {_vendor} != "debbuild"
 
 %if %{_vendor} == "debbuild"
 Requires: python-rpm
@@ -1001,9 +1001,9 @@ make -f Makefile.rhn-client-tools test
 %{python_sitelib}/up2date_client/firstboot/rhn_create_profile_gui.*
 %{python_sitelib}/up2date_client/firstboot/rhn_review_gui.*
 %{python_sitelib}/up2date_client/firstboot/rhn_finish_gui.*
-%endif # 0%{?rhel} == 6
-%endif # 0%{?rhel} == 5
-%endif # 0%{?build_py2}
+%endif # 0{?rhel} == 6
+%endif # 0{?rhel} == 5
+%endif # 0{?build_py2}
 
 %if 0%{?build_py3}
 %files -n python3-spacewalk-client-setup-gnome
@@ -1020,9 +1020,9 @@ make -f Makefile.rhn-client-tools test
 %{python3_sitelib}/up2date_client/__pycache__/gtk_compat.*
 %{python3_sitelib}/up2date_client/__pycache__/gui.*
 %{python3_sitelib}/up2date_client/__pycache__/progress.*
-%endif # %{_vendor} != "debbuild"
-%endif # 0%{?build_py3}
-%endif # ! 0%{?without_rhn_register}
+%endif # {_vendor} != "debbuild"
+%endif # 0{?build_py3}
+%endif # ! 0{?without_rhn_register}
 
 %if %{_vendor} == "debbuild"
 

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -131,7 +131,7 @@ BuildRequires:  java-devel >= 11
 BuildRequires:  jpam
 BuildRequires:  oscache
 
-%endif # 0%{?suse_version}
+%endif # 0{?suse_version}
 Requires:       jakarta-commons-el
 Requires:       jakarta-commons-fileupload
 Requires:       jcommon
@@ -152,7 +152,7 @@ Requires:       xerces-j2
 %if 0%{?fedora}
 Requires:       classpathx-jaf
 
-%endif # 0%{?fedora}
+%endif # 0{?fedora}
 # EL5 = Struts 1.2 and Tomcat 5, EL6+/recent Fedoras = 1.3 and Tomcat 6
 %if 0%{?fedora} || 0%{?rhel} >= 7
 Requires:       servlet >= 3.0
@@ -181,8 +181,8 @@ BuildRequires:  struts >= 1.3.0
 BuildRequires:  struts-taglib >= 1.3.0
 BuildRequires:  tomcat6
 BuildRequires:  tomcat6-lib
-%endif # 0%{?suse_version}
-%endif # 0%{?fedora} || 0%{?rhel} >= 7
+%endif # 0{?suse_version}
+%endif # 0{?fedora} || 0{?rhel} >= 7
 %if 0%{?fedora} || 0%{?rhel} >=7
 Requires:       apache-commons-cli
 Requires:       apache-commons-codec
@@ -254,8 +254,8 @@ BuildRequires:  jakarta-commons-io
 BuildRequires:  jakarta-commons-logging
 BuildRequires:  jakarta-commons-validator
 BuildRequires:  jpackage-utils
-%endif #0%{?suse_version}
-%endif #0%{?fedora} || 0%{?rhel} >=7
+%endif # 0{?suse_version}
+%endif # 0{?fedora} || 0{?rhel} >=7
 
 # for RHEL6 we need to filter out several package versions
 %if  0%{?rhel} && 0%{?rhel} >= 6
@@ -275,7 +275,7 @@ BuildRequires:  tomcat-taglibs-standard
 BuildRequires:  /usr/bin/perl
 BuildRequires:  /usr/bin/xmllint
 BuildRequires:  jakarta-taglibs-standard
-%endif # 0%{?suse_version}
+%endif # 0{?suse_version}
 BuildRequires:  ant
 BuildRequires:  ant-apache-regexp
 BuildRequires:  ant-junit
@@ -472,8 +472,8 @@ Requires:       jakarta-commons-cli
 Requires:       jakarta-commons-codec
 Requires:       jakarta-commons-lang
 Requires:       jakarta-commons-logging
-%endif # 0%{?suse_version}
-%endif # 0%{?fedora} || 0%{?rhel} >= 7
+%endif # 0{?suse_version}
+%endif # 0{?fedora} || 0{?rhel} >= 7
 Conflicts:      quartz < 2.0
 Obsoletes:      taskomatic < 5.3.0
 Obsoletes:      taskomatic-sat < 5.3.0
@@ -609,7 +609,7 @@ install -d -m 755 $RPM_BUILD_ROOT%{appdir}/rhn/META-INF/
 install -m 644 conf/rhn-tomcat8.xml $RPM_BUILD_ROOT%{appdir}/rhn/META-INF/context.xml
 %else
 install -m 644 conf/rhn-tomcat5.xml $RPM_BUILD_ROOT%{appdir}/rhn/META-INF/context.xml
-%endif # 0%{?fedora} >= 23
+%endif # 0{?fedora} >= 23
 
 %else
 %if 0%{?suse_version}
@@ -621,13 +621,13 @@ install -m 755 conf/rhn-tomcat8.xml $RPM_BUILD_ROOT%{appdir}/rhn/META-INF/contex
 ant -Dprefix=$RPM_BUILD_ROOT -Dtomcat="tomcat9" install-tomcat9-suse
 install -d -m 755 $RPM_BUILD_ROOT%{appdir}/rhn/META-INF/
 install -m 755 conf/rhn-tomcat9.xml $RPM_BUILD_ROOT%{appdir}/rhn/META-INF/context.xml
-%endif # 0%{?suse_version} < 1500
+%endif # 0{?suse_version} < 1500
 %else
 ant -Dprefix=$RPM_BUILD_ROOT install-tomcat6
 install -d -m 755 $RPM_BUILD_ROOT%{appdir}/rhn/META-INF/
 install -m 644 conf/rhn-tomcat5.xml $RPM_BUILD_ROOT%{appdir}/rhn/META-INF/context.xml
-%endif # 0%{?suse_version}
-%endif # 0%{?fedora} || 0%{?rhel} >= 7
+%endif # 0{?suse_version}
+%endif # 0{?fedora} || 0{?rhel} >= 7
 
 # check spelling errors in all resources for English if aspell installed
 [ -x "$(which aspell)" ] && scripts/spelling/check_java.sh .. en_US
@@ -924,7 +924,6 @@ fi
 %{jardir}/simple-xml.jar
 %{jardir}/sitemesh.jar
 %{jardir}/stringtree-json.jar
-# %{jardir}/velocity-*.jar
 %{jardir}/xalan-j2.jar
 %{jardir}/xalan-j2-serializer.jar
 %{jardir}/xerces-j2.jar


### PR DESCRIPTION
## What does this PR change?

rpm is expands macros regardless if something is commented out or not, so we better avoid mistakes.

The fix is easy, remove `%` from the comments that contains macros.

I am not adding changelogs in the hope we'll have some more changes for the packages before next release. Otherwise I will add them at that moment.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: SPEC fixes

- [x] **DONE**

## Test coverage
- No tests: SPEC fixes

- [x] **DONE**

## Links

None.

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"   
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
