### PR TITLE
Use python3 for spacewalk-report (bsc#1132353)

### DIFF
--- a/reporting/spacewalk-report
+++ b/reporting/spacewalk-report
@@ -1,4 +1,4 @@
-#!/usr/bin/python -u
+#!/usr/bin/python3 -u
 #
 # Copyright (c) 2008--2015 Red Hat, Inc.
 #

--- a/reporting/spacewalk-reports.changes
+++ b/reporting/spacewalk-reports.changes
@@ -1,3 +1,4 @@
+- Use Python 3 to run spacewalk-reports (bsc#1132353)
 - add makefile and pylint configuration
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Use python3 for `spacewalk-report`.

## GUI diff

No difference.

## Documentation
- No documentation needed

## Test coverage
- No tests

## Links

Fixes https://github.com/SUSE/spacewalk/issues/7580

# Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
