### PR TITLE
Content management: errata-related fixes

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/errata/ErrataFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/errata/ErrataFactory.java
@@ -994,6 +994,20 @@ public class ErrataFactory extends HibernateFactory {
         singleton.removeObject(deleteme);
     }
 
+    /**
+     * Lists errata assigned to a particular channel.
+     *
+     * @param org the Org in question
+     * @param channel the channel you want to get the errata for
+     * @return A list of Errata objects
+     */
+    public static List<PublishedErrata> listByChannel(Org org, Channel channel) {
+        return HibernateFactory.getSession().
+                getNamedQuery("PublishedErrata.listByChannel")
+                .setParameter("org", org)
+                .setParameter("channel", channel)
+                .list();
+    }
 
     /**
      * Lists errata assigned to a particular channel,

--- a/java/code/src/com/redhat/rhn/domain/errata/impl/PublishedErrata.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/errata/impl/PublishedErrata.hbm.xml
@@ -143,6 +143,16 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         <![CDATA[from com.redhat.rhn.domain.errata.impl.PublishedErrata as e
                  where e.advisory = :advisory and (e.org = :org or e.org is null)]]>
     </query>
+
+    <query name="PublishedErrata.listByChannel">
+        <![CDATA[
+        select e
+         from PublishedErrata e
+         where
+          :channel member of e.channels
+          and (e.org = :org or e.org is null)]]>
+    </query>
+
     <query name="PublishedErrata.lookupSortedByChannel">
         <![CDATA[select e
                         from com.redhat.rhn.domain.errata.impl.PublishedErrata as e

--- a/java/code/src/com/redhat/rhn/domain/errata/test/ErrataFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/errata/test/ErrataFactoryTest.java
@@ -545,5 +545,19 @@ public class ErrataFactoryTest extends BaseTestCaseWithUser {
         }
     }
 
+    /**
+     * Test listing errata by channel
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testListErrataByChannel() throws Exception {
+        Channel chan = ChannelTestUtils.createBaseChannel(user);
+        Errata e = ErrataFactoryTest.createTestErrata(user.getId());
+        chan.getErratas().add(e);
+
+        List<PublishedErrata> errata = ErrataFactory.listByChannel(user.getOrg(), chan);
+        assertEquals(1, errata.size());
+        assertEquals(e, errata.iterator().next());
+    }
 }
 

--- a/java/code/src/com/redhat/rhn/domain/errata/test/ErrataFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/errata/test/ErrataFactoryTest.java
@@ -520,7 +520,7 @@ public class ErrataFactoryTest extends BaseTestCaseWithUser {
         assertTrue(clone.getOriginal().equals(published));
     }
 
-    public void listErrataChannelPackages() {
+    public void testListErrataChannelPackages() {
         try {
             Channel chan = ChannelTestUtils.createBaseChannel(user);
             Errata e = ErrataFactoryTest.createTestErrata(user.getId());

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -317,11 +317,14 @@ public class ErrataManager extends BaseManager {
      * @param user the user
      */
     public static void truncateErrata(Channel srcChannel, Channel tgtChannel, User user) {
-        // 2-pass approach to prevent concurrent modification error
-        Set<Errata> toRemove = tgtChannel.getErratas().stream()
-                .filter(e -> !srcChannel.getErratas().contains(e))
-                .collect(toSet());
-        toRemove.forEach(e -> removeErratumFromChannel(e, tgtChannel, user));
+        Set<Errata> srcErrata = new HashSet<>(ErrataFactory.listByChannel(user.getOrg(), srcChannel));
+        Set<Errata> tgtErrata = new HashSet<>(ErrataFactory.listByChannel(user.getOrg(), tgtChannel));
+
+        // select errata that are exclusively in tgt channel
+        tgtErrata.removeAll(srcErrata);
+
+        // and remove them
+        tgtErrata.forEach(e -> removeErratumFromChannel(e, tgtChannel, user));
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -263,7 +263,7 @@ public class ErrataManager extends BaseManager {
      */
     public static Set<Errata> mergeErrataToChannel(User user, Set<Errata> errataToMergeIn,
             Channel toChannel, Channel fromChannel) {
-        return mergeErrataToChannel(user, errataToMergeIn, toChannel, fromChannel, false, true);
+        return mergeErrataToChannel(user, errataToMergeIn, toChannel, fromChannel, true, true);
     }
 
     /**


### PR DESCRIPTION
## What does this PR change?
 
This PR contains a couple of fixes related to errata handling in content management. Commit messages are mostly self-explanatory.

Explicit note to the last commit (Fix: Truncating errata - take cloned errata into account):
This was a bug in the content management errata truncating: when building a project, errata are cloned from the source channel to target channel in the first environment. If for some reason, an erratum is removed from the source channel and the project is built again, its clone of this erratum should also be removed from the target channel.
 
 ## GUI diff
 
 No difference.
 
 Before:
 
 After:
 
 - [x] **DONE**
 
 ## Documentation
 - No documentation needed: bugfixes
 
 - [x] **DONE**
 
 ## Test coverage
 - Unit tests were added
 
 - [x] **DONE**
 
 
 ## Changelogs
 
 If you don't need a changelog check, please mark this checkbox:
 
 - [x] No changelog needed
 
 If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
 
 
 ## Re-run a test
 
 If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:
 
 - [ ] Re-run test "changelog_test"
 - [ ] Re-run test "backend_unittests_pgsql"
 - [ ] Re-run test "java_lint_checkstyle"		 
 - [ ] Re-run test "java_pgsql_tests"		 
 - [ ] Re-run test "ruby_rubocop"
 - [ ] Re-run test "schema_migration_test_oracle"
 - [ ] Re-run test "schema_migration_test_pgsql"		 
 - [ ] Re-run test "susemanager_unittests"
 - [ ] Re-run test "javascript_lint"