### PR TITLE
Update get_kernel_live_version to support Salt < 2018

### DIFF
--- a/susemanager-utils/susemanager-sls/src/modules/sumautil.py
+++ b/susemanager-utils/susemanager-sls/src/modules/sumautil.py
@@ -140,7 +140,12 @@ def _klp():
     :return:
     '''
     # get 'kgr' for versions prior to SLE 15
-    klp = salt.utils.path.which_bin(['klp', 'kgr'])
+    try:
+        from salt.utils.path import which_bin
+    except:
+        from salt.utils import which_bin
+
+    klp = which_bin(['klp', 'kgr'])
     patchname = None
     if klp is not None:
         try:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- Update get_kernel_live_version module to support older Salt versions (bsc#1131490)
+
 -------------------------------------------------------------------
 Fri Mar 29 10:37:42 CET 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
Fix `get_kernel_live_version` to support Salt pre-2018 vesions.

## Links

Fixes https://github.com/SUSE/spacewalk/issues/7505
https://bugzilla.suse.com/1131490

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
