### PR TITLE
Testsuite - HTTP proxy moved to variable

### DIFF
--- a/testsuite/documentation/optional.md
+++ b/testsuite/documentation/optional.md
@@ -308,3 +308,19 @@ Inside of the testsuite, the scenarios that are tagged with
 @pxeboot_minion
 ```
 are executed only if the PXE boot minion is available.
+
+
+## HTTP Proxy setting
+
+If you need to specify HTTP Proxy on SUSE Manager "Setup Wizard" page, you can use 
+variable `http_proxy` from `controller` module in your `main.tf` file with following syntax:
+```
+http_proxy = "hostname:port"
+```
+It is set to `galaxy-proxy.mgr.suse.de:3128` by default.
+
+Sumaform creates `$SUMA_HTTP_PROXY` variable with corresponding settings in `/root/.bashrc` file
+on the controller. It is also possible to tag the scenarios with:
+```
+@http_proxy
+```

--- a/testsuite/features/core_first_settings.feature
+++ b/testsuite/features/core_first_settings.feature
@@ -80,6 +80,7 @@ Feature: Very first settings
     And service "tomcat" is enabled on "server"
     And service "tomcat" is active on "server"
 
+@http_proxy
   Scenario: Setup HTTP proxy
     When I am authorized as "admin" with password "admin"
     And I follow "Admin" in the left menu
@@ -87,7 +88,7 @@ Feature: Very first settings
     Then I should see a "HTTP Proxy Hostname" text
     And I should see a "HTTP Proxy Username" text
     And I should see a "HTTP Proxy Password" text
-    When I enter "galaxy-proxy.mgr.suse.de:3128" as "HTTP Proxy Hostname"
+    When I enter the address of the HTTP proxy as "HTTP Proxy Hostname"
     And I enter "suma" as "HTTP Proxy Username"
     And I enter "P4$$word" as "HTTP Proxy Password"
     And I click on "Save and Verify"

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -475,6 +475,10 @@ Then(/^I see verification succeeded/) do
   find('i.text-success')
 end
 
+When(/^I enter the address of the HTTP proxy as "([^"]*)"/) do |hostname|
+  step %(I enter "#{$http_proxy}" as "#{hostname}")
+end
+
 # configuration management steps
 
 Then(/^I should see a table line with "([^"]*)", "([^"]*)", "([^"]*)"$/) do |arg1, arg2, arg3|

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -127,3 +127,4 @@ $private_net = ENV['PRIVATENET'] if ENV['PRIVATENET']
 $mirror = ENV['MIRROR']
 $git_profiles = ENV['GITPROFILES']
 $product = product
+$http_proxy = ENV['SUMA_HTTP_PROXY'] if ENV['SUMA_HTTP_PROXY']


### PR DESCRIPTION
## What does this PR change?

PR removes hardcoded values for http proxy (`galaxy-proxy.mgr.suse.de:3128`) settings from `core_first_settings.feature` and moves those values to separate variable created by sumaform.

Please **do not merge before** https://github.com/moio/sumaform/pull/528.

## Links

Original issue: https://github.com/SUSE/spacewalk/issues/7726
PR with change of sumaform: https://github.com/moio/sumaform/pull/528

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
