### PR TITLE
Take into account only synced products when scheduling SP migration from the API (bsc#1131929)

### DIFF
--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Take into account only synced products when scheduling SP migration from the API (bsc#1131929)
+
 -------------------------------------------------------------------
 Fri Apr 26 09:57:29 CEST 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Take into account only synced products when scheduling SP migration from the API.

## GUI diff

No difference.

## Documentation
- No documentation needed: bugfix

## Test coverage
- No tests

## Links

Fixes https://github.com/SUSE/spacewalk/issues/7535
Tracks https://github.com/SUSE/spacewalk/pull/7637

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
