### PR TITLE
Show minion_id in System Details info (GUI and API)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/Server.java
+++ b/java/code/src/com/redhat/rhn/domain/server/Server.java
@@ -35,16 +35,7 @@ import com.redhat.rhn.manager.configuration.ConfigurationManager;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.kickstart.cobbler.CobblerXMLRPCHelper;
 import com.redhat.rhn.manager.system.SystemManager;
-
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
-import org.apache.log4j.Logger;
-import org.cobbler.CobblerConnection;
-import org.cobbler.SystemRecord;
-
+import com.suse.utils.Opt;
 import java.net.IDN;
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -60,6 +51,14 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.apache.log4j.Logger;
+import org.cobbler.CobblerConnection;
+import org.cobbler.SystemRecord;
 
 /**
  * Server - Class representation of the table rhnServer.
@@ -2075,6 +2074,13 @@ public class Server extends BaseDomainHelper implements Identifiable {
      */
     public void setMachineId(String machineIdIn) {
         this.machineId = machineIdIn;
+    }
+
+    /**
+     * @return the minion id if the server is a salt minion client, else empty string
+     */
+    public String getMinionId() {
+        return Opt.fold(this.asMinionServer(), () -> "", m -> m.getMinionId());
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemOverviewAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemOverviewAction.java
@@ -140,6 +140,7 @@ public class SystemOverviewAction extends RhnAction {
         request.setAttribute("installedProducts", s.getInstalledProductSet().orElse(null));
         request.setAttribute("prefs", findUserServerPreferences(user, s));
         request.setAttribute("system", s);
+        request.setAttribute("minionId", s.getMinionId());
         request.setAttribute("hasLocation",
                 !(s.getLocation() == null || s.getLocation().isEmpty()));
         request.setAttribute("activationKey", SystemManager.getActivationKeys(s));

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -17097,6 +17097,12 @@ The Tree Path, Kickstart RPM, Base Channel, and Installer Generation should alwa
           <context context-type="sourcefile">/systems/details/Overview.do</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sdc.details.overview.minionId">
+        <source>Minion Id:</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/systems/details/Overview.do</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="sdc.details.overview.hostname">
         <source>Hostname:</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ServerSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ServerSerializer.java
@@ -41,6 +41,7 @@ import com.redhat.rhn.manager.entitlement.EntitlementManager;
  *         #prop_desc("int", "id", "System id")
  *         #prop("string", "profile_name")
  *         #prop("string", "machine_id")
+ *         #prop("string", "minion_id")
  *         #prop_desc("string", "base_entitlement", "System's base entitlement label")
  *
  *         #prop_array("string", "addon_entitlements","System's addon entitlements labels,
@@ -97,6 +98,7 @@ public class ServerSerializer extends RhnXmlRpcCustomSerializer {
         helper.add("profile_name", server.getName());
         helper.add("machine_id", server.getMachineId());
         helper.add("hostname", server.getHostname());
+        helper.add("minion_id", server.getMinionId());
 
         // Find this server's base entitlement:
         String baseEntitlement = EntitlementManager.UNENTITLED;

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -14,8 +14,6 @@
  */
 package com.redhat.rhn.frontend.xmlrpc.system;
 
-import static java.util.stream.Collectors.toList;
-
 import com.redhat.rhn.FaultException;
 import com.redhat.rhn.common.client.ClientCertificate;
 import com.redhat.rhn.common.conf.ConfigDefaults;
@@ -154,13 +152,7 @@ import com.redhat.rhn.manager.system.UpdateChildChannelsCommand;
 import com.redhat.rhn.manager.system.VirtualizationActionCommand;
 import com.redhat.rhn.manager.token.ActivationKeyManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
-
 import com.suse.manager.webui.utils.gson.BootstrapHostsJson;
-
-import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
-import org.cobbler.SystemRecord;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -185,6 +177,11 @@ import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.log4j.Logger;
+import org.cobbler.SystemRecord;
+
+import static java.util.stream.Collectors.toList;
 
 /**
  * SystemHandler
@@ -754,6 +751,7 @@ public class SystemHandler extends BaseHandler {
      *     #struct("server details")
      *       #prop_desc("int", "id", "The server's id")
      *       #prop_desc("string", "name", "The server's name")
+     *       #prop_desc("string", "minion_id", "The server's minion id, in case it is a salt minion client")
      *       #prop_desc("dateTime.iso8601", "last_checkin",
      *         "Last time server successfully checked in (in UTC)")
      *       #prop_desc("int", "ram", "The amount of physical memory in MB.")
@@ -789,6 +787,7 @@ public class SystemHandler extends BaseHandler {
                 Map<String, Object> m = new HashMap<String, Object>();
                 m.put("id", server.getId());
                 m.put("name", server.getName());
+                m.put("minion_id", server.getMinionId());
                 m.put("last_checkin", convertLocalToUtc(server.getLastCheckin()));
 
                 m.put("ram", server.getRam());

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -2686,6 +2686,18 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         assertEquals(result, server.getId().intValue());
     }
 
+    /**
+     * Create a minion server, get details by id, compare the returned server minion_id
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testGetMinionId() throws Exception {
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(admin);
+        Server server = (Server) getMockedHandler().getDetails(admin, minion.getId().intValue());
+
+        assertEquals(minion.getMinionId(), server.getMinionId());
+    }
+
     private SystemHandler getMockedHandler() throws Exception {
         TaskomaticApi taskomaticMock = MOCK_CONTEXT.mock(TaskomaticApi.class);
         SystemHandler systemHandler = new SystemHandler(taskomaticMock);

--- a/java/code/webapp/WEB-INF/pages/systems/sdc/overview.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/sdc/overview.jsp
@@ -112,6 +112,12 @@
             </c:choose>
             </td>
           </tr>
+          <c:if test="${minionId != ''}">
+            <tr>
+              <td><bean:message key="sdc.details.overview.minionId"/></td>
+              <td><c:out value="${minionId}" /></td>
+            </tr>
+          </c:if>
           <c:if test="${system.virtualGuest}">
             <tr>
               <td><bean:message key="sdc.details.overview.virtualization"/></td>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Show minion id in System Details GUI and API
 - Fix base channel selection for Ubuntu systems (bsc#1132579)
 - Fix retrieval of build time for .deb repositories (bsc#1131721)
 - Fix product package conflicts with SLES for SAP systems (bsc#1130551)


### PR DESCRIPTION
## What does this PR change?

Add `minion id` info to System Details both in GUI and API. If the `client` is a `salt minion` client the field will be filled by the `minion id` value, if not it will be hidden in the GUI and returned an empty `String` in the API.

GUI: `System > Details > System Info Box`
API: `system.getDetails` and `system.listActiveSystemsDetails` calls

## GUI diff

After:

![Screenshot from 2019-04-24 12-10-02](https://user-images.githubusercontent.com/7080830/56651750-0ceeb000-668a-11e9-9480-4aa9f64310d4.png)


- [x] **DONE**

## Documentation
- https://github.com/SUSE/doc-susemanager/pull/438

- [x] **DONE**

## Test coverage
- Unit tests were added for `SystemHandler.java` class

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/7532
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests" 		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint" (Test skipped, there are no changes to test)		 
