### PR TITLE
Fix: Do not assume parent channel when cloning (bsc#1130492)

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/channel/CloneChannelCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/CloneChannelCommand.java
@@ -64,7 +64,6 @@ public class CloneChannelCommand extends CreateChannelCommand {
         gpgKeyId = cloneFrom.getGPGKeyId();
         gpgKeyFp = cloneFrom.getGPGKeyFp();
         gpgCheck  = cloneFrom.isGPGCheck();
-        parentId = Optional.ofNullable(cloneFrom.getParentChannel()).map(Channel::getId).orElse(null);
         archLabel = Optional.ofNullable(cloneFrom.getChannelArch()).map(ChannelArch::getLabel).orElse("");
     }
 

--- a/java/code/src/com/redhat/rhn/manager/channel/test/CloneChannelCommandTest.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/test/CloneChannelCommandTest.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.manager.channel.test;
+
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.channel.ChannelFactory;
+import com.redhat.rhn.manager.channel.CloneChannelCommand;
+import com.redhat.rhn.testing.BaseTestCaseWithUser;
+import com.redhat.rhn.testing.ChannelTestUtils;
+
+public class CloneChannelCommandTest extends BaseTestCaseWithUser {
+
+    /**
+     * Tests that cloning a channel does NOT respect the parent of the original
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testNoParentOnClone() throws Exception {
+        Channel originalBase = ChannelTestUtils.createBaseChannel(user);
+        Channel originalChild = ChannelTestUtils.createChildChannel(user, originalBase);
+        originalChild.setChecksumType(ChannelFactory.findChecksumTypeByLabel("sha256"));
+        originalChild.setSummary("summary");
+        CloneChannelCommand ccc = new CloneChannelCommand(
+                CloneChannelCommand.CloneBehavior.ORIGINAL_STATE, originalChild);
+        ccc.setUser(user);
+
+        Channel clone = ccc.create();
+        assertNull(clone.getParentChannel());
+    }
+}

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Do not implicitly set parent channel when cloning (bsc#1130492)
 - Do not report Provisioning installed product to subscription matcher (bsc#1128838)
 - Show minion id in System Details GUI and API
 - Fix base channel selection for Ubuntu systems (bsc#1132579)


### PR DESCRIPTION
When cloning a channel, the "very old" original logic (before fixing this [old
bug](https://bugzilla.suse.com/show_bug.cgi?id=1080290)) was **not** to
implicitly set the parent channel of the clone to the parent of the original.

This fix restores the original behavior.


No difference.


- [x] **DONE**

- No documentation needed: Bugfix

- [x] **DONE**

- Unit tests were added TODO

- [x] **DONE**


Tracks https://github.com/SUSE/spacewalk/issues/7486

- [x] **DONE**


If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)



If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"

Parent channel should not be implicitly set when cloning channel. It
should be explicitly set instead.