### PR TITLE
let system action fail when cancle is not possible anymore

### DIFF
--- a/testsuite/features/step_definitions/xmlrpc_common.rb
+++ b/testsuite/features/step_definitions/xmlrpc_common.rb
@@ -349,6 +349,7 @@ end
 Then(/^I delete all action chains$/) do
   begin
     rpc.list_chains.each do |label|
+      puts "Delete chain: #{label}"
       rpc.delete_chain(label)
     end
   rescue XMLRPC::FaultException => e
@@ -479,8 +480,15 @@ Then(/^I cancel all scheduled actions$/) do
   end
 
   actions.each do |action|
-    scdrpc.cancel_actions([action['id']])
-    puts "\t- Removed \"" + action['name'] + '" action'
+    puts "\t- Try to cancel \"#{action['name']}\" action"
+    begin
+      scdrpc.cancel_actions([action['id']])
+    rescue XMLRPC::FaultException
+      scdrpc.list_in_progress_systems(action['id']).each do |system|
+        scdrpc.fail_system_action(system['server_id'], action['id'])
+      end
+    end
+    puts "\t- Removed \"#{action['name']}\" action"
   end
 end
 

--- a/testsuite/features/support/xmlrpc_schedule.rb
+++ b/testsuite/features/support/xmlrpc_schedule.rb
@@ -10,8 +10,16 @@ class XMLRPCScheduleTest < XMLRPCBaseTest
     @connection.call('schedule.list_in_progress_actions', @sid)
   end
 
+  def list_in_progress_systems(action_id)
+    @connection.call('schedule.list_in_progress_systems', @sid, action_id)
+  end
+
   def cancel_actions(actions)
     @connection.call('schedule.cancel_actions', @sid, actions)
+  end
+
+  def fail_system_action(system_id, action_id)
+    @connection.call('schedule.fail_system_action', @sid, system_id, action_id)
   end
 
   def list_failed_actions


### PR DESCRIPTION
## What does this PR change?

As a cleanup task we try to cancle all scheduled actions. But when such an action is already
picked-up we cannot cancle it anymore. The only option is to let it "fail".

This change does it.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- fix a test

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/7724
Tracks https://github.com/SUSE/spacewalk/pull/7723

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
