### PR TITLE
Use "suseLib.get_proxy" to get the HTTP proxy configuration properly on DEB repos

### DIFF
--- a/backend/satellite_tools/repo_plugins/deb_src.py
+++ b/backend/satellite_tools/repo_plugins/deb_src.py
@@ -22,6 +22,7 @@ import fnmatch
 import requests
 from functools import cmp_to_key
 from spacewalk.common import fileutils
+from spacewalk.common.suseLib import get_proxy
 from spacewalk.satellite_tools.download import get_proxies
 from spacewalk.satellite_tools.repo_plugins import ContentPackage, CACHE_DIR
 from spacewalk.satellite_tools.syncLib import log2
@@ -207,9 +208,8 @@ class ContentSource(object):
 
         # read the proxy configuration in /etc/rhn/rhn.conf
         initCFG('server.satellite')
-        self.proxy_addr = CFG.http_proxy
-        self.proxy_user = CFG.http_proxy_username
-        self.proxy_pass = CFG.http_proxy_password
+
+        self.proxy_addr, self.proxy_user, self.proxy_pass = get_proxy(self.url)
         self.authtoken = None
 
         self.repo = DebRepo(url, os.path.join(CACHE_DIR, self.org, name),

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,6 @@
+- Use suseLib.get_proxy to get the HTTP proxy configuration 
+  properly on DEB repos (bsc#1133424)
+
 -------------------------------------------------------------------
 Mon Apr 22 12:07:39 CEST 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue on the `deb_src` plugin from `spacewalk-repo-sync` when a HTTP proxy is enabled but the URL from the repo to sync is pointing to `localhost`.

Currently, `spacewalk-repo-sync` is always reporting 0 packages on the repo.

This PR makes the `deb_src` plugin to use `suseLib.get_proxy` helper to avoid using the proxy configuration when the URL of the repository is pointing to `localhost`.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **already tested by cucumber**

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
