### PR TITLE
Content management filters [2/2]: Implement filtering packages with Content Filters

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentFilter.java
@@ -34,6 +34,7 @@ import javax.persistence.InheritanceType;
 import javax.persistence.ManyToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
+import javax.persistence.Transient;
 
 /**
  * Content Filter
@@ -49,6 +50,45 @@ public abstract class ContentFilter extends BaseDomainHelper {
     private String name;
     private Rule rule;
     private FilterCriteria criteria;
+
+    /**
+     * Entity type that is dealt with by filter.
+     */
+    public enum EntityType {
+        PACKAGE("package"),
+        ERRATUM("erratum");
+
+        private String label;
+
+        EntityType(String labelIn) {
+            this.label = labelIn;
+        }
+
+        /**
+         * Gets the label.
+         *
+         * @return label
+         */
+        public String getLabel() {
+            return label;
+        }
+
+        /**
+         * Looks up Entity type by label
+         *
+         * @param label the label
+         * @throws java.lang.IllegalArgumentException if no matching Entity type is found
+         * @return the matching Entity type
+         */
+        public static EntityType lookupByLabel(String label) {
+            for (EntityType value : values()) {
+                if (value.label.equals(label)) {
+                    return value;
+                }
+            }
+            throw new IllegalArgumentException("Unsupported label: " + label);
+        }
+    }
 
     /**
      * Type of the filter
@@ -88,6 +128,13 @@ public abstract class ContentFilter extends BaseDomainHelper {
             throw new IllegalArgumentException("Unsupported label: " + label);
         }
     }
+
+    /**
+     * Get {@link EntityType} of this object
+     * @return the {@link EntityType}
+     */
+    @Transient
+    public abstract EntityType getEntityType();
 
     /**
      * Gets the id.

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentFilter.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorColumn;
+import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -44,7 +45,7 @@ public abstract class ContentFilter extends BaseDomainHelper {
     private Long id;
     private Org org;
     private String name;
-    private String criteria;
+    private FilterCriteria criteria;
 
     /**
      * Gets the id.
@@ -110,8 +111,8 @@ public abstract class ContentFilter extends BaseDomainHelper {
      *
      * @return criteria
      */
-    @Column
-    public String getCriteria() {
+    @Embedded
+    public FilterCriteria getCriteria() {
         return criteria;
     }
 
@@ -120,7 +121,7 @@ public abstract class ContentFilter extends BaseDomainHelper {
      *
      * @param criteriaIn - the criteria
      */
-    public void setCriteria(String criteriaIn) {
+    public void setCriteria(FilterCriteria criteriaIn) {
         criteria = criteriaIn;
     }
 

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentFilter.java
@@ -20,6 +20,7 @@ import com.redhat.rhn.domain.org.Org;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
+import java.util.Optional;
 import java.util.function.Predicate;
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorColumn;
@@ -138,6 +139,20 @@ public abstract class ContentFilter<T> extends BaseDomainHelper implements Predi
      */
     @Transient
     public abstract EntityType getEntityType();
+
+    /**
+     * Returns the filter as {@link PackageFilter} if it is one
+     *
+     * @return Optional of {@link PackageFilter}
+     */
+    public abstract Optional<PackageFilter> asPackageFilter();
+
+    /**
+     * Returns the filter as {@link ErrataFilter} if it is one
+     *
+     * @return Optional of {@link ErrataFilter}
+     */
+    public abstract Optional<ErrataFilter> asErrataFilter();
 
     /**
      * Test whether an object passes the filter

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentFilter.java
@@ -24,6 +24,8 @@ import javax.persistence.Column;
 import javax.persistence.DiscriminatorColumn;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -45,7 +47,47 @@ public abstract class ContentFilter extends BaseDomainHelper {
     private Long id;
     private Org org;
     private String name;
+    private Rule rule;
     private FilterCriteria criteria;
+
+    /**
+     * Type of the filter
+     */
+    public enum Rule {
+        ALLOW("allow"),
+        DENY("deny");
+
+        private final String label;
+
+        Rule(String typeIn) {
+            this.label = typeIn;
+        }
+
+        /**
+         * Gets the label.
+         *
+         * @return label
+         */
+        public String getLabel() {
+            return label;
+        }
+
+        /**
+         * Looks up Rule by label
+         *
+         * @param label the label
+         * @throws java.lang.IllegalArgumentException if no matching Rule is found
+         * @return the matching Rule
+         */
+        public static Rule lookupByLabel(String label) {
+            for (Rule value : values()) {
+                if (value.label.equals(label)) {
+                    return value;
+                }
+            }
+            throw new IllegalArgumentException("Unsupported label: " + label);
+        }
+    }
 
     /**
      * Gets the id.
@@ -104,6 +146,25 @@ public abstract class ContentFilter extends BaseDomainHelper {
      */
     public void setName(String nameIn) {
         name = nameIn;
+    }
+
+    /**
+     * Gets the rule.
+     *
+     * @return rule
+     */
+    @Enumerated(EnumType.STRING)
+    public Rule getRule() {
+        return rule;
+    }
+
+    /**
+     * Sets the rule.
+     *
+     * @param ruleIn the rule
+     */
+    public void setRule(Rule ruleIn) {
+        this.rule = ruleIn;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentFilter.java
@@ -20,6 +20,7 @@ import com.redhat.rhn.domain.org.Org;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
+import java.util.function.Predicate;
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorColumn;
 import javax.persistence.Embedded;
@@ -38,12 +39,14 @@ import javax.persistence.Transient;
 
 /**
  * Content Filter
+ *
+ * @param <T> the entity being filtered
  */
 @Entity
 @Table(name = "suseContentFilter")
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "type")
-public abstract class ContentFilter extends BaseDomainHelper {
+public abstract class ContentFilter<T> extends BaseDomainHelper implements Predicate<T> {
 
     private Long id;
     private Org org;

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentFilter.java
@@ -140,6 +140,21 @@ public abstract class ContentFilter<T> extends BaseDomainHelper implements Predi
     public abstract EntityType getEntityType();
 
     /**
+     * Test whether an object passes the filter
+     *
+     * @param t the object
+     * @return true if the object passes the filter
+     */
+    public abstract boolean testInternal(T t);
+
+    @Override
+    public boolean test(T t) {
+        boolean result = testInternal(t);
+        // we want to invert the test if Rule type is DENY
+        return rule == Rule.ALLOW ? result : !result;
+    }
+
+    /**
      * Gets the id.
      *
      * @return id

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProject.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProject.java
@@ -308,6 +308,51 @@ public class ContentProject extends BaseDomainHelper {
     }
 
     /**
+     * Attach a {@link ContentFilter} to {@link ContentProject}
+     *
+     * @param filter the filter to attach
+     */
+    public void attachFilter(ContentFilter filter) {
+        ContentProjectFilter projectFilter = new ContentProjectFilter(this, filter);
+
+        int idx = filters.indexOf(projectFilter);
+        if (idx != -1) {
+            ContentProjectFilter toUpdate = filters.get(idx);
+            if (toUpdate.getState() == ContentProjectFilter.State.DETACHED) {
+                toUpdate.setState(ContentProjectFilter.State.BUILT);
+            }
+        }
+        else {
+            filters.add(projectFilter);
+        }
+    }
+
+    /**
+     * Detach a {@link ContentFilter} from a {@link ContentProject}
+     *
+     * @param filter the filter to detach
+     */
+    public void detachFilter(ContentFilter filter) {
+        ContentProjectFilter projectFilter = new ContentProjectFilter(this, filter);
+
+        int idx = filters.indexOf(projectFilter);
+        if (idx != -1) {
+            ContentProjectFilter toUpdate = filters.get(idx);
+
+            switch (toUpdate.getState()) {
+                case BUILT:
+                    toUpdate.setState(ContentProjectFilter.State.DETACHED);
+                    break;
+                case ATTACHED:
+                    filters.remove(idx);
+                    break;
+                default:
+                    // no-op
+            }
+        }
+    }
+
+    /**
      * Gets the historyEntries.
      *
      * @return historyEntries

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProject.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProject.java
@@ -294,7 +294,7 @@ public class ContentProject extends BaseDomainHelper {
      */
     @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, mappedBy = "project", orphanRemoval = true)
     @OrderColumn(name = "position")
-    protected List<ContentProjectFilter> getProjectFilters() {
+    public List<ContentProjectFilter> getProjectFilters() {
         return filters;
     }
 

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProject.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProject.java
@@ -38,7 +38,6 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.OrderBy;
-import javax.persistence.OrderColumn;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.persistence.Transient;
@@ -294,7 +293,6 @@ public class ContentProject extends BaseDomainHelper {
      * @return filters
      */
     @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, mappedBy = "project", orphanRemoval = true)
-    @OrderColumn(name = "position")
     public List<ContentProjectFilter> getProjectFilters() {
         return filters;
     }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProject.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProject.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -296,6 +297,18 @@ public class ContentProject extends BaseDomainHelper {
     @OrderColumn(name = "position")
     public List<ContentProjectFilter> getProjectFilters() {
         return filters;
+    }
+
+    /**
+     * Get the {@link PackageFilter}s
+     *
+     * @return the Package filters
+     */
+    @Transient
+    public List<PackageFilter> getPackageFilters() {
+        return (List<PackageFilter>) getProjectFilters().stream()
+                .flatMap(f -> Opt.stream(f.getFilter().asPackageFilter()))
+                .collect(Collectors.toList());
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
@@ -495,6 +495,14 @@ public class ContentProjectFactory extends HibernateFactory {
     }
 
     /**
+     * Remove {@link ContentProjectFilter}
+     * @param filter the filter
+     */
+    public static void remove(ContentProjectFilter filter) {
+        INSTANCE.removeObject(filter);
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
@@ -432,6 +432,10 @@ public class ContentProjectFactory extends HibernateFactory {
      */
     public static ContentFilter createFilter(String name, ContentFilter.Rule rule, ContentFilter.EntityType entityType,
             FilterCriteria criteria, User user) {
+        if (rule == ContentFilter.Rule.ALLOW) {
+            throw new UnsupportedOperationException("Rule ALLOW is not supported yet");
+        }
+
         ContentFilter filter;
         switch (entityType) {
             case PACKAGE:
@@ -463,6 +467,11 @@ public class ContentProjectFactory extends HibernateFactory {
      */
     public static ContentFilter updateFilter(ContentFilter filter, Optional<String> name,
             Optional<ContentFilter.Rule> rule, Optional<FilterCriteria> criteria) {
+        rule.ifPresent(r -> {
+            if (r == ContentFilter.Rule.ALLOW) {
+                throw new UnsupportedOperationException("Rule ALLOW is not supported yet");
+            }
+        });
         name.ifPresent(n -> filter.setName(n));
         rule.ifPresent(r -> filter.setRule(r));
         criteria.ifPresent(c -> filter.setCriteria(c));

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
@@ -480,6 +480,21 @@ public class ContentProjectFactory extends HibernateFactory {
     }
 
     /**
+     * List {@link ContentProject}s using given {@link ContentFilter}
+     *
+     * @param filter the Filter
+     * @return list of Projects
+     */
+    public static List<ContentProject> listFilterProjects(ContentFilter filter) {
+        return HibernateFactory.getSession()
+                .createQuery("SELECT cp FROM ContentProject cp " +
+                                "WHERE cp.id IN (SELECT cpf.project.id FROM ContentProjectFilter cpf " +
+                                                 "WHERE cpf.filter.id = :fid)")
+                .setParameter("fid", filter.getId())
+                .list();
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
@@ -393,6 +393,93 @@ public class ContentProjectFactory extends HibernateFactory {
     }
 
     /**
+     * List filters visible to given user
+     *
+     * @param user the user
+     * @return the filters
+     */
+    public static List<ContentFilter> listFilters(User user) {
+        CriteriaBuilder builder = getSession().getCriteriaBuilder();
+        CriteriaQuery<ContentFilter> criteria = builder.createQuery(ContentFilter.class);
+        Root<ContentFilter> root = criteria.from(ContentFilter.class);
+        criteria.where(builder.equal(root.get("org"), user.getOrg()));
+        return getSession().createQuery(criteria).list();
+    }
+
+    /**
+     * Look up filter by id
+     *
+     * @param id the id
+     * @return the matching filter
+     */
+    public static Optional<ContentFilter> lookupFilterById(Long id) {
+        CriteriaBuilder builder = getSession().getCriteriaBuilder();
+        CriteriaQuery<ContentFilter> criteria = builder.createQuery(ContentFilter.class);
+        Root<ContentFilter> root = criteria.from(ContentFilter.class);
+        criteria.where(builder.equal(root.get("id"), id));
+        return getSession().createQuery(criteria).uniqueResultOptional();
+    }
+
+    /**
+     * Create a new {@link ContentFilter}
+     *
+     * @param name the filter name
+     * @param rule the filter {@link ContentFilter.Rule}
+     * @param entityType the entity type that the filter will deal with
+     * @param criteria the {@link FilterCriteria} for filtering
+     * @param user the User
+     * @return the created filter
+     */
+    public static ContentFilter createFilter(String name, ContentFilter.Rule rule, ContentFilter.EntityType entityType,
+            FilterCriteria criteria, User user) {
+        ContentFilter filter;
+        switch (entityType) {
+            case PACKAGE:
+                filter = new PackageFilter();
+                break;
+            case ERRATUM:
+                filter = new ErrataFilter();
+                break;
+            default:
+                throw new IllegalArgumentException("Incompatible type " + entityType);
+        }
+
+        filter.setName(name);
+        filter.setOrg(user.getOrg());
+        filter.setRule(rule);
+        filter.setCriteria(criteria);
+        INSTANCE.saveObject(filter);
+        return filter;
+    }
+
+    /**
+     * Update a {@link ContentFilter}
+     *
+     * @param filter the filter to update
+     * @param name optional with name to update
+     * @param rule optional with {@link ContentFilter.Rule} to update
+     * @param criteria optional with {@link FilterCriteria} to update
+     * @return the updated filter
+     */
+    public static ContentFilter updateFilter(ContentFilter filter, Optional<String> name,
+            Optional<ContentFilter.Rule> rule, Optional<FilterCriteria> criteria) {
+        name.ifPresent(n -> filter.setName(n));
+        rule.ifPresent(r -> filter.setRule(r));
+        criteria.ifPresent(c -> filter.setCriteria(c));
+        return filter;
+    }
+
+    /**
+     * Remove {@link ContentFilter}
+     *
+     * @param filter the filter
+     * @return true if removed
+     */
+    public static boolean remove(ContentFilter filter) {
+        return INSTANCE.removeObject(filter) != 0;
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFilter.java
@@ -19,6 +19,8 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -93,6 +95,7 @@ public class ContentProjectFilter {
      *
      * @return state
      */
+    @Enumerated(EnumType.STRING)
     public State getState() {
         return state;
     }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ErrataFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ErrataFilter.java
@@ -17,6 +17,7 @@ package com.redhat.rhn.domain.contentmgmt;
 
 import com.redhat.rhn.domain.errata.Errata;
 
+import java.util.Optional;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import javax.persistence.Transient;
@@ -37,5 +38,15 @@ public class ErrataFilter extends ContentFilter<Errata> {
     @Transient
     public EntityType getEntityType() {
         return EntityType.ERRATUM;
+    }
+
+    @Override
+    public Optional<PackageFilter> asPackageFilter() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<ErrataFilter> asErrataFilter() {
+        return Optional.of(this);
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ErrataFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ErrataFilter.java
@@ -29,7 +29,7 @@ import javax.persistence.Transient;
 public class ErrataFilter extends ContentFilter<Errata> {
 
     @Override
-    public boolean test(Errata errata) {
+    public boolean testInternal(Errata errata) {
         return false;
     }
 

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ErrataFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ErrataFilter.java
@@ -15,6 +15,8 @@
 
 package com.redhat.rhn.domain.contentmgmt;
 
+import com.redhat.rhn.domain.errata.Errata;
+
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import javax.persistence.Transient;
@@ -24,7 +26,12 @@ import javax.persistence.Transient;
  */
 @Entity
 @DiscriminatorValue("errata")
-public class ErrataFilter extends ContentFilter {
+public class ErrataFilter extends ContentFilter<Errata> {
+
+    @Override
+    public boolean test(Errata errata) {
+        return false;
+    }
 
     @Override
     @Transient

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ErrataFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ErrataFilter.java
@@ -17,6 +17,7 @@ package com.redhat.rhn.domain.contentmgmt;
 
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
+import javax.persistence.Transient;
 
 /**
  * Errata Filter
@@ -25,4 +26,9 @@ import javax.persistence.Entity;
 @DiscriminatorValue("errata")
 public class ErrataFilter extends ContentFilter {
 
+    @Override
+    @Transient
+    public EntityType getEntityType() {
+        return EntityType.ERRATUM;
+    }
 }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
@@ -1,0 +1,163 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.domain.contentmgmt;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+
+/**
+ * The criteria used for matching objects (Package, Errata) in {@link ContentFilter}
+ *
+ * Consist of 3 fields:
+ * - matcher - the matcher type (equals, contains, greater-than...)
+ * - field - the field of the examined object (e.g. Package name)
+ * - value - the user-defined value for matching (e.g. "libsolv", for package name)
+ */
+@Embeddable
+public class FilterCriteria {
+
+    private Matcher matcher;
+    private String field;
+    private String value;
+
+    /**
+     * The matcher type
+     */
+    public enum Matcher {
+        CONTAINS;
+    }
+
+    /**
+     * Standard constructor
+     */
+    public FilterCriteria() {
+    }
+
+    /**
+     * Standard constructor
+     *
+     * @param matcherIn the matcher type
+     * @param fieldIn the field to match
+     * @param valueIn the match value
+     */
+    public FilterCriteria(Matcher matcherIn, String fieldIn, String valueIn) {
+        this.matcher = matcherIn;
+        this.field = fieldIn;
+        this.value = valueIn;
+    }
+
+    /**
+     * Gets the type.
+     *
+     * @return type
+     */
+    @Column(name = "matcher")
+    @Enumerated(EnumType.STRING)
+    public Matcher getMatcher() {
+        return matcher;
+    }
+
+    /**
+     * Sets the matcher type.
+     *
+     * @param matcherIn the matcher type
+     */
+    public void setMatcher(Matcher matcherIn) {
+        this.matcher = matcherIn;
+    }
+
+    /**
+     * Gets the field.
+     *
+     * @return field
+     */
+    @Column(name = "field")
+    public String getField() {
+        return field;
+    }
+
+    /**
+     * Sets the field.
+     *
+     * @param fieldIn the field
+     */
+    public void setField(String fieldIn) {
+        this.field = fieldIn;
+    }
+
+    /**
+     * Gets the value.
+     *
+     * @return value
+     */
+    @Column(name = "value")
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Sets the value.
+     *
+     * @param valueIn the value
+     */
+    public void setValue(String valueIn) {
+        this.value = valueIn;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        FilterCriteria that = (FilterCriteria) o;
+
+        return new EqualsBuilder()
+                .append(matcher, that.matcher)
+                .append(field, that.field)
+                .append(value, that.value)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+                .append(matcher)
+                .append(field)
+                .append(value)
+                .toHashCode();
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .append("matcher", matcher)
+                .append("field", field)
+                .append("value", value)
+                .toString();
+    }
+
+}

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
@@ -43,7 +43,38 @@ public class FilterCriteria {
      * The matcher type
      */
     public enum Matcher {
-        CONTAINS;
+        CONTAINS("contains");
+
+        private String label;
+
+        Matcher(String labelIn) {
+            this.label = labelIn;
+        }
+
+        /**
+         * Gets the label.
+         *
+         * @return label
+         */
+        public String getLabel() {
+            return label;
+        }
+
+        /**
+         * Looks up Matcher by label
+         *
+         * @param label the label
+         * @throws java.lang.IllegalArgumentException if no matching matcher is found
+         * @return the matching matcher
+         */
+        public static Matcher lookupByLabel(String label) {
+            for (Matcher value : values()) {
+                if (value.label.equals(label)) {
+                    return value;
+                }
+            }
+            throw new IllegalArgumentException("Unsupported label: " + label);
+        }
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
@@ -17,6 +17,7 @@ package com.redhat.rhn.domain.contentmgmt;
 
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
+import javax.persistence.Transient;
 
 /**
  * Package Filter
@@ -25,4 +26,9 @@ import javax.persistence.Entity;
 @DiscriminatorValue("package")
 public class PackageFilter extends ContentFilter {
 
+    @Override
+    @Transient
+    public EntityType getEntityType() {
+        return EntityType.PACKAGE;
+    }
 }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
@@ -17,6 +17,7 @@ package com.redhat.rhn.domain.contentmgmt;
 
 import com.redhat.rhn.domain.rhnpackage.Package;
 
+import java.util.Optional;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import javax.persistence.Transient;
@@ -56,5 +57,15 @@ public class PackageFilter extends ContentFilter<Package> {
     @Transient
     public EntityType getEntityType() {
         return EntityType.PACKAGE;
+    }
+
+    @Override
+    public Optional<PackageFilter> asPackageFilter() {
+        return Optional.of(this);
+    }
+
+    @Override
+    public Optional<ErrataFilter> asErrataFilter() {
+        return Optional.empty();
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
@@ -24,7 +24,11 @@ import javax.persistence.Transient;
  */
 @Entity
 @DiscriminatorValue("package")
-public class PackageFilter extends ContentFilter {
+public class PackageFilter extends ContentFilter<Package> {
+
+    @Override
+    public boolean test(Package pack) {
+    }
 
     @Override
     @Transient

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
@@ -15,6 +15,8 @@
 
 package com.redhat.rhn.domain.contentmgmt;
 
+import com.redhat.rhn.domain.rhnpackage.Package;
+
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import javax.persistence.Transient;
@@ -27,7 +29,7 @@ import javax.persistence.Transient;
 public class PackageFilter extends ContentFilter<Package> {
 
     @Override
-    public boolean test(Package pack) {
+    public boolean testInternal(Package pack) {
         FilterCriteria.Matcher matcher = getCriteria().getMatcher();
         String field = getCriteria().getField();
         String value = getCriteria().getValue();
@@ -44,7 +46,7 @@ public class PackageFilter extends ContentFilter<Package> {
     private static <T> T getField(Package pack, String field, Class<T> type) {
         switch (field) {
             case "name":
-                return type.cast(pack.getName());
+                return type.cast(pack.getPackageName().getName());
             default:
                 throw new UnsupportedOperationException("Field " + field + " not supported");
         }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
@@ -28,6 +28,26 @@ public class PackageFilter extends ContentFilter<Package> {
 
     @Override
     public boolean test(Package pack) {
+        FilterCriteria.Matcher matcher = getCriteria().getMatcher();
+        String field = getCriteria().getField();
+        String value = getCriteria().getValue();
+
+        switch (matcher) {
+            case CONTAINS:
+                return getField(pack, field, String.class).contains(value);
+            default:
+                throw new UnsupportedOperationException("Matcher " + matcher + " not supported");
+
+        }
+    }
+
+    private static <T> T getField(Package pack, String field, Class<T> type) {
+        switch (field) {
+            case "name":
+                return type.cast(pack.getName());
+            default:
+                throw new UnsupportedOperationException("Field " + field + " not supported");
+        }
     }
 
     @Override

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentFilterTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentFilterTest.java
@@ -48,7 +48,8 @@ public class ContentFilterTest extends JMockBaseTestCaseWithUser {
         assertFalse(filter.test(pack));
     }
 
-    public void testPackageAllowFilter() throws Exception {
+    // TODO fkobzik enable test after Beta3 release
+    public void disabledTestPackageAllowFilter() throws Exception {
         Package pack = PackageTest.createTestPackage(user.getOrg());
         String packageName = pack.getPackageName().getName();
 

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentFilterTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentFilterTest.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.domain.contentmgmt.test;
+
+import com.redhat.rhn.domain.contentmgmt.ContentFilter;
+import com.redhat.rhn.domain.contentmgmt.FilterCriteria;
+import com.redhat.rhn.domain.rhnpackage.Package;
+import com.redhat.rhn.domain.rhnpackage.test.PackageTest;
+import com.redhat.rhn.manager.contentmgmt.ContentManager;
+import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
+import com.redhat.rhn.testing.UserTestUtils;
+
+import static com.redhat.rhn.domain.contentmgmt.ContentFilter.EntityType.PACKAGE;
+import static com.redhat.rhn.domain.contentmgmt.ContentFilter.Rule.ALLOW;
+import static com.redhat.rhn.domain.contentmgmt.ContentFilter.Rule.DENY;
+import static com.redhat.rhn.domain.role.RoleFactory.ORG_ADMIN;
+
+/**
+ * Tests for {@link ContentFilter}
+ */
+public class ContentFilterTest extends JMockBaseTestCaseWithUser {
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        UserTestUtils.addUserRole(user, ORG_ADMIN);
+    }
+
+    public void testPackageDenyFilter() throws Exception {
+        Package pack = PackageTest.createTestPackage(user.getOrg());
+        String packageName = pack.getPackageName().getName();
+
+        FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.CONTAINS, "name", packageName);
+        ContentFilter filter = ContentManager.createFilter(packageName + "-filter", DENY, PACKAGE, criteria, user);
+        assertFalse(filter.test(pack));
+    }
+
+    public void testPackageAllowFilter() throws Exception {
+        Package pack = PackageTest.createTestPackage(user.getOrg());
+        String packageName = pack.getPackageName().getName();
+
+        FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.CONTAINS, "name", packageName);
+        ContentFilter filter = ContentManager.createFilter(packageName + "-filter", ALLOW, PACKAGE, criteria, user);
+        assertTrue(filter.test(pack));
+    }
+}

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentProjectFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentProjectFactoryTest.java
@@ -20,10 +20,12 @@ import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.ChannelFactory;
 import com.redhat.rhn.domain.contentmgmt.ContentEnvironment;
+import com.redhat.rhn.domain.contentmgmt.ContentFilter;
 import com.redhat.rhn.domain.contentmgmt.ContentProject;
 import com.redhat.rhn.domain.contentmgmt.ContentProjectFactory;
 import com.redhat.rhn.domain.contentmgmt.ContentProjectHistoryEntry;
 import com.redhat.rhn.domain.contentmgmt.EnvironmentTarget;
+import com.redhat.rhn.domain.contentmgmt.FilterCriteria;
 import com.redhat.rhn.domain.contentmgmt.ProjectSource;
 import com.redhat.rhn.domain.contentmgmt.ProjectSource.State;
 import com.redhat.rhn.domain.contentmgmt.SoftwareEnvironmentTarget;
@@ -31,6 +33,7 @@ import com.redhat.rhn.domain.contentmgmt.SoftwareProjectSource;
 import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.user.UserFactory;
+import com.redhat.rhn.manager.contentmgmt.ContentManager;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.ChannelTestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
@@ -40,6 +43,7 @@ import java.util.Optional;
 
 import static com.redhat.rhn.domain.contentmgmt.ProjectSource.Type.SW_CHANNEL;
 import static com.redhat.rhn.domain.contentmgmt.ProjectSource.Type.lookupByLabel;
+import static com.redhat.rhn.domain.role.RoleFactory.ORG_ADMIN;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.Optional.empty;
@@ -544,5 +548,25 @@ public class ContentProjectFactoryTest extends BaseTestCaseWithUser {
         ContentProjectFactory.purgeTarget(target);
         assertEquals(0, envdev.getTargets().size());
         assertNull(ChannelFactory.lookupByLabel(channelLabel));
+    }
+
+    /**
+     * Test listing {@link ContentProject}s used by given {@link ContentFilter}
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testListFilterProjects() throws Exception {
+        user.addPermanentRole(ORG_ADMIN);
+        FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.CONTAINS, "name", "aaa");
+        ContentFilter filter = ContentManager.createFilter("my-filter", ContentFilter.Rule.ALLOW, ContentFilter.EntityType.PACKAGE, criteria, user);
+        ContentProject cp = new ContentProject("cplabel", "cpname", "cpdesc", user.getOrg());
+        ContentProjectFactory.save(cp);
+
+        assertTrue(ContentProjectFactory.listFilterProjects(filter).isEmpty());
+        cp.attachFilter(filter);
+        assertEquals(1, ContentProjectFactory.listFilterProjects(filter).size());
+        assertEquals(cp, ContentProjectFactory.listFilterProjects(filter).get(0));
+        cp.detachFilter(filter);
+        assertTrue(ContentProjectFactory.listFilterProjects(filter).isEmpty());
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentProjectFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentProjectFactoryTest.java
@@ -558,7 +558,7 @@ public class ContentProjectFactoryTest extends BaseTestCaseWithUser {
     public void testListFilterProjects() throws Exception {
         user.addPermanentRole(ORG_ADMIN);
         FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.CONTAINS, "name", "aaa");
-        ContentFilter filter = ContentManager.createFilter("my-filter", ContentFilter.Rule.ALLOW, ContentFilter.EntityType.PACKAGE, criteria, user);
+        ContentFilter filter = ContentManager.createFilter("my-filter", ContentFilter.Rule.DENY, ContentFilter.EntityType.PACKAGE, criteria, user);
         ContentProject cp = new ContentProject("cplabel", "cpname", "cpdesc", user.getOrg());
         ContentProjectFactory.save(cp);
 

--- a/java/code/src/com/redhat/rhn/frontend/events/AlignSoftwareTargetAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/AlignSoftwareTargetAction.java
@@ -22,6 +22,7 @@ import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.ChannelFactory;
 import com.redhat.rhn.domain.contentmgmt.ContentProjectFactory;
 import com.redhat.rhn.domain.contentmgmt.EnvironmentTarget.Status;
+import com.redhat.rhn.domain.contentmgmt.PackageFilter;
 import com.redhat.rhn.domain.contentmgmt.SoftwareEnvironmentTarget;
 import com.redhat.rhn.manager.EntityNotExistsException;
 import com.redhat.rhn.manager.channel.ChannelManager;
@@ -30,6 +31,7 @@ import org.apache.log4j.Logger;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import java.util.function.Consumer;
 
 /**
@@ -58,7 +60,8 @@ public class AlignSoftwareTargetAction implements MessageAction {
 
             LOG.info("Asynchronously aligning: " + msg);
             Instant start = Instant.now();
-            ChannelManager.alignEnvironmentTargetSync(source, targetChannel, msg.getUser());
+            List<PackageFilter> packageFilters = target.getContentEnvironment().getContentProject().getPackageFilters();
+            ChannelManager.alignEnvironmentTargetSync(packageFilters, source, targetChannel, msg.getUser());
             target.setStatus(Status.GENERATING_REPODATA);
             LOG.info("Finished aligning " + msg + " in " + Duration.between(start, Instant.now()));
         }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ContentFilterSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ContentFilterSerializer.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.frontend.xmlrpc.serializer;
+
+import com.redhat.rhn.domain.contentmgmt.ContentFilter;
+import com.redhat.rhn.domain.contentmgmt.FilterCriteria;
+import com.redhat.rhn.frontend.xmlrpc.serializer.util.SerializerHelper;
+import redstone.xmlrpc.XmlRpcException;
+import redstone.xmlrpc.XmlRpcSerializer;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.HashMap;
+
+/**
+ * Serializer for {@link ContentFilter}
+ *
+ * @xmlrpc.doc
+ * #struct("Content Filter information")
+ *   #prop("int", "id")
+ *   #prop("string", "name")
+ *   #prop("int", "orgId")
+ *   #prop("entityType", "Entity type (e.g. 'package')")
+ *   #prop("rule", "Rule (e.g. 'deny')")
+ *   #struct("criteria")
+ *       #prop_desc("string", "matcher", "The matcher type of the filter (e.g. 'contains')")
+ *       #prop_desc("string", "field", "The entity field to match (e.g. 'name'")
+ *       #prop_desc("string", "value", "The field value to match (e.g. 'kernel')")
+ *   #struct_end()
+ * #struct_end()
+ */
+public class ContentFilterSerializer extends RhnXmlRpcCustomSerializer {
+
+    @Override
+    public Class getSupportedClass() {
+        return ContentFilter.class;
+    }
+
+    @Override
+    protected void doSerialize(Object obj, Writer writer, XmlRpcSerializer serializer)
+            throws XmlRpcException, IOException {
+        ContentFilter filter = (ContentFilter) obj;
+        SerializerHelper helper = new SerializerHelper(serializer);
+        helper.add("id", filter.getId());
+        helper.add("name", filter.getName());
+        helper.add("orgId", filter.getOrg().getId());
+        helper.add("entityType", filter.getEntityType().getLabel());
+        helper.add("rule", filter.getRule().getLabel());
+        helper.add("criteria", criteriaToMap(filter.getCriteria()));
+        helper.writeTo(writer);
+    }
+
+    private HashMap<Object, Object> criteriaToMap(FilterCriteria criteria) {
+        HashMap<Object, Object> map = new HashMap<>();
+        map.put("matcher", criteria.getMatcher().getLabel());
+        map.put("field", criteria.getField());
+        map.put("value", criteria.getValue());
+        return map;
+    }
+}

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ContentProjectFilterSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ContentProjectFilterSerializer.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.frontend.xmlrpc.serializer;
+
+import com.redhat.rhn.domain.contentmgmt.ContentProjectFilter;
+import com.redhat.rhn.frontend.xmlrpc.serializer.util.SerializerHelper;
+import redstone.xmlrpc.XmlRpcException;
+import redstone.xmlrpc.XmlRpcSerializer;
+
+import java.io.IOException;
+import java.io.Writer;
+
+/**
+ * Serializer for {@link ContentProjectFilter}
+ * Also serializes the information about the associated {@link ContentFilter}
+ *
+ * @xmlrpc.doc
+ * #struct("Assigned Content Filter information")
+ *   #prop("string", "state")
+ *   $ContentFilterSerializer
+ * #struct_end()
+ */
+public class ContentProjectFilterSerializer extends RhnXmlRpcCustomSerializer {
+
+    @Override
+    public Class getSupportedClass() {
+        return ContentProjectFilter.class;
+    }
+
+    @Override
+    protected void doSerialize(Object obj, Writer writer, XmlRpcSerializer serializer)
+            throws XmlRpcException, IOException {
+        ContentProjectFilter filter = (ContentProjectFilter) obj;
+        SerializerHelper helper = new SerializerHelper(serializer);
+        helper.add("state", filter.getState());
+        helper.add("filter", filter.getFilter());
+        helper.writeTo(writer);
+    }
+}

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/SerializerRegistry.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/SerializerRegistry.java
@@ -135,6 +135,8 @@ public class SerializerRegistry {
         SERIALIZER_CLASSES.add(ContentProjectSerializer.class);
         SERIALIZER_CLASSES.add(ContentEnvironmentSerializer.class);
         SERIALIZER_CLASSES.add(ContentProjectSourceSerializer.class);
+        SERIALIZER_CLASSES.add(ContentFilterSerializer.class);
+        SERIALIZER_CLASSES.add(ContentProjectFilterSerializer.class);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
@@ -41,6 +41,7 @@ import com.redhat.rhn.domain.channel.ProductName;
 import com.redhat.rhn.domain.channel.ReleaseChannelMap;
 import com.redhat.rhn.domain.contentmgmt.ContentProjectFactory;
 import com.redhat.rhn.domain.contentmgmt.EnvironmentTarget;
+import com.redhat.rhn.domain.contentmgmt.PackageFilter;
 import com.redhat.rhn.domain.contentmgmt.SoftwareEnvironmentTarget;
 import com.redhat.rhn.domain.errata.Errata;
 import com.redhat.rhn.domain.kickstart.KickstartData;
@@ -2777,13 +2778,15 @@ public class ChannelManager extends BaseManager {
      * Synchronously align packages and errata of the {@link SoftwareEnvironmentTarget} to the source {@link Channel}
      * This method is potentially time-expensive and should be run asynchronously (@see alignEnvironmentTarget)
      *
+     * @param filters the {@link PackageFilter}s
      * @param src the source {@link Channel}
      * @param tgt the target {@link SoftwareEnvironmentTarget}
      * @param user the user
      */
-    public static void alignEnvironmentTargetSync(Channel src, Channel tgt, User user) {
+    public static void alignEnvironmentTargetSync(Collection<PackageFilter> filters, Channel src, Channel tgt,
+            User user) {
         // align packages and the cache (rhnServerNeededCache)
-        alignPackages(src, tgt);
+        alignPackages(src, tgt, filters);
 
         // align errata and the cache (rhnServerNeededCache)
         ErrataManager.mergeErrataToChannel(user, src.getErratas(), tgt, src, false, false);
@@ -2798,7 +2801,7 @@ public class ChannelManager extends BaseManager {
         ChannelManager.queueChannelChange(tgt.getLabel(), "java::alignChannel", "Channel aligned");
     }
 
-    private static void alignPackages(Channel srcChannel, Channel tgtChannel) {
+    private static void alignPackages(Channel srcChannel, Channel tgtChannel, Collection<PackageFilter> filters) {
         Set<Package> onlyInTgt = new HashSet<>(tgtChannel.getPackages());
         onlyInTgt.removeAll(srcChannel.getPackages());
         Set<Package> onlyInSrc = new HashSet<>(srcChannel.getPackages());

--- a/java/code/src/com/redhat/rhn/manager/channel/test/ChannelManagerContentAlignmentTest.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/test/ChannelManagerContentAlignmentTest.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.redhat.rhn.domain.role.RoleFactory.ORG_ADMIN;
+import static java.util.Collections.emptyList;
 import static java.util.Optional.of;
 import static java.util.stream.Collectors.toSet;
 
@@ -88,7 +89,7 @@ public class ChannelManagerContentAlignmentTest extends BaseTestCaseWithUser {
     public void testAlignEntities() throws Exception {
         // let's add a package to the target. it should be removed after aligning
         tgtChannel.getPackages().add(PackageTest.createTestPackage(user.getOrg()));
-        ChannelManager.alignEnvironmentTargetSync(srcChannel, tgtChannel, user);
+        ChannelManager.alignEnvironmentTargetSync(emptyList(), srcChannel, tgtChannel, user);
 
         // check that newest packages cache has been updated
         assertEquals(
@@ -116,7 +117,7 @@ public class ChannelManagerContentAlignmentTest extends BaseTestCaseWithUser {
         assertEquals(pack2.getId(), ChannelManager.getLatestPackageEqual(tgtChannel.getId(), pack2.getPackageName().getName()));
         assertNull(ChannelManager.getLatestPackageEqual(tgtChannel.getId(), pkg.getPackageName().getName()));
 
-        ChannelManager.alignEnvironmentTargetSync(srcChannel, tgtChannel, user);
+        ChannelManager.alignEnvironmentTargetSync(emptyList(), srcChannel, tgtChannel, user);
         assertEquals(pkg.getId(), ChannelManager.getLatestPackageEqual(tgtChannel.getId(), pkg.getPackageName().getName()));
         assertNull(ChannelManager.getLatestPackageEqual(tgtChannel.getId(), pack2.getPackageName().getName()));
     }
@@ -136,7 +137,7 @@ public class ChannelManagerContentAlignmentTest extends BaseTestCaseWithUser {
 
         SystemManager.subscribeServerToChannel(user, server, tgtChannel);
 
-        ChannelManager.alignEnvironmentTargetSync(srcChannel, tgtChannel, user);
+        ChannelManager.alignEnvironmentTargetSync(emptyList(), srcChannel, tgtChannel, user);
         assertEquals(errata.getId(), SystemManager.relevantErrata(user, server.getId()).get(0).getId());
     }
 
@@ -158,7 +159,7 @@ public class ChannelManagerContentAlignmentTest extends BaseTestCaseWithUser {
         List<SystemOverview> systemsWithNeededPackage = SystemManager.listSystemsWithNeededPackage(user, pkg.getId());
         assertTrue(systemsWithNeededPackage.isEmpty());
 
-        ChannelManager.alignEnvironmentTargetSync(srcChannel, tgtChannel, user);
+        ChannelManager.alignEnvironmentTargetSync(emptyList(), srcChannel, tgtChannel, user);
         systemsWithNeededPackage = SystemManager.listSystemsWithNeededPackage(user, pkg.getId());
         assertEquals(1, systemsWithNeededPackage.size());
         assertEquals(server.getId(), systemsWithNeededPackage.get(0).getId());
@@ -188,7 +189,7 @@ public class ChannelManagerContentAlignmentTest extends BaseTestCaseWithUser {
         assertEquals(1, systemsWithNeededPackage.size());
         assertEquals(server.getId(), systemsWithNeededPackage.get(0).getId());
 
-        ChannelManager.alignEnvironmentTargetSync(srcChannel, tgtChannel, user);
+        ChannelManager.alignEnvironmentTargetSync(emptyList(), srcChannel, tgtChannel, user);
         systemsWithNeededPackage = SystemManager.listSystemsWithNeededPackage(user, otherPkg.getId());
         assertTrue(systemsWithNeededPackage.isEmpty());
     }
@@ -204,7 +205,7 @@ public class ChannelManagerContentAlignmentTest extends BaseTestCaseWithUser {
         Errata toRemove = ErrataFactoryTest.createTestPublishedErrata(user.getOrg().getId());;
         tgtChannel.addErrata(toRemove);
 
-        ChannelManager.alignEnvironmentTargetSync(srcChannel, tgtChannel, user);
+        ChannelManager.alignEnvironmentTargetSync(emptyList(), srcChannel, tgtChannel, user);
 
         // check that packages and errata have been aligned
         assertEquals(srcChannel.getPackages(), tgtChannel.getPackages());

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -426,6 +426,9 @@ public class ContentManager {
         ensureOrgAdmin(user);
         ContentFilter filter = lookupFilterById(id, user)
                 .orElseThrow(() -> new EntityNotExistsException(id));
+        if (!ContentProjectFactory.listFilterProjects(filter).isEmpty()) {
+            throw new ContentManagementException("Can't delete filter " + id + " - it is used in Content Projects");
+        }
         return ContentProjectFactory.remove(filter);
     }
 

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
@@ -594,11 +594,11 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
 
     public void testLookupFilter() {
         FilterCriteria criteria = new FilterCriteria(Matcher.CONTAINS, "name", "aaa");
-        ContentFilter filter = ContentManager.createFilter("my-filter", Rule.ALLOW, EntityType.PACKAGE, criteria, user);
+        ContentFilter filter = ContentManager.createFilter("my-filter", Rule.DENY, EntityType.PACKAGE, criteria, user);
 
         ContentFilter fromDb = ContentManager.lookupFilterById(filter.getId(), user).get();
         assertEquals(filter, fromDb);
-        assertEquals(Rule.ALLOW, fromDb.getRule());
+        assertEquals(Rule.DENY, fromDb.getRule());
     }
 
     public void testLookupFilterNonAuthorizedUser() {
@@ -1035,7 +1035,7 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
         ContentEnvironment env = ContentManager.createEnvironment(cp.getLabel(), empty(), "fst", "first env", "desc", false, user);
         assertEquals(Long.valueOf(0), env.getVersion());
         FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.CONTAINS, "name", "aaa");
-        ContentFilter filter = ContentManager.createFilter("my-filter", ContentFilter.Rule.ALLOW, ContentFilter.EntityType.PACKAGE, criteria, user);
+        ContentFilter filter = ContentManager.createFilter("my-filter", ContentFilter.Rule.DENY, ContentFilter.EntityType.PACKAGE, criteria, user);
         Channel channel = createPopulatedChannel();
         ContentManager.attachSource("cplabel", SW_CHANNEL, channel.getLabel(), empty(), user);
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Implement packages filtering on Content Project build
 - Implement Content Filters operations and expose them in XMLRPC
 - Track and expose build status of Content Environment
 - Enable SLES11 OS Image Build Host

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Implement Content Filters operations and expose them in XMLRPC
 - Track and expose build status of Content Environment
 - Enable SLES11 OS Image Build Host
 - Add support for Salt batch execution mode

--- a/schema/spacewalk/common/tables/suseContentFilter.sql
+++ b/schema/spacewalk/common/tables/suseContentFilter.sql
@@ -22,7 +22,9 @@ CREATE TABLE suseContentFilter(
                      ON DELETE CASCADE,
     type     VARCHAR2(16) NOT NULL,
     name     VARCHAR2(128) NOT NULL,
-    criteria CLOB,
+    matcher  VARCHAR2(32) NOT NULL,
+    field    VARCHAR2(32) NOT NULL,
+    value    VARCHAR2(128) NOT NULL,
     created  TIMESTAMP WITH LOCAL TIME ZONE
                  DEFAULT (current_timestamp) NOT NULL,
     modified TIMESTAMP WITH LOCAL TIME ZONE

--- a/schema/spacewalk/common/tables/suseContentFilter.sql
+++ b/schema/spacewalk/common/tables/suseContentFilter.sql
@@ -21,6 +21,7 @@ CREATE TABLE suseContentFilter(
                      REFERENCES web_customer(id)
                      ON DELETE CASCADE,
     type     VARCHAR2(16) NOT NULL,
+    rule     VARCHAR2(16) NOT NULL,
     name     VARCHAR2(128) NOT NULL,
     matcher  VARCHAR2(32) NOT NULL,
     field    VARCHAR2(32) NOT NULL,

--- a/schema/spacewalk/common/tables/suseContentFilterProject.sql
+++ b/schema/spacewalk/common/tables/suseContentFilterProject.sql
@@ -24,8 +24,7 @@ CREATE TABLE suseContentFilterProject(
                    CONSTRAINT suse_ct_filter_pid_fk
                        REFERENCES suseContentProject(id)
                        ON DELETE CASCADE,
-    state      VARCHAR2(16),
-    position   NUMBER
+    state      VARCHAR2(16)
 )
 ENABLE ROW MOVEMENT
 ;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.10-to-susemanager-schema-4.0.11/030-content-filter-criteria.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.10-to-susemanager-schema-4.0.11/030-content-filter-criteria.sql.oracle
@@ -1,0 +1,2 @@
+-- intentionally left empty
+

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.10-to-susemanager-schema-4.0.11/030-content-filter-criteria.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.10-to-susemanager-schema-4.0.11/030-content-filter-criteria.sql.postgresql
@@ -1,0 +1,7 @@
+-- oracle equivalent source sha1 98c02e574d4346f7eecade4697a2b26a13abaa28
+
+ALTER TABLE suseContentFilter ADD COLUMN IF NOT EXISTS matcher VARCHAR(32);
+ALTER TABLE suseContentFilter ADD COLUMN IF NOT EXISTS field VARCHAR(32);
+ALTER TABLE suseContentFilter ADD COLUMN IF NOT EXISTS value VARCHAR(128);
+ALTER TABLE suseContentFilter DROP COLUMN IF EXISTS criteria;
+

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.10-to-susemanager-schema-4.0.11/040-content-filter-rule.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.10-to-susemanager-schema-4.0.11/040-content-filter-rule.sql.oracle
@@ -1,0 +1,2 @@
+-- intentionally left empty
+

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.10-to-susemanager-schema-4.0.11/040-content-filter-rule.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.10-to-susemanager-schema-4.0.11/040-content-filter-rule.sql.postgresql
@@ -1,0 +1,4 @@
+-- oracle equivalent source sha1 98c02e574d4346f7eecade4697a2b26a13abaa28
+
+ALTER TABLE suseContentFilter ADD COLUMN IF NOT EXISTS rule VARCHAR(16);
+

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.10-to-susemanager-schema-4.0.11/050-drop-susecontentfilterproject-position.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.10-to-susemanager-schema-4.0.11/050-drop-susecontentfilterproject-position.sql.oracle
@@ -1,0 +1,2 @@
+-- intentionally left empty
+

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.10-to-susemanager-schema-4.0.11/050-drop-susecontentfilterproject-position.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.10-to-susemanager-schema-4.0.11/050-drop-susecontentfilterproject-position.sql.postgresql
@@ -1,0 +1,4 @@
+-- oracle equivalent source sha1 98c02e574d4346f7eecade4697a2b26a13abaa28
+
+ALTER TABLE suseContentFilterProject DROP COLUMN IF EXISTS position;
+


### PR DESCRIPTION
## What does this PR change?
 
The PR https://github.com/uyuni-project/uyuni/pull/842 introduced Content
Filters CRUD/Attaching/Detaching.

This PR is a follow up and contains implementation of filtering the content on
Project build.

For now only `DENY` filters on package name are supported.

Review commit-by-commit. The PR contains all dependant commits from other PRs.
Without them it's pretty small (~200 LOC).
 
 ## GUI diff
 
 No difference.
 
 Before:
 
 After:
 
 - [x] **DONE**
 
 ## Documentation
 - No documentation needed: **add explanation. This can't be used if there is a GUI diff**
 - [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)
 
 - [ ] **DONE**
 
 ## Test coverage
 - Unit tests were added
 
 - [x] **DONE**
 
 ## Links
 
 Tracks https://github.com/SUSE/spacewalk/issues/6540
 
 - [x] **DONE**
 
 ## Changelogs
 
 If you don't need a changelog check, please mark this checkbox:
 
 - [ ] No changelog needed
 
 If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
 
 
 ## Re-run a test
 
 If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:
 
 - [ ] Re-run test "changelog_test"
 - [ ] Re-run test "backend_unittests_pgsql"
 - [ ] Re-run test "java_lint_checkstyle"		 
 - [ ] Re-run test "java_pgsql_tests"		 
 - [ ] Re-run test "ruby_rubocop"
 - [ ] Re-run test "schema_migration_test_oracle"
 - [ ] Re-run test "schema_migration_test_pgsql"		 
 - [ ] Re-run test "susemanager_unittests"
 - [ ] Re-run test "javascript_lint"