### PR TITLE
Fix build for non SUSE/openSUSE distributions

### DIFF
--- a/client/tools/mgr-cfg/mgr-cfg.changes
+++ b/client/tools/mgr-cfg/mgr-cfg.changes
@@ -1,3 +1,5 @@
+- Fix build for non SUSE/openSUSE distributions
+
 -------------------------------------------------------------------
 Mon Apr 22 12:00:20 CEST 2019 - jgonzalez@suse.com
 

--- a/client/tools/mgr-cfg/mgr-cfg.spec
+++ b/client/tools/mgr-cfg/mgr-cfg.spec
@@ -444,9 +444,7 @@ py3clean -p python3-%{name}-actions
 %files client
 %defattr(-,root,root,-)
 %{_bindir}/rhncfg-client
-%if 0%{?suse_version}
 %{_bindir}/mgrcfg-client
-%endif
 %attr(644,root,root) %config(noreplace) %{rhnconf}/rhncfg-client.conf
 %{_mandir}/man8/rhncfg-client.8*
 
@@ -466,9 +464,7 @@ py3clean -p python3-%{name}-actions
 
 %files management
 %defattr(-,root,root,-)
-%if 0%{?suse_version}
 %{_bindir}/mgrcfg-manager
-%endif
 %{_bindir}/rhncfg-manager
 %attr(644,root,root) %config(noreplace) %{rhnconf}/rhncfg-manager.conf
 %{_mandir}/man8/rhncfg-manager.8*
@@ -489,9 +485,7 @@ py3clean -p python3-%{name}-actions
 
 %files actions
 %defattr(-,root,root,-)
-%if 0%{?suse_version}
 %{_bindir}/mgr-actions-control
-%endif
 %{_bindir}/rhn-actions-control
 %config(noreplace) %{client_caps_dir}/*
 %{_mandir}/man8/rhn-actions-control.8*


### PR DESCRIPTION
## What does this PR change?

Fix build for non SUSE/openSUSE distributions. https://github.com/uyuni-project/uyuni/pull/854#issuecomment-485407462

Without this fix, at non SUSE/openSUSE distributions:
```
[   59s] RPM build errors:
[   59s]     Installed (but unpackaged) file(s) found:
[   59s]    /usr/bin/mgr-actions-control
[   59s]    /usr/bin/mgrcfg-client
[   59s]    /usr/bin/mgrcfg-manager
``` 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: SPEC fix.

- [x] **DONE**

## Test coverage
- No tests: SPEC fix.

- [x] **DONE**

## Links

https://github.com/uyuni-project/uyuni/pull/854

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
