### PR TITLE
Fix spacewalk-schema-upgrade regex to also match 'lp' within 'release' string of 'Leap' packages

### DIFF
--- a/schema/spacewalk/spacewalk-schema-upgrade
+++ b/schema/spacewalk/spacewalk-schema-upgrade
@@ -96,7 +96,7 @@ if ($ENV{SUMA_TEST_SCHEMA_VERSION}) {
 }
 
 my $target_schema = join '-', $my_schema_name, $my_schema_version, $my_schema_release;
-(my $target_schema_norm = $target_schema) =~ s!^(.+-\d+(\.\d+)*-[a-z0-9]*?)(\..*)*$!$1!;
+(my $target_schema_norm = $target_schema) =~ s!^(.+-\d+(\.\d+)*-[a-zA-Z0-9]*)(\..*)*$!$1!;
 
 my $schema_version = run_query(<<EOF);
     select rhnPackageName.name || '-' || (PE.evr).version || '-' || (PE.evr).release
@@ -129,7 +129,7 @@ if (not $schema_version =~ /^rhn-satellite-schema-|^spacewalk-schema-|^satellite
 }
 
 my $start_schema = $schema_version;
-(my $start_schema_norm = $start_schema) =~ s!^(.+-\d+(\.\d+)*-[a-z0-9]*?)(\..*)*$!$1!;
+(my $start_schema_norm = $start_schema) =~ s!^(.+-\d+(\.\d+)*-[a-zA-Z0-9]*)(\..*)*$!$1!;
 
 print "Schema upgrade: [$start_schema] -> [$target_schema]\n";
 
@@ -161,7 +161,7 @@ while (@queue) {
 
 if (!$foundtarget) {
     if (not $retried) {
-        if ($target_schema_norm =~ s!^(.+-.+)-[a-z0-9]+(\.\d+)*$!$1!) {
+        if ($target_schema_norm =~ s!^(.+-.+)-[a-zA-Z0-9]+(\.\d+)*$!$1!) {
             $retried++;
             goto RETRY;
         }

--- a/schema/spacewalk/spacewalk-schema-upgrade
+++ b/schema/spacewalk/spacewalk-schema-upgrade
@@ -96,7 +96,7 @@ if ($ENV{SUMA_TEST_SCHEMA_VERSION}) {
 }
 
 my $target_schema = join '-', $my_schema_name, $my_schema_version, $my_schema_release;
-(my $target_schema_norm = $target_schema) =~ s!^(.+-\d+(\.\d+)*)(\..*)*$!$1!;
+(my $target_schema_norm = $target_schema) =~ s!^(.+-\d+(\.\d+)*-[a-z0-9]*?)(\..*)*$!$1!;
 
 my $schema_version = run_query(<<EOF);
     select rhnPackageName.name || '-' || (PE.evr).version || '-' || (PE.evr).release
@@ -129,7 +129,7 @@ if (not $schema_version =~ /^rhn-satellite-schema-|^spacewalk-schema-|^satellite
 }
 
 my $start_schema = $schema_version;
-(my $start_schema_norm = $start_schema) =~ s!^(.+-\d+(\.\d+)*)(\..*)*$!$1!;
+(my $start_schema_norm = $start_schema) =~ s!^(.+-\d+(\.\d+)*-[a-z0-9]*?)(\..*)*$!$1!;
 
 print "Schema upgrade: [$start_schema] -> [$target_schema]\n";
 
@@ -161,7 +161,7 @@ while (@queue) {
 
 if (!$foundtarget) {
     if (not $retried) {
-        if ($target_schema_norm =~ s!^(.+-.+)-\d+(\.\d+)*$!$1!) {
+        if ($target_schema_norm =~ s!^(.+-.+)-[a-z0-9]+(\.\d+)*$!$1!) {
             $retried++;
             goto RETRY;
         }

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,5 @@
+- changed regex in spacewalk-schema-upgrade to also match alnum characters in release
+
 -------------------------------------------------------------------
 Fri Mar 29 10:37:00 CET 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
... to also match alnum characters in 'release' part of package name.

This should fix #792

## What does this PR change?

It fixes a problem with ```spacewalk-schema-upgrade``` where the regex does not match anymore because of the ```lp``` string within the ```release``` of the package

## GUI diff

No difference.

Before:

After:

- [X] **DONE**

## Documentation
- No documentation needed: Bugfix
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [X] **DONE**

## Test coverage
- No tests: Currently unable to write test cases.

- [ ] **DONE**

## Links

Fixes #792 

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [X] Re-run test "schema_migration_test_oracle"
- [X] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
