### PR TITLE
Image-sync state needs to install xdelta so enable repositories

### DIFF
--- a/testsuite/features/min_osimage_build_image.feature
+++ b/testsuite/features/min_osimage_build_image.feature
@@ -29,6 +29,7 @@ Feature: Build OS images
 @private_net
   Scenario: Move the image to the branch server
     When I manually install the "image-sync" formula on the server
+    And I enable repositories before installing branch server
     And I synchronize all Salt dynamic modules on "proxy"
     And I apply state "image-sync" to "proxy"
     Then the image "POS_Image_JeOS6" should exist on "proxy"
@@ -41,3 +42,6 @@ Feature: Build OS images
     And I click on "Delete"
     And I click on "Delete" in "Delete Selected Image(s)" modal
     And I wait until I see "Deleted successfully." text
+
+  Scenario: Cleanup: Disable the repositories on branch server
+    When I disable repositories after installing branch server


### PR DESCRIPTION
## What does this PR change?

Depending on the test order, repositories may not be enabled on the proxy during image build test. Retail image-sync formula however requires to install additional package xdelta3 to support delta-sync feature.

This PR enables repositories for the test and then disables them after the test.

## GUI diff

No difference.

## Documentation
- No documentation needed: test suite change

## Test coverage

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"    
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
