### PR TITLE
[WIP] Apache rewrite rules for documentation URLs

### DIFF
--- a/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-docs.conf
+++ b/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-docs.conf
@@ -1,0 +1,12 @@
+RewriteEngine on
+RewriteOptions inherit
+
+<Directory "/srv/www/htdocs/docs">
+  # Prepend "/product/version/" to the paths, if the original path is not available
+  RewriteCond %{REQUEST_FILENAME} !-f
+  RewriteCond %{REQUEST_FILENAME} !-d
+  # Rewrite only if the prepended path is available
+  RewriteCond %{DOCUMENT_ROOT}/docs/@PRODUCT/@VERSION/$1 -f [OR]
+  RewriteCond %{DOCUMENT_ROOT}/docs/@PRODUCT/@VERSION/$1 -d
+  RewriteRule ^(.*)$ /docs/@PRODUCT/@VERSION/$1 [R]
+</Directory>

--- a/spacewalk/config/spacewalk-config.changes
+++ b/spacewalk/config/spacewalk-config.changes
@@ -1,3 +1,5 @@
+- Add apache config file for documentation URLs
+
 -------------------------------------------------------------------
 Wed Apr 03 17:10:37 CEST 2019 - jgonzalez@suse.com
 

--- a/spacewalk/config/spacewalk-config.spec
+++ b/spacewalk/config/spacewalk-config.spec
@@ -86,6 +86,12 @@ mv $RPM_BUILD_ROOT/etc/httpd $RPM_BUILD_ROOT%{apacheconfdir}
 sed -i 's|var/www/html|srv/www/htdocs|g' $RPM_BUILD_ROOT%{apacheconfdir}/conf.d/zz-spacewalk-www.conf
 %endif
 
+%if 0%{?sle_version} && !0%{?is_opensuse}
+sed -i -e 's|@PRODUCT|suse-manager|g' -e 's|@VERSION|beta3|g' $RPM_BUILD_ROOT%{apacheconfdir}/conf.d/zz-spacewalk-docs.conf
+%else
+sed -i -e 's|@PRODUCT|uyuni|g' -e 's|@VERSION|4.0|g' $RPM_BUILD_ROOT%{apacheconfdir}/conf.d/zz-spacewalk-docs.conf
+%endif
+
 tar -C $RPM_BUILD_ROOT%{prepdir} -cf - etc \
      | tar -C $RPM_BUILD_ROOT -xvf -
 
@@ -105,6 +111,7 @@ ln -sf  %{apacheconfdir}/conf/ssl.crt/server.crt $RPM_BUILD_ROOT/etc/pki/tls/cer
 %defattr(-,root,root,-)
 %attr(400,root,root) %config(noreplace) %{_sysconfdir}/rhn/spacewalk-repo-sync/uln.conf
 %config(noreplace) %{apacheconfdir}/conf.d/zz-spacewalk-www.conf
+%config(noreplace) %{apacheconfdir}/conf.d/zz-spacewalk-docs.conf
 %config(noreplace) %{apacheconfdir}/conf.d/os-images.conf
 %config(noreplace) %{_sysconfdir}/webapp-keyring.gpg
 %attr(440,root,root) %config %{_sysconfdir}/sudoers.d/spacewalk


### PR DESCRIPTION
Adds rewrite rules to allow for the translation of doc URLs of the following structure:

`/docs/my/help/page.html` to `/docs/suse-manager/beta3/my/help/page.html`
or
`/docs/my/help/page.html` to `/docs/uyuni/4.0/my/help/page.html`

depending on the build.

This will allow simple URLs to be linked throughout the codebase, without any Uyuni/SUMA conditioning required, thus, preventing code separation.

## Links

Fixes partly https://github.com/SUSE/spacewalk/issues/7198

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
