### PR TITLE
Hide provisioning product from matcher (bsc#1128838)

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/content/test/sccdata_lifecycle_products/organizations_orders.json
+++ b/java/code/src/com/redhat/rhn/manager/content/test/sccdata_lifecycle_products/organizations_orders.json
@@ -19,24 +19,6 @@
             "sku" : "874-005118",
             "fulfillid" : 555555556,
             "start_date" : "2013-01-01T00:00:00.000Z"
-         },
-         {
-            "quantity" : 1,
-            "subscription_id" : 3,
-            "id" : 13,
-            "end_date" : "2017-01-01T00:00:00.000Z",
-            "sku" : "874-005119",
-            "fulfillid" : 555555557,
-            "start_date" : "2013-01-01T00:00:00.000Z"
-         },
-         {
-            "quantity" : 1,
-            "subscription_id" : 4,
-            "id" : 14,
-            "end_date" : "2017-01-01T00:00:00.000Z",
-            "sku" : "874-005120",
-            "fulfillid" : 555555558,
-            "start_date" : "2013-01-01T00:00:00.000Z"
          }
       ]
    }

--- a/java/code/src/com/redhat/rhn/manager/content/test/sccdata_lifecycle_products/organizations_subscriptions.json
+++ b/java/code/src/com/redhat/rhn/manager/content/test/sccdata_lifecycle_products/organizations_subscriptions.json
@@ -46,53 +46,5 @@
       "product_ids" : [
          1078
       ]
-   },
-   {
-      "systems" : [
-         {
-            "password" : "secret",
-            "id" : 1245678,
-            "login" : "1234567890945aaa14fa3ba67b1f83b"
-         }
-      ],
-      "id" : 3,
-      "regcode" : "55REGCODE182",
-      "status" : "ACTIVE",
-      "product_classes" : [
-      ],
-      "system_limit" : 1,
-      "type" : "full",
-      "systems_count" : 1,
-      "expires_at" : "2017-12-31T00:00:00.000Z",
-      "virtual_count" : null,
-      "name" : "Mock lifecycle subscription - Provisioning - Single",
-      "starts_at" : "2012-01-01T00:00:00.000Z",
-      "product_ids" : [
-         1097
-      ]
-   },
-   {
-      "systems" : [
-         {
-            "password" : "secret",
-            "id" : 1245678,
-            "login" : "1234567890945aaa14fa3ba67b1f83b"
-         }
-      ],
-      "id" : 4,
-      "regcode" : "55REGCODE183",
-      "status" : "ACTIVE",
-      "product_classes" : [
-      ],
-      "system_limit" : 1,
-      "type" : "full",
-      "systems_count" : 1,
-      "expires_at" : "2017-12-31T00:00:00.000Z",
-      "virtual_count" : null,
-      "name" : "Mock lifecycle subscription - Provisioning - Unlimited Virtualization",
-      "starts_at" : "2012-01-01T00:00:00.000Z",
-      "product_ids" : [
-         1204
-      ]
    }
 ]

--- a/java/code/src/com/suse/manager/matcher/MatcherJsonIO.java
+++ b/java/code/src/com/suse/manager/matcher/MatcherJsonIO.java
@@ -110,9 +110,6 @@ public class MatcherJsonIO {
         lifecycleProductsTranslation = new HashMap<>();
         productIdForEntitlement("SUSE-Manager-Mgmt-Unlimited-Virtual").ifPresent(
                 from -> productIdForSystem.ifPresent(to -> lifecycleProductsTranslation.put(from, to)));
-        productIdForEntitlement("SUSE-Manager-Prov-Unlimited-Virtual").ifPresent(
-                from -> productIdForEntitlement("SUSE-Manager-Prov-Single")
-                        .ifPresent(to -> lifecycleProductsTranslation.put(from, to)));
 
         productFactory = new CachingSUSEProductFactory();
     }

--- a/java/code/src/com/suse/manager/matcher/MatcherJsonIO.java
+++ b/java/code/src/com/suse/manager/matcher/MatcherJsonIO.java
@@ -105,25 +105,19 @@ public class MatcherJsonIO {
         s390arch = ServerFactory.lookupServerArchByLabel("s390x");
 
         productIdsForS390xSystem = of(
-                productIdForEntitlement("SUSE-Manager-Mgmt-Unlimited-Virtual-Z"),
-                productIdForEntitlement("SUSE-Manager-Prov-Unlimited-Virtual-Z")
+                productIdForEntitlement("SUSE-Manager-Mgmt-Unlimited-Virtual-Z")
         ).filter(Optional::isPresent).map(Optional::get).collect(toList());
 
         Optional<Long> mgmtUnlimitedVirtualProd = productIdForEntitlement("SUSE-Manager-Mgmt-Unlimited-Virtual");
-        Optional<Long> provUnlimitedVirtualProd = productIdForEntitlement("SUSE-Manager-Prov-Unlimited-Virtual");
 
         Optional<Long> mgmtSingleProd = productIdForEntitlement("SUSE-Manager-Mgmt-Single");
-        Optional<Long> provSingleProd = productIdForEntitlement("SUSE-Manager-Prov-Single");
         productIdsForSystem = of(
-                mgmtSingleProd,
-                provSingleProd
+                mgmtSingleProd
         ).filter(Optional::isPresent).map(Optional::get).collect(toList());
 
         lifecycleProductsTranslation = new HashMap<>();
         mgmtUnlimitedVirtualProd.ifPresent(
                 from -> mgmtSingleProd.ifPresent(to -> lifecycleProductsTranslation.put(from, to)));
-        provUnlimitedVirtualProd.ifPresent(
-                from -> provSingleProd.ifPresent(to -> lifecycleProductsTranslation.put(from, to)));
 
         productFactory = new CachingSUSEProductFactory();
     }

--- a/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
+++ b/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
@@ -99,20 +99,18 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
                 result.stream().filter(s -> s.getId().equals(g1.getId())).findFirst().get();
         assertNotNull(resultG1);
         assertEquals("guest1.example.com", resultG1.getName());
-        assertEquals(4, resultG1.getProductIds().size());
+        assertEquals(3, resultG1.getProductIds().size());
         assertTrue(resultG1.getProductIds().contains(1322L));
         assertTrue(resultG1.getProductIds().contains(MGMT_SINGLE_PROD_ID));
-        assertTrue(resultG1.getProductIds().contains(PROV_SINGLE_PROD_ID));
         assertTrue(resultG1.getProductIds().contains(1324L));
 
         SystemJson resultG2 =
                 result.stream().filter(s -> s.getId().equals(g2.getId())).findFirst().get();
         assertNotNull(resultG2);
         assertEquals("guest2.example.com", resultG2.getName());
-        assertEquals(4, resultG2.getProductIds().size());
+        assertEquals(3, resultG2.getProductIds().size());
         assertTrue(resultG2.getProductIds().contains(1322L));
         assertTrue(resultG2.getProductIds().contains(MGMT_SINGLE_PROD_ID));
-        assertTrue(resultG2.getProductIds().contains(PROV_SINGLE_PROD_ID));
         assertTrue(resultG2.getProductIds().contains(1324L));
 
         // ISS Master should add itself
@@ -176,11 +174,9 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
         SystemJson guest = systems.stream().filter(s -> s.getId().equals(guestServer.getId())).findFirst().get();
 
         assertTrue(host.getProductIds().contains(MGMT_SINGLE_PROD_ID));
-        assertTrue(host.getProductIds().contains(PROV_SINGLE_PROD_ID));
         assertFalse(host.getProductIds().contains(MGMT_UNLIMITED_VIRT_PROD_ID));
         assertFalse(host.getProductIds().contains(PROV_UNLIMITED_VIRT_PROD_ID));
         assertTrue(guest.getProductIds().contains(MGMT_SINGLE_PROD_ID));
-        assertTrue(guest.getProductIds().contains(PROV_SINGLE_PROD_ID));
         assertFalse(guest.getProductIds().contains(MGMT_UNLIMITED_VIRT_PROD_ID));
         assertFalse(guest.getProductIds().contains(PROV_UNLIMITED_VIRT_PROD_ID));
     }
@@ -243,20 +239,13 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
         withSetupContentSyncManager("/com/redhat/rhn/manager/content/test/sccdata_lifecycle_products", () -> {
             List<SubscriptionJson> subscriptions = new MatcherJsonIO().getJsonSubscriptions();
 
-            assertEquals(4, subscriptions.size());
+            assertEquals(2, subscriptions.size());
 
             subscriptions.stream()
                     .filter(s -> s.getId() == 11 || s.getId() == 12) // Management
                     .forEach(s -> {
                         assertTrue(s.getProductIds().contains(MGMT_SINGLE_PROD_ID));
                         assertFalse(s.getProductIds().contains(MGMT_UNLIMITED_VIRT_PROD_ID));
-                    });
-
-            subscriptions.stream()
-                    .filter(s -> s.getId() == 13 || s.getId() == 14) // Provisioning
-                    .forEach(s -> {
-                        assertTrue(s.getProductIds().contains(PROV_SINGLE_PROD_ID));
-                        assertFalse(s.getProductIds().contains(PROV_UNLIMITED_VIRT_PROD_ID));
                     });
         });
     }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Do not report Provisioning installed product to subscription matcher (bsc#1128838)
 - Show minion id in System Details GUI and API
 - Fix base channel selection for Ubuntu systems (bsc#1132579)
 - Fix retrieval of build time for .deb repositories (bsc#1131721)


### PR DESCRIPTION
## What does this PR change?
 
 bugzilla.suse.com/1128838

 Review commit-by-commit.
 
 ## GUI diff
 
 No difference.
 
 - [x] **DONE**
 
 ## Documentation
 - No documentation needed: bugfix
 
 - [x] **DONE**
 
 ## Test coverage
 - Unit tests were adjusted
 
 - [x] **DONE**
 
 ## Links
 
 Tracks github.com/SUSE/spacewalk/issues/7281
 
 - [x] **DONE**
 
 ## Changelogs
 
 If you don't need a changelog check, please mark this checkbox:
 
 - [ ] No changelog needed
 
 If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
 
 
 ## Re-run a test
 
 If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:
 
 - [ ] Re-run test "changelog_test"
 - [ ] Re-run test "backend_unittests_pgsql"
 - [ ] Re-run test "java_lint_checkstyle"		 
 - [ ] Re-run test "java_pgsql_tests"		 
 - [ ] Re-run test "ruby_rubocop"
 - [ ] Re-run test "schema_migration_test_oracle"
 - [ ] Re-run test "schema_migration_test_pgsql"		 
 - [ ] Re-run test "susemanager_unittests"
 - [ ] Re-run test "javascript_lint" (Test skipped, there are no changes to test)