### PR TITLE
Reenable osimage build tests

### DIFF
--- a/testsuite/run_sets/testsuite.yml
+++ b/testsuite/run_sets/testsuite.yml
@@ -86,7 +86,8 @@
 - features/srv_docker_advanced_content_management.feature
 - features/srv_docker_cve_audit.feature
 # too many failures and takes too long, needs some investigation
-# - features/min_osimage_build_image.feature
+# OS image build tests are required for proxy_retail_pxeboot feature
+- features/min_osimage_build_image.feature
 - features/min_salt_install_package.feature
 - features/srv_power_management.feature
 - features/srv_datepicker.feature


### PR DESCRIPTION
OS Image build tests are required for proxy_retail_pxeboot feature.

## What does this PR change?

PR reenabled OS image feature test.

Note that that test is not 100% idempotent as it calls image-sync state which transfers built image to the proxy and create boot structure for PXE boot.

This is on one hand required for pxeminion boot and provisioning, on the second hand it breaks idempotency as the proxy part is not cleaned up.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: Testsuite change

- [X] **DONE**

## Test coverage
- Cucumber tests were added

- [X] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/6267

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"     
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
