### PR TITLE
Better workaround for IPv6 default route problem

### DIFF
--- a/testsuite/features/core_proxy_branch_network.feature
+++ b/testsuite/features/core_proxy_branch_network.feature
@@ -125,6 +125,9 @@ Feature: Setup SUSE Manager for Retail branch network
 @private_net
   Scenario: Let avahi work on the branch server
     When I open avahi port on the proxy
+    # WORKAROUND
+    # bsc#1132908 - Branch network formula closes IPv6 default route, potentially making further networking fail
+    And I enable SLAAC on the proxy
 
 @proxy
 @private_net
@@ -140,13 +143,6 @@ Feature: Setup SUSE Manager for Retail branch network
     And service "named" is active on "proxy"
     And service "firewalld" is enabled on "proxy"
     And service "firewalld" is active on "proxy"
-
-@proxy
-@private_net
-  Scenario: Workaround - reopen default IPv6 route
-    # WORKAROUND
-    # bsc#1132908 - Branch network formula closes IPv6 default route, potentially making further networking fail
-    When I reopen the IPv6 default route on the proxy
 
 @proxy
 @private_net

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -629,8 +629,10 @@ end
 
 # WORKAROUND
 # bsc#1132908 - Branch network formula closes IPv6 default route, potentially making further networking fail
-When(/^I reopen the IPv6 default route on the proxy$/) do
-  $proxy.run('ip -6 r a default via fe80::1 dev eth0')
+When(/^I enable SLAAC on the proxy$/) do
+  cmd = 'echo "net.ipv6.conf.eth0.accept_ra = 2" > /etc/sysctl.d/98-slaac.conf && '
+  cmd += 'sysctl -p /etc/sysctl.d/98-slaac.conf'
+  $proxy.run(cmd)
 end
 
 When(/^I copy server\'s keys to the proxy$/) do


### PR DESCRIPTION
## What does this PR change?

This PR works around

https://bugzilla.suse.com/show_bug.cgi?id=1132908
Branch network formula closes IPv6 default route, potentially making further networking fail

in the test suite.

Instead of re-adding the route after the formula removed it, it sets up SLAAC correctly so it will not get removed.

Port to 3.2: TBD

- [x] No changelog needed

**not tested yet**