### PR TITLE
Fix check on mgractionchains job when the module is not there

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/JobReturnEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/JobReturnEventMessageAction.java
@@ -120,7 +120,8 @@ public class JobReturnEventMessageAction implements MessageAction {
             // The Salt reactor triggers a "suma-action-chain" job (mgractionchains.resume) at
             // 'minion/startup/event/'. This means the result might not be a JSON in case of
             // a Salt error when the 'mgractionchains' custom module is not yet deployed.
-            if (jobReturnEvent.getData().getRetcode() == 1 && !jobReturnEvent.getData().isSuccess() &&
+            if (Arrays.asList(1, 254).contains(jobReturnEvent.getData().getRetcode()) &&
+                    !jobReturnEvent.getData().isSuccess() &&
                     jobReturnEvent.getData().getResult().toString()
                             .contains("'mgractionchains.resume' is not available")) {
                 return;

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Handle the different retcodes that are being returned when salt module is not available (bsc#1131704)
 - Improve salt events processing performance (bsc#1125097)
 - Prevent Actions that were actually completed to be displayed as "in progress" forever(bsc#1131780)
 - Disable Salt presence ping for synchronous calls


### PR DESCRIPTION
## What does this PR change?
Continuation of this change https://github.com/uyuni-project/uyuni/pull/605.  This PR include the old retcode '254' , when the custom module is not available, in check as well to avoid parse exception.

Salt used to return retcode 254 when a module was not available. It changed recently and now salt returns 1. But in case of some clients(ubuntu in this case) with an older version of salt, it still return 254 so we need to handle that as well.

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **Just a bug fix **

- [ ] **DONE**

## Test coverage
- Unit tests were already there

- [x] **DONE**

## Links

Tracks # **https://github.com/SUSE/spacewalk/pull/7753**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
