### PR TITLE
Testsuite - ubuntu package installation check

### DIFF
--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -406,6 +406,7 @@ The check box can be identified by name, id or label text.
   When I wait for "virgo-dummy-1.0" to be installed on this "sle-minion"
   When I wait for "milkyway-dummy" to be uninstalled on "sle-minion"
   When I wait until refresh package list on "sle-minion" is finished
+  When I wait until package "virgo-dummy" is installed on "sle-minion" via spacecmd
   Then "man" should be installed on "sle-client"
   Then "milkyway-dummy" should not be installed on "sle-minion"
   Then spacecmd should show packages "virgo-dummy-1.0 milkyway-dummy" installed on "sle-minion"

--- a/testsuite/features/min_ubuntu_salt_install_package.feature
+++ b/testsuite/features/min_ubuntu_salt_install_package.feature
@@ -14,6 +14,7 @@ Feature: Install and upgrade package on the Ubuntu minion via Salt through the U
     And I click on "Update Package List"
     And I follow "Events" in the content area
     And I wait until I do not see "Package List Refresh scheduled by admin" text, refreshing the page
+    And I wait until package "virgo-dummy" is installed on "ubuntu-minion" via spacecmd
 
 @ubuntu_minion
   Scenario: Install a package on the minion

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -994,3 +994,20 @@ When(/^spacecmd should show packages "([^"]*)" installed on "([^"]*)"$/) do |pac
     raise "package #{pkg} is not installed" unless result.include? pkg
   end
 end
+
+When(/^I wait until package "([^"]*)" is installed on "([^"]*)" via spacecmd$/) do |pkg, client|
+  node = get_system_name(client)
+  command = "spacecmd -u admin -p admin system_listinstalledpackages #{node}"
+  long_wait_delay = 600
+  begin
+    Timeout.timeout(long_wait_delay) do
+      loop do
+        result, code = $server.run(command, false)
+        break if result.include? pkg
+        sleep 1
+      end
+    end
+  rescue Timeout::Error
+    raise "package #{pkg} is not installed after #{long_wait_delay} seconds"
+  end
+end


### PR DESCRIPTION
## What does this PR change?

PR adds check via spacecmd to ensure installed package is known to suse manager via spacecmd command. This prevents feature `Install and upgrade package on the Ubuntu minion via Salt through the UI` from random timing based failures.

## Links

Port of: https://github.com/SUSE/spacewalk/pull/7623
Issue: https://github.com/SUSE/spacewalk/issues/7536

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
