### PR TITLE
Fix path to the RPM database used by Zypper at reposync

### DIFF
--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -491,7 +491,7 @@ type=rpm-md
             zypper_cmd,
             REPOSYNC_ZYPPER_ROOT,
             os.path.join(repo.root, "etc/zypp/repos.d/"),
-            os.path.join(repo.root, "var/cache/zypp/"),
+            'var/lib/rpm',
             os.path.join(repo.root, "var/cache/zypp/raw/"),
             os.path.join(repo.root, "var/cache/zypp/solv/")
         ))

--- a/backend/server/rhnPackage.py
+++ b/backend/server/rhnPackage.py
@@ -206,7 +206,7 @@ def get_info_for_package(pkg, channel_id, org_id):
               'org_id': org_id}
     # yum repo has epoch="0" not only when epoch is "0" but also if it's NULL
     # in DB we cannot insert an empty string, so we check for NULL or '0'
-    if pkg[3] == '0' or pkg[3] == '':
+    if pkg[3] == '0' or pkg[3] == '' or pkg[3] is None:
         epochStatement = "(epoch is null or epoch = '0')"
     else:
         epochStatement = "epoch = :epoch"

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,6 @@
+- Solve situations where synced packages have epoch 0 but reposync
+  does not find them them on the database.
+- Fix path to the RPM database used by Zypper at reposync.
 - add makefile for python linter and unit/integration tests
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

This PR fixes two issues on Zypper reposync:

- Solve situations where synced packages have epoch 0 but reposync does not find them them on the database.
- Fix path to the Zypper "cachedir"  to use the shared RPM database for reposync and prevent issues with imported custom GPG keys.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **tested on cucumber**

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
