### PR TITLE
Add a link to the highstate page after formula was saved

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/FormulaController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/FormulaController.java
@@ -212,7 +212,7 @@ public class FormulaController {
                     SaltService.INSTANCE.refreshPillar(new MinionList(minionIds));
                     break;
                 default:
-                    return errorResponse(response, Arrays.asList("Invalid target type!"));
+                    return errorResponse(response, Arrays.asList("error_invalid_target")); //Invalid target type!
             }
         }
         catch (IOException | UnsupportedOperationException e) {
@@ -220,7 +220,7 @@ public class FormulaController {
                     Arrays.asList("Error while saving formula data: " +
                             e.getMessage()));
         }
-        return GSON.toJson(Arrays.asList("Formula saved!"));
+        return GSON.toJson(Arrays.asList("formula_saved")); // Formula saved!
     }
 
     /**
@@ -312,14 +312,14 @@ public class FormulaController {
                     FormulaFactory.saveGroupFormulas(id, selectedFormulas, user.getOrg());
                     break;
                 default:
-                    return errorResponse(response, Arrays.asList("Invalid target type!"));
+                    return errorResponse(response, Arrays.asList("error_invalid_target"));
             }
         }
         catch (IOException | UnsupportedOperationException e) {
             return errorResponse(response,
                     Arrays.asList("Error while saving formula data: " + e.getMessage()));
         }
-        return GSON.toJson(Arrays.asList("Formulas saved!"));
+        return GSON.toJson(Arrays.asList("formulas_saved"));
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add a link to the highstate page after formula was saved
 - Fix deleting server when minion_formulas.json is empty (bsc#1122230)
 - Handle the different retcodes that are being returned when salt module is not available (bsc#1131704)
 - Improve salt events processing performance (bsc#1125097)

--- a/web/html/src/components/FormulaForm.js
+++ b/web/html/src/components/FormulaForm.js
@@ -23,7 +23,7 @@ class FormulaForm extends React.Component {
     constructor(props) {
         super(props);
 
-        ["saveFormula", "handleChange", "clearValues"].forEach(method => this[method] = this[method].bind(this));
+        ["saveFormula", "handleChange", "clearValues", "getMessageText"].forEach(method => this[method] = this[method].bind(this));
 
         const previewMessage = <p>On this page you can configure <a href="https://docs.saltstack.com/en/latest/topics/development/conventions/formulas.html" target="_blank" rel="noopener noreferrer">Salt Formulas</a> to automatically install and configure software.</p>;
 
@@ -98,7 +98,7 @@ class FormulaForm extends React.Component {
             this.props.saveUrl,
             JSON.stringify(formData),
             "application/json"
-        ).promise.then(function (data) { if (data instanceof Array) this.setState({ messages: data }); }.bind(this),
+        ).promise.then(function (data) { if (data instanceof Array) this.setState({ messages: data.map(msg => this.getMessageText(msg)) }); }.bind(this),
             function (error) {
                 try {
                     this.setState({
@@ -210,6 +210,10 @@ class FormulaForm extends React.Component {
         for (let key in layout)
             form.push(generateFormulaComponent(layout[key], values[key], this));
         return form;
+    }
+
+    getMessageText(msg) {
+      return this.props.messageTexts[msg] ? t(this.props.messageTexts[msg]) : msg;
     }
 
     render() {

--- a/web/html/src/manager/group-formula-selection.js
+++ b/web/html/src/manager/group-formula-selection.js
@@ -8,6 +8,15 @@ const Network = require("../utils/network");
 const FormulaSelection = require("../components/formula-selection").FormulaSelection;
 const capitalize = require("../utils/functions").Utils.capitalize;
 
+const messageTexts = {
+  "formulas_saved" : <p>{t("Formula saved. Apply the ")}<a href={'/rhn/manager/groups/details/highstate?sgid=' + groupId}>{t("Highstate")}</a>{t(" for the changes to take effect.")}</p>,
+  "error_invalid_target" : t("Invalid target type.")
+}
+
+function getMessageText(msg) {
+  return messageTexts[msg] ? t(messageTexts[msg]) : msg;
+}
+
 function saveRequest(component, selectedFormulas) {
     const formData = {};
     formData.type = "GROUP";
@@ -20,7 +29,7 @@ function saveRequest(component, selectedFormulas) {
         "application/json"
     ).promise.then(data => {
         component.setState({
-            messages: data
+            messages: data.map(msg => getMessageText(msg))
         });
     },
     (xhr) => {

--- a/web/html/src/manager/group-formula.js
+++ b/web/html/src/manager/group-formula.js
@@ -9,6 +9,11 @@ var FormulaFormModule = require("../components/FormulaForm");
 var FormulaForm = FormulaFormModule.FormulaForm;
 const capitalize = require("../utils/functions").Utils.capitalize;
 
+const msgMap = {
+  "formula_saved" : <p>{t("Formula saved. Apply the ")}<a href={'/rhn/manager/groups/details/highstate?sgid=' + groupId}>{t("Highstate")}</a>{t(" for the changes to take effect.")}</p>,
+  "error_invalid_target" : t("Invalid target type.")
+}
+
 function addFormulaNavBar(formulaList, activeId) {
     $("#formula-nav-bar").remove();
 
@@ -28,7 +33,8 @@ ReactDOM.render(
           formulaId={formulaId}
           systemId={groupId}
           getFormulaUrl={function(id) {return "/rhn/manager/groups/details/formula/" + id + "?sgid=" + groupId;}}
-          scope="group" />,
+          scope="group"
+          messageTexts={msgMap} />,
     document.getElementById('formula')
 );
 

--- a/web/html/src/manager/minion-formula-selection.js
+++ b/web/html/src/manager/minion-formula-selection.js
@@ -8,6 +8,15 @@ const Network = require("../utils/network");
 const FormulaSelection = require("../components/formula-selection").FormulaSelection;
 const capitalize = require("../utils/functions").Utils.capitalize;
 
+const messageTexts = {
+  "formulas_saved" : <p>{t("Formula saved. Apply the ")}<a href={'/rhn/manager/systems/details/highstate?sid=' + serverId}>{t("Highstate")}</a>{t(" for the changes to take effect.")}</p>,
+  "error_invalid_target" : t("Invalid target type.")
+}
+
+function getMessageText(msg) {
+  return messageTexts[msg] ? t(messageTexts[msg]) : msg;
+}
+
 function saveRequest(component, selectedFormulas) {
     const formData = {};
     formData.type = "SERVER";
@@ -20,7 +29,7 @@ function saveRequest(component, selectedFormulas) {
         "application/json"
     ).promise.then(data => {
         component.setState({
-            messages: data
+            messages: data.map(msg => getMessageText(msg))
         });
     },
     (xhr) => {

--- a/web/html/src/manager/minion-formula.js
+++ b/web/html/src/manager/minion-formula.js
@@ -9,6 +9,11 @@ var FormulaFormModule = require("../components/FormulaForm");
 var FormulaForm = FormulaFormModule.FormulaForm;
 const capitalize = require("../utils/functions").Utils.capitalize;
 
+const msgMap = {
+  "formula_saved" : <p>{t("Formula saved. Apply the ")}<a href={'/rhn/manager/systems/details/highstate?sid=' + serverId}>{t("Highstate")}</a>{t(" for the changes to take effect.")}</p>,
+  "error_invalid_target" : t("Invalid target type.")
+}
+
 function addFormulaNavBar(formulaList, activeId) {
     $("#formula-nav-bar").remove();
 
@@ -28,7 +33,8 @@ ReactDOM.render(
           formulaId={formulaId}
           systemId={serverId}
           getFormulaUrl={function(id) {return "/rhn/manager/systems/details/formula/" + id + "?sid=" + serverId;}}
-          scope="system" />,
+          scope="system"
+          messageTexts={msgMap} />,
     document.getElementById('formula')
 );
 

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Add a link to the highstate page after formula was saved
 - New menu look&feel
 - Remove feature preview message from Formulas pages
 


### PR DESCRIPTION
## What does this PR change?

Add a link to the highstate page after formula was saved

## GUI diff

No difference.

Before:

After:
![group_save_formula_after](https://user-images.githubusercontent.com/11468018/56821711-5f2cfe00-684f-11e9-89b4-b6204f217af3.png)


- [ ] **DONE**

## Documentation
- No documentation needed: small UI change

- [ ] **DONE**

## Test coverage
- No tests: small UI change

- [ ] **DONE**

## Links

Fixes #https://github.com/SUSE/spacewalk/issues/7686

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
