### PR TITLE
Disable batching mode for synchronous salt calls

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -746,10 +746,10 @@ public class SaltService {
         }
 
         if (!regularMinionIds.isEmpty()) {
-            ScheduleMetadata metadata = ScheduleMetadata.getDefaultMetadata().withBatchMode();
+            ScheduleMetadata metadata = ScheduleMetadata.getDefaultMetadata();
             List<Map<String, Result<T>>> callResult =
                     adaptException(callIn.withMetadata(metadata).callSync(SALT_CLIENT,
-                            new MinionList(regularMinionIds), PW_AUTH, defaultBatch));
+                            new MinionList(regularMinionIds), PW_AUTH, Optional.empty()));
             results.putAll(
                     callResult.stream().flatMap(map -> map.entrySet().stream())
                             .collect(Collectors.toMap(Entry<String, Result<T>>::getKey,


### PR DESCRIPTION
## What does this PR change?

Disable batching mode for synchronous salt calls.
Problem is Salt returns different responses for synchronous batching and none-batching, and the salt-net-api client fails to parse it.
This is a temporary work around that address this situation.

The following are examples of Salt responses in both scenarios:
Failing synchronous batching response:
```json
{
    "file_|-mgrchannels_repo_clean_all_|-/etc/yum.repos.d/susemanager:channels.repo_|-absent": {
        "__id__": "mgrchannels_repo_clean_all",
        "__run_num__": 0,
        "__sls__": "cleanup_minion",
        "changes": {},
        "comment": "File /etc/yum.repos.d/susemanager:channels.repo is not present",
        "duration": 0.704,
        "name": "/etc/yum.repos.d/susemanager:channels.repo",
        "pchanges": {},
        "result": true,
        "start_time": "15:56:06.338933"
    },
    "retcode": 0
}
```

Successful response without batching:
```json
{
    "file_|-mgrchannels_repo_clean_all_|-/etc/yum.repos.d/susemanager:channels.repo_|-absent": {
        "__id__": "mgrchannels_repo_clean_all",
        "__run_num__": 0,
        "__sls__": "cleanup_minion",
        "changes": {},
        "comment": "File /etc/yum.repos.d/susemanager:channels.repo is not present",
        "duration": 0.848,
        "name": "/etc/yum.repos.d/susemanager:channels.repo",
        "pchanges": {},
        "result": true,
        "start_time": "15:58:00.264906"
    }
}
```

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
