### PR TITLE
Fix retrieval of build time for .deb repositories

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
@@ -2519,7 +2519,7 @@ public class ChannelManager extends BaseManager {
                 "/pub");
         File theFile = new File(mountPoint + File.separator + pathPrefix +
                 File.separator + channel.getLabel() + File.separator +
-                "repomd.xml");
+                (channel.isTypeDeb() ? "Release" : "repomd.xml"));
         if (!theFile.exists()) {
             // No repo file, dont bother computing build date
             return null;

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix retrieval of build time for .deb repositories (bsc#1131721)
 - Fix product package conflicts with SLES for SAP systems (bsc#1130551)
 - Take into account only synced products when scheduling SP migration from the API (bsc#1131929)
 


### PR DESCRIPTION
Fix retrieval of build time for .deb repositories, which caused repo sync to report failure in the UI.
https://bugzilla.suse.com/1131721

Tracks https://github.com/SUSE/spacewalk/pull/7519

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
