### PR TITLE
Subscription matcher message decoded properly (bsc#1125600)

### DIFF
--- a/web/html/src/manager/subscription-matching-messages.js
+++ b/web/html/src/manager/subscription-matching-messages.js
@@ -13,7 +13,7 @@ const Messages = createReactClass({
   displayName: 'Messages',
   mixins: [StatePersistedMixin],
 
-  buildRows: function(rawMessages, systems) {
+  buildRows: function(rawMessages, systems, subscriptions) {
     return rawMessages.map(function(rawMessage, index) {
       const data = rawMessage["data"];
       var message;
@@ -35,6 +35,10 @@ const Messages = createReactClass({
           message = t("System has an unknown number of sockets, assuming 16");
           additionalInformation = systems[data["id"]].name;
           break;
+        case "hb_merge_subscriptions" :
+          message = t("Two subscriptions with the same part number are in a bundle - merged into a single one");
+          additionalInformation = subscriptions[data["new_subscription_id"]].partNumber;
+          break;
         default:
           message = rawMessage["type"];
           // we do not know the shape of the data, it could even be a complex nested object (bsc#1125600)
@@ -55,7 +59,7 @@ const Messages = createReactClass({
         <div>
           <p>{t("Please review warning and information messages below.")}</p>
           <Table
-            data={this.buildRows(this.props.messages, this.props.systems)}
+            data={this.buildRows(this.props.messages, this.props.systems, this.props.subscriptions)}
             identifier={(row) => row.id}
             loadState={this.props.loadState}
             saveState={this.props.saveState}

--- a/web/html/src/manager/subscription-matching-messages.js
+++ b/web/html/src/manager/subscription-matching-messages.js
@@ -37,7 +37,8 @@ const Messages = createReactClass({
           break;
         default:
           message = rawMessage["type"];
-          additionalInformation = data;
+          // we do not know the shape of the data, it could even be a complex nested object (bsc#1125600)
+          additionalInformation = JSON.stringify(data);
       }
       return {
         id: index,

--- a/web/html/src/manager/subscription-matching.js
+++ b/web/html/src/manager/subscription-matching.js
@@ -149,6 +149,7 @@ class SubscriptionMatchingTabContainer extends React.Component {
           <Messages
             messages={data.messages}
             systems={data.systems}
+            subscriptions={data.subscriptions}
             saveState={(state) => {this.state["messageTableState"] = state;}}
             loadState={() => this.state["messageTableState"]}
           />

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- Show undetected subscription-matching message object as a string anyway (bsc#1125600)
+
 -------------------------------------------------------------------
 Fri Mar 29 10:34:19 CET 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR is a bugfix: in the Subscription Matching feature, in the *#message* tab there is a `switch-case` statement with a `default` fallback in case nothing is detected properly. In this last case, we cannot guess how the `data` is shaped, then we cannot treat it as a `String` easily, but it is a `JSON` object we need to convert to a `String` properly. At least we will have a `stringified` version of the Object, but it will not cause a `js` error that prevents the entire tab-page to be rendered properly. 
In addition to that fix, this PR adds a proper decoder case for the `hb_merge_subscriptions` message type.

## GUI diff

No difference.

Before:
*failure*

After:
![Screenshot from 2019-04-04 11-22-47](https://user-images.githubusercontent.com/7080830/55548928-eebe1180-56d4-11e9-8a03-f0d8d165b797.png)
- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #
Tracks # https://github.com/SUSE/spacewalk/pull/7506

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
