### PR TITLE
Fix a race condition (bsc#1131780)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
@@ -861,6 +861,25 @@ public class ActionFactory extends HibernateFactory {
     }
 
     /**
+     * Update the status of several rhnServerAction rows identified by server and action IDs.
+     * @param actionIn associated action of rhnServerAction records
+     * @param serverIds server Ids for which action is scheduled
+     * @param status {@link ActionStatus} object that needs to be set
+     */
+    public static void updateServerActions(Action actionIn, List<Long> serverIds, ActionStatus status) {
+        List list = HibernateFactory.getSession()
+                .getNamedQuery("Action.updateServerActions")
+                .setParameter("action_id", actionIn.getId())
+                .setParameter("server_ids", serverIds)
+                .setParameter("status", status.getId())
+                .list();
+        if (log.isDebugEnabled()) {
+            log.debug("Updated number of serverActions " + list.size() + " for action " + actionIn.getId());
+            log.debug("Action status" + status.getName() + " set for these servers: " + list);
+        }
+    }
+
+    /**
      * Save a {@link ServerAction} object.
      * @param serverActionIn the server action to save
      */

--- a/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
@@ -570,7 +570,7 @@ select {ra.*}
                 AND action_id = :id
     ]]>
     </query>
-    
+
     <query name="Action.findMinionSummaries">
     <![CDATA[
         SELECT sa.server.id, s.minionId, s.digitalServerId, s.machineId, c.label
@@ -621,4 +621,15 @@ select sa.server_id
         <return alias="ra" class="com.redhat.rhn.domain.action.Action"/>
     </sql-query>
 
+    <sql-query name="Action.updateServerActions">
+        <return-scalar column="server_id" type="long"/>
+        <![CDATA[
+            UPDATE rhnServerAction
+                SET status = :status
+            WHERE action_id  = :action_id
+                AND server_id  IN (:server_ids)
+                AND status NOT IN(2,3)
+            RETURNING server_id;
+        ]]>
+    </sql-query>
 </hibernate-mapping>

--- a/java/code/src/com/redhat/rhn/domain/action/test/ActionFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/test/ActionFactoryTest.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.domain.action.test;
 
+import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.util.test.TimeUtilsTest;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
@@ -57,8 +58,10 @@ import com.redhat.rhn.testing.RhnBaseTestCase;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * ActionFactoryTest
@@ -341,6 +344,36 @@ public class ActionFactoryTest extends RhnBaseTestCase {
                 .createOrg("testOrg" + this.getClass().getSimpleName())),
                     ActionFactory.TYPE_PACKAGES_VERIFY);
         assertTrue(ActionFactory.checkActionArchType(newA, "verify"));
+    }
+
+    public void testUpdateServerActions() throws Exception {
+        User user1 = UserTestUtils.findNewUser("testUser", "testOrg" + this.getClass().getSimpleName());
+        Action a1 = ActionFactoryTest.createAction(user1, ActionFactory.TYPE_REBOOT);
+        Server newS = ServerFactoryTest.createTestServer(user1, true);
+        a1.addServerAction(ServerActionTest.createServerAction(newS, a1));
+        ServerAction sa1 = (ServerAction) a1.getServerActions().toArray()[0];
+        ServerAction sa2 = (ServerAction) a1.getServerActions().toArray()[1];
+
+        sa1.setStatus(ActionFactory.STATUS_FAILED);
+        sa1.setRemainingTries(0L);
+        ActionFactory.save(a1);
+        flushAndEvict(sa1);
+        flushAndEvict(sa2);
+
+        List<Long> list = new ArrayList<>();
+        list.add(sa1.getServerId());
+
+        // Should NOT update if already in final state.
+        ActionFactory.updateServerActions(a1, list, ActionFactory.STATUS_PICKED_UP);
+        HibernateFactory.reload(sa1);
+        assertTrue(sa1.getStatus().equals(ActionFactory.STATUS_FAILED));
+
+        list.clear();
+        list.add(sa2.getServerId());
+        //Should update to STATUS_COMPLETED
+        ActionFactory.updateServerActions(a1, list, ActionFactory.STATUS_COMPLETED);
+        HibernateFactory.reload(sa2);
+        assertTrue(sa2.getStatus().equals(ActionFactory.STATUS_COMPLETED));
     }
 
     public static Action createAction(User usr, ActionType type) throws Exception {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Prevent Actions that were actually completed to be displayed as "in progress" forever(bsc#1131780)
 - Disable Salt presence ping for synchronous calls
 - Add unit tests for base channel assignments when registering RES minions
 - Enable batching mode for salt synchronous calls


### PR DESCRIPTION
User visible behavior: Actions stay in "Picked up" state forever, despite being successfully completed on minions.

Explanation: there is a race condition between scheduling an action (and updating its status) from Taskomatic and processing the response for that action in Tomcat.

Problem is more apparent when an action is scheduled on both ssh-minions and regular minions simultaneously. It is more obvious because we are scheduling actions on ssh-minion after regular minions in the scope of single transaction. Now because for ssh-minion we do synchronous call which is slow and takes time, if in the meanwhile, Tomcat has already received the response from salt reactor, it will update the status of that server actions. But now original transaction from Taskomatic which was supposed to update the status to ''Picked Up"  for server actions will simply overwrite the result of the server actions which has been already completed.

## What does this PR change?

This PR fix this race condition by using an `UPDATE` command which will block any other transaction to update that record unless current transaction is complete.

This PR  also improves performance. Before if there were 1000 server action, we were performing 1000 update statements but after this PR It will always be 1 single database query to update the status of all the server actions in question.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **Bug fix**

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/7189
Tracks https://github.com/SUSE/spacewalk/pull/7668

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle" 		 
- [ ] Re-run test "java_pgsql_tests" 		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
