### PR TITLE
32 schema to master

### DIFF
--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,7 @@
+- copy 3.2 schema migrations to 4.0 to be able to migrate from an older
+  schema version to 4.0
+- clean the susesccrepository table before modify it (bsc#1125456)
+
 -------------------------------------------------------------------
 Mon Apr 22 12:23:15 CEST 2019 - jgonzalez@suse.com
 

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/000-helper-functions.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/000-helper-functions.sql.oracle
@@ -1,0 +1,103 @@
+CREATE OR REPLACE PROCEDURE create_table_if_not_exists(
+  p_table_name VARCHAR2,
+  create_table_query VARCHAR2
+) IS
+  n NUMBER;
+BEGIN
+  SELECT COUNT(*) INTO n FROM user_tables WHERE table_name = UPPER(p_table_name);
+  IF (n = 0) THEN
+    EXECUTE IMMEDIATE create_table_query;
+  END IF;
+END;
+/
+show errors
+
+CREATE OR REPLACE PROCEDURE create_seq_if_not_exists(
+  isSeqName VARCHAR2,
+  isSeqOptions VARCHAR2
+) IS
+  lnSeqCount NUMBER;
+BEGIN
+  -- try to find sequence in data dictionary
+  SELECT count(1)
+    INTO lnSeqCount
+    FROM user_sequences
+    WHERE UPPER(sequence_name) = UPPER(isSeqName);
+  -- if sequence not found, create it
+  IF lnSeqCount = 0 THEN
+    EXECUTE IMMEDIATE 'CREATE SEQUENCE ' || UPPER(isSeqName) || ' ' || isSeqOptions;
+  END IF;
+END;
+/
+show errors
+
+CREATE OR REPLACE PROCEDURE add_column_if_not_exists(
+  alter_table_query VARCHAR2
+) IS
+    column_exists exception;
+    pragma exception_init (column_exists , -01430);
+begin
+  begin
+    execute immediate alter_table_query;
+  exception
+    when column_exists then null;
+  end;
+end;
+/
+show errors
+
+create or replace procedure drop_if_exists(type_in varchar2, name_in varchar2)
+is
+  cnt number := 0;
+begin
+  select count(*) into cnt from user_objects where object_type = upper(type_in) and object_name = upper(name_in);
+  if cnt > 0 then
+    if upper(type_in) = 'TABLE' then
+      execute immediate 'drop ' || type_in || ' ' || name_in || ' purge';
+    else
+      execute immediate 'drop ' || type_in || ' ' || name_in;
+    end if;
+  end if;
+end;
+/
+show errors
+
+
+create or replace procedure drop_constraint_if_exists(p_table_name varchar2, p_constraint_name varchar2)
+is
+  l_cnt integer;
+BEGIN
+    SELECT COUNT(*)
+      INTO l_cnt
+      FROM user_constraints
+     WHERE constraint_name = UPPER(p_constraint_name);
+
+    IF( l_cnt = 1 )
+    THEN
+        EXECUTE IMMEDIATE 'ALTER TABLE ' || p_table_name || ' DROP CONSTRAINT ' || p_constraint_name;
+    END IF;
+END;
+/
+show errors
+
+
+CREATE OR REPLACE PROCEDURE drop_column_if_exists(
+  p_table_name VARCHAR2,
+  p_column_name VARCHAR2
+) IS
+  l_cnt integer;
+BEGIN
+  SELECT COUNT(*)
+    INTO l_cnt 
+    FROM user_tab_columns
+   WHERE table_name = UPPER(p_table_name)
+     and column_name = UPPER(p_column_name);
+
+  IF( l_cnt = 1 )
+  THEN
+    EXECUTE IMMEDIATE 'ALTER TABLE ' || p_table_name || ' DROP COLUMN ' || p_column_name;
+  END IF;
+END;
+/
+show errors
+

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/000-helper-functions.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/000-helper-functions.sql.postgresql
@@ -1,0 +1,2 @@
+-- oracle equivalent source sha1 08235393522863268d2f685d4bb123aae5fd29fe
+-- This file is intentionally left empty.

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/001-create-susesaltevent.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/001-create-susesaltevent.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to create-susesaltevent.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/001-create-susesaltevent.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/001-create-susesaltevent.sql.postgresql
@@ -1,0 +1,10 @@
+-- oracle equivalent source sha1 9798b2a30dc466d9ec024456bcaa572f7e56c939
+
+CREATE TABLE IF NOT EXISTS suseSaltEvent (
+  id SERIAL PRIMARY KEY,
+  minion_id CHARACTER VARYING(256),
+  data TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS suse_salt_event_minion_id_idx
+  ON suseSaltEvent (minion_id NULLS LAST, id);

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/001-suseSCCRepository.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/001-suseSCCRepository.sql.oracle
@@ -1,0 +1,57 @@
+--
+-- Copyright (c) 2014--2018 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+DECLARE
+  already_not_null exception;
+  pragma exception_init (already_not_null, -01442);
+begin
+  begin
+    execute immediate 'ALTER TABLE suseSCCRepository MODIFY (scc_id NUMBER NOT NULL)';
+  exception
+    when already_not_null then null;
+  end;
+
+  begin
+    execute immediate 'ALTER TABLE suseSCCRepository MODIFY (name VARCHAR2(256) NOT NULL)';
+  exception
+    when already_not_null then null;
+  end;
+
+  begin
+    execute immediate 'ALTER TABLE suseSCCRepository MODIFY (description VARCHAR2(2048) NOT NULL)';
+  exception
+    when already_not_null then null;
+  end;
+
+  begin
+    execute immediate 'ALTER TABLE suseSCCRepository MODIFY (url VARCHAR2(2048) NOT NULL)';
+  exception
+    when already_not_null then null;
+  end;
+end;
+/
+
+call drop_column_if_exists('suseSCCRepository', 'credentials_id');
+call add_column_if_not_exists('alter table suseSCCRepository add signed CHAR(1) DEFAULT (''N'') NOT NULL CONSTRAINT suse_sccrepo_sig_ck CHECK (signed in (''Y'', ''N''))');
+
+call drop_if_exists('INDEX', 'suse_sccrepo_sccid_idx');
+call drop_constraint_if_exists('suseSCCRepository', 'suse_sccrepo_sccid_uq');
+call drop_if_exists('INDEX', 'suse_sccrepo_sccid_uq');
+CREATE UNIQUE INDEX suse_sccrepo_sccid_uq
+    ON suseSCCRepository (scc_id);
+
+call drop_if_exists('INDEX', 'suse_sccrepo_url_idx');
+CREATE INDEX suse_sccrepo_url_idx
+    ON suseSCCRepository (url);

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/001-suseSCCRepository.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/001-suseSCCRepository.sql.postgresql
@@ -1,0 +1,37 @@
+-- oracle equivalent source sha1 1edf5de5dfa84a6d8e2a71fe6f344cf6815fa970
+--
+-- Copyright (c) 2014--2018 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+delete from susesccrepository;
+
+ALTER TABLE suseSCCRepository
+  ALTER COLUMN scc_id SET NOT NULL,
+  ALTER COLUMN name SET NOT NULL,
+  ALTER COLUMN description SET NOT NULL,
+  ALTER COLUMN url SET NOT NULL;
+  
+alter table suseSCCRepository drop column if exists credentials_id;
+alter table suseSCCRepository add column if not exists
+    signed CHAR(1) DEFAULT ('N') NOT NULL;
+
+alter table suseSCCRepository drop CONSTRAINT if exists suse_sccrepo_sig_ck;
+alter table suseSCCRepository add CONSTRAINT suse_sccrepo_sig_ck CHECK (signed in ('Y', 'N'));
+
+DROP INDEX if exists suse_sccrepo_sccid_idx;
+CREATE UNIQUE INDEX if not exists suse_sccrepo_sccid_uq
+    ON suseSCCRepository (scc_id);
+
+CREATE INDEX if not exists suse_sccrepo_url_idx
+    ON suseSCCRepository (url);

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/002-suseProductSCCRepository.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/002-suseProductSCCRepository.sql.oracle
@@ -1,0 +1,45 @@
+call create_table_if_not_exists('suseProductSCCRepository', '
+CREATE TABLE
+suseProductSCCRepository
+(
+    id                     NUMBER NOT NULL primary key,
+    product_id             NUMBER NOT NULL
+                                  CONSTRAINT suse_prdrepo_pid_fk
+                                  REFERENCES suseProducts (id)
+                                  ON DELETE CASCADE,
+    root_product_id        NUMBER NOT NULL
+                                  CONSTRAINT suse_prdrepo_rpid_fk
+                                  REFERENCES suseProducts (id)
+                                  ON DELETE CASCADE,
+    repo_id                NUMBER NOT NULL
+                                  CONSTRAINT suse_prdrepo_rid_fk
+                                  REFERENCES suseSCCRepository (id)
+                                  ON DELETE CASCADE,
+    channel_label          VARCHAR2(128) not null,
+    parent_channel_label   VARCHAR2(128),
+    channel_name           VARCHAR2(256) not null,
+    mandatory              CHAR(1) DEFAULT (''N'') NOT NULL
+                                   CONSTRAINT suse_prdrepo_mand_ck
+                                   CHECK (mandatory in (''Y'', ''N'')),
+    update_tag             VARCHAR2(128),
+    created                timestamp with local time zone
+                           DEFAULT (current_timestamp) NOT NULL,
+    modified               timestamp with local time zone
+                           DEFAULT (current_timestamp) NOT NULL
+)');
+
+call create_seq_if_not_exists('suse_prdrepo_id_seq', 'START WITH 1');
+
+call drop_constraint_if_exists('suseProductSCCRepository', 'suse_prdrepo_pid_rid_cl_uq');
+call drop_if_exists('INDEX', 'suse_prdrepo_pid_rid_cl_uq');
+
+call drop_constraint_if_exists('suseProductSCCRepository', 'suse_prdrepo_pid_rpid_rid_uq');
+call drop_if_exists('INDEX', 'suse_prdrepo_pid_rpid_rid_uq');
+CREATE UNIQUE INDEX suse_prdrepo_pid_rpid_rid_uq
+ON suseProductSCCRepository (product_id, root_product_id, repo_id)
+;
+
+call drop_if_exists('INDEX', 'suse_prdrepo_chl_idx');
+CREATE INDEX suse_prdrepo_chl_idx
+ON suseProductSCCRepository (channel_label)
+;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/002-suseProductSCCRepository.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/002-suseProductSCCRepository.sql.postgresql
@@ -1,0 +1,39 @@
+-- oracle equivalent source sha1 07bba32d848d39b080335f039dd0a42a065e2338
+
+CREATE TABLE if not exists
+suseProductSCCRepository
+(
+    id                     NUMERIC NOT NULL primary key,
+    product_id             NUMERIC NOT NULL
+                                  CONSTRAINT suse_prdrepo_pid_fk
+                                  REFERENCES suseProducts (id)
+                                  ON DELETE CASCADE,
+    root_product_id        NUMERIC NOT NULL
+                                  CONSTRAINT suse_prdrepo_rpid_fk
+                                  REFERENCES suseProducts (id)
+                                  ON DELETE CASCADE,
+    repo_id                NUMERIC NOT NULL
+                                  CONSTRAINT suse_prdrepo_rid_fk
+                                  REFERENCES suseSCCRepository (id)
+                                  ON DELETE CASCADE,
+    channel_label          VARCHAR(128) not null,
+    parent_channel_label   VARCHAR(128),
+    channel_name           VARCHAR(256) not null,
+    mandatory              CHAR(1) DEFAULT ('N') NOT NULL
+                                   CONSTRAINT suse_prdrepo_mand_ck
+                                   CHECK (mandatory in ('Y', 'N')),
+    update_tag             VARCHAR(128),
+    created                TIMESTAMPTZ
+                           DEFAULT (current_timestamp) NOT NULL,
+    modified               TIMESTAMPTZ
+                           DEFAULT (current_timestamp) NOT NULL
+);
+
+CREATE SEQUENCE if not exists suse_prdrepo_id_seq START WITH 1;
+
+DROP INDEX if exists suse_prdrepo_pid_rid_cl_uq;
+CREATE UNIQUE INDEX if not exists suse_prdrepo_pid_rpid_rid_uq
+ON suseProductSCCRepository (product_id, root_product_id, repo_id);
+
+CREATE INDEX if not exists suse_prdrepo_chl_idx
+ON suseProductSCCRepository (channel_label);

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/003-change-suseProductChannel.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/003-change-suseProductChannel.sql.oracle
@@ -1,0 +1,23 @@
+
+DELETE FROM suseProductChannel WHERE channel_id IS NULL;
+
+DECLARE
+  already_not_null exception;
+  pragma exception_init (already_not_null, -01442);
+begin
+  begin
+    execute immediate 'ALTER TABLE suseProductChannel MODIFY (channel_id NUMBER NOT NULL)';
+  exception
+    when already_not_null then null;
+  end;
+end;
+/
+
+call add_column_if_not_exists('alter table suseProductChannel add mandatory  CHAR(1) DEFAULT (''N'') NOT NULL CONSTRAINT spc_mand_ck CHECK (mandatory in (''Y'', ''N''))');
+
+call drop_column_if_exists('SUSEPRODUCTCHANNEL', 'CHANNEL_LABEL');
+call drop_column_if_exists('SUSEPRODUCTCHANNEL', 'PARENT_CHANNEL_LABEL');
+call drop_if_exists('index', 'suse_prd_chan_label_uq');
+call drop_if_exists('index', 'suse_prd_chan_pcl_idx');
+call drop_if_exists('index', 'suse_prd_chan_chan_idx');
+

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/003-change-suseProductChannel.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/003-change-suseProductChannel.sql.postgresql
@@ -1,0 +1,18 @@
+-- oracle equivalent source sha1 6c90b0d33249b99a6ba9855be7927cadaf2a15f0
+
+DELETE FROM suseProductChannel WHERE channel_id IS NULL;
+
+ALTER TABLE suseProductChannel ALTER COLUMN channel_id SET NOT NULL;
+
+alter table suseProductChannel drop column if exists channel_label;
+alter table suseProductChannel drop column if exists parent_channel_label;
+
+alter table suseProductChannel add column if not exists
+    mandatory  CHAR(1) DEFAULT ('N') NOT NULL;
+
+alter table suseProductChannel drop CONSTRAINT if exists spc_mand_ck;
+alter table suseProductChannel add CONSTRAINT spc_mand_ck CHECK (mandatory in ('Y', 'N'));
+
+drop index if exists suse_prd_chan_label_uq;
+drop index if exists suse_prd_chan_pcl_idx;
+drop index if exists suse_prd_chan_chan_idx;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/004-change-suseProducts.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/004-change-suseProducts.sql.oracle
@@ -1,0 +1,8 @@
+
+call add_column_if_not_exists('alter table suseProducts add release_stage VARCHAR2(10) DEFAULT (''released'') NOT NULL');
+call add_column_if_not_exists('alter table suseProducts add description VARCHAR2(4000)');
+
+call drop_if_exists('INDEX', 'suseprod_pdid_idx');
+call drop_constraint_if_exists('suseProducts', 'suseprod_pdid_uq');
+call drop_if_exists('INDEX', 'suseprod_pdid_uq');
+CREATE UNIQUE INDEX suseprod_pdid_uq ON suseProducts (product_id);

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/004-change-suseProducts.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/004-change-suseProducts.sql.postgresql
@@ -1,0 +1,7 @@
+-- oracle equivalent source sha1 5f5f67f470cbd485de8cfb181fcb42f165dcfa1f
+
+alter table suseProducts add column if not exists release_stage VARCHAR(10) DEFAULT ('released') NOT NULL;
+alter table suseProducts add column if not exists description VARCHAR(4000);
+
+CREATE UNIQUE INDEX if not exists suseprod_pdid_uq
+ON suseProducts (product_id);

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/005-drop-productUrl.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/005-drop-productUrl.sql.oracle
@@ -1,0 +1,3 @@
+
+call drop_column_if_exists('RHNCHANNELFAMILY', 'PRODUCT_URL');
+

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/005-drop-productUrl.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/005-drop-productUrl.sql.postgresql
@@ -1,0 +1,3 @@
+-- oracle equivalent source sha1 fe575f2bb3655c036bde1ec2315303b9f083a758
+
+alter table rhnChannelFamily drop column if exists product_url;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/006-suseSCCRepositoryAuth.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/006-suseSCCRepositoryAuth.sql.oracle
@@ -1,0 +1,42 @@
+--
+-- Copyright (c) 2018 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+call create_table_if_not_exists('suseSCCRepositoryAuth', '
+CREATE TABLE suseSCCRepositoryAuth
+(
+    id             NUMBER NOT NULL PRIMARY KEY,
+    repo_id        NUMBER NOT NULL
+                       CONSTRAINT suse_sccrepoauth_rid_fk
+		       REFERENCES suseSCCRepository (id),
+--                     NO ON DELETE !
+    credentials_id NUMBER NULL
+                       CONSTRAINT suse_sccrepo_credsid_fk
+                       REFERENCES suseCredentials (id),
+--                     NO ON DELETE !,
+    source_id      NUMBER NULL
+                         CONSTRAINT suse_sccrepo_src_id_fk
+                             REFERENCES rhnContentSource (id)
+                             ON DELETE SET NULL,
+    auth_type      VARCHAR2(10) NOT NULL,
+    auth           VARCHAR2(4000) NULL,
+    created        timestamp with local time zone
+                       DEFAULT (current_timestamp) NOT NULL,
+    modified       timestamp with local time zone
+                       DEFAULT (current_timestamp) NOT NULL
+)
+ENABLE ROW MOVEMENT');
+
+call create_seq_if_not_exists('suse_sccrepoauth_id_seq', '');
+

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/006-suseSCCRepositoryAuth.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/006-suseSCCRepositoryAuth.sql.postgresql
@@ -1,0 +1,40 @@
+-- oracle equivalent source sha1 a5861db362dc3a687e979cf2fd6025a0a21b360e
+--
+-- Copyright (c) 2018 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+CREATE TABLE if not exists suseSCCRepositoryAuth
+(
+    id             NUMERIC NOT NULL PRIMARY KEY,
+    repo_id        NUMERIC NOT NULL
+                       CONSTRAINT suse_sccrepoauth_rid_fk
+		       REFERENCES suseSCCRepository (id),
+--                     NO ON DELETE !
+    credentials_id NUMERIC NULL
+                       CONSTRAINT suse_sccrepo_credsid_fk
+                       REFERENCES suseCredentials (id),
+--                     NO ON DELETE !,
+    source_id      NUMERIC NULL
+                         CONSTRAINT suse_sccrepo_src_id_fk
+                             REFERENCES rhnContentSource (id)
+                             ON DELETE SET NULL,
+    auth_type      VARCHAR(10) NOT NULL,
+    auth           VARCHAR(4000) NULL,
+    created        TIMESTAMPTZ
+                       DEFAULT (current_timestamp) NOT NULL,
+    modified       TIMESTAMPTZ
+                       DEFAULT (current_timestamp) NOT NULL
+) ;
+
+CREATE SEQUENCE if not exists suse_sccrepoauth_id_seq;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/007-suseManagerInfo.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/007-suseManagerInfo.sql.oracle
@@ -1,0 +1,21 @@
+--
+-- Copyright (c) 2018 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+call create_table_if_not_exists('suseManagerInfo', '
+CREATE TABLE suseManagerInfo
+(
+    last_mgr_sync_refresh   TIMESTAMP WITH LOCAL TIME ZONE
+)
+ENABLE ROW MOVEMENT');

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/007-suseManagerInfo.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/007-suseManagerInfo.sql.postgresql
@@ -1,0 +1,20 @@
+-- oracle equivalent source sha1 489aa134083de95bf893a0d67545146414c7e8c5
+--
+-- Copyright (c) 2018 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+CREATE TABLE if not exists suseManagerInfo
+(
+    last_mgr_sync_refresh   TIMESTAMPTZ
+);

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/200-suseUserRoleView.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/200-suseUserRoleView.sql
@@ -1,0 +1,78 @@
+--
+-- Copyright (c) 2018 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+CREATE OR REPLACE VIEW
+suseChannelUserRoleView
+AS
+  SELECT
+    combination.channel_id,
+    combination.user_id,
+    combination.role,
+    CASE
+      -- if channel is in an org trusted by the user's org, and if the channel itself is shared between the two, then user can subscribe it
+      WHEN combination.role = 'subscribe' AND combination.user_id IN (
+        SELECT u.id
+        FROM web_contact u
+          JOIN rhnSharedChannelView s ON s.org_trust_id = u.org_id
+        WHERE channel_id = combination.channel_id
+      )
+        THEN NULL
+      -- otherwise, if channel is not in user's org, then user can't manage it
+      WHEN combination.role = 'manage' AND combination.channel_org_id IS NULL OR combination.channel_org_id <> combination.user_org_id
+        THEN 'channel_not_owned'
+      -- otherwise, if channel is in a family without permissions for the user's org, then user can't subscribe it
+      WHEN combination.role = 'subscribe' AND combination.user_org_id NOT IN (
+        SELECT cfp.org_id
+          FROM rhnChannelFamilyMembers cfm
+            JOIN rhnOrgChannelFamilyPermissions cfp ON cfp.channel_family_id = cfm.channel_family_id
+            WHERE cfm.channel_id = combination.channel_id
+      )
+        THEN 'channel_not_available'
+      -- otherwise, if user is a channel admin or an org admin, he can both manage and subscribe it
+      WHEN combination.user_id IN (
+        SELECT u.id
+          FROM web_contact u
+            JOIN rhnUserGroupMembers m ON m.user_id = u.id
+            JOIN rhnUserGroup g ON g.id = m.user_group_id
+            JOIN rhnUserGroupType t ON t.id = g.group_type
+          WHERE t.label = 'channel_admin' OR t.label = 'org_admin'
+      )
+        THEN NULL
+      -- otherwise, if channel does not have the "not_globally_subscribable" bit set, user can subscribe it
+      WHEN combination.role = 'subscribe' AND combination.channel_id NOT IN (
+        SELECT ocs.channel_id
+        FROM rhnOrgChannelSettings ocs
+          JOIN rhnOrgChannelSettingsType ocst ON ocst.id = ocs.setting_id
+        WHERE ocst.label = 'not_globally_subscribable' AND ocs.org_id = combination.user_org_id
+      )
+        THEN NULL
+      -- otherwise, user might have an explicit permission on this channel
+      WHEN combination.role IN (
+        SELECT cpr.label
+          FROM rhnChannelPermission cp
+            JOIN rhnChannelPermissionRole cpr ON cpr.id = cp.role_id
+          WHERE cp.channel_id = combination.channel_id AND cp.user_id = combination.user_id
+      )
+        THEN NULL
+        -- otherwise, user can't either manage nor subscribe the channel
+        ELSE 'direct_permission'
+    END AS deny_reason
+    FROM
+      (SELECT
+          c.id AS channel_id,
+          c.org_id AS channel_org_id,
+          u.id AS user_id,
+          u.org_id AS user_org_id,
+          r.label AS role
+          FROM rhnChannel c, web_contact u, rhnChannelPermissionRole r
+      ) combination
+    -- ORDER BY channel_id, user_id, role, result
+;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/201-rhn_channel.pkb.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/201-rhn_channel.pkb.sql.oracle
@@ -1,0 +1,822 @@
+--
+-- Copyright (c) 2008--2018 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+CREATE OR REPLACE
+PACKAGE BODY rhn_channel
+IS
+        body_version varchar2(100) := '';
+
+    -- Cursor that fetches all the possible base channels for a
+    -- (server_arch_id, release, org_id) combination
+        cursor  base_channel_cursor(
+                release_in in varchar2,
+                server_arch_id_in in number,
+                org_id_in in number
+        ) return rhnChannel%ROWTYPE is
+                select distinct c.*
+                from    rhnOrgDistChannelMap                       odcm,
+                                rhnServerChannelArchCompat      scac,
+                                rhnChannel                                      c
+                where   c.parent_channel is null
+                        and c.id = odcm.channel_id
+                        and c.channel_arch_id = odcm.channel_arch_id
+                        and odcm.release = release_in
+                        and odcm.for_org_id = org_id_in
+                        and scac.server_arch_id = server_arch_id_in
+                        and scac.channel_arch_id = c.channel_arch_id;
+
+    PROCEDURE subscribe_server(server_id_in IN NUMBER, channel_id_in NUMBER, immediate_in NUMBER := 1, user_id_in in number := null)
+    IS
+        channel_parent_val      rhnChannel.parent_channel%TYPE;
+        parent_subscribed       BOOLEAN;
+        server_has_base_chan    BOOLEAN;
+        server_already_in_chan  BOOLEAN;
+        channel_family_id_val   NUMBER;
+        allowed                 number := 0;
+    BEGIN
+        if user_id_in is not null then
+            allowed := rhn_channel.user_role_check(channel_id_in, user_id_in, 'subscribe');
+        else
+            allowed := 1;
+        end if;
+
+        if allowed = 0 then
+            rhn_exception.raise_exception('no_subscribe_permissions');
+        end if;
+        
+        FOR check_subscription IN check_server_subscription(server_id_in, channel_id_in)
+        LOOP
+            server_already_in_chan := TRUE;
+        END LOOP check_subscription;
+
+        IF server_already_in_chan
+        THEN
+            RETURN;
+        END IF;
+
+        SELECT parent_channel INTO channel_parent_val FROM rhnChannel WHERE id = channel_id_in;
+
+        IF channel_parent_val IS NOT NULL
+        THEN
+            -- child channel; if attempting to cross-subscribe a child to the wrong base, silently ignore
+            parent_subscribed := FALSE;
+
+            FOR check_subscription IN check_server_subscription(server_id_in, channel_parent_val)
+            LOOP
+                parent_subscribed := TRUE;
+            END LOOP check_subscription;
+
+            IF NOT parent_subscribed
+            THEN
+                RETURN;
+            END IF;
+        ELSE
+            -- base channel
+            server_has_base_chan := FALSE;
+            FOR base IN server_base_subscriptions(server_id_in)
+            LOOP
+                server_has_base_chan := TRUE;
+            END LOOP base;
+
+            IF server_has_base_chan
+            THEN
+                rhn_exception.raise_exception('channel_server_one_base');
+            END IF;
+        END IF;
+
+        channel_family_id_val := rhn_channel.family_for_channel(channel_id_in);
+        IF channel_family_id_val IS NULL
+        THEN
+            rhn_exception.raise_exception('channel_subscribe_no_family');
+        END IF;
+
+        insert into rhnServerHistory (id,server_id,summary,details) (
+            select  rhn_event_id_seq.nextval,
+                    server_id_in,
+                    'subscribed to channel ' || SUBSTR(c.label, 0, 106),
+                    c.label
+            from    rhnChannel c
+            where   c.id = channel_id_in
+        );
+
+        INSERT INTO rhnServerChannel (server_id, channel_id) VALUES (server_id_in, channel_id_in);
+        queue_server(server_id_in, immediate_in);
+
+        update rhnServer
+           set channels_changed = current_timestamp
+         where id = server_id_in;
+    END subscribe_server;
+
+    function guess_server_base(
+        server_id_in in number
+    ) RETURN number is
+        cursor server_cursor is
+            select s.server_arch_id, s.release, s.org_id
+              from rhnServer s
+             where s.id = server_id_in;
+    begin
+        for s in server_cursor loop
+            for channel in base_channel_cursor(s.release,
+                s.server_arch_id, s.org_id)
+            loop
+                return channel.id;
+            end loop base_channel_cursor;
+        end loop server_cursor;
+        -- Server not found, or no base channel applies to it
+        return null;
+    end;
+
+    -- Private function
+    function normalize_server_arch(server_arch_in in varchar2)
+    return varchar2
+    deterministic
+    is
+        suffix VARCHAR2(128) := '-redhat-linux';
+        suffix_len NUMBER := length(suffix);
+    begin
+        if server_arch_in is NULL then
+            return NULL;
+        end if;
+        if instr(server_arch_in, '-') > 0
+        then
+            -- Suffix already present
+            return server_arch_in;
+        end if;
+        return server_arch_in || suffix;
+    end normalize_server_arch;
+
+    --
+    --
+    -- Raises:
+    --   server_arch_not_found
+    --   no_subscribe_permissions
+    function base_channel_for_release_arch(
+        release_in in varchar2,
+        server_arch_in in varchar2,
+        org_id_in in number := -1,
+        user_id_in in number := null
+    ) return number is
+        server_arch varchar2(256) := normalize_server_arch(server_arch_in);
+        server_arch_id number;
+    begin
+        -- Look up the server arch
+        begin
+            select id
+              into server_arch_id
+              from rhnServerArch
+             where label = server_arch;
+        exception
+            when no_data_found then
+                rhn_exception.raise_exception('server_arch_not_found');
+        end;
+        return base_channel_rel_archid(release_in, server_arch_id,
+            org_id_in, user_id_in);
+    end base_channel_for_release_arch;
+
+    function base_channel_rel_archid(
+        release_in in varchar2,
+        server_arch_id_in in number,
+        org_id_in in number := -1,
+        user_id_in in number := null
+    ) return number is
+        denied_channel_id number := null;
+        valid_org_id number := org_id_in;
+        valid_user_id number := user_id_in;
+        channel_subscribable number;
+    begin
+        if org_id_in = -1 and user_id_in is not null then
+            -- Get the org id from the user id
+            begin
+                select org_id
+                  into valid_org_id
+                  from web_contact
+                 where id = user_id_in;
+            exception
+                when no_data_found then
+                    -- User doesn't exist
+                    -- XXX Only list public stuff for now
+                    valid_user_id := null;
+                    valid_org_id := -1;
+            end;
+        end if;
+
+        for c in base_channel_cursor(release_in, server_arch_id_in, valid_org_id)
+        loop
+            -- This row is a possible match
+            if valid_user_id is null then
+                -- User ID not specified, so no user to channel permissions to
+                -- check
+                return c.id;
+            end if;
+
+            -- Check user to channel permissions
+            select loose_user_role_check(c.id, user_id_in, 'subscribe')
+              into channel_subscribable
+              from dual;
+
+            if channel_subscribable = 1 then
+                return c.id;
+            end if;
+
+            -- Base channel exists, but is not subscribable; keep trying
+            denied_channel_id := c.id;
+        end loop base_channel_fetch;
+
+        if denied_channel_id is not null then
+            rhn_exception.raise_exception('no_subscribe_permissions');
+        end if;
+        -- No base channel applies
+        return NULL;
+    end base_channel_rel_archid;
+
+    PROCEDURE clear_subscriptions(server_id_in IN NUMBER, deleting_server IN NUMBER := 0)
+    IS
+        cursor server_channels(server_id_in in number) is
+                select  s.org_id, sc.channel_id, cfm.channel_family_id
+                from    rhnServer s,
+                        rhnServerChannel sc,
+                        rhnChannelFamilyMembers cfm
+                where   s.id = server_id_in
+                        and s.id = sc.server_id
+                        and sc.channel_id = cfm.channel_id
+                order by cfm.channel_family_id;
+        last_channel_family_id rhnChannelFamilyMembers.channel_family_id%type := -1;
+        last_channel_org_id    rhnServer.org_id%type := -1;
+    BEGIN
+        for channel in server_channels(server_id_in)
+        loop
+                unsubscribe_server(server_id_in, channel.channel_id, 1, 1, deleting_server);
+        end loop channel;
+    END clear_subscriptions;
+
+    PROCEDURE unsubscribe_server(server_id_in IN NUMBER, channel_id_in NUMBER, immediate_in NUMBER := 1, unsubscribe_children_in number := 0,
+                                 deleting_server IN NUMBER := 0)
+    IS
+        channel_family_id_val   NUMBER;
+        server_org_id_val       NUMBER;
+        server_already_in_chan  BOOLEAN;
+        cursor  channel_family_is_proxy(channel_family_id_in in number) is
+                select  1
+                from    rhnChannelFamily
+                where   id = channel_family_id_in
+                    and label = 'rhn-proxy';
+        cursor  channel_family_is_satellite(channel_family_id_in in number) is
+                select  1
+                from    rhnChannelFamily
+                where   id = channel_family_id_in
+                    and label = 'rhn-satellite';
+        -- this is *EXACTLY* like check_server_parent_membership, but if we recurse
+        -- with the package-level one, we get a "cursor already open", so we need a
+        -- copy on our call stack instead.  GROAN.
+        cursor local_chk_server_parent_memb (
+                        server_id_in number,
+                        channel_id_in number ) is
+                select  c.id
+                from    rhnChannel                      c,
+                                rhnServerChannel        sc
+                where   1=1
+                        and c.parent_channel = channel_id_in
+                        and c.id = sc.channel_id
+                        and sc.server_id = server_id_in;
+    BEGIN
+        FOR child IN local_chk_server_parent_memb(server_id_in, channel_id_in)
+        LOOP
+            if unsubscribe_children_in = 1 then
+                unsubscribe_server(server_id_in => server_id_in,
+                                                                channel_id_in => child.id,
+                                                                immediate_in => immediate_in,
+                                                                unsubscribe_children_in => unsubscribe_children_in,
+                        deleting_server => deleting_server);
+            else
+                rhn_exception.raise_exception('channel_unsubscribe_child_exists');
+            end if;
+        END LOOP child;
+
+        server_already_in_chan := FALSE;
+
+        FOR check_subscription IN check_server_subscription(server_id_in, channel_id_in)
+        LOOP
+            server_already_in_chan := TRUE;
+        END LOOP check_subscription;
+
+        IF NOT server_already_in_chan
+        THEN
+            RETURN;
+        END IF;
+
+   if deleting_server = 0 then
+      insert into rhnServerHistory (id,server_id,summary,details) (
+          select  rhn_event_id_seq.nextval,
+                server_id_in,
+             'unsubscribed from channel ' || SUBSTR(c.label, 0, 106),
+             c.label
+          from    rhnChannel c
+          where   c.id = channel_id_in
+      );
+   end if;
+
+   DELETE FROM rhnServerChannel WHERE server_id = server_id_in AND channel_id = channel_id_in;
+
+   if deleting_server = 0 then
+        queue_server(server_id_in, immediate_in);
+
+        update rhnServer
+           set channels_changed = current_timestamp
+         where id = server_id_in;
+   end if;
+
+        channel_family_id_val := rhn_channel.family_for_channel(channel_id_in);
+        IF channel_family_id_val IS NULL
+        THEN
+            rhn_exception.raise_exception('channel_unsubscribe_no_family');
+        END IF;
+
+        for ignore in channel_family_is_satellite(channel_family_id_val) loop
+                delete from rhnSatelliteInfo where server_id = server_id_in;
+        end loop;
+
+        for ignore in channel_family_is_proxy(channel_family_id_val) loop
+                delete from rhnProxyInfo where server_id = server_id_in;
+        end loop;
+        SELECT org_id INTO server_org_id_val
+          FROM rhnServer
+         WHERE id = server_id_in;
+
+    END unsubscribe_server;
+
+
+    FUNCTION family_for_channel(channel_id_in IN NUMBER)
+    RETURN NUMBER
+    IS
+        channel_family_id_val NUMBER;
+    BEGIN
+        SELECT channel_family_id INTO channel_family_id_val
+          FROM rhnChannelFamilyMembers
+         WHERE channel_id = channel_id_in;
+
+        RETURN channel_family_id_val;
+    EXCEPTION
+        WHEN NO_DATA_FOUND
+        THEN
+            RETURN NULL;
+    END family_for_channel;
+
+    procedure unsubscribe_server_from_family(server_id_in in number,
+                                             channel_family_id_in in number)
+    is
+    begin
+        delete
+        from    rhnServerChannel rsc
+        where   rsc.server_id = server_id_in
+            and channel_id in (
+                select  rcfm.channel_id
+                from    rhnChannelFamilyMembers rcfm
+                where   rcfm.channel_family_id = channel_family_id_in);
+    end;
+
+    function get_org_id(channel_id_in in number)
+    return number
+    is
+        org_id_out number;
+    begin
+        select org_id into org_id_out
+            from rhnChannel
+            where id = channel_id_in;
+
+            return org_id_out;
+    end get_org_id;
+
+    function get_cfam_org_access(cfam_id_in in number, org_id_in in number)
+    return number
+    is
+        cursor  families is
+                        select  1
+                        from    rhnOrgChannelFamilyPermissions cfp
+                        where   cfp.org_id = org_id_in;
+    begin
+                -- the idea: if we get past this query,
+        -- the user has the role, else catch the exception and return 0
+                for family in families loop
+                return 1;
+                end loop;
+                return 0;
+    end;
+
+    function get_org_access(channel_id_in in number, org_id_in in number)
+    return number
+    is
+        throwaway number;
+    begin
+        -- the idea: if we get past this query,
+        -- the org has access to the channel, else catch the exception and return 0
+        select distinct 1 into throwaway
+          from rhnChannelFamilyMembers CFM,
+               rhnOrgChannelFamilyPermissions CFP
+         where cfp.org_id = org_id_in
+           and CFM.channel_family_id = CFP.channel_family_id
+           and CFM.channel_id = channel_id_in;
+
+        return 1;
+        exception
+            when no_data_found
+            then
+            return 0;
+    end;
+
+    -- check if a user has a given role, or if such a role is inferrable
+    -- returns NULL if OK, error message otherwise
+    function user_role_check_debug(channel_id_in in number,
+                                   user_id_in in number,
+                                   role_in in varchar2)
+    return varchar2
+    is
+        org_id number;
+    begin
+        org_id := rhn_user.get_org_id(user_id_in);
+
+        -- channel might be shared
+        if role_in = 'subscribe' and
+           rhn_channel.shared_user_role_check(channel_id_in, user_id_in, role_in) = 1 then
+            return NULL;
+        end if;
+
+        if role_in = 'manage' and
+           NVL(rhn_channel.get_org_id(channel_id_in), -1) <> org_id then
+               return 'channel_not_owned';
+        end if;
+
+        if role_in = 'subscribe' and
+           rhn_channel.get_org_access(channel_id_in, org_id) = 0 then
+                return 'channel_not_available';
+        end if;
+
+        -- channel admins have all roles
+        if rhn_user.check_role_implied(user_id_in, 'channel_admin') = 1 then
+            return NULL;
+        end if;
+
+        -- the subscribe permission is inferred
+        -- UNLESS the not_globally_subscribable flag is set
+        if role_in = 'subscribe'
+        then
+            if rhn_channel.org_channel_setting(channel_id_in,
+                       org_id,
+                       'not_globally_subscribable') = 0 then
+                    return NULL;
+            end if;
+        end if;
+
+        -- all other roles (manage right now) are explicitly granted
+        if rhn_channel.direct_user_role_check(channel_id_in,
+                                              user_id_in, role_in) = 1 then
+            return NULL;
+        end if;
+        return 'direct_permission';
+    end;
+
+    -- same as above, but with 1/0 output; useful in views, etc
+    function user_role_check(channel_id_in in number, user_id_in in number, role_in in varchar2)
+    return number
+    is
+    begin
+        if rhn_channel.user_role_check_debug(channel_id_in,
+                                             user_id_in, role_in) is NULL then
+            return 1;
+        else
+            return 0;
+        end if;
+    end;
+
+    --
+    -- For multiorg phase II, this function simply checks to see if the user's
+    -- has a trust relationship that includes this channel by id.
+    --
+    function shared_user_role_check(channel_id in number, user_id in number, role in varchar2)
+    return number
+    is
+      n number;
+      oid number;
+    begin
+      oid := rhn_user.get_org_id(user_id);
+      select 1 into n
+      from rhnSharedChannelView s
+      where s.id = channel_id and s.org_trust_id = oid;
+      return 1;
+      exception
+        when no_data_found then
+          return 0;
+    end;
+
+    -- same as above, but returns 1 if user_id_in is null
+    -- This is useful in queries where user_id is not specified
+    function loose_user_role_check(channel_id_in in number, user_id_in in number, role_in in varchar2)
+    return number
+    is
+    begin
+        if user_id_in is null then
+            return 1;
+        end if;
+        return user_role_check(channel_id_in, user_id_in, role_in);
+    end loose_user_role_check;
+
+    -- directly checks the table, no inferred permissions
+    function direct_user_role_check(channel_id_in in number, user_id_in in number, role_in in varchar2)
+    return number
+    is
+        throwaway number;
+    begin
+        -- the idea: if we get past this query, the user has the role, else catch the exception and return 0
+        select 1 into throwaway
+          from rhnChannelPermissionRole CPR,
+               rhnChannelPermission CP
+         where CP.user_id = user_id_in
+           and CP.channel_id = channel_id_in
+           and CPR.label = role_in
+           and CP.role_id = CPR.id;
+
+        return 1;
+    exception
+        when no_data_found
+            then
+            return 0;
+    end;
+
+    -- check if an org has a certain setting
+    function org_channel_setting(channel_id_in in number, org_id_in in number, setting_in in varchar2)
+    return number
+    is
+        throwaway number;
+    begin
+        -- the idea: if we get past this query, the org has the setting, else catch the exception and return 0
+        select 1 into throwaway
+          from rhnOrgChannelSettingsType OCST,
+               rhnOrgChannelSettings OCS
+         where OCS.org_id = org_id_in
+           and OCS.channel_id = channel_id_in
+           and OCST.label = setting_in
+           and OCS.setting_id = OCST.id;
+
+        return 1;
+    exception
+        when no_data_found
+            then
+            return 0;
+    end;
+
+    FUNCTION channel_priority(channel_id_in IN number)
+    RETURN number
+    IS
+         channel_name varchar2(256);
+         priority number;
+         end_of_life_val timestamp with local time zone;
+         org_id_val number;
+    BEGIN
+
+        select name, end_of_life, org_id
+        into channel_name, end_of_life_val, org_id_val
+        from rhnChannel
+        where id = channel_id_in;
+
+        if end_of_life_val is not null then
+          return -400;
+        end if;
+
+        if channel_name like 'Red Hat Enterprise Linux%' or channel_name like 'RHEL%' then
+          priority := 1000;
+          if channel_name not like '%Beta%' then
+            priority := priority + 1000;
+          end if;
+
+          priority := priority +
+            case
+              when channel_name like '%v. 5%' then 600
+              when channel_name like '%v. 4%' then 500
+              when channel_name like '%v. 3%' then 400
+              when channel_name like '%v. 2%' then 300
+              when channel_name like '%v. 1%' then 200
+              else 0
+            end;
+
+          priority := priority +
+            case
+              when channel_name like 'Red Hat Enterprise Linux (v. 5%' then 60
+              when (channel_name like '%AS%' and channel_name not like '%Extras%') then 50
+              when (channel_name like '%ES%' and channel_name not like '%Extras%') then 40
+              when (channel_name like '%WS%' and channel_name not like '%Extras%') then 30
+              when (channel_name like '%Desktop%' and channel_name not like '%Extras%') then 20
+              when channel_name like '%Extras%' then 10
+              else 0
+            end;
+
+          priority := priority +
+            case
+              when channel_name like '%)' then 5
+              else 0
+            end;
+
+          priority := priority +
+            case
+              when channel_name like '%32-bit x86%' then 4
+              when channel_name like '%64-bit Intel Itanium%' then 3
+              when channel_name like '%64-bit AMD64/Intel EM64T%' then 2
+              else 0
+            end;
+        elsif channel_name like 'Red Hat Desktop%' then
+            priority := 900;
+
+            if channel_name not like '%Beta%' then
+               priority := priority + 50;
+            end if;
+
+          priority := priority +
+            case
+              when channel_name like '%v. 4%' then 40
+              when channel_name like '%v. 3%' then 30
+              when channel_name like '%v. 2%' then 20
+              when channel_name like '%v. 1%' then 10
+              else 0
+            end;
+
+          priority := priority +
+            case
+              when channel_name like '%32-bit x86%' then 4
+              when channel_name like '%64-bit Intel Itanium%' then 3
+              when channel_name like '%64-bit AMD64/Intel EM64T%' then 2
+              else 0
+            end;
+
+        elsif org_id_val is not null then
+          priority := 600;
+        else
+          priority := 500;
+        end if;
+
+      return -priority;
+
+    end channel_priority;
+
+    -- this could certainly be optimized to do updates if needs be
+    procedure refresh_newest_package(channel_id_in in number,
+                                     caller_in in varchar2 := '(unknown)',
+                                     package_name_id_in in number := null)
+    is
+    -- procedure refreshes rows for name_id = package_name_id_in or
+    -- all rows if package_name_id_in is null
+    begin
+        delete from rhnChannelNewestPackage
+              where channel_id = channel_id_in
+                and (package_name_id_in is null
+                     or name_id = package_name_id_in);
+        insert into rhnChannelNewestPackage
+                (channel_id, name_id, evr_id, package_id, package_arch_id)
+                (select channel_id,
+                        name_id, evr_id,
+                        package_id, package_arch_id
+                   from rhnChannelNewestPackageView
+                  where channel_id = channel_id_in
+                    and (package_name_id_in is null
+                         or name_id = package_name_id_in)
+                );
+        insert into rhnChannelNewestPackageAudit (channel_id, caller)
+             values (channel_id_in, caller_in);
+        update rhnChannel
+           set last_modified = greatest(current_timestamp, last_modified + interval '1' second)
+         where id = channel_id_in;
+    end;
+
+
+   procedure update_channel ( channel_id_in in number, invalidate_ss in number := 0,
+                              date_to_use in timestamp with local time zone := current_timestamp )
+   is
+
+   channel_last_modified timestamp with local time zone;
+   last_modified_value timestamp with local time zone;
+
+   cursor snapshots is
+   select  snapshot_id id
+   from    rhnSnapshotChannel
+   where   channel_id = channel_id_in;
+
+   begin
+
+      select last_modified
+      into channel_last_modified
+      from rhnChannel
+      where id = channel_id_in;
+
+      last_modified_value := date_to_use;
+
+      if last_modified_value <= channel_last_modified then
+          last_modified_value := last_modified_value + 1/86400;
+      end if;
+
+      update rhnChannel set last_modified = last_modified_value
+      where id = channel_id_in;
+
+      if invalidate_ss = 1 then
+        for snapshot in snapshots loop
+            update rhnSnapshot
+            set invalid = lookup_snapshot_invalid_reason('channel_modified')
+            where id = snapshot.id;
+        end loop;
+      end if;
+
+   end update_channel;
+
+   procedure update_channels_by_package ( package_id_in in number, date_to_use in timestamp with local time zone := current_timestamp )
+   is
+
+   cursor channels is
+   select channel_id
+   from rhnChannelPackage
+   where package_id = package_id_in
+   order by channel_id;
+
+   begin
+      for channel in channels loop
+         -- we want to invalidate the snapshot assocated with the channel when we
+         -- do this b/c we know we've added or removed or packages
+         rhn_channel.update_channel ( channel.channel_id, 1, date_to_use );
+      end loop;
+   end update_channels_by_package;
+
+
+   procedure update_channels_by_errata ( errata_id_in number, date_to_use in timestamp with local time zone := current_timestamp )
+   is
+
+   cursor channels is
+   select channel_id
+   from rhnChannelErrata
+   where errata_id = errata_id_in
+   order by channel_id;
+
+   begin
+      for channel in channels loop
+         -- we won't invalidate snapshots, b/c just changing the errata associated with
+         -- a channel shouldn't invalidate snapshots
+         rhn_channel.update_channel ( channel.channel_id, 0, date_to_use );
+      end loop;
+   end update_channels_by_errata;
+
+   procedure update_needed_cache(channel_id_in in number)
+   is
+       -- update of needed cache ican be commited on a per server basis
+       -- b/c failure of update for a server means nothing for the other servers
+   begin
+      -- we intentionaly do a loop here instead of one huge select
+      -- b/c we want to break update into smaller transaction to unblock other sessions
+      -- querying rhnServerNeededCache
+      for server in (
+                select sc.server_id as id
+                  from rhnServerChannel sc
+                 where sc.channel_id = channel_id_in
+                 order by id asc
+      ) loop
+         queue_server(server.id, 0); -- NOT IMMEDIATELY
+      end loop;
+      for image in (
+        select ic.image_info_id as id
+          from suseImageInfoChannel ic
+         where ic.channel_id = channel_id_in
+        order by id asc
+      ) loop
+        queue_image(image.id, 0);
+      end loop;
+   end update_needed_cache;
+
+    procedure set_comps(channel_id_in in number, path_in in varchar2, comps_type_id_in in number, timestamp_in in varchar2)
+    is
+    begin
+        for row in (
+            select relative_filename, last_modified
+            from rhnChannelComps
+            where channel_id = channel_id_in
+            and comps_type_id = comps_type_id_in
+            ) loop
+            if row.relative_filename = path_in
+                and row.last_modified = to_date(timestamp_in, 'YYYYMMDDHH24MISS') then
+                return;
+            end if;
+        end loop;
+        delete from rhnChannelComps
+        where channel_id = channel_id_in
+        and comps_type_id = comps_type_id_in;
+        insert into rhnChannelComps (id, channel_id, relative_filename, comps_type_id, last_modified, created, modified)
+        values (sequence_nextval('rhn_channelcomps_id_seq'), channel_id_in, path_in, comps_type_id_in, to_date(timestamp_in, 'YYYYMMDDHH24MISS'), current_timestamp, current_timestamp);
+    end set_comps;
+
+END rhn_channel;
+/
+SHOW ERRORS

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/201-rhn_channel.pkb.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/201-rhn_channel.pkb.sql.postgresql
@@ -1,0 +1,813 @@
+-- oracle equivalent source sha1 31306ef50aaa30b52c7dd02adcb94ab66de8fb25
+--
+-- Copyright (c) 2008--2018 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+--
+--
+--
+
+-- create schema rhn_channel;
+
+--update pg_setting
+update pg_settings set setting = 'rhn_channel,' || setting where name = 'search_path';
+
+    -- this "emulates" cursor server_base_subscriptions defined in oracle/rhn_channel.pks
+    create or replace function server_base_subscriptions(server_id_in NUMERIC)
+    returns boolean as $$
+    begin
+      return exists(SELECT C.id FROM rhnChannel C, rhnServerChannel SC
+		    WHERE C.id = SC.channel_id
+		      AND SC.server_id = server_id_in
+		      AND C.parent_channel IS NULL);
+    end$$ language plpgsql;
+
+    -- this "emulates" cursor server_base_subscriptions defined in oracle/rhn_channel.pks
+    create or replace function check_server_subscription(server_id_in NUMERIC, channel_id_in NUMERIC)
+    returns boolean as $$
+    begin
+      return exists(SELECT channel_id FROM rhnServerChannel WHERE server_id = server_id_in AND channel_id = channel_id_in);
+    end$$ language plpgsql;
+
+
+    CREATE OR REPLACE FUNCTION subscribe_server(server_id_in IN NUMERIC, channel_id_in NUMERIC, immediate_in NUMERIC default 1, user_id_in in numeric default null) returns void
+    AS $$
+    declare
+        channel_parent_val      rhnChannel.parent_channel%TYPE;
+        parent_subscribed       BOOLEAN;
+        server_has_base_chan    BOOLEAN;
+        server_already_in_chan  BOOLEAN;
+        channel_family_id_val   NUMERIC;
+        allowed                 numeric;
+    BEGIN
+        if user_id_in is not null then
+            allowed := rhn_channel.user_role_check(channel_id_in, user_id_in, 'subscribe');
+        else
+            allowed := 1;
+        end if;
+
+        if allowed = 0 then
+            perform rhn_exception.raise_exception('no_subscribe_permissions');
+        end if;
+        
+        server_already_in_chan := rhn_channel.check_server_subscription(server_id_in, channel_id_in);
+
+        IF server_already_in_chan
+        THEN
+            RETURN;
+        END IF;
+
+        SELECT parent_channel INTO channel_parent_val FROM rhnChannel WHERE id = channel_id_in;
+
+        IF channel_parent_val IS NOT NULL
+        THEN
+            -- child channel; if attempting to cross-subscribe a child to the wrong base, silently ignore
+            parent_subscribed := rhn_channel.check_server_subscription(server_id_in, channel_parent_val);
+
+            IF NOT parent_subscribed
+            THEN
+                RETURN;
+            END IF;
+        ELSE
+            -- base channel
+            server_has_base_chan := rhn_channel.server_base_subscriptions(server_id_in);
+
+            IF server_has_base_chan
+            THEN
+                perform rhn_exception.raise_exception('channel_server_one_base');
+            END IF;
+        END IF;
+
+        channel_family_id_val := rhn_channel.family_for_channel(channel_id_in);
+        IF channel_family_id_val IS NULL
+        THEN
+            perform rhn_exception.raise_exception('channel_subscribe_no_family');
+        END IF;
+
+        insert into rhnServerHistory (id,server_id,summary,details) (
+            select  nextval('rhn_event_id_seq'),
+                    server_id_in,
+                    'subscribed to channel ' || SUBSTR(c.label, 0, 106),
+                    c.label
+            from    rhnChannel c
+            where   c.id = channel_id_in
+        );
+
+        INSERT INTO rhnServerChannel (server_id, channel_id) VALUES (server_id_in, channel_id_in);
+
+        perform queue_server(server_id_in, immediate_in);
+
+        update rhnServer
+           set channels_changed = current_timestamp
+         where id = server_id_in;
+    END$$ language plpgsql;
+
+    create or replace function guess_server_base(
+        server_id_in in numeric
+    ) RETURNS numeric as $$
+    declare
+        server_cursor cursor for
+            select s.server_arch_id, s.release, s.org_id
+              from rhnServer s
+             where s.id = server_id_in;
+    -- Cursor that fetches all the possible base channels for a
+    -- (server_arch_id, release, org_id) combination
+        base_channel_cursor cursor(
+                release_in varchar,
+                server_arch_id_in numeric,
+                org_id_in numeric
+        ) for
+                select distinct c.*
+                from    rhnOrgDistChannelMap                       odcm,
+                                rhnServerChannelArchCompat      scac,
+                                rhnChannel                                      c
+                where   c.parent_channel is null
+                        and c.id = odcm.channel_id
+                        and c.channel_arch_id = odcm.channel_arch_id
+                        and odcm.release = release_in
+                        and odcm.for_org_id = org_id_in
+                        and scac.server_arch_id = server_arch_id_in
+                        and scac.channel_arch_id = c.channel_arch_id;
+
+    begin
+        for s in server_cursor loop
+            for channel in base_channel_cursor(s.release,
+                s.server_arch_id, s.org_id)
+            loop
+                return channel.id;
+            end loop;
+        end loop;
+        -- Server not found, or no base channel applies to it
+        return null;
+    end$$ language plpgsql;
+
+    -- Private function
+    create or replace function normalize_server_arch(server_arch_in in varchar)
+    returns varchar
+    as $$
+    declare
+        suffix VARCHAR(128) := '-redhat-linux';
+    begin
+        if server_arch_in is NULL then
+            return NULL;
+        end if;
+        if position('-' IN server_arch_in) > 0
+        then
+            -- Suffix already present
+            return server_arch_in;
+        end if;
+        return server_arch_in || suffix;
+    end$$ language plpgsql;
+
+    --
+    -- Raises:
+    --   server_arch_not_found
+    --   no_subscribe_permissions
+    create or replace function base_channel_for_release_arch(
+        release_in in varchar,
+        server_arch_in in varchar,
+        org_id_in in numeric default -1,
+        user_id_in in numeric default null
+    ) returns numeric as $$
+    declare
+        server_arch varchar(256) := rhn_channel.normalize_server_arch(server_arch_in);
+        server_arch_id numeric;
+    begin
+        -- Look up the server arch
+            select id
+              into server_arch_id
+              from rhnServerArch
+             where label = server_arch;
+            if not found then
+                perform rhn_exception.raise_exception('server_arch_not_found');
+            end if;
+
+        return rhn_channel.base_channel_rel_archid(release_in, server_arch_id,
+            org_id_in, user_id_in);
+    end$$ language plpgsql;
+
+    create or replace function base_channel_rel_archid(
+        release_in in varchar,
+        server_arch_id_in in numeric,
+        org_id_in in numeric default -1,
+        user_id_in in numeric default null
+    ) returns numeric as $$
+    declare
+        denied_channel_id numeric := null;
+        valid_org_id numeric := org_id_in;
+        valid_user_id numeric := user_id_in;
+        channel_subscribable numeric;
+    -- Cursor that fetches all the possible base channels for a
+    -- (server_arch_id, release, org_id) combination
+        base_channel_cursor cursor(
+                release_in varchar,
+                server_arch_id_in numeric,
+                org_id_in numeric
+        ) for
+                select distinct c.*
+                from    rhnOrgDistChannelMap                       odcm,
+                                rhnServerChannelArchCompat      scac,
+                                rhnChannel                                      c
+                where   c.parent_channel is null
+                        and c.id = odcm.channel_id
+                        and c.channel_arch_id = odcm.channel_arch_id
+                        and odcm.release = release_in
+                        and odcm.for_org_id = org_id_in
+                        and scac.server_arch_id = server_arch_id_in
+                        and scac.channel_arch_id = c.channel_arch_id;
+
+    begin
+        if org_id_in = -1 and user_id_in is not null then
+            -- Get the org id from the user id
+
+                select org_id
+                  into valid_org_id
+                  from web_contact
+                 where id = user_id_in;
+
+                if not found then
+                    -- User doesn't exist
+                    -- XXX Only list public stuff for now
+                    valid_user_id := null;
+                    valid_org_id := -1;
+                end if;
+        end if;
+
+        for c in base_channel_cursor(release_in, server_arch_id_in, valid_org_id)
+        loop
+            -- This row is a possible match
+            if valid_user_id is null then
+                -- User ID not specified, so no user to channel permissions to
+                -- check
+                return c.id;
+            end if;
+
+            -- Check user to channel permissions
+            select rhn_channel.loose_user_role_check(c.id, user_id_in, 'subscribe')
+              into channel_subscribable;
+
+            if channel_subscribable = 1 then
+                return c.id;
+            end if;
+
+            -- Base channel exists, but is not subscribable; keep trying
+            denied_channel_id := c.id;
+        end loop;
+
+        if denied_channel_id is not null then
+            perform rhn_exception.raise_exception('no_subscribe_permissions');
+        end if;
+        -- No base channel applies
+        return NULL;
+    end$$ language plpgsql;
+
+    CREATE OR REPLACE FUNCTION clear_subscriptions(server_id_in IN NUMERIC, deleting_server IN NUMERIC default 0) returns void
+    AS $$
+    declare
+        server_channels cursor(server_id_in numeric) for
+                select  s.org_id, sc.channel_id, cfm.channel_family_id
+                from    rhnServer s,
+                        rhnServerChannel sc,
+                        rhnChannelFamilyMembers cfm
+                where   s.id = server_id_in
+                        and s.id = sc.server_id
+                        and sc.channel_id = cfm.channel_id
+                order by cfm.channel_family_id;
+        last_channel_family_id rhnChannelFamilyMembers.channel_family_id%type := -1;
+        last_channel_org_id    rhnServer.org_id%type := -1;
+    BEGIN
+        for channel in server_channels(server_id_in)
+        loop
+                perform rhn_channel.unsubscribe_server(server_id_in, channel.channel_id, 1, 1, deleting_server);
+        end loop;
+    END$$ language plpgsql;
+
+    CREATE OR REPLACE FUNCTION unsubscribe_server(server_id_in IN NUMERIC, channel_id_in NUMERIC, immediate_in NUMERIC default 1, unsubscribe_children_in numeric default 0,
+                                 deleting_server in numeric default 0) returns void
+    AS $$
+    declare
+        channel_family_id_val   NUMERIC;
+        server_org_id_val       NUMERIC;
+        server_already_in_chan  BOOLEAN;
+        channel_family_is_proxy cursor(channel_family_id_in numeric) for
+                select  1
+                from    rhnChannelFamily
+                where   id = channel_family_id_in
+                    and label = 'rhn-proxy';
+        channel_family_is_satellite cursor(channel_family_id_in numeric) for
+                select  1
+                from    rhnChannelFamily
+                where   id = channel_family_id_in
+                    and label = 'rhn-satellite';
+        child record;
+    BEGIN
+        -- In PostgreSQL recursion with opened cursors is not allowed so we use
+        -- FOR IN SELECT form which is ok.
+        FOR child IN select  c.id
+                from    rhnChannel                      c,
+                                rhnServerChannel        sc
+                where   1=1
+                        and c.parent_channel = channel_id_in
+                        and c.id = sc.channel_id
+                        and sc.server_id = server_id_in
+        LOOP
+            if unsubscribe_children_in = 1 then
+                perform rhn_channel.unsubscribe_server(server_id_in,
+                                                       child.id,
+                                                       immediate_in,
+                                                       unsubscribe_children_in,
+                                                       deleting_server);
+            else
+                perform rhn_exception.raise_exception('channel_unsubscribe_child_exists');
+            end if;
+        END LOOP;
+
+        server_already_in_chan := rhn_channel.check_server_subscription(server_id_in, channel_id_in);
+
+        IF NOT server_already_in_chan
+        THEN
+            RETURN;
+        END IF;
+
+   if deleting_server = 0 then
+      insert into rhnServerHistory (id,server_id,summary,details) (
+          select  nextval('rhn_event_id_seq'),
+                server_id_in,
+             'unsubscribed from channel ' || SUBSTR(c.label, 0, 106),
+             c.label
+          from    rhnChannel c
+          where   c.id = channel_id_in
+      );
+   end if;
+
+   DELETE FROM rhnServerChannel WHERE server_id = server_id_in AND channel_id = channel_id_in;
+
+   if deleting_server = 0 then
+        perform queue_server(server_id_in, immediate_in);
+
+        update rhnServer
+           set channels_changed = current_timestamp
+         where id = server_id_in;
+   end if;
+
+        channel_family_id_val := rhn_channel.family_for_channel(channel_id_in);
+        IF channel_family_id_val IS NULL
+        THEN
+            perform rhn_exception.raise_exception('channel_unsubscribe_no_family');
+        END IF;
+
+        for ignore in channel_family_is_satellite(channel_family_id_val) loop
+                delete from rhnSatelliteInfo where server_id = server_id_in;
+        end loop;
+
+        for ignore in channel_family_is_proxy(channel_family_id_val) loop
+                delete from rhnProxyInfo where server_id = server_id_in;
+        end loop;
+        SELECT org_id INTO server_org_id_val
+          FROM rhnServer
+         WHERE id = server_id_in;
+
+    END$$ language plpgsql;
+
+    CREATE OR REPLACE FUNCTION family_for_channel(channel_id_in IN NUMERIC)
+    RETURNS NUMERIC
+    AS $$
+    declare
+        channel_family_id_val NUMERIC;
+    BEGIN
+        SELECT channel_family_id INTO channel_family_id_val
+          FROM rhnChannelFamilyMembers
+         WHERE channel_id = channel_id_in;
+
+        IF NOT FOUND THEN
+          RETURN NULL;
+        END IF;
+
+        RETURN channel_family_id_val;
+    END$$ language plpgsql;
+
+    create or replace function unsubscribe_server_from_family(server_id_in in numeric,
+                                             channel_family_id_in in numeric)
+    returns void
+    as $$
+    begin
+        delete
+        from    rhnServerChannel rsc
+        where   rsc.server_id = server_id_in
+            and channel_id in (
+                select  rcfm.channel_id
+                from    rhnChannelFamilyMembers rcfm
+                where   rcfm.channel_family_id = channel_family_id_in);
+    end$$ language plpgsql;
+
+    create or replace function get_org_id(channel_id_in in numeric)
+    returns numeric
+    as $$
+    declare
+        org_id_out numeric;
+    begin
+        select org_id into strict org_id_out
+            from rhnChannel
+            where id = channel_id_in;
+
+            return org_id_out;
+    end$$ language plpgsql;
+
+    create or replace function get_cfam_org_access(cfam_id_in in numeric, org_id_in in numeric)
+    returns numeric
+    as $$
+    begin
+      if exists(
+                        select  1
+                        from    rhnOrgChannelFamilyPermissions cfp
+                        where   cfp.org_id = org_id_in
+      ) then
+                return 1;
+      else
+                return 0;
+      end if;
+    end$$ language plpgsql;
+
+    create or replace function get_org_access(channel_id_in in numeric, org_id_in in numeric)
+    returns integer
+    as $$
+    begin
+        -- the idea: if we get past this query,
+        -- the org has access to the channel, else not
+        if exists(
+        select 1
+          from rhnChannelFamilyMembers CFM,
+               rhnOrgChannelFamilyPermissions CFP
+         where cfp.org_id = org_id_in
+           and CFM.channel_family_id = CFP.channel_family_id
+           and CFM.channel_id = channel_id_in)
+        then
+          return 1;
+        else
+          return 0;
+        end if;
+    end$$ language plpgsql;
+
+    create or replace function rhn_channel.user_role_check(channel_id_in in numeric, user_id_in in numeric, role_in in varchar)
+    returns numeric
+    as $$
+    declare
+        result NUMERIC;
+    begin
+        SELECT
+          INTO result
+          CASE
+            WHEN suseChannelUserRoleView.deny_reason IS NULL THEN 1
+            ELSE 0
+            END
+          FROM suseChannelUserRoleView
+          WHERE channel_id = channel_id_in AND
+            user_id = user_id_in AND
+            role = role_in;
+
+         if result IS NULL then
+           result := 0;
+         end if;
+
+         RETURN result;
+    end$$ language plpgsql;
+
+    --
+    -- For multiorg phase II, this function simply checks to see if the user's
+    -- has a trust relationship that includes this channel by id.
+    --
+    create or replace function shared_user_role_check(channel_id in numeric, user_id in numeric, role in varchar)
+    returns numeric
+    as $$
+    declare
+      n numeric;
+      oid numeric;
+    begin
+      oid := rhn_user.get_org_id(user_id);
+      select 1 into n
+      from rhnSharedChannelView s
+      where s.id = channel_id and s.org_trust_id = oid;
+
+      if not found then
+        return 0;
+      end if;
+
+      return 1;
+    end$$ language plpgsql;
+
+    -- same as above, but returns 1 if user_id_in is null
+    -- This is useful in queries where user_id is not specified
+    create or replace function loose_user_role_check(channel_id_in in numeric, user_id_in in numeric, role_in in varchar)
+    returns numeric
+    as $$
+    begin
+        if user_id_in is null then
+            return 1;
+        end if;
+        return rhn_channel.user_role_check(channel_id_in, user_id_in, role_in);
+    end$$ language plpgsql;
+
+    -- directly checks the table, no inferred permissions
+    create or replace function direct_user_role_check(channel_id_in in numeric, user_id_in in numeric, role_in in varchar)
+    returns numeric
+    as $$
+    declare
+        throwaway numeric;
+    begin
+        -- the idea: if we get past this query, the user has the role, else no
+        select 1 into throwaway
+          from rhnChannelPermissionRole CPR,
+               rhnChannelPermission CP
+         where CP.user_id = user_id_in
+           and CP.channel_id = channel_id_in
+           and CPR.label = role_in
+           and CP.role_id = CPR.id;
+
+      if not found then
+        return 0;
+      end if;
+
+      return 1;
+    end$$ language plpgsql;
+
+    -- check if an org has a certain setting
+    create or replace function org_channel_setting(channel_id_in in numeric, org_id_in in numeric, setting_in in varchar)
+    returns numeric
+    as $$
+    declare
+        throwaway numeric;
+    begin
+        -- the idea: if we get past this query, the org has the setting
+        select 1 into throwaway
+          from rhnOrgChannelSettingsType OCST,
+               rhnOrgChannelSettings OCS
+         where OCS.org_id = org_id_in
+           and OCS.channel_id = channel_id_in
+           and OCST.label = setting_in
+           and OCS.setting_id = OCST.id;
+
+      if not found then
+        return 0;
+      end if;
+
+      return 1;
+    end$$ language plpgsql;
+
+    CREATE OR REPLACE FUNCTION channel_priority(channel_id_in IN numeric)
+    RETURNS numeric
+    AS $$
+    declare
+         channel_name varchar(256);
+         priority numeric;
+         end_of_life_val timestamptz;
+         org_id_val numeric;
+    BEGIN
+
+        select name, end_of_life, org_id
+        into channel_name, end_of_life_val, org_id_val
+        from rhnChannel
+        where id = channel_id_in;
+
+        if end_of_life_val is not null then
+          return -400;
+        end if;
+
+        if channel_name like 'Red Hat Enterprise Linux%' or channel_name like 'RHEL%' then
+          priority := 1000;
+          if channel_name not like '%Beta%' then
+            priority := priority + 1000;
+          end if;
+
+          priority := priority +
+            case
+              when channel_name like '%v. 5%' then 600
+              when channel_name like '%v. 4%' then 500
+              when channel_name like '%v. 3%' then 400
+              when channel_name like '%v. 2%' then 300
+              when channel_name like '%v. 1%' then 200
+              else 0
+            end;
+
+          priority := priority +
+            case
+              when channel_name like 'Red Hat Enterprise Linux (v. 5%' then 60
+              when (channel_name like '%AS%' and channel_name not like '%Extras%') then 50
+              when (channel_name like '%ES%' and channel_name not like '%Extras%') then 40
+              when (channel_name like '%WS%' and channel_name not like '%Extras%') then 30
+              when (channel_name like '%Desktop%' and channel_name not like '%Extras%') then 20
+              when channel_name like '%Extras%' then 10
+              else 0
+            end;
+
+          priority := priority +
+            case
+              when channel_name like '%)' then 5
+              else 0
+            end;
+
+          priority := priority +
+            case
+              when channel_name like '%32-bit x86%' then 4
+              when channel_name like '%64-bit Intel Itanium%' then 3
+              when channel_name like '%64-bit AMD64/Intel EM64T%' then 2
+              else 0
+            end;
+        elsif channel_name like 'Red Hat Desktop%' then
+            priority := 900;
+
+            if channel_name not like '%Beta%' then
+               priority := priority + 50;
+            end if;
+
+          priority := priority +
+            case
+              when channel_name like '%v. 4%' then 40
+              when channel_name like '%v. 3%' then 30
+              when channel_name like '%v. 2%' then 20
+              when channel_name like '%v. 1%' then 10
+              else 0
+            end;
+
+          priority := priority +
+            case
+              when channel_name like '%32-bit x86%' then 4
+              when channel_name like '%64-bit Intel Itanium%' then 3
+              when channel_name like '%64-bit AMD64/Intel EM64T%' then 2
+              else 0
+            end;
+
+        elsif org_id_val is not null then
+          priority := 600;
+        else
+          priority := 500;
+        end if;
+
+      return -priority;
+
+    end$$ language plpgsql;
+
+    -- this could certainly be optimized to do updates if needs be
+    create or replace function refresh_newest_package(channel_id_in in numeric,
+                                      caller_in in varchar default '(unknown)',
+                                      package_name_id_in in numeric default null)
+    returns void
+    as $$
+    -- procedure refreshes rows for name_id = package_name_id_in or
+    -- all rows if package_name_id_in is null
+    begin
+        delete from rhnChannelNewestPackage
+              where channel_id = channel_id_in
+                and (package_name_id_in is null
+                     or name_id = package_name_id_in);
+        insert into rhnChannelNewestPackage
+                (channel_id, name_id, evr_id, package_id, package_arch_id)
+                (select channel_id,
+                        name_id, evr_id,
+                        package_id, package_arch_id
+                   from rhnChannelNewestPackageView
+                  where channel_id = channel_id_in
+                    and (package_name_id_in is null
+                         or name_id = package_name_id_in)
+                );
+        insert into rhnChannelNewestPackageAudit (channel_id, caller)
+             values (channel_id_in, caller_in);
+        update rhnChannel
+           set last_modified = greatest(current_timestamp,
+                                        last_modified + interval '1 second')
+         where id = channel_id_in;
+    end$$ language plpgsql;
+
+   create or replace function update_channel ( channel_id_in in numeric, invalidate_ss in numeric default 0,
+                              date_to_use in timestamptz default current_timestamp ) returns void
+   as $$
+   declare
+   channel_last_modified timestamptz;
+   last_modified_value timestamptz;
+
+   snapshots cursor for
+   select  snapshot_id id
+   from    rhnSnapshotChannel
+   where   channel_id = channel_id_in;
+
+   begin
+
+      select last_modified
+      into channel_last_modified
+      from rhnChannel
+      where id = channel_id_in;
+
+      last_modified_value := date_to_use;
+
+      if last_modified_value <= channel_last_modified then
+          last_modified_value := last_modified_value + interval '1 second';
+      end if;
+
+      update rhnChannel set last_modified = last_modified_value
+      where id = channel_id_in;
+
+      if invalidate_ss = 1 then
+        for snapshot in snapshots loop
+            update rhnSnapshot
+            set invalid = lookup_snapshot_invalid_reason('channel_modified')
+            where id = snapshot.id;
+        end loop;
+      end if;
+
+   end$$ language plpgsql;
+
+   create or replace function update_channels_by_package ( package_id_in in numeric, date_to_use in timestamptz default current_timestamp ) returns void
+   as $$
+   declare
+   channels cursor for
+   select channel_id
+   from rhnChannelPackage
+   where package_id = package_id_in
+   order by channel_id;
+
+   begin
+      for channel in channels loop
+         -- we want to invalidate the snapshot assocated with the channel when we
+         -- do this b/c we know we've added or removed or packages
+         perform rhn_channel.update_channel ( channel.channel_id, 1, date_to_use );
+      end loop;
+   end$$ language plpgsql;
+
+
+   create or replace function update_channels_by_errata ( errata_id_in numeric, date_to_use in timestamptz default current_timestamp ) returns void
+   as $$
+   declare
+   channels cursor for
+   select channel_id
+   from rhnChannelErrata
+   where errata_id = errata_id_in
+   order by channel_id;
+
+   begin
+      for channel in channels loop
+         -- we won't invalidate snapshots, b/c just changing the errata associated with
+         -- a channel shouldn't invalidate snapshots
+         perform rhn_channel.update_channel ( channel.channel_id, 0, date_to_use );
+      end loop;
+   end$$ language plpgsql;
+
+   create or replace function update_needed_cache(channel_id_in in numeric) returns void
+   as $$
+   declare
+   server record;
+   image record;
+   begin
+      -- we intentionaly do a loop here instead of one huge select
+      -- b/c we want to break update into smaller transaction to unblock other sessions
+      -- querying rhnServerNeededCache
+      for server in (
+                select sc.server_id as id
+                  from rhnServerChannel sc
+                 where sc.channel_id = channel_id_in
+                 order by id asc
+      ) loop
+         perform queue_server(server.id, 0); -- NOT IMMEDIATE
+      end loop;
+      for image in (
+        select ic.image_info_id as id
+          from suseImageInfoChannel ic
+         where ic.channel_id = channel_id_in
+        order by id asc
+      ) loop
+         perform queue_image(image.id, 0);
+      end loop;
+   end$$ language plpgsql;
+
+    create or replace function set_comps(channel_id_in in numeric, path_in in varchar, comps_type_id_in in numeric, timestamp_in in varchar) returns void
+    as $$
+    declare
+    row record;
+    begin
+        for row in (
+            select relative_filename, last_modified
+            from rhnChannelComps
+            where channel_id = channel_id_in
+            and comps_type_id = comps_type_id_in
+            ) loop
+            if row.relative_filename = path_in
+                and row.last_modified = to_timestamp(timestamp_in, 'YYYYMMDDHH24MISS') then
+                return;
+            end if;
+        end loop;
+        delete from rhnChannelComps
+        where channel_id = channel_id_in and comps_type_id = comps_type_id_in;
+        insert into rhnChannelComps (id, channel_id, relative_filename, comps_type_id, last_modified, created, modified)
+        values (sequence_nextval('rhn_channelcomps_id_seq'), channel_id_in, path_in, comps_type_id_in, to_timestamp(timestamp_in, 'YYYYMMDDHH24MISS'), current_timestamp, current_timestamp);
+    end$$ language plpgsql;
+
+-- restore the original setting
+update pg_settings set setting = overlay( setting placing '' from 1 for (length('rhn_channel')+1) ) where name = 'search_path';

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/202-rhnUserChannel.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/202-rhnUserChannel.sql
@@ -1,0 +1,68 @@
+--
+-- Copyright (c) 2008 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+-- 
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation. 
+--
+--
+--
+--
+
+create or replace view rhnUserChannel
+as
+select
+   cfp.user_id,
+   cfp.org_id,
+   cfm.channel_id,
+   'manage' as role
+from rhnChannelFamilyMembers cfm,
+      rhnUserChannelFamilyPerms cfp
+where
+   cfp.channel_family_id = cfm.channel_family_id and
+   (select deny_reason
+      from suseChannelUserRoleView scur
+      where scur.channel_id = cfm.channel_id and
+        scur.user_id = cfp.user_id and
+        scur.role = 'manage'
+   ) is null
+union all
+select
+   cfp.user_id,
+   cfp.org_id,
+   cfm.channel_id,
+   'subscribe' as role
+from rhnChannelFamilyMembers cfm,
+      rhnUserChannelFamilyPerms cfp
+where
+   cfp.channel_family_id = cfm.channel_family_id and
+   (select deny_reason
+      from suseChannelUserRoleView scur
+      where scur.channel_id = cfm.channel_id and
+        scur.user_id = cfp.user_id and
+        scur.role = 'subscribe'
+   ) is null
+union all
+select
+   w.id as user_id,
+   w.org_id,
+   s.id as channel_id,
+   'subscribe' as role
+from rhnSharedChannelView s,
+      web_contact w
+where
+   w.org_id = s.org_trust_id and
+   (select deny_reason
+      from suseChannelUserRoleView scur
+      where scur.channel_id = s.id and
+        scur.user_id = w.id and
+        scur.role = 'subscribe'
+   ) is null
+;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/300-delete_server-archive-actions.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/300-delete_server-archive-actions.sql.oracle
@@ -1,0 +1,216 @@
+--
+-- Copyright (c) 2008--2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+--
+--
+-- This deletes a server.  All codepaths which delete servers should hit this
+-- or delete_server_bulk()
+
+create or replace
+procedure delete_server (
+	server_id_in in number
+) is
+	cursor servergroups is
+		select	server_id, server_group_id
+		from	rhnServerGroupMembers sgm
+		where	sgm.server_id = server_id_in;
+	cursor configchannels is
+		select	cc.id
+		from	rhnConfigChannel cc,
+			rhnConfigChannelType cct,
+			rhnServerConfigChannel scc
+		where	1=1
+			and scc.server_id = server_id_in
+			and scc.config_channel_id = cc.id
+			-- these config channel types are reserved
+			-- for use by a single server, so we don't
+			-- need to check for other servers subscribed
+			and cct.label in
+				('local_override','server_import')
+			and cct.id = cc.confchan_type_id;
+        type filelistsid_t is table of rhnServerPreserveFileList.file_list_id%type;
+        filelistsid_c filelistsid_t;
+
+    update_lock number;
+begin
+    -- lock the rhnServer row to prevent deadlocks
+    -- we want rhnServer to be locked first, followed by tables that depend on it
+    select id into update_lock from rhnServer where id = server_id_in for update;
+
+        -- filelists
+	select	spfl.file_list_id id bulk collect into filelistsid_c
+	  from	rhnServerPreserveFileList spfl
+	 where	spfl.server_id = server_id_in
+			and not exists (
+				select	1
+				from	rhnServerPreserveFileList
+				where	file_list_id = spfl.file_list_id
+					and server_id != server_id_in
+				union
+				select	1
+				from	rhnKickstartPreserveFileList
+				where	file_list_id = spfl.file_list_id
+			);
+        if filelistsid_c.first is not null then
+            forall i in filelistsid_c.first..filelistsid_c.last
+                delete from rhnFileList where id = filelistsid_c(i);
+        end if;
+
+	for configchannel in configchannels loop
+		rhn_config.delete_channel(configchannel.id);
+	end loop;
+
+	for sgm in servergroups loop
+		rhn_server.delete_from_servergroup(
+			sgm.server_id, sgm.server_group_id);
+	end loop;
+
+	-- we're handling this instead of letting an "on delete
+	-- set null" do it so that we don't run the risk
+	-- of setting off the triggers and killing us with a
+	-- mutating table
+
+	-- this is merge of two single updates:
+        --  update ... set old_server_id = null where old_server_id = server_id_in;
+        --  update ... set new_server_id = null where new_server_id = server_id_in;
+        -- so we scan rhnKickstartSession table only once
+	update rhnKickstartSession
+		set old_server_id = case when old_server_id = server_id_in then null else old_server_id end,
+		    new_server_id = case when new_server_id = server_id_in then null else new_server_id end
+		where old_server_id = server_id_in
+		   or new_server_id = server_id_in;
+
+	rhn_channel.clear_subscriptions(server_id_in, 1);
+
+	-- A little complicated here, but the goal is to
+	-- delete records from rhnVirtualInstace only if we don't
+	-- care about them anymore.  We don't care about records
+	-- in rhnVirtualInstance if we are deleting the host
+	-- system and the virtual system is already null, or
+	-- vice-versa.  We *do* care about them if either the
+	-- host or virtual system is still registered because we
+	-- still want them to show up in the UI.
+    -- If there's a newer row in rhnVirtualInstance with the same
+    -- uuid, this guest must have been re-registered, so we can clean
+    -- this data up.
+
+        delete from rhnVirtualInstance vi
+	      where (host_system_id = server_id_in and virtual_system_id is null)
+                 or (virtual_system_id = server_id_in and host_system_id is null)
+                 or (vi.virtual_system_id = server_id_in and vi.modified < (select max(vi2.modified)
+                    from rhnVirtualInstance vi2 where vi2.uuid = vi.uuid));
+
+        -- this is merge of two single updates:
+        --  update ... set host_system_id = null where host_system_id = server_id_in;
+        --  update ... set virtual_system_id = null where virtual_system_id = server_id_in;
+        -- so we scan rhnVirtualInstance table only once
+        update rhnVirtualInstance
+	   set host_system_id = case when host_system_id = server_id_in then null else host_system_id end,
+	       virtual_system_id = case when virtual_system_id = server_id_in then null else virtual_system_id end
+	 where host_system_id = server_id_in
+	    or virtual_system_id = server_id_in;
+
+        -- this is merge of two single updates:
+        --  update ... set old_host_system_id = null when old_host_system_id = server_id_in;
+        --  update ... set new_host_system_id = null when new_host_system_id = server_id_in;
+        -- so we scan rhnVirtualInstanceEventLog table only once
+	update rhnVirtualInstanceEventLog
+	   set old_host_system_id = case when old_host_system_id = server_id_in then null else old_host_system_id end,
+               new_host_system_id = case when new_host_system_id = server_id_in then null else new_host_system_id end
+         where old_host_system_id = server_id_in
+            or new_host_system_id = server_id_in;
+
+        -- archive related actions, only if they have no other servers assigned
+        update rhnAction set archived = 1 where id in (
+            select action_id from rhnServerAction sa
+            where not exists (
+                select server_id from rhnServerAction
+                where action_id = sa.action_id and server_id != server_id_in
+            )
+        );
+
+	-- We're deleting everything with a foreign key to rhnServer
+	-- here, now.  I'm hoping this will help aleviate our deadlock
+	-- problem.
+
+	delete from rhnActionApplyStatesResult where server_id = server_id_in;
+	delete from rhnActionConfigChannel where server_id = server_id_in;
+	delete from rhnActionConfigRevision where server_id = server_id_in;
+	delete from rhnActionPackageRemovalFailure where server_id = server_id_in;
+	delete from rhnClientCapability where server_id = server_id_in;
+	delete from rhnCpu where server_id = server_id_in;
+	-- there's still a cascade here, because the constraint keeps the
+	-- table locked for too long to rebuild it.  Ugh...
+	delete from rhnDevice where server_id = server_id_in;
+	delete from rhnProxyInfo where server_id = server_id_in;
+	delete from rhnRam where server_id = server_id_in;
+	delete from rhnRegToken where server_id = server_id_in;
+	delete from rhnSatelliteInfo where server_id = server_id_in;
+	-- this cascades to rhnActionConfigChannel and rhnActionConfigFileName
+	delete from rhnServerAction where server_id = server_id_in;
+	delete from rhnServerActionPackageResult where server_id = server_id_in;
+	delete from rhnServerActionScriptResult where server_id = server_id_in;
+	delete from rhnServerActionVerifyResult where server_id = server_id_in;
+	delete from rhnServerActionVerifyMissing where server_id = server_id_in;
+	-- counts are handled above.  this should be a delete_ function.
+	delete from rhnServerChannel where server_id = server_id_in;
+	delete from rhnServerConfigChannel where server_id = server_id_in;
+	delete from rhnServerCustomDataValue where server_id = server_id_in;
+	delete from rhnServerDMI where server_id = server_id_in;
+	delete from rhnServerEvent where server_id = server_id_in;
+	delete from rhnServerFQDN where server_id = server_id_in;
+	delete from rhnServerHistory where server_id = server_id_in;
+	delete from rhnServerInfo where server_id = server_id_in;
+	delete from rhnServerInstallInfo where server_id = server_id_in;
+	delete from rhnServerLocation where server_id = server_id_in;
+	delete from rhnServerLock where server_id = server_id_in;
+	delete from rhnServerNeededCache where server_id = server_id_in;
+	delete from rhnServerNotes where server_id = server_id_in;
+	-- I'm not removing the foreign key from rhnServerPackage; that'll
+	-- take forever.  Do the delete anyway.
+	delete from rhnServerPackage where server_id = server_id_in;
+	delete from rhnServerTokenRegs where server_id = server_id_in;
+	delete from rhnSnapshotTag where server_id = server_id_in;
+	-- this cascades to:
+	--   rhnSnapshotChannel, rhnSnapshotConfigChannel, rhnSnapshotPackage,
+	--   rhnSnapshotConfigRevision, rhnSnapshotServerGroup,
+	--   rhnSnapshotTag.
+	-- We may want to consider delete_snapshot() at some point, but
+	--   I don't think we need to yet.
+	delete from rhnSnapshot where server_id = server_id_in;
+	delete from rhnUserServerPrefs where server_id = server_id_in;
+	-- hrm, this one's interesting... we _probably_ should delete
+	-- everything for the parent server_id when we delete the proxy,
+	-- but we don't currently.
+	delete from rhnServerPath where server_id_in in (server_id, proxy_server_id);
+	delete from rhnUserServerPerms where server_id = server_id_in;
+
+	delete from rhnServerNetInterface where server_id = server_id_in;
+
+	delete from rhnServerUuid where server_id = server_id_in;
+
+    delete from rhnPushClient where server_id = server_id_in;
+
+	-- now get rhnServer itself.
+	delete
+	from	rhnServer
+		where id = server_id_in;
+
+	delete
+	from	rhnSet
+	where	label = 'system_list'
+		and element = server_id_in;
+end delete_server;
+/
+show errors;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/300-delete_server-archive-actions.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/300-delete_server-archive-actions.sql.postgresql
@@ -1,0 +1,218 @@
+-- oracle equivalent source sha1 646886c7e0c3af74b258e07c5968c81f081d5ef4
+--
+-- Copyright (c) 2008--2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+--
+--
+-- This deletes a server.  All codepaths which delete servers should hit this
+-- or delete_server_bulk()
+
+create or replace
+function delete_server (
+        server_id_in in numeric
+) returns void
+as
+$$
+declare
+         servergroups cursor for
+                select  server_id, server_group_id
+                from    rhnServerGroupMembers sgm
+                where   sgm.server_id = server_id_in;
+
+         configchannels cursor for
+                select  cc.id
+                from    rhnConfigChannel cc,
+                        rhnConfigChannelType cct,
+                        rhnServerConfigChannel scc
+                where   1=1
+                        and scc.server_id = server_id_in
+                        and scc.config_channel_id = cc.id
+                        -- these config channel types are reserved
+                        -- for use by a single server, so we don't
+                        -- need to check for other servers subscribed
+                        and cct.label in
+                                ('local_override','server_import')
+                        and cct.id = cc.confchan_type_id;
+
+    update_lock numeric;
+begin
+    -- lock the rhnServer row to prevent deadlocks
+    -- we want rhnServer to be locked first, followed by tables that depend on it
+    select id into update_lock from rhnServer where id = server_id_in for update;
+
+        -- filelists
+        delete from rhnFileList where id in (
+	select	spfl.file_list_id
+	  from	rhnServerPreserveFileList spfl
+	 where	spfl.server_id = server_id_in
+			and not exists (
+				select	1
+				from	rhnServerPreserveFileList
+				where	file_list_id = spfl.file_list_id
+					and server_id != server_id_in
+				union all
+				select	1
+				from	rhnKickstartPreserveFileList
+				where	file_list_id = spfl.file_list_id
+			)
+        );
+
+	for configchannel in configchannels loop
+		perform rhn_config.delete_channel(configchannel.id);
+	end loop;
+
+	for sgm in servergroups loop
+		perform rhn_server.delete_from_servergroup(
+			sgm.server_id, sgm.server_group_id);
+	end loop;
+
+
+        -- we're handling this instead of letting an "on delete
+        -- set null" do it so that we don't run the risk
+        -- of setting off the triggers and killing us with a
+        -- mutating table
+
+        -- this is merge of two single updates:
+        --  update ... set old_server_id = null where old_server_id = server_id_in;
+        --  update ... set new_server_id = null where new_server_id = server_id_in;
+        -- so we scan rhnKickstartSession table only once
+        update rhnKickstartSession
+                set old_server_id = case when old_server_id = server_id_in then null else old_server_id end,
+                    new_server_id = case when new_server_id = server_id_in then null else new_server_id end
+                where old_server_id = server_id_in
+                   or new_server_id = server_id_in;
+
+        perform rhn_channel.clear_subscriptions(server_id_in, 1);
+
+        -- A little complicated here, but the goal is to
+        -- delete records from rhnVirtualInstace only if we don't
+        -- care about them anymore.  We don't care about records
+        -- in rhnVirtualInstance if we are deleting the host
+        -- system and the virtual system is already null, or
+        -- vice-versa.  We *do* care about them if either the
+        -- host or virtual system is still registered because we
+        -- still want them to show up in the UI.
+    -- If there's a newer row in rhnVirtualInstance with the same
+    -- uuid, this guest must have been re-registered, so we can clean
+    -- this data up.
+
+        delete from rhnVirtualInstance vi
+              where (host_system_id = server_id_in and virtual_system_id is null)
+                 or (virtual_system_id = server_id_in and host_system_id is null)
+                 or (vi.virtual_system_id = server_id_in and vi.modified < (select max(vi2.modified)
+                    from rhnVirtualInstance vi2 where vi2.uuid = vi.uuid));
+
+        -- this is merge of two single updates:
+        --  update ... set host_system_id = null where host_system_id = server_id_in;
+        --  update ... set virtual_system_id = null where virtual_system_id = server_id_in;
+        -- so we scan rhnVirtualInstance table only once
+        update rhnVirtualInstance
+           set host_system_id = case when host_system_id = server_id_in then null else host_system_id end,
+               virtual_system_id = case when virtual_system_id = server_id_in then null else virtual_system_id end
+         where host_system_id = server_id_in
+            or virtual_system_id = server_id_in;
+
+        -- this is merge of two single updates:
+        --  update ... set old_host_system_id = null when old_host_system_id = server_id_in;
+        --  update ... set new_host_system_id = null when new_host_system_id = server_id_in;
+        -- so we scan rhnVirtualInstanceEventLog table only once
+        update rhnVirtualInstanceEventLog
+           set old_host_system_id = case when old_host_system_id = server_id_in then null else old_host_system_id end,
+               new_host_system_id = case when new_host_system_id = server_id_in then null else new_host_system_id end
+         where old_host_system_id = server_id_in
+            or new_host_system_id = server_id_in;
+
+        -- archive related actions, only if they have no other servers assigned
+        update rhnAction set archived = 1 where id in (
+            select action_id from rhnServerAction sa
+            where not exists (
+                select server_id from rhnServerAction
+                where action_id = sa.action_id and server_id != server_id_in
+            )
+        );
+
+        -- We're deleting everything with a foreign key to rhnServer
+        -- here, now.  I'm hoping this will help aleviate our deadlock
+        -- problem.
+
+        delete from rhnActionApplyStatesResult where server_id = server_id_in;
+        delete from rhnActionConfigChannel where server_id = server_id_in;
+        delete from rhnActionConfigRevision where server_id = server_id_in;
+        delete from rhnActionPackageRemovalFailure where server_id = server_id_in;
+        delete from rhnClientCapability where server_id = server_id_in;
+        delete from rhnCpu where server_id = server_id_in;
+        -- there's still a cascade here, because the constraint keeps the
+        -- table locked for too long to rebuild it.  Ugh...
+        delete from rhnDevice where server_id = server_id_in;
+        delete from rhnProxyInfo where server_id = server_id_in;
+        delete from rhnRam where server_id = server_id_in;
+        delete from rhnRegToken where server_id = server_id_in;
+        delete from rhnSatelliteInfo where server_id = server_id_in;
+        -- this cascades to rhnActionConfigChannel and rhnActionConfigFileName
+        delete from rhnServerAction where server_id = server_id_in;
+        delete from rhnServerActionPackageResult where server_id = server_id_in;
+        delete from rhnServerActionScriptResult where server_id = server_id_in;
+        delete from rhnServerActionVerifyResult where server_id = server_id_in;
+        delete from rhnServerActionVerifyMissing where server_id = server_id_in;
+        -- counts are handled above.  this should be a delete_ function.
+        delete from rhnServerChannel where server_id = server_id_in;
+        delete from rhnServerConfigChannel where server_id = server_id_in;
+        delete from rhnServerCustomDataValue where server_id = server_id_in;
+        delete from rhnServerDMI where server_id = server_id_in;
+        delete from rhnServerEvent where server_id = server_id_in;
+        delete from rhnServerFQDN where server_id = server_id_in;
+        delete from rhnServerHistory where server_id = server_id_in;
+        delete from rhnServerInfo where server_id = server_id_in;
+        delete from rhnServerInstallInfo where server_id = server_id_in;
+        delete from rhnServerLocation where server_id = server_id_in;
+        delete from rhnServerLock where server_id = server_id_in;
+        delete from rhnServerNeededCache where server_id = server_id_in;
+        delete from rhnServerNotes where server_id = server_id_in;
+        -- I'm not removing the foreign key from rhnServerPackage; that'll
+        -- take forever.  Do the delete anyway.
+        delete from rhnServerPackage where server_id = server_id_in;
+        delete from rhnServerTokenRegs where server_id = server_id_in;
+        delete from rhnSnapshotTag where server_id = server_id_in;
+        -- this cascades to:
+        --   rhnSnapshotChannel, rhnSnapshotConfigChannel, rhnSnapshotPackage,
+        --   rhnSnapshotConfigRevision, rhnSnapshotServerGroup,
+        --   rhnSnapshotTag.
+        -- We may want to consider delete_snapshot() at some point, but
+        --   I don't think we need to yet.
+        delete from rhnSnapshot where server_id = server_id_in;
+        delete from rhnUserServerPrefs where server_id = server_id_in;
+        -- hrm, this one's interesting... we _probably_ should delete
+        -- everything for the parent server_id when we delete the proxy,
+        -- but we don't currently.
+        delete from rhnServerPath where server_id_in in (server_id, proxy_server_id);
+        delete from rhnUserServerPerms where server_id = server_id_in;
+
+        delete from rhnServerNetInterface where server_id = server_id_in;
+
+        delete from rhnServerUuid where server_id = server_id_in;
+
+        delete from rhnPushClient where server_id = server_id_in;
+
+        -- now get rhnServer itself.
+        delete
+        from    rhnServer
+                where id = server_id_in;
+
+        delete
+        from    rhnSet
+        where   label = 'system_list'
+                and element = server_id_in;
+end;
+$$
+language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/301-rhnUserActionOverview-include-orphans.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/301-rhnUserActionOverview-include-orphans.sql
@@ -1,0 +1,55 @@
+--
+-- Copyright (c) 2008 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+--
+--
+--
+-- rhnActionOverview, but on a per-user basis.
+
+-- invoke as:
+--
+-- select	*
+-- from		rhnUserActionOverview
+-- where	org_id = :oid
+--		and user_id = :uid;
+--
+
+create or replace view rhnUserActionOverview as
+select	ao.org_id                                       as org_id,
+	usp.user_id                                     as user_id,
+        ao.action_id                                    as id,
+	ao.type_name                                    as type_name,
+        ao.scheduler                                    as scheduler,
+	ao.earliest_action                              as earliest_action,
+	coalesce( ao.name, ao.type_name )		as action_name,
+	sa.status					as action_status_id,
+	astat.name                                      as action_status,
+	count(sa.action_id)				as tally,
+	ao.archived                                     as archived
+from    rhnActionOverview ao
+        left join rhnServerAction sa on ao.action_id = sa.action_id
+        left join rhnActionStatus astat on sa.status = astat.id
+        left join rhnUserServerPerms usp on sa.server_id = usp.server_id
+group by ao.org_id,
+	 usp.user_id,
+	 ao.action_id,
+	 ao.type_name,
+	 ao.scheduler,
+	 ao.earliest_action,
+	 coalesce( ao.name, ao.type_name ),
+	 sa.status,
+	 astat.name,
+	 ao.archived
+order by earliest_action;
+

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/302-rhnAction-archive-orphan-actions.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.15-to-susemanager-schema-3.2.16/302-rhnAction-archive-orphan-actions.sql
@@ -1,0 +1,5 @@
+-- Archive actions which have no servers assigned
+UPDATE rhnAction SET archived = 1 WHERE id IN (
+    SELECT id FROM rhnUserActionOverview
+    WHERE user_id IS NULL
+);

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/001-rhnXccdfIdent-ident.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/001-rhnXccdfIdent-ident.sql.oracle
@@ -1,0 +1,1 @@
+alter table rhnXccdfIdent modify identifier varchar2(255);

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/001-rhnXccdfIdent-ident.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/001-rhnXccdfIdent-ident.sql.postgresql
@@ -1,0 +1,3 @@
+-- oracle equivalent source sha1 54996beeccadd6cc52ddfa4d5da8fbfaa388d07a
+
+alter table rhnXccdfIdent alter column identifier type varchar(255);

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/001-rhn_user.pkb.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/001-rhn_user.pkb.sql.oracle
@@ -1,0 +1,175 @@
+--
+-- Copyright (c) 2019 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+create or replace
+package body rhn_user
+is
+	body_version varchar2(100) := '';
+	
+    function check_role(user_id_in in number, role_in in varchar2)
+    return number
+    is
+    	throwaway number;
+    begin
+    	-- the idea: if we get past this query, the org has the setting, else catch the exception and return 0
+	select 1 into throwaway
+	  from rhnUserGroupType UGT,
+	       rhnUserGroup UG,
+	       rhnUserGroupMembers UGM
+	 where UGM.user_id = user_id_in
+	   and UGM.user_group_id = UG.id
+	   and UG.group_type = UGT.id
+	   and UGT.label = role_in;
+	   
+	return 1;
+    exception
+    	when no_data_found
+	    then
+	    return 0;
+    end check_role;
+    
+    function check_role_implied(user_id_in in number, role_in in varchar2)
+    return number
+    is
+    	throwaway number;
+    begin
+    	-- if the user directly has the role, they win
+    	if rhn_user.check_role(user_id_in, role_in) = 1
+	then
+	    return 1;
+    	end if;
+
+	-- config_admin and channel_admin are automatically implied for org admins	
+	if role_in = 'config_admin' and rhn_user.check_role(user_id_in, 'org_admin') = 1
+	then
+	    return 1;
+	end if;
+
+	if role_in = 'channel_admin' and rhn_user.check_role(user_id_in, 'org_admin') = 1
+	then
+	    return 1;
+	end if;
+
+	if role_in = 'image_admin' and rhn_user.check_role(user_id_in, 'org_admin') = 1
+	then
+	    return 1;
+	end if;
+
+	return 0;	
+    end check_role_implied;
+    
+    function get_org_id(user_id_in in number)
+    return number
+    is
+    	org_id_out number;
+    begin
+    	select org_id into org_id_out
+	  from web_contact
+	 where id = user_id_in;
+	 
+	return org_id_out;
+    end get_org_id;
+
+	procedure add_servergroup_perm(
+		user_id_in in number,
+		server_group_id_in in number
+	) is
+		cursor	orgs_match is
+			select	1
+			from	rhnServerGroup sg,
+					web_contact u
+			where	u.id = user_id_in
+				and sg.id = server_group_id_in
+				and sg.org_id = u.org_id;
+	begin
+		for okay in orgs_match loop
+			insert into rhnUserServerGroupPerms(user_id, server_group_id)
+				values (user_id_in, server_group_id_in);
+			rhn_cache.update_perms_for_user(user_id_in);
+			return;
+		end loop;
+		rhn_exception.raise_exception('usgp_different_orgs');
+	exception when dup_val_on_index then
+		rhn_exception.raise_exception('usgp_already_allowed');
+	end add_servergroup_perm;
+
+	procedure add_to_usergroup(
+		user_id_in in number,
+		user_group_id_in in number
+	) is
+		cursor perm_granting_usergroups is
+			select	user_group_id_in
+			from	rhnUserGroup		ug,
+					rhnUserGroupType	ugt
+			where	ugt.label in ('org_admin') -- and server_group_admin ?
+				and ug.id = user_group_id_in
+				and ug.group_type = ugt.id;
+	begin
+		insert into rhnUserGroupMembers(user_id, user_group_id)
+			values (user_id_in, user_group_id_in);
+
+		for ug in perm_granting_usergroups loop
+			rhn_cache.update_perms_for_user(user_id_in);
+			return;
+		end loop;
+	end add_to_usergroup;
+
+	procedure remove_from_usergroup(
+		user_id_in in number,
+		user_group_id_in in number
+	) is
+		cursor perm_granting_usergroups is
+			select	label
+			from	rhnUserGroupType	ugt,
+					rhnUserGroupMembers	ugm,
+					rhnUserGroup		ug
+			where	1=1
+				and ug.id = user_group_id_in
+				and ugm.user_group_id = user_group_id_in
+				and ug.group_type = ugt.id
+				and ugm.user_id = user_id_in;
+	begin
+		-- we only do anything if you're really in the group, because
+		-- testing is significantly cheaper than rebuilding the user's
+		-- cache for no reason.
+		for ug in perm_granting_usergroups loop
+			delete from rhnUserGroupMembers
+				where	user_id = user_id_in
+					and user_group_id = user_group_id_in;
+			if ug.label in ('org_admin') then
+				rhn_cache.update_perms_for_user(user_id_in);
+			end if;
+		end loop;
+	end remove_from_usergroup;
+
+	function role_names (user_id_in in number)
+	return varchar2
+	is
+		tmp varchar2(4000);
+	begin
+		for rec in (
+			select type_name
+			from rhnUserTypeBase
+			where user_id = user_id_in
+			order by type_id
+			) loop
+			if tmp is null then
+				tmp := rec.type_name;
+			else
+				tmp := tmp || ', ' || rec.type_name;
+			end if;
+		end loop;
+		return tmp;
+	end;
+
+end rhn_user;
+/
+SHOW ERRORS

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/001-rhn_user.pkb.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/001-rhn_user.pkb.sql.postgresql
@@ -1,0 +1,15 @@
+-- oracle equivalent source sha1 091ea3a6c07f2c88369299a7b0bbdf72d559bde9
+--
+-- Copyright (c) 2019 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+DROP FUNCTION IF EXISTS rhn_user.remove_servergroup_perm(user_id_in in numeric, server_group_id_in in numeric);
+
+

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/001-rhn_user.pks.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/001-rhn_user.pks.sql.oracle
@@ -1,0 +1,45 @@
+--
+-- Copyright (c) 2019 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+create or replace
+package rhn_user
+is
+	version varchar2(100) := '';
+
+    function check_role(user_id_in in number, role_in in varchar2) return number;
+    PRAGMA RESTRICT_REFERENCES(check_role, WNDS, RNPS, WNPS);
+
+    function check_role_implied(user_id_in in number, role_in in varchar2) return number;
+    PRAGMA RESTRICT_REFERENCES(check_role_implied, WNDS, RNPS, WNPS);
+
+    function get_org_id(user_id_in in number) return number;
+    PRAGMA RESTRICT_REFERENCES(get_org_id, WNDS, RNPS, WNPS);
+
+	procedure add_servergroup_perm(
+		user_id_in in number,
+		server_group_id_in in number
+	);
+
+	procedure add_to_usergroup(
+		user_id_in in number,
+		user_group_id_in in number
+	);
+
+	procedure remove_from_usergroup(
+		user_id_in in number,
+		user_group_id_in in number
+	);
+
+	function role_names (user_id_in in number) return varchar2;
+
+end rhn_user;
+/
+SHOW ERRORS

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/001-rhn_user.pks.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/001-rhn_user.pks.sql.postgresql
@@ -1,0 +1,3 @@
+-- oracle equivalent source sha1 2d7d0c121775c20421fc008d65571b2229c17c75
+-- This file has intentionally been left empty.
+

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/100-rhnTaskoSchedule-cron-freq.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/100-rhnTaskoSchedule-cron-freq.sql
@@ -1,0 +1,4 @@
+UPDATE rhnTaskoSchedule SET cron_expr = '0 0 0 * * ?'
+    WHERE job_label = 'minion-action-cleanup-default'
+        AND active_till IS NULL
+        AND cron_expr = '0 0 * * * ?';

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/201-insert_checksum.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/201-insert_checksum.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 201-insert_checksum.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/201-insert_checksum.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/201-insert_checksum.sql.postgresql
@@ -1,0 +1,29 @@
+-- oracle equivalent source sha1 a33ba03f0c524385bfbfb25056d7aa750253e226
+
+create or replace function
+insert_checksum(checksum_type_in in varchar, checksum_in in varchar)
+returns numeric
+as
+$$
+declare
+    checksum_id     numeric;
+begin
+    checksum_id := nextval('rhnchecksum_seq');
+
+    insert into rhnChecksum (id, checksum_type_id, checksum)
+      values (
+          checksum_id,
+          (select id from rhnChecksumType where label = checksum_type_in),
+          checksum_in
+      )
+      on conflict do nothing;
+
+    select c.id
+        into strict checksum_id
+        from rhnChecksumView c
+        where c.checksum = checksum_in and
+            c.checksum_type = checksum_type_in;
+
+    return checksum_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/202-insert_client_capability.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/202-insert_client_capability.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 202-insert_client_capability.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/202-insert_client_capability.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/202-insert_client_capability.sql.postgresql
@@ -1,0 +1,23 @@
+-- oracle equivalent source sha1 ff61eb257641743139b48e5fbc5ebfd37c62ebc6
+
+create or replace function
+insert_client_capability(name_in in varchar)
+returns numeric
+as $$
+declare
+    cap_name_id     numeric;
+begin
+    cap_name_id := nextval('rhn_client_capname_id_seq');
+
+    insert into rhnClientCapabilityName(id, name)
+        values (cap_name_id, name_in)
+        on conflict do nothing;
+
+    select id
+        into strict cap_name_id
+        from rhnclientcapabilityname
+        where name = name_in;
+
+    return cap_name_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/203-insert_config_filename.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/203-insert_config_filename.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 203-insert_config_filename.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/203-insert_config_filename.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/203-insert_config_filename.sql.postgresql
@@ -1,0 +1,23 @@
+-- oracle equivalent source sha1 f5d7ec855a5948ae80f2b24283fcb74465023105
+
+create or replace function
+insert_config_filename(name_in in varchar)
+returns numeric as
+$$
+declare
+    name_id     numeric;
+begin
+    name_id := nextval('rhn_cfname_id_seq');
+
+    insert into rhnConfigFileName (id, path)
+        values (name_id, name_in)
+        on conflict do nothing;
+
+    select id
+        into strict name_id
+        from rhnconfigfilename
+        where path = name_in;
+
+    return name_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/204-insert_config_info.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/204-insert_config_info.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 204-insert_config_info.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/204-insert_config_info.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/204-insert_config_info.sql.postgresql
@@ -1,0 +1,34 @@
+-- oracle equivalent source sha1 7b48bde51b6771a3cdbeb32a7750faca2086a004
+
+create or replace function
+insert_config_info(
+    username_in     in varchar,
+    groupname_in    in varchar,
+    filemode_in     in numeric,
+    selinux_ctx_in  in varchar,
+    symlink_target_id in numeric
+)
+returns numeric
+as
+$$
+declare
+    config_info_id    numeric;
+begin
+    config_info_id := nextval('rhn_confinfo_id_seq');
+
+    insert into rhnConfigInfo (id, username, groupname, filemode, selinux_ctx, symlink_target_filename_id)
+        values (config_info_id, username_in, groupname_in, filemode_in, selinux_ctx_in, symlink_target_id)
+        on conflict do nothing;
+
+    select id
+      into config_info_id
+      from rhnConfigInfo
+      where (username = username_in or (username is null and username_in is null))
+        and (groupname = groupname_in or (groupname is null and groupname_in is null))
+        and (filemode = filemode_in or (filemode is null and filemode_in is null))
+        and (selinux_ctx = selinux_ctx_in or (selinux_ctx is null and selinux_ctx_in is null))
+        and (symlink_target_filename_id = symlink_target_id or (symlink_target_filename_id is null and symlink_target_id is null));
+
+    return config_info_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/205-insert_cve.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/205-insert_cve.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 205-insert_cve.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/205-insert_cve.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/205-insert_cve.sql.postgresql
@@ -1,0 +1,23 @@
+-- oracle equivalent source sha1 00b9d668dd63e47dd1180a909468ddd7971201d2
+
+create or replace function
+insert_cve(name_in in varchar)
+returns numeric
+as $$
+declare
+    name_id     numeric;
+begin
+    name_id := nextval('rhn_cve_id_seq');
+
+    insert into rhnCVE (id, name)
+        values (name_id, name_in)
+        on conflict do nothing;
+
+    select id
+        into strict name_id
+        from rhnCVE
+        where name = name_in;
+
+    return name_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/206-insert_evr.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/206-insert_evr.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 206-insert_evr.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/206-insert_evr.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/206-insert_evr.sql.postgresql
@@ -1,0 +1,25 @@
+-- oracle equivalent source sha1 4e2700d50093e37c44abcaeed16abc6f79298e2e
+
+create or replace function
+insert_evr(e_in in varchar, v_in in varchar, r_in in varchar)
+returns numeric
+as
+$$
+declare
+    evr_id  numeric;
+begin
+    evr_id := nextval('rhn_pkg_evr_seq');
+
+    insert into rhnPackageEVR(id, epoch, version, release, evr)
+        values (evr_id, e_in, v_in, r_in, evr_t(e_in, v_in, r_in))
+        on conflict do nothing;
+
+    select id
+        into strict evr_id
+        from rhnPackageEVR
+        where ((epoch is null and e_in is null) or (epoch = e_in)) and
+           version = v_in and release = r_in;
+
+    return evr_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/207-insert_md_keyword.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/207-insert_md_keyword.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 207-insert_md_keyword.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/207-insert_md_keyword.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/207-insert_md_keyword.sql.postgresql
@@ -1,0 +1,24 @@
+-- oracle equivalent source sha1 60edd88d0e8f4bb54a90f8151e11c8f99269e1de
+
+create or replace function
+insert_md_keyword(label_in in varchar)
+returns numeric
+as
+$$
+declare
+    md_keyword_id numeric;
+begin
+    md_keyword_id := nextval('suse_mdkeyword_id_seq');
+
+    insert into suseMdKeyword (id, label)
+        values (md_keyword_id, label_in)
+        on conflict do nothing;
+
+    select id
+        into strict md_keyword_id
+        from suseMdKeyword
+        where label = label_in;
+
+    return md_keyword_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/208-insert_package_capability.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/208-insert_package_capability.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 208-insert_package_capability.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/208-insert_package_capability.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/208-insert_package_capability.sql.postgresql
@@ -1,0 +1,31 @@
+-- oracle equivalent source sha1 d6d6cf9ab9b366582b15e59824fae47e64d539cf
+
+create or replace function
+insert_package_capability(name_in in varchar, version_in in varchar default null)
+returns numeric
+as
+$$
+declare
+    name_id numeric;
+begin
+    name_id := nextval('rhn_pkg_capability_id_seq');
+
+    insert into rhnPackageCapability(id, name, version)
+        values (name_id, name_in, version_in)
+        on conflict do nothing;
+
+    if version_in is null then
+        select id
+            into strict name_id
+            from rhnpackagecapability
+            where name = name_in and version is null;
+    else
+        select id
+            into strict name_id
+            from rhnpackagecapability
+            where name = name_in and version = version_in;
+    end if;
+
+    return name_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/209-insert_package_delta.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/209-insert_package_delta.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 209-insert_package_delta.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/209-insert_package_delta.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/209-insert_package_delta.sql.postgresql
@@ -1,0 +1,24 @@
+-- oracle equivalent source sha1 fd8006960682fb6224dc9574ce45b39ba7f0543b
+
+create or replace function
+insert_package_delta(n_in in varchar)
+returns numeric
+as
+$$
+declare
+    name_id     numeric;
+begin
+    name_id := nextval('rhn_packagedelta_id_seq');
+
+    insert into rhnPackageDelta(id, label)
+        values (name_id, n_in)
+        on conflict do nothing;
+
+    select id
+        into strict name_id
+        from rhnpackagedelta
+        where label = n_in;
+
+    return name_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/210-insert_package_group.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/210-insert_package_group.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 210-insert_package_group.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/210-insert_package_group.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/210-insert_package_group.sql.postgresql
@@ -1,0 +1,24 @@
+-- oracle equivalent source sha1 2c8c6a13345933bcfeb186df98b18ebadfd8a5eb
+
+create or replace function
+insert_package_group(name_in in varchar)
+returns numeric
+as
+$$
+declare
+    package_id   numeric;
+begin
+    package_id := nextval('rhn_package_group_id_seq');
+
+    insert into rhnPackageGroup(id, name)
+        values (package_id, name_in)
+        on conflict do nothing;
+
+    select id
+        into strict package_id
+        from rhnPackageGroup
+        where name = name_in;
+
+    return package_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/211-insert_package_name.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/211-insert_package_name.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 211-insert_package_name.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/211-insert_package_name.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/211-insert_package_name.sql.postgresql
@@ -1,0 +1,24 @@
+-- oracle equivalent source sha1 735d7b9591a39522072bb44129692eaedad34099
+
+create or replace function
+insert_package_name(name_in in varchar)
+returns numeric
+as
+$$
+declare
+    name_id     numeric;
+begin
+    name_id := nextval('rhn_pkg_name_seq');
+
+    insert into rhnPackageName(id, name)
+        values (name_id, name_in)
+        on conflict do nothing;
+
+    select id
+        into strict name_id
+        from rhnPackageName
+        where name = name_in;
+
+    return name_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/212-insert_package_nevra.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/212-insert_package_nevra.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 212-insert_package_nevra.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/212-insert_package_nevra.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/212-insert_package_nevra.sql.postgresql
@@ -1,0 +1,30 @@
+-- oracle equivalent source sha1 7221154e7bcec7277ef2ecfc3f6902be54af288c
+-- This file is intentionally left empty.
+
+create or replace function
+insert_package_nevra(
+        name_id_in in numeric,
+        evr_id_in in numeric,
+        package_arch_id_in in numeric
+) returns numeric
+as
+$$
+declare
+    nevra_id numeric;
+begin
+    nevra_id := nextval('rhn_pkgnevra_id_seq');
+
+    insert into rhnPackageNEVRA(id, name_id, evr_id, package_arch_id)
+        values (nevra_id, name_id_in, evr_id_in, package_arch_id_in)
+        on conflict do nothing;
+
+    select id
+        into strict nevra_id
+        from rhnPackageNEVRA
+        where name_id = name_id_in and evr_id = evr_id_in and
+            (package_arch_id = package_arch_id_in or
+            (package_arch_id is null and package_arch_id_in is null));
+
+    return nevra_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/213-insert_source_name.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/213-insert_source_name.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 213-insert_source_name.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/213-insert_source_name.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/213-insert_source_name.sql.postgresql
@@ -1,0 +1,24 @@
+-- oracle equivalent source sha1 9dcda626b05182af31c7aa7adcbd4cfad975cdf7
+
+create or replace function
+insert_source_name(name_in in varchar)
+returns numeric
+as
+$$
+declare
+    source_id   numeric;
+begin
+    source_id := nextval('rhn_sourcerpm_id_seq');
+
+    insert into rhnSourceRPM(id, name)
+        values (source_id, name_in)
+        on conflict do nothing;
+
+    select id
+        into strict source_id
+        from rhnSourceRPM
+        where name = name_in;
+
+    return source_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/214-insert_tag.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/214-insert_tag.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 214-insert_tag.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/214-insert_tag.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/214-insert_tag.sql.postgresql
@@ -1,0 +1,24 @@
+-- oracle equivalent source sha1 59e609a31cf66327dd886cd0570f9caafc85b294
+
+create or replace function
+insert_tag(org_id_in in numeric, tag_name_id_in in numeric)
+returns numeric
+as $$
+declare
+    tag_id  numeric;
+begin
+    tag_id := nextval('rhn_tag_id_seq');
+
+    insert into rhnTag(id, org_id, name_id)
+        values (tag_id, org_id_in, tag_name_id_in)
+        on conflict do nothing;
+
+    select id
+        into strict tag_id
+        from rhnTag
+        where org_id = org_id_in and
+            name_id = tag_name_id_in;
+
+    return tag_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/215-insert_tag_name.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/215-insert_tag_name.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 215-insert_tag_name.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/215-insert_tag_name.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/215-insert_tag_name.sql.postgresql
@@ -1,0 +1,24 @@
+-- oracle equivalent source sha1 18fc84b57c86a2f030171c1dbc959b0ebfb5e34b
+
+create or replace function
+insert_tag_name(name_in in varchar)
+returns numeric
+as
+$$
+declare
+    name_id numeric;
+begin
+    name_id := nextval('rhn_tagname_id_seq');
+
+    insert into rhnTagName(id, name)
+        values (name_id, name_in)
+        on conflict do nothing;
+
+    select id
+        into strict name_id
+        from rhnTagName
+        where name = name_in;
+
+    return name_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/216-insert_transaction_package.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/216-insert_transaction_package.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 216-insert_transaction_package.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/216-insert_transaction_package.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/216-insert_transaction_package.sql.postgresql
@@ -1,0 +1,30 @@
+-- oracle equivalent source sha1 43bcf92c476a4eb52f539c63577d349109b65e38
+
+create or replace function
+insert_transaction_package(
+    o_id_in      in numeric,
+    n_id_in      in numeric,
+    e_id_in      in numeric,
+    p_arch_id_in in numeric
+)
+returns numeric
+as
+$$
+declare
+    tp_id       numeric;
+begin
+    tp_id := nextval('rhn_transpack_id_seq');
+
+    insert into rhnTransactionPackage (id, operation, name_id, evr_id, package_arch_id)
+        values (tp_id, o_id_in, n_id_in, e_id_in, p_arch_id_in)
+        on conflict do nothing;
+
+    select id
+        into strict tp_id
+        from rhnTransactionPackage
+     where operation = o_id_in and name_id = n_id_in and evr_id = e_id_in and
+        (package_arch_id = p_arch_id_in or (p_arch_id_in is null and package_arch_id is null));
+
+    return tp_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/217-insert_xccdf_benchmark.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/217-insert_xccdf_benchmark.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 217-insert_xccdf_benchmark.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/217-insert_xccdf_benchmark.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/217-insert_xccdf_benchmark.sql.postgresql
@@ -1,0 +1,25 @@
+-- oracle equivalent source sha1 7577dba0c92727a81399fda3e5bd412bcb202270
+-- This file is intentionally left empty.
+
+create or replace function
+insert_xccdf_benchmark(identifier_in in varchar, version_in in varchar)
+returns numeric
+as
+$$
+declare
+    benchmark_id numeric;
+begin
+    benchmark_id := nextval('rhn_xccdf_benchmark_id_seq');
+
+    insert into rhnXccdfBenchmark (id, identifier, version)
+        values (benchmark_id, identifier_in, version_in)
+        on conflict do nothing;
+
+    select id
+        into strict benchmark_id
+        from rhnXccdfBenchmark
+        where identifier = identifier_in and version = version_in;
+
+    return benchmark_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/218-insert_xccdf_ident.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/218-insert_xccdf_ident.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 218-insert_xccdf_ident.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/218-insert_xccdf_ident.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/218-insert_xccdf_ident.sql.postgresql
@@ -1,0 +1,24 @@
+-- oracle equivalent source sha1 da49e184ecfbbc965fc65549e7ffecef9f1a2ffc
+
+create or replace function
+insert_xccdf_ident(ident_sys_id_in in numeric, identifier_in in varchar)
+returns numeric
+as
+$$
+declare
+    xccdf_ident_id numeric;
+begin
+    xccdf_ident_id := nextval('rhn_xccdf_ident_id_seq');
+
+    insert into rhnXccdfIdent (id, identsystem_id, identifier)
+        values (xccdf_ident_id, ident_sys_id_in, identifier_in)
+        on conflict do nothing;
+
+    select id
+        into strict xccdf_ident_id
+        from rhnXccdfIdent
+        where identsystem_id = ident_sys_id_in and identifier = identifier_in;
+
+    return xccdf_ident_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/219-insert_xccdf_ident_system.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/219-insert_xccdf_ident_system.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 219-insert_xccdf_ident_system.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/219-insert_xccdf_ident_system.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/219-insert_xccdf_ident_system.sql.postgresql
@@ -1,0 +1,24 @@
+-- oracle equivalent source sha1 85a789886d7e22a484ca46e3b7a527b64f7e32bd
+
+create or replace function
+insert_xccdf_ident_system(system_in in varchar)
+returns numeric
+as
+$$
+declare
+    ident_sys_id numeric;
+begin
+    ident_sys_id := nextval('rhn_xccdf_identsytem_id_seq');
+
+    insert into rhnXccdfIdentSystem (id, system)
+        values (ident_sys_id, system_in)
+        on conflict do nothing;
+
+    select id
+        into strict ident_sys_id
+        from rhnXccdfIdentSystem
+        where system = system_in;
+
+    return ident_sys_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/220-insert_xccdf_profile.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/220-insert_xccdf_profile.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 220-insert_xccdf_profile.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/220-insert_xccdf_profile.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/220-insert_xccdf_profile.sql.postgresql
@@ -1,0 +1,24 @@
+-- oracle equivalent source sha1 790b20d085c594409001151e850f9bc7b0e7000b
+
+create or replace function
+insert_xccdf_profile(identifier_in in varchar, title_in in varchar)
+returns numeric
+as
+$$
+declare
+    profile_id numeric;
+begin
+    profile_id := nextval('rhn_xccdf_profile_id_seq');
+
+    insert into rhnXccdfProfile (id, identifier, title)
+        values (profile_id, identifier_in, title_in)
+        on conflict do nothing;
+
+    select id
+        into profile_id
+        from rhnXccdfProfile
+        where identifier = identifier_in and title = title_in;
+
+    return profile_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/221-lookup_checksum.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/221-lookup_checksum.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 221-lookup_checksum.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/221-lookup_checksum.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/221-lookup_checksum.sql.postgresql
@@ -1,0 +1,76 @@
+-- oracle equivalent source sha1 dcd44b89b407b3cc017d4027a235bfcb6fdabb2f
+--
+-- Copyright (c) 2010 - 2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+create or replace function
+lookup_checksum(checksum_type_in in varchar, checksum_in in varchar)
+returns numeric
+as
+$$
+declare
+    checksum_id     numeric;
+begin
+    if checksum_in is null then
+        return null;
+    end if;
+
+    select c.id
+      into checksum_id
+      from rhnChecksumView c
+     where c.checksum = checksum_in and
+           c.checksum_type = checksum_type_in;
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_checksum(checksum_type_in, checksum_in);
+    end if;
+
+    return checksum_id;
+end;
+$$ language plpgsql immutable;
+
+-- NOTE: This is intentionally not thread safe! You must lock rhnChecksum
+-- if you are going to use this procedure!
+create or replace function
+lookup_checksum_fast(checksum_type_in in varchar, checksum_in in varchar)
+returns numeric
+as
+$$
+declare
+    checksum_id     numeric;
+begin
+    if checksum_in is null then
+        return null;
+    end if;
+
+    select c.id
+      into checksum_id
+      from rhnChecksumView c
+     where c.checksum = checksum_in and
+           c.checksum_type = checksum_type_in;
+
+    if not found then
+        checksum_id := nextval('rhnchecksum_seq');
+        insert into rhnChecksum (id, checksum_type_id, checksum) values (
+            checksum_id,
+            (select id from rhnChecksumType where label = checksum_type_in),
+            checksum_in);
+    end if;
+
+    return checksum_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/222-lookup_client_capability.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/222-lookup_client_capability.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 222-lookup_client_capability.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/222-lookup_client_capability.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/222-lookup_client_capability.sql.postgresql
@@ -1,0 +1,37 @@
+-- oracle equivalent source sha1 50cd93ea6be30230db8c8a80276c6d53da0e61c7
+--
+-- Copyright (c) 2008--2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+-- 
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation. 
+
+create or replace function
+lookup_client_capability(name_in in varchar)
+returns numeric
+as $$
+declare
+    cap_name_id     numeric;
+begin
+    select id
+      into cap_name_id
+      from rhnclientcapabilityname
+     where name = name_in;
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_client_capability(name_in);
+    end if;
+
+    return cap_name_id;
+end;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/223-lookup_config_filename.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/223-lookup_config_filename.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 223-lookup_config_filename.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/223-lookup_config_filename.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/223-lookup_config_filename.sql.postgresql
@@ -1,0 +1,37 @@
+-- oracle equivalent source sha1 2a62eaf3854ba63493d587039b6c906af7257e65
+--
+-- Copyright (c) 2008--2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+
+create or replace function
+lookup_config_filename(name_in in varchar)
+returns numeric as
+$$
+declare
+    name_id     numeric;
+begin
+    select id
+      into name_id
+      from rhnconfigfilename
+     where path = name_in;
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_config_filename(name_in);
+    end if;
+
+    return name_id;
+end;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/224-lookup_config_info.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/224-lookup_config_info.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 224-lookup_config_info.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/224-lookup_config_info.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/224-lookup_config_info.sql.postgresql
@@ -1,0 +1,49 @@
+-- oracle equivalent source sha1 5b033033b7eff4183fd9c3398c2027e4923e8ed9
+--
+-- Copyright (c) 2008--2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+create or replace function
+lookup_config_info(
+    username_in     in varchar,
+    groupname_in    in varchar,
+    filemode_in     in numeric,
+    selinux_ctx_in  in varchar,
+    symlink_target_id in numeric
+)
+returns numeric
+as
+$$
+declare
+    config_info_id    numeric;
+begin
+    select id
+      into config_info_id
+      from rhnConfigInfo
+      where (username = username_in or (username is null and username_in is null))
+        and (groupname = groupname_in or (groupname is null and groupname_in is null))
+        and (filemode = filemode_in or (filemode is null and filemode_in is null))
+        and (selinux_ctx = selinux_ctx_in or (selinux_ctx is null and selinux_ctx_in is null))
+        and (symlink_target_filename_id = symlink_target_id or (symlink_target_filename_id is null and symlink_target_id is null));
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_config_info(username_in, groupname_in, filemode_in, selinux_ctx_in, symlink_target_id);
+    end if;
+
+    return config_info_id;
+end;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/225-lookup_cve.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/225-lookup_cve.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 225-lookup_cve.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/225-lookup_cve.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/225-lookup_cve.sql.postgresql
@@ -1,0 +1,37 @@
+-- oracle equivalent source sha1 9f54bbf662b97c8168cc7deb42399e3f4ee17409
+--
+-- Copyright (c) 2008--2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+
+create or replace function
+lookup_cve(name_in in varchar)
+returns numeric
+as $$
+declare
+    name_id     numeric;
+begin
+    select id
+      into name_id
+      from rhnCVE
+     where name = name_in;
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_cve(name_in);
+    end if;
+
+    return name_id;
+end;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/226-lookup_evr.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/226-lookup_evr.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 226-lookup_evr.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/226-lookup_evr.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/226-lookup_evr.sql.postgresql
@@ -1,0 +1,40 @@
+-- oracle equivalent source sha1 fea9bf6e4df0ab1c2654501af40bdb91b39457b3
+--
+-- Copyright (c) 2008--2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+
+create or replace function
+lookup_evr(e_in in varchar, v_in in varchar, r_in in varchar)
+returns numeric
+as
+$$
+declare
+    evr_id  numeric;
+begin
+    select id
+      into evr_id
+      from rhnPackageEVR
+     where ((epoch is null and e_in is null) or (epoch = e_in)) and
+           version = v_in and
+           release = r_in;
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_evr(e_in, v_in, r_in);
+    end if;
+
+    return evr_id;
+end;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/227-lookup_md_keyword.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/227-lookup_md_keyword.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 227-lookup_md_keyword.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/227-lookup_md_keyword.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/227-lookup_md_keyword.sql.postgresql
@@ -1,0 +1,35 @@
+-- oracle equivalent source sha1 6024f71b2e4b2db76b0a26e97be4cd69d4f9a893
+--
+-- Copyright (c) 2012 Novell
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+create or replace function
+lookup_md_keyword(label_in in varchar)
+returns numeric
+as
+$$
+declare
+    md_keyword_id numeric;
+begin
+    select id
+      into md_keyword_id
+      from suseMdKeyword
+     where label = label_in;
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_md_keyword(label_in);
+    end if;
+
+    return md_keyword_id;
+end;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/228-lookup_package_capability.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/228-lookup_package_capability.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 228-lookup_package_capability.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/228-lookup_package_capability.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/228-lookup_package_capability.sql.postgresql
@@ -1,0 +1,80 @@
+-- oracle equivalent source sha1 d3b5c7a74a87caed2bb73e40ad371c19fe8be006
+--
+-- Copyright (c) 2008--2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+-- 
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation. 
+
+create or replace function
+lookup_package_capability(name_in in varchar, version_in in varchar default null)
+returns numeric
+as
+$$
+declare
+    name_id numeric;
+begin
+    if version_in is null then
+        select id
+          into name_id
+          from rhnpackagecapability
+         where name = name_in and
+               version is null;
+    else
+        select id
+          into name_id
+          from rhnpackagecapability
+         where name = name_in and
+               version = version_in;
+    end if;
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_package_capability(name_in, version_in);
+    end if;
+
+    return name_id;
+end;
+$$ language plpgsql immutable;
+
+-- Note: intentionally not thread-safe! You must aquire a write lock on the
+-- rhnPackageCapability tabel if you are going to use this proc!
+create or replace function lookup_package_capability_fast(name_in in varchar, version_in in varchar default null)
+returns numeric
+as
+$$
+declare
+    name_id numeric;
+begin
+    if version_in is null then
+        select id
+          into name_id
+          from rhnpackagecapability
+         where name = name_in and
+               version is null;
+    else
+        select id
+          into name_id
+          from rhnpackagecapability
+         where name = name_in and
+               version = version_in;
+    end if;
+
+    if not found then
+        name_id := nextval('rhn_pkg_capability_id_seq');
+        insert into rhnPackageCapability(id, name, version) values (
+               name_id, name_in, version_in);
+    end if;
+
+    return name_id;
+end;
+$$ language plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/229-lookup_package_delta.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/229-lookup_package_delta.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 229-lookup_package_delta.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/229-lookup_package_delta.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/229-lookup_package_delta.sql.postgresql
@@ -1,0 +1,38 @@
+-- oracle equivalent source sha1 1f09a67a79da1af9216220511923bf7de3dead16
+--
+-- Copyright (c) 2008--2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+-- 
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation. 
+
+create or replace function
+lookup_package_delta(n_in in varchar)
+returns numeric
+as
+$$
+declare
+    name_id     numeric;
+begin
+    select id
+      into name_id
+      from rhnPackageDelta
+     where label = n_in;
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_package_delta(n_in);
+    end if;
+
+    return name_id;
+end;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/230-lookup_package_group.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/230-lookup_package_group.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 230-lookup_package_group.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/230-lookup_package_group.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/230-lookup_package_group.sql.postgresql
@@ -1,0 +1,38 @@
+-- oracle equivalent source sha1 4ff287490d6c14a83b79b3eaf26de735c2edfdb8
+--
+-- Copyright (c) 2008--2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+-- 
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation. 
+
+create or replace function
+lookup_package_group(name_in in varchar)
+returns numeric
+as
+$$
+declare
+    package_id   numeric;
+begin
+    select id
+      into package_id
+      from rhnPackageGroup
+     where name = name_in;
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_package_group(name_in);
+    end if;
+
+    return package_id;
+end;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/231-lookup_package_name.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/231-lookup_package_name.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 231-lookup_package_name.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/231-lookup_package_name.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/231-lookup_package_name.sql.postgresql
@@ -1,0 +1,42 @@
+-- oracle equivalent source sha1 32f647631729b240b2401f0cb428a7c24c531f47
+--
+-- Copyright (c) 2008--2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+-- 
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation. 
+
+create or replace function
+lookup_package_name(name_in in varchar, ignore_null in numeric default 0)
+returns numeric
+as
+$$
+declare
+    name_id     numeric;
+begin
+    if ignore_null = 1 and name_in is null then
+        return null;
+    end if;
+
+    select id
+      into name_id
+      from rhnPackageName
+     where name = name_in;
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_package_name(name_in);
+    end if;
+
+    return name_id;
+end;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/232-lookup_package_nevra.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/232-lookup_package_nevra.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 232-lookup_package_nevra.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/232-lookup_package_nevra.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/232-lookup_package_nevra.sql.postgresql
@@ -1,0 +1,49 @@
+-- oracle equivalent source sha1 7afd7f634f614dd0a9e6f9e972d975f603a84213
+--
+-- Copyright (c) 2008--2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+-- 
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation. 
+
+create or replace function
+lookup_package_nevra(
+        name_id_in in numeric,
+        evr_id_in in numeric,
+        package_arch_id_in in numeric,
+        ignore_null_name in numeric default 0
+) returns numeric
+as
+$$
+declare
+    nevra_id numeric;
+begin
+    if ignore_null_name = 1 and name_id_in is null then
+        return null;
+    end if;
+
+    select id
+      into nevra_id
+      from rhnPackageNEVRA
+     where name_id = name_id_in and
+           evr_id = evr_id_in and
+           (package_arch_id = package_arch_id_in or
+            (package_arch_id is null and package_arch_id_in is null));
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_package_nevra(name_id_in, evr_id_in, package_arch_id_in);
+    end if;
+
+    return nevra_id;
+end;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/233-lookup_source_name.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/233-lookup_source_name.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 233-lookup_source_name.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/233-lookup_source_name.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/233-lookup_source_name.sql.postgresql
@@ -1,0 +1,38 @@
+-- oracle equivalent source sha1 64626f32be1906c8654f489772a6ce4ea8bd50f6
+--
+-- Copyright (c) 2008--2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+-- 
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation. 
+
+create or replace function
+lookup_source_name(name_in in varchar)
+returns numeric
+as
+$$
+declare
+    source_id   numeric;
+begin
+    select id
+      into source_id
+      from rhnSourceRPM
+     where name = name_in;
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_source_name(name_in);
+    end if;
+
+    return source_id;
+end;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/234-lookup_tag.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/234-lookup_tag.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 234-lookup_tag.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/234-lookup_tag.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/234-lookup_tag.sql.postgresql
@@ -1,0 +1,41 @@
+-- oracle equivalent source sha1 87c823807dcd5403d7cf875fc1f6aee0e4f3fc6b
+--
+-- Copyright (c) 2008--2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+-- 
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation. 
+
+create or replace function
+lookup_tag(org_id_in in numeric, name_in in varchar)
+returns numeric
+as $$
+declare
+    tag_id  numeric;
+    tag_name_id numeric;
+begin
+    tag_name_id := lookup_tag_name(name_in);
+
+    select id
+      into tag_id
+      from rhnTag
+     where org_id = org_id_in and
+           name_id = tag_name_id;
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_tag(org_id_in, tag_name_id);
+    end if;
+
+    return tag_id;
+end;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/235-lookup_tag_name.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/235-lookup_tag_name.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 235-lookup_tag_name.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/235-lookup_tag_name.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/235-lookup_tag_name.sql.postgresql
@@ -1,0 +1,38 @@
+-- oracle equivalent source sha1 6e2666f48253a15f40b6003f22359bf334bc1b35
+--
+-- Copyright (c) 2008--2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+-- 
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation. 
+
+create or replace function
+lookup_tag_name(name_in in varchar)
+returns numeric
+as
+$$
+declare
+    name_id numeric;
+begin
+    select id
+      into name_id
+      from rhnTagName
+     where name = name_in;
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_tag_name(name_in);
+    end if;
+
+    return name_id;
+end;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/236-lookup_transaction_package.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/236-lookup_transaction_package.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 236-lookup_transaction_package.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/236-lookup_transaction_package.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/236-lookup_transaction_package.sql.postgresql
@@ -1,0 +1,67 @@
+-- oracle equivalent source sha1 14a86a37406ecfb22852f3d7e268f247a55d6cf7
+--
+-- Copyright (c) 2008--2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+-- 
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation. 
+
+create or replace function
+lookup_transaction_package(
+    o_in in varchar,
+    n_in in varchar,
+    e_in in varchar,
+    v_in in varchar,
+    r_in in varchar,
+    a_in in varchar)
+returns numeric
+as
+$$
+declare
+    o_id        numeric;
+    n_id        numeric;
+    e_id        numeric;
+    p_arch_id   numeric;
+    tp_id       numeric;
+begin
+    select id
+      into o_id
+      from rhnTransactionOperation
+     where label = o_in;
+
+    if not found then
+        perform rhn_exception.raise_exception('invalid_transaction_operation');
+    end if;
+
+    n_id := lookup_package_name(n_in);
+    e_id := lookup_evr(e_in, v_in, r_in);
+    p_arch_id := null;
+
+    if a_in is not null then
+        p_arch_id := lookup_package_arch(a_in);
+    end if;
+
+    select id
+      into tp_id
+      from rhnTransactionPackage
+     where operation = o_id and
+           name_id = n_id and
+           evr_id = e_id and
+           (package_arch_id = p_arch_id or (p_arch_id is null and package_arch_id is null));
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_transaction_package(o_id, n_id, e_id, p_arch_id);
+    end if;
+    return tp_id;
+end;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/237-lookup_xccdf_benchmark.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/237-lookup_xccdf_benchmark.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 237-lookup_xccdf_benchmark.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/237-lookup_xccdf_benchmark.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/237-lookup_xccdf_benchmark.sql.postgresql
@@ -1,0 +1,39 @@
+-- oracle equivalent source sha1 0906e01dd65e2499755bf22cc09ea761d33dfeb8
+--
+-- Copyright (c) 2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+create or replace function
+lookup_xccdf_benchmark(identifier_in in varchar, version_in in varchar)
+returns numeric
+as
+$$
+declare
+    benchmark_id numeric;
+begin
+    select id
+      into benchmark_id
+      from rhnXccdfBenchmark
+     where identifier = identifier_in and version = version_in;
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_xccdf_benchmark(identifier_in, version_in);
+    end if;
+
+    return benchmark_id;
+end;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/238-lookup_xccdf_ident.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/238-lookup_xccdf_ident.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 238-lookup_xccdf_ident.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/238-lookup_xccdf_ident.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/238-lookup_xccdf_ident.sql.postgresql
@@ -1,0 +1,48 @@
+-- oracle equivalent source sha1 716dbf40cfe2e527bb1fbf98a7a514d256cc5a8f
+--
+-- Copyright (c) 2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+
+create or replace function
+lookup_xccdf_ident(system_in in varchar, identifier_in in varchar)
+returns numeric
+as
+$$
+declare
+    xccdf_ident_id numeric;
+    ident_sys_id numeric;
+begin
+    select id
+      into ident_sys_id
+      from rhnXccdfIdentSystem
+     where system = system_in;
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        ident_sys_id := insert_xccdf_ident_system(system_in);
+    end if;
+
+    select id
+      into xccdf_ident_id
+      from rhnXccdfIdent
+     where identsystem_id = ident_sys_id and identifier = identifier_in;
+
+    if not found then
+        return insert_xccdf_ident(ident_sys_id, identifier_in);
+    end if;
+
+    return xccdf_ident_id;
+end;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/239-lookup_xccdf_profile.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/239-lookup_xccdf_profile.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 239-lookup_xccdf_profile.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/239-lookup_xccdf_profile.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.16-to-susemanager-schema-3.2.17/239-lookup_xccdf_profile.sql.postgresql
@@ -1,0 +1,39 @@
+-- oracle equivalent source sha1 cc7718d6336ad3ecce4391540b38e3c2b2630dc0
+--
+-- Copyright (c) 2012 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+create or replace function
+lookup_xccdf_profile(identifier_in in varchar, title_in in varchar)
+returns numeric
+as
+$$
+declare
+    profile_id numeric;
+begin
+    select id
+      into profile_id
+      from rhnXccdfProfile
+     where identifier = identifier_in and title = title_in;
+
+    if not found then
+        -- HACK: insert is isolated in own function in order to be able to declare this function immutable
+        -- Postgres optimizes immutable functions calls but those are compatible with the contract of lookup_\*
+        -- see https://www.postgresql.org/docs/9.6/xfunc-volatility.html
+        return insert_xccdf_profile(identifier_in, title_in);
+    end if;
+
+    return profile_id;
+end;
+$$ language plpgsql immutable;

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.17-to-susemanager-schema-3.2.18/001-add-minion-checkin-tasko-job.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.17-to-susemanager-schema-3.2.18/001-add-minion-checkin-tasko-job.sql
@@ -1,0 +1,44 @@
+-- Copyright (c) 2019 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+INSERT INTO rhnTaskoBunch (id, name, description, org_bunch)
+    SELECT sequence_nextval('rhn_tasko_bunch_id_seq'), 'minion-checkin-bunch', 'Perform a regular check-in on minions', null
+    FROM dual WHERE NOT EXISTS (
+        SELECT 1 FROM rhnTaskoBunch WHERE
+        name='minion-checkin-bunch'
+    );
+
+INSERT INTO rhnTaskoSchedule (id, job_label, bunch_id, active_from, cron_expr)
+    SELECT sequence_nextval('rhn_tasko_schedule_id_seq'), 'minion-checkin-default',
+        (SELECT id FROM rhnTaskoBunch WHERE name='minion-checkin-bunch'),
+        current_timestamp, '0 0 * * * ?'
+    FROM dual WHERE NOT EXISTS (
+        SELECT 1 FROM rhnTaskoSchedule WHERE
+        job_label='minion-checkin-default'
+    );
+
+INSERT INTO rhnTaskoTask (id, name, class)
+    SELECT sequence_nextval('rhn_tasko_task_id_seq'), 'minion-checkin', 'com.redhat.rhn.taskomatic.task.MinionCheckin'
+    FROM dual WHERE NOT EXISTS (
+        SELECT 1 FROM rhnTaskoTask WHERE
+        name='minion-checkin'
+    );
+
+INSERT INTO rhnTaskoTemplate (id, bunch_id, task_id, ordering, start_if)
+    SELECT sequence_nextval('rhn_tasko_template_id_seq'),
+                        (SELECT id FROM rhnTaskoBunch WHERE name='minion-checkin-bunch'),
+                        (SELECT id FROM rhnTaskoTask WHERE name='minion-checkin'),
+                        0,
+                        null
+    FROM dual WHERE NOT EXISTS (
+        SELECT 1 FROM rhnTaskoTemplate WHERE
+        bunch_id=(SELECT id FROM rhnTaskoBunch WHERE name='minion-checkin-bunch') AND
+        task_id=(SELECT id FROM rhnTaskoTask WHERE name='minion-checkin')
+    );

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.17-to-susemanager-schema-3.2.18/002-alter-susesaltevent.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.17-to-susemanager-schema-3.2.18/002-alter-susesaltevent.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to alter-susesaltevent.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.17-to-susemanager-schema-3.2.18/002-alter-susesaltevent.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.17-to-susemanager-schema-3.2.18/002-alter-susesaltevent.sql.postgresql
@@ -1,0 +1,6 @@
+-- oracle equivalent source sha1 81eaaa6f639e70eb12dc131d659536c6ec576644
+
+DROP INDEX IF EXISTS suse_salt_event_minion_id_idx;
+
+CREATE INDEX IF NOT EXISTS suse_salt_event_minion_id_idx
+  ON suseSaltEvent (minion_id NULLS FIRST, id);

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.3-to-susemanager-schema-4.0.4/001-suseSCCRepository.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.3-to-susemanager-schema-4.0.4/001-suseSCCRepository.sql.postgresql
@@ -14,6 +14,8 @@
 -- in this software or its documentation.
 --
 
+delete from susesccrepository;
+
 ALTER TABLE suseSCCRepository
   ALTER COLUMN scc_id SET NOT NULL,
   ALTER COLUMN name SET NOT NULL,


### PR DESCRIPTION
## What does this PR change?

To successfully migrate from 3.2 to 4.0 the customer either need to be on the latest 3.2 schema already or we provide also older 3.2 schema migration scripts in 4.0 package.
To be on the safe side it is better to provide also the older migrations.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **existing tests should cover it**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
