### PR TITLE
Manager bsc1133560

### DIFF
--- a/spacewalk/setup/lib/Spacewalk/Setup.pm
+++ b/spacewalk/setup/lib/Spacewalk/Setup.pm
@@ -185,7 +185,7 @@ sub read_config {
   open(CONFIG, '<', $config_file) or die "Could not open $config_file: $!";
 
   while (my $line = <CONFIG>) {
-    if ($line =~ /^#/ or $line =~ /\[comment\]/ or $line =~ "^\n") {
+    if ($line =~ /^#/ or $line =~ /\[comment\]/ or $line =~ /^\s*$/) {
       next;
     } else {
       chomp($line);

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,5 @@
+- fix check for empty lines in rhn.conf for spacewalk-setup (bsc#1133560)
+
 -------------------------------------------------------------------
 Mon Apr 22 12:15:57 CEST 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?
If rhn.conf contains a line consisting only of white spaces, Setup.pm will fail as it only checks for completely empty lines (containing nothing but a newline character). This PR fixes the regular expression to also catch lines consisting of white spaces only.