### PR TITLE
Fix build-packages-local-obs.sh check_repo to use the value of $untracked instead and ignore grep exit code

### DIFF
--- a/rel-eng/build-packages-local-obs.sh
+++ b/rel-eng/build-packages-local-obs.sh
@@ -57,14 +57,14 @@ EOF
 # Check if there are uncommitted changes
 #
 check_repo () {
-    filelist=$(git status -s | grep -e '^\sM\s')
+    filelist=$(git status -s | grep -e '^\sM\s' || true)
     is_dirty=""
     if [[ ! -z $filelist ]]; then
 	echo -e "There are following uncommitted changes found:\n\n$filelist\n"
 	is_dirty="1"
     fi
 
-    untracked=$(git status -s | grep -e '^??\s')
+    untracked=$(git status -s | grep -e '^??\s' || true)
     if [[ ! -z $untracked ]]; then
 	echo -e "There are still untracked files found in this repository:\n"
 	echo -e "$(echo "$untracked" | sed -e 's/[? ]*//')\n"

--- a/rel-eng/build-packages-local-obs.sh
+++ b/rel-eng/build-packages-local-obs.sh
@@ -65,7 +65,7 @@ check_repo () {
     fi
 
     untracked=$(git status -s | grep -e '^??\s')
-    if [[ ! -z untracked ]]; then
+    if [[ ! -z $untracked ]]; then
 	echo -e "There are still untracked files found in this repository:\n"
 	echo -e "$(echo "$untracked" | sed -e 's/[? ]*//')\n"
 	is_dirty="1"


### PR DESCRIPTION
## What does this PR change?

Fix build-packages-local-obs.sh check_repo to use the value of $untracked instead and ignore grep exit code

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed.

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
