### PR TITLE
Fix overriding of the suma-minion-startup flag

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -875,10 +875,8 @@ public class SaltService {
      */
     public void updateSystemInfo(MinionList minionTarget) {
         try {
-            Map<String, Object> metadata = new HashMap<>();
-            metadata.put(ScheduleMetadata.SUMA_MINION_STARTUP, true);
-            callAsync(State.apply(Arrays.asList(ApplyStatesEventMessage.SYSTEM_INFO),
-                            Optional.empty()).withMetadata(metadata), minionTarget);
+            callAsync(State.apply(Arrays.asList(ApplyStatesEventMessage.SYSTEM_INFO), Optional.empty()), minionTarget,
+                    Optional.of(ScheduleMetadata.getDefaultMetadata().withMinionStartup()));
         }
         catch (SaltException ex) {
             LOG.debug("Error while executing util.systeminfo state: " + ex.getMessage());

--- a/java/code/src/com/suse/manager/webui/utils/salt/custom/ScheduleMetadata.java
+++ b/java/code/src/com/suse/manager/webui/utils/salt/custom/ScheduleMetadata.java
@@ -39,20 +39,25 @@ public class ScheduleMetadata {
     @SerializedName(BATCH_MODE)
     private final boolean batchMode;
 
+    @SerializedName(SUMA_MINION_STARTUP)
+    private boolean minionStartup;
+
     /**
      * Constructor for ScheduleMetadata
      * @param sumaActionIdIn the Id of the action
      * @param forcePackageListRefreshIn whether the schedule action should force a package list refresh
      * @param actionChainIn whether the schedule action is corresponds to an action chain
      * @param batchModeIn whether the schedule action is executed in batch mode
+     * @param minionStartupIn whether the schedule action corresponds to a minion start up
      */
     public ScheduleMetadata(Long sumaActionIdIn, boolean forcePackageListRefreshIn, boolean actionChainIn,
-            boolean batchModeIn) {
+            boolean batchModeIn, boolean minionStartupIn) {
         super();
         this.sumaActionId = sumaActionIdIn;
         this.forcePackageListRefresh = forcePackageListRefreshIn;
         this.actionChain = actionChainIn;
         this.batchMode = batchModeIn;
+        this.minionStartup = minionStartupIn;
     }
 
     /**
@@ -60,13 +65,15 @@ public class ScheduleMetadata {
      * @param forcePackageListRefreshIn whether the schedule action should force a package list refresh
      * @param actionChainIn whether the schedule action is corresponds to an action chain
      * @param batchModeIn whether the schedule action is executed in batch mode
+     * @param minionStartupIn whether the schedule action corresponds to a minion start up
      */
     public ScheduleMetadata(boolean forcePackageListRefreshIn, boolean actionChainIn,
-            boolean batchModeIn) {
+            boolean batchModeIn, boolean minionStartupIn) {
         super();
         this.forcePackageListRefresh = forcePackageListRefreshIn;
         this.actionChain = actionChainIn;
         this.batchMode = batchModeIn;
+        this.minionStartup = minionStartupIn;
     }
 
     /**
@@ -74,11 +81,8 @@ public class ScheduleMetadata {
      * @return the new instance of ScheduleMetadata
      */
     public static ScheduleMetadata getDefaultMetadata() {
-        return new ScheduleMetadata(false, false, false);
+        return new ScheduleMetadata(false, false, false, false);
     }
-
-    @SerializedName(SUMA_MINION_STARTUP)
-    private boolean minionStartup;
 
     /**
      * Returns a new instance of ScheduleMetadata for actions to be executed in regular minions.
@@ -90,9 +94,9 @@ public class ScheduleMetadata {
     public static ScheduleMetadata getMetadataForRegularMinionActions(boolean isStagingJob,
             boolean forcePackageListRefresh, long actionId) {
         if (!isStagingJob) {
-            return new ScheduleMetadata(actionId, forcePackageListRefresh, false, false);
+            return new ScheduleMetadata(actionId, forcePackageListRefresh, false, false, false);
         }
-        return new ScheduleMetadata(forcePackageListRefresh, false, false);
+        return new ScheduleMetadata(forcePackageListRefresh, false, false, false);
     }
 
     /**
@@ -100,7 +104,7 @@ public class ScheduleMetadata {
      * @return an instance of ScheduleMetadata with batchMode flag set in true
      */
     public ScheduleMetadata withBatchMode() {
-        return new ScheduleMetadata(sumaActionId, forcePackageListRefresh, actionChain, true);
+        return new ScheduleMetadata(sumaActionId, forcePackageListRefresh, actionChain, true, minionStartup);
     }
 
     /**
@@ -108,7 +112,15 @@ public class ScheduleMetadata {
      * @return an instance of ScheduleMetadata with the actionChain flag set in true
      */
     public ScheduleMetadata withActionChain() {
-        return new ScheduleMetadata(sumaActionId, forcePackageListRefresh, true, batchMode);
+        return new ScheduleMetadata(sumaActionId, forcePackageListRefresh, true, batchMode, minionStartup);
+    }
+
+    /**
+     * Sets the minionStartup flag in true
+     * @return an instance of ScheduleMetadata with the minionStartup flag set in true
+     */
+    public ScheduleMetadata withMinionStartup() {
+        return new ScheduleMetadata(sumaActionId, forcePackageListRefresh, actionChain, batchMode, true);
     }
 
     /**


### PR DESCRIPTION
## What does this PR change?
Fix the overriding of the suma-minion-startup flag, introduced in https://github.com/uyuni-project/uyuni/pull/831

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bug fixing

- [ ] **DONE**

## Test coverage
- No tests: bug fixing

- [x] **DONE**

## Links

Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
