### PR TITLE
MinionActionChainCleanup should only be performed in case database is oracle

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/test/MinionActionCleanupTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/MinionActionCleanupTest.java
@@ -240,10 +240,17 @@ public class MinionActionCleanupTest extends JMockBaseTestCaseWithUser {
             }
 
             private void mockListJob(String jid) throws Exception {
-                allowing(saltServiceMock).listJob(jid);
-                will(returnValue(Optional.of(listJob("jobs.list_jobs." + jid + ".json",
-                        minion1.getMinionId(), Arrays.asList(action1_1.getId() + "", action1_2.getId() + ""),
-                        minion2.getMinionId(), Arrays.asList(action2_1.getId() + "", action2_2.getId() + "")))));
+                if (MinionActionUtils.POSTGRES) {
+                    never(saltServiceMock).jobsByMetadata(with(any(Object.class)));
+                    never(saltServiceMock).listJob(with(any(String.class)));
+                }
+                else {
+                    atLeast(1).of(saltServiceMock).listJob(jid);
+                    will(returnValue(Optional.of(listJob("jobs.list_jobs." + jid + ".json",
+                            minion1.getMinionId(), Arrays.asList(action1_1.getId() + "", action1_2.getId() + ""),
+                            minion2.getMinionId(), Arrays.asList(action2_1.getId() + "", action2_2.getId() + "")))));
+                }
+               
             }
         });
 
@@ -252,11 +259,13 @@ public class MinionActionCleanupTest extends JMockBaseTestCaseWithUser {
         ActionChainFactory.delete(actionChain);
 
         MinionActionUtils.cleanupMinionActionChains(saltServiceMock);
-
-        assertActionCompleted(action1_1);
-        assertActionCompleted(action1_2);
-        assertActionCompleted(action2_1);
-        assertActionCompleted(action2_2);
+        
+        if (!MinionActionUtils.POSTGRES) {
+            assertActionCompleted(action1_1);
+            assertActionCompleted(action1_2);
+            assertActionCompleted(action2_1);
+            assertActionCompleted(action2_2);
+        }
     }
 
     private void assertActionCompleted(Action action) {

--- a/java/code/src/com/suse/manager/webui/utils/MinionActionUtils.java
+++ b/java/code/src/com/suse/manager/webui/utils/MinionActionUtils.java
@@ -249,6 +249,11 @@ public class MinionActionUtils {
      * @param salt a SaltService instance
      */
     public static void cleanupMinionActionChains(SaltService salt) {
+        // if we are running on Postgres, there is no need to check Salt's job cache as job return events are already
+        // stored persistently via the database (see PGEventStream)
+        if (POSTGRES) {
+            return;
+        }
         Map<String, Object> metadata = new HashMap<>();
         metadata.put(ScheduleMetadata.SUMA_ACTION_CHAIN, true);
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Disable ActionChainCleanup if database is Postgres
 - Track and expose build status of Content Environment
 - Enable SLES11 OS Image Build Host
 - Add support for Salt batch execution mode


### PR DESCRIPTION
## What does this PR change?
This PR just adds a check so that MinionActionChainCleanup gets executed only for Oracle.


## GUI diff

No difference.


- [ ] **DONE**

## Documentation
-- No documentation needed: Performance improvement, nothing to be documented

- [ ] **DONE**

## Test coverage
- No tests: **Existing tests should cover it, needed modifications are done**

- [ ] **DONE**

## Links

Fixes #   https://github.com/SUSE/spacewalk/issues/7404
Tracks # **https://github.com/SUSE/spacewalk/pull/7568**

- [ ] **DONE**


- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test



- [ ] Re-run test "changelog_test"    
