### PR TITLE
Add support for solving "mirrorlist" and "metalink" URLs for Zypper at "reposync" 

### DIFF
--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Add support for mirrorlist and metalink on Zypper reposync.
 - Solve situations where synced packages have epoch 0 but reposync
   does not find them them on the database.
 - Fix path to the RPM database used by Zypper at reposync.


### PR DESCRIPTION
## What does this PR change?

This PR adds support for `metalink` and `mirrorlist` on the URL to repositories defined for Zypper at `spacewalk-repo-sync`.

When using `spacewalk-common-channels`, some of the repositories that are added (i.a. for "centos7" or "fedora"), are not directly mapped to the actual repository path but instead to a `metalink` or `mirrorlist` URL:

```
fedora29-x86_64 | https://mirrors.fedoraproject.org/metalink?repo=fedora-29&arch=x86_64
centos7-x86_64 | http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=os
```

Currently, before this PR, the Zypper-based `spacewalk-repo-sync` is not able to gather the metadata and synchronize those channels.

This PR mimics the behavior of the previous "yum"-based reposync plugin which used the old `yumRepo` library in order to handle a possible "metalink" or "mirrorlist":

- It tries first to read a possible metalink XML from the URL.
- Otherwise tries to read mirrorlist.
- If not, then it tries as a normal repo.

Alternative:
- Use `librepo` ("dnf" also uses "librepo" for this). Really easy but it needs to download all the repo metadata. This is redundant at the momento, since Zypper is already downloading the metadata just in the next step. In the future we could explore the chance of delegating this to `librepo`.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **bugfix**

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
