### PR TITLE
Fix build error in Eclipse

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProject.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProject.java
@@ -304,8 +304,8 @@ public class ContentProject extends BaseDomainHelper {
      */
     @Transient
     public List<PackageFilter> getPackageFilters() {
-        return (List<PackageFilter>) getProjectFilters().stream()
-                .flatMap(f -> Opt.stream(f.getFilter().asPackageFilter()))
+        return getProjectFilters().stream()
+                .flatMap(f -> Opt.stream(((ContentFilter<?>) f.getFilter()).asPackageFilter()))
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
## What does this PR change?

Eclipse needed to cast ContentFilter into ContentFilter<?> in order to
build.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: Build fix

- [X] **DONE**

## Test coverage
- No tests: Build fix

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"  
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint" (Test skipped, there are no changes to test)		 
