### PR TITLE
Reload Salt modules after installing formulas

### DIFF
--- a/testsuite/features/allcli_system_group.feature
+++ b/testsuite/features/allcli_system_group.feature
@@ -58,9 +58,12 @@ Feature: Manage a group of systems
     And I should see "sle-client" as link
     And I should see "sle-minion" as link
 
-  Scenario: Check formula page is rendered for the system group
+  Scenario: Install some formula on the server
     Given I am on the groups page
     When I manually install the "locale" formula on the server
+    And I synchronize the Salt execution modules on "sle-minion"
+
+  Scenario: New formula page is rendered for the system group
     And I follow "new-systems-group"
     And I follow "Formulas"
     Then I should see a "Choose formulas:" text

--- a/testsuite/features/core_proxy_branch_network.feature
+++ b/testsuite/features/core_proxy_branch_network.feature
@@ -15,7 +15,7 @@ Feature: Setup SUSE Manager for Retail branch network
     When I manually install the "branch-network" formula on the server
     And I manually install the "dhcpd" formula on the server
     And I manually install the "bind" formula on the server
-    And I wait for "16" seconds
+    And I synchronize the Salt execution modules on "proxy"
 
 @proxy
 @private_net

--- a/testsuite/features/min_osimage_build_image.feature
+++ b/testsuite/features/min_osimage_build_image.feature
@@ -29,7 +29,7 @@ Feature: Build OS images
 @private_net
   Scenario: Move the image to the branch server
     When I manually install the "image-sync" formula on the server
-    And I wait for "16" seconds
+    And I synchronize the Salt execution modules on "proxy"
     And I apply state "image-sync" to "proxy"
     Then the image "POS_Image_JeOS6" should exist on "proxy"
 

--- a/testsuite/features/min_salt_formulas.feature
+++ b/testsuite/features/min_salt_formulas.feature
@@ -9,7 +9,10 @@ Feature: Use salt formulas
   Scenario: Install a formula package on the server
      Given I am authorized
      When I manually install the "locale" formula on the server
-     And I reload the page
+     And I synchronize the Salt execution modules on "sle-minion"
+
+  Scenario: The new formula appears on the server
+     Given I am authorized
      And I follow "Salt"
      And I follow "Formula Catalog"
      Then I should see a "locale" text

--- a/testsuite/features/proxy_retail_pxeboot.feature
+++ b/testsuite/features/proxy_retail_pxeboot.feature
@@ -24,7 +24,7 @@ Feature: PXE boot a Retail terminal
     And I manually install the "vsftpd" formula on the server
     And I manually install the "saltboot" formula on the server
     And I manually install the "pxe" formula on the server
-    And I wait for "16" seconds
+    And I synchronize the Salt execution modules on "proxy"
 
 @proxy
 @private_net

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -286,6 +286,15 @@ When(/^I manually uninstall the "([^"]*)" formula from the server$/) do |package
   $server.run("zypper --non-interactive remove #{package}-formula")
 end
 
+When(/^I synchronize the Salt execution modules on "([^"]*)"$/) do |host|
+  # WORKAROUND - remove me when fixed
+  # bsc#1131846 - salt chokes on ipv6 addresses when synchronizing client exec execution modules
+  $server.run("sed -i \"s/'ss', '-ant'/'ss', '-ant4'/\" /usr/lib/python3.6/site-packages/salt/utils/network.py", false)
+  # ---------------------------------
+  system_name = get_system_name(host)
+  $server.run("salt #{system_name} saltutil.sync_modules")
+end
+
 When(/^I ([^ ]*) the "([^"]*)" formula$/) do |action, formula|
   # Complicated code because the checkbox is not a <input type=checkbox> but an <i>
   xpath_query = "//a[@id = '#{formula}']/i[@class = 'fa fa-lg fa-square-o']" if action == 'check'


### PR DESCRIPTION
## What does this PR change?

This PR attempts to fix test suite failures when moving images through a formula.

It synchronizes Salt execution modules after installing formulas and before using them.

## Links

Fixes the test suite

Tracks 3.1: SUSE/spacewalk#7531
            3.2: SUSE/spacewalk#7530

- [x] No changelog needed
