### PR TITLE
Content Lifecycle Management: Implement package NEVR(A) filters

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
@@ -123,11 +123,6 @@ public class FilterCriteria {
         }
     }
 
-    // todo remove
-    public static void main(String[] args) {
-        validate(Matcher.CONTAINS, "name2");
-    }
-
     /**
      * Gets the type.
      *

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
@@ -18,7 +18,9 @@ package com.redhat.rhn.domain.contentmgmt;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.tuple.Pair;
 
+import java.util.HashSet;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.EnumType;
@@ -38,6 +40,14 @@ public class FilterCriteria {
     private Matcher matcher;
     private String field;
     private String value;
+
+    private static HashSet<Pair<Matcher, String>> validCombinations = new HashSet<>();
+
+    static {
+        validCombinations.add(Pair.of(Matcher.CONTAINS, "name"));
+        validCombinations.add(Pair.of(Matcher.EQUALS, "nevr"));
+        validCombinations.add(Pair.of(Matcher.EQUALS, "nevra"));
+    }
 
     /**
      * The matcher type
@@ -90,11 +100,32 @@ public class FilterCriteria {
      * @param matcherIn the matcher type
      * @param fieldIn the field to match
      * @param valueIn the match value
+     * @throws IllegalArgumentException when the matcher-field combination is not allowed
      */
     public FilterCriteria(Matcher matcherIn, String fieldIn, String valueIn) {
+        validate(matcherIn, fieldIn);
         this.matcher = matcherIn;
         this.field = fieldIn;
         this.value = valueIn;
+    }
+
+    /**
+     * Validate the matcher-field combination
+     *
+     * @param matcher the matcher
+     * @param field the field
+     * @throws IllegalArgumentException when validation does not pass
+     */
+    public static void validate(Matcher matcher, String field) throws IllegalArgumentException {
+        if (!validCombinations.contains(Pair.of(matcher, field))) {
+            throw new IllegalArgumentException(
+                    String.format("Invalid criteria combination (matcher: '%s', field: '%s')", matcher, field));
+        }
+    }
+
+    // todo remove
+    public static void main(String[] args) {
+        validate(Matcher.CONTAINS, "name2");
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
@@ -43,7 +43,8 @@ public class FilterCriteria {
      * The matcher type
      */
     public enum Matcher {
-        CONTAINS("contains");
+        CONTAINS("contains"),
+        EQUALS("equals");
 
         private String label;
 

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
@@ -38,9 +38,10 @@ public class PackageFilter extends ContentFilter<Package> {
         switch (matcher) {
             case CONTAINS:
                 return getField(pack, field, String.class).contains(value);
+            case EQUALS:
+                return getField(pack, field, String.class).equals(value);
             default:
                 throw new UnsupportedOperationException("Matcher " + matcher + " not supported");
-
         }
     }
 
@@ -48,6 +49,10 @@ public class PackageFilter extends ContentFilter<Package> {
         switch (field) {
             case "name":
                 return type.cast(pack.getPackageName().getName());
+            case "nevr":
+                return type.cast(pack.getNameEvr());
+            case "nevra":
+                return type.cast(pack.getNameEvra());
             default:
                 throw new UnsupportedOperationException("Field " + field + " not supported");
         }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentFilterTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentFilterTest.java
@@ -57,4 +57,38 @@ public class ContentFilterTest extends JMockBaseTestCaseWithUser {
         ContentFilter filter = ContentManager.createFilter(packageName + "-filter", ALLOW, PACKAGE, criteria, user);
         assertTrue(filter.test(pack));
     }
+
+    public void testPackageNevrFilter() throws Exception {
+        Package pack = PackageTest.createTestPackage(user.getOrg());
+        String packageName = pack.getPackageName().getName();
+
+        FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.EQUALS, "nevr", pack.getNameEvr());
+        ContentFilter filter = ContentManager.createFilter(packageName + "-nevr-filter", DENY, PACKAGE, criteria, user);
+        assertFalse(filter.test(pack));
+
+        criteria = new FilterCriteria(FilterCriteria.Matcher.EQUALS, "nevr", pack.getNameEvra());
+        filter = ContentManager.createFilter(packageName + "nevr2-filter", DENY, PACKAGE, criteria, user);
+        assertTrue(filter.test(pack));
+
+        criteria = new FilterCriteria(FilterCriteria.Matcher.EQUALS, "nevr", packageName);
+        filter = ContentManager.createFilter(packageName + "nevr3-filter", DENY, PACKAGE, criteria, user);
+        assertTrue(filter.test(pack));
+    }
+
+    public void testPackageNevraFilter() throws Exception {
+        Package pack = PackageTest.createTestPackage(user.getOrg());
+        String packageName = pack.getPackageName().getName();
+
+        FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.EQUALS, "nevra", pack.getNameEvra());
+        ContentFilter filter = ContentManager.createFilter(packageName + "-nevra-filter", DENY, PACKAGE, criteria, user);
+        assertFalse(filter.test(pack));
+
+        criteria = new FilterCriteria(FilterCriteria.Matcher.EQUALS, "nevra", pack.getNameEvr());
+        filter = ContentManager.createFilter(packageName + "nevra2-filter", DENY, PACKAGE, criteria, user);
+        assertTrue(filter.test(pack));
+
+        criteria = new FilterCriteria(FilterCriteria.Matcher.EQUALS, "nevra", packageName);
+        filter = ContentManager.createFilter(packageName + "nevra3-filter", DENY, PACKAGE, criteria, user);
+        assertTrue(filter.test(pack));
+    }
 }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentFilterTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentFilterTest.java
@@ -48,16 +48,6 @@ public class ContentFilterTest extends JMockBaseTestCaseWithUser {
         assertFalse(filter.test(pack));
     }
 
-    // TODO fkobzik enable test after Beta3 release
-    public void disabledTestPackageAllowFilter() throws Exception {
-        Package pack = PackageTest.createTestPackage(user.getOrg());
-        String packageName = pack.getPackageName().getName();
-
-        FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.CONTAINS, "name", packageName);
-        ContentFilter filter = ContentManager.createFilter(packageName + "-filter", ALLOW, PACKAGE, criteria, user);
-        assertTrue(filter.test(pack));
-    }
-
     public void testPackageNevrFilter() throws Exception {
         Package pack = PackageTest.createTestPackage(user.getOrg());
         String packageName = pack.getPackageName().getName();

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/test/FilterCriteriaTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/test/FilterCriteriaTest.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.domain.contentmgmt.test;
+
+import com.redhat.rhn.domain.contentmgmt.FilterCriteria;
+import junit.framework.TestCase;
+
+import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.validate;
+
+/**
+ * Tests for {@link FilterCriteria}
+ */
+public class FilterCriteriaTest extends TestCase {
+
+    public void testLegalValidation() {
+        validate(FilterCriteria.Matcher.CONTAINS, "name");
+        validate(FilterCriteria.Matcher.EQUALS, "nevr");
+        validate(FilterCriteria.Matcher.EQUALS, "nevra");
+    }
+
+    public void testIllegalValidation() {
+        try {
+            validate(FilterCriteria.Matcher.CONTAINS, "nonsense");
+            fail("An exception should have been thrown");
+        }
+        catch (IllegalArgumentException e) {
+            // pass
+        }
+
+        try {
+            validate(FilterCriteria.Matcher.EQUALS, "foo");
+            fail("An exception should have been thrown");
+        }
+        catch (IllegalArgumentException e) {
+                // pass
+        }
+    }
+}

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
@@ -616,7 +616,7 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
         FilterCriteria criteria = new FilterCriteria(Matcher.CONTAINS, "name", "aaa");
         ContentFilter filter = ContentManager.createFilter("my-filter", Rule.DENY, EntityType.PACKAGE, criteria, user);
 
-        FilterCriteria newCriteria = new FilterCriteria(Matcher.CONTAINS, "newname", "bbb");
+        FilterCriteria newCriteria = new FilterCriteria(Matcher.CONTAINS, "name", "bbb");
         ContentManager.updateFilter(filter.getId(), of("newname"), empty(), of(newCriteria), user);
         ContentFilter fromDb = ContentManager.lookupFilterById(filter.getId(), user).get();
         assertEquals("newname", fromDb.getName());

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
@@ -1029,6 +1029,11 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
         }
     }
 
+    /**
+     * Test that building a Project sets the correct state of assigned Filters
+     *
+     * @throws Exception if anything goes wrong
+     */
     public void testBuildProjectWithFilters() throws Exception {
         ContentProject cp = new ContentProject("cplabel", "cpname", "cpdesc", user.getOrg());
         ContentProjectFactory.save(cp);
@@ -1049,6 +1054,56 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
         ContentManager.detachFilter("cplabel", filter.getId(), user);
         ContentManager.buildProject("cplabel", empty(), false, user);
         assertTrue(cp.getProjectFilters().isEmpty());
+    }
+
+    /**
+     * Test building a Project and filtering out Package using NEVR Filters
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testBuildProjectWithNevrFilters() throws Exception {
+        ContentProject cp = new ContentProject("cplabel", "cpname", "cpdesc", user.getOrg());
+        ContentProjectFactory.save(cp);
+        ContentEnvironment env = ContentManager.createEnvironment(cp.getLabel(), empty(), "fst", "first env", "desc", false, user);
+        Channel channel = createPopulatedChannel();
+        ContentManager.attachSource("cplabel", SW_CHANNEL, channel.getLabel(), empty(), user);
+
+        // build without filters
+        ContentManager.buildProject("cplabel", empty(), false, user);
+        assertEquals(1, env.getTargets().get(0).asSoftwareTarget().get().getChannel().getPackageCount());
+
+        // build with filters
+        Package pack = channel.getPackages().iterator().next();
+        FilterCriteria criteria = new FilterCriteria(Matcher.EQUALS, "nevr", pack.getNameEvr());
+        ContentFilter filter = ContentManager.createFilter("my-filter", ContentFilter.Rule.DENY, ContentFilter.EntityType.PACKAGE, criteria, user);
+        ContentManager.attachFilter("cplabel", filter.getId(), user);
+        ContentManager.buildProject("cplabel", empty(), false, user);
+        assertEquals(0, env.getTargets().get(0).asSoftwareTarget().get().getChannel().getPackageCount());
+    }
+
+    /**
+     * Test building a Project and filtering out Package using NEVRA Filters
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testBuildProjectWithNevraFilters() throws Exception {
+        ContentProject cp = new ContentProject("cplabel", "cpname", "cpdesc", user.getOrg());
+        ContentProjectFactory.save(cp);
+        ContentEnvironment env = ContentManager.createEnvironment(cp.getLabel(), empty(), "fst", "first env", "desc", false, user);
+        Channel channel = createPopulatedChannel();
+        ContentManager.attachSource("cplabel", SW_CHANNEL, channel.getLabel(), empty(), user);
+
+        // build without filters
+        ContentManager.buildProject("cplabel", empty(), false, user);
+        assertEquals(1, env.getTargets().get(0).asSoftwareTarget().get().getChannel().getPackageCount());
+
+        // build with filters
+        Package pack = channel.getPackages().iterator().next();
+        FilterCriteria criteria = new FilterCriteria(Matcher.EQUALS, "nevra", pack.getNameEvra());
+        ContentFilter filter = ContentManager.createFilter("my-filter", ContentFilter.Rule.DENY, ContentFilter.EntityType.PACKAGE, criteria, user);
+        ContentManager.attachFilter("cplabel", filter.getId(), user);
+        ContentManager.buildProject("cplabel", empty(), false, user);
+        assertEquals(0, env.getTargets().get(0).asSoftwareTarget().get().getChannel().getPackageCount());
     }
 
     private Channel createPopulatedChannel() throws Exception {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Implement NEVR(A) filtering in Content Lifecycle Management
 - Adjust product tree tag according to the base OS
 - Add a link to the highstate page after formula was saved
 - Fix deleting server when minion_formulas.json is empty (bsc#1122230)


### PR DESCRIPTION
## What does this PR change?
 
 Allow filtering packages based on their Name, Epoch, Version, Release and Architecture when building a content project.
 
 ## GUI diff
 
 No difference.
 
 Before:
 
 After:
 
 - [x] **DONE**
 
 ## Documentation
 - No documentation needed: **add explanation. This can't be used if there is a GUI diff**
 - [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)
 
 - [ ] **DONE**
 
 ## Test coverage
 - Unit tests were added
 
 - [x] **DONE**
 
 ## Links
 
 Tracks https://github.com/SUSE/spacewalk/issues/7704
 
 - [x] **DONE**
 
 ## Changelogs
 
 If you don't need a changelog check, please mark this checkbox:
 
 - [ ] No changelog needed
 
 If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
 
 
 ## Re-run a test
 
 If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:
 
 - [ ] Re-run test "changelog_test"
 - [ ] Re-run test "backend_unittests_pgsql"
 - [ ] Re-run test "java_lint_checkstyle"		 
 - [ ] Re-run test "java_pgsql_tests" 		 
 - [ ] Re-run test "ruby_rubocop"
 - [ ] Re-run test "schema_migration_test_oracle"
 - [ ] Re-run test "schema_migration_test_pgsql"		 
 - [ ] Re-run test "susemanager_unittests"
 - [ ] Re-run test "javascript_lint"
 