### PR TITLE
Fix spacewalk-common-channels interpolation error (bsc#1131988)

### DIFF
--- a/utils/spacewalk-common-channels
+++ b/utils/spacewalk-common-channels
@@ -87,12 +87,12 @@ def add_channels(channels, section, arch, client):
                 'yum_repo_label', 'dist_map_release']
     mandatory = ['label', 'name', 'summary', 'checksum', 'arch', 'section']
 
+    config.set(section, 'arch', arch)
+    config.set(section, 'section', section)
     if config.has_option(section, 'base_channels'):
         base_channels = re.split(SPLIT_PATTERN,
                                  config.get(section, 'base_channels'), 1)
 
-    config.set(section, 'arch', arch)
-    config.set(section, 'section', section)
     for base_channel in base_channels:
         config.set(section, 'base_channel', base_channel)
         channel = {'base_channel': config.get(section, 'base_channel')}
@@ -262,7 +262,7 @@ Create everything as well as unlimited activation key for every channel:
             if options.verbose:
                 sys.stdout.write("Base channel '%s' - creating...\n"
                                  % base_info['name'])
-            if options.verbose > 1:
+            if options.verbose and options.verbose > 1:
                 sys.stdout.write(
                     "* label=%s, summary=%s, arch=%s, checksum=%s\n" % (
                         base_info['label'], base_info['summary'],
@@ -336,7 +336,7 @@ Create everything as well as unlimited activation key for every channel:
             if options.verbose:
                 sys.stdout.write("* Child channel '%s' - creating...\n"
                                  % child_info['name'])
-            if options.verbose > 1:
+            if options.verbose and options.verbose > 1:
                 sys.stdout.write(
                     "** label=%s, summary=%s, arch=%s, parent=%s, checksum=%s\n"
                     % (child_info['label'], child_info['summary'],

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,4 @@
+- Fix spacewalk-common-channels interpolation error (bsc#1131988)
 - add makefile and pylint configuration
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue when using `spacewalk-common-channels` to add channels:
```console
d284:~ # spacewalk-common-channels -u admin -p admin -a x86_64 'opensuse_leap15_0*'
Traceback (most recent call last):
  File "/usr/bin/spacewalk-common-channels", line 229, in <module>
    add_channels(channels, section, arch, client)
  File "/usr/bin/spacewalk-common-channels", line 92, in add_channels
    config.get(section, 'base_channels'), 1)
  File "/usr/lib64/python3.6/configparser.py", line 800, in get
    d)
  File "/usr/lib64/python3.6/configparser.py", line 394, in before_get
    self._interpolate_some(parser, option, L, value, section, defaults, 1)
  File "/usr/lib64/python3.6/configparser.py", line 434, in _interpolate_some
    option, section, rawval, var) from None
configparser.InterpolationMissingOptionError: Bad value substitution: option 'base_channels' in section 'fedora27-updates' contains an interpolation key 'arch' which is not a valid option name. Raw value: 'fedora27-%(arch)s'
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **tested manually**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/salt-board/issues/318

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
