### PR TITLE
Revert changelog entry bsc#1107850 removed by mistake

### DIFF
--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -237,6 +237,7 @@ Fri Oct 26 10:29:32 CEST 2018 - jgonzalez@suse.com
 - Fix displayed number of systems requiring reboot in Tasks pane (bsc#1106875)
 - Added link from virtualization tab to Scheduled > Pending Actions (bsc#1037389)
 - Better error handling when a websocket connection is aborted (bsc#1080474)
+- Remove the reference of channel from revision before deleting it(bsc#1107850)
 - Enable auto patch updates for salt clients
 - Fix ACLs for system details settings
 - Method to Unsubscribe channel from system(bsc#1104120)


### PR DESCRIPTION
## What does this PR change?

Revert changelog entry bsc#1107850 removed by mistake

## GUI diff

No difference.
- [ ] **DONE**

## Documentation
- No documentation needed

- [ ] **DONE**

## Test coverage
- No tests

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
