### PR TITLE
Remove work around closed proxy ports

### DIFF
--- a/testsuite/features/core_proxy_branch_network.feature
+++ b/testsuite/features/core_proxy_branch_network.feature
@@ -137,8 +137,7 @@ Feature: Setup SUSE Manager for Retail branch network
 @private_net
   Scenario: Enable avahi and proxy services on the branch server
     Given service "firewalld" is active on "proxy"
-    And I open avahi port on the proxy
-    And I open proxy ports on the proxy
+    When I open avahi port on the proxy
 
 @proxy
 @private_net

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -625,12 +625,7 @@ end
 
 When(/^I open avahi port on the proxy$/) do
   $proxy.run('firewall-cmd --permanent --add-service=mdns')
-  $proxy.run('firewall-cmd --state 2>/dev/null && firewall-cmd --reload')
-end
-
-When(/^I open proxy ports on the proxy$/) do
-  $proxy.run('firewall-cmd --permanent --add-service=suse-manager-proxy')
-  $proxy.run('firewall-cmd --state 2>/dev/null && firewall-cmd --reload')
+  $proxy.run('firewall-cmd --reload')
 end
 
 When(/^I copy server\'s keys to the proxy$/) do


### PR DESCRIPTION
## What does this PR change?

This PR removes a work around from the test suite.

The work around addressed [bsc#1131231 - During installation of server and proxy, firewall ports not open if firewalld is not running](https://bugzilla.suse.com/show_bug.cgi?id=1131231), which has been fixed in PR #779.

## Links

No backports, uyuni only.

- [x] No changelog needed
