### PR TITLE
Fix backend's build makefiles

### DIFF
--- a/backend/Makefile.backend
+++ b/backend/Makefile.backend
@@ -1,8 +1,5 @@
 # Makefile for the backend directory
 #
-THIS_MAKEFILE := $(realpath $(lastword $(MAKEFILE_LIST)))
-CURRENT_DIR := $(dir $(THIS_MAKEFILE))
-
 CODE_DIRS = common server upload_server satellite_tools satellite_exporter po wsgi cdn_tools
 PYLINT_DIRS = common upload_server satellite_tools satellite_exporter wsgi
 CONF_DIRS = apache-conf rhn-conf logrotate
@@ -28,10 +25,6 @@ all :: all-code all-conf
 
 # now include some Macros
 include Makefile.defs
-
-__pylint ::
-	$(call update_pip_env)
-	pylint --rcfile=pylintrc $(shell find -name '*.py') > reports/pylint.log || true
 
 install :: install-code install-conf
 
@@ -67,12 +60,9 @@ docker_oracle_tests ::
 	@echo "Running Oracle tests"
 	docker run --privileged --rm=true -e $(DOCKER_RUN_EXPORT) $(DOCKER_VOLUMES) $(DOCKER_REGISTRY)/$(DOCKER_CONTAINER_BASE)-ora /manager/backend/test/docker-backend-oracle-tests.sh
 
+# This is obsolete target. Use Makefile.python
 docker_pylint ::
-	docker run --rm -e $(DOCKER_RUN_EXPORT) $(DOCKER_VOLUMES) $(DOCKER_REGISTRY)/$(DOCKER_CONTAINER_BASE)-pgsql /bin/sh -c "cd /manager/backend; make -f Makefile.backend __pylint"
+	docker run --rm -e $(DOCKER_RUN_EXPORT) $(DOCKER_VOLUMES) $(DOCKER_REGISTRY)/$(DOCKER_CONTAINER_BASE)-pgsql /bin/sh -c "cd /manager/backend; make -f Makefile.python __pylint"
 
 docker_shell ::
 	docker run --rm=true -t -i -e $(DOCKER_RUN_EXPORT) $(DOCKER_VOLUMES) $(DOCKER_REGISTRY)/$(DOCKER_CONTAINER_BASE)-pgsql /bin/bash
-
-test ::
-	echo "test"
-

--- a/backend/Makefile.backend
+++ b/backend/Makefile.backend
@@ -1,5 +1,6 @@
 # Makefile for the backend directory
 #
+SPACEWALK_FILES = __init__
 CODE_DIRS = common server upload_server satellite_tools satellite_exporter po wsgi cdn_tools
 PYLINT_DIRS = common upload_server satellite_tools satellite_exporter wsgi
 CONF_DIRS = apache-conf rhn-conf logrotate

--- a/backend/Makefile.defs
+++ b/backend/Makefile.defs
@@ -8,10 +8,6 @@ TOP		?= .
 ROOT		?= /usr/share/rhn
 export ROOT
 
-ifeq ("$(PYTHON_BIN)", "")
-    PYTHON_BIN = "python"
-endif
-
 SPACEWALK_ROOT	?= $(shell $(PYTHON_BIN) -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")/spacewalk
 export SPACEWALK_ROOT
 


### PR DESCRIPTION
## What does this PR change?

Reverts some changes to the standard Makefiles of the backend.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
