### PR TITLE
Manager bsc1132080

### DIFF
--- a/proxy/installer/configure-proxy.sh
+++ b/proxy/installer/configure-proxy.sh
@@ -344,7 +344,10 @@ SQUID_DIR=/etc/squid
 UP2DATE_FILE=$SYSCONFIG_DIR/up2date
 SYSTEMID_PATH=$(awk -F '=[[:space:]]*' '/^[[:space:]]*systemIdPath[[:space:]]*=/ {print $2}' $UP2DATE_FILE)
 
-/usr/sbin/fetch-certificate $SYSTEMID_PATH
+systemctl status salt-minion > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+    /usr/sbin/fetch-certificate $SYSTEMID_PATH
+fi
 
 if [ ! -r $SYSTEMID_PATH ]; then
     echo ERROR: SUSE Manager Proxy does not appear to be registered

--- a/proxy/installer/spacewalk-proxy-installer.changes
+++ b/proxy/installer/spacewalk-proxy-installer.changes
@@ -1,3 +1,4 @@
+- fix connection type test for proxy (bsc#1132080)
 - open needed firewall ports also when firewall not currently
   running (bsc#1131231)
 - Add makefile and lintrc for pylint


### PR DESCRIPTION
## What does this PR change?

The configure-proxy.sh script is implicitly testing the connection type in fetch-certificate by trying to load salt functionality. This will always succeed as at least the salt-broker is installed so a proxy always gets detected as being a salt minion even when it is a traditionally connected client. So try to fetch the certificate only when a salt-minion is actually running on the proxy.