### PR TITLE
Revert "Revert any changes to the original makefiles" (fixes "manager-Head-python-tests")

### DIFF
--- a/backend/Makefile.backend
+++ b/backend/Makefile.backend
@@ -27,6 +27,10 @@ all :: all-code all-conf
 # now include some Macros
 include Makefile.defs
 
+__pylint ::
+	$(call update_pip_env)
+	pylint --rcfile=pylintrc $(shell find -name '*.py') > reports/pylint.log || true
+
 install :: install-code install-conf
 
 clean :: clean-code clean-conf
@@ -61,9 +65,12 @@ docker_oracle_tests ::
 	@echo "Running Oracle tests"
 	docker run --privileged --rm=true -e $(DOCKER_RUN_EXPORT) $(DOCKER_VOLUMES) $(DOCKER_REGISTRY)/$(DOCKER_CONTAINER_BASE)-ora /manager/backend/test/docker-backend-oracle-tests.sh
 
-# This is obsolete target. Use Makefile.python
 docker_pylint ::
-	docker run --rm -e $(DOCKER_RUN_EXPORT) $(DOCKER_VOLUMES) $(DOCKER_REGISTRY)/$(DOCKER_CONTAINER_BASE)-pgsql /bin/sh -c "cd /manager/backend; make -f Makefile.python __pylint"
+	docker run --rm -e $(DOCKER_RUN_EXPORT) $(DOCKER_VOLUMES) $(DOCKER_REGISTRY)/$(DOCKER_CONTAINER_BASE)-pgsql /bin/sh -c "cd /manager/backend; make -f Makefile.backend __pylint"
 
 docker_shell ::
 	docker run --rm=true -t -i -e $(DOCKER_RUN_EXPORT) $(DOCKER_VOLUMES) $(DOCKER_REGISTRY)/$(DOCKER_CONTAINER_BASE)-pgsql /bin/bash
+
+test ::
+	echo "test"
+

--- a/backend/Makefile.defs
+++ b/backend/Makefile.defs
@@ -8,6 +8,10 @@ TOP		?= .
 ROOT		?= /usr/share/rhn
 export ROOT
 
+ifeq ("$(PYTHON_BIN)", "")
+    PYTHON_BIN = "python"
+endif
+
 SPACEWALK_ROOT	?= $(shell $(PYTHON_BIN) -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")/spacewalk
 export SPACEWALK_ROOT
 


### PR DESCRIPTION
## What does this PR change?

This PR reverts commit 6396e130a0017acfc62cbc7e9f2ef2abb7c4887f which is currently causing breaking the `Makefile.backend` and preventing tests to run due a missing file.

It seems that during the last refactor made on this file a file called `Makefile.python` is missing.

As soon as @isbm is back and he provides the missing file we can revert this.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal tests**

- [x] **DONE**

## Test coverage
- No tests: **internal tests**

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
