### PR TITLE
Work around IPv6 default route bug

### DIFF
--- a/testsuite/features/core_proxy_branch_network.feature
+++ b/testsuite/features/core_proxy_branch_network.feature
@@ -141,6 +141,9 @@ Feature: Setup SUSE Manager for Retail branch network
   Scenario: Let avahi work on the branch server
     Given service "firewalld" is active on "proxy"
     When I open avahi port on the proxy
+    # WORKAROUND
+    # bsc#1132908 - Branch network formula closes IPv6 default route, potentially making further networking fail
+    And I reopen the IPv6 default route on the proxy
 
 @proxy
 @private_net

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -628,6 +628,12 @@ When(/^I open avahi port on the proxy$/) do
   $proxy.run('firewall-cmd --reload')
 end
 
+# WORKAROUND
+# bsc#1132908 - Branch network formula closes IPv6 default route, potentially making further networking fail
+When(/^I reopen the IPv6 default route on the proxy$/) do
+  $proxy.run('ip -6 r a default via fe80::1 dev eth0')
+end
+
 When(/^I copy server\'s keys to the proxy$/) do
   ['RHN-ORG-PRIVATE-SSL-KEY', 'RHN-ORG-TRUSTED-SSL-CERT', 'rhn-ca-openssl.cnf'].each do |file|
     return_code = file_extract($server, '/root/ssl-build/' + file, '/tmp/' + file)


### PR DESCRIPTION
## What does this PR change?

This PR works around https://bugzilla.suse.com/show_bug.cgi?id=1132908 in the test suite:

   Branch network formula closes IPv6 default route, potentially making further networking fail

uyuni only (firewalld-specific).

- [x] No changelog needed
