### PR TITLE
Run "yarn autoclean" before "yarn zip"

### DIFF
--- a/susemanager-frontend/susemanager-nodejs-sdk-devel/setup.sh
+++ b/susemanager-frontend/susemanager-nodejs-sdk-devel/setup.sh
@@ -1,6 +1,6 @@
 set -euxo pipefail
 (cd susemanager-frontend/susemanager-nodejs-sdk-devel; rm -rf node_modules)
 yarn install --frozen-lockfile
-(cd susemanager-frontend/susemanager-nodejs-sdk-devel; yarn zip)
 yarn autoclean --force
+(cd susemanager-frontend/susemanager-nodejs-sdk-devel; yarn zip)
 echo "susemanager-nodejs-modules.tar.gz"


### PR DESCRIPTION
## What does this PR change?

Run "yarn autoclean" before "yarn zip"
## GUI diff

No difference.
- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
