### PR TITLE
Align newly inserted Environments

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentEnvironment.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentEnvironment.java
@@ -20,6 +20,8 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import javax.persistence.CascadeType;
@@ -31,6 +33,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
@@ -51,6 +54,7 @@ public class ContentEnvironment extends BaseDomainHelper {
     private String description;
     private Long version = 0L;
     private ContentProject contentProject;
+    private List<EnvironmentTarget> targets = new ArrayList<>();
     private ContentEnvironment nextEnvironment;
     private ContentEnvironment prevEnvironment;
 
@@ -124,6 +128,44 @@ public class ContentEnvironment extends BaseDomainHelper {
     @JoinColumn(name = "project_id")
     public ContentProject getContentProject() {
         return contentProject;
+    }
+
+    /**
+     * Gets the targets.
+     *
+     * @return targets
+     */
+    @OneToMany(mappedBy = "contentEnvironment", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    public List<EnvironmentTarget> getTargets() {
+        return targets;
+    }
+
+    /**
+     * Sets the targets.
+     *
+     * @param targetsIn the targets
+     */
+    public void setTargets(List<EnvironmentTarget> targetsIn) {
+        this.targets = targetsIn;
+    }
+
+    /**
+     * Add target
+     *
+     * @param target the target
+     */
+    public void addTarget(EnvironmentTarget target) {
+        target.setContentEnvironment(this);
+        targets.add(target);
+    }
+
+    /**
+     * Remove target
+     * @param target the target
+     */
+    public void removeTarget(EnvironmentTarget target) {
+        targets.remove(target);
+        target.setContentEnvironment(null);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
@@ -26,7 +26,6 @@ import org.apache.log4j.Logger;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Stream;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Predicate;
@@ -280,20 +279,6 @@ public class ContentProjectFactory extends HibernateFactory {
         return getSession().createQuery(query)
                 .uniqueResultOptional()
                 .filter(tgt -> ChannelFactory.isAccessibleByUser(tgt.getChannel().getLabel(), user.getId()));
-    }
-
-    /**
-     * Looks up {@link EnvironmentTarget}s of given {@link ContentEnvironment}
-     *
-     * @param env the Environment
-     * @return the Stream of {@link EnvironmentTarget}s
-     */
-    public static Stream<EnvironmentTarget> lookupEnvironmentTargets(ContentEnvironment env) {
-        CriteriaBuilder builder = getSession().getCriteriaBuilder();
-        CriteriaQuery<EnvironmentTarget> query = builder.createQuery(EnvironmentTarget.class);
-        Root<EnvironmentTarget> root = query.from(EnvironmentTarget.class);
-        query.where(builder.equal(root.get("contentEnvironment"), env));
-        return getSession().createQuery(query).stream();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
@@ -260,6 +260,7 @@ public class ContentProjectFactory extends HibernateFactory {
      * @param target the Environment Target
      */
     public static void purgeTarget(EnvironmentTarget target) {
+        target.getContentEnvironment().removeTarget(target);
         INSTANCE.removeObject(target);
         target.asSoftwareTarget().ifPresent(swTgt -> ChannelFactory.remove(swTgt.getChannel()));
     }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentProjectFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentProjectFactoryTest.java
@@ -44,7 +44,6 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
-import static java.util.stream.Collectors.toList;
 
 /**
  * Tests for {@link com.redhat.rhn.domain.contentmgmt.ContentProjectFactory}
@@ -421,20 +420,20 @@ public class ContentProjectFactoryTest extends BaseTestCaseWithUser {
 
         Channel channel = ChannelTestUtils.createBaseChannel(user);
         SoftwareEnvironmentTarget target = new SoftwareEnvironmentTarget(envdev, channel);
-        ContentProjectFactory.save(target);
+        envdev.addTarget(target);
         Channel channel2 = ChannelTestUtils.createBaseChannel(user);
         SoftwareEnvironmentTarget target2 = new SoftwareEnvironmentTarget(envdev, channel2);
-        ContentProjectFactory.save(target2);
+        envdev.addTarget(target2);
 
-        List<EnvironmentTarget> targetsDev = ContentProjectFactory.lookupEnvironmentTargets(envdev).collect(toList());
+        List<EnvironmentTarget> targetsDev = envdev.getTargets();
         assertEquals(2, targetsDev.size());
         assertContains(targetsDev, target);
         assertContains(targetsDev, target2);
 
         Channel channel3 = ChannelTestUtils.createBaseChannel(user);
         SoftwareEnvironmentTarget target3 = new SoftwareEnvironmentTarget(envtest, channel3);
-        ContentProjectFactory.save(target3);
-        List<EnvironmentTarget> targetsTest = ContentProjectFactory.lookupEnvironmentTargets(envtest).collect(toList());
+        envtest.addTarget(target3);
+        List<EnvironmentTarget> targetsTest = envtest.getTargets();
         assertEquals(1, targetsTest.size());
         assertContains(targetsTest, target3);
     }
@@ -452,13 +451,13 @@ public class ContentProjectFactoryTest extends BaseTestCaseWithUser {
         cp.setFirstEnvironment(envdev);
         Channel channel = ChannelTestUtils.createBaseChannel(user);
         SoftwareEnvironmentTarget target = new SoftwareEnvironmentTarget(envdev, channel);
-        ContentProjectFactory.save(target);
+        envdev.addTarget(target);
         String channelLabel = channel.getLabel();
 
-        assertEquals(1, ContentProjectFactory.lookupEnvironmentTargets(envdev).count());
+        assertEquals(1, envdev.getTargets().size());
         assertNotNull(ChannelFactory.lookupByLabel(channelLabel));
         ContentProjectFactory.purgeTarget(target);
-        assertEquals(0, ContentProjectFactory.lookupEnvironmentTargets(envdev).count());
+        assertEquals(0, envdev.getTargets().size());
         assertNull(ChannelFactory.lookupByLabel(channelLabel));
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentProjectFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentProjectFactoryTest.java
@@ -33,7 +33,6 @@ import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.user.UserFactory;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.ChannelTestUtils;
-import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
 import java.util.List;

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentProjectFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentProjectFactoryTest.java
@@ -119,12 +119,7 @@ public class ContentProjectFactoryTest extends BaseTestCaseWithUser {
         ContentProjectFactory.save(envprod);
         ContentProjectFactory.insertEnvironment(envprod, of(envtest));
 
-        HibernateFactory.getSession().flush();
-        envtest = TestUtils.reload(envtest);
-
         ContentProjectFactory.removeEnvironment(envtest);
-
-        HibernateFactory.getSession().flush();
 
         ContentProject fromDb = ContentProjectFactory.lookupProjectByLabelAndOrg("project1", user.getOrg()).get();
         assertEquals("project1", fromDb.getLabel());
@@ -142,8 +137,6 @@ public class ContentProjectFactoryTest extends BaseTestCaseWithUser {
         assertEquals(empty(), first.getPrevEnvironmentOpt());
 
         ContentProjectFactory.removeEnvironment(envdev);
-
-        HibernateFactory.getSession().flush();
 
         fromDb = ContentProjectFactory.lookupProjectByLabelAndOrg("project1", user.getOrg()).get();
         ContentEnvironment newfirst = fromDb.getFirstEnvironmentOpt().get();

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
@@ -233,7 +233,7 @@ public class ContentManagementHandler extends BaseHandler {
         ensureOrgAdmin(loggedInUser);
         try {
             return ContentManager.createEnvironment(projectLabel, ofNullable(nullIfEmpty(predecessorLabel)), label,
-                    name, description, loggedInUser);
+                    name, description, true, loggedInUser);
         }
         catch (EntityNotExistsException e) {
             throw new EntityNotExistsFaultException(e);

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -156,6 +156,7 @@ public class ContentManager {
      * @param label - the Environment label
      * @param name - the Environment name
      * @param description - the Environment description
+     * @param async run the time-expensive operations asynchronously?
      * @param user - the user performing the action
      * @throws EntityNotExistsException - if Content Project with given label or Content Environment in the Project
      * is not found
@@ -164,7 +165,7 @@ public class ContentManager {
      * @return the created Content Environment
      */
     public static ContentEnvironment createEnvironment(String projectLabel, Optional<String> predecessorLabel,
-            String label, String name, String description, User user) {
+            String label, String name, String description, boolean async, User user) {
         ensureOrgAdmin(user);
         lookupEnvironment(label, projectLabel, user).ifPresent(e -> { throw new EntityExistsException(e); });
         return lookupProject(projectLabel, user)
@@ -174,6 +175,13 @@ public class ContentManager {
                             ContentProjectFactory.lookupEnvironmentByLabelAndProject(pl, cp)
                                     .orElseThrow(() -> new EntityNotExistsException(ContentEnvironment.class, label)));
                     ContentProjectFactory.insertEnvironment(newEnv, predecessor);
+                    // TODO: for now only support populating non-first environments
+                    // populating first environment will be implemented as soon as backward-promote is implemented
+                    predecessor.ifPresent(p -> {
+                        if (!p.getTargets().isEmpty()) {
+                            promoteProject(projectLabel, p.getLabel(), true, user);
+                        }
+                    });
                     return newEnv;
                 }).orElseThrow(() -> new EntityNotExistsException(ContentProject.class, projectLabel));
     }

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -366,7 +366,7 @@ public class ContentManager {
                 .orElseThrow(() -> new ContentManagementException("Environment " + envLabel +
                         " does not have successor"));
 
-        Map<Boolean, List<Channel>> envChannels = ContentProjectFactory.lookupEnvironmentTargets(env)
+        Map<Boolean, List<Channel>> envChannels = env.getTargets().stream()
                 .flatMap(tgt -> stream(tgt.asSoftwareTarget()))
                 .map(tgt -> tgt.getChannel())
                 .collect(partitioningBy(Channel::isBaseChannel));
@@ -456,7 +456,7 @@ public class ContentManager {
         Set<Channel> newTargets = newSrcTgtPairs.stream()
                 .map(pair -> pair.getRight())
                 .collect(toSet());
-        ContentProjectFactory.lookupEnvironmentTargets(env)
+        env.getTargets().stream()
                 .flatMap(t -> stream(t.asSoftwareTarget()))
                 .filter(tgt -> !newTargets.contains(tgt.getChannel()))
                 .sorted((c1, c2) -> Boolean.compare(c1.getChannel().isBaseChannel(), c2.getChannel().isBaseChannel()))

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -523,7 +523,7 @@ public class ContentManager {
                 });
 
         SoftwareEnvironmentTarget target = new SoftwareEnvironmentTarget(env, targetChannel);
-        ContentProjectFactory.save(target);
+        env.addTarget(target);
         return targetChannel;
     }
 

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
@@ -586,7 +586,7 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
         assertEquals(channel, cp.lookupSwSourceLeader().get().getChannel());
         ContentManager.buildProject("cplabel", empty(), false, user);
 
-        List<EnvironmentTarget> tgts = ContentProjectFactory.lookupEnvironmentTargets(env).collect(toList());
+        List<EnvironmentTarget> tgts = env.getTargets();
         assertEquals(1, tgts.size());
         Channel tgtChannel = tgts.get(0).asSoftwareTarget().get().getChannel();
         assertEquals("cplabel-fst-" + channel.getLabel(), tgtChannel.getLabel());
@@ -603,7 +603,6 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
         ContentManager.buildProject("cplabel", empty(), false, user);
         assertEquals(Long.valueOf(2), env.getVersion());
 
-        tgts = ContentProjectFactory.lookupEnvironmentTargets(env).collect(toList());
         assertEquals(2, tgts.size());
         Set<String> tgtLabels = tgts.stream().map(tgt -> tgt.asSoftwareTarget().get().getChannel().getLabel()).collect(toSet());
         assertContains(tgtLabels, "cplabel-fst-" + channel.getLabel());
@@ -626,7 +625,6 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
         assertEquals(Long.valueOf(3), env.getVersion());
 
         assertEquals(newChannel, cp.lookupSwSourceLeader().get().getChannel()); // leader is changed
-        tgts = ContentProjectFactory.lookupEnvironmentTargets(env).collect(toList());
         assertEquals(1, tgts.size());
         assertEquals("cplabel-fst-" + newChannel.getLabel(), tgts.get(0).asSoftwareTarget().get().getChannel().getLabel());
         assertEquals(channel.getPackages(), tgtChannel.getPackages());
@@ -650,7 +648,7 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
         alreadyExistingTgt.setLabel("cplabel-fst-" + channel.getLabel());
 
         ContentManager.buildProject("cplabel", empty(), false, user);
-        List<EnvironmentTarget> environmentTargets = ContentProjectFactory.lookupEnvironmentTargets(env).collect(toList());
+        List<EnvironmentTarget> environmentTargets = env.getTargets();
         assertEquals(1, environmentTargets.size());
         assertEquals(alreadyExistingTgt, environmentTargets.get(0).asSoftwareTarget().get().getChannel());
     }
@@ -708,7 +706,7 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
         assertEquals(Long.valueOf(1), env.getVersion());
 
         ContentEnvironment envUser1 = ContentManager.lookupEnvironment("fst", "cplabel", userSameOrg).get();
-        List<EnvironmentTarget> tgts = ContentProjectFactory.lookupEnvironmentTargets(envUser1).collect(toList());
+        List<EnvironmentTarget> tgts = envUser1.getTargets();
         assertEquals(1, tgts.size());
         Channel tgtChannel = tgts.get(0).asSoftwareTarget().get().getChannel();
         // its assets should be accessible to a regular user in the org
@@ -771,7 +769,7 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
         // 3. promote
         ContentManager.promoteProject("cplabel", "dev", false, user);
         assertEquals(devEnv.getVersion(), testEnv.getVersion());
-        List<EnvironmentTarget> testTgts = ContentProjectFactory.lookupEnvironmentTargets(testEnv).collect(toList());
+        List<EnvironmentTarget> testTgts = testEnv.getTargets();
         assertEquals(2, testTgts.size());
         Channel tgtChannel1 = testTgts.get(0).asSoftwareTarget().get().getChannel();
         Channel tgtChannel2 = testTgts.get(1).asSoftwareTarget().get().getChannel();
@@ -784,7 +782,7 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
         // 4. promote further
         ContentManager.promoteProject("cplabel", "test", false, user);
         assertEquals(devEnv.getVersion(), prodEnv.getVersion());
-        List<EnvironmentTarget> prodTgts = ContentProjectFactory.lookupEnvironmentTargets(prodEnv).collect(toList());
+        List<EnvironmentTarget> prodTgts = prodEnv.getTargets();
         assertEquals(2, prodTgts.size());
         tgtChannel1 = prodTgts.get(0).asSoftwareTarget().get().getChannel();
         tgtChannel2 = prodTgts.get(1).asSoftwareTarget().get().getChannel();
@@ -794,15 +792,15 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
         // 5. build with changed sources
         ContentManager.buildProject("cplabel", empty(), false, user);
         assertEquals(Long.valueOf(2), devEnv.getVersion());
-        assertEquals(1, ContentProjectFactory.lookupEnvironmentTargets(devEnv).count());
-        assertEquals(2, ContentProjectFactory.lookupEnvironmentTargets(testEnv).count());
-        assertEquals(2, ContentProjectFactory.lookupEnvironmentTargets(prodEnv).count());
+        assertEquals(1, devEnv.getTargets().size());
+        assertEquals(2, testEnv.getTargets().size());
+        assertEquals(2, prodEnv.getTargets().size());
         assertNull(ChannelFactory.lookupByLabel("cplabel-dev-" + channel1.getLabel())); // channel has been deleted
 
         // 6. next promotion cycle
         ContentManager.promoteProject("cplabel", "dev", false, user);
         assertEquals(devEnv.getVersion(), testEnv.getVersion());
-        testTgts = ContentProjectFactory.lookupEnvironmentTargets(testEnv).collect(toList());
+        testTgts = testEnv.getTargets();
         assertEquals(1, testTgts.size());
         Channel tgtChannel = testTgts.get(0).asSoftwareTarget().get().getChannel();
         assertEquals("cplabel-test-" + channel2.getLabel(), tgtChannel.getLabel());
@@ -811,7 +809,7 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
         // 7. last promotion cycle
         ContentManager.promoteProject("cplabel", "test", false, user);
         assertEquals(devEnv.getVersion(), prodEnv.getVersion());
-        prodTgts = ContentProjectFactory.lookupEnvironmentTargets(prodEnv).collect(toList());
+        prodTgts = prodEnv.getTargets();
         assertEquals(1, prodTgts.size());
         tgtChannel = prodTgts.get(0).asSoftwareTarget().get().getChannel();
         assertEquals("cplabel-prod-" + channel2.getLabel(), tgtChannel.getLabel());

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/EnvironmentApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/EnvironmentApiController.java
@@ -81,6 +81,7 @@ public class EnvironmentApiController {
                 createEnvironmentRequest.getLabel(),
                 createEnvironmentRequest.getName(),
                 createEnvironmentRequest.getDescription(),
+                true,
                 user
         );
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Populate Content Environment on inserting it in a Project
 - Add makefile and pylint configuration
 
 -------------------------------------------------------------------


### PR DESCRIPTION
Previously, when inserting a new Content Environment in a Project, this Environment was not aligned with the contents of the previous Environment in the Project. This PR fixes that.

Corner case (to be addressed separately):
When inserting an Environment in the first place, its contents should be back-promoted from the old first Environment. This is to be implemented after back-promote functionality is done.

## How to review
Commit-by-commit.

There is also a small refactoring in this PR (2 commits): Mapping `EnvironmentTarget` directly to `Environments` in a proper way using `@OneToMany` hibernate mapping.

## UI
No difference.

- [x] **DONE**

# Doc
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Tests
- Unit tests were added

- [x] **DONE**

## Links
Tracks https://github.com/SUSE/spacewalk/issues/7436

- [x] **DONE**

## Misc
If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)



If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"