### PR TITLE
Integrate with latest changes of salt-netapi-client library

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
@@ -53,7 +53,7 @@ import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.utils.salt.custom.PkgProfileUpdateSlsResult;
 import com.suse.salt.netapi.calls.modules.State;
 import com.suse.salt.netapi.calls.modules.Zypper;
-import com.suse.salt.netapi.results.CmdExecCodeAll;
+import com.suse.salt.netapi.results.CmdResult;
 import com.suse.utils.Opt;
 import org.apache.log4j.Logger;
 
@@ -336,13 +336,13 @@ public class RegistrationUtils {
                     .applyState(server.getMinionId(), "packages.redhatproductinfo");
             Optional<String> centosReleaseContent = applyResultMap.map(
                     map -> map.get(PkgProfileUpdateSlsResult.PKG_PROFILE_CENTOS_RELEASE))
-                    .map(r -> r.getChanges(CmdExecCodeAll.class)).map(c -> c.getStdout());
+                    .map(r -> r.getChanges(CmdResult.class)).map(c -> c.getStdout());
             Optional<String> rhelReleaseContent = applyResultMap.map(
                     map -> map.get(PkgProfileUpdateSlsResult.PKG_PROFILE_REDHAT_RELEASE))
-                    .map(r -> r.getChanges(CmdExecCodeAll.class)).map(c -> c.getStdout());
+                    .map(r -> r.getChanges(CmdResult.class)).map(c -> c.getStdout());
             Optional<String> whatProvidesRes = applyResultMap.map(map -> map
                     .get(PkgProfileUpdateSlsResult.PKG_PROFILE_WHATPROVIDES_SLES_RELEASE))
-                    .map(r -> r.getChanges(CmdExecCodeAll.class)).map(c -> c.getStdout());
+                    .map(r -> r.getChanges(CmdResult.class)).map(c -> c.getStdout());
 
             Optional<RhelUtils.RhelProduct> rhelProduct = RhelUtils.detectRhelProduct(
                     server, whatProvidesRes, rhelReleaseContent, centosReleaseContent);

--- a/java/code/src/com/suse/manager/reactor/utils/test/RhelUtilsTest.java
+++ b/java/code/src/com/suse/manager/reactor/utils/test/RhelUtilsTest.java
@@ -33,7 +33,7 @@ import com.redhat.rhn.testing.TestUtils;
 import com.suse.manager.reactor.utils.RhelUtils;
 import com.suse.salt.netapi.calls.modules.State;
 import com.suse.salt.netapi.parser.JsonParser;
-import com.suse.salt.netapi.results.CmdExecCodeAll;
+import com.suse.salt.netapi.results.CmdResult;
 import org.jmock.lib.legacy.ClassImposteriser;
 
 import java.util.Collections;
@@ -64,6 +64,7 @@ public class RhelUtilsTest extends JMockBaseTestCaseWithUser {
 
     }
 
+    @Override
     public void setUp() throws Exception {
         super.setUp();
         setImposteriser(ClassImposteriser.INSTANCE);
@@ -106,13 +107,13 @@ public class RhelUtilsTest extends JMockBaseTestCaseWithUser {
         Map<String, State.ApplyResult> map = new JsonParser<>(State.apply(Collections.emptyList()).getReturnType()).parse(
                 TestUtils.readAll(TestUtils.findTestData(json)));
         String centosReleaseContent = map.get("cmd_|-centosrelease_|-cat /etc/centos-release_|-run")
-                .getChanges(CmdExecCodeAll.class)
+                .getChanges(CmdResult.class)
                 .getStdout();
         String rhelReleaseContent = map.get("cmd_|-rhelrelease_|-cat /etc/redhat-release_|-run")
-                .getChanges(CmdExecCodeAll.class)
+                .getChanges(CmdResult.class)
                 .getStdout();
         String whatProvidesRes = map.get("cmd_|-respkgquery_|-rpm -q --whatprovides 'sles_es-release-server'_|-run")
-                .getChanges(CmdExecCodeAll.class)
+                .getChanges(CmdResult.class)
                 .getStdout();
         MinionServer minionServer = MinionServerFactoryTest.createTestMinionServer(user);
         if (setupMinion != null) {

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -112,7 +112,7 @@ import com.suse.salt.netapi.datatypes.target.MinionList;
 import com.suse.salt.netapi.errors.JsonParsingError;
 import com.suse.salt.netapi.errors.SaltError;
 import com.suse.salt.netapi.results.Change;
-import com.suse.salt.netapi.results.CmdExecCodeAll;
+import com.suse.salt.netapi.results.CmdResult;
 import com.suse.salt.netapi.results.ModuleRun;
 import com.suse.salt.netapi.results.Ret;
 import com.suse.salt.netapi.results.StateApplyResult;
@@ -511,11 +511,11 @@ public class SaltUtils {
             serverAction.setResultMsg(message);
         }
         else if (action.getActionType().equals(ActionFactory.TYPE_SCRIPT_RUN)) {
-            Map<String, StateApplyResult<CmdExecCodeAll>> stateApplyResult = Json.GSON.fromJson(jsonResult,
-                    new TypeToken<Map<String, StateApplyResult<CmdExecCodeAll>>>() { }.getType());
-            CmdExecCodeAll result = stateApplyResult.entrySet().stream()
+            Map<String, StateApplyResult<CmdResult>> stateApplyResult = Json.GSON.fromJson(jsonResult,
+                    new TypeToken<Map<String, StateApplyResult<CmdResult>>>() { }.getType());
+            CmdResult result = stateApplyResult.entrySet().stream()
                     .findFirst().map(e -> e.getValue().getChanges())
-                    .orElseGet(() -> new CmdExecCodeAll());
+                    .orElseGet(() -> new CmdResult());
             ScriptRunAction scriptAction = (ScriptRunAction) action;
             ScriptResult scriptResult = Optional.ofNullable(
                     scriptAction.getScriptActionDetails().getResults())
@@ -1069,17 +1069,17 @@ public class SaltUtils {
                         Optional.ofNullable(ret.getRhelReleaseFile())
                                 .map(StateApplyResult::getChanges)
                                 .filter(res -> res.getStdout() != null)
-                                .map(CmdExecCodeAll::getStdout);
+                                .map(CmdResult::getStdout);
                 Optional<String> centosReleaseFile =
                         Optional.ofNullable(ret.getCentosReleaseFile())
                                 .map(StateApplyResult::getChanges)
                                 .filter(res -> res.getStdout() != null)
-                                .map(CmdExecCodeAll::getStdout);
+                                .map(CmdResult::getStdout);
                 Optional<String> resReleasePkg =
                         Optional.ofNullable(ret.getWhatProvidesResReleasePkg())
                                 .map(StateApplyResult::getChanges)
                                 .filter(res -> res.getStdout() != null)
-                                .map(CmdExecCodeAll::getStdout);
+                                .map(CmdResult::getStdout);
                 if (rhelReleaseFile.isPresent() || centosReleaseFile.isPresent() ||
                         resReleasePkg.isPresent()) {
                     Set<InstalledProduct> products = getInstalledProductsForRhel(
@@ -1143,17 +1143,17 @@ public class SaltUtils {
                 Optional.ofNullable(result.getRhelReleaseFile())
                 .map(StateApplyResult::getChanges)
                 .filter(ret -> ret.getStdout() != null)
-                .map(CmdExecCodeAll::getStdout);
+                .map(CmdResult::getStdout);
         Optional<String> centosReleaseFile =
                 Optional.ofNullable(result.getCentosReleaseFile())
                 .map(StateApplyResult::getChanges)
                 .filter(ret -> ret.getStdout() != null)
-                .map(CmdExecCodeAll::getStdout);
+                .map(CmdResult::getStdout);
         Optional<String> resReleasePkg =
                 Optional.ofNullable(result.getWhatProvidesResReleasePkg())
                 .map(StateApplyResult::getChanges)
                 .filter(ret -> ret.getStdout() != null)
-                .map(CmdExecCodeAll::getStdout);
+                .map(CmdResult::getStdout);
         if (rhelReleaseFile.isPresent() || centosReleaseFile.isPresent() ||
                 resReleasePkg.isPresent()) {
             Set<InstalledProduct> products = getInstalledProductsForRhel(

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -823,7 +823,7 @@ public class SaltService {
      * @return the LocalAsyncResult of the test.ping call
      * @throws SaltException if we get a failure from Salt
      */
-    public LocalAsyncResult<Boolean> ping(MinionList targetIn) throws SaltException {
+    public Optional<LocalAsyncResult<Boolean>> ping(MinionList targetIn) throws SaltException {
         try {
             LocalCall<Boolean> call = Test.ping();
             return callAsync(call, targetIn);

--- a/java/code/src/com/suse/manager/webui/utils/salt/custom/PkgProfileUpdateSlsResult.java
+++ b/java/code/src/com/suse/manager/webui/utils/salt/custom/PkgProfileUpdateSlsResult.java
@@ -16,7 +16,7 @@ package com.suse.manager.webui.utils.salt.custom;
 
 import com.suse.salt.netapi.calls.modules.Pkg;
 import com.suse.salt.netapi.calls.modules.Zypper;
-import com.suse.salt.netapi.results.CmdExecCodeAll;
+import com.suse.salt.netapi.results.CmdResult;
 import com.suse.salt.netapi.results.Ret;
 import com.suse.salt.netapi.results.StateApplyResult;
 import com.suse.salt.netapi.utils.Xor;
@@ -55,13 +55,13 @@ public class PkgProfileUpdateSlsResult {
     private StateApplyResult<Ret<Map<String, Xor<Pkg.Info, List<Pkg.Info>>>>> infoInstalled;
 
     @SerializedName(PKG_PROFILE_REDHAT_RELEASE)
-    private StateApplyResult<CmdExecCodeAll> rhelReleaseFile;
+    private StateApplyResult<CmdResult> rhelReleaseFile;
 
     @SerializedName(PKG_PROFILE_CENTOS_RELEASE)
-    private StateApplyResult<CmdExecCodeAll> centosReleaseFile;
+    private StateApplyResult<CmdResult> centosReleaseFile;
 
     @SerializedName(PKG_PROFILE_WHATPROVIDES_SLES_RELEASE)
-    private StateApplyResult<CmdExecCodeAll> whatProvidesResReleasePkg;
+    private StateApplyResult<CmdResult> whatProvidesResReleasePkg;
 
     /**
      * Gets live patching info.
@@ -98,21 +98,21 @@ public class PkgProfileUpdateSlsResult {
     /**
      * @return the content of the file /etc/redhat-release
      */
-    public StateApplyResult<CmdExecCodeAll> getRhelReleaseFile() {
+    public StateApplyResult<CmdResult> getRhelReleaseFile() {
         return rhelReleaseFile;
     }
 
     /**
      * @return the content of the file /etc/centos-release
      */
-    public StateApplyResult<CmdExecCodeAll> getCentosReleaseFile() {
+    public StateApplyResult<CmdResult> getCentosReleaseFile() {
         return centosReleaseFile;
     }
 
     /**
      * @return the package that provides 'sles_es-release-server'
      */
-    public StateApplyResult<CmdExecCodeAll> getWhatProvidesResReleasePkg() {
+    public StateApplyResult<CmdResult> getWhatProvidesResReleasePkg() {
         return whatProvidesResReleasePkg;
     }
 }


### PR DESCRIPTION
## What does this PR change?

Update CmdExecCodeAll refrences to CmdResult as class gets renamed in salt-net-api

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: just a renaming of classes

- [x] **DONE**

## Test coverage
- No tests: just a renaming of classes

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/7495

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
