### PR TITLE
Fix utils (bsc#1132361)

### DIFF
--- a/rel-eng/Makefile.python
+++ b/rel-eng/Makefile.python
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL  :=  __unspecified
 
 define update_pip_env
-	rpm -e python3-pylint &>/dev/null
+	rpm -e python3-pylint &>/dev/null || true
 	pip3 install --upgrade pip
 	pip3 uninstall -y pylint
 	pip3 install pylint==2.3.1

--- a/utils/Makefile.python
+++ b/utils/Makefile.python
@@ -10,7 +10,7 @@ DOCKER_VOLUMES        = -v "$(CURDIR)/..:/manager"
 
 __pylint ::
 	$(call update_pip_env)
-	pylint --rcfile=pylintrc $(shell find -name '*.py') > reports/pylint.log || true
+	pylint --rcfile=pylintrc $(shell grep python ./* | grep -rIzl '^#!/usr/bin') > reports/pylint.log || true
 
 docker_pylint ::
 	docker run --rm -e $(DOCKER_RUN_EXPORT) $(DOCKER_VOLUMES) $(DOCKER_REGISTRY)/$(DOCKER_CONTAINER_BASE)-pgsql /bin/sh -c "cd /manager/utils; make -f Makefile.python __pylint"

--- a/utils/Makefile.python
+++ b/utils/Makefile.python
@@ -12,8 +12,17 @@ __pylint ::
 	$(call update_pip_env)
 	pylint --rcfile=pylintrc $(shell grep python ./* | grep -rIzl '^#!/usr/bin') > reports/pylint.log || true
 
+__pytest ::
+	$(call update_pip_env)
+	$(call install_pytest)
+	cd tests
+	pytest --disable-warnings --tb=native --color=yes -v
+
 docker_pylint ::
 	docker run --rm -e $(DOCKER_RUN_EXPORT) $(DOCKER_VOLUMES) $(DOCKER_REGISTRY)/$(DOCKER_CONTAINER_BASE)-pgsql /bin/sh -c "cd /manager/utils; make -f Makefile.python __pylint"
+
+docker_pytest ::
+	docker run --rm -e $(DOCKER_RUN_EXPORT) $(DOCKER_VOLUMES) $(DOCKER_REGISTRY)/$(DOCKER_CONTAINER_BASE)-pgsql /bin/sh -c "cd /manager/utils; make -f Makefile.python __pytest"
 
 docker_shell ::
 	docker run -t -i --rm -e $(DOCKER_RUN_EXPORT) $(DOCKER_VOLUMES) $(DOCKER_REGISTRY)/$(DOCKER_CONTAINER_BASE)-pgsql /bin/bash

--- a/utils/pylintrc
+++ b/utils/pylintrc
@@ -13,39 +13,40 @@ persistent=no
 
 # Disable the message(s) with the given id(s).
 
+disable=C0103
 
-disable=I0011,
-        C0103,
-	C0302,
-	C0111,
-	R0801,
-	R0902,
-	R0903,
-	R0904,
-	R0912,
-	R0913,
-	R0914,
-	R0915,
-	R0921,
-	R0922,
-	W0142,
-	W0403,
-	W0603,
-	C1001,
-	W0121,
-	useless-else-on-loop,
-	bad-whitespace,
-	unpacking-non-sequence,
-	superfluous-parens,
-	cyclic-import,
-	redefined-variable-type,
-	no-else-return,
-
-        # Uyuni disabled
-	E0203,
-	E0611,
-	E1101,
-	E1102
+;disable=I0011,
+;		C0103,
+;		C0302,
+;		C0111,
+;		R0801,
+;		R0902,
+;		R0903,
+;		R0904,
+;		R0912,
+;		R0913,
+;		R0914,
+;		R0915,
+;		R0921,
+;		R0922,
+;		W0142,
+;		W0403,
+;		W0603,
+;		C1001,
+;		W0121,
+;		useless-else-on-loop,
+;		bad-whitespace,
+;		unpacking-non-sequence,
+;		superfluous-parens,
+;		cyclic-import,
+;		redefined-variable-type,
+;		no-else-return,
+;
+;		# Uyuni disabled
+;		E0203,
+;		E0611,
+;		E1101,
+;		E1102
 
 [REPORTS]
 

--- a/utils/pylintrc
+++ b/utils/pylintrc
@@ -15,6 +15,7 @@ persistent=no
 
 
 disable=I0011,
+        C0103,
 	C0302,
 	C0111,
 	R0801,
@@ -45,30 +46,6 @@ disable=I0011,
 	E0611,
 	E1101,
 	E1102
-
-# list of disabled messages:
-#I0011: 62: Locally disabling R0201
-#C0302:  1: Too many lines in module (2425)
-#C0111:  1: Missing docstring
-#R0902: 19:RequestedChannels: Too many instance attributes (9/7)
-#R0903:  Too few public methods
-#R0904: 26:Transport: Too many public methods (22/20)
-#R0912:171:set_slots_from_cert: Too many branches (59/20)
-#R0913:101:GETServer.__init__: Too many arguments (11/10)
-#R0914:171:set_slots_from_cert: Too many local variables (38/20)
-#R0915:171:set_slots_from_cert: Too many statements (169/50)
-#W0142:228:MPM_Package.write: Used * or ** magic
-#W0403: 28: Relative import 'rhnLog', should be 'backend.common.rhnLog'
-#W0603: 72:initLOG: Using the global statement
-# for pylint-1.0 we also disable
-#C1001: 46, 0: Old-style class defined. (old-style-class)
-#W0121: 33,16: Use raise ErrorClass(args) instead of raise ErrorClass, args. (old-raise-syntax)
-#W:243, 8: Else clause on loop without a break statement (useless-else-on-loop)
-# pylint-1.1 checks
-#C:334, 0: No space allowed after bracket (bad-whitespace)
-#W:162, 8: Attempting to unpack a non-sequence defined at line 6 of (unpacking-non-sequence)
-#C: 37, 0: Unnecessary parens after 'not' keyword (superfluous-parens)
-#C:301, 0: Unnecessary parens after 'if' keyword (superfluous-parens)
 
 [REPORTS]
 

--- a/utils/spacewalk-manage-channel-lifecycle
+++ b/utils/spacewalk-manage-channel-lifecycle
@@ -322,7 +322,7 @@ def build_channel_labels(source):
             destination = '{phase}{dlm}{src}'.format(phase=phases[0], dlm=options.delimiter, src=source)
     elif options.rollback:
         # strip off the archive prefix when rolling back
-        destination = re.sub('archive{dlm}\d{{8}}{dlm}'.format(dlm=options.delimiter), '', source)
+        destination = re.sub(r'archive{dlm}\d{{8}}{dlm}'.format(dlm=options.delimiter), '', source)
 
     return source, destination
 

--- a/utils/spacewalk-manage-channel-lifecycle
+++ b/utils/spacewalk-manage-channel-lifecycle
@@ -118,8 +118,6 @@ CONF_DIR = os.path.expanduser("~/.spacewalk-manage-channel-lifecycle")
 USER_CONF_FILE = os.path.join(CONF_DIR, "settings.conf")
 SESSION_CACHE = os.path.join(CONF_DIR, "session")
 
-##############################################################################
-
 
 def setup_config(cfg):
     """
@@ -164,10 +162,9 @@ def parse_enumerated(data):
     return items
 
 
-# determine the name of the next phase
 def get_next_phase(current_name: str) -> str:
     """
-    Gets next phase of the workflow.
+    Gets the name of the next phase of the workflow.
 
     :param current_name:
     :return:

--- a/utils/spacewalk-manage-channel-lifecycle
+++ b/utils/spacewalk-manage-channel-lifecycle
@@ -265,28 +265,25 @@ def clone_channel(source_label, details):
                 sys.exit(1)
 
 
-def clear_channel(label):
-    logging.info('Clearing all errata from %s', label)
+def clear_channel(lbl):
+    logging.info('Clearing all errata from %s', lbl)
 
     if not options.dry_run:
         # attempt to clear the errata from the channel
         try:
-            all_errata = client.channel.software.listErrata(session, label)
+            all_errata = client.channel.software.listErrata(session, lbl)
             errata_names = [e.get('advisory_name') for e in all_errata]
-            client.channel.software.removeErrata(session,
-                                                 label,
-                                                 errata_names,
-                                                 False)
+            client.channel.software.removeErrata(session, lbl, errata_names, False)
         except xmlrpclib.Fault as e:
             if options.debug:
                 logging.exception(e)
-            logging.warning('Failed to clear errata from %s', label)
+            logging.warning('Failed to clear errata from %s', lbl)
 
     if not options.dry_run:
-        logging.info('Clearing all packages from %s', label)
-        all_packages = client.channel.software.listAllPackages(session, label)
+        logging.info('Clearing all packages from %s', lbl)
+        all_packages = client.channel.software.listAllPackages(session, lbl)
         package_ids = [p.get('id') for p in all_packages]
-        client.channel.software.removePackages(session, label, package_ids)
+        client.channel.software.removePackages(session, lbl, package_ids)
 
 
 def get_current_phase(source):

--- a/utils/spacewalk-manage-channel-lifecycle
+++ b/utils/spacewalk-manage-channel-lifecycle
@@ -31,7 +31,7 @@ import xmlrpc.client as xmlrpclib
 import configparser as ConfigParser
 
 
-class Config(object):
+class Config:
 
     """
     Configuration parser with defaults handling.

--- a/utils/spacewalk-manage-channel-lifecycle
+++ b/utils/spacewalk-manage-channel-lifecycle
@@ -242,6 +242,13 @@ def merge_channels(source_label, dest_label):
 
 
 def clone_channel(source_label, details):
+    """
+    Clone channel.
+
+    :param source_label:
+    :param source_details:
+    :return: None
+    """
     if options.exclude_channel:
         for pattern in options.exclude_channel:
             if source_label == pattern:
@@ -266,6 +273,12 @@ def clone_channel(source_label, details):
 
 
 def clear_channel(lbl):
+    """
+    Clears all the errata in the channel.
+
+    :param lbl:
+    :return: None
+    """
     logging.info('Clearing all errata from %s', lbl)
 
     if not options.dry_run:
@@ -299,6 +312,12 @@ def get_current_phase(source):
 
 
 def build_channel_labels(source):
+    """
+    Build channel labels.
+
+    :param source:
+    :return: source, destination
+    """
     destination = None
     if options.archive:
         # prefix the existing channel with 'archive-YYYYMMDD-'

--- a/utils/spacewalk-manage-channel-lifecycle
+++ b/utils/spacewalk-manage-channel-lifecycle
@@ -18,6 +18,10 @@
 #
 # Copyright 2012 Aron Parsons <aronparsons@gmail.com>
 #
+# coding: utf-8
+"""
+Manage channels lifecycle.
+"""
 
 import os
 import getpass
@@ -25,6 +29,7 @@ import logging
 import re
 import sys
 import time
+import typing
 from optparse import Option, OptionParser  # pylint: disable=W0402
 from socket import gethostname
 import xmlrpc.client as xmlrpclib
@@ -45,7 +50,16 @@ class Config:
         self.default_section = Config.SECTION_GENERAL
         self._cfg = ConfigParser.RawConfigParser()
 
-    def get(self, section, option, default=None):
+    # pylint: disable=R1705
+    def get(self, section: str, option: str, default: typing.Any = None) -> typing.Any:
+        """
+        Get data from the configuration.
+
+        :param section:
+        :param option:
+        :param default:
+        :return:
+        """
         if not self._cfg.has_section(section):
             if not self._cfg.has_section(self.default_section):
                 return default
@@ -59,21 +73,45 @@ class Config:
                 return default
 
         return self._cfg.get(section, option)
+    # pylint: enable=R1705
 
-    def set(self, section, option, value):
+    def set(self, section: str, option: str, value: typing.Any) -> None:
+        """
+        Set section to the configuration structure.
+
+        :param section: name of the section
+        :param option: option name
+        :param value: value
+        :return: None
+        """
         if not self._cfg.has_section(section):
             self._cfg.add_section(section)
         self._cfg.set(section, option, value)
 
-    def write(self):
+    def write(self) -> None:
+        """
+        Write configuration to the INI file.
+
+        :return: None
+        """
         with open(self.path, "w") as handle:
             self._cfg.write(handle)
 
-    def read(self):
+    def read(self) -> None:
+        """
+        Read configuration from the INI file.
+
+        :return: None
+        """
         self._cfg.read(self.path)
 
-    def sections(self):
-        return [i for i in self._cfg.sections() if i != self.default_section]
+    def sections(self) -> typing.List[typing.AnyStr]:
+        """
+        Returns sections of the configuration INI.
+
+        :return: list of the sections
+        """
+        return [section for section in self._cfg.sections() if section != self.default_section]
 
 
 CONF_DIR = os.path.expanduser("~/.spacewalk-manage-channel-lifecycle")
@@ -127,7 +165,13 @@ def parse_enumerated(data):
 
 
 # determine the name of the next phase
-def get_next_phase(current_name):
+def get_next_phase(current_name: str) -> str:
+    """
+    Gets next phase of the workflow.
+
+    :param current_name:
+    :return:
+    """
     if current_name not in phases:
         logging.error('Invalid phase name: %s', current_name)
         sys.exit(1)
@@ -142,7 +186,12 @@ def get_next_phase(current_name):
         sys.exit(1)
 
 
-def print_channel_tree():
+def print_channel_tree() -> None:
+    """
+    Prints the tree of existing channels to STDOUT.
+
+    :return: None
+    """
     tree = {}
 
     # determine parent channels so we can make a pretty tree for the user

--- a/utils/spacewalk-manage-channel-lifecycle
+++ b/utils/spacewalk-manage-channel-lifecycle
@@ -435,15 +435,11 @@ elif not options.list_channels and not options.channel:
     sys.exit(1)
 
 # parse the list of phases
-phases = parse_enumerated(options.phases or config.get(options.workflow,
-                                                       Config.OPT_PHASES,
-                                                       "dev,test,prod"))
+phases = parse_enumerated(options.phases or config.get(options.workflow, Config.OPT_PHASES, "dev,test,prod"))
 
 # update exclude channel option
-options.exclude_channel = options.exclude_channel or \
-    parse_enumerated(config.get(options.workflow,
-                                Config.OPT_EXCLUDE_CHNL, ""))
-
+options.exclude_channel = options.exclude_channel or parse_enumerated(config.get(options.workflow,
+                                                                                 Config.OPT_EXCLUDE_CHNL, ""))
 if len(phases) < 2:
     logging.error('You must define at least 2 phases')
     sys.exit(1)

--- a/utils/spacewalk-manage-channel-lifecycle
+++ b/utils/spacewalk-manage-channel-lifecycle
@@ -290,9 +290,12 @@ def get_current_phase(source):
     """
     Get current phase from the source channel label.
     """
+    out = None
     for phase in phases:
         if source.startswith(phase):
-            return phase
+            out = phase
+            break
+    return out
 
 
 def build_channel_labels(source):

--- a/utils/spacewalk-manage-channel-lifecycle
+++ b/utils/spacewalk-manage-channel-lifecycle
@@ -50,7 +50,6 @@ class Config:
         self.default_section = Config.SECTION_GENERAL
         self._cfg = ConfigParser.RawConfigParser()
 
-    # pylint: disable=R1705
     def get(self, section: str, option: str, default: typing.Any = None) -> typing.Any:
         """
         Get data from the configuration.
@@ -63,17 +62,14 @@ class Config:
         if not self._cfg.has_section(section):
             if not self._cfg.has_section(self.default_section):
                 return default
-            else:
-                if not self._cfg.has_option(self.default_section, option):
-                    return default
-                else:
-                    return self._cfg.get(self.default_section, option)
-        else:
-            if not self._cfg.has_option(section, option):
+            if not self._cfg.has_option(self.default_section, option):
                 return default
+            return self._cfg.get(self.default_section, option)
+
+        if not self._cfg.has_option(section, option):
+            return default
 
         return self._cfg.get(section, option)
-    # pylint: enable=R1705
 
     def set(self, section: str, option: str, value: typing.Any) -> None:
         """
@@ -178,9 +174,9 @@ def get_next_phase(current_name: str) -> str:
     # return the next phase name
     if current_num + 1 < len(phases):
         return phases[current_num + 1]
-    else:
-        logging.error("Maximum phase exceeded!  You can't move past '%s'.", phases[-1])
-        sys.exit(1)
+
+    logging.error("Maximum phase exceeded!  You can't move past '%s'.", phases[-1])
+    sys.exit(1)
 
 
 def print_channel_tree() -> None:

--- a/utils/spacewalk-manage-channel-lifecycle
+++ b/utils/spacewalk-manage-channel-lifecycle
@@ -83,7 +83,7 @@ SESSION_CACHE = os.path.join(CONF_DIR, "session")
 ##############################################################################
 
 
-def setup_config(config):
+def setup_config(cfg):
     """
     Setup configuration.
     """
@@ -99,12 +99,12 @@ def setup_config(config):
             sys.exit(1)
 
     if not os.path.exists(USER_CONF_FILE):
-        logging.debug("Creating configuration file: %s" % USER_CONF_FILE)
-        config.set(Config.SECTION_GENERAL, Config.OPT_PHASES, "dev, test, prod")
-        config.set(Config.SECTION_GENERAL, Config.OPT_EXCLUDE_CHNL, "")
-        config.write()
+        logging.debug("Creating configuration file: %s", USER_CONF_FILE)
+        cfg.set(Config.SECTION_GENERAL, Config.OPT_PHASES, "dev, test, prod")
+        cfg.set(Config.SECTION_GENERAL, Config.OPT_EXCLUDE_CHNL, "")
+        cfg.write()
     else:
-        config.read()
+        cfg.read()
 
 
 def ask(msg, password=False):

--- a/utils/spacewalk-manage-channel-lifecycle
+++ b/utils/spacewalk-manage-channel-lifecycle
@@ -397,6 +397,7 @@ def build_channel_labels(source):
 
     return source, destination
 
+
 def get_config_credentials(conf, opts):
     '''
     Look into configuration for credentials for the admin user.
@@ -407,244 +408,244 @@ def get_config_credentials(conf, opts):
         opts.username = username
         opts.password = password
 
-##############################################################################
 
-usage = '''usage: %prog [options]
+if __name__ == "__main__":
+    usage = '''usage: %prog [options]
 
-Create a 'dev' channel based on the latest packages:
-spacewalk-manage-channel-lifecycle -c sles11-sp3-pool-x86_64 --init
+    Create a 'dev' channel based on the latest packages:
+    spacewalk-manage-channel-lifecycle -c sles11-sp3-pool-x86_64 --init
 
-Promote the packages from 'dev' to 'test':
-spacewalk-manage-channel-lifecycle -c dev-sles11-sp3-pool-x86_64 --promote
+    Promote the packages from 'dev' to 'test':
+    spacewalk-manage-channel-lifecycle -c dev-sles11-sp3-pool-x86_64 --promote
 
-Promote the packages from 'test' to 'prod':
-spacewalk-manage-channel-lifecycle -c test-sles11-sp3-pool-x86_64 --promote
+    Promote the packages from 'test' to 'prod':
+    spacewalk-manage-channel-lifecycle -c test-sles11-sp3-pool-x86_64 --promote
 
-Archive a production channel:
-spacewalk-manage-channel-lifecycle -c prod-sles11-sp3-pool-x86_64 --archive
+    Archive a production channel:
+    spacewalk-manage-channel-lifecycle -c prod-sles11-sp3-pool-x86_64 --archive
 
-Rollback the production channel to an archived version:
-spacewalk-manage-channel-lifecycle \\
-    -c archive-20110520-prod-sles11-sp3-pool-x86_64 --rollback'''
+    Rollback the production channel to an archived version:
+    spacewalk-manage-channel-lifecycle \\
+        -c archive-20110520-prod-sles11-sp3-pool-x86_64 --rollback'''
 
-option_list = [
-    Option('-l', '--list-channels', help='list existing channels',
-           action='store_true'),
-    Option('', '--init', help='initialize a development channel',
-           action='store_true'),
-    Option('-w', '--workflow', help='use configured workflow', default=""),
-    Option('-D', '--delimiter', type='choice', choices=['-', '_', '.'],
-           help='delimiter used between workflow and channel name', default="-"),
-    Option('-f', '--list-workflows', help='list configured workflows', default=False,
-           action='store_true'),
-    Option('', '--promote', help='promote a channel to the next phase',
-           action='store_true'),
-    Option('', '--archive', help='archive a channel', action='store_true'),
-    Option('', '--rollback', help='rollback', action='store_true'),
-    Option('-c', '--channel', help='channel to init/promote/archive/rollback'),
-    Option('-C', '--clear-channel',
-           help='clear all packages/errata from the channel before merging',
-           action='store_true'),
-    Option('-x', '--exclude-channel', help='skip these channels',
-           action='append'),
-    Option('', '--no-errata', help="don't merge errata data with --promote",
-           action='store_true'),
-    Option('', '--no-children', help="don't operate on child channels",
-           action='store_true'),
-    Option('-P', '--phases', default='',
-           help='comma-separated list of phases [default: dev,test,prod]'),
-    Option('-u', '--username', help='Spacewalk username'),
-    Option('-p', '--password', help='Spacewalk password'),
-    Option('-s', '--server',
-           help='Spacewalk server [default: %default]', default=gethostname()),
-    Option('-n', '--dry-run', help="don't perform any operations",
-           action='store_true'),
-    Option('-t', '--tolerant', help='be tolerant of errors',
-           action='store_true'),
-    Option('-d', '--debug', help='enable debug logging', action='count')
-]
+    option_list = [
+        Option('-l', '--list-channels', help='list existing channels',
+               action='store_true'),
+        Option('', '--init', help='initialize a development channel',
+               action='store_true'),
+        Option('-w', '--workflow', help='use configured workflow', default=""),
+        Option('-D', '--delimiter', type='choice', choices=['-', '_', '.'],
+               help='delimiter used between workflow and channel name', default="-"),
+        Option('-f', '--list-workflows', help='list configured workflows', default=False,
+               action='store_true'),
+        Option('', '--promote', help='promote a channel to the next phase',
+               action='store_true'),
+        Option('', '--archive', help='archive a channel', action='store_true'),
+        Option('', '--rollback', help='rollback', action='store_true'),
+        Option('-c', '--channel', help='channel to init/promote/archive/rollback'),
+        Option('-C', '--clear-channel',
+               help='clear all packages/errata from the channel before merging',
+               action='store_true'),
+        Option('-x', '--exclude-channel', help='skip these channels',
+               action='append'),
+        Option('', '--no-errata', help="don't merge errata data with --promote",
+               action='store_true'),
+        Option('', '--no-children', help="don't operate on child channels",
+               action='store_true'),
+        Option('-P', '--phases', default='',
+               help='comma-separated list of phases [default: dev,test,prod]'),
+        Option('-u', '--username', help='Spacewalk username'),
+        Option('-p', '--password', help='Spacewalk password'),
+        Option('-s', '--server',
+               help='Spacewalk server [default: %default]', default=gethostname()),
+        Option('-n', '--dry-run', help="don't perform any operations",
+               action='store_true'),
+        Option('-t', '--tolerant', help='be tolerant of errors',
+               action='store_true'),
+        Option('-d', '--debug', help='enable debug logging', action='count')
+    ]
 
-parser = OptionParser(option_list=option_list, usage=usage)
-(options, args) = parser.parse_args()
+    parser = OptionParser(option_list=option_list, usage=usage)
+    (options, args) = parser.parse_args()
 
-if options.debug:
-    level = logging.DEBUG
-else:
-    level = logging.INFO
+    if options.debug:
+        level = logging.DEBUG
+    else:
+        level = logging.INFO
 
-logging.basicConfig(level=level, format='%(levelname)s: %(message)s')
+    logging.basicConfig(level=level, format='%(levelname)s: %(message)s')
 
-options.workflow = options.workflow or Config.SECTION_GENERAL
-config = Config(USER_CONF_FILE)
-try:
-    setup_config(config)
-except ConfigParser.ParsingError as ex:
-    logging.error("Unable to process configuration:\n%s", str(ex))
-    sys.exit(1)
-
-if options.list_workflows:
-    workflows = config.sections()
-    if not workflows:
-        print("There are no additinal configured workflows except default.")
-        sys.exit(0)
-
-    print("Configured additional workflows:")
-    idx = 1
-    for workflow in workflows:
-        print("  %s. %s" % (idx, workflow))
-        idx += 1
-    print()
-    sys.exit(0)
-
-# sanity check
-if not (options.init or options.promote or options.archive or options.rollback
-        or options.list_channels):
-    logging.error("You must provide an action: %s", "(--init/--promote/--archive/--rollback/--list-channels)")
-    sys.exit(1)
-elif not options.list_channels and not options.channel:
-    logging.error('--channel is required')
-    sys.exit(1)
-
-# parse the list of phases
-phases = parse_enumerated(options.phases or config.get(options.workflow, Config.OPT_PHASES, "dev,test,prod"))
-
-# update exclude channel option
-options.exclude_channel = options.exclude_channel or parse_enumerated(config.get(options.workflow,
-                                                                                 Config.OPT_EXCLUDE_CHNL, ""))
-if len(phases) < 2:
-    logging.error('You must define at least 2 phases')
-    sys.exit(1)
-
-# determine if you want to enable XMLRPC debugging
-xmlrpc_debug = options.debug and options.debug > 1
-
-# connect to the server
-client = xmlrpclib.Server('https://%s/rpc/api' % options.server,
-                          verbose=xmlrpc_debug)
-
-session = None
-
-# check for an existing session
-if os.path.exists(SESSION_CACHE):
+    options.workflow = options.workflow or Config.SECTION_GENERAL
+    config = Config(USER_CONF_FILE)
     try:
-        fh = open(SESSION_CACHE, 'r')
-        session = fh.readline()
-        fh.close()
-    except IOError as e:
-        if options.debug:
-            logging.exception(e)
-        logging.debug('Failed to read session cache')
-
-    # validate the session
-    try:
-        client.channel.listMyChannels(session)
-    except xmlrpclib.Fault as e:
-        if options.debug:
-            logging.exception(e)
-        logging.warning('Existing session is invalid')
-        session = None
-
-# Look for credentials in settings.conf
-get_config_credentials(config, options)
-
-if not session:
-    # prompt for the username
-    if not options.username:
-        while not options.username:
-            options.username = ask('Spacewalk Username')
-
-    # prompt for the password
-    if not options.password:
-        options.password = ask('Spacewalk Password', password=True)
-    if not options.password:
-        logging.warning("Empty password is not a good practice!")
-
-    # login to the server
-    try:
-        session = client.auth.login(options.username, options.password)
-    except xmlrpclib.Fault as e:
-        if options.debug:
-            logging.exception(e)
-        logging.error('Failed to log into %s', options.server)
+        setup_config(config)
+    except ConfigParser.ParsingError as ex:
+        logging.error("Unable to process configuration:\n%s", str(ex))
         sys.exit(1)
 
-    # save the session for subsuquent runs
+    if options.list_workflows:
+        workflows = config.sections()
+        if not workflows:
+            print("There are no additinal configured workflows except default.")
+            sys.exit(0)
+
+        print("Configured additional workflows:")
+        idx = 1
+        for workflow in workflows:
+            print("  %s. %s" % (idx, workflow))
+            idx += 1
+        print()
+        sys.exit(0)
+
+    # sanity check
+    if not (options.init or options.promote or options.archive or options.rollback
+            or options.list_channels):
+        logging.error("You must provide an action: %s", "(--init/--promote/--archive/--rollback/--list-channels)")
+        sys.exit(1)
+    elif not options.list_channels and not options.channel:
+        logging.error('--channel is required')
+        sys.exit(1)
+
+    # parse the list of phases
+    phases = parse_enumerated(options.phases or config.get(options.workflow, Config.OPT_PHASES, "dev,test,prod"))
+
+    # update exclude channel option
+    options.exclude_channel = options.exclude_channel or parse_enumerated(config.get(options.workflow,
+                                                                                     Config.OPT_EXCLUDE_CHNL, ""))
+    if len(phases) < 2:
+        logging.error('You must define at least 2 phases')
+        sys.exit(1)
+
+    # determine if you want to enable XMLRPC debugging
+    xmlrpc_debug = options.debug and options.debug > 1
+
+    # connect to the server
+    client = xmlrpclib.Server('https://%s/rpc/api' % options.server,
+                              verbose=xmlrpc_debug)
+
+    session = None
+
+    # check for an existing session
+    if os.path.exists(SESSION_CACHE):
+        try:
+            fh = open(SESSION_CACHE, 'r')
+            session = fh.readline()
+            fh.close()
+        except IOError as e:
+            if options.debug:
+                logging.exception(e)
+            logging.debug('Failed to read session cache')
+
+        # validate the session
+        try:
+            client.channel.listMyChannels(session)
+        except xmlrpclib.Fault as e:
+            if options.debug:
+                logging.exception(e)
+            logging.warning('Existing session is invalid')
+            session = None
+
+    # Look for credentials in settings.conf
+    get_config_credentials(config, options)
+
+    if not session:
+        # prompt for the username
+        if not options.username:
+            while not options.username:
+                options.username = ask('Spacewalk Username')
+
+        # prompt for the password
+        if not options.password:
+            options.password = ask('Spacewalk Password', password=True)
+        if not options.password:
+            logging.warning("Empty password is not a good practice!")
+
+        # login to the server
+        try:
+            session = client.auth.login(options.username, options.password)
+        except xmlrpclib.Fault as e:
+            if options.debug:
+                logging.exception(e)
+            logging.error('Failed to log into %s', options.server)
+            sys.exit(1)
+
+        # save the session for subsuquent runs
+        try:
+            fh = open(SESSION_CACHE, 'w')
+            fh.write(session)
+            fh.close()
+        except IOError as e:
+            if options.debug:
+                logging.exception(e)
+            logging.warning('Failed to write session cache')
+
+    # list all of the channels once
     try:
-        fh = open(SESSION_CACHE, 'w')
-        fh.write(session)
-        fh.close()
-    except IOError as e:
+        all_channels = client.channel.listSoftwareChannels(session)
+        all_channel_labels = [c.get('label') for c in all_channels]
+    except xmlrpclib.Fault as e:
         if options.debug:
             logging.exception(e)
-        logging.warning('Failed to write session cache')
+        logging.error('Could not retrieve the list of software channels')
+        sys.exit(1)
 
-# list all of the channels once
-try:
-    all_channels = client.channel.listSoftwareChannels(session)
-    all_channel_labels = [c.get('label') for c in all_channels]
-except xmlrpclib.Fault as e:
-    if options.debug:
-        logging.exception(e)
-    logging.error('Could not retrieve the list of software channels')
-    sys.exit(1)
+    # list the available custom channels and exit
+    if options.list_channels:
+        print_channel_tree()
+        sys.exit(0)
 
-# list the available custom channels and exit
-if options.list_channels:
-    print_channel_tree()
-    sys.exit(0)
+    # ensure the source channel exists
+    if not channel_exists(options.channel):
+        sys.exit(1)
 
-# ensure the source channel exists
-if not channel_exists(options.channel):
-    sys.exit(1)
+    # determine the channel labels for the parent channel
+    (parent_source, parent_dest) = build_channel_labels(options.channel)
 
-# determine the channel labels for the parent channel
-(parent_source, parent_dest) = build_channel_labels(options.channel)
+    # inform the user that no changes will take place
+    if options.dry_run:
+        logging.info('DRY RUN - No changes are being made to the channels')
+        time.sleep(2)
+        print()
 
-# inform the user that no changes will take place
-if options.dry_run:
-    logging.info('DRY RUN - No changes are being made to the channels')
-    time.sleep(2)
-    print()
+    # merge packages/errata if the destination channel label already exists,
+    # otherwise clone it from the source channel
+    if parent_dest in all_channel_labels:
+        merge_channels(parent_source, parent_dest)
+    else:
+        # channel doesn't exist, clone it from the original
+        # let's check if there's a parent for the original channel and if so, clone it in the right place
+        new_parent_source = client.channel.software.getDetails(session, parent_source)['parent_channel_label']
+        new_parent_dest = ""
+        if new_parent_source:
+            (new_parent_source, new_parent_dest) = build_channel_labels(new_parent_source)
 
-# merge packages/errata if the destination channel label already exists,
-# otherwise clone it from the source channel
-if parent_dest in all_channel_labels:
-    merge_channels(parent_source, parent_dest)
-else:
-    # channel doesn't exist, clone it from the original
-    # let's check if there's a parent for the original channel and if so, clone it in the right place
-    new_parent_source = client.channel.software.getDetails(session, parent_source)['parent_channel_label']
-    new_parent_dest = ""
-    if new_parent_source:
-        (new_parent_source, new_parent_dest) = build_channel_labels(new_parent_source)
+        details = {'label': parent_dest,
+                   'name': parent_dest,
+                   'summary': parent_dest,
+                   'parent_label': new_parent_dest}
 
-    details = {'label': parent_dest,
-               'name': parent_dest,
-               'summary': parent_dest,
-               'parent_label': new_parent_dest}
+        clone_channel(parent_source, details)
 
-    clone_channel(parent_source, details)
+    if not options.no_children:
+        children = []
 
-if not options.no_children:
-    children = []
+        # get the child channels for the source parent channel
+        for channel in all_channels:
+            if channel.get('parent_label') == parent_source:
+                children.append(channel.get('label'))
 
-    # get the child channels for the source parent channel
-    for channel in all_channels:
-        if channel.get('parent_label') == parent_source:
-            children.append(channel.get('label'))
+        for label in children:
+            # determine the child channels for the source parent channel
+            (child_source, child_dest) = build_channel_labels(label)
 
-    for label in children:
-        # determine the child channels for the source parent channel
-        (child_source, child_dest) = build_channel_labels(label)
+            # merge packages/errata if the destination channel label already exists,
+            # otherwise clone it from the source channel
+            if child_dest in all_channel_labels:
+                merge_channels(child_source, child_dest)
+            else:
+                details = {'label': child_dest,
+                           'name': child_dest,
+                           'summary': child_dest,
+                           'parent_label': parent_dest}
 
-        # merge packages/errata if the destination channel label already exists,
-        # otherwise clone it from the source channel
-        if child_dest in all_channel_labels:
-            merge_channels(child_source, child_dest)
-        else:
-            details = {'label': child_dest,
-                       'name': child_dest,
-                       'summary': child_dest,
-                       'parent_label': parent_dest}
-
-            clone_channel(child_source, details)
+                clone_channel(child_source, details)

--- a/utils/spacewalk-manage-channel-lifecycle
+++ b/utils/spacewalk-manage-channel-lifecycle
@@ -256,11 +256,11 @@ def clone_channel(source_label, source_details) -> None:
                 return
 
     # channel doesn't exist, clone it from the original
-    logging.info('Cloning %s from %s', details['label'], source_label)
+    logging.info('Cloning %s from %s', source_details['label'], source_label)
 
     if not options.dry_run:
         try:
-            client.channel.software.clone(session, source_label, details, False)
+            client.channel.software.clone(session, source_label, source_details, False)
         except xmlrpclib.Fault as e:
             if options.debug:
                 logging.exception(e)

--- a/utils/spacewalk-manage-channel-lifecycle
+++ b/utils/spacewalk-manage-channel-lifecycle
@@ -91,11 +91,11 @@ def setup_config(cfg):
         os.unlink(CONF_DIR)
 
     if not os.path.exists(CONF_DIR):
-        logging.debug("Creating directory: %s" % CONF_DIR)
+        logging.debug("Creating directory: %s", CONF_DIR)
         try:
             os.mkdir(CONF_DIR, 0o700)
         except IOError:
-            logging.error("Unable to create %s" % CONF_DIR)
+            logging.error("Unable to create %s", CONF_DIR)
             sys.exit(1)
 
     if not os.path.exists(USER_CONF_FILE):
@@ -135,7 +135,7 @@ def parse_enumerated(data):
 # determine the name of the next phase
 def get_next_phase(current_name):
     if current_name not in phases:
-        logging.error('Invalid phase name: %s' % current_name)
+        logging.error('Invalid phase name: %s', current_name)
         sys.exit(1)
     else:
         current_num = phases.index(current_name)
@@ -144,7 +144,7 @@ def get_next_phase(current_name):
     if current_num + 1 < len(phases):
         return phases[current_num + 1]
     else:
-        logging.error("Maximum phase exceeded!  You can't move past '%s'." % phases[-1])
+        logging.error("Maximum phase exceeded!  You can't move past '%s'.", phases[-1])
         sys.exit(1)
 
 
@@ -186,7 +186,7 @@ def channel_exists(channel, quiet=False):
         if options.debug:
             logging.exception(e)
         if not quiet:
-            logging.error('Channel %s does not exist' % channel)
+            logging.error('Channel %s does not exist', channel)
         return False
 
 
@@ -199,25 +199,20 @@ def merge_channels(source_label, dest_label):
     if options.exclude_channel:
         for pattern in options.exclude_channel:
             if source_label == pattern:
-                logging.info('Skipping %s due to an exclude filter'
-                             % source_label)
+                logging.info('Skipping %s due to an exclude filter', source_label)
                 return
 
     # remove all the packages from the channel if requested
     if options.clear_channel or options.rollback:
         clear_channel(dest_label)
 
-    logging.info('Merging packages from %s into %s' %
-                 (source_label, dest_label))
+    logging.info('Merging packages from %s into %s', source_label, dest_label)
 
     if not options.dry_run:
         # merge the packages from one channel into another
         try:
-            packages = client.channel.software.mergePackages(session,
-                                                             source_label,
-                                                             dest_label)
-
-            logging.info('Added %i packages' % len(packages))
+            packages = client.channel.software.mergePackages(session, source_label, dest_label)
+            logging.info('Added %i packages', len(packages))
         except xmlrpclib.Fault as e:
             if options.debug:
                 logging.exception(e)
@@ -229,7 +224,7 @@ def merge_channels(source_label, dest_label):
                 sys.exit(1)
 
     if not options.no_errata:
-        logging.info('Merging errata into %s' % dest_label)
+        logging.info('Merging errata into %s', dest_label)
 
         if not options.dry_run:
             # merge the errata from one channel into another
@@ -238,7 +233,7 @@ def merge_channels(source_label, dest_label):
                                                              source_label,
                                                              dest_label)
 
-                logging.info('Added %i errata' % len(errata))
+                logging.info('Added %i errata', len(errata))
             except xmlrpclib.Fault as e:
                 if options.debug:
                     logging.exception(e)
@@ -256,12 +251,11 @@ def clone_channel(source_label, details):
     if options.exclude_channel:
         for pattern in options.exclude_channel:
             if source_label == pattern:
-                logging.info('Skipping %s due to an exclude filter'
-                             % source_label)
+                logging.info('Skipping %s due to an exclude filter', source_label)
                 return
 
     # channel doesn't exist, clone it from the original
-    logging.info('Cloning %s from %s' % (details['label'], source_label))
+    logging.info('Cloning %s from %s', details['label'], source_label)
 
     if not options.dry_run:
         try:
@@ -278,7 +272,7 @@ def clone_channel(source_label, details):
 
 
 def clear_channel(label):
-    logging.info('Clearing all errata from %s' % label)
+    logging.info('Clearing all errata from %s', label)
 
     if not options.dry_run:
         # attempt to clear the errata from the channel
@@ -292,10 +286,10 @@ def clear_channel(label):
         except xmlrpclib.Fault as e:
             if options.debug:
                 logging.exception(e)
-            logging.warning('Failed to clear errata from %s' % label)
+            logging.warning('Failed to clear errata from %s', label)
 
     if not options.dry_run:
-        logging.info('Clearing all packages from %s' % label)
+        logging.info('Clearing all packages from %s', label)
         all_packages = client.channel.software.listAllPackages(session, label)
         package_ids = [p.get('id') for p in all_packages]
         client.channel.software.removePackages(session, label, package_ids)
@@ -320,8 +314,7 @@ def build_channel_labels(source):
         destination = '{phase}{dlm}{src}'.format(phase=phases[0], dlm=options.delimiter, src=source)
 
         if channel_exists(destination, quiet=True):
-            logging.error('%s already exists.  Use --promote instead.'
-                          % destination)
+            logging.error('%s already exists.  Use --promote instead.', destination)
             sys.exit(1)
     elif options.promote:
         # get the phase label from the channel label

--- a/utils/spacewalk-manage-channel-lifecycle
+++ b/utils/spacewalk-manage-channel-lifecycle
@@ -174,14 +174,15 @@ def print_channel_tree():
 
 def channel_exists(channel, quiet=False):
     try:
-        client.channel.software.getDetails(session, channel)
-        return True
+        client.channel.software.getDetails(session, ch_label)
+        exists = True
     except xmlrpclib.Fault as e:
         if options.debug:
             logging.exception(e)
         if not quiet:
-            logging.error('Channel %s does not exist', channel)
-        return False
+            logging.error('Channel %s does not exist', ch_label)
+        exists = False
+    return exists
 
 
 def merge_channels(source_label, dest_label):
@@ -212,9 +213,7 @@ def merge_channels(source_label, dest_label):
                 logging.exception(e)
             logging.error('Failed to merge packages')
 
-            if options.tolerant:
-                return False
-            else:
+            if not options.tolerant:
                 sys.exit(1)
 
     if not options.no_errata:
@@ -233,9 +232,7 @@ def merge_channels(source_label, dest_label):
                     logging.exception(e)
                 logging.error('Failed to merge errata')
 
-                if options.tolerant:
-                    return False
-                else:
+                if not options.tolerant:
                     sys.exit(1)
 
     print()

--- a/utils/spacewalk-manage-channel-lifecycle
+++ b/utils/spacewalk-manage-channel-lifecycle
@@ -19,26 +19,16 @@
 # Copyright 2012 Aron Parsons <aronparsons@gmail.com>
 #
 
-import os.path
+import os
 import getpass
 import logging
-import os
 import re
 import sys
 import time
-from salt.ext import six
-from optparse import Option, OptionParser
+from optparse import Option, OptionParser  # pylint: disable=W0402
 from socket import gethostname
-
-try:
-    import xmlrpclib
-except ImportError:
-    import xmlrpc.client as xmlrpclib  # pylint: disable=F0401
-
-try:
-    import ConfigParser
-except ImportError:
-    import configparser as ConfigParser
+import xmlrpc.client as xmlrpclib
+import configparser as ConfigParser
 
 
 class Config(object):

--- a/utils/spacewalk-manage-channel-lifecycle
+++ b/utils/spacewalk-manage-channel-lifecycle
@@ -241,7 +241,7 @@ def merge_channels(source_label, dest_label):
     print()
 
 
-def clone_channel(source_label, details):
+def clone_channel(source_label, source_details) -> None:
     """
     Clone channel.
 
@@ -272,7 +272,7 @@ def clone_channel(source_label, details):
                 sys.exit(1)
 
 
-def clear_channel(lbl):
+def clear_channel(lbl) -> None:
     """
     Clears all the errata in the channel.
 

--- a/utils/spacewalk-manage-channel-lifecycle
+++ b/utils/spacewalk-manage-channel-lifecycle
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # Licensed under the GNU General Public License Version 3
 #

--- a/utils/spacewalk-manage-channel-lifecycle
+++ b/utils/spacewalk-manage-channel-lifecycle
@@ -449,10 +449,7 @@ if len(phases) < 2:
     sys.exit(1)
 
 # determine if you want to enable XMLRPC debugging
-if options.debug and options.debug > 1:
-    xmlrpc_debug = True
-else:
-    xmlrpc_debug = False
+xmlrpc_debug = options.debug and options.debug > 1
 
 # connect to the server
 client = xmlrpclib.Server('https://%s/rpc/api' % options.server,

--- a/utils/spacewalk-manage-channel-lifecycle
+++ b/utils/spacewalk-manage-channel-lifecycle
@@ -112,13 +112,7 @@ def ask(msg, password=False):
     Ask input from the console. Hide the echo, in case of password or sensitive information.
     """
     msg += ": "
-    if password:
-        return getpass.getpass(msg)
-    if six.PY2:
-        inputfn = raw_input
-    else:
-        inputfn = input
-    return inputfn(msg)
+    return getpass.getpass(msg) if password else input(msg)
 
 
 def parse_enumerated(data):

--- a/utils/spacewalk-manage-channel-lifecycle
+++ b/utils/spacewalk-manage-channel-lifecycle
@@ -266,9 +266,7 @@ def clone_channel(source_label, source_details) -> None:
                 logging.exception(e)
             logging.error('Failed to clone channel')
 
-            if options.tolerant:
-                return False
-            else:
+            if not options.tolerant:
                 sys.exit(1)
 
 

--- a/utils/spacewalk-manage-channel-lifecycle
+++ b/utils/spacewalk-manage-channel-lifecycle
@@ -146,26 +146,26 @@ def print_channel_tree():
     tree = {}
 
     # determine parent channels so we can make a pretty tree for the user
-    for channel in all_channels:
-        if channel.get('parent_label'):
-            if channel.get('parent_label') not in tree:
-                tree[channel.get('parent_label')] = []
+    for ch_data in all_channels:
+        if ch_data.get('parent_label'):
+            if ch_data.get('parent_label') not in tree:
+                tree[ch_data.get('parent_label')] = []
 
-            tree[channel.get('parent_label')].append(channel.get('label'))
+            tree[ch_data.get('parent_label')].append(ch_data.get('label'))
         else:
-            if channel.get('label') not in tree:
-                tree[channel.get('label')] = []
+            if ch_data.get('label') not in tree:
+                tree[ch_data.get('label')] = []
 
     # print the channels in a tree format
     print("Channel tree:")
-    idx = 1
+    index = 1
     step = len(str(len(list(tree.keys()))))
     for parent in sorted(tree.keys()):
-        if len(tree[parent]):
+        if tree[parent]:
             print()
-        print(" %s. %s" % (str(idx).rjust(step), parent))
-        idx += 1
-        if len(tree[parent]):
+        print(" %s. %s" % (str(index).rjust(step), parent))
+        index += 1
+        if tree[parent]:
             for child in sorted(tree[parent]):
                 print((' ' * step) + '     \\__ %s' % child)
             print()

--- a/utils/spacewalk-manage-channel-lifecycle
+++ b/utils/spacewalk-manage-channel-lifecycle
@@ -553,7 +553,7 @@ else:
     new_parent_dest = ""
     if new_parent_source:
         (new_parent_source, new_parent_dest) = build_channel_labels(new_parent_source)
-    
+
     details = {'label': parent_dest,
                'name': parent_dest,
                'summary': parent_dest,

--- a/utils/spacewalk-manage-channel-lifecycle
+++ b/utils/spacewalk-manage-channel-lifecycle
@@ -172,7 +172,7 @@ def print_channel_tree():
     print()
 
 
-def channel_exists(channel, quiet=False):
+def channel_exists(ch_label, quiet=False) -> bool:
     """
     Check if named channel exists.
 
@@ -192,7 +192,8 @@ def channel_exists(channel, quiet=False):
     return exists
 
 
-def merge_channels(source_label, dest_label):
+# pylint: disable=R0912
+def merge_channels(source_label, dest_label) -> None:
     """
     Merge channels data.
 
@@ -248,8 +249,8 @@ def merge_channels(source_label, dest_label):
 
                 if not options.tolerant:
                     sys.exit(1)
-
     print()
+# pylint: enable=R0912
 
 
 def clone_channel(source_label, source_details) -> None:

--- a/utils/spacewalk-manage-channel-lifecycle
+++ b/utils/spacewalk-manage-channel-lifecycle
@@ -173,6 +173,13 @@ def print_channel_tree():
 
 
 def channel_exists(channel, quiet=False):
+    """
+    Check if named channel exists.
+
+    :param ch_label: channel label
+    :param quiet: suppresses error log if True
+    :return: returns True if channel exists.
+    """
     try:
         client.channel.software.getDetails(session, ch_label)
         exists = True
@@ -186,6 +193,13 @@ def channel_exists(channel, quiet=False):
 
 
 def merge_channels(source_label, dest_label):
+    """
+    Merge channels data.
+
+    :param source_label:
+    :param dest_label:
+    :return: None
+    """
     if dest_label.startswith('rhel') and not options.tolerant:
         logging.error("Destination label starts with 'rhel'.  Aborting!")
         logging.error("Pass --tolerant to override this")

--- a/utils/spacewalk-manage-channel-lifecycle
+++ b/utils/spacewalk-manage-channel-lifecycle
@@ -523,7 +523,7 @@ if not session:
     except xmlrpclib.Fault as e:
         if options.debug:
             logging.exception(e)
-        logging.error('Failed to log into %s',  options.server)
+        logging.error('Failed to log into %s', options.server)
         sys.exit(1)
 
     # save the session for subsuquent runs
@@ -571,7 +571,7 @@ if parent_dest in all_channel_labels:
 else:
     # channel doesn't exist, clone it from the original
     # let's check if there's a parent for the original channel and if so, clone it in the right place
-    new_parent_source = client.channel.software.getDetails(session,parent_source)['parent_channel_label']
+    new_parent_source = client.channel.software.getDetails(session, parent_source)['parent_channel_label']
     new_parent_dest = ""
     if new_parent_source:
         (new_parent_source, new_parent_dest) = build_channel_labels(new_parent_source)

--- a/utils/spacewalk-manage-channel-lifecycle
+++ b/utils/spacewalk-manage-channel-lifecycle
@@ -408,7 +408,7 @@ config = Config(USER_CONF_FILE)
 try:
     setup_config(config)
 except ConfigParser.ParsingError as ex:
-    logging.error("Unable to process configuration:\n" + str(ex))
+    logging.error("Unable to process configuration:\n%s", str(ex))
     sys.exit(1)
 
 if options.list_workflows:
@@ -428,8 +428,7 @@ if options.list_workflows:
 # sanity check
 if not (options.init or options.promote or options.archive or options.rollback
         or options.list_channels):
-    logging.error("You must provide an action " +
-                  "(--init/--promote/--archive/--rollback/--list-channels)")
+    logging.error("You must provide an action: %s", "(--init/--promote/--archive/--rollback/--list-channels)")
     sys.exit(1)
 elif not options.list_channels and not options.channel:
     logging.error('--channel is required')
@@ -502,7 +501,7 @@ if not session:
     except xmlrpclib.Fault as e:
         if options.debug:
             logging.exception(e)
-        logging.error('Failed to log into %s' % options.server)
+        logging.error('Failed to log into %s',  options.server)
         sys.exit(1)
 
     # save the session for subsuquent runs

--- a/utils/spacewalk-manage-channel-lifecycle
+++ b/utils/spacewalk-manage-channel-lifecycle
@@ -66,7 +66,7 @@ class Config:
         self._cfg.set(section, option, value)
 
     def write(self):
-        with open(self.path, "wb") as handle:
+        with open(self.path, "w") as handle:
             self._cfg.write(handle)
 
     def read(self):

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,7 @@
+- Fixes numerous Python3 errors in spacewalk-manage-channel-lifecycle
+- Fixes bsc#1132361 (an attempt to write in binary mode a string type)
+- Adds some integration and unit tests
+
 -------------------------------------------------------------------
 Mon Apr 22 12:17:00 CEST 2019 - jgonzalez@suse.com
 

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,5 +1,5 @@
 - Fixes numerous Python3 errors in spacewalk-manage-channel-lifecycle
-- Fixes bsc#1132361 (an attempt to write in binary mode a string type)
+- Fixes an attempt to write in binary mode a string type (bsc#1132361)
 - Adds some integration and unit tests
 
 -------------------------------------------------------------------

--- a/utils/tests/helpers.py
+++ b/utils/tests/helpers.py
@@ -1,0 +1,38 @@
+# coding: utf-8
+"""
+Helpers for the test suite.
+"""
+import os
+
+
+def symlink_source(script_name: str, mod_name: str, path: str = None) -> None:
+    """
+    Create a symlink for Python source that contains no .py extension.
+
+    :param script_name: script name
+    :param mod_name: name of the module
+    :param path: path to that script.
+    :return: None
+    """
+    if path is None:
+        path = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+
+    s_link_path = os.path.join(path, "tests", "{}.py".format(mod_name))
+    if not os.path.exists(s_link_path):
+        os.symlink(os.path.join(path, script_name), s_link_path)
+
+
+def unsymlink_source(mod_name: str, path: str = None) -> None:
+    """
+    Remove symlink for Python source that contains no .py extension.
+
+    :param mod_name: name of the symlink without an extension
+    :param path:
+    :return:
+    """
+    if path is None:
+        path = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+    mod_path = os.path.join(path, "tests", "{}.py".format(mod_name))
+
+    if os.path.exists(mod_path):
+        os.unlink(mod_path)

--- a/utils/tests/test_spacewalk_manage_channel_lifecycle.py
+++ b/utils/tests/test_spacewalk_manage_channel_lifecycle.py
@@ -2,8 +2,9 @@
 """
 Tests for spacewalk-manager-channel-lifecycle script.
 """
-
+import os
 import pytest
+import tempfile
 from mock import MagicMock, patch
 from . import helpers
 
@@ -33,9 +34,29 @@ class TestSMCL:
         :return:
         """
 
-    def test_configuration_saved(self):
+    def test_configuration_saved_read(self):
         """
-        Test configuration file is saved to the disk.
+        Test configuration file is saved to the disk and can be read.
 
         :return:
         """
+        with tempfile.TemporaryDirectory(prefix="smcl-", dir="/tmp") as tmpdir:
+            smcl.CONF_DIR = os.path.join(tmpdir, ".spacewalk-manage-channel-lifecycle")
+            smcl.USER_CONF_FILE = os.path.join(smcl.CONF_DIR, "settings.conf")
+            smcl.SESSION_CACHE = os.path.join(smcl.CONF_DIR, "session")
+
+            config = smcl.Config(smcl.USER_CONF_FILE)
+            config.set("Millenium Falcon", "space speed", "75 MGLT")
+            config.set("Millenium Falcon", "atmospheric speed", "1050 km/h")
+            smcl.setup_config(config)
+
+            # Save
+            assert os.path.exists(os.path.join(tmpdir, ".spacewalk-manage-channel-lifecycle/settings.conf"))
+
+            r_cfg = smcl.Config(smcl.USER_CONF_FILE)
+            smcl.setup_config(r_cfg)
+
+            assert r_cfg.get("Millenium Falcon", "space speed") == "75 MGLT"
+            assert r_cfg.get("Millenium Falcon", "atmospheric speed") == "1050 km/h"
+            assert r_cfg.get("general", "phases") == "dev, test, prod"
+            assert r_cfg.get("general", "exclude channels") == ""

--- a/utils/tests/test_spacewalk_manage_channel_lifecycle.py
+++ b/utils/tests/test_spacewalk_manage_channel_lifecycle.py
@@ -1,0 +1,32 @@
+# coding: utf-8
+"""
+Tests for spacewalk-manager-channel-lifecycle script.
+"""
+
+from mock import MagicMock, patch
+from . import helpers
+
+helpers.symlink_source("spacewalk-manage-channel-lifecycle", "smcl")
+from . import smcl
+helpers.unsymlink_source("smcl")
+
+
+class TestSMCL:
+    """
+    Integration/unit tests fusion for spacewalk-manage-channel-lifecycle script.
+    """
+    def test_get_current_phase(self):
+        """
+        Get configuration credentials.
+
+        :return:
+        """
+        smcl.phases = ["dev", "test", "prod"]
+        assert smcl.get_current_phase("develop") == "dev"
+
+    def test_configuration_saved(self):
+        """
+        Test configuration file is saved to the disk.
+
+        :return:
+        """

--- a/utils/tests/test_spacewalk_manage_channel_lifecycle.py
+++ b/utils/tests/test_spacewalk_manage_channel_lifecycle.py
@@ -3,6 +3,7 @@
 Tests for spacewalk-manager-channel-lifecycle script.
 """
 
+import pytest
 from mock import MagicMock, patch
 from . import helpers
 
@@ -23,6 +24,14 @@ class TestSMCL:
         """
         smcl.phases = ["dev", "test", "prod"]
         assert smcl.get_current_phase("develop") == "dev"
+
+    @pytest.mark.skip(reason="TBD")
+    def test_argparse_port(self):
+        """
+        Dummy stub test for porting deprecated optparser to argparse.
+
+        :return:
+        """
 
     def test_configuration_saved(self):
         """


### PR DESCRIPTION
## What does this PR change?

- Removes Python2 support entirely (not needed)
- Runs only on Py3 (required)
- Cleans up major linting issues
- Fixes a bug writing config in binary mode (bsc#1132361)
- Includes missing Python scripts into a linter watch
