### PR TITLE
Revert "Disable batching mode for synchronous saslt calls"

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -788,10 +788,10 @@ public class SaltService {
         }
 
         if (!regularMinionIds.isEmpty()) {
-            ScheduleMetadata metadata = ScheduleMetadata.getDefaultMetadata();
+            ScheduleMetadata metadata = ScheduleMetadata.getDefaultMetadata().withBatchMode();
             List<Map<String, Result<T>>> callResult =
                     adaptException(callIn.withMetadata(metadata).callSync(SALT_CLIENT,
-                            new MinionList(regularMinionIds), PW_AUTH, Optional.empty()));
+                            new MinionList(regularMinionIds), PW_AUTH, defaultBatch));
             results.putAll(
                     callResult.stream().flatMap(map -> map.entrySet().stream())
                             .collect(Collectors.toMap(Entry<String, Result<T>>::getKey,

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Enable batching mode for salt synchronous calls
 - Do not implicitly set parent channel when cloning (bsc#1130492)
 - Do not report Provisioning installed product to subscription matcher (bsc#1128838)
 - Show minion id in System Details GUI and API


### PR DESCRIPTION
This reverts commit 4bd4f5d40874b08ba0a6feb42e9d8ea07b606f15.

## What does this PR change?

Enables salt synchronous batching calls, given that PR SUSE/salt-netapi-client#273 addresses https://github.com/uyuni-project/uyuni/pull/865 , which was the cause to disable sync batching calls.

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: doc issue created already

- [ ] **DONE**

## Test coverage
- No tests: tests created already

- [ ] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/7720

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
