### PR TITLE
Fix access compat removal

### DIFF
--- a/proxy/proxy/spacewalk-proxy.changes
+++ b/proxy/proxy/spacewalk-proxy.changes
@@ -1,3 +1,5 @@
+- remove apache access_compat module from config if it exists
+
 -------------------------------------------------------------------
 Mon Mar 25 16:43:43 CET 2019 - jgonzalez@suse.com
 

--- a/proxy/proxy/spacewalk-proxy.spec
+++ b/proxy/proxy/spacewalk-proxy.spec
@@ -330,6 +330,7 @@ sysconf_addword /etc/sysconfig/apache2 APACHE_MODULES proxy
 sysconf_addword /etc/sysconfig/apache2 APACHE_MODULES rewrite
 sysconf_addword /etc/sysconfig/apache2 APACHE_MODULES version
 sysconf_addword /etc/sysconfig/apache2 APACHE_SERVER_FLAGS SSL
+sysconf_addword -r /etc/sysconfig/apache2 APACHE_MODULES access_compat
 
 # In case of an update, remove superfluous stuff
 # from cobbler-proxy.conf (bnc#796581)

--- a/spacewalk/config/spacewalk-config.changes
+++ b/spacewalk/config/spacewalk-config.changes
@@ -1,3 +1,5 @@
+- remove apache access_compat module from config if it exists
+
 -------------------------------------------------------------------
 Mon Mar 25 16:42:45 CET 2019 - jgonzalez@suse.com
 

--- a/spacewalk/config/spacewalk-config.spec
+++ b/spacewalk/config/spacewalk-config.spec
@@ -169,6 +169,7 @@ sysconf_addword /etc/sysconfig/apache2 APACHE_MODULES headers
 sysconf_addword /etc/sysconfig/apache2 APACHE_MODULES xsendfile
 sysconf_addword /etc/sysconfig/apache2 APACHE_SERVER_FLAGS SSL
 sysconf_addword /etc/sysconfig/apache2 APACHE_SERVER_FLAGS ISSUSE
+sysconf_addword -r /etc/sysconfig/apache2 APACHE_MODULES access_compat
 %endif
 if [ -e %{apacheconfdir}/ssl.key/spacewalk.key ]; then
   ln -s spacewalk.key %{apacheconfdir}/ssl.key/server.key


### PR DESCRIPTION
## What does this PR change?

Activly remove `access_compat´ module when installing the new package.
The module requires incompatible syntax. We now have everywhere the new correct syntax
and if that module is configured, SUSE Manager will not work anymore.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **otherwise SUSE Manager will not work at all**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
