### PR TITLE
Cobbler: change return type of last_modified_time to Double

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/CobblerSyncTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/CobblerSyncTask.java
@@ -68,9 +68,8 @@ public class CobblerSyncTask extends RhnJavaJob {
 
             Double mtime = null;
             try {
-                String mtimeStr = (String) invoker.invokeMethod("last_modified_time",
+                mtime = (Double)invoker.invokeMethod("last_modified_time",
                         new ArrayList());
-                mtime = Double.parseDouble(mtimeStr);
             }
             catch (XmlRpcFault e) {
                 log.error("Error calling cobbler.", e);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Change the return type of the Cobbler method last_modified_time to Double
 - Populate Content Environment on inserting it in a Project
 - Add makefile and pylint configuration
 


### PR DESCRIPTION
## What does this PR change?

Change return type of `last_modified_time` to Double according to https://build.suse.de/request/show/189876.

## GUI diff

No difference.

## Documentation
- No documentation needed

## Test coverage
- No tests

## Links

Fixes https://github.com/SUSE/spacewalk/issues/7430

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
