### PR TITLE
Testsuite - andromeda package checked for removal

### DIFF
--- a/testsuite/features/min_ubuntu_salt_install_package.feature
+++ b/testsuite/features/min_ubuntu_salt_install_package.feature
@@ -15,6 +15,7 @@ Feature: Install and upgrade package on the Ubuntu minion via Salt through the U
     And I follow "Events" in the content area
     And I wait until I do not see "Package List Refresh scheduled by admin" text, refreshing the page
     And I wait until package "virgo-dummy" is installed on "ubuntu-minion" via spacecmd
+    And I wait until package "andromeda-dummy" is removed from "ubuntu-minion" via spacecmd
 
 @ubuntu_minion
   Scenario: Install a package on the minion

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1020,3 +1020,22 @@ When(/^I wait until package "([^"]*)" is installed on "([^"]*)" via spacecmd$/) 
     raise "package #{pkg} is not installed after #{long_wait_delay} seconds"
   end
 end
+
+When(/^I wait until package "([^"]*)" is removed from "([^"]*)" via spacecmd$/) do |pkg, client|
+  node = get_system_name(client)
+  $server.run("spacecmd -u admin -p admin clear_caches")
+  command = "spacecmd -u admin -p admin system_listinstalledpackages #{node}"
+  long_wait_delay = 600
+  begin
+    Timeout.timeout(long_wait_delay) do
+      loop do
+        result, code = $server.run(command, false)
+        sleep 1
+        next if result.include? pkg
+        break
+      end
+    end
+  rescue Timeout::Error
+    raise "package #{pkg} is still present after #{long_wait_delay} seconds"
+  end
+end


### PR DESCRIPTION
## What does this PR change?

PR adds waiting for package `andromeda-dummy` to be removed in feature `Install and upgrade package on the Ubuntu minion via Salt through the UI`. (As this package is expected to be removed in first step.) This prevents the rest of feature from failure.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
