### PR TITLE
Manager bsc1132343

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -219,6 +219,7 @@ RES6 = [
     "python-six",
     "python-babel",
     "dbus",
+    "dbus-libs",
     "yum-plugin-security",
     "yum-rhn-plugin",
     "yum",

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- add dbus-lib to RES6 bootstrap repo (bsc#1132343)
 - create bootstrap repo for new Red Hat channels (bsc#1133587)
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

The bootstrap repo for RES6 is adding "dbus" which requires a specific version of dbus-libs. This fix ensures this package is available in the bootstrap repo as well else bootstrapping will fail due to unsatisfied dependency.