### PR TITLE
Replace deprecated gpg options with newer ones in mgr-sign-metadata-ctl

### DIFF
--- a/backend/satellite_tools/mgr-sign-metadata-ctl
+++ b/backend/satellite_tools/mgr-sign-metadata-ctl
@@ -197,7 +197,7 @@ elif [[  $ACTION = "check-config" ]]; then
         fi
 
         if [ -f $GPG_PUB_EXPORT_FILE ]; then
-            if gpg --with-fingerprint $GPG_PUB_EXPORT_FILE | grep --quiet $KEYID; then
+            if cat $GPG_PUB_EXPORT_FILE | gpg -q --with-colons --import-options show-only --import | grep --quiet $KEYID; then
                 echo "OK. Key ${KEYID} was exported to ${GPG_PUB_EXPORT_FILE}."
             else
                 echo "ERROR. Public key file ${GPG_PUB_EXPORT_FILE} exists but it doesn't contain key ${KEYID}."


### PR DESCRIPTION
## What does this PR change?

`gpg` 2.2.25 used in SLE15-SP1 produces an error in case of using `gpg --with-fingerprint <keyfile>` to print the content of the given file.
Older `gpg` in SLE12-SP3 (Manager 3.2) doesn't produce this error.

## GUI diff

No difference.


## Documentation
- No documentation needed: internal script change

## Test coverage
- No tests

## Links

Fixes #

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
