### PR TITLE
Fix NPE when minion_formulas.json is empty (bsc#1122230)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
@@ -454,7 +454,9 @@ public class FormulaFactory {
             serverFormulas = new HashMap<>();
         }
         else {
-            serverFormulas = GSON.fromJson(new BufferedReader(new FileReader(dataFile)), Map.class);
+            serverFormulas = Optional
+                    .ofNullable(GSON.fromJson(new BufferedReader(new FileReader(dataFile)), Map.class))
+                    .orElse(new HashMap());
         }
 
         // Remove formula data for unselected formulas

--- a/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
@@ -185,9 +185,9 @@ public class FormulaFactory {
         catch (FileAlreadyExistsException e) {
         }
 
-        BufferedWriter writer = new BufferedWriter(new FileWriter(file));
-        writer.write(GSON.toJson(formData));
-        writer.close();
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(file))) {
+            writer.write(GSON.toJson(formData));
+        }
     }
 
     /**
@@ -209,9 +209,9 @@ public class FormulaFactory {
         catch (FileAlreadyExistsException e) {
         }
 
-        BufferedWriter writer = new BufferedWriter(new FileWriter(file));
-        writer.write(GSON.toJson(formData));
-        writer.close();
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(file))) {
+            writer.write(GSON.toJson(formData));
+        }
     }
 
     /**
@@ -429,9 +429,9 @@ public class FormulaFactory {
 
         // Save selected Formulas
         groupFormulas.put(groupId.toString(), orderFormulas(selectedFormulas));
-        BufferedWriter writer = new BufferedWriter(new FileWriter(dataFile));
-        writer.write(GSON.toJson(groupFormulas));
-        writer.close();
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(dataFile))) {
+            writer.write(GSON.toJson(groupFormulas));
+        }
     }
 
     /**
@@ -477,9 +477,9 @@ public class FormulaFactory {
         }
 
         // Write server_formulas file
-        BufferedWriter writer = new BufferedWriter(new FileWriter(dataFile));
-        writer.write(GSON.toJson(serverFormulas));
-        writer.close();
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(dataFile))) {
+            writer.write(GSON.toJson(serverFormulas));
+        }
     }
 
     /**

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -1608,7 +1608,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
     public void testSubscribeChannelsActionNullTokens() throws Exception {
         TaskomaticApi taskomaticMock = mock(TaskomaticApi.class);
-        ActionManager.setTaskomaticApi(taskomaticMock);
+        ActionChainManager.setTaskomaticApi(taskomaticMock);
         context().checking(new Expectations() { {
             allowing(taskomaticMock).scheduleSubscribeChannels(with(any(User.class)),
                     with(any(SubscribeChannelsAction.class)));

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix deleting server when minion_formulas.json is empty (bsc#1122230)
 - Handle the different retcodes that are being returned when salt module is not available (bsc#1131704)
 - Improve salt events processing performance (bsc#1125097)
 - Prevent Actions that were actually completed to be displayed as "in progress" forever(bsc#1131780)


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/7020

## GUI diff

No difference.

## Documentation
- No documentation needed: bugfix

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests" 		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
