### PR TITLE
mgr-create-bootstrap-repo needs to stop looking when alternative is found (bsc#1132526)

### DIFF
--- a/susemanager/src/mgr-create-bootstrap-repo
+++ b/susemanager/src/mgr-create-bootstrap-repo
@@ -282,6 +282,7 @@ def create_repo(label, flush, additional=[]):
                 logging.debug("copy {0} / {1} to {2}".format(basepath, p['path'], rpmdir))
                 if not dryrun:
                     shutil.copy2(os.path.join(basepath, p['path']), rpmdir)
+            break
 
     if dryrun:
         if repotype == 'deb':

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,7 @@
+- mgr-create-bootstrap-repo will stop looking for alternatives
+  when one is found, to avoid failures when one of them is
+  missing (bsc#1132526)
+
 -------------------------------------------------------------------
 Mon Apr 22 12:19:36 CEST 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

mgr-create-bootstrap-repo will now stop looking for alternatives when one is found, to avoid failures when one of them is missing (bsc#1132526)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Bugfix

- [x] **DONE**

## Test coverage
- No tests: Bugfix, not covered by tests (Leap 15)

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/7660 and https://bugzilla.suse.com/show_bug.cgi?id=1132526

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
