### PR TITLE
Adapt test suite to new Retail naming convention

### DIFF
--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -87,7 +87,7 @@ def get_system_name(host)
     # The PXE boot minion is not directly accessible on the network,
     # therefore it is not represented by a twopence node
     output, _code = $server.run('salt-key')
-    system_name = output.split.find { |word| word =~ /example.Intel-Genuine-None-/ }
+    system_name = output.split.find { |word| word =~ /example.pxeboot-/ }
     system_name = '' if system_name.nil?
   else
     node = get_target(host)


### PR DESCRIPTION
## What does this PR change?

This PR adapts the test suite to the new terminal names.

Fixes SUSE/spacewalk#7574
3.2 port: SUSE/spacewalk#7612

- [x] No changelog needed
