### PR TITLE
Content lifecycle management - Implement frontend permissions

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/ContentManagementViewsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/ContentManagementViewsController.java
@@ -15,7 +15,7 @@
 package com.suse.manager.webui.controllers.contentmanagement;
 
 import static com.suse.manager.webui.utils.SparkApplicationHelper.withCsrfToken;
-import static com.suse.manager.webui.utils.SparkApplicationHelper.withUser;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withRolesTemplate;
 import static spark.Spark.get;
 
 import com.redhat.rhn.domain.contentmgmt.ContentEnvironment;
@@ -60,11 +60,11 @@ public class ContentManagementViewsController {
      */
     public static void initRoutes(JadeTemplateEngine jade) {
         get("/manager/contentmanagement/project",
-                withCsrfToken(ContentManagementViewsController::createProjectView), jade);
+                withCsrfToken(withRolesTemplate(ContentManagementViewsController::createProjectView)), jade);
         get("/manager/contentmanagement/project/:label",
-                withCsrfToken(withUser(ContentManagementViewsController::editProjectView)), jade);
+                withCsrfToken(withRolesTemplate(ContentManagementViewsController::editProjectView)), jade);
         get("/manager/contentmanagement/projects",
-                withUser(ContentManagementViewsController::listProjectsView), jade);
+                withRolesTemplate(ContentManagementViewsController::listProjectsView), jade);
     }
 
     /**
@@ -72,9 +72,10 @@ public class ContentManagementViewsController {
      *
      * @param req the request object
      * @param res the response object
+     * @param user the current user
      * @return the ModelAndView object to render the page
      */
-    public static ModelAndView createProjectView(Request req, Response res) {
+    public static ModelAndView createProjectView(Request req, Response res, User user) {
         Map<String, Object> data = new HashMap<>();
         return new ModelAndView(data, "controllers/contentmanagement/templates/create-project.jade");
     }

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/templates/create-project.jade
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/templates/create-project.jade
@@ -1,5 +1,7 @@
 include /templates/common.jade
 
++userRoles
+
 #content-management-create-project
 
 script(type='text/javascript').

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/templates/list-projects.jade
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/templates/list-projects.jade
@@ -1,5 +1,7 @@
 include /templates/common.jade
 
++userRoles
+
 #content-management-list-projects
 
 div#init_data_projects(style="display: none")

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/templates/project.jade
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/templates/project.jade
@@ -1,5 +1,7 @@
 include /templates/common.jade
 
++userRoles
+
 #content-management-project
 
 script(type='text/javascript').

--- a/java/code/src/com/suse/manager/webui/templates/common.jade
+++ b/java/code/src/com/suse/manager/webui/templates/common.jade
@@ -8,3 +8,7 @@ mixin csrfToken
 mixin userPreferences
   script(type='text/javascript').
       const userPrefPageSize = #{pageSize};
+
+mixin userRoles
+    script(type='text/javascript').
+        const global_userRoles = !{roles};

--- a/web/html/src/components/panels/CreatorPanel.js
+++ b/web/html/src/components/panels/CreatorPanel.js
@@ -13,6 +13,7 @@ type Props = {
   onSave: Function,
   renderCreationContent: Function,
   renderContent: Function,
+  disableEditing?: boolean,
   className?: string,
   onCancel?: Function,
   onOpen?: Function,
@@ -47,6 +48,7 @@ const CreatorPanel = (props: Props) => {
         title={props.title}
         className={props.className}
         buttons={
+          !props.disableEditing &&
           <ModalLink
             id={`${props.id}-modal-link`}
             icon="fa-plus"
@@ -65,61 +67,64 @@ const CreatorPanel = (props: Props) => {
       </Panel>
 
 
-      <Dialog id={modalNameId}
-              title={props.title}
-              closableModal={false}
-              className="modal-lg"
-              content={
-                props.renderCreationContent({
-                  open,
-                  item,
-                  setItem: setStateItem
-                })
-              }
-              onClosePopUp={() => setOpen(false)}
-              buttons={
-                <React.Fragment>
-                  <div className="btn-group col-lg-6">
-                    {
-                      props.onDelete && <Button
-                        id={`${props.id}-modal-delete-button`}
-                        className="btn-danger"
-                        text={t('Delete')}
-                        disabled={props.disableOperations}
-                        handler={() => props.onDelete && props.onDelete({
-                          item,
-                          closeDialog: () => closeDialog(modalNameId)
-                        })}
-                      />
-                    }
-                  </div>
-                  <div className="col-lg-6">
-                    <div className="pull-right btn-group">
-                      <Button
-                        id={`${props.id}-modal-cancel-button`}
-                        className="btn-default"
-                        text={t('Cancel')}
-                        handler={() => {
-                          if (props.onCancel) {
-                            props.onCancel();
-                          }
-                          closeDialog(modalNameId);
-                        }}
-                      />
-                      <Button
-                        id={`${props.id}-modal-save-button`}
-                        className="btn-primary"
-                        text={t('Save')}
-                        disabled={props.disableOperations}
-                        handler={() => props.onSave({
-                          item,
-                          closeDialog: () => closeDialog(modalNameId)
-                        })}
-                      />
+      {
+        !props.disableEditing &&
+        <Dialog id={modalNameId}
+                title={props.title}
+                closableModal={false}
+                className="modal-lg"
+                content={
+                  props.renderCreationContent({
+                    open,
+                    item,
+                    setItem: setStateItem
+                  })
+                }
+                onClosePopUp={() => setOpen(false)}
+                buttons={
+                  <React.Fragment>
+                    <div className="btn-group col-lg-6">
+                      {
+                        props.onDelete && <Button
+                          id={`${props.id}-modal-delete-button`}
+                          className="btn-danger"
+                          text={t('Delete')}
+                          disabled={props.disableOperations}
+                          handler={() => props.onDelete && props.onDelete({
+                            item,
+                            closeDialog: () => closeDialog(modalNameId)
+                          })}
+                        />
+                      }
                     </div>
-                  </div>
-                </React.Fragment>
-              } />
+                    <div className="col-lg-6">
+                      <div className="pull-right btn-group">
+                        <Button
+                          id={`${props.id}-modal-cancel-button`}
+                          className="btn-default"
+                          text={t('Cancel')}
+                          handler={() => {
+                            if (props.onCancel) {
+                              props.onCancel();
+                            }
+                            closeDialog(modalNameId);
+                          }}
+                        />
+                        <Button
+                          id={`${props.id}-modal-save-button`}
+                          className="btn-primary"
+                          text={t('Save')}
+                          disabled={props.disableOperations}
+                          handler={() => props.onSave({
+                            item,
+                            closeDialog: () => closeDialog(modalNameId)
+                          })}
+                        />
+                      </div>
+                    </div>
+                  </React.Fragment>
+                }/>
+      }
     </React.Fragment>
   );
 };

--- a/web/html/src/core/auth/auth.utils.js
+++ b/web/html/src/core/auth/auth.utils.js
@@ -1,0 +1,5 @@
+import type {rolesType} from "./roles-context";
+
+export function isOrgAdmin(roles: rolesType) {
+  return roles.includes("org_admin");
+}

--- a/web/html/src/core/auth/roles-context.js
+++ b/web/html/src/core/auth/roles-context.js
@@ -1,0 +1,17 @@
+// @flow
+// Note: to use this component you have to make sure the current user roles are injected with withRolesTemplate
+// and jade mixin userRoles
+import React from 'react';
+import type {Node} from 'react';
+
+export type rolesType = Array<string>;
+declare var global_userRoles: rolesType;
+
+const RolesContext = React.createContext<rolesType>([]);
+
+const RolesProvider = ({children}: {children: Node}) =>
+  <RolesContext.Provider value={typeof global_userRoles !== 'undefined' ? global_userRoles : []}>
+    {children}
+  </RolesContext.Provider>
+
+export { RolesProvider, RolesContext};

--- a/web/html/src/core/auth/use-roles.js
+++ b/web/html/src/core/auth/use-roles.js
@@ -1,0 +1,8 @@
+// @flow
+// Note: To use this component make sure it's used in a placed wrapped by the roles-context-provider
+import React, {useContext} from 'react';
+import {RolesContext} from './roles-context';
+
+const useRoles = () => useContext(RolesContext);
+
+export default useRoles;

--- a/web/html/src/manager/content-management/create-project/create-project.js
+++ b/web/html/src/manager/content-management/create-project/create-project.js
@@ -7,6 +7,8 @@ import PropertiesCreate from "../shared/components/panels/properties/properties-
 import {showErrorToastr} from "components/toastr/toastr";
 import withPageWrapper from 'components/general/with-page-wrapper';
 import {hot} from 'react-hot-loader';
+import useRoles from "core/auth/use-roles";
+import {isOrgAdmin} from "core/auth/auth.utils";
 
 const CreateProject = () => {
 
@@ -20,6 +22,12 @@ const CreateProject = () => {
   });
 
   const { onAction } = useProjectActionsApi({});
+  const roles = useRoles();
+  const hasEditingPermissions = isOrgAdmin(roles);
+
+  if(!hasEditingPermissions) {
+    return (<p>{t("You do not have permissions to perform this action")}</p>)
+  }
 
   return (
           <TopPanel

--- a/web/html/src/manager/content-management/create-project/create-project.renderer.js
+++ b/web/html/src/manager/content-management/create-project/create-project.renderer.js
@@ -1,13 +1,16 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import CreateProject from './create-project';
+import {RolesProvider} from "core/auth/roles-context";
 
 window.pageRenderers = window.pageRenderers || {};
 window.pageRenderers.contentManagement = window.pageRenderers.contentManagement || {};
 window.pageRenderers.contentManagement.createProject = window.pageRenderers.contentManagement.createProject || {};
 window.pageRenderers.contentManagement.createProject.renderer = (id) => {
   ReactDOM.render(
-    <CreateProject />,
+    <RolesProvider>
+      <CreateProject />
+    </RolesProvider>,
     document.getElementById(id),
   );
 };

--- a/web/html/src/manager/content-management/list-projects/list-projects.js
+++ b/web/html/src/manager/content-management/list-projects/list-projects.js
@@ -1,12 +1,14 @@
 // @flow
 import React, {useEffect} from 'react';
 import {TopPanel} from 'components/panels/TopPanel';
-import {Table, Column, SearchField} from 'components/table';
+import {Column, SearchField, Table} from 'components/table';
 import Functions from 'utils/functions';
 import {LinkButton} from 'components/buttons';
-import { showSuccessToastr } from 'components/toastr/toastr';
+import {showSuccessToastr} from 'components/toastr/toastr';
 import withPageWrapper from 'components/general/with-page-wrapper';
-import { hot } from 'react-hot-loader';
+import {hot} from 'react-hot-loader';
+import useRoles from "core/auth/use-roles";
+import {isOrgAdmin} from "core/auth/auth.utils";
 
 type ContentProjectOverviewType = {
   properties: {
@@ -24,6 +26,8 @@ type Props = {
 };
 
 const ListProjects = (props: Props) => {
+  const roles = useRoles();
+  const hasEditingPermissions = isOrgAdmin(roles);
 
   useEffect(()=> {
     if(props.flashMessage) {
@@ -48,14 +52,17 @@ const ListProjects = (props: Props) => {
 
   const panelButtons = (
     <div className="pull-right btn-group">
-      <LinkButton
-        id="createcontentproject"
-        icon="fa-plus"
-        className="btn-link"
-        title={t('Create a new content lifecycle project')}
-        text={t('Create Project')}
-        href="/rhn/manager/contentmanagement/project"
-      />
+      {
+        hasEditingPermissions &&
+          <LinkButton
+            id="createcontentproject"
+            icon="fa-plus"
+            className="btn-link"
+            title={t('Create a new content lifecycle project')}
+            text={t('Create Project')}
+            href="/rhn/manager/contentmanagement/project"
+          />
+      }
     </div>
   );
 

--- a/web/html/src/manager/content-management/list-projects/list-projects.renderer.js
+++ b/web/html/src/manager/content-management/list-projects/list-projects.renderer.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import ListProjects from './list-projects';
+import {RolesProvider} from "core/auth/roles-context";
 
 window.pageRenderers = window.pageRenderers || {};
 window.pageRenderers.contentManagement = window.pageRenderers.contentManagement || {};
@@ -13,10 +14,12 @@ window.pageRenderers.contentManagement.listProjects.renderer = (id, {projects, f
   }  catch(error) {}
 
   ReactDOM.render(
+    <RolesProvider>
       <ListProjects
         projects={projectsJson}
         flashMessage={flashMessage}
-      />,
-      document.getElementById(id),
-    );
+      />
+    </RolesProvider>,
+    document.getElementById(id),
+  );
 };

--- a/web/html/src/manager/content-management/project/project.renderer.js
+++ b/web/html/src/manager/content-management/project/project.renderer.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Project from './project';
+import {RolesProvider} from "core/auth/roles-context";
 
 window.pageRenderers = window.pageRenderers || {};
 window.pageRenderers.contentManagement = window.pageRenderers.contentManagement || {};
@@ -12,10 +13,12 @@ window.pageRenderers.contentManagement.project.renderer = (id, {project, wasFres
   }  catch(error) {}
 
   ReactDOM.render(
-    <Project
-      project={projectJson}
-      { ...( wasFreshlyCreatedMessage && { wasFreshlyCreatedMessage } ) }
-    />,
+    <RolesProvider>
+      <Project
+        project={projectJson}
+        { ...( wasFreshlyCreatedMessage && { wasFreshlyCreatedMessage } ) }
+      />
+    </RolesProvider>,
     document.getElementById(id),
   );
 };

--- a/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-lifecycle.js
+++ b/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-lifecycle.js
@@ -11,6 +11,8 @@ import {mapAddEnvironmentRequest, mapUpdateEnvironmentRequest} from './environme
 
 import type {ProjectEnvironmentType} from '../../../type/project.type.js';
 import type {ProjectHistoryEntry} from "../../../type/project.type";
+import useRoles from "core/auth/use-roles";
+import {isOrgAdmin} from "core/auth/auth.utils";
 
 type Props = {
   projectId: string,
@@ -24,6 +26,8 @@ const EnvironmentLifecycle = (props: Props) => {
   const {onAction, cancelAction, isLoading} = useProjectActionsApi({
     projectId: props.projectId, projectResource:"environments"
   });
+  const roles = useRoles();
+  const hasEditingPermissions = isOrgAdmin(roles);
 
   return (
     <CreatorPanel
@@ -31,6 +35,7 @@ const EnvironmentLifecycle = (props: Props) => {
       title="Environment Lifecycle"
       creatingText="Add new Environment"
       panelLevel="2"
+      disableEditing={!hasEditingPermissions}
       collapsible
       customIconClass="fa-small"
       disableOperations={isLoading}
@@ -81,6 +86,7 @@ const EnvironmentLifecycle = (props: Props) => {
                       title={environment.name}
                       creatingText="Edit"
                       panelLevel="3"
+                      disableEditing={!hasEditingPermissions}
                       disableOperations={isLoading}
                       onSave={({ item, closeDialog }) =>
                         onAction(mapUpdateEnvironmentRequest(item, props.projectId), "update")

--- a/web/html/src/manager/content-management/shared/components/panels/promote/promote.js
+++ b/web/html/src/manager/content-management/shared/components/panels/promote/promote.js
@@ -9,6 +9,8 @@ import {getVersionMessageByNumber} from "../properties/properties.utils";
 import useProjectActionsApi from "../../../api/use-project-actions-api";
 import {showErrorToastr, showSuccessToastr} from "components/toastr/toastr";
 import {Loading} from "components/loading/loading";
+import useRoles from "core/auth/use-roles";
+import {isOrgAdmin} from "core/auth/auth.utils";
 
 
 type Props = {
@@ -25,6 +27,8 @@ const Promote = (props: Props) => {
   const {onAction, cancelAction, isLoading} = useProjectActionsApi({
     projectId: props.projectId, projectResource: "promote"
   });
+  const roles = useRoles();
+  const hasEditingPermissions = isOrgAdmin(roles);
 
   useEffect(() => {
     if(!open){
@@ -34,7 +38,9 @@ const Promote = (props: Props) => {
 
   const versionMessage = getVersionMessageByNumber(props.environmentPromote.version, props.historyEntries) || "not built";
   const modalNameId = `${props.environmentPromote.label}-cm-promote-env-modal`;
-  const disabled = !props.environmentPromote.version
+  const disabled =
+    !hasEditingPermissions
+    || !props.environmentPromote.version
     || props.environmentPromote.version <= props.environmentTarget.version;
   return (
     <div

--- a/web/html/src/manager/content-management/shared/components/panels/properties/properties-edit.js
+++ b/web/html/src/manager/content-management/shared/components/panels/properties/properties-edit.js
@@ -9,6 +9,8 @@ import PropertiesView from "./properties-view";
 import produce from "immer";
 
 import type {ProjectHistoryEntry, ProjectPropertiesType} from '../../../type/project.type.js';
+import useRoles from "core/auth/use-roles";
+import {isOrgAdmin} from "core/auth/auth.utils";
 
 type Props = {
   projectId: string,
@@ -22,6 +24,8 @@ const PropertiesEdit = (props: Props) => {
   const {onAction, cancelAction, isLoading} = useProjectActionsApi({
     projectId: props.projectId, projectResource: "properties"
   });
+  const roles = useRoles();
+  const hasEditingPermissions = isOrgAdmin(roles);
 
   const defaultDraftHistory = {
     version: props.currentHistoryEntry ? props.currentHistoryEntry.version + 1 : 1 ,
@@ -39,6 +43,7 @@ const PropertiesEdit = (props: Props) => {
         id="properties"
         creatingText="Edit"
         panelLevel="2"
+        disableEditing={!hasEditingPermissions}
         title={t('Project Properties')}
         collapsible
         customIconClass="fa-small"

--- a/web/html/src/manager/content-management/shared/components/panels/sources/sources.js
+++ b/web/html/src/manager/content-management/shared/components/panels/sources/sources.js
@@ -9,6 +9,8 @@ import useProjectActionsApi from "../../../api/use-project-actions-api";
 import ChannelsSelection from "./channels/channels-selection";
 import {Panel} from "../../../../../../components/panels/Panel";
 import styles from "./sources.css";
+import useRoles from "core/auth/use-roles";
+import {isOrgAdmin} from "core/auth/auth.utils";
 
 type SourcesProps = {
   projectId: string,
@@ -78,7 +80,8 @@ const Sources = (props: SourcesProps) => {
   const {onAction, cancelAction, isLoading} = useProjectActionsApi({
     projectId: props.projectId, projectResource: "softwaresources"
   });
-
+  const roles = useRoles();
+  const hasEditingPermissions = isOrgAdmin(roles);
 
   return (
     <CreatorPanel
@@ -86,6 +89,7 @@ const Sources = (props: SourcesProps) => {
       title="Sources"
       creatingText="Add new Source"
       panelLevel="2"
+      disableEditing={!hasEditingPermissions}
       collapsible
       customIconClass="fa-small"
       onCancel={() => cancelAction()}

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Content lifecycle management - show destructive operations only for users with the org admin role
 - Add cache buster for static files (js/css) to fix caching issues after upgrading.
 - Show undetected subscription-matching message object as a string anyway (bsc#1125600)
 


### PR DESCRIPTION
## What does this PR change?

Content lifecycle management - Implement frontend permissions.

Show destructive operations only for users with the org admin role.
Also added util components to manage roles in React easily in the future 

## GUI diff

For users without the org admin role, destructive operations will not appear.

- [ ] **DONE**

## Documentation
- No documentation needed.

- [ ] **DONE**

## Test coverage
- No tests.

- [ ] **DONE**

## Links

Fixes #https://github.com/SUSE/spacewalk/issues/7144

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
