### PR TITLE
Adjust product tree tag according to the base OS

### DIFF
--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Adjust product tree tag according to the base OS
 - Add a link to the highstate page after formula was saved
 - Fix deleting server when minion_formulas.json is empty (bsc#1122230)
 - Handle the different retcodes that are being returned when salt module is not available (bsc#1131704)

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -685,6 +685,12 @@ install -m 644 conf/default/rhn_taskomatic_daemon.conf $RPM_BUILD_ROOT%{_prefix}
 install -m 644 conf/default/taskomatic.conf $RPM_BUILD_ROOT%{_sysconfdir}/rhn/taskomatic.conf
 install -m 644 conf/default/rhn_org_quartz.conf $RPM_BUILD_ROOT%{_prefix}/share/rhn/config-defaults/rhn_org_quartz.conf
 install -m 644 conf/rhn_java.conf $RPM_BUILD_ROOT%{_prefix}/share/rhn/config-defaults
+# Adjust product tree tag
+%if 0%{?sle_version} && !0%{?is_opensuse}
+sed -i -e 's/^java.product_tree.tag =.*$/java.product_tree.tag = SUMA4.0/' $RPM_BUILD_ROOT%{_prefix}/share/rhn/config-defaults/rhn_java.conf
+%else
+sed -i -e 's/^java.product_tree.tag =.*$/java.product_tree.tag = Uyuni/' $RPM_BUILD_ROOT%{_prefix}/share/rhn/config-defaults/rhn_java.conf
+%endif
 install -m 644 conf/logrotate/rhn_web_api $RPM_BUILD_ROOT%{_sysconfdir}/logrotate.d/rhn_web_api
 install -m 644 conf/logrotate/gatherer $RPM_BUILD_ROOT%{_sysconfdir}/logrotate.d/gatherer
 %if 0%{?fedora} || 0%{?rhel} >= 7 || 0%{?suse_version} >= 1310


### PR DESCRIPTION
## What does this PR change?

Adjust product tree tag according to the base OS at `conf/rhn_java.conf`.

If the base OS is SLE, then set `SUMA4.0`, otherwise `Uyuni`.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: SPEC changed.

- [x] **DONE**

## Test coverage
- No tests: SPEC changed.

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/7713

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
