### PR TITLE
Fix missing product packages query

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/Package_satellite.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/Package_satellite.hbm.xml
@@ -225,6 +225,11 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
              ) latest
              JOIN rhnPackageName pn ON pn.id = latest.name_id
             where pn.name not like '%-migration'
+              and EXISTS (
+                     SELECT 1
+                       FROM rhnServerPackage SP
+                      WHERE SP.server_id = :sid
+              )
               and NOT EXISTS (
                      SELECT 1
                        FROM rhnServerPackage SP

--- a/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
@@ -100,14 +100,6 @@ public class RegistrationUtils {
         // get hardware and network async
         triggerHardwareRefresh(minion);
 
-        // Get the product packages from subscribed channels and install them.
-        List<Package> prodPkgs = PackageFactory.findMissingProductPackagesOnServer(minion.getId());
-        StateFactory.addPackagesToNewStateRevision(minion, creator.map(c -> c.getId()), prodPkgs);
-
-        LOG.info("Finished minion registration: " + minionId);
-
-        StatesAPI.generateServerPackageState(minion);
-
         // Asynchronously get the uptime of this minion
         MessageQueue.publish(new MinionStartEventDatabaseMessage(minionId));
 
@@ -123,6 +115,14 @@ public class RegistrationUtils {
         catch (RuntimeException e) {
             LOG.error("Error generating Salt files for minion '" + minionId + "':" + e.getMessage());
         }
+
+        // Get the product packages from subscribed channels and install them.
+        List<Package> prodPkgs = PackageFactory.findMissingProductPackagesOnServer(minion.getId());
+        StateFactory.addPackagesToNewStateRevision(minion, creator.map(User::getId), prodPkgs);
+
+        LOG.info("Finished minion registration: " + minionId);
+
+        StatesAPI.generateServerPackageState(minion);
 
         // Should we apply the highstate?
         boolean applyHighstate = activationKey.isPresent() && activationKey.get().getDeployConfigs();

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix product package conflicts with SLES for SAP systems (bsc#1130551)
 - Take into account only synced products when scheduling SP migration from the API (bsc#1131929)
 
 -------------------------------------------------------------------


### PR DESCRIPTION
Prevent querying for missing product packages if package profile data is not available.

https://bugzilla.suse.com/1130551

## Test coverage
- Unit tests were added

## Links

Tracks https://github.com/SUSE/spacewalk/pull/7566

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
