### PR TITLE
Fix display number background color for dark themed browsers

### DIFF
--- a/branding/css/susemanager-theme.less
+++ b/branding/css/susemanager-theme.less
@@ -640,6 +640,7 @@ header, nav.navbar-pf {
   display: inline-block;
   width: 5em;
   border: 1px solid #dddddd;
+  background-color: @spacewalk-gray-light-background;
 }
 .view-systems-registered{
   .input-sm;

--- a/branding/css/susemanager-variables.less
+++ b/branding/css/susemanager-variables.less
@@ -19,6 +19,7 @@
 @spacewalk-blue:         #00243e; // dark blue
 @spacewalk-blue-light:   #003258; // light blue
 @spacewalk-violet:       #841781;
+@spacewalk-gray-light-background: #ebebeb;
 @spacewalk-header:       @spacewalk-blue;
 @spacewalk-aside:        @spacewalk-blue-light;
 @spacewalk-notification-badge: @spacewalk-orange-light;

--- a/branding/spacewalk-branding.changes
+++ b/branding/spacewalk-branding.changes
@@ -1,3 +1,5 @@
+- Fix dropdown background in dark themed Firefox
+
 -------------------------------------------------------------------
 Mon Apr 22 12:08:09 CEST 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Fix the background color of numbers for dark themed browsers. Pretty visible in number drop down boxes

## GUI diff

No difference, just a color adjustment

- [X] **DONE**

## Documentation
- No documentation needed: just a colo change

- [X] **DONE**

## Test coverage
- No tests: Just a color change

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"  
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
