### PR TITLE
add content lifecycle test suite

### DIFF
--- a/testsuite/features/srv_content_lifecycle.feature
+++ b/testsuite/features/srv_content_lifecycle.feature
@@ -1,0 +1,141 @@
+# Copyright (c) 2019 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: Content lifecycle management
+
+  Scenario: Create a content lifecycle project
+    Given I am authorized as "admin" with password "admin"
+    When I follow "Content Lifecycle Management"
+    And I follow "Projects"
+    Then I should see a "Content Lifecycle Projects" text
+    And I should see a "There are no entries to show." text
+    When I follow "Create Project"
+    Then I should see a "Create a new Content Lifecycle Project" text
+    And I should see a "Project Properties" text
+    When I enter "clp_label" as "label"
+    And I enter "clp_name" as "name"
+    And I enter "clp_desc" as "description"
+    And I click on "Create"
+    Then I should see a "Project clp_label created successfully" text
+    And I should see a "Content Lifecycle Project - clp_name" text
+
+  Scenario: Verify the content lifecycle project page
+    Given I am authorized as "admin" with password "admin"
+    When I follow "Content Lifecycle Management"
+    And  I follow "Projects"
+    Then I should see a "clp_name" text
+    And I should see a "clp_desc" text
+    When I follow "clp_name"
+    Then I should see a "Project Properties" text
+    And I should see a "Versions history" text
+    And I should see a "Sources" text
+    And I should see a "Filters" text
+    And I should see a "Environment Lifecycle" text
+
+  Scenario: Add a source to the project
+    Given I am authorized as "admin" with password "admin"
+    When I follow "Content Lifecycle Management"
+    And I follow "Projects"
+    And I follow "clp_name"
+    And I follow "Edit Sources"
+    And I select "SLES12-SP4-Pool for x86_64" from "selectedBaseChannel"
+    And I click on "Save"
+    Then I should see a "Sources edited successfully" text
+    And I should see a "SLES12-SP4-Pool for x86_64" text
+    And I should see a "SLE-Manager-Tools12-Updates for x86_64 SP4" text
+    And I should see a "SLES12-SP4-Updates for x86_64" text
+    And I should see a "SLE-Manager-Tools12-Pool for x86_64 SP4" text
+    And I should see a "Build (4)" text
+    And I should see a "Version 1: (draft - not built) - Check the colors below for all the changes" text
+
+  Scenario: Add environments to the project
+    Given I am authorized as "admin" with password "admin"
+    When I follow "Content Lifecycle Management"
+    And I follow "Projects"
+    And I follow "clp_name"
+    Then I should see a "No environments created" text
+    When I follow "Add Environment"
+    And I enter "dev_name" as "name"
+    And I enter "dev_desc" as "description"
+    And I click on "Save"
+    Then I should see a "Environment created successfully" text
+    And I should see a "dev_name" text
+    And I should see a "dev_desc" text
+    When I follow "Add Environment"
+    And I enter "prod_name" as "name"
+    And I enter "prod_desc" as "description"
+    And I click on "Save"
+    Then I should see a "Environment created successfully" text
+    And I should see a "prod_name" text
+    And I should see a "prod_desc" text
+    When I follow "Add Environment"
+    And I enter "qa_name" as "name"
+    And I enter "qa_desc" as "description"
+    And I select "prod_name" from "predecessorLabel"
+    And I click on "Save"
+    Then I should see a "Environment created successfully" text
+    And I should see a "qa_name" text
+    And I should see a "qa_desc" text
+
+  Scenario: Build the sources in the project
+    Given I am authorized as "admin" with password "admin"
+    When I follow "Content Lifecycle Management"
+    And I follow "Projects"
+    And I follow "clp_name"
+    Then I should see a "not built" text in the environment "qa_name"
+    When I click on "Build (4)"
+    Then I should see a "Version 1: test version message 1" text in the environment "dev_name"
+    And I should see a "Version 1 history" text
+    #And I should see a "Sources edited successfully" text
+    When I enter "test version message 1" as "message"
+    And I click the environment build button
+    Then I should see a "Version 1 successfully built into dev_name" text
+    And I should see a "Version 1: test version message 1" text
+
+  Scenario: Promote promote the sources in the project
+    Given I am authorized as "admin" with password "admin"
+    When I follow "Content Lifecycle Management"
+    And I follow "Projects"
+    Then I should see a "clp_name" text
+    And I should see a "clp_desc" text
+    And I should see a "dev_name - qa_name - prod_name" text
+    When I follow "clp_name"
+    Then I should see a "qa_desc" text in the environment "qa_name"
+    And I should see a "not built" text in the environment "qa_name"
+    When I click promote for Development to QA
+    And I click on "Promote environment" in "Promote version 1 into qa_name" modal
+    Then I should see a "Version 1 successfully promoted into qa_name" text
+    And I should see a "Version 1: test version message 1" text in the environment "qa_name"
+    When I click promote for QA to Production
+    And I click on "Promote environment" in "Promote version 1 into prod_name" modal
+    Then I should see a "Version 1 successfully promoted into prod_name" text
+    And I should see a "Version 1: test version message 1" text in the environment "prod_name"
+
+  Scenario: Add new sources and promote again
+    Given I am authorized as "admin" with password "admin"
+    When I follow "Content Lifecycle Management"
+    And I follow "Projects"
+    And I follow "clp_name"
+    Then I should see a "Build (0)" text
+    When I follow "Edit Sources"
+    And I add the "Test Base Channel" channel to sources
+    And I click on "Save"
+    Then I should see a "Sources edited successfully" text
+    And I should see a "Test Base Channel" text
+    And I should see a "Build (1)" text
+    And I should see a "Version 2: (draft - not built) - Check the colors below for all the changes" text
+    When I click on "Build (1)"
+    Then I should see a "Version 2 history" text
+    When I enter "test version message 2" as "message"
+    And I enter "test version message 2" as "message"
+    And I click the environment build button
+    Then I should see a "Version 2 successfully built into dev_name" text
+    And I should see a "Version 2: test version message 2" text
+    When I click promote for Development to QA
+    And I click on "Promote environment" in "Promote version 2 into qa_name" modal
+    Then I should see a "Version 2 successfully promoted into qa_name" text
+    And I should see a "Version 2: test version message 2" text in the environment "qa_name"
+    When I click promote for QA to Production
+    And I click on "Promote environment" in "Promote version 2 into prod_name" modal
+    Then I should see a "Version 2 successfully promoted into prod_name" text
+    And I should see a "Version 2: test version message 2" text in the environment "prod_name"

--- a/testsuite/features/step_definitions/content_lifecycle_steps.rb
+++ b/testsuite/features/step_definitions/content_lifecycle_steps.rb
@@ -1,0 +1,23 @@
+When(/^I click the environment build button$/) do
+  page.find(:xpath, '//*[@id="cm-build-modal-save-button"]').click
+end
+
+When(/^I click promote for Development to QA$/) do
+  page.find(:xpath, '//*[@id="dev_name-promote-modal-link"]').click
+end
+
+When(/^I click promote for QA to Production$/) do
+  page.find(:xpath, '//*[@id="qa_name-promote-modal-link"]').click
+end
+
+When(/^I should see a "([^"]*)" text in the environment "([^"]*)"$/) do |text, env|
+  within(:xpath, "//h3[text()='#{env}']/../..") do
+    page.has_content?(text)
+  end
+end
+
+When(/^I add the "([^"]*)" channel to sources$/) do |channel|
+  within(:xpath, "//span[text()='#{channel}']/../..") do
+    find(:xpath, './/input[@type="checkbox"]').set(true)
+  end
+end

--- a/testsuite/run_sets/testsuite.yml
+++ b/testsuite/run_sets/testsuite.yml
@@ -115,6 +115,7 @@
 - features/min_salt_pkgset_beacon.feature
 - features/srv_patches_page.feature
 - features/srv_spacewalk_channel.feature
+- features/srv_content_lifecycle.feature
 - features/allcli_software_channels.feature
 - features/allcli_software_channels_dependencies.feature
 - features/srv_change_task_schedule.feature


### PR DESCRIPTION
## What does this PR change?
Adds a feature to test the 
## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/7468
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
