### PR TITLE
Rhel bootstrap repo

### DIFF
--- a/susemanager/src/mgr-create-bootstrap-repo
+++ b/susemanager/src/mgr-create-bootstrap-repo
@@ -234,7 +234,7 @@ def create_repo(label, flush, additional=[]):
         else:
             os.makedirs(destdir)
 
-    if label.startswith('RES'):
+    if label.startswith('RES') or label.startswith('RHEL'):
         print("Creating bootstrap repo for latest Service Pack of {0}".format(label))
     else:
         print("Creating bootstrap repo for {0}".format(label))
@@ -321,7 +321,7 @@ def create_repo(label, flush, additional=[]):
     if errors:
         for m in messages:
             print(m)
-        if (label.startswith('RES') or label.lower().startswith('ubuntu'))  and not options.usecustomchannels:
+        if (label.startswith('RES') or label.startswith('RHEL') or label.lower().startswith('ubuntu'))  and not options.usecustomchannels:
             print("If the installation media was imported into a custom channel, try to run again with --with-custom-channels option")
         suggestions = list([_f for _f in list(suggestions.values()) if _f])
         if suggestions:

--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -761,6 +761,18 @@ DATA = {
         'BASECHANNEL' : 'centos7-x86_64', 'PKGLIST' : RES7,
         'DEST' : '/srv/www/htdocs/pub/repositories/centos/7/bootstrap/'
     },
+    'RHEL6-x86_64' : {
+        'PDID' : [-5, 1682], 'PKGLIST' : RES6,
+        'DEST' : '/srv/www/htdocs/pub/repositories/res/6/bootstrap/'
+    },
+    'RHEL6-i386' : {
+        'PDID' : [-6, 1681], 'PKGLIST' : RES6,
+        'DEST' : '/srv/www/htdocs/pub/repositories/res/6/bootstrap/'
+    },
+    'RHEL7-x86_64' : {
+        'PDID' : [-7, 1683], 'PKGLIST' : RES7,
+        'DEST' : '/srv/www/htdocs/pub/repositories/res/7/bootstrap/'
+    },
     'ubuntu-16.04-amd64' : {
         'PDID' : [-2, 1917], 'PKGLIST' : PKGLISTUBUNTU1604,
         'DEST' : '/srv/www/htdocs/pub/repositories/ubuntu/16/4/bootstrap/',

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- create bootstrap repo for new Red Hat channels (bsc#1133587)
+
 -------------------------------------------------------------------
 Tue Apr 23 23:20:07 CEST 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Unable to create a bootstrap repo from the new Channel Tree for RH .
This PR should fix it.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **not tested**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/7696
Tracks https://github.com/SUSE/spacewalk/pull/7697

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
