### PR TITLE
Testsuite - waiting for timeout is reached after system deletion

### DIFF
--- a/testsuite/features/min_salt_minions_page.feature
+++ b/testsuite/features/min_salt_minions_page.feature
@@ -64,7 +64,7 @@ Feature: Management of minion keys
     And I follow "Delete System"
     Then I should see a "Confirm System Profile Deletion" text
     When I click on "Delete Profile"
-    Then I should see a "Cleanup timed out. Please check if the machine is reachable." text
+    Then I wait until I see "Cleanup timed out. Please check if the machine is reachable." text
     When I click on "Delete Profile Without Cleanup"
     And I wait until I see "has been deleted" text
     Then "sle-minion" should not be registered


### PR DESCRIPTION
## What does this PR change?

PR replaces checking for text message by waiting for it. This prevents scenario `Delete profile of unreacheable minion` from failure because message is not shown immediately after delete button is clicked on.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
