### PR TITLE
Manager bsc1132197

### DIFF
--- a/proxy/proxy/spacewalk-proxy.changes
+++ b/proxy/proxy/spacewalk-proxy.changes
@@ -1,3 +1,4 @@
+- do not reset rhn.conf on proxy during upgrade (bsc#1132197)
 - fix proxying chunked HTTP content via suse manager proxy
   This happens when calling XMLRPC API via the proxy
   (bsc#1128133)

--- a/proxy/proxy/spacewalk-proxy.spec
+++ b/proxy/proxy/spacewalk-proxy.spec
@@ -476,7 +476,7 @@ fi
 %attr(770,root,%{apache_group}) %dir %{_var}/log/rhn
 # config files
 %attr(755,root,%{apache_group}) %dir %{rhnconf}
-%attr(645,root,%{apache_group}) %config %{rhnconf}/rhn.conf
+%attr(640,root,%{apache_group}) %config(missingok,noreplace) %verify(not md5 size mtime) %{rhnconf}/rhn.conf
 %attr(644,root,%{apache_group}) %{_prefix}/share/rhn/config-defaults/rhn_proxy.conf
 %attr(644,root,%{apache_group}) %config %{httpdconf}/spacewalk-proxy.conf
 # this file is created by either cli or webui installer


### PR DESCRIPTION
## What does this PR change?

On the proxy, /etc/rhn/rhn.conf is packaged incorrectly and not tagged as "noreplace". In the past we have been lucky because rpm would notice that the file has not changed and will not reset it. However, rpm in SLES15 is using different checksums, so rpm no longer can detect the file is unchanged and will reset it with the (zero length) version of the new package.

https://bugzilla.suse.com/show_bug.cgi?id=1132197