### PR TITLE
Manager bsc1131408

### DIFF
--- a/client/tools/mgr-cfg/mgr-cfg.changes
+++ b/client/tools/mgr-cfg/mgr-cfg.changes
@@ -1,3 +1,5 @@
+- create client tools compat links also for non-SUSE systems
+  (bsc#1131408)
 - Add makefile and configuration for pylint
 
 -------------------------------------------------------------------

--- a/client/tools/mgr-cfg/mgr-cfg.spec
+++ b/client/tools/mgr-cfg/mgr-cfg.spec
@@ -345,10 +345,11 @@ for i in \
     ln -s $(basename "$i")%{default_suffix} "$RPM_BUILD_ROOT$i"
 done
 
-%if 0%{?suse_version}
 ln -s rhncfg-manager $RPM_BUILD_ROOT/%{_bindir}/mgrcfg-manager
 ln -s rhncfg-client $RPM_BUILD_ROOT/%{_bindir}/mgrcfg-client
 ln -s rhn-actions-control $RPM_BUILD_ROOT/%{_bindir}/mgr-actions-control
+
+%if 0%{?suse_version}
 %if 0%{?build_py2}
 %py_compile -O %{buildroot}/%{python_sitelib}
 %endif


### PR DESCRIPTION
## What does this PR change?

Client tools such as "mgr-actions-control" should be available under the old name AND under their new name on all systems, not just SUSE systems. Create respective symbolic links unconditionally.