### PR TITLE
Fix pymakefiles

### DIFF
--- a/backend/Makefile.backend
+++ b/backend/Makefile.backend
@@ -2,7 +2,6 @@
 #
 THIS_MAKEFILE := $(realpath $(lastword $(MAKEFILE_LIST)))
 CURRENT_DIR := $(dir $(THIS_MAKEFILE))
-include $(CURRENT_DIR)../rel-eng/Makefile.python
 
 CODE_DIRS = common server upload_server satellite_tools satellite_exporter po wsgi cdn_tools
 PYLINT_DIRS = common upload_server satellite_tools satellite_exporter wsgi

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- add makefile for python linter and unit/integration tests
+
 -------------------------------------------------------------------
 Fri Mar 29 10:29:46 CET 2019 - jgonzalez@suse.com
 

--- a/client/rhel/rhnlib/Makefile.rhnlib
+++ b/client/rhel/rhnlib/Makefile.rhnlib
@@ -1,8 +1,6 @@
 # Makefile for the rhn modules
 #
 
-include     Makefile.python
-
 PYTHON      = /usr/bin/python
 
 NAME	    = rhnlib

--- a/client/rhel/rhnlib/rhnlib.spec
+++ b/client/rhel/rhnlib/rhnlib.spec
@@ -40,7 +40,6 @@
 
 Summary:        Python libraries for the Spacewalk project
 License:        GPL-2.0-only
-Group:          Development/Libraries
 Name:           rhnlib
 Version:        4.0.6
 Release:        1%{?dist}

--- a/proxy/proxy/Makefile.proxy
+++ b/proxy/proxy/Makefile.proxy
@@ -1,7 +1,6 @@
 # Makefile for building Spacewalk Proxy snapshots
 #
 
-include Makefile.python
 .DEFAULT_GOAL  :=  all
 
 TOP	= .


### PR DESCRIPTION
This removes:
- Forgotten Makefile inclusion which breaks build.
- An extra group `Development/Libraries` was added to the specfile