### PR TITLE
return empty list if a mirror list does not exist

### DIFF
--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -467,7 +467,11 @@ class ContentSource:
         mirrorlist_path = os.path.join(repo.root, 'mirrorlist.txt')
         returnlist = []
         content = []
-        urlgrabber.urlgrab(url, mirrorlist_path)
+        try:
+            urlgrabber.urlgrab(url, mirrorlist_path)
+        except Exception as exc:
+            # no mirror list found continue without
+            return returnlist
 
         def _replace_and_check_url(url_list):
             goodurls = []


### PR DESCRIPTION
## What does this PR change?

When a repository does not have a mirrorlist we sometimes get an exception which block the sync:

```
  File "/usr/lib/python3.6/site-packages/spacewalk/satellite_tools/repo_plugins/yum_src.py", line 470, in _get_mirror_list
    urlgrabber.urlgrab(url, mirrorlist_path)
  File "/usr/lib/python3.6/site-packages/urlgrabber/grabber.py", line 784, in urlgrab
    return default_grabber.urlgrab(url, filename, **kwargs)
  File "/usr/lib/python3.6/site-packages/urlgrabber/grabber.py", line 1205, in urlgrab
    raise err
urlgrabber.grabber.URLGrabError: [Errno 3] Not a normal file: /srv/www/htdocs/pub/TestRepo/
```

Now we catch the exception and return an empty list which continue the reposync process.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- fixes a test

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
