### PR TITLE
Uyuni fix spacewalk report shebang

### DIFF
--- a/reporting/spacewalk-reports.changes
+++ b/reporting/spacewalk-reports.changes
@@ -1,3 +1,5 @@
+- Fix shebang for spacewalk-reports when built for Python3 (bsc#1132353)
+
 -------------------------------------------------------------------
 Mon Apr 22 12:14:54 CEST 2019 - jgonzalez@suse.com
 

--- a/reporting/spacewalk-reports.spec
+++ b/reporting/spacewalk-reports.spec
@@ -47,6 +47,14 @@ Script based reporting to retrieve data from Spacewalk server in CSV format.
 %build
 /usr/bin/docbook2man *.sgml
 
+# Fixing shebang for Python 3
+%if 0%{?build_py3}
+for i in $(find . -type f);
+do
+    sed -i '1s=^#!/usr/bin/\(python\|env python\)[0-9.]*=#!/usr/bin/python3=' $i;
+done
+%endif
+
 %install
 install -d $RPM_BUILD_ROOT/%{_bindir}
 install -d $RPM_BUILD_ROOT/%{_prefix}/share/spacewalk
@@ -57,14 +65,6 @@ install reports.py $RPM_BUILD_ROOT/%{_prefix}/share/spacewalk
 install -m 644 reports/data/* $RPM_BUILD_ROOT/%{_prefix}/share/spacewalk/reports/data
 install *.8 $RPM_BUILD_ROOT/%{_mandir}/man8
 chmod -x $RPM_BUILD_ROOT/%{_mandir}/man8/spacewalk-report.8*
-
-# Fixing shebang for Python 3
-%if 0%{?build_py3}
-for i in $(find . -type f);
-do
-    sed -i '1s=^#!/usr/bin/\(python\|env python\)[0-9.]*=#!/usr/bin/python3=' $i;
-done
-%endif
 
 %files
 %defattr(-,root,root)


### PR DESCRIPTION
## What does this PR change?

This PR supersedes https://github.com/uyuni-project/uyuni/pull/845.

This fixes an issue on the `spacewalk-reports` spec file that is preventing the shebang to be changed to `python3` when the package is built for Python3.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **not tested**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/7580

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
