### PR TITLE
Content lifecycle management - first version of filters

### DIFF
--- a/branding/java/code/src/com/redhat/rhn/branding/strings/StringResource_en_US.xml
+++ b/branding/java/code/src/com/redhat/rhn/branding/strings/StringResource_en_US.xml
@@ -2089,9 +2089,8 @@ tree will not be usable for autoinstalling.
         <source>Content Lifecycle Management</source>
       </trans-unit>
       <trans-unit id="contentmanagement.nav.projects">
-        <source>Content Lifecycle Projects</source>
+        <source>Projects</source>
       </trans-unit>
-
       <trans-unit id="contentmanagement.nav.filters">
         <source>Filters</source>
       </trans-unit>

--- a/branding/java/code/src/com/redhat/rhn/branding/strings/StringResource_en_US.xml
+++ b/branding/java/code/src/com/redhat/rhn/branding/strings/StringResource_en_US.xml
@@ -2092,6 +2092,10 @@ tree will not be usable for autoinstalling.
         <source>Content Lifecycle Projects</source>
       </trans-unit>
 
+      <trans-unit id="contentmanagement.nav.filters">
+        <source>Filters</source>
+      </trans-unit>
+
       <!-- CVE Audit Messages -->
       <trans-unit id="cveaudit.nav.title">
         <source>CVE Audit</source>

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentFilter.java
@@ -34,6 +34,7 @@ import javax.persistence.InheritanceType;
 import javax.persistence.ManyToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
+import javax.persistence.Transient;
 
 /**
  * Content Filter
@@ -49,6 +50,45 @@ public abstract class ContentFilter extends BaseDomainHelper {
     private String name;
     private Rule rule;
     private FilterCriteria criteria;
+
+    /**
+     * Entity type that is dealt with by filter.
+     */
+    public enum EntityType {
+        PACKAGE("package"),
+        ERRATUM("erratum");
+
+        private String label;
+
+        EntityType(String labelIn) {
+            this.label = labelIn;
+        }
+
+        /**
+         * Gets the label.
+         *
+         * @return label
+         */
+        public String getLabel() {
+            return label;
+        }
+
+        /**
+         * Looks up Entity type by label
+         *
+         * @param label the label
+         * @throws java.lang.IllegalArgumentException if no matching Entity type is found
+         * @return the matching Entity type
+         */
+        public static EntityType lookupByLabel(String label) {
+            for (EntityType value : values()) {
+                if (value.label.equals(label)) {
+                    return value;
+                }
+            }
+            throw new IllegalArgumentException("Unsupported label: " + label);
+        }
+    }
 
     /**
      * Type of the filter
@@ -88,6 +128,13 @@ public abstract class ContentFilter extends BaseDomainHelper {
             throw new IllegalArgumentException("Unsupported label: " + label);
         }
     }
+
+    /**
+     * Get {@link EntityType} of this object
+     * @return the {@link EntityType}
+     */
+    @Transient
+    public abstract EntityType getEntityType();
 
     /**
      * Gets the id.

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentFilter.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorColumn;
+import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -44,7 +45,7 @@ public abstract class ContentFilter extends BaseDomainHelper {
     private Long id;
     private Org org;
     private String name;
-    private String criteria;
+    private FilterCriteria criteria;
 
     /**
      * Gets the id.
@@ -110,8 +111,8 @@ public abstract class ContentFilter extends BaseDomainHelper {
      *
      * @return criteria
      */
-    @Column
-    public String getCriteria() {
+    @Embedded
+    public FilterCriteria getCriteria() {
         return criteria;
     }
 
@@ -120,7 +121,7 @@ public abstract class ContentFilter extends BaseDomainHelper {
      *
      * @param criteriaIn - the criteria
      */
-    public void setCriteria(String criteriaIn) {
+    public void setCriteria(FilterCriteria criteriaIn) {
         criteria = criteriaIn;
     }
 

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentFilter.java
@@ -20,6 +20,7 @@ import com.redhat.rhn.domain.org.Org;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
+import java.util.Optional;
 import java.util.function.Predicate;
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorColumn;
@@ -138,6 +139,20 @@ public abstract class ContentFilter<T> extends BaseDomainHelper implements Predi
      */
     @Transient
     public abstract EntityType getEntityType();
+
+    /**
+     * Returns the filter as {@link PackageFilter} if it is one
+     *
+     * @return Optional of {@link PackageFilter}
+     */
+    public abstract Optional<PackageFilter> asPackageFilter();
+
+    /**
+     * Returns the filter as {@link ErrataFilter} if it is one
+     *
+     * @return Optional of {@link ErrataFilter}
+     */
+    public abstract Optional<ErrataFilter> asErrataFilter();
 
     /**
      * Test whether an object passes the filter

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentFilter.java
@@ -17,11 +17,13 @@ package com.redhat.rhn.domain.contentmgmt;
 
 import com.redhat.rhn.domain.BaseDomainHelper;
 import com.redhat.rhn.domain.org.Org;
+
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.Optional;
 import java.util.function.Predicate;
+
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorColumn;
 import javax.persistence.Embedded;

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentFilter.java
@@ -24,6 +24,8 @@ import javax.persistence.Column;
 import javax.persistence.DiscriminatorColumn;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -45,7 +47,47 @@ public abstract class ContentFilter extends BaseDomainHelper {
     private Long id;
     private Org org;
     private String name;
+    private Rule rule;
     private FilterCriteria criteria;
+
+    /**
+     * Type of the filter
+     */
+    public enum Rule {
+        ALLOW("allow"),
+        DENY("deny");
+
+        private final String label;
+
+        Rule(String typeIn) {
+            this.label = typeIn;
+        }
+
+        /**
+         * Gets the label.
+         *
+         * @return label
+         */
+        public String getLabel() {
+            return label;
+        }
+
+        /**
+         * Looks up Rule by label
+         *
+         * @param label the label
+         * @throws java.lang.IllegalArgumentException if no matching Rule is found
+         * @return the matching Rule
+         */
+        public static Rule lookupByLabel(String label) {
+            for (Rule value : values()) {
+                if (value.label.equals(label)) {
+                    return value;
+                }
+            }
+            throw new IllegalArgumentException("Unsupported label: " + label);
+        }
+    }
 
     /**
      * Gets the id.
@@ -104,6 +146,25 @@ public abstract class ContentFilter extends BaseDomainHelper {
      */
     public void setName(String nameIn) {
         name = nameIn;
+    }
+
+    /**
+     * Gets the rule.
+     *
+     * @return rule
+     */
+    @Enumerated(EnumType.STRING)
+    public Rule getRule() {
+        return rule;
+    }
+
+    /**
+     * Sets the rule.
+     *
+     * @param ruleIn the rule
+     */
+    public void setRule(Rule ruleIn) {
+        this.rule = ruleIn;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentFilter.java
@@ -20,6 +20,7 @@ import com.redhat.rhn.domain.org.Org;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
+import java.util.function.Predicate;
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorColumn;
 import javax.persistence.Embedded;
@@ -38,12 +39,14 @@ import javax.persistence.Transient;
 
 /**
  * Content Filter
+ *
+ * @param <T> the entity being filtered
  */
 @Entity
 @Table(name = "suseContentFilter")
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "type")
-public abstract class ContentFilter extends BaseDomainHelper {
+public abstract class ContentFilter<T> extends BaseDomainHelper implements Predicate<T> {
 
     private Long id;
     private Org org;

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentFilter.java
@@ -140,6 +140,21 @@ public abstract class ContentFilter<T> extends BaseDomainHelper implements Predi
     public abstract EntityType getEntityType();
 
     /**
+     * Test whether an object passes the filter
+     *
+     * @param t the object
+     * @return true if the object passes the filter
+     */
+    public abstract boolean testInternal(T t);
+
+    @Override
+    public boolean test(T t) {
+        boolean result = testInternal(t);
+        // we want to invert the test if Rule type is DENY
+        return rule == Rule.ALLOW ? result : !result;
+    }
+
+    /**
      * Gets the id.
      *
      * @return id

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProject.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProject.java
@@ -308,6 +308,51 @@ public class ContentProject extends BaseDomainHelper {
     }
 
     /**
+     * Attach a {@link ContentFilter} to {@link ContentProject}
+     *
+     * @param filter the filter to attach
+     */
+    public void attachFilter(ContentFilter filter) {
+        ContentProjectFilter projectFilter = new ContentProjectFilter(this, filter);
+
+        int idx = filters.indexOf(projectFilter);
+        if (idx != -1) {
+            ContentProjectFilter toUpdate = filters.get(idx);
+            if (toUpdate.getState() == ContentProjectFilter.State.DETACHED) {
+                toUpdate.setState(ContentProjectFilter.State.BUILT);
+            }
+        }
+        else {
+            filters.add(projectFilter);
+        }
+    }
+
+    /**
+     * Detach a {@link ContentFilter} from a {@link ContentProject}
+     *
+     * @param filter the filter to detach
+     */
+    public void detachFilter(ContentFilter filter) {
+        ContentProjectFilter projectFilter = new ContentProjectFilter(this, filter);
+
+        int idx = filters.indexOf(projectFilter);
+        if (idx != -1) {
+            ContentProjectFilter toUpdate = filters.get(idx);
+
+            switch (toUpdate.getState()) {
+                case BUILT:
+                    toUpdate.setState(ContentProjectFilter.State.DETACHED);
+                    break;
+                case ATTACHED:
+                    filters.remove(idx);
+                    break;
+                default:
+                    // no-op
+            }
+        }
+    }
+
+    /**
      * Gets the historyEntries.
      *
      * @return historyEntries

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProject.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProject.java
@@ -294,7 +294,7 @@ public class ContentProject extends BaseDomainHelper {
      */
     @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, mappedBy = "project", orphanRemoval = true)
     @OrderColumn(name = "position")
-    protected List<ContentProjectFilter> getProjectFilters() {
+    public List<ContentProjectFilter> getProjectFilters() {
         return filters;
     }
 

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProject.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProject.java
@@ -38,7 +38,6 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.OrderBy;
-import javax.persistence.OrderColumn;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.persistence.Transient;
@@ -294,7 +293,6 @@ public class ContentProject extends BaseDomainHelper {
      * @return filters
      */
     @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, mappedBy = "project", orphanRemoval = true)
-    @OrderColumn(name = "position")
     public List<ContentProjectFilter> getProjectFilters() {
         return filters;
     }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProject.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProject.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -296,6 +297,18 @@ public class ContentProject extends BaseDomainHelper {
     @OrderColumn(name = "position")
     public List<ContentProjectFilter> getProjectFilters() {
         return filters;
+    }
+
+    /**
+     * Get the {@link PackageFilter}s
+     *
+     * @return the Package filters
+     */
+    @Transient
+    public List<PackageFilter> getPackageFilters() {
+        return (List<PackageFilter>) getProjectFilters().stream()
+                .flatMap(f -> Opt.stream(f.getFilter().asPackageFilter()))
+                .collect(Collectors.toList());
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
@@ -495,6 +495,14 @@ public class ContentProjectFactory extends HibernateFactory {
     }
 
     /**
+     * Remove {@link ContentProjectFilter}
+     * @param filter the filter
+     */
+    public static void remove(ContentProjectFilter filter) {
+        INSTANCE.removeObject(filter);
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
@@ -432,6 +432,10 @@ public class ContentProjectFactory extends HibernateFactory {
      */
     public static ContentFilter createFilter(String name, ContentFilter.Rule rule, ContentFilter.EntityType entityType,
             FilterCriteria criteria, User user) {
+        if (rule == ContentFilter.Rule.ALLOW) {
+            throw new UnsupportedOperationException("Rule ALLOW is not supported yet");
+        }
+
         ContentFilter filter;
         switch (entityType) {
             case PACKAGE:
@@ -463,6 +467,11 @@ public class ContentProjectFactory extends HibernateFactory {
      */
     public static ContentFilter updateFilter(ContentFilter filter, Optional<String> name,
             Optional<ContentFilter.Rule> rule, Optional<FilterCriteria> criteria) {
+        rule.ifPresent(r -> {
+            if (r == ContentFilter.Rule.ALLOW) {
+                throw new UnsupportedOperationException("Rule ALLOW is not supported yet");
+            }
+        });
         name.ifPresent(n -> filter.setName(n));
         rule.ifPresent(r -> filter.setRule(r));
         criteria.ifPresent(c -> filter.setCriteria(c));

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
@@ -480,6 +480,21 @@ public class ContentProjectFactory extends HibernateFactory {
     }
 
     /**
+     * List {@link ContentProject}s using given {@link ContentFilter}
+     *
+     * @param filter the Filter
+     * @return list of Projects
+     */
+    public static List<ContentProject> listFilterProjects(ContentFilter filter) {
+        return HibernateFactory.getSession()
+                .createQuery("SELECT cp FROM ContentProject cp " +
+                                "WHERE cp.id IN (SELECT cpf.project.id FROM ContentProjectFilter cpf " +
+                                                 "WHERE cpf.filter.id = :fid)")
+                .setParameter("fid", filter.getId())
+                .list();
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
@@ -393,6 +393,93 @@ public class ContentProjectFactory extends HibernateFactory {
     }
 
     /**
+     * List filters visible to given user
+     *
+     * @param user the user
+     * @return the filters
+     */
+    public static List<ContentFilter> listFilters(User user) {
+        CriteriaBuilder builder = getSession().getCriteriaBuilder();
+        CriteriaQuery<ContentFilter> criteria = builder.createQuery(ContentFilter.class);
+        Root<ContentFilter> root = criteria.from(ContentFilter.class);
+        criteria.where(builder.equal(root.get("org"), user.getOrg()));
+        return getSession().createQuery(criteria).list();
+    }
+
+    /**
+     * Look up filter by id
+     *
+     * @param id the id
+     * @return the matching filter
+     */
+    public static Optional<ContentFilter> lookupFilterById(Long id) {
+        CriteriaBuilder builder = getSession().getCriteriaBuilder();
+        CriteriaQuery<ContentFilter> criteria = builder.createQuery(ContentFilter.class);
+        Root<ContentFilter> root = criteria.from(ContentFilter.class);
+        criteria.where(builder.equal(root.get("id"), id));
+        return getSession().createQuery(criteria).uniqueResultOptional();
+    }
+
+    /**
+     * Create a new {@link ContentFilter}
+     *
+     * @param name the filter name
+     * @param rule the filter {@link ContentFilter.Rule}
+     * @param entityType the entity type that the filter will deal with
+     * @param criteria the {@link FilterCriteria} for filtering
+     * @param user the User
+     * @return the created filter
+     */
+    public static ContentFilter createFilter(String name, ContentFilter.Rule rule, ContentFilter.EntityType entityType,
+            FilterCriteria criteria, User user) {
+        ContentFilter filter;
+        switch (entityType) {
+            case PACKAGE:
+                filter = new PackageFilter();
+                break;
+            case ERRATUM:
+                filter = new ErrataFilter();
+                break;
+            default:
+                throw new IllegalArgumentException("Incompatible type " + entityType);
+        }
+
+        filter.setName(name);
+        filter.setOrg(user.getOrg());
+        filter.setRule(rule);
+        filter.setCriteria(criteria);
+        INSTANCE.saveObject(filter);
+        return filter;
+    }
+
+    /**
+     * Update a {@link ContentFilter}
+     *
+     * @param filter the filter to update
+     * @param name optional with name to update
+     * @param rule optional with {@link ContentFilter.Rule} to update
+     * @param criteria optional with {@link FilterCriteria} to update
+     * @return the updated filter
+     */
+    public static ContentFilter updateFilter(ContentFilter filter, Optional<String> name,
+            Optional<ContentFilter.Rule> rule, Optional<FilterCriteria> criteria) {
+        name.ifPresent(n -> filter.setName(n));
+        rule.ifPresent(r -> filter.setRule(r));
+        criteria.ifPresent(c -> filter.setCriteria(c));
+        return filter;
+    }
+
+    /**
+     * Remove {@link ContentFilter}
+     *
+     * @param filter the filter
+     * @return true if removed
+     */
+    public static boolean remove(ContentFilter filter) {
+        return INSTANCE.removeObject(filter) != 0;
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFilter.java
@@ -19,6 +19,8 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -93,6 +95,7 @@ public class ContentProjectFilter {
      *
      * @return state
      */
+    @Enumerated(EnumType.STRING)
     public State getState() {
         return state;
     }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ErrataFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ErrataFilter.java
@@ -17,6 +17,7 @@ package com.redhat.rhn.domain.contentmgmt;
 
 import com.redhat.rhn.domain.errata.Errata;
 
+import java.util.Optional;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import javax.persistence.Transient;
@@ -37,5 +38,15 @@ public class ErrataFilter extends ContentFilter<Errata> {
     @Transient
     public EntityType getEntityType() {
         return EntityType.ERRATUM;
+    }
+
+    @Override
+    public Optional<PackageFilter> asPackageFilter() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<ErrataFilter> asErrataFilter() {
+        return Optional.of(this);
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ErrataFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ErrataFilter.java
@@ -29,7 +29,7 @@ import javax.persistence.Transient;
 public class ErrataFilter extends ContentFilter<Errata> {
 
     @Override
-    public boolean test(Errata errata) {
+    public boolean testInternal(Errata errata) {
         return false;
     }
 

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ErrataFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ErrataFilter.java
@@ -15,6 +15,8 @@
 
 package com.redhat.rhn.domain.contentmgmt;
 
+import com.redhat.rhn.domain.errata.Errata;
+
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import javax.persistence.Transient;
@@ -24,7 +26,12 @@ import javax.persistence.Transient;
  */
 @Entity
 @DiscriminatorValue("errata")
-public class ErrataFilter extends ContentFilter {
+public class ErrataFilter extends ContentFilter<Errata> {
+
+    @Override
+    public boolean test(Errata errata) {
+        return false;
+    }
 
     @Override
     @Transient

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ErrataFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ErrataFilter.java
@@ -17,6 +17,7 @@ package com.redhat.rhn.domain.contentmgmt;
 
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
+import javax.persistence.Transient;
 
 /**
  * Errata Filter
@@ -25,4 +26,9 @@ import javax.persistence.Entity;
 @DiscriminatorValue("errata")
 public class ErrataFilter extends ContentFilter {
 
+    @Override
+    @Transient
+    public EntityType getEntityType() {
+        return EntityType.ERRATUM;
+    }
 }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
@@ -1,0 +1,163 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.domain.contentmgmt;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+
+/**
+ * The criteria used for matching objects (Package, Errata) in {@link ContentFilter}
+ *
+ * Consist of 3 fields:
+ * - matcher - the matcher type (equals, contains, greater-than...)
+ * - field - the field of the examined object (e.g. Package name)
+ * - value - the user-defined value for matching (e.g. "libsolv", for package name)
+ */
+@Embeddable
+public class FilterCriteria {
+
+    private Matcher matcher;
+    private String field;
+    private String value;
+
+    /**
+     * The matcher type
+     */
+    public enum Matcher {
+        CONTAINS;
+    }
+
+    /**
+     * Standard constructor
+     */
+    public FilterCriteria() {
+    }
+
+    /**
+     * Standard constructor
+     *
+     * @param matcherIn the matcher type
+     * @param fieldIn the field to match
+     * @param valueIn the match value
+     */
+    public FilterCriteria(Matcher matcherIn, String fieldIn, String valueIn) {
+        this.matcher = matcherIn;
+        this.field = fieldIn;
+        this.value = valueIn;
+    }
+
+    /**
+     * Gets the type.
+     *
+     * @return type
+     */
+    @Column(name = "matcher")
+    @Enumerated(EnumType.STRING)
+    public Matcher getMatcher() {
+        return matcher;
+    }
+
+    /**
+     * Sets the matcher type.
+     *
+     * @param matcherIn the matcher type
+     */
+    public void setMatcher(Matcher matcherIn) {
+        this.matcher = matcherIn;
+    }
+
+    /**
+     * Gets the field.
+     *
+     * @return field
+     */
+    @Column(name = "field")
+    public String getField() {
+        return field;
+    }
+
+    /**
+     * Sets the field.
+     *
+     * @param fieldIn the field
+     */
+    public void setField(String fieldIn) {
+        this.field = fieldIn;
+    }
+
+    /**
+     * Gets the value.
+     *
+     * @return value
+     */
+    @Column(name = "value")
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Sets the value.
+     *
+     * @param valueIn the value
+     */
+    public void setValue(String valueIn) {
+        this.value = valueIn;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        FilterCriteria that = (FilterCriteria) o;
+
+        return new EqualsBuilder()
+                .append(matcher, that.matcher)
+                .append(field, that.field)
+                .append(value, that.value)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+                .append(matcher)
+                .append(field)
+                .append(value)
+                .toHashCode();
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .append("matcher", matcher)
+                .append("field", field)
+                .append("value", value)
+                .toString();
+    }
+
+}

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
@@ -43,7 +43,38 @@ public class FilterCriteria {
      * The matcher type
      */
     public enum Matcher {
-        CONTAINS;
+        CONTAINS("contains");
+
+        private String label;
+
+        Matcher(String labelIn) {
+            this.label = labelIn;
+        }
+
+        /**
+         * Gets the label.
+         *
+         * @return label
+         */
+        public String getLabel() {
+            return label;
+        }
+
+        /**
+         * Looks up Matcher by label
+         *
+         * @param label the label
+         * @throws java.lang.IllegalArgumentException if no matching matcher is found
+         * @return the matching matcher
+         */
+        public static Matcher lookupByLabel(String label) {
+            for (Matcher value : values()) {
+                if (value.label.equals(label)) {
+                    return value;
+                }
+            }
+            throw new IllegalArgumentException("Unsupported label: " + label);
+        }
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
@@ -17,6 +17,7 @@ package com.redhat.rhn.domain.contentmgmt;
 
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
+import javax.persistence.Transient;
 
 /**
  * Package Filter
@@ -25,4 +26,9 @@ import javax.persistence.Entity;
 @DiscriminatorValue("package")
 public class PackageFilter extends ContentFilter {
 
+    @Override
+    @Transient
+    public EntityType getEntityType() {
+        return EntityType.PACKAGE;
+    }
 }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
@@ -17,6 +17,7 @@ package com.redhat.rhn.domain.contentmgmt;
 
 import com.redhat.rhn.domain.rhnpackage.Package;
 
+import java.util.Optional;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import javax.persistence.Transient;
@@ -56,5 +57,15 @@ public class PackageFilter extends ContentFilter<Package> {
     @Transient
     public EntityType getEntityType() {
         return EntityType.PACKAGE;
+    }
+
+    @Override
+    public Optional<PackageFilter> asPackageFilter() {
+        return Optional.of(this);
+    }
+
+    @Override
+    public Optional<ErrataFilter> asErrataFilter() {
+        return Optional.empty();
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
@@ -24,7 +24,11 @@ import javax.persistence.Transient;
  */
 @Entity
 @DiscriminatorValue("package")
-public class PackageFilter extends ContentFilter {
+public class PackageFilter extends ContentFilter<Package> {
+
+    @Override
+    public boolean test(Package pack) {
+    }
 
     @Override
     @Transient

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
@@ -15,6 +15,8 @@
 
 package com.redhat.rhn.domain.contentmgmt;
 
+import com.redhat.rhn.domain.rhnpackage.Package;
+
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import javax.persistence.Transient;
@@ -27,7 +29,7 @@ import javax.persistence.Transient;
 public class PackageFilter extends ContentFilter<Package> {
 
     @Override
-    public boolean test(Package pack) {
+    public boolean testInternal(Package pack) {
         FilterCriteria.Matcher matcher = getCriteria().getMatcher();
         String field = getCriteria().getField();
         String value = getCriteria().getValue();
@@ -44,7 +46,7 @@ public class PackageFilter extends ContentFilter<Package> {
     private static <T> T getField(Package pack, String field, Class<T> type) {
         switch (field) {
             case "name":
-                return type.cast(pack.getName());
+                return type.cast(pack.getPackageName().getName());
             default:
                 throw new UnsupportedOperationException("Field " + field + " not supported");
         }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
@@ -28,6 +28,26 @@ public class PackageFilter extends ContentFilter<Package> {
 
     @Override
     public boolean test(Package pack) {
+        FilterCriteria.Matcher matcher = getCriteria().getMatcher();
+        String field = getCriteria().getField();
+        String value = getCriteria().getValue();
+
+        switch (matcher) {
+            case CONTAINS:
+                return getField(pack, field, String.class).contains(value);
+            default:
+                throw new UnsupportedOperationException("Matcher " + matcher + " not supported");
+
+        }
+    }
+
+    private static <T> T getField(Package pack, String field, Class<T> type) {
+        switch (field) {
+            case "name":
+                return type.cast(pack.getName());
+            default:
+                throw new UnsupportedOperationException("Field " + field + " not supported");
+        }
     }
 
     @Override

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentFilterTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentFilterTest.java
@@ -48,7 +48,8 @@ public class ContentFilterTest extends JMockBaseTestCaseWithUser {
         assertFalse(filter.test(pack));
     }
 
-    public void testPackageAllowFilter() throws Exception {
+    // TODO fkobzik enable test after Beta3 release
+    public void disabledTestPackageAllowFilter() throws Exception {
         Package pack = PackageTest.createTestPackage(user.getOrg());
         String packageName = pack.getPackageName().getName();
 

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentFilterTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentFilterTest.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.domain.contentmgmt.test;
+
+import com.redhat.rhn.domain.contentmgmt.ContentFilter;
+import com.redhat.rhn.domain.contentmgmt.FilterCriteria;
+import com.redhat.rhn.domain.rhnpackage.Package;
+import com.redhat.rhn.domain.rhnpackage.test.PackageTest;
+import com.redhat.rhn.manager.contentmgmt.ContentManager;
+import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
+import com.redhat.rhn.testing.UserTestUtils;
+
+import static com.redhat.rhn.domain.contentmgmt.ContentFilter.EntityType.PACKAGE;
+import static com.redhat.rhn.domain.contentmgmt.ContentFilter.Rule.ALLOW;
+import static com.redhat.rhn.domain.contentmgmt.ContentFilter.Rule.DENY;
+import static com.redhat.rhn.domain.role.RoleFactory.ORG_ADMIN;
+
+/**
+ * Tests for {@link ContentFilter}
+ */
+public class ContentFilterTest extends JMockBaseTestCaseWithUser {
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        UserTestUtils.addUserRole(user, ORG_ADMIN);
+    }
+
+    public void testPackageDenyFilter() throws Exception {
+        Package pack = PackageTest.createTestPackage(user.getOrg());
+        String packageName = pack.getPackageName().getName();
+
+        FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.CONTAINS, "name", packageName);
+        ContentFilter filter = ContentManager.createFilter(packageName + "-filter", DENY, PACKAGE, criteria, user);
+        assertFalse(filter.test(pack));
+    }
+
+    public void testPackageAllowFilter() throws Exception {
+        Package pack = PackageTest.createTestPackage(user.getOrg());
+        String packageName = pack.getPackageName().getName();
+
+        FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.CONTAINS, "name", packageName);
+        ContentFilter filter = ContentManager.createFilter(packageName + "-filter", ALLOW, PACKAGE, criteria, user);
+        assertTrue(filter.test(pack));
+    }
+}

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentProjectFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentProjectFactoryTest.java
@@ -20,10 +20,12 @@ import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.ChannelFactory;
 import com.redhat.rhn.domain.contentmgmt.ContentEnvironment;
+import com.redhat.rhn.domain.contentmgmt.ContentFilter;
 import com.redhat.rhn.domain.contentmgmt.ContentProject;
 import com.redhat.rhn.domain.contentmgmt.ContentProjectFactory;
 import com.redhat.rhn.domain.contentmgmt.ContentProjectHistoryEntry;
 import com.redhat.rhn.domain.contentmgmt.EnvironmentTarget;
+import com.redhat.rhn.domain.contentmgmt.FilterCriteria;
 import com.redhat.rhn.domain.contentmgmt.ProjectSource;
 import com.redhat.rhn.domain.contentmgmt.ProjectSource.State;
 import com.redhat.rhn.domain.contentmgmt.SoftwareEnvironmentTarget;
@@ -31,6 +33,7 @@ import com.redhat.rhn.domain.contentmgmt.SoftwareProjectSource;
 import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.user.UserFactory;
+import com.redhat.rhn.manager.contentmgmt.ContentManager;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.ChannelTestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
@@ -40,6 +43,7 @@ import java.util.Optional;
 
 import static com.redhat.rhn.domain.contentmgmt.ProjectSource.Type.SW_CHANNEL;
 import static com.redhat.rhn.domain.contentmgmt.ProjectSource.Type.lookupByLabel;
+import static com.redhat.rhn.domain.role.RoleFactory.ORG_ADMIN;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.Optional.empty;
@@ -544,5 +548,25 @@ public class ContentProjectFactoryTest extends BaseTestCaseWithUser {
         ContentProjectFactory.purgeTarget(target);
         assertEquals(0, envdev.getTargets().size());
         assertNull(ChannelFactory.lookupByLabel(channelLabel));
+    }
+
+    /**
+     * Test listing {@link ContentProject}s used by given {@link ContentFilter}
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testListFilterProjects() throws Exception {
+        user.addPermanentRole(ORG_ADMIN);
+        FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.CONTAINS, "name", "aaa");
+        ContentFilter filter = ContentManager.createFilter("my-filter", ContentFilter.Rule.ALLOW, ContentFilter.EntityType.PACKAGE, criteria, user);
+        ContentProject cp = new ContentProject("cplabel", "cpname", "cpdesc", user.getOrg());
+        ContentProjectFactory.save(cp);
+
+        assertTrue(ContentProjectFactory.listFilterProjects(filter).isEmpty());
+        cp.attachFilter(filter);
+        assertEquals(1, ContentProjectFactory.listFilterProjects(filter).size());
+        assertEquals(cp, ContentProjectFactory.listFilterProjects(filter).get(0));
+        cp.detachFilter(filter);
+        assertTrue(ContentProjectFactory.listFilterProjects(filter).isEmpty());
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentProjectFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentProjectFactoryTest.java
@@ -558,7 +558,7 @@ public class ContentProjectFactoryTest extends BaseTestCaseWithUser {
     public void testListFilterProjects() throws Exception {
         user.addPermanentRole(ORG_ADMIN);
         FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.CONTAINS, "name", "aaa");
-        ContentFilter filter = ContentManager.createFilter("my-filter", ContentFilter.Rule.ALLOW, ContentFilter.EntityType.PACKAGE, criteria, user);
+        ContentFilter filter = ContentManager.createFilter("my-filter", ContentFilter.Rule.DENY, ContentFilter.EntityType.PACKAGE, criteria, user);
         ContentProject cp = new ContentProject("cplabel", "cpname", "cpdesc", user.getOrg());
         ContentProjectFactory.save(cp);
 

--- a/java/code/src/com/redhat/rhn/frontend/events/AlignSoftwareTargetAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/AlignSoftwareTargetAction.java
@@ -22,6 +22,7 @@ import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.ChannelFactory;
 import com.redhat.rhn.domain.contentmgmt.ContentProjectFactory;
 import com.redhat.rhn.domain.contentmgmt.EnvironmentTarget.Status;
+import com.redhat.rhn.domain.contentmgmt.PackageFilter;
 import com.redhat.rhn.domain.contentmgmt.SoftwareEnvironmentTarget;
 import com.redhat.rhn.manager.EntityNotExistsException;
 import com.redhat.rhn.manager.channel.ChannelManager;
@@ -30,6 +31,7 @@ import org.apache.log4j.Logger;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import java.util.function.Consumer;
 
 /**
@@ -58,7 +60,8 @@ public class AlignSoftwareTargetAction implements MessageAction {
 
             LOG.info("Asynchronously aligning: " + msg);
             Instant start = Instant.now();
-            ChannelManager.alignEnvironmentTargetSync(source, targetChannel, msg.getUser());
+            List<PackageFilter> packageFilters = target.getContentEnvironment().getContentProject().getPackageFilters();
+            ChannelManager.alignEnvironmentTargetSync(packageFilters, source, targetChannel, msg.getUser());
             target.setStatus(Status.GENERATING_REPODATA);
             LOG.info("Finished aligning " + msg + " in " + Duration.between(start, Instant.now()));
         }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ContentFilterSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ContentFilterSerializer.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.frontend.xmlrpc.serializer;
+
+import com.redhat.rhn.domain.contentmgmt.ContentFilter;
+import com.redhat.rhn.domain.contentmgmt.FilterCriteria;
+import com.redhat.rhn.frontend.xmlrpc.serializer.util.SerializerHelper;
+import redstone.xmlrpc.XmlRpcException;
+import redstone.xmlrpc.XmlRpcSerializer;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.HashMap;
+
+/**
+ * Serializer for {@link ContentFilter}
+ *
+ * @xmlrpc.doc
+ * #struct("Content Filter information")
+ *   #prop("int", "id")
+ *   #prop("string", "name")
+ *   #prop("int", "orgId")
+ *   #prop("entityType", "Entity type (e.g. 'package')")
+ *   #prop("rule", "Rule (e.g. 'deny')")
+ *   #struct("criteria")
+ *       #prop_desc("string", "matcher", "The matcher type of the filter (e.g. 'contains')")
+ *       #prop_desc("string", "field", "The entity field to match (e.g. 'name'")
+ *       #prop_desc("string", "value", "The field value to match (e.g. 'kernel')")
+ *   #struct_end()
+ * #struct_end()
+ */
+public class ContentFilterSerializer extends RhnXmlRpcCustomSerializer {
+
+    @Override
+    public Class getSupportedClass() {
+        return ContentFilter.class;
+    }
+
+    @Override
+    protected void doSerialize(Object obj, Writer writer, XmlRpcSerializer serializer)
+            throws XmlRpcException, IOException {
+        ContentFilter filter = (ContentFilter) obj;
+        SerializerHelper helper = new SerializerHelper(serializer);
+        helper.add("id", filter.getId());
+        helper.add("name", filter.getName());
+        helper.add("orgId", filter.getOrg().getId());
+        helper.add("entityType", filter.getEntityType().getLabel());
+        helper.add("rule", filter.getRule().getLabel());
+        helper.add("criteria", criteriaToMap(filter.getCriteria()));
+        helper.writeTo(writer);
+    }
+
+    private HashMap<Object, Object> criteriaToMap(FilterCriteria criteria) {
+        HashMap<Object, Object> map = new HashMap<>();
+        map.put("matcher", criteria.getMatcher().getLabel());
+        map.put("field", criteria.getField());
+        map.put("value", criteria.getValue());
+        return map;
+    }
+}

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ContentProjectFilterSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ContentProjectFilterSerializer.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.frontend.xmlrpc.serializer;
+
+import com.redhat.rhn.domain.contentmgmt.ContentProjectFilter;
+import com.redhat.rhn.frontend.xmlrpc.serializer.util.SerializerHelper;
+import redstone.xmlrpc.XmlRpcException;
+import redstone.xmlrpc.XmlRpcSerializer;
+
+import java.io.IOException;
+import java.io.Writer;
+
+/**
+ * Serializer for {@link ContentProjectFilter}
+ * Also serializes the information about the associated {@link ContentFilter}
+ *
+ * @xmlrpc.doc
+ * #struct("Assigned Content Filter information")
+ *   #prop("string", "state")
+ *   $ContentFilterSerializer
+ * #struct_end()
+ */
+public class ContentProjectFilterSerializer extends RhnXmlRpcCustomSerializer {
+
+    @Override
+    public Class getSupportedClass() {
+        return ContentProjectFilter.class;
+    }
+
+    @Override
+    protected void doSerialize(Object obj, Writer writer, XmlRpcSerializer serializer)
+            throws XmlRpcException, IOException {
+        ContentProjectFilter filter = (ContentProjectFilter) obj;
+        SerializerHelper helper = new SerializerHelper(serializer);
+        helper.add("state", filter.getState());
+        helper.add("filter", filter.getFilter());
+        helper.writeTo(writer);
+    }
+}

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/SerializerRegistry.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/SerializerRegistry.java
@@ -135,6 +135,8 @@ public class SerializerRegistry {
         SERIALIZER_CLASSES.add(ContentProjectSerializer.class);
         SERIALIZER_CLASSES.add(ContentEnvironmentSerializer.class);
         SERIALIZER_CLASSES.add(ContentProjectSourceSerializer.class);
+        SERIALIZER_CLASSES.add(ContentFilterSerializer.class);
+        SERIALIZER_CLASSES.add(ContentProjectFilterSerializer.class);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
@@ -41,6 +41,7 @@ import com.redhat.rhn.domain.channel.ProductName;
 import com.redhat.rhn.domain.channel.ReleaseChannelMap;
 import com.redhat.rhn.domain.contentmgmt.ContentProjectFactory;
 import com.redhat.rhn.domain.contentmgmt.EnvironmentTarget;
+import com.redhat.rhn.domain.contentmgmt.PackageFilter;
 import com.redhat.rhn.domain.contentmgmt.SoftwareEnvironmentTarget;
 import com.redhat.rhn.domain.errata.Errata;
 import com.redhat.rhn.domain.kickstart.KickstartData;
@@ -2777,13 +2778,15 @@ public class ChannelManager extends BaseManager {
      * Synchronously align packages and errata of the {@link SoftwareEnvironmentTarget} to the source {@link Channel}
      * This method is potentially time-expensive and should be run asynchronously (@see alignEnvironmentTarget)
      *
+     * @param filters the {@link PackageFilter}s
      * @param src the source {@link Channel}
      * @param tgt the target {@link SoftwareEnvironmentTarget}
      * @param user the user
      */
-    public static void alignEnvironmentTargetSync(Channel src, Channel tgt, User user) {
+    public static void alignEnvironmentTargetSync(Collection<PackageFilter> filters, Channel src, Channel tgt,
+            User user) {
         // align packages and the cache (rhnServerNeededCache)
-        alignPackages(src, tgt);
+        alignPackages(src, tgt, filters);
 
         // align errata and the cache (rhnServerNeededCache)
         ErrataManager.mergeErrataToChannel(user, src.getErratas(), tgt, src, false, false);
@@ -2798,7 +2801,7 @@ public class ChannelManager extends BaseManager {
         ChannelManager.queueChannelChange(tgt.getLabel(), "java::alignChannel", "Channel aligned");
     }
 
-    private static void alignPackages(Channel srcChannel, Channel tgtChannel) {
+    private static void alignPackages(Channel srcChannel, Channel tgtChannel, Collection<PackageFilter> filters) {
         Set<Package> onlyInTgt = new HashSet<>(tgtChannel.getPackages());
         onlyInTgt.removeAll(srcChannel.getPackages());
         Set<Package> onlyInSrc = new HashSet<>(srcChannel.getPackages());

--- a/java/code/src/com/redhat/rhn/manager/channel/test/ChannelManagerContentAlignmentTest.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/test/ChannelManagerContentAlignmentTest.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.redhat.rhn.domain.role.RoleFactory.ORG_ADMIN;
+import static java.util.Collections.emptyList;
 import static java.util.Optional.of;
 import static java.util.stream.Collectors.toSet;
 
@@ -88,7 +89,7 @@ public class ChannelManagerContentAlignmentTest extends BaseTestCaseWithUser {
     public void testAlignEntities() throws Exception {
         // let's add a package to the target. it should be removed after aligning
         tgtChannel.getPackages().add(PackageTest.createTestPackage(user.getOrg()));
-        ChannelManager.alignEnvironmentTargetSync(srcChannel, tgtChannel, user);
+        ChannelManager.alignEnvironmentTargetSync(emptyList(), srcChannel, tgtChannel, user);
 
         // check that newest packages cache has been updated
         assertEquals(
@@ -116,7 +117,7 @@ public class ChannelManagerContentAlignmentTest extends BaseTestCaseWithUser {
         assertEquals(pack2.getId(), ChannelManager.getLatestPackageEqual(tgtChannel.getId(), pack2.getPackageName().getName()));
         assertNull(ChannelManager.getLatestPackageEqual(tgtChannel.getId(), pkg.getPackageName().getName()));
 
-        ChannelManager.alignEnvironmentTargetSync(srcChannel, tgtChannel, user);
+        ChannelManager.alignEnvironmentTargetSync(emptyList(), srcChannel, tgtChannel, user);
         assertEquals(pkg.getId(), ChannelManager.getLatestPackageEqual(tgtChannel.getId(), pkg.getPackageName().getName()));
         assertNull(ChannelManager.getLatestPackageEqual(tgtChannel.getId(), pack2.getPackageName().getName()));
     }
@@ -136,7 +137,7 @@ public class ChannelManagerContentAlignmentTest extends BaseTestCaseWithUser {
 
         SystemManager.subscribeServerToChannel(user, server, tgtChannel);
 
-        ChannelManager.alignEnvironmentTargetSync(srcChannel, tgtChannel, user);
+        ChannelManager.alignEnvironmentTargetSync(emptyList(), srcChannel, tgtChannel, user);
         assertEquals(errata.getId(), SystemManager.relevantErrata(user, server.getId()).get(0).getId());
     }
 
@@ -158,7 +159,7 @@ public class ChannelManagerContentAlignmentTest extends BaseTestCaseWithUser {
         List<SystemOverview> systemsWithNeededPackage = SystemManager.listSystemsWithNeededPackage(user, pkg.getId());
         assertTrue(systemsWithNeededPackage.isEmpty());
 
-        ChannelManager.alignEnvironmentTargetSync(srcChannel, tgtChannel, user);
+        ChannelManager.alignEnvironmentTargetSync(emptyList(), srcChannel, tgtChannel, user);
         systemsWithNeededPackage = SystemManager.listSystemsWithNeededPackage(user, pkg.getId());
         assertEquals(1, systemsWithNeededPackage.size());
         assertEquals(server.getId(), systemsWithNeededPackage.get(0).getId());
@@ -188,7 +189,7 @@ public class ChannelManagerContentAlignmentTest extends BaseTestCaseWithUser {
         assertEquals(1, systemsWithNeededPackage.size());
         assertEquals(server.getId(), systemsWithNeededPackage.get(0).getId());
 
-        ChannelManager.alignEnvironmentTargetSync(srcChannel, tgtChannel, user);
+        ChannelManager.alignEnvironmentTargetSync(emptyList(), srcChannel, tgtChannel, user);
         systemsWithNeededPackage = SystemManager.listSystemsWithNeededPackage(user, otherPkg.getId());
         assertTrue(systemsWithNeededPackage.isEmpty());
     }
@@ -204,7 +205,7 @@ public class ChannelManagerContentAlignmentTest extends BaseTestCaseWithUser {
         Errata toRemove = ErrataFactoryTest.createTestPublishedErrata(user.getOrg().getId());;
         tgtChannel.addErrata(toRemove);
 
-        ChannelManager.alignEnvironmentTargetSync(srcChannel, tgtChannel, user);
+        ChannelManager.alignEnvironmentTargetSync(emptyList(), srcChannel, tgtChannel, user);
 
         // check that packages and errata have been aligned
         assertEquals(srcChannel.getPackages(), tgtChannel.getPackages());

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -15,6 +15,22 @@
 
 package com.redhat.rhn.manager.contentmgmt;
 
+import static com.redhat.rhn.domain.contentmgmt.ProjectSource.State.ATTACHED;
+import static com.redhat.rhn.domain.contentmgmt.ProjectSource.State.BUILT;
+import static com.redhat.rhn.domain.contentmgmt.ProjectSource.State.DETACHED;
+import static com.redhat.rhn.domain.contentmgmt.ProjectSource.Type.SW_CHANNEL;
+import static com.redhat.rhn.domain.role.RoleFactory.ORG_ADMIN;
+import static com.redhat.rhn.manager.channel.CloneChannelCommand.CloneBehavior.EMPTY;
+import static com.suse.utils.Opt.stream;
+import static java.util.Collections.emptyList;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+import static java.util.Optional.ofNullable;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.partitioningBy;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+
 import com.redhat.rhn.common.hibernate.LookupException;
 import com.redhat.rhn.common.security.PermissionException;
 import com.redhat.rhn.domain.channel.Channel;
@@ -36,6 +52,7 @@ import com.redhat.rhn.manager.EntityExistsException;
 import com.redhat.rhn.manager.EntityNotExistsException;
 import com.redhat.rhn.manager.channel.ChannelManager;
 import com.redhat.rhn.manager.channel.CloneChannelCommand;
+
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.List;
@@ -43,22 +60,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
-
-import static com.redhat.rhn.domain.contentmgmt.ProjectSource.State.ATTACHED;
-import static com.redhat.rhn.domain.contentmgmt.ProjectSource.State.BUILT;
-import static com.redhat.rhn.domain.contentmgmt.ProjectSource.State.DETACHED;
-import static com.redhat.rhn.domain.contentmgmt.ProjectSource.Type.SW_CHANNEL;
-import static com.redhat.rhn.domain.role.RoleFactory.ORG_ADMIN;
-import static com.redhat.rhn.manager.channel.CloneChannelCommand.CloneBehavior.EMPTY;
-import static com.suse.utils.Opt.stream;
-import static java.util.Collections.emptyList;
-import static java.util.Optional.empty;
-import static java.util.Optional.of;
-import static java.util.Optional.ofNullable;
-import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.partitioningBy;
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toSet;
 
 /**
  * Content Management functionality
@@ -448,6 +449,7 @@ public class ContentManager {
         ContentFilter filter = lookupFilterById(filterId, user)
                 .orElseThrow(() -> new EntityNotExistsException(ContentFilter.class, filterId));
         project.attachFilter(filter);
+        ContentProjectFactory.save(project);
         return filter;
     }
 
@@ -465,6 +467,7 @@ public class ContentManager {
         ContentFilter filter = lookupFilterById(filterId, user)
                 .orElseThrow(() -> new EntityNotExistsException(ContentFilter.class, filterId));
         project.detachFilter(filter);
+        ContentProjectFactory.save(project);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -426,6 +426,9 @@ public class ContentManager {
         ensureOrgAdmin(user);
         ContentFilter filter = lookupFilterById(id, user)
                 .orElseThrow(() -> new EntityNotExistsException(id));
+        if (!ContentProjectFactory.listFilterProjects(filter).isEmpty()) {
+            throw new ContentManagementException("Can't delete filter " + id + " - it is used in Content Projects");
+        }
         return ContentProjectFactory.remove(filter);
     }
 

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
@@ -594,11 +594,11 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
 
     public void testLookupFilter() {
         FilterCriteria criteria = new FilterCriteria(Matcher.CONTAINS, "name", "aaa");
-        ContentFilter filter = ContentManager.createFilter("my-filter", Rule.ALLOW, EntityType.PACKAGE, criteria, user);
+        ContentFilter filter = ContentManager.createFilter("my-filter", Rule.DENY, EntityType.PACKAGE, criteria, user);
 
         ContentFilter fromDb = ContentManager.lookupFilterById(filter.getId(), user).get();
         assertEquals(filter, fromDb);
-        assertEquals(Rule.ALLOW, fromDb.getRule());
+        assertEquals(Rule.DENY, fromDb.getRule());
     }
 
     public void testLookupFilterNonAuthorizedUser() {
@@ -1035,7 +1035,7 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
         ContentEnvironment env = ContentManager.createEnvironment(cp.getLabel(), empty(), "fst", "first env", "desc", false, user);
         assertEquals(Long.valueOf(0), env.getVersion());
         FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.CONTAINS, "name", "aaa");
-        ContentFilter filter = ContentManager.createFilter("my-filter", ContentFilter.Rule.ALLOW, ContentFilter.EntityType.PACKAGE, criteria, user);
+        ContentFilter filter = ContentManager.createFilter("my-filter", ContentFilter.Rule.DENY, ContentFilter.EntityType.PACKAGE, criteria, user);
         Channel channel = createPopulatedChannel();
         ContentManager.attachSource("cplabel", SW_CHANNEL, channel.getLabel(), empty(), user);
 

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/ContentManagementApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/ContentManagementApiController.java
@@ -15,6 +15,7 @@
 package com.suse.manager.webui.controllers.contentmanagement;
 
 import com.suse.manager.webui.controllers.contentmanagement.handlers.EnvironmentApiController;
+import com.suse.manager.webui.controllers.contentmanagement.handlers.FilterApiController;
 import com.suse.manager.webui.controllers.contentmanagement.handlers.ProjectActionsApiController;
 import com.suse.manager.webui.controllers.contentmanagement.handlers.ProjectApiController;
 import com.suse.manager.webui.controllers.contentmanagement.handlers.ProjectSourcesApiController;
@@ -32,6 +33,7 @@ public class ContentManagementApiController {
     public static void initRoutes() {
         ProjectApiController.initRoutes();
         ProjectSourcesApiController.initRoutes();
+        FilterApiController.initRoutes();
         EnvironmentApiController.initRoutes();
         ProjectActionsApiController.initRoutes();
     }

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/ContentManagementViewsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/ContentManagementViewsController.java
@@ -16,33 +16,35 @@ package com.suse.manager.webui.controllers.contentmanagement;
 
 import static com.suse.manager.webui.utils.SparkApplicationHelper.withCsrfToken;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.withRolesTemplate;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withUser;
 import static spark.Spark.get;
 
-import com.google.gson.Gson;
 import com.redhat.rhn.domain.contentmgmt.ContentEnvironment;
 import com.redhat.rhn.domain.contentmgmt.ContentFilter;
 import com.redhat.rhn.domain.contentmgmt.ContentProject;
 import com.redhat.rhn.domain.contentmgmt.ContentProjectFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.contentmgmt.ContentManager;
+
 import com.suse.manager.webui.controllers.contentmanagement.mappers.ResponseMappers;
 import com.suse.manager.webui.controllers.contentmanagement.response.FilterResponse;
 import com.suse.manager.webui.utils.FlashScopeHelper;
 import com.suse.utils.Json;
+
+import com.google.gson.Gson;
+
+import org.apache.log4j.Logger;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import org.apache.log4j.Logger;
+
 import spark.ModelAndView;
 import spark.Request;
 import spark.Response;
 import spark.template.jade.JadeTemplateEngine;
-
-import static com.suse.manager.webui.utils.SparkApplicationHelper.withCsrfToken;
-import static com.suse.manager.webui.utils.SparkApplicationHelper.withUser;
-import static spark.Spark.get;
 
 /**
  * Spark controller class for content management pages.
@@ -139,7 +141,7 @@ public class ContentManagementViewsController {
      * @param req the request object
      * @param res the response object
      * @param user the current user
-     * @return
+     * @return the ModelAndView object to render the page
      */
     public static ModelAndView listFiltersView(Request req, Response res, User user) {
         Map<String, Object> data = new HashMap<>();

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ControllerApiUtils.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ControllerApiUtils.java
@@ -17,7 +17,9 @@ package com.suse.manager.webui.controllers.contentmanagement.handlers;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.json;
 
 import com.redhat.rhn.domain.contentmgmt.ContentEnvironment;
+import com.redhat.rhn.domain.contentmgmt.ContentFilter;
 import com.redhat.rhn.domain.contentmgmt.ContentProject;
+import com.redhat.rhn.domain.contentmgmt.ContentProjectFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.contentmgmt.ContentManager;
 
@@ -28,31 +30,49 @@ import com.suse.utils.Json;
 import com.google.gson.Gson;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import spark.Response;
 
 /**
  * Utility class to all the api Controllers
  */
-public class ControllerUtils {
+public class ControllerApiUtils {
     private static final Gson GSON = Json.GSON;
 
-    private ControllerUtils() { }
+    private ControllerApiUtils() { }
 
     /**
-     * Map the full project data to json
+     * Map the full project data to json and return as a Controller response
      * @param res the http response
      * @param projectLabel - the label
      * @param user - the user
      * @return return the full project as json
      */
-    public static String fullProjectJson(Response res, String projectLabel, User user) {
+    public static String fullProjectJsonResponse(Response res, String projectLabel, User user) {
         ContentProject dbContentProject = ContentManager.lookupProject(projectLabel, user).get();
 
         List<ContentEnvironment> dbContentEnvironments = ContentManager.listProjectEnvironments(projectLabel, user);
 
         return json(GSON, res, ResultJson.success(
                 ResponseMappers.mapProjectFromDB(dbContentProject, dbContentEnvironments)
+        ));
+    }
+
+    /**
+     * Map the full filters list data to json and return as a Controller response
+     * @param res the http response
+     * @param user - the user
+     * @return return the full project as json
+     */
+    public static String listFiltersJsonResponse(Response res, User user) {
+        Map<ContentFilter, List<ContentProject>> filtersWithProjects = ContentManager.listFilters(user)
+                .stream()
+                .collect(Collectors.toMap(p -> p, p -> ContentProjectFactory.listFilterProjects(p)));
+
+        return json(GSON, res, ResultJson.success(
+                ResponseMappers.mapFilterListingFromDB(filtersWithProjects)
         ));
     }
 

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/EnvironmentApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/EnvironmentApiController.java
@@ -85,7 +85,7 @@ public class EnvironmentApiController {
                 user
         );
 
-        return ControllerUtils.fullProjectJson(res, createEnvironmentRequest.getProjectLabel(), user);
+        return ControllerApiUtils.fullProjectJsonResponse(res, createEnvironmentRequest.getProjectLabel(), user);
     }
 
     /**
@@ -111,7 +111,7 @@ public class EnvironmentApiController {
                 user
         );
 
-        return ControllerUtils.fullProjectJson(res, updateEnvironmentRequest.getProjectLabel(), user);
+        return ControllerApiUtils.fullProjectJsonResponse(res, updateEnvironmentRequest.getProjectLabel(), user);
 
     }
 
@@ -136,7 +136,7 @@ public class EnvironmentApiController {
                 user
         );
 
-        return ControllerUtils.fullProjectJson(res, removeEnvironmentRequest.getProjectLabel(), user);
+        return ControllerApiUtils.fullProjectJsonResponse(res, removeEnvironmentRequest.getProjectLabel(), user);
     }
 
 }

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/FilterApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/FilterApiController.java
@@ -1,0 +1,216 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.webui.controllers.contentmanagement.handlers;
+
+import static com.suse.manager.webui.utils.SparkApplicationHelper.json;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withUser;
+import static spark.Spark.delete;
+import static spark.Spark.get;
+import static spark.Spark.post;
+import static spark.Spark.put;
+
+import com.redhat.rhn.domain.contentmgmt.ContentFilter;
+import com.redhat.rhn.domain.contentmgmt.ContentManagementException;
+import com.redhat.rhn.domain.contentmgmt.ContentProject;
+import com.redhat.rhn.domain.contentmgmt.FilterCriteria;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.manager.contentmgmt.ContentManager;
+
+import com.suse.manager.webui.controllers.contentmanagement.request.FilterRequest;
+import com.suse.manager.webui.controllers.contentmanagement.request.ProjectFiltersUpdateRequest;
+import com.suse.manager.webui.utils.gson.ResultJson;
+import com.suse.utils.Json;
+
+import com.google.gson.Gson;
+
+import org.apache.http.HttpStatus;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import spark.Request;
+import spark.Response;
+
+/**
+ * Spark controller ContentManagement Filter Api.
+ */
+public class FilterApiController {
+
+    private static final Gson GSON = Json.GSON;
+
+    private FilterApiController() {
+    }
+
+    /** Init routes for ContentManagement Filter Api.*/
+    public static void initRoutes() {
+
+        put("/manager/contentmanagement/api/projects/:projectId/filters",
+                withUser(FilterApiController::updateFiltersOfProject));
+
+        get("/manager/contentmanagement/api/filters",
+                withUser(FilterApiController::getContentFilters));
+
+        post("/manager/contentmanagement/api/filters",
+                withUser(FilterApiController::createContentFilter));
+
+        put("/manager/contentmanagement/api/filters/:filterId",
+                withUser(FilterApiController::updateContentFilter));
+
+        delete("/manager/contentmanagement/api/filters/:filterId",
+                withUser(FilterApiController::removeContentFilter));
+    }
+
+    /**
+     * Return the project JSON with the result of updating the filters of a project.
+     * @param req the http request
+     * @param res the http response
+     * @param user the current user
+     * @return the JSON data
+     */
+    public static String updateFiltersOfProject(Request req, Response res, User user) {
+        ProjectFiltersUpdateRequest projectFiltersUpdateRequest = FilterHandler.getProjectFiltersRequest(req);
+        String projectLabel = projectFiltersUpdateRequest.getProjectLabel();
+        List<Long> filtersIdToUpdate =  projectFiltersUpdateRequest.getFiltersIds();
+
+        ContentProject dbContentProject = ContentManager.lookupProject(
+                projectFiltersUpdateRequest.getProjectLabel(), user
+        ).get();
+
+
+        List<Long> filterIdsToDetach = dbContentProject.getProjectFilters()
+                .stream()
+                .map(filter -> filter.getFilter().getId())
+                .filter(filterId -> !filtersIdToUpdate.contains(filterId))
+                .collect(Collectors.toList());
+        filterIdsToDetach.forEach(filterId -> ContentManager.detachFilter(
+                projectLabel,
+                filterId,
+                user
+        ));
+
+        List<Long> filterIdsToAttach = filtersIdToUpdate
+                .stream()
+                .filter(filterId ->
+                        !dbContentProject.getProjectFilters()
+                                .stream()
+                                .filter(filter -> filter.getId() == filterId)
+                                .findFirst()
+                                .isPresent()
+                )
+                .collect(Collectors.toList());
+        filterIdsToAttach
+                .forEach(filterId ->
+                        ContentManager.attachFilter(
+                                projectLabel,
+                                filterId,
+                                user
+                        ));
+
+        return ControllerApiUtils.fullProjectJsonResponse(res, projectLabel, user);
+    }
+
+    /**
+     * Return the JSON with all the available filters.
+     * @param req the http request
+     * @param res the http response
+     * @param user the current user
+     * @return the JSON data
+     */
+    public static String getContentFilters(Request req, Response res, User user) {
+        return ControllerApiUtils.listFiltersJsonResponse(res, user);
+    }
+
+    /**
+     * Return the JSON with the result of the creation of a filter.
+     * @param req the http request
+     * @param res the http response
+     * @param user the current user
+     * @return the JSON data
+     */
+    public static String createContentFilter(Request req, Response res, User user) {
+        FilterRequest createFilterRequest = FilterHandler.getFilterRequest(req);
+
+        HashMap<String, String> requestErrors = FilterHandler.validateFilterRequest(createFilterRequest);
+        if (!requestErrors.isEmpty()) {
+            return json(GSON, res, HttpStatus.SC_BAD_REQUEST, ResultJson.error(Arrays.asList(""), requestErrors));
+        }
+
+        FilterCriteria filterCriteria = new FilterCriteria(
+                FilterCriteria.Matcher.CONTAINS,
+                "name",
+                createFilterRequest.getCriteria());
+        ContentManager.createFilter(
+                createFilterRequest.getName(),
+                createFilterRequest.getDeny() ? ContentFilter.Rule.DENY : ContentFilter.Rule.ALLOW,
+                ContentFilter.EntityType.lookupByLabel(createFilterRequest.getType()),
+                filterCriteria,
+                user
+        );
+
+        return ControllerApiUtils.listFiltersJsonResponse(res, user);
+    }
+
+    /**
+     * Return the JSON with the result of updating a content project environemnt.
+     * @param req the http request
+     * @param res the http response
+     * @param user the current user
+     * @return the JSON data
+     */
+    public static String updateContentFilter(Request req, Response res, User user) {
+        FilterRequest updateFilterRequest = FilterHandler.getFilterRequest(req);
+
+        HashMap<String, String> requestErrors = FilterHandler.validateFilterRequest(updateFilterRequest);
+        if (!requestErrors.isEmpty()) {
+            return json(GSON, res, HttpStatus.SC_BAD_REQUEST, ResultJson.error(Arrays.asList(""), requestErrors));
+        }
+
+        FilterCriteria filterCriteria = new FilterCriteria(
+                FilterCriteria.Matcher.CONTAINS,
+                "name",
+                updateFilterRequest.getCriteria());
+        ContentManager.updateFilter(
+                Long.parseLong(req.params("filterId")),
+                Optional.ofNullable(updateFilterRequest.getName()),
+                Optional.of(updateFilterRequest.getDeny() ? ContentFilter.Rule.DENY : ContentFilter.Rule.ALLOW),
+                Optional.of(filterCriteria),
+                user
+        );
+
+        return ControllerApiUtils.listFiltersJsonResponse(res, user);
+    }
+
+    /**
+     * Return the JSON with the result of removing a content project environemnt.
+     * @param req the http request
+     * @param res the http response
+     * @param user the current user
+     * @return the JSON data
+     */
+    public static String removeContentFilter(Request req, Response res, User user) {
+        try {
+            ContentManager.removeFilter(Long.parseLong(req.params("filterId")), user);
+        }
+        catch (ContentManagementException error) {
+            return json(GSON, res, HttpStatus.SC_BAD_REQUEST, ResultJson.error(error.getMessage()));
+        }
+
+        return ControllerApiUtils.listFiltersJsonResponse(res, user);
+    }
+
+}

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/FilterHandler.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/FilterHandler.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.webui.controllers.contentmanagement.handlers;
+
+import com.suse.manager.webui.controllers.contentmanagement.request.FilterRequest;
+import com.suse.manager.webui.controllers.contentmanagement.request.ProjectFiltersUpdateRequest;
+import com.suse.utils.Json;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonParseException;
+
+import org.apache.http.HttpStatus;
+
+import java.util.HashMap;
+
+import spark.Request;
+import spark.Spark;
+
+/**
+ * Utility class to help the handling of the FilterApiController
+ */
+public class FilterHandler {
+    private static final Gson GSON = Json.GSON;
+
+    private FilterHandler() { }
+
+
+    /**
+     * map request into the project update filters request bean
+     * @param req the http request
+     * @return environment request bean
+     */
+    public static ProjectFiltersUpdateRequest getProjectFiltersRequest(Request req) {
+        try {
+            return GSON.fromJson(req.body(), ProjectFiltersUpdateRequest.class);
+        }
+        catch (JsonParseException e) {
+            throw Spark.halt(HttpStatus.SC_BAD_REQUEST);
+        }
+    }
+
+    /**
+     * map request into the filter request bean
+     * @param req the http request
+     * @return environment request bean
+     */
+    public static FilterRequest getFilterRequest(Request req) {
+        try {
+            return GSON.fromJson(req.body(), FilterRequest.class);
+        }
+        catch (JsonParseException e) {
+            throw Spark.halt(HttpStatus.SC_BAD_REQUEST);
+        }
+    }
+
+    /**
+     * map validate filter request bean
+     * @param envRequest the environment request bean
+     * @return validation errors
+     */
+    public static HashMap<String, String> validateFilterRequest(FilterRequest envRequest) {
+        HashMap<String, String> requestErrors = new HashMap<>();
+
+        // TODO: validations
+
+        return requestErrors;
+    }
+}

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ProjectActionsApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ProjectActionsApiController.java
@@ -67,7 +67,7 @@ public class ProjectActionsApiController {
      */
     public static String project(Request req, Response res, User user) {
         String projectLabel = req.params("projectId");
-        return ControllerUtils.fullProjectJson(res, projectLabel, user);
+        return ControllerApiUtils.fullProjectJsonResponse(res, projectLabel, user);
     }
 
     /**
@@ -87,7 +87,7 @@ public class ProjectActionsApiController {
         String projectLabel = projectLabelRequest.getProjectLabel();
         ContentManager.buildProject(projectLabel, Optional.ofNullable(projectLabelRequest.getMessage()), true, user);
 
-        return ControllerUtils.fullProjectJson(res, projectLabel, user);
+        return ControllerApiUtils.fullProjectJsonResponse(res, projectLabel, user);
     }
 
     /**
@@ -107,7 +107,7 @@ public class ProjectActionsApiController {
         String projectLabel = projectPromoteReq.getProjectLabel();
         ContentManager.promoteProject(projectLabel, projectPromoteReq.getEnvironmentPromoteLabel(), true, user);
 
-        return ControllerUtils.fullProjectJson(res, projectLabel, user);
+        return ControllerApiUtils.fullProjectJsonResponse(res, projectLabel, user);
     }
 
 

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ProjectApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ProjectApiController.java
@@ -104,7 +104,7 @@ public class ProjectApiController {
                 String.format("Project %s created successfully.", projectPropertiesRequest.getLabel())
         );
 
-        return ControllerUtils.fullProjectJson(res, createdProject.getLabel(), user);
+        return ControllerApiUtils.fullProjectJsonResponse(res, createdProject.getLabel(), user);
     }
 
     /**
@@ -161,7 +161,7 @@ public class ProjectApiController {
             return json(GSON, res, HttpStatus.SC_BAD_REQUEST, ResultJson.error(error.getMessage()));
         }
 
-        return ControllerUtils.fullProjectJson(res, updatedProject.getLabel(), user);
+        return ControllerApiUtils.fullProjectJsonResponse(res, updatedProject.getLabel(), user);
     }
 
 }

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ProjectSourcesApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ProjectSourcesApiController.java
@@ -91,7 +91,7 @@ public class ProjectSourcesApiController {
                 user
         ));
 
-        return ControllerUtils.fullProjectJson(res, projectLabel, user);
+        return ControllerApiUtils.fullProjectJsonResponse(res, projectLabel, user);
     }
 
 }

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/request/FilterRequest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/request/FilterRequest.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.webui.controllers.contentmanagement.request;
+
+/**
+ * JSON request wrapper for an environment of a content project.
+ */
+public class FilterRequest {
+
+    private String name;
+    private String type;
+    private String criteria;
+    private Boolean deny;
+
+    public String getCriteria() {
+        return criteria;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Boolean getDeny() {
+        return deny;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+}

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/request/ProjectFiltersUpdateRequest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/request/ProjectFiltersUpdateRequest.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.webui.controllers.contentmanagement.request;
+
+import java.util.List;
+
+/**
+ * JSON request wrapper to update the filters of a content project.
+ */
+public class ProjectFiltersUpdateRequest {
+
+    private String projectLabel;
+    private List<Long> filtersIds;
+
+    public String getProjectLabel() {
+        return projectLabel;
+    }
+
+    public List<Long> getFiltersIds() {
+        return filtersIds;
+    }
+
+}

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/response/FilterResponse.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/response/FilterResponse.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.webui.controllers.contentmanagement.response;
+
+import java.util.List;
+
+/**
+ * JSON response wrapper for a content filter resume.
+ */
+public class FilterResponse {
+
+    private Long id;
+    private String name;
+    private String type;
+    private String criteria;
+    private Boolean deny;
+    private List<String> projects;
+
+    public void setId(Long idIn) {
+        this.id = idIn;
+    }
+
+    public void setType(String typeIn) {
+        this.type = typeIn;
+    }
+
+    public void setCriteria(String criteriaIn) {
+        this.criteria = criteriaIn;
+    }
+
+    public void setDeny(Boolean denyIn) {
+        this.deny = denyIn;
+    }
+
+    public void setName(String nameIn) {
+        this.name = nameIn;
+    }
+
+    public void setProjects(List<String> projectsIn) {
+        this.projects = projectsIn;
+    }
+}

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/response/ProjectFilterResponse.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/response/ProjectFilterResponse.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.webui.controllers.contentmanagement.response;
+
+/**
+ * JSON response wrapper for a content filter resume.
+ */
+public class ProjectFilterResponse {
+
+    private Long id;
+    private String name;
+    private String type;
+    private String criteria;
+    private Boolean deny;
+    private String state;
+
+    public void setId(Long idIn) {
+        this.id = idIn;
+    }
+
+    public void setType(String typeIn) {
+        this.type = typeIn;
+    }
+
+    public void setCriteria(String criteriaIn) {
+        this.criteria = criteriaIn;
+    }
+
+    public void setDeny(Boolean denyIn) {
+        this.deny = denyIn;
+    }
+
+    public void setName(String nameIn) {
+        this.name = nameIn;
+    }
+
+    public void setState(String stateIn) {
+        this.state = stateIn;
+    }
+}

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/response/ProjectResponse.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/response/ProjectResponse.java
@@ -23,10 +23,15 @@ public class ProjectResponse {
 
     private ProjectPropertiesResponse properties;
     private List<ProjectSoftwareSourceResponse> softwareSources;
+    private List<ProjectFilterResponse> filters;
     private List<EnvironmentResponse> environments;
 
     public void setProperties(ProjectPropertiesResponse propertiesIn) {
         this.properties = propertiesIn;
+    }
+
+    public void setFilters(List<ProjectFilterResponse> filtersIn) {
+        this.filters = filtersIn;
     }
 
     public void setEnvironments(List<EnvironmentResponse> environmentsIn) {

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/templates/list-filters.jade
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/templates/list-filters.jade
@@ -1,0 +1,21 @@
+include /templates/common.jade
+
+#content-management-list-filters
+
+script(type='text/javascript').
+    const csrfToken = "#{csrf_token}";
+
+div#init_data_filters(style="display: none")
+    | #{contentFilters}
+
+script(src='/javascript/manager/content-management/list-filters/list-filters.renderer.bundle.js')
+
+script(type='text/javascript').
+    pageRenderers.contentManagement.listFilters.renderer(
+        'content-management-list-filters',
+        {
+          filters: document.getElementById('init_data_filters').textContent,
+          openFilterId: #{openFilterId ? openFilterId : "null" },
+          flashMessage: "#{flashMessage}"
+        }
+    );

--- a/java/code/src/com/suse/manager/webui/menu/MenuTree.java
+++ b/java/code/src/com/suse/manager/webui/menu/MenuTree.java
@@ -235,7 +235,10 @@ public class MenuTree {
                     .withDir("/rhn/manager/contentmanagement")
                 .addChild(new MenuItem("contentmanagement.nav.projects")
                         .withPrimaryUrl("/rhn/manager/contentmanagement/projects")
-                        .withDir("/rhn/manager/contentmanagement/project")));
+                        .withDir("/rhn/manager/contentmanagement/project"))
+                .addChild(new MenuItem("contentmanagement.nav.filters")
+                        .withPrimaryUrl("/rhn/manager/contentmanagement/filters")
+                        .withDir("/rhn/manager/contentmanagement/filter")));
 
             // Audit
             nodes.add(new MenuItem("Audit").withIcon("fa-search").withDir("/rhn/audit")

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Implement packages filtering on Content Project build
 - Implement Content Filters operations and expose them in XMLRPC
 - Disable ActionChainCleanup if database is Postgres
 - Track and expose build status of Content Environment

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Implement Content Filters operations and expose them in XMLRPC
 - Disable ActionChainCleanup if database is Postgres
 - Track and expose build status of Content Environment
 - Enable SLES11 OS Image Build Host

--- a/schema/spacewalk/common/tables/suseContentFilter.sql
+++ b/schema/spacewalk/common/tables/suseContentFilter.sql
@@ -22,7 +22,9 @@ CREATE TABLE suseContentFilter(
                      ON DELETE CASCADE,
     type     VARCHAR2(16) NOT NULL,
     name     VARCHAR2(128) NOT NULL,
-    criteria CLOB,
+    matcher  VARCHAR2(32) NOT NULL,
+    field    VARCHAR2(32) NOT NULL,
+    value    VARCHAR2(128) NOT NULL,
     created  TIMESTAMP WITH LOCAL TIME ZONE
                  DEFAULT (current_timestamp) NOT NULL,
     modified TIMESTAMP WITH LOCAL TIME ZONE

--- a/schema/spacewalk/common/tables/suseContentFilter.sql
+++ b/schema/spacewalk/common/tables/suseContentFilter.sql
@@ -21,6 +21,7 @@ CREATE TABLE suseContentFilter(
                      REFERENCES web_customer(id)
                      ON DELETE CASCADE,
     type     VARCHAR2(16) NOT NULL,
+    rule     VARCHAR2(16) NOT NULL,
     name     VARCHAR2(128) NOT NULL,
     matcher  VARCHAR2(32) NOT NULL,
     field    VARCHAR2(32) NOT NULL,

--- a/schema/spacewalk/common/tables/suseContentFilterProject.sql
+++ b/schema/spacewalk/common/tables/suseContentFilterProject.sql
@@ -24,8 +24,7 @@ CREATE TABLE suseContentFilterProject(
                    CONSTRAINT suse_ct_filter_pid_fk
                        REFERENCES suseContentProject(id)
                        ON DELETE CASCADE,
-    state      VARCHAR2(16),
-    position   NUMBER
+    state      VARCHAR2(16)
 )
 ENABLE ROW MOVEMENT
 ;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.10-to-susemanager-schema-4.0.11/030-content-filter-criteria.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.10-to-susemanager-schema-4.0.11/030-content-filter-criteria.sql.oracle
@@ -1,0 +1,2 @@
+-- intentionally left empty
+

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.10-to-susemanager-schema-4.0.11/030-content-filter-criteria.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.10-to-susemanager-schema-4.0.11/030-content-filter-criteria.sql.postgresql
@@ -1,0 +1,7 @@
+-- oracle equivalent source sha1 98c02e574d4346f7eecade4697a2b26a13abaa28
+
+ALTER TABLE suseContentFilter ADD COLUMN IF NOT EXISTS matcher VARCHAR(32);
+ALTER TABLE suseContentFilter ADD COLUMN IF NOT EXISTS field VARCHAR(32);
+ALTER TABLE suseContentFilter ADD COLUMN IF NOT EXISTS value VARCHAR(128);
+ALTER TABLE suseContentFilter DROP COLUMN IF EXISTS criteria;
+

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.10-to-susemanager-schema-4.0.11/040-content-filter-rule.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.10-to-susemanager-schema-4.0.11/040-content-filter-rule.sql.oracle
@@ -1,0 +1,2 @@
+-- intentionally left empty
+

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.10-to-susemanager-schema-4.0.11/040-content-filter-rule.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.10-to-susemanager-schema-4.0.11/040-content-filter-rule.sql.postgresql
@@ -1,0 +1,4 @@
+-- oracle equivalent source sha1 98c02e574d4346f7eecade4697a2b26a13abaa28
+
+ALTER TABLE suseContentFilter ADD COLUMN IF NOT EXISTS rule VARCHAR(16);
+

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.10-to-susemanager-schema-4.0.11/050-drop-susecontentfilterproject-position.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.10-to-susemanager-schema-4.0.11/050-drop-susecontentfilterproject-position.sql.oracle
@@ -1,0 +1,2 @@
+-- intentionally left empty
+

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.10-to-susemanager-schema-4.0.11/050-drop-susecontentfilterproject-position.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.10-to-susemanager-schema-4.0.11/050-drop-susecontentfilterproject-position.sql.postgresql
@@ -1,0 +1,4 @@
+-- oracle equivalent source sha1 98c02e574d4346f7eecade4697a2b26a13abaa28
+
+ALTER TABLE suseContentFilterProject DROP COLUMN IF EXISTS position;
+

--- a/web/html/src/components/toastr/toastr.css
+++ b/web/html/src/components/toastr/toastr.css
@@ -14,7 +14,7 @@
     background-color: #dff0d8 !important;
     border-color: #d6e9c6 !important;
     color: #3c763d !important;
-    opacity: 0.95 !important;
+    opacity: 1 !important;
     position: relative !important;
     background-image: none !important;
 }

--- a/web/html/src/manager/content-management/create-project/create-project.js
+++ b/web/html/src/manager/content-management/create-project/create-project.js
@@ -1,6 +1,5 @@
 // @flow
 import React, {useState} from 'react';
-import useProjectActionsApi from "../shared/api/use-project-actions-api";
 import {TopPanel} from "components/panels/TopPanel";
 import TopPanelButtons from "./top-panel-buttons";
 import PropertiesCreate from "../shared/components/panels/properties/properties-create";
@@ -9,6 +8,7 @@ import withPageWrapper from 'components/general/with-page-wrapper';
 import {hot} from 'react-hot-loader';
 import useRoles from "core/auth/use-roles";
 import {isOrgAdmin} from "core/auth/auth.utils";
+import useLifecycleActionsApi from "../shared/api/use-lifecycle-actions-api";
 
 const CreateProject = () => {
 
@@ -20,8 +20,7 @@ const CreateProject = () => {
         historyEntries: [],
       }
   });
-
-  const { onAction } = useProjectActionsApi({});
+  const { onAction } = useLifecycleActionsApi({resource: 'projects'});
   const roles = useRoles();
   const hasEditingPermissions = isOrgAdmin(roles);
 

--- a/web/html/src/manager/content-management/index.js
+++ b/web/html/src/manager/content-management/index.js
@@ -3,5 +3,6 @@ module.exports = {
     'create-project/create-project.renderer.js',
     'list-projects/list-projects.renderer.js',
     'project/project.renderer.js',
+    'list-filters/list-filters.renderer.js',
   ],
 };

--- a/web/html/src/manager/content-management/list-filters/filter-edit.js
+++ b/web/html/src/manager/content-management/list-filters/filter-edit.js
@@ -1,0 +1,162 @@
+// @flow
+import React, {useState, useEffect} from 'react';
+import {ModalLink} from "../../../components/dialog/ModalLink";
+import {closeDialog, Dialog} from "../../../components/dialog/Dialog";
+import {Button} from "../../../components/buttons";
+import useLifecycleActionsApi from "../shared/api/use-lifecycle-actions-api";
+import {Loading} from "components/loading/loading";
+import {showErrorToastr, showSuccessToastr} from "components/toastr/toastr";
+
+import type {FilterType} from '../shared/type/filter.type.js';
+import FilterForm from "./filter-form";
+import {showDialog} from "components/dialog/util";
+
+const FilterEditModalContent = ({open, isLoading, filter, onChange, editing}) => {
+  if (!open) {
+    return null;
+  }
+
+  if (isLoading) {
+    return (
+      <Loading text={t('Updating the filter...')}/>
+    )
+  }
+
+  return (
+    <FilterForm
+      filter={filter}
+      editing={editing}
+      onChange={(updatedFilter) => onChange(updatedFilter)}/>
+  )
+}
+
+type FilterEditProps = {
+  id: string,
+  filter: FilterType,
+  icon: string,
+  buttonText: string,
+  onChange: Function,
+  openFilterId: number,
+  editing?: boolean,
+};
+
+const FilterEdit = (props: FilterEditProps) => {
+
+  const [open, setOpen] = useState(false);
+  const [item, setItem] = useState(props.filter);
+
+  const modalNameId = `${props.id}-modal`;
+
+  useEffect(() => {
+    if(props.filter.id === props.openFilterId) {
+      showDialog(modalNameId);
+      setOpen(true);
+      setItem(props.filter);
+    }
+  }, []);
+
+  const {onAction, cancelAction, isLoading} = useLifecycleActionsApi({resource: 'filters'});
+
+  const modalTitle = props.editing
+    ? t('Update filter')
+    : t('Create a new filter')
+
+  return (
+    <React.Fragment>
+      <ModalLink
+        id={`${props.id}-modal-link`}
+        icon={props.icon}
+        className="btn-link"
+        text={props.buttonText}
+        target={modalNameId}
+        onClick={() => {
+          setOpen(true);
+          setItem(props.filter);
+        }}
+      />
+
+      <Dialog id={modalNameId}
+              title={modalTitle}
+              closableModal={false}
+              className="modal-lg"
+              content={
+                <FilterEditModalContent
+                  filter={item}
+                  open={open}
+                  onChange={setItem}
+                  isLoading={isLoading}
+                  editing={props.editing}
+                />}
+              onClosePopUp={() => setOpen(false)}
+              buttons={
+                <React.Fragment>
+                  <div className="btn-group col-lg-6">
+                    {
+                      props.editing && <Button
+                        id={`${props.id}-modal-delete-button`}
+                        className="btn-danger"
+                        text={t('Delete')}
+                        disabled={isLoading}
+                        handler={() => {
+                          onAction(item, "delete", item.id)
+                            .then((updatedListOfFilters) => {
+                              closeDialog(modalNameId);
+                              showSuccessToastr(t("Filter deleted successfully"));
+                              props.onChange(updatedListOfFilters);
+                            })
+                            .catch((error) => {
+                              showErrorToastr(error);
+                            })
+                        }}
+                      />
+                    }
+                  </div>
+                  <div className="col-lg-6">
+                    <div className="pull-right btn-group">
+                      <Button
+                        id={`${props.id}-modal-cancel-button`}
+                        className="btn-default"
+                        text={t('Cancel')}
+                        handler={() => {
+                          cancelAction();
+                          closeDialog(modalNameId);
+                        }}
+                      />
+                      <Button
+                        id={`${props.id}-modal-save-button`}
+                        className="btn-primary"
+                        text={t('Save')}
+                        disabled={isLoading}
+                        handler={() => {
+                          if(props.editing) {
+                            onAction(item, "update", item.id)
+                              .then((updatedListOfFilters) => {
+                                closeDialog(modalNameId);
+                                showSuccessToastr(t("Filter updated successfully"));
+                                props.onChange(updatedListOfFilters);
+                              })
+                              .catch((error) => {
+                                showErrorToastr(error);
+                              })
+                          } else {
+                            onAction(item, "create")
+                              .then((updatedListOfFilters) => {
+                                closeDialog(modalNameId);
+                                showSuccessToastr(t("Filter created successfully"));
+                                props.onChange(updatedListOfFilters);
+                              })
+                              .catch((error) => {
+                                showErrorToastr(error);
+                              })
+                          }
+                        }}
+                      />
+                    </div>
+                  </div>
+                </React.Fragment>
+              } />
+    </React.Fragment>
+  );
+};
+
+export default FilterEdit;

--- a/web/html/src/manager/content-management/list-filters/filter-edit.js
+++ b/web/html/src/manager/content-management/list-filters/filter-edit.js
@@ -48,7 +48,7 @@ const FilterEdit = (props: FilterEditProps) => {
   const modalNameId = `${props.id}-modal`;
 
   useEffect(() => {
-    if(props.filter.id === props.openFilterId) {
+    if(props.filter.id === props.openFilterId || (props.openFilterId === -1 && !props.editing)) {
       showDialog(modalNameId);
       setOpen(true);
       setItem(props.filter);

--- a/web/html/src/manager/content-management/list-filters/filter-form.js
+++ b/web/html/src/manager/content-management/list-filters/filter-form.js
@@ -1,0 +1,59 @@
+//@flow
+import React from 'react';
+import {Text} from "components/input/Text";
+import {Select} from "components/input/Select";
+import {Form} from "components/input/Form";
+import {Check} from "components/input/Check";
+
+import type {FilterType} from '../shared/type/filter.type.js';
+
+type Props = {
+  filter: FilterType,
+  onChange: Function,
+  editing?: boolean
+}
+
+const FilterForm = (props: Props) =>
+  <Form
+    model={{...props.filter}}
+    onChange={model => {
+      props.onChange(model);
+    }}
+  >
+    <React.Fragment>
+      <div className="row">
+        <Text
+          name="name"
+          label={t("Name")}
+          labelClass="col-md-3"
+          divClass="col-md-8"
+          disabled={props.editing}
+        />
+      </div>
+      <div className="row">
+        <Select
+          name="type"
+          label={t("Filter Type")}
+          labelClass="col-md-3"
+          divClass="col-md-8">
+          <option key={'package'} value={'package'} selected>{t('package')}</option>
+          <option key={'patch'} value={'patch'} disabled>{t('patch (To be implemented for RC)')}</option>
+        </Select>
+      </div>
+      <div className="row">
+        <Text
+          name="criteria"
+          label={t("Name criteria")}
+          labelClass="col-md-3"
+          divClass="col-md-8"/>
+      </div>
+        <Check
+          name="deny"
+          disabled
+          label={t("deny")}
+          divClass="col-md-8 col-md-offset-3"/>
+    </React.Fragment>
+  </Form>
+
+
+export default FilterForm;

--- a/web/html/src/manager/content-management/list-filters/list-filters.css
+++ b/web/html/src/manager/content-management/list-filters/list-filters.css
@@ -1,0 +1,11 @@
+/*Grouped Pannels*/
+
+:global(.project-tag-link) {
+    display: inline-block;
+    padding: 2px 4px;
+    border: 1px solid #ccc;
+    margin: 0 3px;
+    border-radius: 1px;
+    background-color: #eee;
+    color: inherit;
+}

--- a/web/html/src/manager/content-management/list-filters/list-filters.js
+++ b/web/html/src/manager/content-management/list-filters/list-filters.js
@@ -1,0 +1,97 @@
+// @flow
+import React, {useEffect, useState} from 'react';
+import {TopPanel} from 'components/panels/TopPanel';
+import {Column, SearchField, Table} from 'components/table';
+import Functions from 'utils/functions';
+import {showSuccessToastr} from 'components/toastr/toastr';
+import withPageWrapper from 'components/general/with-page-wrapper';
+import type {FilterType} from '../shared/type/filter.type.js';
+import {hot} from 'react-hot-loader';
+import FilterEdit from "./filter-edit";
+
+type Props = {
+  filters: Array<FilterType>,
+  openFilterId: number,
+  flashMessage: string,
+};
+
+const ListFilters = (props: Props) => {
+
+  const [displayedFilters, setDisplayedFilters] = useState(props.filters);
+
+  useEffect(()=> {
+    if(props.flashMessage) {
+      showSuccessToastr(props.flashMessage)
+    }
+  }, [])
+
+  const searchData = (row, criteria) => {
+    const keysToSearch = ['name'];
+    if (criteria) {
+      return keysToSearch.map(key => row[key]).join().toLowerCase().includes(criteria.toLowerCase());
+    }
+    return true;
+  };
+
+  const panelButtons = (
+    <div className="pull-right btn-group">
+      <FilterEdit
+        id="create-filter-button"
+        filter={{type: 'package', deny: true}}
+        icon='fa-plus'
+        buttonText='Create Filter'
+        openFilterId={props.openFilterId}
+        onChange={setDisplayedFilters}
+      />
+    </div>
+  );
+
+  return (
+    <TopPanel title={t('Filter')} icon="spacewalk-icon-software-channels" button={panelButtons}>
+      <Table
+        data={displayedFilters}
+        identifier={row => row.name}
+        searchField={(
+          <SearchField
+            filter={searchData}
+            placeholder={t('Filter by any value')}
+          />
+        )}
+      >
+        <Column
+          columnKey="name"
+          comparator={Functions.Utils.sortByText}
+          header={t('Name')}
+          cell={row => row.name}
+        />
+        <Column
+          columnKey="projects"
+          header={t('Projects in use')}
+          cell={row => row.projects.map(p =>
+            <a className="project-tag-link" href={`/rhn/manager/contentmanagement/project/${p}`}>
+              {p}
+            </a>
+          )}
+        />
+        <Column
+          columnKey="action-buttons"
+          header={t('Action buttons')}
+          cell={ row =>
+            <FilterEdit
+              id={`edit-filter-button-${row.id}`}
+              filter={row}
+              icon='fa-edit'
+              buttonText='Edit Filter'
+              onChange={setDisplayedFilters}
+              openFilterId={props.openFilterId}
+              editing
+            />
+          }
+
+        />
+      </Table>
+    </TopPanel>
+  );
+}
+
+export default hot(module)(withPageWrapper<Props>(ListFilters));

--- a/web/html/src/manager/content-management/list-filters/list-filters.js
+++ b/web/html/src/manager/content-management/list-filters/list-filters.js
@@ -47,7 +47,7 @@ const ListFilters = (props: Props) => {
   );
 
   return (
-    <TopPanel title={t('Filter')} icon="spacewalk-icon-software-channels" button={panelButtons}>
+    <TopPanel title={t('Filter')} icon="fa-filter" button={panelButtons}>
       <Table
         data={displayedFilters}
         identifier={row => row.name}

--- a/web/html/src/manager/content-management/list-filters/list-filters.js
+++ b/web/html/src/manager/content-management/list-filters/list-filters.js
@@ -75,7 +75,7 @@ const ListFilters = (props: Props) => {
         />
         <Column
           columnKey="action-buttons"
-          header={t('Action buttons')}
+          header={t('')}
           cell={ row =>
             <FilterEdit
               id={`edit-filter-button-${row.id}`}

--- a/web/html/src/manager/content-management/list-filters/list-filters.renderer.js
+++ b/web/html/src/manager/content-management/list-filters/list-filters.renderer.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import ListFilters from './list-filters';
+import "./list-filters.css";
+
+window.pageRenderers = window.pageRenderers || {};
+window.pageRenderers.contentManagement = window.pageRenderers.contentManagement || {};
+window.pageRenderers.contentManagement.listFilters = window.pageRenderers.contentManagement.listFilters || {};
+window.pageRenderers.contentManagement.listFilters.renderer = (id, {filters, openFilterId, flashMessage}) => {
+
+  console.log(openFilterId);
+
+  let filtersJson = [];
+  try{
+    filtersJson = JSON.parse(filters);
+  }  catch(error) {}
+
+  ReactDOM.render(
+      <ListFilters
+        filters={filtersJson}
+        openFilterId={openFilterId}
+        flashMessage={flashMessage}
+      />,
+      document.getElementById(id),
+    );
+};

--- a/web/html/src/manager/content-management/shared/api/use-lifecycle-actions-api.js
+++ b/web/html/src/manager/content-management/shared/api/use-lifecycle-actions-api.js
@@ -4,13 +4,13 @@ import {useState} from 'react';
 import Network from '../../../../utils/network';
 
 type Props = {
-  projectId?: string,
-  projectResource?: string,
+  resource: string,
+  nestedResource?: string,
 };
 
 type returnUseProjectActionsApi = {
-  onAction: Function,
-  cancelAction: Function,
+  onAction: (Object, string, ?string) => Promise<Object>,
+  cancelAction: () => void,
   isLoading: boolean,
 }
 
@@ -22,14 +22,14 @@ const networkAction = {
   "delete": Network.del,
 }
 
-const getApiUrl = (projectId, projectResource) => {
-  if (!projectId) {
-    return "/rhn/manager/contentmanagement/api/projects";
+const getApiUrl = (resource, nestedResource, id) => {
+  if (!id) {
+    return `/rhn/manager/contentmanagement/api/${resource}`;
   } else {
-    if(!projectResource) {
-      return `/rhn/manager/contentmanagement/api/projects/${projectId}`;
+    if(!nestedResource) {
+      return `/rhn/manager/contentmanagement/api/${resource}/${id}`;
     } else {
-      return `/rhn/manager/contentmanagement/api/projects/${projectId}/${projectResource}`;
+      return `/rhn/manager/contentmanagement/api/${resource}/${id}/${nestedResource}`;
     }
   }
 }
@@ -37,15 +37,15 @@ const getApiUrl = (projectId, projectResource) => {
 const getErrorMessage = ({messages = [], errors}) => messages.filter(Boolean).concat(Object.values(errors)).join("</br>");
 
 
-const useProjectActionsApi = (props:Props): returnUseProjectActionsApi => {
+const useLifecycleActionsApi = (props:Props): returnUseProjectActionsApi => {
   const [isLoading, setIsLoading] = useState(false);
   const [onGoingNetworkRequest, setOnGoingNetworkRequest] = useState(null);
 
-  const onAction = (actionBodyRequest: Object, action: string) => {
+  const onAction = (actionBodyRequest, action, id) => {
     if(!isLoading) {
       setIsLoading(true);
 
-      const apiUrl = getApiUrl(props.projectId, props.projectResource);
+      const apiUrl = getApiUrl(props.resource, props.nestedResource, id);
       const networkMethod = networkAction[action] || networkAction["get"];
       const networkRequest = networkMethod(apiUrl, JSON.stringify(actionBodyRequest), 'application/json');
       setOnGoingNetworkRequest(networkRequest);
@@ -73,10 +73,10 @@ const useProjectActionsApi = (props:Props): returnUseProjectActionsApi => {
 
           setIsLoading(false);
 
-
-
           throw errMessages;
         });
+    } else {
+      return new Promise(() => {});
     }
   }
 
@@ -91,4 +91,4 @@ const useProjectActionsApi = (props:Props): returnUseProjectActionsApi => {
   };
 }
 
-export default useProjectActionsApi
+export default useLifecycleActionsApi

--- a/web/html/src/manager/content-management/shared/components/panels/build/build.js
+++ b/web/html/src/manager/content-management/shared/components/panels/build/build.js
@@ -9,21 +9,16 @@ import {Form} from "../../../../../../components/input/Form";
 import {Text} from "../../../../../../components/input/Text";
 import {Loading} from "../../../../../../components/loading/loading";
 import DownArrow from '../../down-arrow/down-arrow';
-import useProjectActionsApi from "../../../api/use-project-actions-api";
 
 import type {ProjectHistoryEntry} from '../../../type/project.type.js';
 import {showErrorToastr, showSuccessToastr} from "../../../../../../components/toastr/toastr";
+import useLifecycleActionsApi from "../../../api/use-lifecycle-actions-api";
 
 type Props = {
   projectId: string,
   onBuild: Function,
   currentHistoryEntry?: ProjectHistoryEntry,
-  changesToBuild: Array<{
-    channelId: number,
-    type: string,
-    name: string,
-    state: string,
-  }>,
+  changesToBuild: Array<string>,
   disabled?: boolean,
 }
 
@@ -31,8 +26,8 @@ const Build = ({projectId, onBuild, currentHistoryEntry = {}, changesToBuild, di
 
   const [open, setOpen] = useState(false);
   const [buildVersionForm, setBuildVersionForm] = useState({})
-  const {onAction, cancelAction, isLoading} = useProjectActionsApi({
-    projectId: projectId, projectResource: "build"
+  const {onAction, cancelAction, isLoading} = useLifecycleActionsApi({
+    resource: 'projects', nestedResource: 'build'
   });
 
   const modalNameId = "cm-create-build-modal";
@@ -98,11 +93,10 @@ const Build = ({projectId, onBuild, currentHistoryEntry = {}, changesToBuild, di
                       <dd className="col-md-9">
                         <ul className="list-unstyled">
                           {
-                            changesToBuild.map((change) => {
-                              const versionMessage = `${change.type} ${change.name} ${change.state}`
+                            changesToBuild.map((change, index) => {
                               return (
-                                <li key={change.channelId}>
-                                  {versionMessage}
+                                <li key={index}>
+                                  {change}
                                 </li>
                               )
                             })
@@ -130,7 +124,7 @@ const Build = ({projectId, onBuild, currentHistoryEntry = {}, changesToBuild, di
                           onAction({
                             projectLabel: projectId,
                             message: buildVersionForm.message,
-                          }, "action")
+                          }, "action", projectId)
                             .then((projectWithUpdatedSources) => {
                               closeDialog(modalNameId);
                               showSuccessToastr(`Version ${buildVersionForm.version} successfully built into ${projectWithUpdatedSources.environments[0].name}`)

--- a/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-lifecycle.js
+++ b/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-lifecycle.js
@@ -4,7 +4,6 @@ import CreatorPanel from "../../../../../../components/panels/CreatorPanel";
 import EnvironmentView from "./environment-view";
 import EnvironmentForm from "./environment-form";
 import {Loading} from "components/loading/loading";
-import useProjectActionsApi from "../../../api/use-project-actions-api";
 import Promote from "../promote/promote";
 import {showErrorToastr, showSuccessToastr} from "components/toastr/toastr";
 import {mapAddEnvironmentRequest, mapUpdateEnvironmentRequest} from './environment.utils';
@@ -13,6 +12,7 @@ import type {ProjectEnvironmentType} from '../../../type/project.type.js';
 import type {ProjectHistoryEntry} from "../../../type/project.type";
 import useRoles from "core/auth/use-roles";
 import {isOrgAdmin} from "core/auth/auth.utils";
+import useLifecycleActionsApi from "../../../api/use-lifecycle-actions-api";
 
 type Props = {
   projectId: string,
@@ -23,8 +23,8 @@ type Props = {
 
 const EnvironmentLifecycle = (props: Props) => {
 
-  const {onAction, cancelAction, isLoading} = useProjectActionsApi({
-    projectId: props.projectId, projectResource:"environments"
+  const {onAction, cancelAction, isLoading} = useLifecycleActionsApi({
+    resource: 'projects', nestedResource:"environments"
   });
   const roles = useRoles();
   const hasEditingPermissions = isOrgAdmin(roles);
@@ -40,7 +40,7 @@ const EnvironmentLifecycle = (props: Props) => {
       customIconClass="fa-small"
       disableOperations={isLoading}
       onSave={({ item, closeDialog }) =>
-        onAction(mapAddEnvironmentRequest(item, props.environments, props.projectId), "create")
+        onAction(mapAddEnvironmentRequest(item, props.environments, props.projectId), "create", props.projectId)
           .then((projectWithCreatedEnvironment) => {
             closeDialog();
             showSuccessToastr(t("Environment created successfully"));
@@ -89,7 +89,7 @@ const EnvironmentLifecycle = (props: Props) => {
                       disableEditing={!hasEditingPermissions}
                       disableOperations={isLoading}
                       onSave={({ item, closeDialog }) =>
-                        onAction(mapUpdateEnvironmentRequest(item, props.projectId), "update")
+                        onAction(mapUpdateEnvironmentRequest(item, props.projectId), "update", props.projectId)
                           .then((projectWithUpdatedEnvironment) => {
                             props.onChange(projectWithUpdatedEnvironment)
                             closeDialog();
@@ -101,7 +101,7 @@ const EnvironmentLifecycle = (props: Props) => {
                       onOpen={({ setItem }) => setItem(environment)}
                       onCancel={() => cancelAction()}
                       onDelete={({ item, closeDialog }) => {
-                        return onAction(item, "delete")
+                        return onAction(item, "delete", props.projectId)
                           .then((projectWithDeleteddEnvironment) => {
                             closeDialog()
                               .then(() => {

--- a/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project-selection.js
+++ b/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project-selection.js
@@ -43,40 +43,35 @@ const FiltersProjectSelection = (props:  FiltersProps): Node => {
     )
   }
 
-  if (allFilters && allFilters.length > 0) {
-    return allFilters.map(filter =>
-      <div key={filter.id} className='checkbox'>
-        <input type='checkbox'
-               value={filter.id}
-               id={'child_' + filter.id}
-               name='filterSelection'
-               checked={onGoingSelectedFilters.includes(filter.id)}
-               onChange={(event) => setOnGoingSelectedFilters(
-                 _xor(onGoingSelectedFilters, [parseInt(event.target.value, 10)])
-               )}
-        />
-        <label
-          htmlFor={"child_" + filter.id}>
-          {`${filter.name}: deny ${filter.type} containing ${filter.criteria} in the name`}
-        </label>
-      </div>
-    );
-  }
-
   return (
-    <div>
-      <h4>
-        No filters defined
-        <LinkButton
-          id={`filters-page-link`}
-          icon='fa-edit'
-          text={t("Filters")}
-          href="/rhn/manager/contentmanagement/filters"
-        />
-      </h4>
-    </div>
-  )
-
+    <React.Fragment>
+    {
+      allFilters && allFilters.length > 0 && allFilters.map(filter =>
+          <div key={filter.id} className='checkbox'>
+            <input type='checkbox'
+                  value={filter.id}
+                  id={'child_' + filter.id}
+                  name='filterSelection'
+                  checked={onGoingSelectedFilters.includes(filter.id)}
+                  onChange={(event) => setOnGoingSelectedFilters(
+                    _xor(onGoingSelectedFilters, [parseInt(event.target.value, 10)])
+                  )}
+            />
+            <label
+              htmlFor={"child_" + filter.id}>
+              {`${filter.name}: deny ${filter.type} containing ${filter.criteria} in the name`}
+            </label>
+          </div>
+      )
+    }
+    <LinkButton
+        id={`create-new-filter-link`}
+        icon='fa-plus'
+        text={t("Create new Filter")}
+        href="/rhn/manager/contentmanagement/filters?openFilterId=-1"
+    />
+    </React.Fragment>
+  );
 };
 
 export default FiltersProjectSelection;

--- a/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project-selection.js
+++ b/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project-selection.js
@@ -1,0 +1,82 @@
+// @flow
+import React, {useEffect, useState} from 'react';
+import {LinkButton} from "components/buttons";
+import useLifecycleActionsApi from "../../../api/use-lifecycle-actions-api";
+import type {FilterType} from "../../../type/filter.type";
+import {Loading} from "components/loading/loading";
+import _xor from "lodash/xor";
+import type {Node} from 'react';
+
+type FiltersProps = {
+  projectId: string,
+  initialSelectedFiltersIds: Array<number>,
+  onChange: Function,
+  isUpdatingFilter: boolean,
+};
+
+const FiltersProjectSelection = (props:  FiltersProps): Node => {
+
+  const {onAction: onActionAllFilters, isLoading: isLoadingAllFilters} = useLifecycleActionsApi({
+    resource: 'filters'
+  });
+  const [allFilters, setAllFilters]: [Array<FilterType>, Function] = useState([]);
+  const [onGoingSelectedFilters, setOnGoingSelectedFilters] = useState(props.initialSelectedFiltersIds);
+
+  useEffect(() => {
+    onActionAllFilters({}, 'get')
+      .then(apiAllFilters => setAllFilters(apiAllFilters))
+  }, [])
+
+  useEffect(() => {
+    props.onChange(onGoingSelectedFilters);
+  }, [onGoingSelectedFilters])
+
+  if (isLoadingAllFilters) {
+    return (
+      <Loading text={t('Loading global filters...')}/>
+    )
+  }
+
+  if(props.isUpdatingFilter) {
+    return (
+      <Loading text={t('Updating project filters...')}/>
+    )
+  }
+
+  if (allFilters && allFilters.length > 0) {
+    return allFilters.map(filter =>
+      <div key={filter.id} className='checkbox'>
+        <input type='checkbox'
+               value={filter.id}
+               id={'child_' + filter.id}
+               name='filterSelection'
+               checked={onGoingSelectedFilters.includes(filter.id)}
+               onChange={(event) => setOnGoingSelectedFilters(
+                 _xor(onGoingSelectedFilters, [parseInt(event.target.value, 10)])
+               )}
+        />
+        <label
+          htmlFor={"child_" + filter.id}>
+          {`${filter.name}: deny ${filter.type} containing ${filter.criteria} in the name`}
+        </label>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h4>
+        No filters defined
+        <LinkButton
+          id={`filters-page-link`}
+          icon='fa-edit'
+          text={t("Filters")}
+          href="/rhn/manager/contentmanagement/filters"
+        />
+      </h4>
+    </div>
+  )
+
+};
+
+export default FiltersProjectSelection;

--- a/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project.css
+++ b/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project.css
@@ -1,0 +1,14 @@
+.wrapper {
+  position: relative
+}
+
+.icon_wrapper_vertical_center {
+  position: absolute;
+  right: 20px;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.dettached {
+  text-decoration: line-through;
+}

--- a/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project.js
+++ b/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project.js
@@ -18,16 +18,16 @@ type FiltersProps = {
 const renderFilterEntry = (filter) => {
   const descr = `${filter.name}: deny ${filter.type} containing ${filter.criteria} in the name`;
   const filterButton =
-    <div className={styles.icon_wrapper_vertical_center}>
-      <LinkButton
-        id={`edit-filter-${filter.id}`}
-        icon='fa-edit'
-        title={t(`Edit Filter ${filter.name}`)}
-        className='pull-right'
-        text={t("Edit")}
-        href={`/rhn/manager/contentmanagement/filters?openFilterId=${filter.id}`}
-      />
-    </div>;
+      <div className={styles.icon_wrapper_vertical_center}>
+        <LinkButton
+          id={`edit-filter-${filter.id}`}
+          icon='fa-edit'
+          title={t(`Edit Filter ${filter.name}`)}
+          className='pull-right'
+          text={t("Edit")}
+          href={`/rhn/manager/contentmanagement/filters?openFilterId=${filter.id}`}
+        />
+      </div>;
 
   if (filter.state === 'ATTACHED') {
     return (

--- a/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project.js
+++ b/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project.js
@@ -1,0 +1,128 @@
+// @flow
+import React from 'react';
+import {LinkButton} from "components/buttons";
+
+import styles from "./filters-project.css"
+import {showErrorToastr, showSuccessToastr} from "components/toastr/toastr";
+import useLifecycleActionsApi from "../../../api/use-lifecycle-actions-api";
+import CreatorPanel from "components/panels/CreatorPanel";
+import type {FilterType} from "../../../type/filter.type";
+import FiltersProjectSelection from "./filters-project-selection";
+
+type FiltersProps = {
+  projectId: string,
+  selectedFilters: Array<FilterType>,
+  onChange: Function,
+};
+
+const renderFilterEntry = (filter) => {
+  const descr = `${filter.name}: deny ${filter.type} containing ${filter.criteria} in the name`;
+  const filterButton =
+    <div className={styles.icon_wrapper_vertical_center}>
+      <LinkButton
+        id={`edit-filter-${filter.id}`}
+        icon='fa-edit'
+        title={t(`Edit Filter ${filter.name}`)}
+        className='pull-right'
+        text={t("Edit")}
+        href={`/rhn/manager/contentmanagement/filters?openFilterId=${filter.id}`}
+      />
+    </div>;
+
+  if (filter.state === 'ATTACHED') {
+    return (
+      <li
+        key={`filter_list_item_${filter.id}`}
+        className={`list-group-item text-success ${styles.wrapper}`}>
+        <i className='fa fa-plus'/>
+        <b>{descr}</b>
+        {filterButton}
+      </li>
+    );
+  }
+  if (filter.state === 'DETACHED') {
+    return (
+      <li
+        key={`filter_list_item_${filter.id}`}
+        className={`list-group-item text-danger ${styles.wrapper} ${styles.dettached}`}>
+        <i className='fa fa-minus'/>
+        <b>{descr}</b>
+        {filterButton}
+      </li>
+    );
+  }
+  return (
+    <li
+      key={`filter_list_item_${filter.id}`}
+      className={`list-group-item text-sucess ${styles.wrapper}`}>
+      {descr}
+      {filterButton}
+    </li>
+  );
+}
+
+const FiltersProject = (props:  FiltersProps) => {
+
+  const {onAction, cancelAction, isLoading} = useLifecycleActionsApi({
+    resource: 'projects', nestedResource: "filters"
+  });
+
+  return (
+
+    <CreatorPanel
+      id="filters"
+      title={t('Filters')}
+      creatingText="Attach/Detach Filters"
+      panelLevel="2"
+      collapsible
+      customIconClass="fa-small"
+      onCancel={() => cancelAction()}
+      onOpen={({setItem}) => setItem(props.selectedFilters.map(filter => filter.id))}
+      onSave={({closeDialog, item}) => {
+        const requestParam = {
+          projectLabel: props.projectId,
+          filtersIds: item,
+        };
+
+        onAction(requestParam, "update", props.projectId)
+          .then((projectWithUpdatedSources) => {
+            closeDialog();
+            showSuccessToastr(t("Filters edited successfully"));
+            props.onChange(projectWithUpdatedSources)
+          })
+          .catch((error) => {
+            showErrorToastr(error);
+          });
+      }}
+      renderCreationContent={({setItem}) => {
+        // TODO: [LuNeves] transform this in an enum and reuse in sources.js as well
+        const selectedStates = ["ATTACHED","BUILT"];
+
+        return (
+          <FiltersProjectSelection
+            isUpdatingFilter={isLoading}
+            projectId={props.projectId}
+            initialSelectedFiltersIds={
+              props.selectedFilters
+                .filter(filter => selectedStates.includes(filter.state))
+                .map(filter => filter.id)
+            }
+            onChange={setItem}
+          />
+        )
+      }}
+      renderContent={() =>
+        <div className="min-height-panel">
+          <ul className="list-group">
+            {
+              props.selectedFilters.map(filter => renderFilterEntry(filter))
+            }
+          </ul>
+        </div>
+      }
+    />
+
+  );
+};
+
+export default FiltersProject;

--- a/web/html/src/manager/content-management/shared/components/panels/promote/promote.js
+++ b/web/html/src/manager/content-management/shared/components/panels/promote/promote.js
@@ -6,11 +6,11 @@ import {closeDialog, Dialog} from "components/dialog/Dialog";
 import {Button} from "components/buttons";
 import type {ProjectEnvironmentType, ProjectHistoryEntry} from "../../../type/project.type";
 import {getVersionMessageByNumber} from "../properties/properties.utils";
-import useProjectActionsApi from "../../../api/use-project-actions-api";
 import {showErrorToastr, showSuccessToastr} from "components/toastr/toastr";
 import {Loading} from "components/loading/loading";
 import useRoles from "core/auth/use-roles";
 import {isOrgAdmin} from "core/auth/auth.utils";
+import useLifecycleActionsApi from "../../../api/use-lifecycle-actions-api";
 
 
 type Props = {
@@ -24,8 +24,8 @@ type Props = {
 
 const Promote = (props: Props) => {
   const [open, setOpen] = useState(false);
-  const {onAction, cancelAction, isLoading} = useProjectActionsApi({
-    projectId: props.projectId, projectResource: "promote"
+  const {onAction, cancelAction, isLoading} = useLifecycleActionsApi({
+    resource: 'projects', nestedResource: 'promote'
   });
   const roles = useRoles();
   const hasEditingPermissions = isOrgAdmin(roles);
@@ -102,7 +102,7 @@ const Promote = (props: Props) => {
                   onAction({
                     projectLabel: props.projectId,
                     environmentPromoteLabel: props.environmentPromote.label
-                  }, "action")
+                  }, "action", props.projectId)
                     .then((projectWithUpdatedSources) => {
                       closeDialog(modalNameId);
                       showSuccessToastr(`Version ${props.versionToPromote} successfully promoted into ${props.environmentTarget.name}`)

--- a/web/html/src/manager/content-management/shared/components/panels/properties/properties-edit.js
+++ b/web/html/src/manager/content-management/shared/components/panels/properties/properties-edit.js
@@ -3,7 +3,6 @@ import React from 'react';
 import CreatorPanel from "../../../../../../components/panels/CreatorPanel";
 import PropertiesForm from "./properties-form";
 import {Loading} from "components/loading/loading";
-import useProjectActionsApi from "../../../api/use-project-actions-api";
 import {showErrorToastr, showSuccessToastr} from "components/toastr/toastr";
 import PropertiesView from "./properties-view";
 import produce from "immer";
@@ -11,6 +10,7 @@ import produce from "immer";
 import type {ProjectHistoryEntry, ProjectPropertiesType} from '../../../type/project.type.js';
 import useRoles from "core/auth/use-roles";
 import {isOrgAdmin} from "core/auth/auth.utils";
+import useLifecycleActionsApi from "../../../api/use-lifecycle-actions-api";
 
 type Props = {
   projectId: string,
@@ -21,8 +21,8 @@ type Props = {
 };
 
 const PropertiesEdit = (props: Props) => {
-  const {onAction, cancelAction, isLoading} = useProjectActionsApi({
-    projectId: props.projectId, projectResource: "properties"
+  const {onAction, cancelAction, isLoading} = useLifecycleActionsApi({
+    resource: 'projects', nestedResource: "properties"
   });
   const roles = useRoles();
   const hasEditingPermissions = isOrgAdmin(roles);
@@ -50,7 +50,7 @@ const PropertiesEdit = (props: Props) => {
         onOpen={({ setItem }) => setItem(props.properties)}
         disableOperations={isLoading}
         onSave={({ item, closeDialog }) => {
-          return onAction(item, "update")
+          return onAction(item, "update", props.projectId)
             .then((editedProject) => {
               closeDialog();
               showSuccessToastr(t("Project properties updated successfully"));

--- a/web/html/src/manager/content-management/shared/components/panels/sources/sources.js
+++ b/web/html/src/manager/content-management/shared/components/panels/sources/sources.js
@@ -5,12 +5,12 @@ import CreatorPanel from "../../../../../../components/panels/CreatorPanel";
 import {showErrorToastr, showSuccessToastr} from "components/toastr/toastr";
 
 import type {ProjectSoftwareSourceType} from '../../../type/project.type.js';
-import useProjectActionsApi from "../../../api/use-project-actions-api";
 import ChannelsSelection from "./channels/channels-selection";
 import {Panel} from "../../../../../../components/panels/Panel";
 import styles from "./sources.css";
 import useRoles from "core/auth/use-roles";
 import {isOrgAdmin} from "core/auth/auth.utils";
+import useLifecycleActionsApi from "../../../api/use-lifecycle-actions-api";
 
 type SourcesProps = {
   projectId: string,
@@ -77,8 +77,8 @@ const renderSourceEntry = (source) => {
 
 const Sources = (props: SourcesProps) => {
 
-  const {onAction, cancelAction, isLoading} = useProjectActionsApi({
-    projectId: props.projectId, projectResource: "softwaresources"
+  const {onAction, cancelAction, isLoading} = useLifecycleActionsApi({
+    resource: 'projects', nestedResource: "softwaresources"
   });
   const roles = useRoles();
   const hasEditingPermissions = isOrgAdmin(roles);
@@ -100,7 +100,7 @@ const Sources = (props: SourcesProps) => {
           softwareSources: item.map(label => ({label})),
         };
 
-        onAction(requestParam, "update")
+        onAction(requestParam, "update", props.projectId)
           .then((projectWithUpdatedSources) => {
             closeDialog();
             showSuccessToastr(t("Sources edited successfully"));

--- a/web/html/src/manager/content-management/shared/type/filter.type.js
+++ b/web/html/src/manager/content-management/shared/type/filter.type.js
@@ -1,0 +1,7 @@
+export type FilterType = {
+  name?: string,
+  target?: string,
+  criteria?: string,
+  deny: boolean,
+  projects: Array<String>
+}

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Content Lifecycle Management: first filter functionality - deny by package name
 - Content lifecycle management - Fix text issues
 - Content lifecycle management - show destructive operations only for users with the org admin role
 - Add cache buster for static files (js/css) to fix caching issues after upgrading.


### PR DESCRIPTION
## What does this PR change?

Implement the first version of filters.
- Add simple filter by package name
- Support to attach global filters to a content project

This PR includes: https://github.com/uyuni-project/uyuni/pull/842 and https://github.com/uyuni-project/uyuni/pull/844

## GUI diff

![Screenshot from 2019-04-18 00-30-04](https://user-images.githubusercontent.com/1140720/56327185-3337bb80-6171-11e9-993f-8a33c3522583.png)
![Screenshot from 2019-04-18 00-29-51](https://user-images.githubusercontent.com/1140720/56327186-3337bb80-6171-11e9-87a2-9eda9f5b21b5.png)
![Screenshot from 2019-04-18 00-29-48](https://user-images.githubusercontent.com/1140720/56327187-3337bb80-6171-11e9-9aca-35e5c0fa9f8e.png)


- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
