### PR TITLE
Content Management: Errata filter

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentFilter.java
@@ -263,8 +263,10 @@ public abstract class ContentFilter<T> extends BaseDomainHelper implements Predi
      * Sets the criteria.
      *
      * @param criteriaIn - the criteria
+     * @throws IllegalArgumentException when the matcher-field combination is not allowed
      */
     public void setCriteria(FilterCriteria criteriaIn) {
+        FilterCriteria.validate(getEntityType(), criteriaIn.getMatcher(), criteriaIn.getField());
         criteria = criteriaIn;
     }
 

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProject.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProject.java
@@ -298,14 +298,15 @@ public class ContentProject extends BaseDomainHelper {
     }
 
     /**
-     * Get the {@link PackageFilter}s
+     * Get the active (non-detached) Project Filters
      *
-     * @return the Package filters
+     * @return the active Project Filters
      */
     @Transient
-    public List<PackageFilter> getPackageFilters() {
+    public List<ContentFilter> getActiveFilters() {
         return getProjectFilters().stream()
-                .flatMap(f -> Opt.stream(((ContentFilter<?>) f.getFilter()).asPackageFilter()))
+                .filter(f -> f.getState() != ContentProjectFilter.State.DETACHED)
+                .map(f -> f.getFilter())
                 .collect(Collectors.toList());
     }
 

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ErrataFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ErrataFilter.java
@@ -30,8 +30,26 @@ import javax.persistence.Transient;
 public class ErrataFilter extends ContentFilter<Errata> {
 
     @Override
-    public boolean testInternal(Errata errata) {
-        return false;
+    public boolean testInternal(Errata erratum) {
+        FilterCriteria.Matcher matcher = getCriteria().getMatcher();
+        String field = getCriteria().getField();
+        String value = getCriteria().getValue();
+
+        switch (matcher) {
+            case EQUALS:
+                return getField(erratum, field, String.class).equals(value);
+            default:
+                throw new UnsupportedOperationException("Matcher " + matcher + " not supported");
+        }
+    }
+
+    private static <T> T getField(Errata erratum, String field, Class<T> type) {
+        switch (field) {
+            case "advisory_name":
+                return type.cast(erratum.getAdvisoryName());
+            default:
+                throw new UnsupportedOperationException("Field " + field + " not supported");
+        }
     }
 
     @Override

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
@@ -47,6 +47,7 @@ public class FilterCriteria {
         validCombinations.add(Pair.of(Matcher.CONTAINS, "name"));
         validCombinations.add(Pair.of(Matcher.EQUALS, "nevr"));
         validCombinations.add(Pair.of(Matcher.EQUALS, "nevra"));
+        validCombinations.add(Pair.of(Matcher.EQUALS, "advisory_name"));
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/test/FilterCriteriaTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/test/FilterCriteriaTest.java
@@ -18,6 +18,9 @@ package com.redhat.rhn.domain.contentmgmt.test;
 import com.redhat.rhn.domain.contentmgmt.FilterCriteria;
 import junit.framework.TestCase;
 
+import static com.redhat.rhn.domain.contentmgmt.ContentFilter.EntityType.PACKAGE;
+import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.CONTAINS;
+import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.EQUALS;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.validate;
 
 /**
@@ -26,14 +29,14 @@ import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.validate;
 public class FilterCriteriaTest extends TestCase {
 
     public void testLegalValidation() {
-        validate(FilterCriteria.Matcher.CONTAINS, "name");
-        validate(FilterCriteria.Matcher.EQUALS, "nevr");
-        validate(FilterCriteria.Matcher.EQUALS, "nevra");
+        validate(PACKAGE, CONTAINS, "name");
+        validate(PACKAGE, EQUALS, "nevr");
+        validate(PACKAGE, EQUALS, "nevra");
     }
 
     public void testIllegalValidation() {
         try {
-            validate(FilterCriteria.Matcher.CONTAINS, "nonsense");
+            validate(PACKAGE, CONTAINS, "nonsense");
             fail("An exception should have been thrown");
         }
         catch (IllegalArgumentException e) {
@@ -41,7 +44,7 @@ public class FilterCriteriaTest extends TestCase {
         }
 
         try {
-            validate(FilterCriteria.Matcher.EQUALS, "foo");
+            validate(PACKAGE, EQUALS, "foo");
             fail("An exception should have been thrown");
         }
         catch (IllegalArgumentException e) {

--- a/java/code/src/com/redhat/rhn/frontend/events/AlignSoftwareTargetAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/AlignSoftwareTargetAction.java
@@ -79,7 +79,7 @@ public class AlignSoftwareTargetAction implements MessageAction {
     public Consumer<Exception> getExceptionHandler() {
         return (e) -> {
             if (e instanceof AlignSoftwareTargetException) {
-                LOG.error("Error aligning channel", e);
+                LOG.error("Error aligning target " + ((AlignSoftwareTargetException) e).getTarget(), e);
                 AlignSoftwareTargetException exc = ((AlignSoftwareTargetException) e);
                 exc.getTarget().setStatus(Status.FAILED);
                 ContentProjectFactory.save(exc.getTarget());

--- a/java/code/src/com/redhat/rhn/frontend/events/AlignSoftwareTargetAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/AlignSoftwareTargetAction.java
@@ -51,6 +51,7 @@ public class AlignSoftwareTargetAction implements MessageAction {
                 .lookupSwEnvironmentTargetById(targetId)
                 .orElseThrow(() -> new EntityNotExistsException(targetId));
         Channel targetChannel = target.getChannel();
+        List<ContentFilter> filters = msg.getFilters();
 
         try {
             if (!UserManager.verifyChannelAdmin(msg.getUser(), targetChannel)) {
@@ -60,8 +61,6 @@ public class AlignSoftwareTargetAction implements MessageAction {
 
             LOG.info("Asynchronously aligning: " + msg);
             Instant start = Instant.now();
-            // todo explicit passing of the filters!
-            List<ContentFilter> filters = target.getContentEnvironment().getContentProject().getActiveFilters();
             ChannelManager.alignEnvironmentTargetSync(filters, sourceChannel, targetChannel, msg.getUser());
             target.setStatus(Status.GENERATING_REPODATA);
             LOG.info("Finished aligning " + msg + " in " + Duration.between(start, Instant.now()));

--- a/java/code/src/com/redhat/rhn/frontend/events/AlignSoftwareTargetMsg.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/AlignSoftwareTargetMsg.java
@@ -18,10 +18,13 @@ package com.redhat.rhn.frontend.events;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.messaging.EventDatabaseMessage;
 import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.contentmgmt.ContentFilter;
 import com.redhat.rhn.domain.contentmgmt.SoftwareEnvironmentTarget;
 import com.redhat.rhn.domain.user.User;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.hibernate.Transaction;
+
+import java.util.List;
 
 /**
  * Message bearing data for {@link AlignSoftwareTargetAction}
@@ -30,6 +33,7 @@ public class AlignSoftwareTargetMsg implements EventDatabaseMessage {
 
     private final Channel source;
     private final SoftwareEnvironmentTarget target;
+    private final List<ContentFilter> filters;
     private final User user;
     private final Transaction txn;
 
@@ -37,11 +41,14 @@ public class AlignSoftwareTargetMsg implements EventDatabaseMessage {
      * Standard constructor
      * @param src the source Channel
      * @param tgt the {@link SoftwareEnvironmentTarget} in which the source channel will be aligned
+     * @param filtersIn the {@link ContentFilter}s
      * @param userIn the User
      */
-    public AlignSoftwareTargetMsg(Channel src, SoftwareEnvironmentTarget tgt, User userIn) {
+    public AlignSoftwareTargetMsg(Channel src, SoftwareEnvironmentTarget tgt, List<ContentFilter> filtersIn,
+            User userIn) {
         this.source = src;
         this.target = tgt;
+        this.filters = filtersIn;
         this.user = userIn;
         this.txn = HibernateFactory.getSession().getTransaction();
     }
@@ -62,6 +69,15 @@ public class AlignSoftwareTargetMsg implements EventDatabaseMessage {
      */
     public SoftwareEnvironmentTarget getTarget() {
         return target;
+    }
+
+    /**
+     * Gets the filters.
+     *
+     * @return filters
+     */
+    public List<ContentFilter> getFilters() {
+        return filters;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
@@ -2760,15 +2760,17 @@ public class ChannelManager extends BaseManager {
      *
      * @param src the source {@link Channel}
      * @param tgt the target {@link SoftwareEnvironmentTarget}
+     * @param filters the {@link ContentFilter}s
      * @param async run this operation asynchronously?
      * @param user the user
      */
-    public static void alignEnvironmentTarget(Channel src, SoftwareEnvironmentTarget tgt, boolean async, User user) {
+    public static void alignEnvironmentTarget(Channel src, SoftwareEnvironmentTarget tgt, List<ContentFilter> filters,
+            boolean async, User user) {
         // adjust the target status
         tgt.setStatus(EnvironmentTarget.Status.BUILDING);
         ContentProjectFactory.save(tgt);
 
-        AlignSoftwareTargetMsg msg = new AlignSoftwareTargetMsg(src, tgt, user);
+        AlignSoftwareTargetMsg msg = new AlignSoftwareTargetMsg(src, tgt, filters, user);
         if (async) {
             MessageQueue.publish(msg);
         }

--- a/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
@@ -2790,8 +2790,7 @@ public class ChannelManager extends BaseManager {
         alignPackages(src, tgt, filters);
 
         // align errata and the cache (rhnServerNeededCache)
-        ErrataManager.mergeErrataToChannel(user, src.getErratas(), tgt, src, false, false);
-        ErrataManager.truncateErrata(src, tgt, user);
+        alignErrata(src, tgt, user);
 
         // update the channel newest packages cache
         ChannelFactory.refreshNewestPackageCache(tgt, "java::alignPackages");
@@ -2819,6 +2818,11 @@ public class ChannelManager extends BaseManager {
         // add cache entries for new ones
         ErrataCacheManager.insertCacheForChannelPackages(tgtChannel.getId(), null,
                 extractPackageIds(filterPackages(onlyInSrc, filters)));
+    }
+
+    private static void alignErrata(Channel src, Channel tgt, User user) {
+        ErrataManager.mergeErrataToChannel(user, src.getErratas(), tgt, src, false, false);
+        ErrataManager.truncateErrata(src, tgt, user);
     }
 
     private static List<Long> extractPackageIds(Collection<Package> packages) {

--- a/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
@@ -2836,10 +2836,10 @@ public class ChannelManager extends BaseManager {
      *
      * Alignment has 4 steps:
      * 1. Compute included and excluded errata based on given source channel and {@link ErrataFilter}s
-     * 2. Merge the included errata to target channel
-     * 3. Remove (truncate) those errata in target channel, which are not in included errata (or which do not have
+     * 2. Remove (truncate) those errata in target channel, which are not in included errata (or which do not have
      * original in the included errata)
-     * 4. Remove the {@link Package}s from excluded errata from target channel
+     * 3. Remove the {@link Package}s from excluded errata from target channel
+     * 4. Merge the included errata to target channel
      *
      * @param src the source {@link Channel}
      * @param tgt the target {@link Channel}
@@ -2857,11 +2857,12 @@ public class ChannelManager extends BaseManager {
         Set<Errata> includedErrata = new HashSet<>(partitionedErrata.get(true));
         List<Errata> excludedErrata = partitionedErrata.get(false);
 
-        ErrataManager.mergeErrataToChannel(user, includedErrata, tgt, src, false, false);
+        // Truncate extra errata in target channel
         ErrataManager.truncateErrata(includedErrata, tgt, user);
-
-        // we want to remove packages of excluded errata
+        // Remove packages from excluded errata
         excludedErrata.forEach(e -> ErrataManager.removeErratumAndPackagesFromChannel(e, tgt, user));
+        // Merge the included errata
+        ErrataManager.mergeErrataToChannel(user, includedErrata, tgt, src, false, false);
     }
 
     private static List<Long> extractPackageIds(Collection<Package> packages) {

--- a/java/code/src/com/redhat/rhn/manager/channel/test/ChannelManagerContentAlignmentTest.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/test/ChannelManagerContentAlignmentTest.java
@@ -225,8 +225,7 @@ public class ChannelManagerContentAlignmentTest extends BaseTestCaseWithUser {
      * Test filtering out errata after channel alignment
      */
     public void testErrataFilters() {
-        Errata erratum = srcChannel.getErratas().iterator().next();
-        FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.EQUALS, "advisory_name", erratum.getAdvisoryName());
+        FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.EQUALS, "advisory_name", errata.getAdvisoryName());
         ContentFilter filter = ContentManager.createFilter("test-filter-123", DENY, ERRATUM, criteria, user);
 
         ChannelManager.alignEnvironmentTargetSync(singleton(filter), srcChannel, tgtChannel, user);

--- a/java/code/src/com/redhat/rhn/manager/channel/test/ChannelManagerContentAlignmentTest.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/test/ChannelManagerContentAlignmentTest.java
@@ -19,6 +19,8 @@ import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.ChannelFactory;
 import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
+import com.redhat.rhn.domain.contentmgmt.ContentFilter;
+import com.redhat.rhn.domain.contentmgmt.FilterCriteria;
 import com.redhat.rhn.domain.errata.Errata;
 import com.redhat.rhn.domain.errata.test.ErrataFactoryTest;
 import com.redhat.rhn.domain.rhnpackage.Package;
@@ -30,17 +32,22 @@ import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.test.ServerFactoryTest;
 import com.redhat.rhn.frontend.dto.SystemOverview;
 import com.redhat.rhn.manager.channel.ChannelManager;
+import com.redhat.rhn.manager.contentmgmt.ContentManager;
 import com.redhat.rhn.manager.errata.cache.ErrataCacheManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.ChannelTestUtils;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import static com.redhat.rhn.domain.contentmgmt.ContentFilter.EntityType.ERRATUM;
+import static com.redhat.rhn.domain.contentmgmt.ContentFilter.Rule.DENY;
 import static com.redhat.rhn.domain.role.RoleFactory.ORG_ADMIN;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.singleton;
 import static java.util.Optional.of;
 import static java.util.stream.Collectors.toSet;
 
@@ -211,6 +218,68 @@ public class ChannelManagerContentAlignmentTest extends BaseTestCaseWithUser {
         assertEquals(srcChannel.getPackages(), tgtChannel.getPackages());
         assertContains(errata.getChannels(), srcChannel);
         assertContains(errata.getChannels(), tgtChannel);
+    }
+
+    /**
+     * Test filtering out errata after channel alignment
+     */
+    public void testErrataFilters() {
+        Errata erratum = srcChannel.getErratas().iterator().next();
+        FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.EQUALS, "advisory_name", erratum.getAdvisoryName());
+        ContentFilter filter = ContentManager.createFilter("test-filter-123", DENY, ERRATUM, criteria, user);
+
+        ChannelManager.alignEnvironmentTargetSync(singleton(filter), srcChannel, tgtChannel, user);
+
+        assertTrue(tgtChannel.getErratas().isEmpty());
+    }
+
+    /**
+     * Test complex scenario of aligning errata (e1 - e6) when filters are involved
+     *
+     * CHANNEL-ERRATUM MAPPING:
+     * Only in src channel: e1 (passes the filter), e2 (does not pass the filter)
+     * Only in tgt channel: e3, e4
+     * In both channels: e5 (passes the filter), e6 (does not pass the filter)
+     *
+     * After aligning, the target channel should only contain errata that are in source and that passed the filters.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testErrataFiltersComplex() throws Exception {
+        Channel srcChan = ChannelFactoryTest.createTestChannel(user, false);
+        Channel tgtChan = ChannelFactoryTest.createTestChannel(user, false);
+
+        Errata e1 = ErrataFactoryTest.createTestPublishedErrata(user.getOrg().getId());
+        Errata e2 = ErrataFactoryTest.createTestPublishedErrata(user.getOrg().getId());
+        Errata e3 = ErrataFactoryTest.createTestPublishedErrata(user.getOrg().getId());
+        Errata e4 = ErrataFactoryTest.createTestPublishedErrata(user.getOrg().getId());
+        Errata e5 = ErrataFactoryTest.createTestPublishedErrata(user.getOrg().getId());
+        Errata e6 = ErrataFactoryTest.createTestPublishedErrata(user.getOrg().getId());
+
+        // src
+        srcChan.addErrata(e1);
+        srcChan.addErrata(e2);
+        // tgt
+        tgtChan.addErrata(e3);
+        tgtChan.addErrata(e4);
+        // both
+        srcChan.addErrata(e5);
+        srcChan.addErrata(e6);
+        tgtChan.addErrata(e5);
+        tgtChan.addErrata(e6);
+
+        FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.EQUALS, "advisory_name", e2.getAdvisoryName());
+        ContentFilter filter = ContentManager.createFilter("test-filter-1234", DENY, ERRATUM, criteria, user);
+
+        FilterCriteria criteria2 = new FilterCriteria(FilterCriteria.Matcher.EQUALS, "advisory_name", e6.getAdvisoryName());
+        ContentFilter filter2 = ContentManager.createFilter("test-filter-1235", DENY, ERRATUM, criteria2, user);
+
+        ChannelManager.alignEnvironmentTargetSync(Arrays.asList(filter, filter2), srcChan, tgtChan, user);
+
+        assertEquals(2, tgtChan.getErrataCount());
+        tgtChan = (Channel) HibernateFactory.reload(tgtChan);
+        assertContains(tgtChan.getErratas(), e1);
+        assertContains(tgtChan.getErratas(), e5);
     }
 
     private static InstalledPackage copyPackage(Package otherPkg, Optional<String> overrideVersion) {

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -496,7 +496,7 @@ public class ContentManager {
             throw new IllegalStateException("Environment " + envLabel + " must have exactly one leader channel");
         }
 
-        alignEnvironment(nextEnv, baseChannels.get(0), childChannels.stream(), async, user);
+        alignEnvironment(nextEnv, baseChannels.get(0), childChannels.stream(), emptyList(), async, user);
 
         nextEnv.setVersion(env.getVersion());
     }
@@ -543,7 +543,7 @@ public class ContentManager {
                 .filter(src -> !src.getChannel().equals(leader) && src.getState() != DETACHED)
                 .map(s -> s.getChannel());
 
-        alignEnvironment(firstEnv, leader, otherChannels, async, user);
+        alignEnvironment(firstEnv, leader, otherChannels, project.getActiveFilters(), async, user);
 
         Map<ProjectSource.State, List<ProjectSource>> sourcesToHandle = project.getSources().stream()
                 .collect(groupingBy(src -> src.getState()));
@@ -581,11 +581,12 @@ public class ContentManager {
      * @param env the Environment
      * @param baseChannel the base Channel
      * @param childChannels the child Channels
+     * @param filters the {@link ContentFilter}s
      * @param async run the time-expensive operations asynchronously?
      * @param user the user
      */
     private static void alignEnvironment(ContentEnvironment env, Channel baseChannel, Stream<Channel> childChannels,
-            boolean async, User user) {
+            List<ContentFilter> filters, boolean async, User user) {
         // ensure targets for the sources exist
         List<Pair<Channel, SoftwareEnvironmentTarget>> newSrcTgtPairs =
                 cloneChannelsToEnv(env, baseChannel, childChannels, user);
@@ -602,7 +603,7 @@ public class ContentManager {
 
         // align the contents
         newSrcTgtPairs.forEach(srcTgt -> ChannelManager.
-                alignEnvironmentTarget(srcTgt.getLeft(), srcTgt.getRight(), async, user));
+                alignEnvironmentTarget(srcTgt.getLeft(), srcTgt.getRight(), filters, async, user));
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -326,7 +326,7 @@ public class ErrataManager extends BaseManager {
         tgtErrata.stream()
                 .filter(e -> !(srcErrata.contains(e) ||
                         asCloned(e).map(er -> srcErrata.contains(er.getOriginal())).orElse(false)))
-                .forEach(e -> removeErratumFromChannel(e, tgtChannel, user));
+                .forEach(e -> removeErratumAndPackagesFromChannel(e, tgtChannel, user));
     }
 
     private static Optional<ClonedErrata> asCloned(Errata e) {
@@ -1454,7 +1454,7 @@ public class ErrataManager extends BaseManager {
 
 
     /**
-     * remove an erratum for a channel and updates the errata cache accordingly
+     * remove an erratum from a channel and updates the errata cache accordingly
      * @param errata the errata to remove
      * @param chan the channel to remove the erratum from
      * @param user the user doing the removing
@@ -1500,6 +1500,30 @@ public class ErrataManager extends BaseManager {
                 ErrataCacheManager.insertCacheForChannelErrataAsync(tmpCidList, errata);
             }
         }
+    }
+
+    /**
+     * Remove an erratum and its packages from a channel and updates the errata cache accordingly.
+     * The errata is not removed from child channels if they exist!
+     *
+     * @param errata the errata to remove
+     * @param chan the channel to remove the erratum from
+     * @param user the user doing the removing
+     */
+    public static void removeErratumAndPackagesFromChannel(Errata errata, Channel chan, User user) {
+        if (!user.hasRole(RoleFactory.CHANNEL_ADMIN)) {
+            throw new PermissionException(RoleFactory.CHANNEL_ADMIN);
+        }
+
+        //Remove the errata from the channel
+        chan.getErratas().remove(errata);
+        List<Long> eList = new ArrayList<Long>();
+        eList.add(errata.getId());
+        //First delete the cache entries
+        ErrataCacheManager.deleteCacheEntriesForChannelErrata(chan.getId(), eList);
+
+        // remove packages
+        ChannelManager.removePackages(chan, errata.getPackages().stream().map(p -> p.getId()).collect(toList()), user);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -1523,7 +1523,7 @@ public class ErrataManager extends BaseManager {
         ErrataCacheManager.deleteCacheEntriesForChannelErrata(chan.getId(), eList);
 
         // remove packages
-        ChannelManager.removePackages(chan, errata.getPackages().stream().map(p -> p.getId()).collect(toList()), user);
+        errata.getPackages().stream().forEach(p -> chan.getPackages().remove(p));
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -312,15 +312,14 @@ public class ErrataManager extends BaseManager {
     }
 
     /**
-     * Removes cloned errata from target channel that are not in the source channel
-     * or that do not have original in the source channel.
+     * Removes cloned errata from target channel that are not in the source errata
+     * or that do not have original in the source errata.
      *
-     * @param srcChannel the source channel
+     * @param srcErrata the source errata
      * @param tgtChannel the target channel
      * @param user the user
      */
-    public static void truncateErrata(Channel srcChannel, Channel tgtChannel, User user) {
-        Set<Errata> srcErrata = new HashSet<>(ErrataFactory.listByChannel(user.getOrg(), srcChannel));
+    public static void truncateErrata(Set<Errata> srcErrata, Channel tgtChannel, User user) {
         Set<Errata> tgtErrata = new HashSet<>(ErrataFactory.listByChannel(user.getOrg(), tgtChannel));
 
         // let's remove errata that aren't in the source errata nor is their original

--- a/java/code/src/com/redhat/rhn/manager/errata/test/ErrataManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/test/ErrataManagerTest.java
@@ -1659,7 +1659,7 @@ public class ErrataManagerTest extends JMockBaseTestCaseWithUser {
      *
      * @throws Exception if anything goes wrong
      */
-    public void testPackagesRemovedOnErratumRemoval() throws Exception {
+    public void testPackagesOnTruncateErrata() throws Exception {
         user.addPermanentRole(ORG_ADMIN);
         Errata errata = ErrataFactoryTest.createTestErrata(user.getOrg().getId());
         TestUtils.saveAndFlush(errata);

--- a/java/code/src/com/redhat/rhn/manager/errata/test/ErrataManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/test/ErrataManagerTest.java
@@ -1617,13 +1617,13 @@ public class ErrataManagerTest extends JMockBaseTestCaseWithUser {
         ErrataFactory.publishToChannel(Arrays.asList(errata1), src, user, false);
         ErrataFactory.publishToChannel(Arrays.asList(errata1, errata2), tgt, user, false);
 
-        ErrataManager.truncateErrata(src, tgt, user);
+        ErrataManager.truncateErrata(src.getErratas(), tgt, user);
 
         assertEquals(src.getErratas(), tgt.getErratas());
     }
 
     /**
-     * Tests truncating errata - simple case (overlap of erratum and its clone in channels)
+     * Tests truncating errata - overlap of erratum and its clone in channels
      *
      * @throws Exception if anything goes wrong
      */
@@ -1643,7 +1643,7 @@ public class ErrataManagerTest extends JMockBaseTestCaseWithUser {
         ErrataFactory.publishToChannel(Arrays.asList(errata1), src, user, false);
         ErrataFactory.publishToChannel(Arrays.asList(errata1Clone, errataInTgt), tgt, user, false);
 
-        ErrataManager.truncateErrata(src, tgt, user);
+        ErrataManager.truncateErrata(src.getErratas(), tgt, user);
 
         assertEquals(1, tgt.getErratas().size());
         // the clone will "survive" in the tgt channel as it has original in the src

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Implement Errata filtering based on advisory name in Content Lifecycle Management
 - UI to enable / disable server monitoring
 - Add monitoring entitlement
 - Log remote commands executed via Salt -> Remote Commands UI to


### PR DESCRIPTION
## What does this PR change?

- Added errata filter by "advisory name" (e.g. `CL-SUSE-15-2019-1022`)
- Take errata filters into account when building Content Project
- Tests
- Bugfix: pass filters explicitly in the asynchronous action (see the commit msg)
- Improved validation of filter criteria (based on entity type, e.g. some `matcher-field` combination make only sense for `Package`, some for `Errata` (`advisory_name`, for instance)).

Review **commit-by-commit**, please. Pay attention to the latest bugfix (I didn't squash it because I wanted to make it more explicit-  we can squash before merging).
 
 ## GUI diff
 
 No difference.
 
  - [x] **DONE**
 
 ## Documentation
 - No documentation needed: **add explanation. This can't be used if there is a GUI diff**
 - [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)
 
 - [ ] **DONE**
 
 ## Test coverage
 - Unit tests were added
 
 - [x] **DONE**
 
 ## Links
 
 Tracks https://github.com/SUSE/spacewalk/issues/7705
 
 - [x] **DONE**
 
 ## Changelogs
 
 If you don't need a changelog check, please mark this checkbox:
 
 - [ ] No changelog needed
 
 If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
 
 
 ## Re-run a test
 
 If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:
 
 - [ ] Re-run test "changelog_test"
 - [ ] Re-run test "backend_unittests_pgsql"
 - [ ] Re-run test "java_lint_checkstyle"		 
 - [ ] Re-run test "java_pgsql_tests"		 
 - [ ] Re-run test "ruby_rubocop"
 - [ ] Re-run test "schema_migration_test_oracle"
 - [ ] Re-run test "schema_migration_test_pgsql"		 
 - [ ] Re-run test "susemanager_unittests"
 - [ ] Re-run test "javascript_lint" (Test skipped, there are no changes to test)