### PR TITLE
Executes an test.echo instead of test.ping for minion-checkin

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/MinionCheckin.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/MinionCheckin.java
@@ -47,7 +47,7 @@ public class MinionCheckin extends RhnJavaJob {
         List<String> minionIds = this.findCheckinCandidatesIds();
         try {
             if (!minionIds.isEmpty()) {
-                this.saltService.ping(new MinionList(minionIds));
+                this.saltService.checkIn(new MinionList(minionIds));
             }
         }
         catch (SaltException e) {

--- a/java/code/src/com/redhat/rhn/taskomatic/task/test/MinionCheckinTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/test/MinionCheckinTest.java
@@ -71,7 +71,7 @@ public class MinionCheckinTest extends JMockBaseTestCaseWithUser {
         SaltService saltServiceMock = mock(SaltService.class);
 
         context().checking(new Expectations() { {
-            never(saltServiceMock).ping(with(any(MinionList.class)));
+            never(saltServiceMock).checkIn(with(any(MinionList.class)));
         } });
 
         MinionCheckin minionCheckinJob = new MinionCheckin();
@@ -103,7 +103,7 @@ public class MinionCheckinTest extends JMockBaseTestCaseWithUser {
         SaltService saltServiceMock = mock(SaltService.class);
 
         context().checking(new Expectations() { {
-            oneOf(saltServiceMock).ping(with(any(MinionList.class)));
+            oneOf(saltServiceMock).checkIn(with(any(MinionList.class)));
         } });
 
         MinionCheckin minionCheckinJob = new MinionCheckin();

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -848,14 +848,14 @@ public class SaltService {
     }
 
     /**
-     * Pings a target set of minions.
+     * Performs an test.echo on a target set of minions for checkIn purpose.
      * @param targetIn the target
-     * @return the LocalAsyncResult of the test.ping call
+     * @return the LocalAsyncResult of the test.echo call
      * @throws SaltException if we get a failure from Salt
      */
-    public Optional<LocalAsyncResult<Boolean>> ping(MinionList targetIn) throws SaltException {
+    public Optional<LocalAsyncResult<String>> checkIn(MinionList targetIn) throws SaltException {
         try {
-            LocalCall<Boolean> call = Test.ping();
+            LocalCall<String> call = Test.echo("checkIn");
             return callAsync(call, targetIn);
         }
         catch (SaltException e) {


### PR DESCRIPTION
## What does this PR change?

Executes a test.echo instead of a test.ping on minions for checkin.

This temporary fix is needed given that we are filtering test.ping events in the salt engine that correspond to internal presence ping events of batching execution mode in Salt and currently we have no way to distinguish between such events.

The correct fix might require adding some extra metadata on the salt-internal presence ping events.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bug fix

- [x] **DONE**

## Test coverage
- Unit tests were updated

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/7735

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
