### PR TITLE
Minor XMLRPC-related fixes for content management

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
@@ -60,7 +60,7 @@ public class ContentProjectFactory extends HibernateFactory {
     /**
      * Save the ContentProject
      *
-     * @param contentProject - the ContentProject
+     * @param contentProject the ContentProject
      */
     public static void save(ContentProject contentProject) {
         INSTANCE.saveObject(contentProject);
@@ -69,7 +69,7 @@ public class ContentProjectFactory extends HibernateFactory {
     /**
      * Remove a Content Project
      *
-     * @param contentProject - the Content Project to remove
+     * @param contentProject the Content Project to remove
      * @return the number of object affected
      */
     public static int remove(ContentProject contentProject) {
@@ -79,8 +79,8 @@ public class ContentProjectFactory extends HibernateFactory {
     /**
      * Looks up a ContentProject by label and organization
      *
-     * @param label - the label
-     * @param org - the org
+     * @param label the label
+     * @param org the org
      * @return Optional with ContentProject with given label
      */
     public static Optional<ContentProject> lookupProjectByLabelAndOrg(String label, Org org) {
@@ -95,7 +95,7 @@ public class ContentProjectFactory extends HibernateFactory {
 
     /**
      * List all ContentProjects with given organization
-     * @param org - the organization
+     * @param org the organization
      * @return the ContentProjects in given organization
      */
     public static List<ContentProject> listProjects(Org org) {
@@ -321,7 +321,7 @@ public class ContentProjectFactory extends HibernateFactory {
     /**
      * Save the Content Project history entry
      *
-     * @param entry  - the Content Project history entry
+     * @param entry the Content Project history entry
      */
     private static void save(ContentProjectHistoryEntry entry) {
         INSTANCE.saveObject(entry);
@@ -330,8 +330,8 @@ public class ContentProjectFactory extends HibernateFactory {
     /**
      * Add a history entry to a Content Project
      *
-     * @param project - Content Project
-     * @param entry - the history entry
+     * @param project Content Project
+     * @param entry the history entry
      */
     public static void addHistoryEntryToProject(ContentProject project, ContentProjectHistoryEntry entry) {
         List<ContentProjectHistoryEntry> entries = project.getHistoryEntries();

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/ContentManagementFaultException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/ContentManagementFaultException.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.frontend.xmlrpc;
+
+import com.redhat.rhn.FaultException;
+
+/**
+ * Fault wrapper for {@link ContentManagementException}
+ */
+public class ContentManagementFaultException extends FaultException {
+
+    private static final int ERROR_CODE = 10102;
+    private static final String ERROR_LABEL = "entityExists";
+
+    /**
+     * Standard constructor
+     *
+     * @param cause the fault cause
+     */
+    public ContentManagementFaultException(Throwable cause) {
+        super(ERROR_CODE, ERROR_LABEL, cause.getMessage(), cause);
+    }
+}

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
@@ -44,8 +44,8 @@ import static java.util.Optional.ofNullable;
  * Content Management XMLRPC handler
  *
  * @xmlrpc.namespace contentmgmt
- * @xmlrpc.doc Provides methods to access and modify Content Lifecycle Managemenet Projects,
- * Environments and more
+ * @xmlrpc.doc Provides methods to access and modify Content Lifecycle Management related entities
+ * (Projects, Environments, Filters, Sources).
  */
 public class ContentManagementHandler extends BaseHandler {
 
@@ -55,7 +55,7 @@ public class ContentManagementHandler extends BaseHandler {
      * @param loggedInUser the logged in user
      * @return the list of Content Projects visible to user
      *
-     * @xmlrpc.doc Look up Content Project with given label
+     * @xmlrpc.doc List Content Projects visible to user
      * @xmlrpc.param #session_key()
      * @xmlrpc.returntype
      * #array()

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
@@ -67,10 +67,11 @@ public class ContentManagementHandler extends BaseHandler {
     }
 
     /**
-     * Look up Content Project
+     * Look up Content Project with given label
      *
      * @param loggedInUser the logged in user
-     * @param label the label
+     * @param label the Content Project label
+     * @throws EntityNotExistsFaultException when the Content Project does not exist
      * @return the Content Project with given label
      *
      * @xmlrpc.doc Look up Content Project with given label
@@ -87,8 +88,8 @@ public class ContentManagementHandler extends BaseHandler {
      * Create Content Project
      *
      * @param loggedInUser the logged in user
-     * @param label the label
-     * @param name the name
+     * @param label the Content Project label
+     * @param name the Content Project name
      * @param description the description
      * @throws EntityExistsFaultException when Project already exists
      * @return the created Content Project
@@ -254,7 +255,7 @@ public class ContentManagementHandler extends BaseHandler {
      * @param projectLabel the Content Project label
      * @param envLabel the Environment label
      * @param props the map with the Environment properties
-     * @throws EntityNotExistsFaultException when Project or predecessor Environment does not exist
+     * @throws EntityNotExistsFaultException when the Environment does not exist
      * @return the updated Environment
      *
      * @xmlrpc.doc Update Content Environment with given label
@@ -332,7 +333,7 @@ public class ContentManagementHandler extends BaseHandler {
      * @param projectLabel the Project label
      * @param sourceType the Source type (e.g. "software")
      * @param sourceLabel the Source label (e.g. software channel label)
-     * @throws EntityNotExistsFaultException if the Project is not found
+     * @throws EntityNotExistsFaultException if the Project or Project Source is not found
      * @return list of Project Sources
      *
      * @xmlrpc.doc Look up Content Project Source
@@ -371,7 +372,7 @@ public class ContentManagementHandler extends BaseHandler {
      * @xmlrpc.param #param_desc("string", "projectLabel", "Content Project label")
      * @xmlrpc.param #param_desc("string", "sourceType", "Project Source type, e.g. 'software'")
      * @xmlrpc.param #param_desc("string", "sourceLabel", "Project Source label")
-     * @xmlrpc.param #param_desc("int", "sourcePosition", "Project Source label")
+     * @xmlrpc.param #param_desc("int", "sourcePosition", "Project Source position")
      * @xmlrpc.returntype $ContentProjectSourceSerializer
      */
     public ProjectSource attachSource(User loggedInUser, String projectLabel, String sourceType, String sourceLabel,
@@ -451,7 +452,7 @@ public class ContentManagementHandler extends BaseHandler {
      * @param loggedInUser the logged in user
      * @return the list of {@link ContentFilter}s
      *
-     * @xmlrpc.doc List all Content Filters
+     * @xmlrpc.doc List all Content Filters visible to given user
      * @xmlrpc.param #session_key()
      * @xmlrpc.returntype
      * #array()
@@ -467,6 +468,7 @@ public class ContentManagementHandler extends BaseHandler {
      *
      * @param loggedInUser the logged in user
      * @param id the filter id
+     * @throws EntityNotExistsFaultException if filter is not found
      * @return the matching {@link ContentFilter}
      *
      * @xmlrpc.doc Lookup a Content Filter by id
@@ -487,6 +489,7 @@ public class ContentManagementHandler extends BaseHandler {
      * @param rule the Filter rule
      * @param entityType the Filter entity type
      * @param criteria the filter criteria
+     * @throws InvalidArgsException when invalid criteria are passed
      * @return the created {@link ContentFilter}
      *
      * @xmlrpc.doc Create a Content Filter
@@ -578,6 +581,7 @@ public class ContentManagementHandler extends BaseHandler {
      *
      * @param loggedInUser the logged in user
      * @param filterId the filter id
+     * @throws EntityNotExistsFaultException when Filter does not exist
      * @return 1 on success
      *
      * @xmlrpc.doc Remove a Content Filter
@@ -621,6 +625,7 @@ public class ContentManagementHandler extends BaseHandler {
      * @param loggedInUser the logged in user
      * @param projectLabel the Project label
      * @param filterId the Filter id to attach
+     * @throws EntityNotExistsException if the Project/Filter does not exist
      * @return the attached Filter
      *
      * @xmlrpc.doc Attach a Filter to a Project
@@ -646,6 +651,7 @@ public class ContentManagementHandler extends BaseHandler {
      * @param loggedInUser the logged in user
      * @param projectLabel the Project label
      * @param filterId the Filter id to detach
+     * @throws EntityNotExistsException if the Project/Filter does not exist
      * @return 1 on success
      *
      * @xmlrpc.doc Detach a Filter from a Project

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
@@ -52,7 +52,7 @@ public class ContentManagementHandler extends BaseHandler {
     /**
      * List Content Projects visible to user
      *
-     * @param loggedInUser - the logged in user
+     * @param loggedInUser the logged in user
      * @return the list of Content Projects visible to user
      *
      * @xmlrpc.doc Look up Content Project with given label
@@ -69,8 +69,8 @@ public class ContentManagementHandler extends BaseHandler {
     /**
      * Look up Content Project
      *
-     * @param loggedInUser - the logged in user
-     * @param label - the label
+     * @param loggedInUser the logged in user
+     * @param label the label
      * @return the Content Project with given label
      *
      * @xmlrpc.doc Look up Content Project with given label
@@ -86,10 +86,10 @@ public class ContentManagementHandler extends BaseHandler {
     /**
      * Create Content Project
      *
-     * @param loggedInUser - the logged in user
-     * @param label - the label
-     * @param name - the name
-     * @param description - the description
+     * @param loggedInUser the logged in user
+     * @param label the label
+     * @param name the name
+     * @param description the description
      * @throws EntityExistsFaultException when Project already exists
      * @return the created Content Project
      *
@@ -113,9 +113,9 @@ public class ContentManagementHandler extends BaseHandler {
     /**
      * Update Content Project
      *
-     * @param loggedInUser - the logged in user
-     * @param label - the new label
-     * @param props - the map with the Content Project properties
+     * @param loggedInUser the logged in user
+     * @param label the new label
+     * @param props the map with the Content Project properties
      * @throws EntityNotExistsFaultException when Project does not exist
      * @return the updated Content Project
      *
@@ -145,8 +145,8 @@ public class ContentManagementHandler extends BaseHandler {
     /**
      * Remove Content Project
      *
-     * @param loggedInUser - the logged in user
-     * @param label - the label
+     * @param loggedInUser the logged in user
+     * @param label the label
      * @throws EntityNotExistsFaultException when Project does not exist
      * @return the number of removed objects
      *
@@ -168,8 +168,8 @@ public class ContentManagementHandler extends BaseHandler {
     /**
      * List Environments in a Content Project with the respect to their ordering
      *
-     * @param loggedInUser - the logged in user
-     * @param projectLabel - the Content Project label
+     * @param loggedInUser the logged in user
+     * @param projectLabel the Content Project label
      * @throws EntityNotExistsFaultException when Project does not exist
      * @return the List of Content Environments with respect to their ordering
      *
@@ -193,9 +193,9 @@ public class ContentManagementHandler extends BaseHandler {
     /**
      * Look up Content Environment based on Content Project and Content Environment label
      *
-     * @param loggedInUser - the logged in user
-     * @param projectLabel - the Content Project label
-     * @param envLabel - the Content Environment label
+     * @param loggedInUser the logged in user
+     * @param projectLabel the Content Project label
+     * @param envLabel the Content Environment label
      * @throws EntityNotExistsException when Project does not exist
      * @return found Content Environment or null if no such environment exists
      *
@@ -213,12 +213,12 @@ public class ContentManagementHandler extends BaseHandler {
     /**
      * Create a Content Environment and appends it behind given Content Environment
      *
-     * @param loggedInUser - the logged in user
-     * @param projectLabel - the Content Project label
-     * @param predecessorLabel - the Predecessor label
-     * @param label - the Content Environment Label
-     * @param name - the Content Environment name
-     * @param description - the Content Environment description
+     * @param loggedInUser the logged in user
+     * @param projectLabel the Content Project label
+     * @param predecessorLabel the Predecessor label
+     * @param label the Content Environment Label
+     * @param name the Content Environment name
+     * @param description the Content Environment description
      * @throws EntityNotExistsFaultException when Project or predecessor Environment does not exist
      * @throws EntityExistsFaultException when Environment with given parameters already exists
      * @return the created Content Environment
@@ -250,10 +250,10 @@ public class ContentManagementHandler extends BaseHandler {
     /**
      * Update Content Environment
      *
-     * @param loggedInUser - the logged in user
-     * @param projectLabel - the Content Project label
-     * @param envLabel - the Environment label
-     * @param props - the map with the Environment properties
+     * @param loggedInUser the logged in user
+     * @param projectLabel the Content Project label
+     * @param envLabel the Environment label
+     * @param props the map with the Environment properties
      * @throws EntityNotExistsFaultException when Project or predecessor Environment does not exist
      * @return the updated Environment
      *
@@ -286,9 +286,9 @@ public class ContentManagementHandler extends BaseHandler {
     /**
      * Remove a Content Environment
      *
-     * @param loggedInUser - the logged in user
-     * @param projectLabel - the Content Project label
-     * @param envLabel - the Content Environment label
+     * @param loggedInUser the logged in user
+     * @param projectLabel the Content Project label
+     * @param envLabel the Content Environment label
      * @throws EntityNotExistsFaultException when Project does not exist
      * @return the number of removed objects
      *

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
@@ -17,6 +17,7 @@ package com.redhat.rhn.frontend.xmlrpc.contentmgmt;
 
 import com.redhat.rhn.domain.contentmgmt.ContentEnvironment;
 import com.redhat.rhn.domain.contentmgmt.ContentFilter;
+import com.redhat.rhn.domain.contentmgmt.ContentManagementException;
 import com.redhat.rhn.domain.contentmgmt.ContentProject;
 import com.redhat.rhn.domain.contentmgmt.ContentProjectFilter;
 import com.redhat.rhn.domain.contentmgmt.FilterCriteria;
@@ -24,6 +25,7 @@ import com.redhat.rhn.domain.contentmgmt.ProjectSource;
 import com.redhat.rhn.domain.contentmgmt.ProjectSource.Type;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.xmlrpc.BaseHandler;
+import com.redhat.rhn.frontend.xmlrpc.ContentManagementFaultException;
 import com.redhat.rhn.frontend.xmlrpc.EntityExistsFaultException;
 import com.redhat.rhn.frontend.xmlrpc.EntityNotExistsFaultException;
 import com.redhat.rhn.frontend.xmlrpc.InvalidArgsException;
@@ -698,6 +700,8 @@ public class ContentManagementHandler extends BaseHandler {
      *
      * @param loggedInUser the user
      * @param projectLabel the Project label
+     * @throws EntityNotExistsFaultException when Project does not exist
+     * @throws ContentManagementFaultException on Content Management-related error
      * @return 1 if successful
      *
      * @xmlrpc.doc Build a Project
@@ -707,7 +711,15 @@ public class ContentManagementHandler extends BaseHandler {
      */
     public int buildProject(User loggedInUser, String projectLabel) {
         ensureOrgAdmin(loggedInUser);
-        ContentManager.buildProject(projectLabel, empty(), true, loggedInUser);
+        try {
+            ContentManager.buildProject(projectLabel, empty(), true, loggedInUser);
+        }
+        catch (EntityNotExistsException e) {
+            throw new EntityExistsFaultException(e);
+        }
+        catch (ContentManagementException e) {
+            throw new ContentManagementFaultException(e);
+        }
         return 1;
     }
 
@@ -717,6 +729,8 @@ public class ContentManagementHandler extends BaseHandler {
      * @param loggedInUser the user
      * @param message the log message to be assigned to the build
      * @param projectLabel the Project label
+     * @throws EntityNotExistsFaultException when Project does not exist
+     * @throws ContentManagementFaultException on Content Management-related error
      * @return 1 if successful
      *
      * @xmlrpc.doc Build a Project
@@ -727,7 +741,15 @@ public class ContentManagementHandler extends BaseHandler {
      */
     public int buildProject(User loggedInUser, String projectLabel, String message) {
         ensureOrgAdmin(loggedInUser);
-        ContentManager.buildProject(projectLabel, of(message), true, loggedInUser);
+        try {
+            ContentManager.buildProject(projectLabel, of(message), true, loggedInUser);
+        }
+        catch (EntityNotExistsException e) {
+            throw new EntityExistsFaultException(e);
+        }
+        catch (ContentManagementException e) {
+            throw new ContentManagementFaultException(e);
+        }
         return 1;
     }
 
@@ -737,6 +759,8 @@ public class ContentManagementHandler extends BaseHandler {
      * @param loggedInUser the user
      * @param projectLabel the Project label
      * @param envLabel the Environment label
+     * @throws EntityNotExistsFaultException when Project does not exist
+     * @throws ContentManagementFaultException on Content Management-related error
      * @return 1 if successful
      *
      * @xmlrpc.doc Promote an Environment in a Project
@@ -747,7 +771,15 @@ public class ContentManagementHandler extends BaseHandler {
      */
     public int promoteProject(User loggedInUser, String projectLabel, String envLabel) {
         ensureOrgAdmin(loggedInUser);
-        ContentManager.promoteProject(projectLabel, envLabel, true, loggedInUser);
+        try {
+            ContentManager.promoteProject(projectLabel, envLabel, true, loggedInUser);
+        }
+        catch (EntityNotExistsException e) {
+            throw new EntityExistsFaultException(e);
+        }
+        catch (ContentManagementException e) {
+            throw new ContentManagementFaultException(e);
+        }
         return 1;
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
@@ -438,7 +438,7 @@ public class ContentManagementHandler extends BaseHandler {
      * @param sourceType the Source type (e.g. "software")
      * @param sourceLabel the Source label (e.g. software channel label)
      * @throws EntityNotExistsFaultException when used entities don't exist or are not accessible
-     * @return the number of Sources detached
+     * @return 1 on success
      *
      * @xmlrpc.doc Detach a Source from a Project
      * @xmlrpc.param #session_key()
@@ -451,7 +451,8 @@ public class ContentManagementHandler extends BaseHandler {
         ensureOrgAdmin(loggedInUser);
         Type type = Type.lookupByLabel(sourceType);
         try {
-            return ContentManager.detachSource(projectLabel, type, sourceLabel, loggedInUser);
+            ContentManager.detachSource(projectLabel, type, sourceLabel, loggedInUser);
+            return 1;
         }
         catch (EntityNotExistsException e) {
             throw new EntityNotExistsFaultException(e);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
@@ -153,7 +153,7 @@ public class ContentManagementHandler extends BaseHandler {
      * @xmlrpc.doc Remove Content Project
      * @xmlrpc.param #session_key()
      * @xmlrpc.param #param_desc("string", "label", "Content Project label")
-     * @xmlrpc.returntype int - the number of removed objects
+     * @xmlrpc.returntype #return_int_success()
      */
     public int removeProject(User loggedInUser, String label) {
         ensureOrgAdmin(loggedInUser);
@@ -296,7 +296,7 @@ public class ContentManagementHandler extends BaseHandler {
      * @xmlrpc.param #session_key()
      * @xmlrpc.param #param_desc("string", "projectLabel", "Content Project label")
      * @xmlrpc.param #param_desc("string", "envLabel", "Content Environment label")
-     * @xmlrpc.returntype int - the number of removed objects
+     * @xmlrpc.returntype #return_int_success()
      */
     public int removeEnvironment(User loggedInUser, String projectLabel, String envLabel) {
         ensureOrgAdmin(loggedInUser);
@@ -425,14 +425,14 @@ public class ContentManagementHandler extends BaseHandler {
      * @param sourceType the Source type (e.g. "software")
      * @param sourceLabel the Source label (e.g. software channel label)
      * @throws EntityNotExistsFaultException when used entities don't exist or are not accessible
-     * @return the number of Sources removed
+     * @return the number of Sources detached
      *
      * @xmlrpc.doc Detach a Source from a Project
      * @xmlrpc.param #session_key()
      * @xmlrpc.param #param_desc("string", "projectLabel", "Content Project label")
      * @xmlrpc.param #param_desc("string", "sourceType", "Project Source type, e.g. 'software'")
      * @xmlrpc.param #param_desc("string", "sourceLabel", "Project Source label")
-     * @xmlrpc.returntype int - the number of detached sources
+     * @xmlrpc.returntype #return_int_success()
      */
     public int detachSource(User loggedInUser, String projectLabel, String sourceType, String sourceLabel) {
         ensureOrgAdmin(loggedInUser);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
@@ -207,8 +207,13 @@ public class ContentManagementHandler extends BaseHandler {
      * @xmlrpc.returntype $ContentEnvironmentSerializer
      */
     public ContentEnvironment lookupEnvironment(User loggedInUser, String projectLabel, String envLabel) {
-        return ContentManager.lookupEnvironment(envLabel, projectLabel, loggedInUser)
-                .orElseThrow(() -> new EntityNotExistsFaultException(envLabel));
+        try {
+            return ContentManager.lookupEnvironment(envLabel, projectLabel, loggedInUser)
+                    .orElseThrow(() -> new EntityNotExistsFaultException(envLabel));
+        }
+        catch (EntityNotExistsException e) {
+            throw new EntityNotExistsFaultException(e);
+        }
     }
 
     /**
@@ -301,7 +306,12 @@ public class ContentManagementHandler extends BaseHandler {
      */
     public int removeEnvironment(User loggedInUser, String projectLabel, String envLabel) {
         ensureOrgAdmin(loggedInUser);
-        return ContentManager.removeEnvironment(envLabel, projectLabel, loggedInUser);
+        try {
+            return ContentManager.removeEnvironment(envLabel, projectLabel, loggedInUser);
+        }
+        catch (EntityNotExistsException e) {
+            throw new EntityNotExistsFaultException(e);
+        }
     }
 
     /**
@@ -526,6 +536,7 @@ public class ContentManagementHandler extends BaseHandler {
      * @param name the Filter name
      * @param rule the Filter rule
      * @param criteria the filter criteria
+     * @throws EntityNotExistsFaultException when Filter is not found
      * @return the updated {@link ContentFilter}
      *
      * @xmlrpc.doc Update a Content Filter
@@ -554,12 +565,17 @@ public class ContentManagementHandler extends BaseHandler {
         }
         Optional<FilterCriteria> criteriaObj = createCriteria(criteria);
 
-        return ContentManager.updateFilter(
-                filterId.longValue(),
-                ofNullable(name),
-                ruleObj,
-                criteriaObj,
-                loggedInUser);
+        try {
+            return ContentManager.updateFilter(
+                    filterId.longValue(),
+                    ofNullable(name),
+                    ruleObj,
+                    criteriaObj,
+                    loggedInUser);
+        }
+        catch (EntityNotExistsException e) {
+            throw new EntityNotExistsFaultException(e);
+        }
     }
 
     private Optional<FilterCriteria> createCriteria(Map<String, Object> criteria) {
@@ -605,6 +621,7 @@ public class ContentManagementHandler extends BaseHandler {
      *
      * @param loggedInUser the logged in user
      * @param projectLabel the Project label
+     * @throws EntityNotExistsFaultException when Project is not found
      * @return the list of filters
      *
      * @xmlrpc.doc List all Filters associated with a Project
@@ -616,7 +633,12 @@ public class ContentManagementHandler extends BaseHandler {
      * #array_end()
      */
     public List<ContentProjectFilter> listProjectFilters(User loggedInUser, String projectLabel) {
-        return lookupProject(loggedInUser, projectLabel).getProjectFilters();
+        try {
+            return lookupProject(loggedInUser, projectLabel).getProjectFilters();
+        }
+        catch (EntityNotExistsException e) {
+            throw new EntityNotExistsFaultException(e);
+        }
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
@@ -355,7 +355,7 @@ public class ContentManagementHandler extends BaseHandler {
      * @xmlrpc.param #param_desc("string", "sourceLabel", "Project Source label")
      * @xmlrpc.returntype $ContentProjectSourceSerializer
      */
-    public ProjectSource lookupProjectSource(User loggedInUser, String projectLabel, String sourceType,
+    public ProjectSource lookupSource(User loggedInUser, String projectLabel, String sourceType,
             String sourceLabel) {
         Type type = Type.lookupByLabel(sourceType);
         try {

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -327,20 +327,17 @@ public class ContentManager {
      * @param sourceType the Source Type (e.g. SW_CHANNEL)
      * @param sourceLabel the Source label (e.g. SoftwareChannel label)
      * @param user the user
-     * @return number of Sources detached
      */
-    public static int detachSource(String projectLabel, Type sourceType, String sourceLabel, User user) {
+    public static void detachSource(String projectLabel, Type sourceType, String sourceLabel, User user) {
         ensureOrgAdmin(user);
-        Optional<? extends ProjectSource> src = lookupProjectSource(projectLabel, sourceType, sourceLabel, user);
-        return src.map(s -> {
-            if (s.getState() == ATTACHED) {
-                s.getContentProject().removeSource(s);
-            }
-            else {
-                s.setState(DETACHED);
-            }
-            return 1;
-        }).orElse(0);
+        ProjectSource src = lookupProjectSource(projectLabel, sourceType, sourceLabel, user)
+                .orElseThrow(() -> (new EntityNotExistsException(sourceLabel)));
+        if (src.getState() == ATTACHED) {
+            src.getContentProject().removeSource(src);
+        }
+        else {
+            src.setState(DETACHED);
+        }
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -512,6 +512,8 @@ public class ContentManager {
      * @param async run the time-expensive operations asynchronously? (in the test code it is useful to run them
      * synchronously)
      * @param user the user
+     * @throws EntityNotExistsException if Project does not exist
+     * @throws ContentManagementException when there are no Environments in the Project
      */
     public static void buildProject(String projectLabel, Optional<String> message, boolean async, User user) {
         ensureOrgAdmin(user);
@@ -531,6 +533,7 @@ public class ContentManager {
      * @param firstEnv first Environment of the Project
      * @param async run the time-expensive operations asynchronously?
      * @param user the user
+     * @throws ContentManagementException when there is no leader channel in the Project
      */
     private static void buildSoftwareSources(ContentEnvironment firstEnv, boolean async, User user) {
         ContentProject project = firstEnv.getContentProject();

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -74,10 +74,10 @@ public class ContentManager {
     /**
      * Create a Content Project
      *
-     * @param label - the label
-     * @param name - the name
-     * @param description - the description
-     * @param user - the creator
+     * @param label the label
+     * @param name the name
+     * @param description the description
+     * @param user the creator
      * @throws EntityExistsException if a project with given label already exists
      * @throws PermissionException if given user does not have required role
      * @return the created Content Project
@@ -105,8 +105,8 @@ public class ContentManager {
     /**
      * Look up Content Project by label
      *
-     * @param label - the label
-     * @param user - the user
+     * @param label the label
+     * @param user the user
      * @return Optional with matching Content Project
      */
     public static Optional<ContentProject> lookupProject(String label, User user) {
@@ -116,11 +116,11 @@ public class ContentManager {
     /**
      * Update Content Project
      *
-     * @param label - the label for lookup
-     * @param newName - new name
-     * @param newDesc - new description
-     * @param user - the user
-     * @throws EntityNotExistsException - if Content Project with given label is not found
+     * @param label the label for lookup
+     * @param newName new name
+     * @param newDesc new description
+     * @param user the user
+     * @throws EntityNotExistsException if Content Project with given label is not found
      * @throws PermissionException if given user does not have required role
      * @return the updated Content Project
      */
@@ -139,10 +139,10 @@ public class ContentManager {
     /**
      * Remove Content Project
      *
-     * @param label - the label
-     * @param user - the user
+     * @param label the label
+     * @param user the user
      * @throws PermissionException if given user does not have required role
-     * @throws EntityNotExistsException - if Content Project with given label is not found
+     * @throws EntityNotExistsException if Content Project with given label is not found
      * @return the number of objects affected
      */
     public static int removeProject(String label, User user) {
@@ -155,16 +155,16 @@ public class ContentManager {
     /**
      * Create Content Environment
      *
-     * @param projectLabel - the Content Project label
-     * @param predecessorLabel - the predecessor Environment label
-     * @param label - the Environment label
-     * @param name - the Environment name
-     * @param description - the Environment description
+     * @param projectLabel the Content Project label
+     * @param predecessorLabel the predecessor Environment label
+     * @param label the Environment label
+     * @param name the Environment name
+     * @param description the Environment description
      * @param async run the time-expensive operations asynchronously?
-     * @param user - the user performing the action
-     * @throws EntityNotExistsException - if Content Project with given label or Content Environment in the Project
+     * @param user the user performing the action
+     * @throws EntityNotExistsException if Content Project with given label or Content Environment in the Project
      * is not found
-     * @throws EntityExistsException - if Environment with given parameters already exists
+     * @throws EntityExistsException if Environment with given parameters already exists
      * @throws PermissionException if given user does not have required role
      * @return the created Content Environment
      */
@@ -193,9 +193,9 @@ public class ContentManager {
     /**
      * List Environments in a Content Project with the respect to their ordering
      *
-     * @param projectLabel - the Content Project label
-     * @param user - the user
-     * @throws EntityNotExistsException - if Content Project with given label is not found
+     * @param projectLabel the Content Project label
+     * @param user the user
+     * @throws EntityNotExistsException if Content Project with given label is not found
      * @return the List of Content Environments with respect to their ordering
      */
     public static List<ContentEnvironment> listProjectEnvironments(String projectLabel, User user) {
@@ -207,10 +207,10 @@ public class ContentManager {
     /**
      * Look up Content Environment based on its label, Content Project label and User
      *
-     * @param envLabel - the Content Environment label
-     * @param projectLabel - the Content Project label
-     * @param user - the user
-     * @throws EntityNotExistsException - if Content Project with given label is not found
+     * @param envLabel the Content Environment label
+     * @param projectLabel the Content Project label
+     * @param user the user
+     * @throws EntityNotExistsException if Content Project with given label is not found
      * @return the optional of matching Content Environment
      */
     public static Optional<ContentEnvironment> lookupEnvironment(String envLabel, String projectLabel, User user) {
@@ -222,12 +222,12 @@ public class ContentManager {
     /**
      * Update Content Environment
      *
-     * @param envLabel - the Environment label
-     * @param projectLabel - the Content Project label
-     * @param newName - new name
-     * @param newDescription - new description
-     * @param user - the user
-     * @throws EntityNotExistsException - if Project or Environment is not found
+     * @param envLabel the Environment label
+     * @param projectLabel the Content Project label
+     * @param newName new name
+     * @param newDescription new description
+     * @param user the user
+     * @throws EntityNotExistsException if Project or Environment is not found
      * @throws PermissionException if given user does not have required role
      * @return the updated Environment
      */
@@ -246,11 +246,11 @@ public class ContentManager {
     /**
      * Remove a Content Environment
      *
-     * @param envLabel - the Content Environment label
-     * @param projectLabel - the Content Project label
-     * @param user - the user
+     * @param envLabel the Content Environment label
+     * @param projectLabel the Content Project label
+     * @param user the user
      * @throws PermissionException if given user does not have required role
-     * @throws EntityNotExistsException - if Project or Environment is not found
+     * @throws EntityNotExistsException if Project or Environment is not found
      * @throws PermissionException if given user does not have required role
      * @return number of deleted objects
      */
@@ -268,10 +268,10 @@ public class ContentManager {
      * Create and attach a Source to given Project.
      * If the Source is already attached to the Project, this is a no-op.
      *
-     * @param projectLabel - the Project label
-     * @param sourceType - the Source Type (e.g. SW_CHANNEL)
-     * @param sourceLabel - the Source label (e.g. SoftwareChannel label)
-     * @param position - the position of the Source (Optional)
+     * @param projectLabel the Project label
+     * @param sourceType the Source Type (e.g. SW_CHANNEL)
+     * @param sourceLabel the Source label (e.g. SoftwareChannel label)
+     * @param position the position of the Source (Optional)
      * @param user the user
      * @throws EntityNotExistsException when either the Project or the Source reference (e.g. Channel) is not found
      * @throws java.lang.IllegalArgumentException if the sourceType is unsupported
@@ -323,9 +323,9 @@ public class ContentManager {
     /**
      * Detach a Source from given Project
      *
-     * @param projectLabel - the Project label
-     * @param sourceType - the Source Type (e.g. SW_CHANNEL)
-     * @param sourceLabel - the Source label (e.g. SoftwareChannel label)
+     * @param projectLabel the Project label
+     * @param sourceType the Source Type (e.g. SW_CHANNEL)
+     * @param sourceLabel the Source label (e.g. SoftwareChannel label)
      * @param user the user
      * @return number of Sources detached
      */

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
@@ -559,7 +559,7 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
 
         assertTrue(ContentManager.lookupProjectSource("cplabel", SW_CHANNEL, channel.getLabel(), user).isPresent());
         ContentManager.removeProject("cplabel", user);
-        // we can't use ContentManager.lookupProjectSource because the project does not exist
+        // we can't use ContentManager.lookupSource because the project does not exist
         assertTrue(HibernateFactory.getSession()
                 .createQuery("SELECT 1 FROM SoftwareProjectSource s where s.contentProject = :cp")
                 .setParameter("cp", cp)


### PR DESCRIPTION
Minor changes:

- adjust javadocs/xmlrpc docs
- in XMLRPC handler, wrap thrown exceptions in `FaultException`s
- rename `lookupProjectSource` to `lookupSource` (so that it is consistent with other lookup methods (`Filter`, `Environment`)
- unify the behavior of return values  on detaching sources and filters

## UI diff
No difference.

Before:

After:

- [x] **DONE**

## Doc
- No documentation needed: minor changes not affecting docs

- [x] **DONE**

## Tests
- No tests: 

- [ ] **DONE**


- [x] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "java_pgsql_tests"  
