### PR TITLE
Testsuite: diff output is correct since Salt 2018.3.1

### DIFF
--- a/testsuite/features/allcli_config_channel.feature
+++ b/testsuite/features/allcli_config_channel.feature
@@ -194,10 +194,6 @@ Feature: Management of configuration of all types of clients in a single channel
     When I wait until event "Show differences between profiled config files and deployed config files scheduled by admin" is completed
     Then I should see a "Differences exist" link
     When I follow "Differences exist"
-    ### WORKAROUND - please uncomment when issue is fixed
-    # bsc#1078764 - CFG-MGMT-SALT: inconsistent UI between traditional clients and Salt minions when comparing files
-    # Then I should see a "-COLOR=white" text
-    # And I should see a "+COLOR=red" text
     Then I should see a "+COLOR=white" text
     And I should see a "-COLOR=red" text
 


### PR DESCRIPTION
Adapts the testsuite now that the following Salt issue is fixed:

https://github.com/saltstack/salt/issues/46931

## What does this PR change?

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **testsuite**

- [x] **DONE**

## Test coverage
- Cucumber tests were adapted

- [x] **DONE**

## Links

Part of downstream https://github.com/SUSE/spacewalk/issues/6267

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

