### PR TITLE
Open avahi port in the correct firewall zone

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -624,7 +624,7 @@ And(/^I create the "([^"]*)" bootstrap repository for "([^"]*)" on the server$/)
 end
 
 When(/^I open avahi port on the proxy$/) do
-  $proxy.run('firewall-cmd --permanent --add-service=mdns')
+  $proxy.run('firewall-cmd --permanent --zone=public --add-service=mdns')
   $proxy.run('firewall-cmd --reload')
 end
 


### PR DESCRIPTION
## What does this PR change?

In the test suite, it opens avahi port in the public firewall zone, instead of the internal one.

Affects uyuni only.

- [x] No changelog needed
