### PR TITLE
CLM - Properties history - hide if more than 5 and show long list on modal

### DIFF
--- a/web/html/src/manager/content-management/shared/components/panels/properties/properties-view.js
+++ b/web/html/src/manager/content-management/shared/components/panels/properties/properties-view.js
@@ -4,15 +4,37 @@ import produce from "immer";
 
 import type {ProjectPropertiesType} from '../../../type/project.type.js';
 import {getVersionMessage} from "./properties.utils";
+import {ModalLink} from "components/dialog/ModalLink";
+import {Dialog} from "components/dialog/Dialog";
 
 type Props = {
   properties: ProjectPropertiesType,
 }
 
-const PropertiesView= (props: Props) => {
+const NUMBER_HISTORY_ENTRIES = 5;
+
+const PropertiesHistoryEntries = (props) =>
+  <ul className="list-unstyled">
+    {
+      props.entries.map((history, index) => {
+        const versionMessage = getVersionMessage(history)
+        return (
+          <li key={`historyentries_${props.id}_${index}`}>
+            {
+              index === 0
+                ? <strong>{versionMessage}</strong>
+                : versionMessage
+            }
+          </li>
+        )
+      })
+    }
+  </ul>
+
+const PropertiesView = (props: Props) => {
 
   let propertiesToShow = produce(props.properties, draftProperties => {
-      draftProperties.historyEntries.sort((a, b) => b.version - a.version)
+    draftProperties.historyEntries.sort((a, b) => b.version - a.version)
   });
 
   return (
@@ -33,22 +55,29 @@ const PropertiesView= (props: Props) => {
         <dl className="row">
           <dt className="col-xs-2">Versions history:</dt>
           <dd className="col-xs-10">
-            <ul className="list-unstyled">
-              {
-                propertiesToShow.historyEntries.map((history, index) => {
-                  const versionMessage = getVersionMessage(history)
-                  return (
-                    <li key={`historyentries_${index}`}>
-                      {
-                        index === 0
-                          ? <strong>{versionMessage}</strong>
-                          : versionMessage
-                      }
-                    </li>
-                  )
-                })
-              }
-            </ul>
+            <PropertiesHistoryEntries
+              id="resume"
+              entries={propertiesToShow.historyEntries.slice(0,NUMBER_HISTORY_ENTRIES)} />
+
+            {
+              propertiesToShow.historyEntries.length > NUMBER_HISTORY_ENTRIES &&
+              <>
+                <ModalLink
+                  id={`properties-longlist-modal-button`}
+                  text="show more"
+                  target="properties-longlist-modal-content"
+                />
+                <Dialog
+                  id="properties-longlist-modal-content"
+                  content={
+                    <PropertiesHistoryEntries
+                      id="longlist"
+                      entries={propertiesToShow.historyEntries} />
+                  }
+                  title="Versions history"
+                />
+              </>
+            }
           </dd>
         </dl>
       </React.Fragment>

--- a/web/html/src/manager/content-management/shared/components/panels/properties/properties-view.js
+++ b/web/html/src/manager/content-management/shared/components/panels/properties/properties-view.js
@@ -41,19 +41,19 @@ const PropertiesView = (props: Props) => {
     <div>
       <React.Fragment>
         <dl className="row">
-          <dt className="col-xs-2">Label:</dt>
+          <dt className="col-xs-2">{t("Label:")}</dt>
           <dd className="col-xs-6">{propertiesToShow.label}</dd>
         </dl>
         <dl className="row">
-          <dt className="col-xs-2">Name</dt>
+          <dt className="col-xs-2">{t("Name")}</dt>
           <dd className="col-xs-10">{propertiesToShow.name}</dd>
         </dl>
         <dl className="row">
-          <dt className="col-xs-2">Description</dt>
+          <dt className="col-xs-2">{t("Description")}</dt>
           <dd className="col-xs-10">{propertiesToShow.description}</dd>
         </dl>
         <dl className="row">
-          <dt className="col-xs-2">Versions history:</dt>
+          <dt className="col-xs-2">{t("Versions history:")}</dt>
           <dd className="col-xs-10">
             <PropertiesHistoryEntries
               id="resume"
@@ -74,7 +74,7 @@ const PropertiesView = (props: Props) => {
                       id="longlist"
                       entries={propertiesToShow.historyEntries} />
                   }
-                  title="Versions history"
+                  title={t("Versions history")}
                 />
               </>
             }


### PR DESCRIPTION
## What does this PR change?

CLM - Properties history - hide if more than 5 and show long list on modal

## GUI diff

![Screenshot from 2019-05-02 14-52-02](https://user-images.githubusercontent.com/1140720/57080172-e3690080-6ce9-11e9-812c-5496e75e97e3.png)

![Screenshot from 2019-05-02 14-52-35](https://user-images.githubusercontent.com/1140720/57080215-f7146700-6ce9-11e9-89ac-9e37d4a87ac9.png)

- [x] **DONE**

## Documentation
- No documentation needed.

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
