### PR TITLE
Match Ubuntu product info from grains (bsc#1132579)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/InstalledProduct.java
+++ b/java/code/src/com/redhat/rhn/domain/server/InstalledProduct.java
@@ -62,6 +62,15 @@ public class InstalledProduct extends BaseDomainHelper {
     }
 
     /**
+     * Instantiates a new installed product from a {@link SUSEProduct}.
+     *
+     * @param product SUSE product
+     */
+    public InstalledProduct(SUSEProduct product) {
+        this(product.getName(), product.getVersion(), product.getArch(), product.getRelease(), product.isBase());
+    }
+
+    /**
      * @return the id
      */
     public Long getId() {

--- a/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
@@ -2519,7 +2519,7 @@ public class ChannelManager extends BaseManager {
                 "/pub");
         File theFile = new File(mountPoint + File.separator + pathPrefix +
                 File.separator + channel.getLabel() + File.separator +
-                "repomd.xml");
+                (channel.isTypeDeb() ? "Release" : "repomd.xml"));
         if (!theFile.exists()) {
             // No repo file, dont bother computing build date
             return null;

--- a/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
@@ -77,6 +77,7 @@ public class RegistrationUtils {
     );
 
     private static final String OS = "os";
+    private static final String OS_ARCH = "osarch";
 
     private static final Logger LOG = Logger.getLogger(RegistrationUtils.class);
 
@@ -357,6 +358,13 @@ public class RegistrationUtils {
                     return Stream.empty();
                 }
             }).collect(toSet());
+        }
+        else if ("ubuntu".equalsIgnoreCase(grains.getValueAsString(OS))) {
+            SUSEProduct product = SUSEProductFactory.findSUSEProduct("ubuntu-client",
+                    grains.getValueAsString("osrelease"), null, grains.getValueAsString(OS_ARCH) + "-deb", false);
+            if (product != null) {
+                return Collections.singleton(product);
+            }
         }
         return emptySet();
     }

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -1161,6 +1161,18 @@ public class SaltUtils {
                     rhelReleaseFile, centosReleaseFile);
             server.setInstalledProducts(products);
         }
+        else if ("ubuntu".equalsIgnoreCase((String) result.getGrains().get("os"))) {
+            String osArch = result.getGrains().get("osarch") + "-deb";
+            String osVersion = (String) result.getGrains().get("osrelease");
+            // Check if we have a product for the specific arch and version
+            SUSEProduct ubuntuProduct = SUSEProductFactory.findSUSEProduct("ubuntu-client", osVersion, null, osArch,
+                    false);
+            if (ubuntuProduct != null) {
+                InstalledProduct installedProduct = SUSEProductFactory.findInstalledProduct(ubuntuProduct)
+                        .orElse(new InstalledProduct(ubuntuProduct));
+                server.setInstalledProducts(Collections.singleton(installedProduct));
+            }
+        }
 
         // Update live patching version
         server.setKernelLiveVersion(result.getKernelLiveVersionInfo()

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix base channel selection for Ubuntu systems (bsc#1132579)
 - Fix retrieval of build time for .deb repositories (bsc#1131721)
 - Fix product package conflicts with SLES for SAP systems (bsc#1130551)
 - Take into account only synced products when scheduling SP migration from the API (bsc#1131929)

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix retrieval of build time for .deb repositories (bsc#1131721)
 - Fix product package conflicts with SLES for SAP systems (bsc#1130551)
 - Take into account only synced products when scheduling SP migration from the API (bsc#1131929)
 


### PR DESCRIPTION
Ubuntu vendor channels are not displayed for assignment, because Ubuntu installations are not recognized as supported products in the system. This PR adds product matching using OS related grains for Ubuntu systems at two points:

1. Match Ubuntu product on registration time to assign default base channels
2. Match Ubuntu products on profile refresh to add the installed product info

https://bugzilla.suse.com/1132579

Port of https://github.com/SUSE/spacewalk/pull/7613

## GUI diff

Before:
![ubuntu-product-before](https://user-images.githubusercontent.com/1103552/56200749-a93c0580-603f-11e9-9193-48ace9578a23.png)

After:
![ubuntu-product-after](https://user-images.githubusercontent.com/1103552/56200752-accf8c80-603f-11e9-9ddf-431346f9e79a.png)

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
