### PR TITLE
Track status of Content Environment when building/promoting

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentEnvironment.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentEnvironment.java
@@ -17,6 +17,8 @@ package com.redhat.rhn.domain.contentmgmt;
 
 import com.redhat.rhn.domain.BaseDomainHelper;
 import com.redhat.rhn.domain.contentmgmt.EnvironmentTarget.Status;
+import com.redhat.rhn.manager.channel.ChannelManager;
+import com.suse.utils.Opt;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -322,9 +324,12 @@ public class ContentEnvironment extends BaseDomainHelper {
         if (statuses.isEmpty() || statuses.stream().allMatch(s -> s == Status.NEW)) {
             return empty();
         }
-        if (statuses.contains(Status.BUILDING)) {
+        if (statuses.contains(Status.BUILDING) || getTargets().stream()
+                .flatMap(t -> Opt.stream(t.asSoftwareTarget()))
+                .anyMatch(st -> ChannelManager.isChannelLabelInProgress(st.getChannel().getLabel()))) {
             return of(Status.BUILDING);
         }
+
         if (statuses.contains(Status.FAILED)) {
             return of(Status.FAILED);
         }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
@@ -282,6 +282,20 @@ public class ContentProjectFactory extends HibernateFactory {
     }
 
     /**
+     * Looks up SoftwareEnvironmentTarget with given id
+     *
+     * @param id the id
+     * @return Optional of {@link com.redhat.rhn.domain.contentmgmt.SoftwareEnvironmentTarget}
+     */
+    public static Optional<SoftwareEnvironmentTarget> lookupSwEnvironmentTargetById(long id) {
+        CriteriaBuilder builder = getSession().getCriteriaBuilder();
+        CriteriaQuery<SoftwareEnvironmentTarget> query = builder.createQuery(SoftwareEnvironmentTarget.class);
+        Root<SoftwareEnvironmentTarget> from = query.from(SoftwareEnvironmentTarget.class);
+        query.where(builder.equal(from.get("id"), id));
+        return getSession().createQuery(query).uniqueResultOptional();
+    }
+
+    /**
      * Save a Project source
      *
      * @param source the project source

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
@@ -284,6 +284,20 @@ public class ContentProjectFactory extends HibernateFactory {
     /**
      * Looks up SoftwareEnvironmentTarget with given id
      *
+     * @param label the {@link Channel} label
+     * @return Optional of {@link com.redhat.rhn.domain.contentmgmt.SoftwareEnvironmentTarget}
+     */
+    public static Optional<SoftwareEnvironmentTarget> lookupEnvironmentTargetByChannelLabel(String label) {
+        CriteriaBuilder builder = getSession().getCriteriaBuilder();
+        CriteriaQuery<SoftwareEnvironmentTarget> query = builder.createQuery(SoftwareEnvironmentTarget.class);
+        Root<SoftwareEnvironmentTarget> from = query.from(SoftwareEnvironmentTarget.class);
+        query.where(builder.equal(from.get("channel").get("label"), label));
+        return getSession().createQuery(query).uniqueResultOptional();
+    }
+
+    /**
+     * Looks up SoftwareEnvironmentTarget with a given channel
+     *
      * @param id the id
      * @return Optional of {@link com.redhat.rhn.domain.contentmgmt.SoftwareEnvironmentTarget}
      */

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/EnvironmentTarget.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/EnvironmentTarget.java
@@ -53,6 +53,7 @@ public abstract class EnvironmentTarget {
     public enum Status {
         NEW("new"),
         BUILDING("building"),
+        GENERATING_REPODATA("generating_repodata"),
         BUILT("built"),
         FAILED("failed");
 

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/EnvironmentTarget.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/EnvironmentTarget.java
@@ -18,8 +18,11 @@ package com.redhat.rhn.domain.contentmgmt;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.Optional;
+import javax.persistence.Column;
 import javax.persistence.DiscriminatorColumn;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -42,11 +45,37 @@ public abstract class EnvironmentTarget {
 
     private Long id;
     private ContentEnvironment contentEnvironment;
+    private Status status;
+
+    /**
+     * Status of the {@link EnvironmentTarget}
+     */
+    public enum Status {
+        NEW("new"),
+        BUILDING("building"),
+        BUILT("built"),
+        FAILED("failed");
+
+        private final String label;
+
+        Status(String labelIn) {
+            this.label = labelIn;
+        }
+
+        /**
+         * Return the label
+         * @return the label
+         */
+        public String getLabel() {
+            return label;
+        }
+    }
 
     /**
      * Standard constructor
      */
     public EnvironmentTarget() {
+        status = Status.NEW;
     }
 
     /**
@@ -55,6 +84,7 @@ public abstract class EnvironmentTarget {
      * @param contentEnvironmentIn the Environment
      */
     public EnvironmentTarget(ContentEnvironment contentEnvironmentIn) {
+        this();
         this.contentEnvironment = contentEnvironmentIn;
     }
 
@@ -106,10 +136,31 @@ public abstract class EnvironmentTarget {
         contentEnvironment = contentEnvironmentIn;
     }
 
+    /**
+     * Gets the status.
+     *
+     * @return status
+     */
+    @Column
+    @Enumerated(EnumType.STRING)
+    public Status getStatus() {
+        return status;
+    }
+
+    /**
+     * Sets the status.
+     *
+     * @param statusIn the status
+     */
+    public void setStatus(Status statusIn) {
+        this.status = statusIn;
+    }
+
     protected ToStringBuilder toStringBuilder() {
         return new ToStringBuilder(this)
                 .append("id", id)
-                .append("contentEnvironment", contentEnvironment);
+                .append("contentEnvironment", contentEnvironment)
+                .append("status", status);
     }
 
     @Override

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentProjectFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentProjectFactoryTest.java
@@ -439,6 +439,34 @@ public class ContentProjectFactoryTest extends BaseTestCaseWithUser {
     }
 
     /**
+     * Tests looking up non-existing {@link SoftwareEnvironmentTarget}
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testLookupNonExistingEnvironmentTargetById() throws Exception {
+        assertFalse(ContentProjectFactory.lookupSwEnvironmentTargetById(123321L).isPresent());
+    }
+
+    /**
+     * Tests looking up {@link SoftwareEnvironmentTarget}
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testLookupEnvironmentTargetById() throws Exception {
+        ContentProject cp = new ContentProject("cplabel", "cpname", "cpdesc", user.getOrg());
+        ContentProjectFactory.save(cp);
+        ContentEnvironment envdev = new ContentEnvironment("dev", "Development", null, cp);
+        ContentProjectFactory.save(envdev);
+        cp.setFirstEnvironment(envdev);
+
+        Channel channel = ChannelTestUtils.createBaseChannel(user);
+        SoftwareEnvironmentTarget target = new SoftwareEnvironmentTarget(envdev, channel);
+        ContentProjectFactory.save(target);
+
+        assertEquals(target, ContentProjectFactory.lookupSwEnvironmentTargetById(target.getId()).get());
+    }
+
+    /**
      * Test purging {@link SoftwareEnvironmentTarget}
      *
      * @throws Exception if anything goes wrong

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentProjectFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentProjectFactoryTest.java
@@ -183,6 +183,10 @@ public class ContentProjectFactoryTest extends BaseTestCaseWithUser {
         SoftwareEnvironmentTarget target2 = new SoftwareEnvironmentTarget(envdev, channel2);
         envdev.addTarget(target2);
 
+        target.setStatus(EnvironmentTarget.Status.NEW);
+        target2.setStatus(EnvironmentTarget.Status.BUILDING);
+        assertEquals(EnvironmentTarget.Status.BUILDING, envdev.computeStatus().get());
+
         target.setStatus(EnvironmentTarget.Status.BUILDING);
         target2.setStatus(EnvironmentTarget.Status.BUILT);
         assertEquals(EnvironmentTarget.Status.BUILDING, envdev.computeStatus().get());
@@ -190,6 +194,18 @@ public class ContentProjectFactoryTest extends BaseTestCaseWithUser {
         target.setStatus(EnvironmentTarget.Status.BUILDING);
         target2.setStatus(EnvironmentTarget.Status.FAILED);
         assertEquals(EnvironmentTarget.Status.BUILDING, envdev.computeStatus().get());
+
+        target.setStatus(EnvironmentTarget.Status.BUILDING);
+        target2.setStatus(EnvironmentTarget.Status.GENERATING_REPODATA);
+        assertEquals(EnvironmentTarget.Status.BUILDING, envdev.computeStatus().get());
+
+        target.setStatus(EnvironmentTarget.Status.GENERATING_REPODATA);
+        target2.setStatus(EnvironmentTarget.Status.FAILED);
+        assertEquals(EnvironmentTarget.Status.GENERATING_REPODATA, envdev.computeStatus().get());
+
+        target.setStatus(EnvironmentTarget.Status.GENERATING_REPODATA);
+        target2.setStatus(EnvironmentTarget.Status.BUILT);
+        assertEquals(EnvironmentTarget.Status.GENERATING_REPODATA, envdev.computeStatus().get());
 
         target.setStatus(EnvironmentTarget.Status.BUILT);
         target2.setStatus(EnvironmentTarget.Status.FAILED);

--- a/java/code/src/com/redhat/rhn/frontend/events/AlignSoftwareTargetAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/AlignSoftwareTargetAction.java
@@ -48,7 +48,7 @@ public class AlignSoftwareTargetAction implements MessageAction {
 
         LOG.info("Asynchronously aligning: " + msg);
         Instant start = Instant.now();
-        ChannelManager.alignChannelsSync(source, target, msg.getUser());
+        ChannelManager.alignEnvironmentTargetSync(source, target, msg.getUser());
         LOG.info("Finished aligning " + msg + " in " + Duration.between(start, Instant.now()));
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/events/AlignSoftwareTargetAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/AlignSoftwareTargetAction.java
@@ -59,7 +59,7 @@ public class AlignSoftwareTargetAction implements MessageAction {
             LOG.info("Asynchronously aligning: " + msg);
             Instant start = Instant.now();
             ChannelManager.alignEnvironmentTargetSync(source, targetChannel, msg.getUser());
-            target.setStatus(Status.BUILT);
+            target.setStatus(Status.GENERATING_REPODATA);
             LOG.info("Finished aligning " + msg + " in " + Duration.between(start, Instant.now()));
         }
         catch (Throwable t) {

--- a/java/code/src/com/redhat/rhn/frontend/events/AlignSoftwareTargetMsg.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/AlignSoftwareTargetMsg.java
@@ -18,6 +18,7 @@ package com.redhat.rhn.frontend.events;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.messaging.EventDatabaseMessage;
 import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.contentmgmt.SoftwareEnvironmentTarget;
 import com.redhat.rhn.domain.user.User;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.hibernate.Transaction;
@@ -28,17 +29,17 @@ import org.hibernate.Transaction;
 public class AlignSoftwareTargetMsg implements EventDatabaseMessage {
 
     private final Channel source;
-    private final Channel target;
+    private final SoftwareEnvironmentTarget target;
     private final User user;
     private final Transaction txn;
 
     /**
      * Standard constructor
      * @param src the source Channel
-     * @param tgt the target Channel
+     * @param tgt the {@link SoftwareEnvironmentTarget} in which the source channel will be aligned
      * @param userIn the User
      */
-    public AlignSoftwareTargetMsg(Channel src, Channel tgt, User userIn) {
+    public AlignSoftwareTargetMsg(Channel src, SoftwareEnvironmentTarget tgt, User userIn) {
         this.source = src;
         this.target = tgt;
         this.user = userIn;
@@ -55,11 +56,11 @@ public class AlignSoftwareTargetMsg implements EventDatabaseMessage {
     }
 
     /**
-     * Gets the target Channel.
+     * Gets the {@link SoftwareEnvironmentTarget}
      *
      * @return target
      */
-    public Channel getTarget() {
+    public SoftwareEnvironmentTarget getTarget() {
         return target;
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ContentEnvironmentSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ContentEnvironmentSerializer.java
@@ -33,6 +33,7 @@ import java.io.Writer;
  *   #prop("string", "name")
  *   #prop("string", "description")
  *   #prop("int", "version")
+ *   #prop("string", "status")
  *   #prop("string", "contentProjectLabel")
  *   #prop("string", "previousEnvironmentLabel")
  *   #prop("string", "nextEnvironmentLabel")
@@ -61,6 +62,7 @@ public class ContentEnvironmentSerializer extends RhnXmlRpcCustomSerializer {
         helper.add("name", environment.getName());
         helper.add("description", environment.getDescription());
         helper.add("version", environment.getVersion());
+        helper.add("status", environment.computeStatus().map(s -> s.getLabel()).orElse("unknown"));
         helper.add("contentProjectLabel", environment.getContentProject().getLabel());
         helper.add("previousEnvironmentLabel", environment.getPrevEnvironmentOpt()
                 .map(e -> e.getLabel()).orElse(null));

--- a/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
@@ -39,6 +39,9 @@ import com.redhat.rhn.domain.channel.DistChannelMap;
 import com.redhat.rhn.domain.channel.InvalidChannelRoleException;
 import com.redhat.rhn.domain.channel.ProductName;
 import com.redhat.rhn.domain.channel.ReleaseChannelMap;
+import com.redhat.rhn.domain.contentmgmt.ContentProjectFactory;
+import com.redhat.rhn.domain.contentmgmt.EnvironmentTarget;
+import com.redhat.rhn.domain.contentmgmt.SoftwareEnvironmentTarget;
 import com.redhat.rhn.domain.errata.Errata;
 import com.redhat.rhn.domain.kickstart.KickstartData;
 import com.redhat.rhn.domain.org.Org;
@@ -2749,19 +2752,19 @@ public class ChannelManager extends BaseManager {
     }
 
     /**
-     * Align packages and errata of the target channel to the source one
+     * Align packages and errata of the {@link SoftwareEnvironmentTarget} to the source {@link Channel}
      *
-     * @param src the source Channel
-     * @param tgt the target Channel
+     * @param src the source {@link Channel}
+     * @param tgt the target {@link SoftwareEnvironmentTarget}
      * @param async run this operation asynchronously?
      * @param user the user
      */
-    public static void alignChannels(Channel src, Channel tgt, boolean async, User user) {
-        if (!UserManager.verifyChannelAdmin(user, tgt)) {
+    public static void alignEnvironmentTarget(Channel src, SoftwareEnvironmentTarget tgt, boolean async, User user) {
+        if (!UserManager.verifyChannelAdmin(user, tgt.getChannel())) {
             throw new PermissionException("User " + user.getLogin() + " has no permission for channel " +
-                    tgt.getLabel());
+                    tgt.getChannel().getLabel());
         }
-        AlignSoftwareTargetMsg msg = new AlignSoftwareTargetMsg(src, tgt, user);
+        AlignSoftwareTargetMsg msg = new AlignSoftwareTargetMsg(src, tgt.getChannel(), user);
         if (async) {
             MessageQueue.publish(msg);
         }
@@ -2771,14 +2774,14 @@ public class ChannelManager extends BaseManager {
     }
 
     /**
-     * Synchronously align packages and errata of the target channel to the source one.
-     * This method is potentially time-expensive and should be run asynchronously (@see alignChannels)
+     * Synchronously align packages and errata of the {@link SoftwareEnvironmentTarget} to the source {@link Channel}
+     * This method is potentially time-expensive and should be run asynchronously (@see alignEnvironmentTarget)
      *
-     * @param src the source
-     * @param tgt the target
+     * @param src the source {@link Channel}
+     * @param tgt the target {@link SoftwareEnvironmentTarget}
      * @param user the user
      */
-    public static void alignChannelsSync(Channel src, Channel tgt, User user) {
+    public static void alignEnvironmentTargetSync(Channel src, Channel tgt, User user) {
         // align packages and the cache (rhnServerNeededCache)
         alignPackages(src, tgt);
 

--- a/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
@@ -39,7 +39,6 @@ import com.redhat.rhn.domain.channel.DistChannelMap;
 import com.redhat.rhn.domain.channel.InvalidChannelRoleException;
 import com.redhat.rhn.domain.channel.ProductName;
 import com.redhat.rhn.domain.channel.ReleaseChannelMap;
-import com.redhat.rhn.domain.contentmgmt.ContentProjectFactory;
 import com.redhat.rhn.domain.contentmgmt.EnvironmentTarget;
 import com.redhat.rhn.domain.contentmgmt.SoftwareEnvironmentTarget;
 import com.redhat.rhn.domain.errata.Errata;
@@ -2764,7 +2763,11 @@ public class ChannelManager extends BaseManager {
             throw new PermissionException("User " + user.getLogin() + " has no permission for channel " +
                     tgt.getChannel().getLabel());
         }
-        AlignSoftwareTargetMsg msg = new AlignSoftwareTargetMsg(src, tgt.getChannel(), user);
+
+        // adjust the target status
+        tgt.setStatus(EnvironmentTarget.Status.BUILDING);
+
+        AlignSoftwareTargetMsg msg = new AlignSoftwareTargetMsg(src, tgt, user);
         if (async) {
             MessageQueue.publish(msg);
         }

--- a/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
@@ -39,6 +39,7 @@ import com.redhat.rhn.domain.channel.DistChannelMap;
 import com.redhat.rhn.domain.channel.InvalidChannelRoleException;
 import com.redhat.rhn.domain.channel.ProductName;
 import com.redhat.rhn.domain.channel.ReleaseChannelMap;
+import com.redhat.rhn.domain.contentmgmt.ContentProjectFactory;
 import com.redhat.rhn.domain.contentmgmt.EnvironmentTarget;
 import com.redhat.rhn.domain.contentmgmt.SoftwareEnvironmentTarget;
 import com.redhat.rhn.domain.errata.Errata;
@@ -2759,13 +2760,9 @@ public class ChannelManager extends BaseManager {
      * @param user the user
      */
     public static void alignEnvironmentTarget(Channel src, SoftwareEnvironmentTarget tgt, boolean async, User user) {
-        if (!UserManager.verifyChannelAdmin(user, tgt.getChannel())) {
-            throw new PermissionException("User " + user.getLogin() + " has no permission for channel " +
-                    tgt.getChannel().getLabel());
-        }
-
         // adjust the target status
         tgt.setStatus(EnvironmentTarget.Status.BUILDING);
+        ContentProjectFactory.save(tgt);
 
         AlignSoftwareTargetMsg msg = new AlignSoftwareTargetMsg(src, tgt, user);
         if (async) {

--- a/java/code/src/com/redhat/rhn/manager/channel/test/ChannelManagerContentAlignmentTest.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/test/ChannelManagerContentAlignmentTest.java
@@ -88,7 +88,7 @@ public class ChannelManagerContentAlignmentTest extends BaseTestCaseWithUser {
     public void testAlignEntities() throws Exception {
         // let's add a package to the target. it should be removed after aligning
         tgtChannel.getPackages().add(PackageTest.createTestPackage(user.getOrg()));
-        ChannelManager.alignChannelsSync(srcChannel, tgtChannel, user);
+        ChannelManager.alignEnvironmentTargetSync(srcChannel, tgtChannel, user);
 
         // check that newest packages cache has been updated
         assertEquals(
@@ -116,7 +116,7 @@ public class ChannelManagerContentAlignmentTest extends BaseTestCaseWithUser {
         assertEquals(pack2.getId(), ChannelManager.getLatestPackageEqual(tgtChannel.getId(), pack2.getPackageName().getName()));
         assertNull(ChannelManager.getLatestPackageEqual(tgtChannel.getId(), pkg.getPackageName().getName()));
 
-        ChannelManager.alignChannelsSync(srcChannel, tgtChannel, user);
+        ChannelManager.alignEnvironmentTargetSync(srcChannel, tgtChannel, user);
         assertEquals(pkg.getId(), ChannelManager.getLatestPackageEqual(tgtChannel.getId(), pkg.getPackageName().getName()));
         assertNull(ChannelManager.getLatestPackageEqual(tgtChannel.getId(), pack2.getPackageName().getName()));
     }
@@ -136,7 +136,7 @@ public class ChannelManagerContentAlignmentTest extends BaseTestCaseWithUser {
 
         SystemManager.subscribeServerToChannel(user, server, tgtChannel);
 
-        ChannelManager.alignChannelsSync(srcChannel, tgtChannel, user);
+        ChannelManager.alignEnvironmentTargetSync(srcChannel, tgtChannel, user);
         assertEquals(errata.getId(), SystemManager.relevantErrata(user, server.getId()).get(0).getId());
     }
 
@@ -158,7 +158,7 @@ public class ChannelManagerContentAlignmentTest extends BaseTestCaseWithUser {
         List<SystemOverview> systemsWithNeededPackage = SystemManager.listSystemsWithNeededPackage(user, pkg.getId());
         assertTrue(systemsWithNeededPackage.isEmpty());
 
-        ChannelManager.alignChannelsSync(srcChannel, tgtChannel, user);
+        ChannelManager.alignEnvironmentTargetSync(srcChannel, tgtChannel, user);
         systemsWithNeededPackage = SystemManager.listSystemsWithNeededPackage(user, pkg.getId());
         assertEquals(1, systemsWithNeededPackage.size());
         assertEquals(server.getId(), systemsWithNeededPackage.get(0).getId());
@@ -188,7 +188,7 @@ public class ChannelManagerContentAlignmentTest extends BaseTestCaseWithUser {
         assertEquals(1, systemsWithNeededPackage.size());
         assertEquals(server.getId(), systemsWithNeededPackage.get(0).getId());
 
-        ChannelManager.alignChannelsSync(srcChannel, tgtChannel, user);
+        ChannelManager.alignEnvironmentTargetSync(srcChannel, tgtChannel, user);
         systemsWithNeededPackage = SystemManager.listSystemsWithNeededPackage(user, otherPkg.getId());
         assertTrue(systemsWithNeededPackage.isEmpty());
     }
@@ -204,7 +204,7 @@ public class ChannelManagerContentAlignmentTest extends BaseTestCaseWithUser {
         Errata toRemove = ErrataFactoryTest.createTestPublishedErrata(user.getOrg().getId());;
         tgtChannel.addErrata(toRemove);
 
-        ChannelManager.alignChannelsSync(srcChannel, tgtChannel, user);
+        ChannelManager.alignEnvironmentTargetSync(srcChannel, tgtChannel, user);
 
         // check that packages and errata have been aligned
         assertEquals(srcChannel.getPackages(), tgtChannel.getPackages());

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
@@ -613,7 +613,7 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
         assertEquals(1, tgts.size());
         EnvironmentTarget target = tgts.get(0);
         Channel tgtChannel = target.asSoftwareTarget().get().getChannel();
-        assertEquals(Status.BUILT, target.getStatus());
+        assertEquals(Status.GENERATING_REPODATA, target.getStatus());
         assertEquals("cplabel-fst-" + channel.getLabel(), tgtChannel.getLabel());
         assertTrue(channel.getClonedChannels().contains(tgtChannel));
         assertEquals(channel, tgtChannel.getOriginal());
@@ -628,7 +628,7 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
         ContentManager.buildProject("cplabel", empty(), false, user);
         assertEquals(Long.valueOf(2), env.getVersion());
 
-        tgts.forEach(t -> assertEquals(Status.BUILT, t.asSoftwareTarget().get().getStatus()));
+        tgts.forEach(t -> assertEquals(Status.GENERATING_REPODATA, t.asSoftwareTarget().get().getStatus()));
         assertEquals(2, tgts.size());
         Set<String> tgtLabels = tgts.stream().map(tgt -> tgt.asSoftwareTarget().get().getChannel().getLabel()).collect(toSet());
         assertContains(tgtLabels, "cplabel-fst-" + channel.getLabel());
@@ -651,7 +651,7 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
         assertEquals(Long.valueOf(3), env.getVersion());
 
         assertEquals(newChannel, cp.lookupSwSourceLeader().get().getChannel()); // leader is changed
-        assertEquals(Status.BUILT, tgts.get(0).asSoftwareTarget().get().getStatus());
+        assertEquals(Status.GENERATING_REPODATA, tgts.get(0).asSoftwareTarget().get().getStatus());
         assertEquals(1, tgts.size());
         assertEquals("cplabel-fst-" + newChannel.getLabel(), tgts.get(0).asSoftwareTarget().get().getChannel().getLabel());
         assertEquals(channel.getPackages(), tgtChannel.getPackages());
@@ -794,7 +794,7 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
         ContentManager.promoteProject("cplabel", "dev", false, user);
         assertEquals(devEnv.getVersion(), testEnv.getVersion());
         List<EnvironmentTarget> testTgts = testEnv.getTargets();
-        testTgts.forEach(t -> assertEquals(Status.BUILT, t.getStatus()));
+        testTgts.forEach(t -> assertEquals(Status.GENERATING_REPODATA, t.getStatus()));
         assertEquals(2, testTgts.size());
         Channel tgtChannel1 = testTgts.get(0).asSoftwareTarget().get().getChannel();
         Channel tgtChannel2 = testTgts.get(1).asSoftwareTarget().get().getChannel();
@@ -808,7 +808,7 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
         ContentManager.promoteProject("cplabel", "test", false, user);
         assertEquals(devEnv.getVersion(), prodEnv.getVersion());
         List<EnvironmentTarget> prodTgts = prodEnv.getTargets();
-        prodTgts.forEach(t -> assertEquals(Status.BUILT, t.getStatus()));
+        prodTgts.forEach(t -> assertEquals(Status.GENERATING_REPODATA, t.getStatus()));
         assertEquals(2, prodTgts.size());
         tgtChannel1 = prodTgts.get(0).asSoftwareTarget().get().getChannel();
         tgtChannel2 = prodTgts.get(1).asSoftwareTarget().get().getChannel();
@@ -827,7 +827,7 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
         ContentManager.promoteProject("cplabel", "dev", false, user);
         assertEquals(devEnv.getVersion(), testEnv.getVersion());
         testTgts = testEnv.getTargets();
-        testTgts.forEach(t -> assertEquals(Status.BUILT, t.getStatus()));
+        testTgts.forEach(t -> assertEquals(Status.GENERATING_REPODATA, t.getStatus()));
         assertEquals(1, testTgts.size());
         Channel tgtChannel = testTgts.get(0).asSoftwareTarget().get().getChannel();
         assertEquals("cplabel-test-" + channel2.getLabel(), tgtChannel.getLabel());
@@ -837,7 +837,7 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
         ContentManager.promoteProject("cplabel", "test", false, user);
         assertEquals(devEnv.getVersion(), prodEnv.getVersion());
         prodTgts = prodEnv.getTargets();
-        prodTgts.forEach(t -> assertEquals(Status.BUILT, t.getStatus()));
+        prodTgts.forEach(t -> assertEquals(Status.GENERATING_REPODATA, t.getStatus()));
         assertEquals(1, prodTgts.size());
         tgtChannel = prodTgts.get(0).asSoftwareTarget().get().getChannel();
         assertEquals("cplabel-prod-" + channel2.getLabel(), tgtChannel.getLabel());

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
@@ -26,6 +26,7 @@ import com.redhat.rhn.domain.contentmgmt.ContentProject;
 import com.redhat.rhn.domain.contentmgmt.ContentProjectFactory;
 import com.redhat.rhn.domain.contentmgmt.ContentProjectHistoryEntry;
 import com.redhat.rhn.domain.contentmgmt.EnvironmentTarget;
+import com.redhat.rhn.domain.contentmgmt.EnvironmentTarget.Status;
 import com.redhat.rhn.domain.contentmgmt.ProjectSource;
 import com.redhat.rhn.domain.contentmgmt.SoftwareEnvironmentTarget;
 import com.redhat.rhn.domain.errata.Errata;
@@ -610,7 +611,9 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
 
         List<EnvironmentTarget> tgts = env.getTargets();
         assertEquals(1, tgts.size());
-        Channel tgtChannel = tgts.get(0).asSoftwareTarget().get().getChannel();
+        EnvironmentTarget target = tgts.get(0);
+        Channel tgtChannel = target.asSoftwareTarget().get().getChannel();
+        assertEquals(Status.BUILT, target.getStatus());
         assertEquals("cplabel-fst-" + channel.getLabel(), tgtChannel.getLabel());
         assertTrue(channel.getClonedChannels().contains(tgtChannel));
         assertEquals(channel, tgtChannel.getOriginal());
@@ -625,6 +628,7 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
         ContentManager.buildProject("cplabel", empty(), false, user);
         assertEquals(Long.valueOf(2), env.getVersion());
 
+        tgts.forEach(t -> assertEquals(Status.BUILT, t.asSoftwareTarget().get().getStatus()));
         assertEquals(2, tgts.size());
         Set<String> tgtLabels = tgts.stream().map(tgt -> tgt.asSoftwareTarget().get().getChannel().getLabel()).collect(toSet());
         assertContains(tgtLabels, "cplabel-fst-" + channel.getLabel());
@@ -647,6 +651,7 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
         assertEquals(Long.valueOf(3), env.getVersion());
 
         assertEquals(newChannel, cp.lookupSwSourceLeader().get().getChannel()); // leader is changed
+        assertEquals(Status.BUILT, tgts.get(0).asSoftwareTarget().get().getStatus());
         assertEquals(1, tgts.size());
         assertEquals("cplabel-fst-" + newChannel.getLabel(), tgts.get(0).asSoftwareTarget().get().getChannel().getLabel());
         assertEquals(channel.getPackages(), tgtChannel.getPackages());
@@ -789,6 +794,7 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
         ContentManager.promoteProject("cplabel", "dev", false, user);
         assertEquals(devEnv.getVersion(), testEnv.getVersion());
         List<EnvironmentTarget> testTgts = testEnv.getTargets();
+        testTgts.forEach(t -> assertEquals(Status.BUILT, t.getStatus()));
         assertEquals(2, testTgts.size());
         Channel tgtChannel1 = testTgts.get(0).asSoftwareTarget().get().getChannel();
         Channel tgtChannel2 = testTgts.get(1).asSoftwareTarget().get().getChannel();
@@ -802,6 +808,7 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
         ContentManager.promoteProject("cplabel", "test", false, user);
         assertEquals(devEnv.getVersion(), prodEnv.getVersion());
         List<EnvironmentTarget> prodTgts = prodEnv.getTargets();
+        prodTgts.forEach(t -> assertEquals(Status.BUILT, t.getStatus()));
         assertEquals(2, prodTgts.size());
         tgtChannel1 = prodTgts.get(0).asSoftwareTarget().get().getChannel();
         tgtChannel2 = prodTgts.get(1).asSoftwareTarget().get().getChannel();
@@ -820,6 +827,7 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
         ContentManager.promoteProject("cplabel", "dev", false, user);
         assertEquals(devEnv.getVersion(), testEnv.getVersion());
         testTgts = testEnv.getTargets();
+        testTgts.forEach(t -> assertEquals(Status.BUILT, t.getStatus()));
         assertEquals(1, testTgts.size());
         Channel tgtChannel = testTgts.get(0).asSoftwareTarget().get().getChannel();
         assertEquals("cplabel-test-" + channel2.getLabel(), tgtChannel.getLabel());
@@ -829,6 +837,7 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
         ContentManager.promoteProject("cplabel", "test", false, user);
         assertEquals(devEnv.getVersion(), prodEnv.getVersion());
         prodTgts = prodEnv.getTargets();
+        prodTgts.forEach(t -> assertEquals(Status.BUILT, t.getStatus()));
         assertEquals(1, prodTgts.size());
         tgtChannel = prodTgts.get(0).asSoftwareTarget().get().getChannel();
         assertEquals("cplabel-prod-" + channel2.getLabel(), tgtChannel.getLabel());

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Track and expose build status of Content Environment
 - Enable SLES11 OS Image Build Host
 - Add support for Salt batch execution mode
 - fix NPE on remote commands when no targets match (bsc1123375)

--- a/schema/spacewalk/common/tables/suseContentEnvironmentTarget.sql
+++ b/schema/spacewalk/common/tables/suseContentEnvironmentTarget.sql
@@ -21,6 +21,7 @@ CREATE TABLE suseContentEnvironmentTarget(
                        REFERENCES suseContentEnvironment(id)
                        ON DELETE CASCADE,
     type       VARCHAR2(16) NOT NULL,
+    status     VARCHAR2(32) NOT NULL DEFAULT 'NEW',
     channel_id NUMBER
                    CONSTRAINT suse_ct_env_tgt_chanid_fk
                        REFERENCES rhnChannel(id)

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.10-to-susemanager-schema-4.0.11/020-environment-target-state.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.10-to-susemanager-schema-4.0.11/020-environment-target-state.sql.oracle
@@ -1,0 +1,2 @@
+-- intentionally blank, corresponds to 20-environment-target-state.sql.postgresql
+

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.10-to-susemanager-schema-4.0.11/020-environment-target-state.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.10-to-susemanager-schema-4.0.11/020-environment-target-state.sql.postgresql
@@ -1,0 +1,5 @@
+-- oracle equivalent source sha1 2abb220ec52fbe102ee7a3a8b9c8a68c6fab86a5
+
+ALTER TABLE suseContentEnvironmentTarget ADD COLUMN IF NOT EXISTS status VARCHAR(32) NOT NULL DEFAULT 'NEW';
+UPDATE suseContentEnvironmentTarget SET status = 'BUILT';
+


### PR DESCRIPTION
## What does this PR change?
 
 
 Track status of Content Environment when building/promoting and expose it in
 EnvironmentTarget entity.

## How to review
 Commit-by-commit

## Post-merge tasks
- [ ] Rebase https://github.com/uyuni-project/uyuni/pull/842 and https://github.com/uyuni-project/uyuni/pull/844

 ## GUI diff
 
 No difference.
 
 Before:
 
 After:
 
 - [x] **DONE**
 
 ## Documentation
 - No documentation needed: **add explanation. This can't be used if there is a GUI diff**
 - [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)
 
 - [ ] **DONE**
 
 ## Test coverage
 - Unit tests were added
 
 - [x] **DONE**
 
 ## Links
 
 Tracks https://github.com/SUSE/spacewalk/issues/7428
 
 - [x] **DONE**
 
 ## Changelogs
 
 If you don't need a changelog check, please mark this checkbox:
 
 - [ ] No changelog needed
 
 If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
 
 
 ## Re-run a test
 
 If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:
 
 - [ ] Re-run test "changelog_test"
 - [ ] Re-run test "backend_unittests_pgsql"
 - [ ] Re-run test "java_lint_checkstyle"		 
 - [ ] Re-run test "java_pgsql_tests"		 
 - [ ] Re-run test "ruby_rubocop"
 - [ ] Re-run test "schema_migration_test_oracle"
 - [ ] Re-run test "schema_migration_test_pgsql"		 
 - [ ] Re-run test "susemanager_unittests"
 - [ ] Re-run test "javascript_lint" (Test skipped, there are no changes to test)