### PR TITLE
Testsuite - cache cleanup before spacecmd

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -965,6 +965,7 @@ end
 
 When(/^I refresh packages list via spacecmd on "([^"]*)"$/) do |client|
   node = get_system_name(client)
+  $server.run("spacecmd -u admin -p admin clear_caches")
   command = "spacecmd -u admin -p admin system_schedulepackagerefresh #{node}"
   $server.run(command)
 end
@@ -975,6 +976,7 @@ Then(/^I wait until refresh package list on "(.*?)" is finished$/) do |client|
   current_time = Time.now.strftime('%Y%m%d%H%M')
   timeout_time = (Time.now + long_wait_delay + round_minute).strftime('%Y%m%d%H%M')
   node = get_system_name(client)
+  $server.run("spacecmd -u admin -p admin clear_caches")
   cmd = "spacecmd -u admin -p admin schedule_listcompleted #{current_time} #{timeout_time} #{node} | grep 'Package List Refresh scheduled by admin' | head -1"
   begin
     Timeout.timeout(long_wait_delay) do
@@ -992,6 +994,7 @@ end
 
 When(/^spacecmd should show packages "([^"]*)" installed on "([^"]*)"$/) do |packages, client|
   node = get_system_name(client)
+  $server.run("spacecmd -u admin -p admin clear_caches")
   command = "spacecmd -u admin -p admin system_listinstalledpackages #{node}"
   result, code = $server.run(command, false)
   packages.split(' ').each do |package|
@@ -1002,6 +1005,7 @@ end
 
 When(/^I wait until package "([^"]*)" is installed on "([^"]*)" via spacecmd$/) do |pkg, client|
   node = get_system_name(client)
+  $server.run("spacecmd -u admin -p admin clear_caches")
   command = "spacecmd -u admin -p admin system_listinstalledpackages #{node}"
   long_wait_delay = 600
   begin


### PR DESCRIPTION
## What does this PR change?

PR adds cache cleanup before spacecmd command to avoid usage of not valid data (as registered system ids) causing failures in testsuite.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
