### PR TITLE
Enable SLES11 OS Image Build Host

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
@@ -135,7 +135,7 @@ public class MinionServer extends Server implements SaltConfigurable {
      */
     @Override
     public boolean doesOsSupportsOSImageBuilding() {
-        return !isSLES10() && !isSLES11() && !isSLES15();
+        return !isSLES10() && !isSLES15();
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Enable SLES11 OS Image Build Host
 - Add support for Salt batch execution mode
 - fix NPE on remote commands when no targets match (bsc1123375)
 - change release notes URL

--- a/spacewalk/certs-tools/mgr-package-rpm-certificate-osimage
+++ b/spacewalk/certs-tools/mgr-package-rpm-certificate-osimage
@@ -31,8 +31,10 @@ def processCommandline():
         OS image building""")
     parser.add_argument('--ca-cert-full-path',
         help='CA certificate filename (default: %s)' % CA_CERT_FULL_PATH_DEFAULT,
-        default=CA_CERT_FULL_PATH_DEFAULT
-        )
+        default=CA_CERT_FULL_PATH_DEFAULT)
+    parser.add_argument('--target-os',
+        help='Target OS',
+        default='')
 
     args = parser.parse_args()
     if not os.path.isfile(args.ca_cert_full_path):
@@ -47,8 +49,12 @@ def processCommandline():
 
 def genCaRpm(options):
     OSIMAGE_RPM_CERTIFICATE_PATH = "/usr/share/susemanager/salt/images"
-    CA_CERT_RPM_NAME_OSIMAGE = CA_CRT_RPM_NAME + "-osimage"
-    OSIMAGE_RPM_REQUIRES = "ca-certificates"
+    if options.target_os == 'SLE11':
+        CA_CERT_RPM_NAME_OSIMAGE = CA_CRT_RPM_NAME + "-osimage-sle11"
+        OSIMAGE_RPM_REQUIRES = ["openssl-certs", "coreutils"]
+    else:
+        CA_CERT_RPM_NAME_OSIMAGE = CA_CRT_RPM_NAME + "-osimage"
+        OSIMAGE_RPM_REQUIRES = ["ca-certificates"]
 
     ca_cert_name = os.path.basename(options.ca_cert_full_path)
     ca_cert = options.ca_cert_full_path
@@ -61,12 +67,13 @@ def genCaRpm(options):
 
     args = (os.path.join(CERT_PATH, 'gen-rpm.sh') + " "
             "--name %s --version %s --release %s --packager %s --vendor %s "
-            "--requires %s "
+            "%s "
             "--group 'RHN/Security' --summary %s --description %s "
             "--post %s --postun %s "
             "/usr/share/rhn/%s=%s"
             % (repr(CA_CERT_RPM_NAME_OSIMAGE), ver, rel, None,
-               None, OSIMAGE_RPM_REQUIRES,
+               None,
+               " ".join("--requires " + r for r in OSIMAGE_RPM_REQUIRES),
                repr(CA_CERT_RPM_SUMMARY),
                repr(CA_CERT_RPM_SUMMARY),
                repr(update_trust_script), repr(update_trust_script),

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,4 @@
+- Generate SLE11 specific ssl-cert-osimage package
 - Add support for Ubuntu to bootstrap script
 - Add makefile and pylintrc for PyLint
 

--- a/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-www.conf
+++ b/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-www.conf
@@ -52,6 +52,10 @@ RewriteRule ^/WEBRPC /rhn/rpc/api
 RewriteRule ^/rhn/manager/download/dists/(.*)/main/(.*)/(Packages.*)$ /rhn/manager/download/$1/repodata/$3
 RewriteRule ^/rhn/manager/download/dists/(.*)/(InRelease|Release.*)$ /rhn/manager/download/$1/repodata/$2
 
+# Workaround for SLE11 Kiwi that unconditionally appends extra params to https urls
+RewriteCond %{QUERY_STRING} ^(.*)\?credentials=kiwiRepoCredentials$
+RewriteRule ^(/rhn/manager/download/.*)$ $1?%1
+
 # increase timeout on proxy requests
 ProxyTimeout 600
 

--- a/spacewalk/setup/bin/spacewalk-setup
+++ b/spacewalk/setup/bin/spacewalk-setup
@@ -737,6 +737,7 @@ sub setup_ssl_certs {
 
     Spacewalk::Setup::system_or_exit(['/usr/bin/rhn-ssl-tool', @opts], 35, 'Could not import CA certificate.');
     Spacewalk::Setup::system_or_exit(['/usr/sbin/mgr-package-rpm-certificate-osimage', @osImageOpts], 35, 'Could not import CA certificate.');
+    Spacewalk::Setup::system_or_exit(['/usr/sbin/mgr-package-rpm-certificate-osimage', '--target-os', 'SLE11', @osImageOpts], 35, 'Could not import CA certificate.');
   } else {
     check_ca_cert();
     print Spacewalk::Setup::loc("** SSL: Generating CA rpm from present CA cert.\n");
@@ -819,7 +820,8 @@ sub generate_ca_cert {
   my @osImageOpts = ( "--ca-cert-full-path=$params{dir}/" . DEFAULT_CA_CERT_NAME);
 
   Spacewalk::Setup::system_or_exit(['/usr/bin/rhn-ssl-tool', @opts], 35, 'Could not generate CA certificate.');
-  Spacewalk::Setup::system_or_exit([('/usr/sbin/mgr-package-rpm-certificate-osimage', @osImageOpts)], 35, 'Could not generate CA certificate.');
+  Spacewalk::Setup::system_or_exit(['/usr/sbin/mgr-package-rpm-certificate-osimage', @osImageOpts], 35, 'Could not generate CA certificate.');
+  Spacewalk::Setup::system_or_exit(['/usr/sbin/mgr-package-rpm-certificate-osimage', '--target-os', 'SLE11', @osImageOpts], 35, 'Could not import CA certificate.');
 
   return;
 }
@@ -832,6 +834,7 @@ sub generate_ca_rpm {
 
   Spacewalk::Setup::system_or_exit(['/usr/bin/rhn-ssl-tool', @opts], 35, 'Could not generate CA certificate.');
   Spacewalk::Setup::system_or_exit(['/usr/sbin/mgr-package-rpm-certificate-osimage', @osImageOpts], 35, 'Could not generate CA certificate.');
+  Spacewalk::Setup::system_or_exit(['/usr/sbin/mgr-package-rpm-certificate-osimage', '--target-os', 'SLE11', @osImageOpts], 35, 'Could not import CA certificate.');
 
   return;
 }

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,4 @@
+- Generate SLE11 specific ssl-cert-osimage package
 - add makefile and configuration for the pylint
 - Add proper argument parsing to the embedded diskspace check.
 - Fix Python3 porting issues

--- a/susemanager-utils/susemanager-sls/salt/images/kiwi-image-build.sls
+++ b/susemanager-utils/susemanager-sls/salt/images/kiwi-image-build.sls
@@ -13,8 +13,21 @@
 {%- set bundle_dir = root_dir + '/images/' %}
 {%- set bundle_id  = pillar.get('build_id') %}
 {%- set activation_key = pillar.get('activation_key') %}
+{%- set kiwi_help = salt['cmd.run']('kiwi --help') %}
+{%- set have_bundle_build = kiwi_help.find('--bundle-build') > 0 %}
 
-{%- set kiwi_params = '--add-repo ' + common_repo + ' --add-repo ' + pillar.get('kiwi_repositories')|join(' --add-repo ') %}
+# i586 build on x86_64 host must be called with linux32
+# let's consider the build i586 if there is no x86_64 repo specified
+{%- set kiwi = 'linux32 kiwi' if (pillar.get('kiwi_repositories')|join(' ')).find('x86_64') == -1 and grains.get('osarch') == 'x86_64' else 'kiwi' %}
+
+# in SLES11 Kiwi the --add-repotype is required
+{%- macro kiwi_params() -%}
+  --add-repo {{ common_repo }} --add-repotype rpm-dir --add-repoalias common_repo {{ ' ' }}
+{%- for repo in pillar.get('kiwi_repositories') -%}
+  --add-repo {{ repo }} --add-repotype rpm-md --add-repoalias key_repo{{ loop.index }} {{ ' ' }}
+{%- endfor -%}
+{%- endmacro %}
+
 mgr_buildimage_prepare_source:
   file.directory:
     - name: {{ root_dir }}
@@ -35,23 +48,47 @@ mgr_buildimage_prepare_activation_key_in_source:
 
 mgr_buildimage_kiwi_prepare:
   cmd.run:
-    - name: "kiwi --nocolor --force-new-root --prepare {{ source_dir }} --root {{ chroot_dir }} {{ kiwi_params }}"
+    - name: "{{ kiwi }} --nocolor --force-new-root --prepare {{ source_dir }} --root {{ chroot_dir }} {{ kiwi_params() }}"
     - require:
       - module: mgr_buildimage_prepare_source
       - file: mgr_buildimage_prepare_activation_key_in_source
 
 mgr_buildimage_kiwi_create:
   cmd.run:
-    - name: "kiwi --nocolor --yes --create {{ chroot_dir }} --dest {{ dest_dir }} {{ kiwi_params }}"
+    - name: "{{ kiwi }} --nocolor --yes --create {{ chroot_dir }} --dest {{ dest_dir }} {{ kiwi_params() }}"
     - require:
       - cmd: mgr_buildimage_kiwi_prepare
 
+{%- if have_bundle_build %}
 mgr_buildimage_kiwi_bundle:
   cmd.run:
-    - name: "kiwi --nocolor --yes --bundle-build {{ dest_dir }} --bundle-id {{ bundle_id }} --destdir {{ bundle_dir }} {{ kiwi_params }}"
+    - name: "{{ kiwi }} --nocolor --yes --bundle-build {{ dest_dir }} --bundle-id {{ bundle_id }} --destdir {{ bundle_dir }}"
     - require:
       - cmd: mgr_buildimage_kiwi_create
 
+{%- else %}
+
+# SLE11 Kiwi does not have --bundle-build option, we have to create the bundle tarball ourselves:
+
+mgr_buildimage_kiwi_bundle_dir:
+  file.directory:
+    - name: {{ bundle_dir }}
+    - require:
+      - cmd: mgr_buildimage_kiwi_create
+
+mgr_buildimage_kiwi_bundle_tarball:
+  cmd.run:
+    - name: "cd '{{ dest_dir }}' && tar czf '{{ bundle_dir }}'`basename *.packages .packages`-{{ bundle_id }}.tgz --no-recursion `find . -maxdepth 1 -type f`"
+    - require:
+      - file: mgr_buildimage_kiwi_bundle_dir
+
+mgr_buildimage_kiwi_bundle:
+  cmd.run:
+    - name: "cd '{{ bundle_dir }}' && sha256sum *.tgz > `echo *.tgz`.sha256"
+    - require:
+      - cmd: mgr_buildimage_kiwi_bundle_tarball
+
+{%- endif %}
 
 {%- if pillar.get('use_salt_transport') %}
 mgr_buildimage_kiwi_collect_image:

--- a/susemanager-utils/susemanager-sls/salt/services/kiwi-image-server.sls
+++ b/susemanager-utils/susemanager-sls/salt/services/kiwi-image-server.sls
@@ -1,6 +1,6 @@
 # Image Server installation state - part of SUSE Manager for Retail
 #
-# Copyright © 2017, 2018 SUSE LLC
+# Copyright (c) 2017 - 2019 SUSE LLC
 
 {% if pillar['addon_group_types'] is defined and 'osimage_build_host' in pillar['addon_group_types'] %}
 {% set kiwi_dir = '/var/lib/Kiwi' %}
@@ -39,8 +39,13 @@ mgr_kiwi_dir_repo_created:
 
 mgr_osimage_cert_deployed:
   file.managed:
+{%- if grains.get('osfullname') == 'SLES' and grains.get('osmajorrelease') == '11' %}
+    - name: {{ kiwi_dir }}/repo/rhn-org-trusted-ssl-cert-osimage-sle11-1.0-1.noarch.rpm
+    - source: salt://images/rhn-org-trusted-ssl-cert-osimage-sle11-1.0-1.noarch.rpm
+{%- else %}
     - name: {{ kiwi_dir }}/repo/rhn-org-trusted-ssl-cert-osimage-1.0-1.noarch.rpm
     - source: salt://images/rhn-org-trusted-ssl-cert-osimage-1.0-1.noarch.rpm
+{%- endif %}
 
 mgr_kiwi_clear_cache:
   file.directory:

--- a/susemanager-utils/susemanager-sls/src/modules/kiwi_source.py
+++ b/susemanager-utils/susemanager-sls/src/modules/kiwi_source.py
@@ -44,7 +44,7 @@ def _prepareDestDir(dest):
   Check target directory does not exists
   '''
   if os.path.isdir(dest):
-    raise salt.exceptions.SaltException('Working directory "{}" exists before sources are prepared'.format(dest))
+    raise salt.exceptions.SaltException('Working directory "{0}" exists before sources are prepared'.format(dest))
 
 def _prepareLocal(source, dest):
   '''
@@ -100,7 +100,7 @@ def _prepareGit(source, dest, root):
   if rev == '':
     rev = 'master'
 
-  log.debug('GIT URL: {}, Revision: {}, subdir: {}'.format(url, rev, subdir))
+  log.debug('GIT URL: {0}, Revision: {1}, subdir: {2}'.format(url, rev, subdir))
   __salt__['git.init'](tmpdir)
   __salt__['git.remote_set'](tmpdir, url)
   __salt__['git.fetch'](tmpdir)
@@ -126,7 +126,7 @@ def prepare_source(source, root):
     [http[s]://|git://][user@]hostname/repository[#revision[:subdirectory]]
   '''
   dest = os.path.join(root, 'source')
-  log.debug('Preparing build source for {} to {}'.format(source, dest))
+  log.debug('Preparing build source for {0} to {1}'.format(source, dest))
   if _isLocal(source):
     return _prepareLocal(source, dest)
   elif _isTarball(source):
@@ -134,4 +134,4 @@ def prepare_source(source, root):
   elif _isGit(source):
     return _prepareGit(source, dest, root)
   else:
-    raise salt.exceptions.SaltException('Unknown source format "{}"'.format(source))
+    raise salt.exceptions.SaltException('Unknown source format "{0}"'.format(source))

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Enable SLES11 OS Image Build Host
 - Add support for Salt batch execution mode
 - Do not configure Salt Mine in newly registered minions (bsc#1122837)
 - use default 'master' branch in OSImage profile URL (bsc#1108218)


### PR DESCRIPTION
## What does this PR change?

This pull request enables building of SLES11 images, including i586 architecture.

- enable SLES11 build host
- python 2.6 compatibility fixes
- adjust Kiwi commandline and inspection scripts to work with SLES11 kiwi
- add a workaround for creating bundle tarball with SLES11 kiwi
- add a workaround for repo URLs problem with SLES11 kiwi
- generate SLE11 specific ssl-cert-osimage package

## GUI diff

No difference.

## Documentation

TBD.

- [ ] **DONE**

## Test coverage

TBD.

- [ ] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/7471

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
