### PR TITLE
Testsuite - test event triggering after package install

### DIFF
--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -402,10 +402,13 @@ The check box can be identified by name, id or label text.
 ```cucumber
   When I install package "virgo-dummy-1.0-1.1" on this "sle-minion"
   When I remove package "orion-dummy" from this "sle-minion"
+  When I refresh packages list via spacecmd on "sle-minion"
   When I wait for "virgo-dummy-1.0" to be installed on this "sle-minion"
   When I wait for "milkyway-dummy" to be uninstalled on "sle-minion"
+  When I wait until refresh package list on "sle-minion" is finished
   Then "man" should be installed on "sle-client"
   Then "milkyway-dummy" should not be installed on "sle-minion"
+  Then spacecmd should show packages "virgo-dummy-1.0 milkyway-dummy" installed on "sle-minion"
 ```
 
 * Services

--- a/testsuite/features/min_action_chain.feature
+++ b/testsuite/features/min_action_chain.feature
@@ -13,9 +13,10 @@ Feature: Action chain on salt minions
     And I run "zypper -n ref" on "sle-minion"
     And I run "echo '/dev/vda1 / ext4 defaults 0 0' > /etc/fstab" on "sle-minion"
 
-  Scenario: Pre-requisite: refresh package list first on SLE minion
+  Scenario: Pre-requisite: refresh package list and check installed packages after downgrade on SLE minion
     When I refresh packages list via spacecmd on "sle-minion"
     And I wait until refresh package list on "sle-minion" is finished
+    Then spacecmd should show packages "milkyway-dummy andromeda-dummy-1.0" installed on "sle-minion"
 
   Scenario: Pre-requisite: wait until downgrade is finished
     Given I am on the Systems overview page of this "sle-minion"

--- a/testsuite/features/min_salt_install_package.feature
+++ b/testsuite/features/min_salt_install_package.feature
@@ -8,9 +8,10 @@ Feature: Install a patch on the client via Salt through the UI
     And I run "zypper -n ref" on "sle-minion"
     And I run "zypper -n in --oldpackage virgo-dummy-1.0" on "sle-minion" without error control
 
-  Scenario: Pre-requisite: refresh package list on SLE minion machine
+  Scenario: Pre-requisite: refresh package list and check old packages installed on SLE minion client
     When I refresh packages list via spacecmd on "sle-minion"
     And I wait until refresh package list on "sle-minion" is finished
+    Then spacecmd should show packages "virgo-dummy-1.0" installed on "sle-minion"
 
   Scenario: Pre-requisite: ensure the errata cache is computed before patchin Salt minion
     Given I am on the Systems overview page of this "sle-minion"

--- a/testsuite/features/min_salt_install_with_staging.feature
+++ b/testsuite/features/min_salt_install_with_staging.feature
@@ -12,16 +12,14 @@
 
 Feature: Install a package on the minion with staging enabled
 
-  Scenario: Pre-requisite: install virgo-dummy-1.0 and orion-dummy-1.1 packages
-    Given I am authorized as "admin" with password "admin"
-    And I run "zypper -n mr -e Devel_Galaxy_BuildRepo" on "sle-minion"
-    And I run "zypper -n ref" on "sle-minion"
-    And I run "zypper -n in --oldpackage virgo-dummy-1.0" on "sle-minion" without error control
-    And I run "zypper -n rm orion-dummy" on "sle-minion" without error control
+  Scenario: Pre-requisite: install virgo-dummy-1.0 package
+    When I enable repository "Devel_Galaxy_BuildRepo" on this "sle-minion"
+    And I install package "virgo-dummy-1.0" on this "sle-minion"
 
-  Scenario: Pre-requisite: refresh package list on SLE minion 
+  Scenario: Pre-requisite: refresh package list and check newly installed packages on SLE minion client
     When I refresh packages list via spacecmd on "sle-minion"
     And I wait until refresh package list on "sle-minion" is finished
+    Then spacecmd should show packages "virgo-dummy-1.0" installed on "sle-minion"
 
   Scenario: Pre-requisite: ensure the errata cache is computed
     Given I am authorized as "admin" with password "admin"
@@ -32,13 +30,6 @@ Feature: Install a package on the minion with staging enabled
     Then I click on "Single Run Schedule"
     And I should see a "bunch was scheduled" text
     Then I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows
-
-  Scenario: Pre-requisite: ensure the known package list is correct
-    Given I am on the Systems overview page of this "sle-minion"
-    When I follow "Software" in the content area
-    And I follow "List / Remove" in the content area
-    And I enter "virgo-dummy" in the css "input[placeholder='Filter by Package Name: ']"
-    And I click on the css "button.spacewalk-button-filter" until page does contain "virgo-dummy-1.0" text
 
   Scenario: Enable content staging
     Given I am authorized as "admin" with password "admin"
@@ -83,8 +74,12 @@ Feature: Install a package on the minion with staging enabled
     And I wait for "virgo-dummy-2.0-1.1" to be installed on this "sle-minion"
     Then I disable repository "Devel_Galaxy_BuildRepo" on this "sle-minion"
 
-  Scenario: Cleanup: remove virgo-dummy and orion-dummy packages from SLES minion
-    Given I am authorized as "admin" with password "admin"
-    And I run "zypper -n rm virgo-dummy" on "sle-minion" without error control
-    And I run "zypper -n rm orion-dummy" on "sle-minion" without error control
-    And I run "zypper -n ref" on "sle-minion"
+  Scenario: Cleanup: remove virgo-dummy package from SLES minion
+    Given I am on the Systems overview page of this "sle-minion"
+    When I follow "Software" in the content area
+    And I follow "List / Remove"
+    And I enter "virgo-dummy" in the css "input[placeholder='Filter by Package Name: ']"
+    And I click on the css "button.spacewalk-button-filter"
+    And I check "virgo-dummy" in the list
+    And I click on "Remove Packages"
+    And I click on "Confirm"

--- a/testsuite/features/min_salt_pkgset_beacon.feature
+++ b/testsuite/features/min_salt_pkgset_beacon.feature
@@ -9,9 +9,10 @@ Feature: System package list is updated if packages are manually installed or re
     And I run "zypper -n ref" on "sle-minion"
     And I run "zypper -n in --oldpackage milkyway-dummy-1.0" on "sle-minion" without error control
 
-  Scenario: Pre-requisite: refresh package list first on SLE minion machine
+  Scenario: Pre-requisite: refresh package list and check installed packages on SLE minion client
     When I refresh packages list via spacecmd on "sle-minion"
     And I wait until refresh package list on "sle-minion" is finished
+    Then spacecmd should show packages "milkyway-dummy-1.0" installed on "sle-minion"
 
   Scenario: Pre-requisite: ensure the errata cache is computed
     Given I am on the Systems overview page of this "sle-minion"

--- a/testsuite/features/min_salt_software_states.feature
+++ b/testsuite/features/min_salt_software_states.feature
@@ -12,9 +12,10 @@ Feature: Salt package states
     And I run "zypper -n in --oldpackage virgo-dummy-1.0" on "sle-minion" without error control
     And I run "zypper -n in --oldpackage andromeda-dummy-1.0" on "sle-minion" without error control
 
-  Scenario: Pre-requisite: refresh package list on SLES minion
+  Scenario: Pre-requisite: refresh package list and check installed packages on SLE minion
     When I refresh packages list via spacecmd on "sle-minion"
     And I wait until refresh package list on "sle-minion" is finished
+    Then spacecmd should show packages "milkyway-dummy-1.0 virgo-dummy-1.0 andromeda-dummy-1.0" installed on "sle-minion"
 
   Scenario: Pre-requisite: ensure the errata cache is computed
     Given I am on the Systems overview page of this "sle-minion"

--- a/testsuite/features/minssh_action_chain.feature
+++ b/testsuite/features/minssh_action_chain.feature
@@ -16,9 +16,10 @@ Feature: Salt SSH action chain
     And I run "zypper -n ref" on "ssh-minion"
 
 @ssh_minion
-  Scenario: Pre-requisite: refresh package list
+  Scenario: Pre-requisite: refresh package list and check newly installed packages on SSH minion
     When I refresh packages list via spacecmd on "ssh-minion"
     And I wait until refresh package list on "ssh-minion" is finished
+    Then spacecmd should show packages "milkyway-dummy andromeda-dummy-1.0" installed on "ssh-minion"
 
 @ssh_minion
   Scenario: Pre-requisite: wait until downgrade is finished

--- a/testsuite/features/minssh_centos_salt_install_package_and_patch.feature
+++ b/testsuite/features/minssh_centos_salt_install_package_and_patch.feature
@@ -4,18 +4,19 @@
 Feature: Install a patch on the CentOS SSH minion via Salt through the UI
 
 @centos_minion
-  Scenario: Pre-requisite: install virgo-dummy-1.0 packages
+  Scenario: Pre-requisite: install virgo-dummy-1.0 and remove andromeda-dummy packages
     When I enable repository "Devel_Galaxy_BuildRepo" on this "ceos-ssh-minion"
     And I remove package "andromeda-dummy" from this "ceos-ssh-minion"
     And I install package "virgo-dummy-1.0" on this "ceos-ssh-minion"
 
 @centos_minion
-  Scenario: Pre-requisite: refresh package list on Centos SSH minion 
+  Scenario: Pre-requisite: refresh package list and check newly installed packages on Centos SSH minion
     When I refresh packages list via spacecmd on "ceos-ssh-minion"
     And I wait until refresh package list on "ceos-ssh-minion" is finished
+    Then spacecmd should show packages "virgo-dummy-1.0" installed on "ceos-ssh-minion"
 
 @centos_minion
-  Scenario: Schedule errata refresh to reflect channel assignment on Centos SSH minion 
+  Scenario: Schedule errata refresh to reflect channel assignment on Centos SSH minion
     Given I am on the Systems overview page of this "ceos-ssh-minion"
     When I follow "Software" in the content area
     And I follow "List / Remove" in the content area
@@ -30,7 +31,7 @@ Feature: Install a patch on the CentOS SSH minion via Salt through the UI
     And I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows
 
 @centos_minion
-  Scenario: Install a patch on the Centos SSH minion 
+  Scenario: Install a patch on the Centos SSH minion
     Given I am on the Systems overview page of this "ceos-ssh-minion"
     And I follow "Software" in the content area
     And I follow "Patches" in the content area
@@ -42,7 +43,7 @@ Feature: Install a patch on the CentOS SSH minion via Salt through the UI
     And I wait for "virgo-dummy-2.0-1.1" to be installed on this "ceos-ssh-minion"
 
 @centos_minion
-  Scenario: Install a package on the Centos SSH minion 
+  Scenario: Install a package on the Centos SSH minion
     Given I am on the Systems overview page of this "ceos-ssh-minion"
     And I follow "Software" in the content area
     And I follow "Install"


### PR DESCRIPTION
## What does this PR change?

PR adds scenario after package refresh which checks previously installed packages (typically by `zypper`) are in the package list. This checks if event triggering works correctly.

PR adds minor change in package refresh step definition to ensure that correct event and time are tracked in event's history. Also install package scenarios are renamed to match its purpose.

## Links

Related issues: https://github.com/SUSE/spacewalk/issues/7272 https://github.com/SUSE/spacewalk/issues/7485

Port of:  https://github.com/SUSE/spacewalk/pull/7452 https://github.com/SUSE/spacewalk/pull/7514

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
