### PR TITLE
Uyuni test suite maintenance

### DIFF
--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -94,6 +94,7 @@ To check for the initial log in, prefer ```Then I am logged in```.
   Then I should not be authorized
 ```
 
+
 <a name="b2" />
 
 #### Navigating through pages
@@ -212,6 +213,7 @@ To check for the initial log in, prefer ```Then I am logged in```.
   When I close the window
 ```
 
+
 <a name="b3" />
 
 #### Texts
@@ -270,6 +272,7 @@ For a test with a regular expression, there is ```I should see a text like "..."
   When I follow first "Schedule System Reboot"
   When I click on "Use in SSM" for "newgroup"
 ```
+
 
 <a name="b5" />
 
@@ -614,6 +617,7 @@ The check box can be identified by name, id or label text.
   When I apply highstate on "sle-minion"
 ```
 
+
 <a name="b12" />
 
 #### XML-RPC
@@ -639,6 +643,7 @@ For example:
 ```cucumber
   When I call actionchain.add_package_install()
 ```
+
 
 <a name="b13" />
 
@@ -680,6 +685,7 @@ Then "test-vm" virtual machine on "virt-server" should have a "disk.qcow2" scsi 
 Then "test-vm" virtual machine on "virt-server" should have a virtio cdrom
 Then "test-vm" virtual machine on "virt-server" should have no cdrom
 ```
+
 
 <a name="c" />
 

--- a/testsuite/documentation/guidelines.md
+++ b/testsuite/documentation/guidelines.md
@@ -6,7 +6,7 @@
 * `testsuite/features/step_definition`: definition of real code executed, in Ruby
 * `testsuite/features/support`: general support functions
 * `testsuite/features/upload_files`: various data files uploaded into test machines by the testsuite
-* `testsuite/features/upload_files`: Docker and Kiwi profiles picked up from this git repository directly by SUSE Manager
+* `testsuite/features/profiles`: Docker and Kiwi profiles picked up from this git repository directly by SUSE Manager
 
 
 ### Grouping steps

--- a/testsuite/documentation/idempotency.md
+++ b/testsuite/documentation/idempotency.md
@@ -12,6 +12,7 @@ To acheive idempotency, you may create preparation scenarios at the beginning of
 
 The rest of this document details individual requirements for idempotency.
 
+
 ## Registration
 
 Each client must be correctly registered (in bootstrapped state) at the beginning of the feature.
@@ -23,9 +24,11 @@ As a standard status, we require that traditional clients and Salt minions have 
 
 If you remove a traditional client or minion, **always re-add** the base channel, otherwise all package and patch tests will fail.
 
+
 ## CentOS and Ubuntu minions
 
 CentOS and Ubuntu clients are always registered as SSH salt minions by defaut.
+
 
 ## Patches tests
 

--- a/testsuite/features/allcli_config_channel.feature
+++ b/testsuite/features/allcli_config_channel.feature
@@ -5,8 +5,7 @@ Feature: Management of configuration of all types of clients in a single channel
 
   Scenario: Create a configuration channel for mixed client types
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Create Config Channel"
     And I enter "Mixed Channel" as "cofName"
@@ -17,8 +16,7 @@ Feature: Management of configuration of all types of clients in a single channel
 
   Scenario: Add a configuration file to the mixed configuration channel
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Mixed Channel"
     And I follow "Create Configuration File or Directory"
@@ -84,8 +82,7 @@ Feature: Management of configuration of all types of clients in a single channel
 
   Scenario: Deploy the file to all systems
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I run "rhn-actions-control --enable-all" on "sle-client"
     And I follow "Channels" in the left menu
     And I follow "Mixed Channel"
@@ -146,8 +143,7 @@ Feature: Management of configuration of all types of clients in a single channel
 @centos_minion
   Scenario: Unsubscribe CentOS minion and delete configuration files
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Mixed Channel"
     And I follow "Systems" in the content area
@@ -159,8 +155,7 @@ Feature: Management of configuration of all types of clients in a single channel
 @ubuntu_minion
   Scenario: Unsubscribe Ubuntu minion and delete configuration files
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Mixed Channel"
     And I follow "Systems" in the content area
@@ -172,8 +167,7 @@ Feature: Management of configuration of all types of clients in a single channel
 @ssh_minion
   Scenario: Unsubscribe SSH minion and delete configuration files
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Mixed Channel"
     And I follow "Systems" in the content area
@@ -247,8 +241,7 @@ Feature: Management of configuration of all types of clients in a single channel
 
   Scenario: Cleanup: remove remaining systems from configuration channel
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Mixed Channel"
     And I follow "Systems" in the content area
@@ -259,8 +252,7 @@ Feature: Management of configuration of all types of clients in a single channel
 
   Scenario: Cleanup: remove the mixed configuration channel
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Mixed Channel"
     And I follow "Delete Channel"

--- a/testsuite/features/allcli_config_channel.feature
+++ b/testsuite/features/allcli_config_channel.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 SUSE LLC
+# Copyright (c) 2018-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Management of configuration of all types of clients in a single channel

--- a/testsuite/features/allcli_overview_systems_details.feature
+++ b/testsuite/features/allcli_overview_systems_details.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 SUSE LLC.
+# Copyright (c) 2017-2019 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 Feature: The system details of each minion and client provides an overview of the system

--- a/testsuite/features/allcli_reboot.feature
+++ b/testsuite/features/allcli_reboot.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2018 SUSE LLC.
+# Copyright (c) 2017-2019 SUSE LLC.
 # Licensed under the terms of the MIT license.
 #
 # Idempotency note:

--- a/testsuite/features/allcli_software_channels.feature
+++ b/testsuite/features/allcli_software_channels.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 SUSE LLC
+# Copyright (c) 2018-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Chanel subscription via SSM

--- a/testsuite/features/allcli_software_channels.feature
+++ b/testsuite/features/allcli_software_channels.feature
@@ -213,7 +213,7 @@ Feature: Chanel subscription via SSM
 
   Scenario: Cleanup: remove remaining systems from SSM
     Given I am authorized as "admin" with password "admin"
-    And I am on the System Overview page
+    When I am on the System Overview page
     And I uncheck the "sle-minion" client
     And I uncheck the "sle-client" client
-    And I should see "0" systems selected for SSM
+    Then I should see "0" systems selected for SSM

--- a/testsuite/features/allcli_software_channels_dependencies.feature
+++ b/testsuite/features/allcli_software_channels_dependencies.feature
@@ -29,8 +29,8 @@ Feature: Chanel subscription with recommended/required dependencies
     When I am on the System Overview page
     And I check the "sle-minion" client
     And I check the "sle-client" client
-    And I should see "2" systems selected for SSM
-    And I am on System Set Manager Overview
+    Then I should see "2" systems selected for SSM
+    When I am on System Set Manager Overview
     And I follow "channel memberships" in the content area
     Then I should see a "Base Channel" text
     And I should see a "Next" text

--- a/testsuite/features/allcli_system_group.feature
+++ b/testsuite/features/allcli_system_group.feature
@@ -84,7 +84,7 @@ Feature: Manage a group of systems
     And I click on "Leave Selected Groups"
     Then I should see a "1 system groups removed." text
 
-  Scenario: Cleanup: uninstall formula package from the server
+  Scenario: Cleanup: uninstall formula from the server
     Given I am authorized
     When I manually uninstall the "locale" formula from the server
 

--- a/testsuite/features/core_centos_salt_ssh.feature
+++ b/testsuite/features/core_centos_salt_ssh.feature
@@ -52,7 +52,7 @@ Feature: Bootstrap a SSH-managed CentOS minion and do some basic operations on i
     And I wait until event "Subscribe channels scheduled by admin" is completed
 
 @centos_minion
-  Scenario: Prepare a SSH-managed CentOS minion 
+  Scenario: Prepare a SSH-managed CentOS minion
     Given I am authorized
     When I enable repository "Devel_Galaxy_Manager_Head_RES-Manager-Tools-7-x86_64" on this "ceos-client"
     And  I enable repository "SLE-Manager-Tools-RES-7-x86_64" on this "ceos-client"

--- a/testsuite/features/core_first_settings.feature
+++ b/testsuite/features/core_first_settings.feature
@@ -80,18 +80,18 @@ Feature: Very first settings
     And service "tomcat" is enabled on "server"
     And service "tomcat" is active on "server"
 
-#  Scenario: Setup HTTP proxy
-#    When I am authorized as "admin" with password "admin"
-#    And I follow "Admin" in the left menu
-#    And I follow "Setup Wizard" in the left menu
-#    Then I should see a "HTTP Proxy Hostname" text
-#    And I should see a "HTTP Proxy Username" text
-#    And I should see a "HTTP Proxy Password" text
-#    When I enter "galaxy-proxy.mgr.suse.de:3128" as "HTTP Proxy Hostname"
-#    And I enter "suma" as "HTTP Proxy Username"
-#    And I enter "P4$$word" as "HTTP Proxy Password"
-#    And I click on "Save and Verify"
-#    Then I see verification succeeded
+  Scenario: Setup HTTP proxy
+    When I am authorized as "admin" with password "admin"
+    And I follow "Admin" in the left menu
+    And I follow "Setup Wizard" in the left menu
+    Then I should see a "HTTP Proxy Hostname" text
+    And I should see a "HTTP Proxy Username" text
+    And I should see a "HTTP Proxy Password" text
+    When I enter "galaxy-proxy.mgr.suse.de:3128" as "HTTP Proxy Hostname"
+    And I enter "suma" as "HTTP Proxy Username"
+    And I enter "P4$$word" as "HTTP Proxy Password"
+    And I click on "Save and Verify"
+    Then I see verification succeeded
 
   Scenario: Detect latest Salt changes on the server
     When I query latest Salt changes on "server"

--- a/testsuite/features/core_min_bootstrap.feature
+++ b/testsuite/features/core_min_bootstrap.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2018 SUSE LLC
+# Copyright (c) 2016-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Be able to bootstrap a Salt minion via the GUI

--- a/testsuite/features/core_min_salt_ssh.feature
+++ b/testsuite/features/core_min_salt_ssh.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2018 SUSE LLC
+# Copyright (c) 2016-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Be able to bootstrap a Salt host managed via salt-ssh

--- a/testsuite/features/core_proxy_branch_network.feature
+++ b/testsuite/features/core_proxy_branch_network.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 SUSE LLC
+# Copyright (c) 2018-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # The scenarios in this feature are skipped if there is no proxy

--- a/testsuite/features/core_proxy_register_as_minion_with_gui.feature
+++ b/testsuite/features/core_proxy_register_as_minion_with_gui.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2018 SUSE LLC
+# Copyright (c) 2017-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # The scenarios in this feature are skipped if there is no proxy

--- a/testsuite/features/core_proxy_register_as_minion_with_script.feature
+++ b/testsuite/features/core_proxy_register_as_minion_with_script.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2018 SUSE LLC
+# Copyright (c) 2017-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # The scenarios in this feature are skipped if there is no proxy

--- a/testsuite/features/core_srv_channels_add.feature
+++ b/testsuite/features/core_srv_channels_add.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 SUSE LLC
+# Copyright (c) 2015-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Adding channels

--- a/testsuite/features/core_srv_create_repository.feature
+++ b/testsuite/features/core_srv_create_repository.feature
@@ -9,8 +9,7 @@ Feature: Add a repository to a channel
 
   Scenario: Add a test repository for x86_64
     Given I am authorized as "testing" with password "testing"
-    When I follow "Home" in the left menu
-    And I follow "Channel List"
+    When I follow "Channel List"
     And I follow "Manage" in the left menu
     And I follow "Repositories" in the left menu
     And I follow "Create Repository"
@@ -22,8 +21,7 @@ Feature: Add a repository to a channel
 
   Scenario: Disable metadata check for the x86_64 test repository
     Given I am authorized as "testing" with password "testing"
-    When I follow "Home" in the left menu
-    And I follow "Channel List"
+    When I follow "Channel List"
     And I follow "Manage" in the left menu
     And I follow "Repositories" in the left menu
     And I follow "Test-Repository-x86_64"
@@ -34,8 +32,7 @@ Feature: Add a repository to a channel
 
   Scenario: Add the repository to the x86_64 channel
     Given I am authorized as "testing" with password "testing"
-    When I follow "Home" in the left menu
-    And I follow "Channel List"
+    When I follow "Channel List"
     And I follow "Manage" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Test-Channel-x86_64"
@@ -47,8 +44,7 @@ Feature: Add a repository to a channel
   Scenario: Synchronize the repository in the x86_64 channel
     Given I am authorized as "testing" with password "testing"
     When I enable source package syncing
-    And I follow "Home" in the left menu
-    And I follow "Channel List"
+    When I follow "Channel List"
     And I follow "Manage" in the left menu
     And I follow "Repositories" in the left menu
     And I follow "Channels" in the left menu
@@ -60,8 +56,7 @@ Feature: Add a repository to a channel
 
   Scenario: Add a test repository for i586
     Given I am authorized as "testing" with password "testing"
-    When I follow "Home" in the left menu
-    And I follow "Channel List"
+    When I follow "Channel List"
     And I follow "Manage" in the left menu
     And I follow "Repositories" in the left menu
     And I follow "Create Repository"
@@ -73,8 +68,7 @@ Feature: Add a repository to a channel
 
   Scenario: Add the repository to the i586 channel
     Given I am authorized as "testing" with password "testing"
-    When I follow "Home" in the left menu
-    And I follow "Channel List"
+    When I follow "Channel List"
     And I follow "Manage" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Test-Channel-i586"
@@ -86,7 +80,6 @@ Feature: Add a repository to a channel
   Scenario: Synchronize the repository in the i586 channel
     Given I am authorized as "testing" with password "testing"
     When I disable source package syncing
-    And I follow "Home" in the left menu
     And I follow "Channel List"
     And I follow "Manage" in the left menu
     And I follow "Channels" in the left menu
@@ -99,8 +92,7 @@ Feature: Add a repository to a channel
 @ubuntu_minion
   Scenario: Add a test repository for Ubuntu
     Given I am authorized as "testing" with password "testing"
-    When I follow "Home" in the left menu
-    And I follow "Channel List"
+    When I follow "Channel List"
     And I follow "Manage" in the left menu
     And I follow "Repositories" in the left menu
     And I follow "Create Repository"
@@ -113,8 +105,7 @@ Feature: Add a repository to a channel
 @ubuntu_minion
   Scenario: Add the Ubuntu repository to the AMD64 channel
     Given I am authorized as "testing" with password "testing"
-    When I follow "Home" in the left menu
-    And I follow "Channel List"
+    When I follow "Channel List"
     And I follow "Manage" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Test-Channel-Deb-AMD64"
@@ -126,8 +117,7 @@ Feature: Add a repository to a channel
 @ubuntu_minion
   Scenario: Synchronize the Ubuntu repository in the AMD64 channel
     Given I am authorized as "testing" with password "testing"
-    When I follow "Home" in the left menu
-    And I follow "Channel List"
+    When I follow "Channel List"
     And I follow "Manage" in the left menu
     And I follow "Repositories" in the left menu
     And I follow "Channels" in the left menu
@@ -160,8 +150,7 @@ Feature: Add a repository to a channel
 
   Scenario: Reposync handles wrong encoding on RPM attributes
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Channel List"
+    When I follow "Channel List"
     And I follow "Test-Channel-x86_64"
     And I follow "Packages" in the content area
     Then I should see a "blackhole-dummy" text
@@ -169,8 +158,7 @@ Feature: Add a repository to a channel
 @ubuntu_minion
   Scenario: Reposync handles wrong encoding on DEB attributes
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Channel List"
+    When I follow "Channel List"
     And I follow "Test-Channel-Deb-AMD64"
     And I follow "Packages" in the content area
     Then I should see a "blackhole-dummy" text

--- a/testsuite/features/core_srv_push_package.feature
+++ b/testsuite/features/core_srv_push_package.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 SUSE LLC
+# Copyright (c) 2015-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Push a package with unset vendor

--- a/testsuite/features/core_srv_setup_wizard.feature
+++ b/testsuite/features/core_srv_setup_wizard.feature
@@ -1,4 +1,4 @@
-# Copyright 2017-2018 SUSE LLC
+# Copyright 2017-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: The Setup Wizard

--- a/testsuite/features/core_srv_setup_wizard.feature
+++ b/testsuite/features/core_srv_setup_wizard.feature
@@ -12,8 +12,8 @@ Feature: The Setup Wizard
     And I should see a "Arch" text
     And I should see a "Channels" text
     And I should not see a "WebYaST 1.3" text
-    And I enter "RHEL Expanded Support 5" in the css "input[name='product-description-filter']"
-    And I should see a "RHEL Expanded Support 5" text
+    And I enter "RHEL Expanded Support 7" in the css "input[name='product-description-filter']"
+    And I should see a "RHEL Expanded Support 7" text
     Then I enter "" in the css "input[name='product-description-filter']"
     And I enter "SUSE Linux Enterprise Server 12 SP2" in the css "input[name='product-description-filter']"
     And I select "x86_64" in the dropdown list of the architecture filter

--- a/testsuite/features/min_action_chain.feature
+++ b/testsuite/features/min_action_chain.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 SUSE LLC
+# Copyright (c) 2018-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Action chain on salt minions

--- a/testsuite/features/min_action_chain.feature
+++ b/testsuite/features/min_action_chain.feature
@@ -74,8 +74,7 @@ Feature: Action chain on salt minions
 
   Scenario: Create a configuration channel for testing action chain on Salt minion
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Create Config Channel"
     And I enter "Action Chain Channel" as "cofName"
@@ -86,8 +85,7 @@ Feature: Action chain on salt minions
 
   Scenario: Add a configuration file to configuration channel for testing action chain on Salt minion
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Action Chain Channel"
     And I follow "Create Configuration File or Directory"
@@ -99,9 +97,7 @@ Feature: Action chain on salt minions
 
   Scenario: Subscribe system to configuration channel for testing action chain on Salt minion
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Systems" in the left menu
-    And I follow "Overview" in the left menu
+    When I follow "Systems > Overview" in the left menu
     And I follow this "sle-minion" link
     And I follow "Configuration" in the content area
     And I follow "Manage Configuration Channels" in the content area
@@ -113,8 +109,7 @@ Feature: Action chain on salt minions
 
   Scenario: Add a configuration file deployment to the action chain on Salt minion
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Action Chain Channel"
     And I follow "Deploy Files" in the content area
@@ -301,7 +296,6 @@ Feature: Action chain on salt minions
 
   Scenario: Cleanup: remove Salt client from configuration channel
     Given I am authorized as "admin" with password "admin"
-    And I follow "Home" in the left menu
     When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Action Chain Channel"
@@ -312,8 +306,7 @@ Feature: Action chain on salt minions
 
   Scenario: Cleanup: remove configuration channel for Salt minion
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Action Chain Channel"
     And I follow "Delete Channel"

--- a/testsuite/features/min_activationkey.feature
+++ b/testsuite/features/min_activationkey.feature
@@ -14,8 +14,7 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
 
   Scenario: Create a configuration channel for the activation key
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Create Config Channel"
     And I enter "Key Channel" as "cofName"
@@ -26,8 +25,7 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
 
   Scenario: Add a configuration file to the key configuration channel
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Key Channel"
     And I follow "Create Configuration File or Directory"
@@ -85,12 +83,12 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
     Then I run spacecmd listevents for "sle-minion"
 
   Scenario: Verify that minion bootstrapped with activation key
-     Given I am on the Systems overview page of this "sle-minion"
-     Then I should see a "Activation Key: 	1-MINION-TEST" text
+    Given I am on the Systems overview page of this "sle-minion"
+    Then I should see a "Activation Key: 	1-MINION-TEST" text
 
   Scenario: Verify that minion bootstrapped with base channel
-     Given I am on the Systems page
-     Then I should see a "Test-Channel-x86_64" text
+    Given I am on the Systems page
+    Then I should see a "Test-Channel-x86_64" text
 
   # bsc#1080807 - Assigning configuration channel in activation key doesn't work
   Scenario: Verify that minion bootstrapped with configuration channel
@@ -117,8 +115,7 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
 
   Scenario: Cleanup: remove the key configuration channel
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Key Channel"
     And I follow "Delete Channel"
@@ -126,7 +123,7 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
 
   Scenario: Cleanup: delete the activation key
     Given I am on the Systems page
-    And I follow "Activation Keys" in the left menu
+    When I follow "Activation Keys" in the left menu
     And I follow "Minion testing" in the content area
     And I follow "Delete Key"
     And I click on "Delete Activation Key"

--- a/testsuite/features/min_config_state_channel.feature
+++ b/testsuite/features/min_config_state_channel.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 SUSE LLC.
+# Copyright (c) 2018-2019 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 Feature: Configuration state channels

--- a/testsuite/features/min_config_state_channel.feature
+++ b/testsuite/features/min_config_state_channel.feature
@@ -7,8 +7,7 @@ Feature: Configuration state channels
 
   Scenario: Create a state channel
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Create State Channel"
     Then I should see a "New Config Channel" text
@@ -34,8 +33,7 @@ Feature: Configuration state channels
 
   Scenario: Salt state details
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "My State Channel"
     Then I should see a "1 system subscribed" text
@@ -56,8 +54,7 @@ Feature: Configuration state channels
 
   Scenario: Try to remove init.sls file
     Given I am authorized as "admin" with password "admin"
-    And I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "My State Channel"
     And I follow "View/Edit 'init.sls' File"
@@ -68,8 +65,7 @@ Feature: Configuration state channels
 
   Scenario: Cleanup: remove the state channel and the file
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "My State Channel"
     And I follow "Delete Channel"

--- a/testsuite/features/min_custom_pkg_download_endpoint.feature
+++ b/testsuite/features/min_custom_pkg_download_endpoint.feature
@@ -3,9 +3,6 @@
 #
 # In order to use different end-point to download rpms other than the manager instance itself, one can do so with 
 # setting pillar data values as mentioned in upload_files/rpm_enpoint.sls. These scenarios test this feature
-#
-#
-
 
 Feature: Repos file generation based on custom pillar data
 

--- a/testsuite/features/min_custom_pkg_download_endpoint.feature
+++ b/testsuite/features/min_custom_pkg_download_endpoint.feature
@@ -23,7 +23,7 @@ Feature: Repos file generation based on custom pillar data
   
   Scenario: Check the default RPM download point values
     Given I am on the Systems overview page of this "sle-minion"
-    Then the susmanager repo file should exist on the "sle-minion"
+    Then the susemanager repo file should exist on the "sle-minion"
     And I should see "https", "proxy" and "443" in the repo file on the "sle-minion"
  
   Scenario: Set the custom RPM download point
@@ -50,7 +50,7 @@ Feature: Repos file generation based on custom pillar data
   
   Scenario: Check the channel.repo file to see the custom RPM download point
     Given I am on the Systems overview page of this "sle-minion"
-    Then the susmanager repo file should exist on the "sle-minion"
+    Then the susemanager repo file should exist on the "sle-minion"
     And I should see "ftp", "scc.com" and "445" in the repo file on the "sle-minion"  
   
   Scenario: Remove the custom RPM download point
@@ -76,6 +76,6 @@ Feature: Repos file generation based on custom pillar data
   
   Scenario: ReCheck the default RPM download point values
     Given I am on the Systems overview page of this "sle-minion"
-    Then the susmanager repo file should exist on the "sle-minion"
+    Then the susemanager repo file should exist on the "sle-minion"
     And I should see "https", "proxy" and "443" in the repo file on the "sle-minion"  
     

--- a/testsuite/features/min_docker_auth_registry.feature
+++ b/testsuite/features/min_docker_auth_registry.feature
@@ -5,7 +5,7 @@ Feature: Build image with authenticated registry
 
   Scenario: Create an authenticated image store as Docker admin
     Given I am authorized as "docker" with password "docker"
-    And I follow "Images" in the left menu
+    When I follow "Images" in the left menu
     And I follow "Stores" in the left menu
     And I follow "Create"
     And I enter "portus" as "label"
@@ -15,7 +15,7 @@ Feature: Build image with authenticated registry
 
   Scenario: Create a profile for the authenticated image store as Docker admin
     Given I am authorized as "docker" with password "docker"
-    And I follow "Images" in the left menu
+    When I follow "Images" in the left menu
     And I follow "Profiles" in the left menu
     And I follow "Create"
     And I enter "portus_profile" as "label"
@@ -26,9 +26,9 @@ Feature: Build image with authenticated registry
 
   Scenario: Build an image in the authenticated image store
     Given I am authorized as "docker" with password "docker"
-    And I navigate to images build webpage
+    When I navigate to images build webpage
     And I select "portus_profile" from "profileId"
-    When I enter "latest" as "version"
+    And I enter "latest" as "version"
     And I select sle-minion hostname in Build Host
     And I click on "submit-btn"
     Then I wait until I see "portus_profile" text

--- a/testsuite/features/min_osimage_build_image.feature
+++ b/testsuite/features/min_osimage_build_image.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 SUSE LLC
+# Copyright (c) 2018-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # This feature relies on having properly configured

--- a/testsuite/features/min_salt_formulas.feature
+++ b/testsuite/features/min_salt_formulas.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2018 SUSE LLC
+# Copyright (c) 2017-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Use salt formulas

--- a/testsuite/features/min_salt_formulas.feature
+++ b/testsuite/features/min_salt_formulas.feature
@@ -50,7 +50,7 @@ Feature: Use salt formulas
      And the pillar data for "timezone" should be empty on "ssh-minion"
      And the pillar data for "keyboard_and_language" should be empty on "ssh-minion"
 
-  Scenario: Test the parametrized formula via the highstate
+  Scenario: Use the parametrized formula in test mode
      Given I am on the Systems overview page of this "sle-minion"
      And I follow "States" in the content area
      Then I should see the toggler "disabled"

--- a/testsuite/features/min_salt_install_package.feature
+++ b/testsuite/features/min_salt_install_package.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2018 SUSE LLC
+# Copyright (c) 2015-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Install a patch on the client via Salt through the UI

--- a/testsuite/features/min_salt_install_with_staging.feature
+++ b/testsuite/features/min_salt_install_with_staging.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2018 SUSE LLC
+# Copyright (c) 2017-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # This feature relies on having properly configured

--- a/testsuite/features/min_salt_pkgset_beacon.feature
+++ b/testsuite/features/min_salt_pkgset_beacon.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2018 SUSE LLC
+# Copyright (c) 2016-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: System package list is updated if packages are manually installed or removed

--- a/testsuite/features/min_salt_software_states.feature
+++ b/testsuite/features/min_salt_software_states.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2018 SUSE LLC
+# Copyright (c) 2016-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Salt package states

--- a/testsuite/features/min_state_config_channel.feature
+++ b/testsuite/features/min_state_config_channel.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 SUSE LLC.
+# Copyright (c) 2018-2019 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 Feature: State Configuration channels

--- a/testsuite/features/min_state_config_channel.feature
+++ b/testsuite/features/min_state_config_channel.feature
@@ -7,8 +7,7 @@ Feature: State Configuration channels
 
   Scenario: Create the 1st state channel
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Create State Channel"
     Then I should see a "New Config Channel" text
@@ -24,8 +23,7 @@ Feature: State Configuration channels
 
   Scenario: Create the 2nd state channel with same name
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Create State Channel"
     Then I should see a "New Config Channel" text
@@ -98,8 +96,7 @@ Feature: State Configuration channels
 
   Scenario: Cleanup: remove the 1st state channel and the deployed file
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow first "My State Channel"
     And I follow "Delete Channel"
@@ -110,8 +107,7 @@ Feature: State Configuration channels
 
   Scenario: Cleanup: remove the 2nd state channel and the deployed file
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow first "My State Channel"
     And I follow "Delete Channel"
@@ -122,8 +118,7 @@ Feature: State Configuration channels
 
   Scenario: Cleanup: remove the 3rd state channel and the deployed file
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow first "statechannel3"
     And I follow "Delete Channel"

--- a/testsuite/features/minssh_action_chain.feature
+++ b/testsuite/features/minssh_action_chain.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 SUSE LLC
+# Copyright (c) 2018-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # This feature is not tested if there is no SSH minion running

--- a/testsuite/features/minssh_action_chain.feature
+++ b/testsuite/features/minssh_action_chain.feature
@@ -84,8 +84,7 @@ Feature: Salt SSH action chain
 @ssh_minion
   Scenario: Create a configuration channel for testing action chain on SSH minion
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Create Config Channel"
     And I enter "Action Chain Channel" as "cofName"
@@ -97,8 +96,7 @@ Feature: Salt SSH action chain
 @ssh_minion
   Scenario: Add a configuration file to configuration channel for testing action chain on SSH minion
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Action Chain Channel"
     And I follow "Create Configuration File or Directory"
@@ -111,9 +109,7 @@ Feature: Salt SSH action chain
 @ssh_minion
   Scenario: Subscribe system to configuration channel for testing action chain on SSH minion
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Systems" in the left menu
-    And I follow "Overview" in the left menu
+    When I follow "Systems > Overview" in the left menu
     And I follow this "ssh-minion" link
     And I follow "Configuration" in the content area
     And I follow "Manage Configuration Channels" in the content area
@@ -126,8 +122,7 @@ Feature: Salt SSH action chain
 @ssh_minion
   Scenario: Add a configuration file deployment to the action chain on SSH minion
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Action Chain Channel"
     And I follow "Deploy Files" in the content area
@@ -281,7 +276,6 @@ Feature: Salt SSH action chain
 @ssh_minion
   Scenario: Cleanup: remove Salt client from configuration channel
     Given I am authorized as "admin" with password "admin"
-    And I follow "Home" in the left menu
     When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Action Chain Channel"
@@ -293,8 +287,7 @@ Feature: Salt SSH action chain
 @ssh_minion
   Scenario: Cleanup: remove configuration channel for SSH minion
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Action Chain Channel"
     And I follow "Delete Channel"

--- a/testsuite/features/srv_check_channels_page.feature
+++ b/testsuite/features/srv_check_channels_page.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-17 SUSE LLC
+# Copyright (c) 2015-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: The channels page

--- a/testsuite/features/srv_custom_system_info.feature
+++ b/testsuite/features/srv_custom_system_info.feature
@@ -5,9 +5,7 @@ Feature: Custom system info key-value pairs
 
   Background:
     Given I am authorized
-    And I follow "Home" in the left menu
-    And I follow "Systems"
-    And I follow "Overview" in the left menu
+    When I follow "Systems > Overview" in the left menu
 
   Scenario: Create a new key
     When I follow "Custom System Info" in the left menu

--- a/testsuite/features/srv_custom_system_info.feature
+++ b/testsuite/features/srv_custom_system_info.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 SUSE LLC
+# Copyright (c) 2017-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Custom system info key-value pairs

--- a/testsuite/features/srv_cve_audit.feature
+++ b/testsuite/features/srv_cve_audit.feature
@@ -93,7 +93,7 @@ Feature: CVE Audit
     Then I should get status "NOT_AFFECTED" for this client
     When I call audit.list_systems_by_patch_status with CVE identifier "CVE-1999-9999"
     Then I should get status "AFFECTED_PATCH_APPLICABLE" for this client
-    And I should get the test-channel
+    And I should get the test channel
     And I should get the "milkyway-dummy-2345" patch
     Then I logout from XML-RPC cve audit namespace
 

--- a/testsuite/features/srv_distro_cobbler.feature
+++ b/testsuite/features/srv_distro_cobbler.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2018 Novell, Inc.
+# Copyright (c) 2010-2019 Novell, Inc.
 # Licensed under the terms of the MIT license.
 
 Feature: Cobbler and distribution autoinstallation

--- a/testsuite/features/srv_distro_cobbler.feature
+++ b/testsuite/features/srv_distro_cobbler.feature
@@ -5,9 +5,7 @@ Feature: Cobbler and distribution autoinstallation
 
   Background:
     Given I am authorized
-    And I follow "Home" in the left menu
-    And I follow "Systems" in the left menu
-    And I follow "Overview" in the left menu
+    When I follow "Systems > Overview" in the left menu
 
   Scenario: Ask cobbler to create a distribution via XML-RPC
     Given cobblerd is running

--- a/testsuite/features/srv_smdba.feature
+++ b/testsuite/features/srv_smdba.feature
@@ -88,7 +88,7 @@ Feature: SMBDA database helper tool
     And when I issue command "smdba db-status"
     Given a postgresql database is running
     And database "susemanager" has no table "dummy"
-    Then I disable backup in the directory "/smdba-backup-test" 
+    When I disable backup in the directory "/smdba-backup-test"
     And I remove backup directory "/smdba-backup-test"
 
   Scenario: Start spacewalk services

--- a/testsuite/features/srv_susemanager_debug.feature
+++ b/testsuite/features/srv_susemanager_debug.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-17 SUSE LLC
+# Copyright (c) 2015-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Debug SUSE Manager after the testsuite has run

--- a/testsuite/features/srv_susemanager_debug.feature
+++ b/testsuite/features/srv_susemanager_debug.feature
@@ -7,10 +7,10 @@ Feature: Debug SUSE Manager after the testsuite has run
     Then I execute spacewalk-debug on the server
 
   Scenario: Check spacewalk upd2date logs on client
-    Then I control that up2date logs on client under test contains no Traceback error
+    Then the up2date logs on client should contain no Traceback error
 
   Scenario: Check the tomcat logs on server
     Then I check the tomcat logs for errors
 
   Scenario: Check salt event log for failures on server
-    Then I control that salt event log on server contains no failures
+    Then the salt event log on server should contain no failures

--- a/testsuite/features/srv_sync_products.feature
+++ b/testsuite/features/srv_sync_products.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 SUSE LLC
+# Copyright (c) 2018-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Be able to list available products and enable them

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -163,7 +163,7 @@ Then(/^I execute spacewalk-debug on the server$/) do
   end
 end
 
-When(/^the susmanager repo file should exist on the "([^"]*)"$/) do |host|
+Then(/^the susemanager repo file should exist on the "([^"]*)"$/) do |host|
   step %(file "/etc/zypp/repos.d/susemanager\:channels.repo" should exist on "#{host}")
 end
 

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -57,6 +57,7 @@ When(/^I wait at most (\d+) seconds until event "([^"]*)" is completed$/) do |fi
     And I wait until I do not see "#{event}" text, refreshing the page
     And I follow "History"
     And I wait until I see "System History" text
+    And I wait until I see "#{event}" text, refreshing the page
     And I follow first "#{event}"
     And I wait at most #{final_timeout} seconds until the event is completed, refreshing the page
   )
@@ -88,14 +89,14 @@ When(/^I follow the event "([^"]*)" completed during last minute$/) do |event|
 end
 
 # spacewalk errors steps
-Then(/^I control that up2date logs on client under test contains no Traceback error$/) do
+Then(/^the up2date logs on client should contain no Traceback error$/) do
   cmd = 'if grep "Traceback" /var/log/up2date ; then exit 1; else exit 0; fi'
   _out, code = $client.run(cmd)
   raise 'error found, check the client up2date logs' if code.nonzero?
 end
 
 # salt failures log check
-Then(/^I control that salt event log on server contains no failures$/) do
+Then(/^the salt event log on server should contain no failures$/) do
   # upload salt event parser log
   file = 'salt_event_parser.py'
   source = File.dirname(__FILE__) + '/../upload_files/' + file
@@ -214,10 +215,8 @@ end
 # systemspage and clobber
 Given(/^I am on the Systems page$/) do
   steps %(
-  When I am authorized as "admin" with password "admin"
-  And I follow "Home" in the left menu
-  And I follow "Systems" in the left menu
-  And I follow "Overview" in the left menu
+    When I am authorized as "admin" with password "admin"
+    And I follow "Systems > Overview" in the left menu
   )
 end
 

--- a/testsuite/features/step_definitions/datepicker_steps.rb
+++ b/testsuite/features/step_definitions/datepicker_steps.rb
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2019 SUSE
+# Licensed under the terms of the MIT license.
+
 require 'date'
 
 # Based on https://github.com/akarzim/capybara-bootstrap-datepicker

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -218,18 +218,13 @@ end
 # Click on a link
 #
 When(/^I follow "([^"]*)"$/) do |text|
-  begin
-    click_link(text)
-  rescue
-    sleep 3
-    click_link(text)
-  end
+  click_link(text, wait: CLICK_TIMEOUT)
 end
 #
 # Click on the first link
 #
 When(/^I follow first "([^"]*)"$/) do |text|
-  click_link(text, match: :first)
+  click_link(text, wait: CLICK_TIMEOUT, match: :first)
 end
 
 #

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2018 Novell, Inc.
+# Copyright (c) 2010-2019 Novell, Inc.
 # Licensed under the terms of the MIT license.
 
 #

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -1,4 +1,6 @@
 # Copyright 2015-2019 SUSE LLC
+# Licensed under the terms of the MIT license.
+
 require 'timeout'
 require 'open-uri'
 require 'tempfile'

--- a/testsuite/features/step_definitions/xmlrpc_common.rb
+++ b/testsuite/features/step_definitions/xmlrpc_common.rb
@@ -532,7 +532,7 @@ Then(/^I should get status "([^\"]+)" for this client$/) do |status|
   step "I should get status \"#{status}\" for system \"#{client_system_id_to_i}\""
 end
 
-Then(/^I should get the test-channel$/) do
+Then(/^I should get the test channel$/) do
   arch = `uname -m`
   arch.chomp!
   channel = if arch != 'x86_64'

--- a/testsuite/features/step_definitions/xmlrpc_common.rb
+++ b/testsuite/features/step_definitions/xmlrpc_common.rb
@@ -1,4 +1,4 @@
-# COPYRIGHT 2015-2018 SUSE LLC
+# COPYRIGHT 2015-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 require 'json'

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 Novell, Inc.
+# Copyright (c) 2013-2019 Novell, Inc.
 # Licensed under the terms of the MIT license.
 
 require 'tempfile'

--- a/testsuite/features/support/setup_browser.rb
+++ b/testsuite/features/support/setup_browser.rb
@@ -10,17 +10,18 @@ require 'capybara/cucumber'
 require 'simplecov'
 require 'minitest/unit'
 require 'securerandom'
-require "selenium-webdriver"
+require 'selenium-webdriver'
 
 ## codecoverage gem
 SimpleCov.start
 server = ENV['SERVER']
 # maximal wait before giving up
 # the tests return much before that delay in case of success
-DEFAULT_TIMEOUT = 250
 $stdout.sync = true
-Capybara.default_wait_time = 10
 STARTTIME = Time.new.to_i
+Capybara.default_max_wait_time = 10
+DEFAULT_TIMEOUT = 250
+CLICK_TIMEOUT = Capybara.default_max_wait_time * 2
 
 def enable_assertions
   # include assertion globally
@@ -47,10 +48,10 @@ Capybara.app_host = "https://#{server}"
 After do |scenario|
   if scenario.failed?
     img_name = "#{SecureRandom.urlsafe_base64}.png"
-    img = save_screenshot(img_name)
+    save_screenshot(img_name)
     encoded_img = Base64.encode64(File.read(img_name))
     FileUtils.rm_rf(img_name)
-    #embedding the base64 image in a cucumber html report
+    # embed the base64 image in the cucumber HTML report
     embed("data:image/png;base64,#{encoded_img}", 'image/png')
     debug_server_on_realtime_failure
   end

--- a/testsuite/features/support/setup_browser.rb
+++ b/testsuite/features/support/setup_browser.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2018 SUSE LLC
+# Copyright (c) 2010-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 require 'English'

--- a/testsuite/features/support/time.rb
+++ b/testsuite/features/support/time.rb
@@ -1,4 +1,5 @@
-# Copyright 2015 SUSE LLC
+# Copyright 2017-2019 SUSE LLC
+# Licensed under the terms of the MIT license.
 
 Before do |_scenario|
   current_time = Time.new

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2018 SUSE-LINUX
+# Copyright (c) 2016-2019 SUSE-LINUX
 # Licensed under the terms of the MIT license.
 
 require 'twopence'

--- a/testsuite/features/support/xmlrpc_system.rb
+++ b/testsuite/features/support/xmlrpc_system.rb
@@ -1,3 +1,6 @@
+# Copyright 2017-2018 SUSE LLC
+# Licensed under the terms of the MIT license.
+
 require_relative 'xmlrpctest'
 
 # system class

--- a/testsuite/features/trad_action_chain.feature
+++ b/testsuite/features/trad_action_chain.feature
@@ -84,8 +84,7 @@ Feature: Action chain on traditional clients
 
   Scenario: Create a configuration channel for testing action chain on traditional client
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Create Config Channel"
     And I enter "Action Chain Channel" as "cofName"
@@ -96,8 +95,7 @@ Feature: Action chain on traditional clients
 
   Scenario: Add a configuration file to configuration channel for testing action chain on traditional client
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Action Chain Channel"
     And I follow "Create Configuration File or Directory"
@@ -109,9 +107,7 @@ Feature: Action chain on traditional clients
 
   Scenario: Subscribe system to configuration channel for testing action chain on traditional client
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Systems" in the left menu
-    And I follow "Overview" in the left menu
+    When I follow "Systems > Overview" in the left menu
     And I follow this "sle-client" link
     And I follow "Configuration" in the content area
     And I follow "Manage Configuration Channels" in the content area
@@ -123,8 +119,7 @@ Feature: Action chain on traditional clients
 
   Scenario: Add a configuration file deployment to the action chain on traditional client
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Action Chain Channel"
     And I follow "Deploy Files" in the content area
@@ -249,7 +244,6 @@ Feature: Action chain on traditional clients
 
   Scenario: Cleanup: remove traditional client from configuration channel
     Given I am authorized as "admin" with password "admin"
-    And I follow "Home" in the left menu
     When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Action Chain Channel"
@@ -260,8 +254,7 @@ Feature: Action chain on traditional clients
 
   Scenario: Cleanup: remove configuration channel for traditional client
     Given I am authorized as "admin" with password "admin"
-    And I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Action Chain Channel"
     And I follow "Delete Channel"
@@ -274,4 +267,4 @@ Feature: Action chain on traditional clients
     And I run "zypper -n mr -d Devel_Galaxy_BuildRepo" on "sle-client" without error control
 
   Scenario: Cleanup: remove temporary files for testing action chains on traditional client
-    When I run "rm -f /tmp/action_chain.log" on "sle-minion" without error control
+    When I run "rm -f /tmp/action_chain.log" on "sle-client" without error control

--- a/testsuite/features/trad_action_chain.feature
+++ b/testsuite/features/trad_action_chain.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 SUSE LLC
+# Copyright (c) 2018-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Action chain on traditional clients

--- a/testsuite/features/trad_check_patches_install.feature
+++ b/testsuite/features/trad_check_patches_install.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2018 SUSE LLC
+# Copyright (c) 2015-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Patches display

--- a/testsuite/features/trad_config_channel.feature
+++ b/testsuite/features/trad_config_channel.feature
@@ -5,8 +5,7 @@ Feature: Configuration management of traditional clients
 
   Scenario: Successfully create configuration channel
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Create Config Channel"
     And I enter "Test Channel" as "cofName"
@@ -26,8 +25,7 @@ Feature: Configuration management of traditional clients
 
   Scenario: Try to create same channel again; this should fail
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Create Config Channel"
     And I enter "Test Channel" as "cofName"
@@ -39,8 +37,7 @@ Feature: Configuration management of traditional clients
 
   Scenario: Try to create a channel with an invalid label
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Create Config Channel"
     And I enter "Test Channel2" as "cofName"
@@ -52,8 +49,7 @@ Feature: Configuration management of traditional clients
 
   Scenario: Successfully create a new configuration channel
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Create Config Channel"
     And I enter "New Test Channel" as "cofName"
@@ -73,8 +69,7 @@ Feature: Configuration management of traditional clients
 
   Scenario: Add a configuration file to new configuration channel
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "New Test Channel"
     And I follow "Create Configuration File or Directory"
@@ -96,8 +91,7 @@ Feature: Configuration management of traditional clients
 
   Scenario: Check centrally managed files
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Files" in the left menu
     And I follow "Centrally Managed" in the left menu
     Then I should see a table line with "/etc/mgr-test-file.cnf", "New Test Channel", "1 system"
@@ -111,8 +105,7 @@ Feature: Configuration management of traditional clients
 
   Scenario: Deploy centrally managed files
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I run "rhn-actions-control --enable-all" on "sle-client"
     And I follow "Channels" in the left menu
     And I follow "New Test Channel"
@@ -196,9 +189,8 @@ Feature: Configuration management of traditional clients
 
   Scenario: Add another configure file to new test channel
     Given I am authorized as "admin" with password "admin"
-    And I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    When I follow "Channels" in the left menu
+    When I follow "Configuration" in the left menu
+    And I follow "Channels" in the left menu
     And I follow "New Test Channel"
     And I follow "Create Configuration File or Directory"
     And I enter "/tmp/mycache.txt" as "cffPath"
@@ -232,10 +224,8 @@ Feature: Configuration management of traditional clients
 
   Scenario: Check configuration page content
    Given I am authorized as "admin" with password "admin"
-   When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Overview" in the left menu
-   Then I should see a "Configuration Overview" text
+    When I follow "Configuration > Overview" in the left menu
+    Then I should see a "Configuration Overview" text
     And I should see a "Configuration Summary" text
     And I should see a "Configuration Actions" text
     And I should see a "Systems with Managed Configuration Files" text
@@ -254,8 +244,7 @@ Feature: Configuration management of traditional clients
 
   Scenario: Show Systems with Managed Configuration Files page
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Overview" in the left menu
     And I follow "View Systems with Managed Configuration Files"
     Then I should see a "Managed" link in the left menu
@@ -263,8 +252,7 @@ Feature: Configuration management of traditional clients
 
   Scenario: Show All Managed Configuration Files page
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Overview" in the left menu
     And I follow "View All Managed Configuration Files"
     Then I should see a "Centrally Managed" link in the left menu
@@ -272,16 +260,14 @@ Feature: Configuration management of traditional clients
 
   Scenario: Show All Managed Configuration Channels page
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Overview" in the left menu
     And I follow "View All Managed Configuration Channels"
     Then I should see a "Create Config Channel" link
 
   Scenario: Show Enable Configuration Management on Systems page
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Overview" in the left menu
     And I follow "Enable Configuration Management on Systems"
     Then I should see a "Managed" link in the left menu
@@ -289,8 +275,7 @@ Feature: Configuration management of traditional clients
 
   Scenario: Cleanup: remove system from new configuration channel
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "New Test Channel"
     And I follow "Systems" in the content area
@@ -300,8 +285,7 @@ Feature: Configuration management of traditional clients
 
   Scenario: Cleanup: remove test configuration channel
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Test Channel"
     And I follow "Delete Channel"
@@ -309,8 +293,7 @@ Feature: Configuration management of traditional clients
 
   Scenario: Cleanup: remove new configuration channel
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
+    When I follow "Configuration" in the left menu
     And I follow "Channels" in the left menu
     And I follow "New Test Channel"
     And I follow "Delete Channel"

--- a/testsuite/features/trad_config_channel.feature
+++ b/testsuite/features/trad_config_channel.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2018 SUSE LLC
+# Copyright (c) 2017-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Configuration management of traditional clients

--- a/testsuite/features/trad_lock_packages.feature
+++ b/testsuite/features/trad_lock_packages.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-17 SUSE LLC
+# Copyright (c) 2015-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Lock packages on traditional client

--- a/testsuite/features/trad_migrate_to_minion.feature
+++ b/testsuite/features/trad_migrate_to_minion.feature
@@ -81,16 +81,18 @@ Feature: Migrate a traditional client into a Salt minion
     When I wait until file "/tmp/remote-command-on-migrated-test" exists on "sle-migrated-minion"
     And I remove "/tmp/remote-command-on-migrated-test" from "sle-migrated-minion"
 
-  Scenario: Cleanup: migrate back to traditional client
+  Scenario: Cleanup: unregister migrated minion
     Given I am on the Systems overview page of this "sle-migrated-minion"
     When I follow "Delete System"
     Then I should see a "Confirm System Profile Deletion" text
     When I click on "Delete Profile"
     And I wait until I see "has been deleted" text
     Then "sle-migrated-minion" should not be registered
-    When I enable SUSE Manager tools repository on "sle-migrated-minion"
-    And I install package "spacewalk-client-setup spacewalk-oscap rhncfg-actions" on this "sle-migrated-minion"
-    And I remove package "salt-minion" from this "sle-migrated-minion"
+
+  Scenario: Cleanup: register minion again as traditional client
+    When I enable SUSE Manager tools repository on "sle-client"
+    And I install package "spacewalk-client-setup spacewalk-oscap rhncfg-actions" on this "sle-client"
+    And I remove package "salt-minion" from this "sle-client"
     And I register using "1-SUSE-DEV-x86_64" key
 
   Scenario: Cleanup: check that this is again a traditional client

--- a/testsuite/features/trad_migrate_to_sshminion.feature
+++ b/testsuite/features/trad_migrate_to_sshminion.feature
@@ -108,20 +108,22 @@ Feature: Migrate a traditional client into a Salt SSH minion
     When I remove package "perseus-dummy-1.1-1.1" from this "sle-migrated-minion"
     And I remove package "orion-dummy-1.1-1.1" from this "sle-migrated-minion"
 
-  Scenario: Cleanup: migrate ssh-minion back to traditional client
+  Scenario: Cleanup: unregister migrated SSH minion
     Given I am on the Systems overview page of this "sle-migrated-minion"
     When I follow "Delete System"
     Then I should see a "Confirm System Profile Deletion" text
     When I click on "Delete Profile"
     And I wait until I see "has been deleted" text
     Then "sle-migrated-minion" should not be registered
-    When I enable SUSE Manager tools repository on "sle-migrated-minion"
-    And I install package "spacewalk-client-setup spacewalk-oscap rhncfg-actions" on this "sle-migrated-minion"
+
+  Scenario: Cleanup: register SSH minion again as traditional client
+    When I enable SUSE Manager tools repository on "sle-client"
+    And I install package "spacewalk-client-setup spacewalk-oscap rhncfg-actions" on this "sle-client"
     And I register using "1-SUSE-DEV-x86_64" key
 
   Scenario: Cleanup: change contact method of activation key back to default
     Given I am authorized as "admin" with password "admin"
-    And I follow "Systems" in the left menu
+    When I follow "Systems" in the left menu
     And I follow "Activation Keys"
     And I follow "SUSE Test PKG Key x86_64" in the content area
     And I select "Default" from "contactMethodId"

--- a/testsuite/features/trad_need_reboot.feature
+++ b/testsuite/features/trad_need_reboot.feature
@@ -1,4 +1,4 @@
-# COPYRIGHT (c) 2017-2018 SUSE LLC
+# COPYRIGHT (c) 2017-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Reboot required after patch

--- a/testsuite/features/trad_need_reboot.feature
+++ b/testsuite/features/trad_need_reboot.feature
@@ -8,12 +8,11 @@ Feature: Reboot required after patch
 
   Scenario: Check requiring reboot in the web UI
     Given I am authorized
-    And I follow "Home" in the left menu
-    And I follow "Systems" in the left menu
+    When I follow "Systems" in the left menu
     And I follow "Overview" in the left menu
-    When I click System List, under Systems node
+    And I click System List, under Systems node
     Then I should see a "All" link in the left menu
-    And  I follow "All" in the left menu
+    When I follow "All" in the left menu
     Then I should see a "Requiring Reboot" link in the left menu
 
   Scenario: No reboot notice if no need to reboot
@@ -53,5 +52,5 @@ Feature: Reboot required after patch
     Then I should see "sle-client" as link
 
   Scenario: Cleanup: remove packages and restore non-update repo after needing reboot tests
-    And I run "zypper -n rm andromeda-dummy" on "sle-client"
+    When I run "zypper -n rm andromeda-dummy" on "sle-client"
     And I run "zypper -n mr -d Devel_Galaxy_BuildRepo" on "sle-client"

--- a/testsuite/run_sets/testsuite.yml
+++ b/testsuite/run_sets/testsuite.yml
@@ -85,7 +85,6 @@
 - features/min_docker_auth_registry.feature
 - features/srv_docker_advanced_content_management.feature
 - features/srv_docker_cve_audit.feature
-# too many failures and takes too long, needs some investigation
 # OS image build tests are required for proxy_retail_pxeboot feature
 - features/min_osimage_build_image.feature
 - features/min_salt_install_package.feature

--- a/testsuite/unit-tests/README.md
+++ b/testsuite/unit-tests/README.md
@@ -4,5 +4,4 @@ This directory will concern unit tests about the ruby code for testing the produ
 
 These scripts are run during Travis
 
-
 To improve the testsuite itself and its stability (avoid testsuite issues)


### PR DESCRIPTION
## What does this PR change?

Cleanup work:￼
- Fixed the copyright for files modified in 2019
- Added missing backward and forward ports (resynchronized 3.1, 3.2, and 4.0 branches)
- Safer migration back to traditional client
- More modern example in the wizard

Port to 3.1: SUSE/spacewalk#7634
to 3.2: SUSE/spacewalk#7635

- [x] No changelog needed
