### PR TITLE
avahi port has to be open *before* the highstate is applied

### DIFF
--- a/testsuite/features/core_proxy_branch_network.feature
+++ b/testsuite/features/core_proxy_branch_network.feature
@@ -123,6 +123,11 @@ Feature: Setup SUSE Manager for Retail branch network
 
 @proxy
 @private_net
+  Scenario: Let avahi work on the branch server
+    When I open avahi port on the proxy
+
+@proxy
+@private_net
   Scenario: Apply the branch network formulas via the highstate
     Given I am on the Systems overview page of this "proxy"
     When I follow "States" in the content area
@@ -138,12 +143,10 @@ Feature: Setup SUSE Manager for Retail branch network
 
 @proxy
 @private_net
-  Scenario: Let avahi work on the branch server
-    Given service "firewalld" is active on "proxy"
-    When I open avahi port on the proxy
+  Scenario: Workaround - reopen default IPv6 route
     # WORKAROUND
     # bsc#1132908 - Branch network formula closes IPv6 default route, potentially making further networking fail
-    And I reopen the IPv6 default route on the proxy
+    When I reopen the IPv6 default route on the proxy
 
 @proxy
 @private_net

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -624,8 +624,7 @@ And(/^I create the "([^"]*)" bootstrap repository for "([^"]*)" on the server$/)
 end
 
 When(/^I open avahi port on the proxy$/) do
-  $proxy.run('firewall-cmd --permanent --zone=public --add-service=mdns')
-  $proxy.run('firewall-cmd --reload')
+  $proxy.run('firewall-offline-cmd --zone=public --add-service=mdns')
 end
 
 # WORKAROUND


### PR DESCRIPTION
## What does this PR change?

This PR enables to use again the test suite with avahi

- [x] No changelog needed
