### PR TITLE
handle empty async response without NPE (bsc1123375)

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -60,7 +60,7 @@
         <dependency org="suse" name="quartz" rev="2.3.0" />
         <dependency org="suse" name="redstone-xmlrpc" rev="1.1_20071120" />
         <dependency org="suse" name="redstone-xmlrpc-client" rev="1.1_20071120" />
-        <dependency org="suse" name="salt-netapi-client" rev="0.15.1" />
+        <dependency org="suse" name="salt-netapi-client" rev="0.16.0" />
         <dependency org="suse" name="simpleclient" rev="0.3.0" />
         <dependency org="suse" name="simpleclient_common" rev="0.3.0" />
         <dependency org="suse" name="simpleclient_httpserver" rev="0.3.0" />

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -1660,7 +1660,7 @@ public class SaltServerActionService {
 
             List<String> results = SaltService.INSTANCE
                     .callAsync(call.withMetadata(metadata), new MinionList(minionIds))
-                    .getMinions();
+                    .get().getMinions();
 
             result = minionSummaries.stream().collect(Collectors
                     .partitioningBy(minionId -> results.contains(minionId.getMinionId())));
@@ -1698,6 +1698,7 @@ public class SaltServerActionService {
         try {
             List<String> results = SaltService.INSTANCE
                     .callAsync(call.withMetadata(metadata), new MinionList(minionIds))
+                    .get()
                     .getMinions();
 
             Map<Boolean, ? extends Collection<MinionSummary>> result = minionSummaries.stream().collect(Collectors

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -514,10 +514,10 @@ public class SaltService {
         }
     }
 
-    private <R> Map<String, CompletionStage<Result<R>>> completableAsyncCall(
+    private <R> Optional<Map<String, CompletionStage<Result<R>>>> completableAsyncCall(
             LocalCall<R> call, Target<?> target, EventStream events,
             CompletableFuture<GenericError> cancel) throws SaltException {
-        return adaptException(call.callAsync(SALT_CLIENT, target, PW_AUTH, events, cancel));
+        return adaptException(call.callAsync(SALT_CLIENT, target, PW_AUTH, events, cancel, Optional.empty()));
     }
 
     /**
@@ -551,7 +551,7 @@ public class SaltService {
             try {
                 results.putAll(
                         completableAsyncCall(call, target,
-                        reactor.getEventStream(), cancel));
+                        reactor.getEventStream(), cancel).orElseGet(Collections::emptyMap));
             }
             catch (SaltException e) {
                 throw new RuntimeException(e);
@@ -635,7 +635,7 @@ public class SaltService {
             String target, CompletableFuture<GenericError> cancel) {
         try {
             return completableAsyncCall(Match.glob(target), new Glob(target),
-                    reactor.getEventStream(), cancel);
+                    reactor.getEventStream(), cancel).orElseGet(Collections::emptyMap);
         }
         catch (SaltException e) {
             throw new RuntimeException(e);
@@ -812,7 +812,7 @@ public class SaltService {
      * @return the LocalAsyncResult of the call
      * @throws SaltException in case of an error executing the job with Salt
      */
-    public <T> LocalAsyncResult<T> callAsync(LocalCall<T> call, Target<?> target)
+    public <T> Optional<LocalAsyncResult<T>> callAsync(LocalCall<T> call, Target<?> target)
             throws SaltException {
         return adaptException(call.callAsync(SALT_CLIENT, target, PW_AUTH));
     }

--- a/java/code/src/com/suse/manager/webui/websocket/RemoteMinionCommands.java
+++ b/java/code/src/com/suse/manager/webui/websocket/RemoteMinionCommands.java
@@ -137,17 +137,13 @@ public class RemoteMinionCommands {
                         SaltService.INSTANCE.matchAsyncSSH(target, failAfter);
 
                 Map<String, CompletionStage<Result<Boolean>>> res = new HashMap<>();
-                try {
-                    res = SaltService.INSTANCE
-                            .matchAsync(target, failAfter);
-                }
-                catch (NullPointerException e) {
-                    if (!resSSH.isPresent()) {
-                        // just return, no need to wait for salt-ssh results
-                        sendMessage(session, new ActionErrorEventDto(null,
-                                "ERR_TARGET_NO_MATCH", e.getMessage()));
-                        return;
-                    }
+
+                res = SaltService.INSTANCE.matchAsync(target, failAfter);
+                if (res.isEmpty() && !resSSH.isPresent()) {
+                    // just return, no need to wait for salt-ssh results
+                    sendMessage(session, new ActionErrorEventDto(null,
+                            "ERR_TARGET_NO_MATCH", ""));
+                    return;
                 }
 
                 previewedMinions = Collections

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- fix NPE on remote commands when no targets match (bsc1123375)
 - change release notes URL
 - provide Proxy release notes as well
 - Add a Taskomatic job to perform minion check-in regularly, drop use of Salt's Mine (bsc#1122837)


### PR DESCRIPTION
## What does this PR change?

addepts spacewalk code to salt-netapi-client changes in
SUSE/salt-netapi-client#264
this fixes #7208



## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: **Bug Fix**

- [ ] **DONE**

## Test coverage
- No tests: **Existing tests should cover this**

- [ ] **DONE**

## Links

Fixes # #7208
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)



