### PR TITLE
Testsuite: add separate definitions for menu steps

### DIFF
--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -99,10 +99,10 @@ To check for the initial log in, prefer ```Then I am logged in```.
 
 #### Navigating through pages
 
-* Go to a given page through a link
+* Go to a given page through a the left menu tree with the complete menu path
 
 ```cucumber
-  When I follow "Salt"
+  When I follow the left menu "Systems > System List > System Currency"
 ```
 
 * Go to Admin => Setup Wizard

--- a/testsuite/features/allcli_config_channel.feature
+++ b/testsuite/features/allcli_config_channel.feature
@@ -5,9 +5,7 @@ Feature: Management of configuration of all types of clients in a single channel
 
   Scenario: Create a configuration channel for mixed client types
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "Create Config Channel"
     And I enter "Mixed Channel" as "cofName"
     And I enter "mixedchannel" as "cofLabel"
@@ -17,9 +15,7 @@ Feature: Management of configuration of all types of clients in a single channel
 
   Scenario: Add a configuration file to the mixed configuration channel
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "Mixed Channel"
     And I follow "Create Configuration File or Directory"
     And I enter "/etc/s-mgr/config" as "cffPath"
@@ -84,10 +80,8 @@ Feature: Management of configuration of all types of clients in a single channel
 
   Scenario: Deploy the file to all systems
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I run "rhn-actions-control --enable-all" on "sle-client"
-    And I follow "Channels" in the left menu
+    When I run "rhn-actions-control --enable-all" on "sle-client"
+    And I follow the left menu "Configuration > Channels"
     And I follow "Mixed Channel"
     And I follow "Deploy all configuration files to all subscribed systems"
     Then I should see a "/etc/s-mgr/config" link
@@ -146,9 +140,7 @@ Feature: Management of configuration of all types of clients in a single channel
 @centos_minion
   Scenario: Unsubscribe CentOS minion and delete configuration files
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "Mixed Channel"
     And I follow "Systems" in the content area
     And I check the "ceos-minion" client
@@ -159,9 +151,7 @@ Feature: Management of configuration of all types of clients in a single channel
 @ubuntu_minion
   Scenario: Unsubscribe Ubuntu minion and delete configuration files
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "Mixed Channel"
     And I follow "Systems" in the content area
     And I check the "ubuntu-minion" client
@@ -172,9 +162,7 @@ Feature: Management of configuration of all types of clients in a single channel
 @ssh_minion
   Scenario: Unsubscribe SSH minion and delete configuration files
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "Mixed Channel"
     And I follow "Systems" in the content area
     And I check the "ssh-minion" client
@@ -243,9 +231,7 @@ Feature: Management of configuration of all types of clients in a single channel
 
   Scenario: Cleanup: remove remaining systems from configuration channel
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "Mixed Channel"
     And I follow "Systems" in the content area
     And I check the "sle-client" client
@@ -255,9 +241,7 @@ Feature: Management of configuration of all types of clients in a single channel
 
   Scenario: Cleanup: remove the mixed configuration channel
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "Mixed Channel"
     And I follow "Delete Channel"
     And I click on "Delete Config Channel"

--- a/testsuite/features/core_first_settings.feature
+++ b/testsuite/features/core_first_settings.feature
@@ -23,9 +23,7 @@ Feature: Very first settings
 
   Scenario: Create testing username
     Given I am authorized as "admin" with password "admin"
-    When I follow "Users" in the left menu
-    And I follow "User List" in the left menu
-    And I follow "Active" in the left menu
+    When I follow the left menu "Users > User List > Active"
     And I follow "Create User"
     And I enter "testing" as "login"
     And I enter "testing" as "desiredpassword"
@@ -40,9 +38,7 @@ Feature: Very first settings
 
   Scenario: Grant testing user administrative priviledges
     Given I am authorized as "admin" with password "admin"
-    When I follow "Users" in the left menu
-    And I follow "User List" in the left menu
-    And I follow "Active" in the left menu
+    When I follow the left menu "Users > User List > Active"
     And I follow "testing"
     And I check "role_org_admin"
     And I check "role_system_group_admin"
@@ -83,8 +79,7 @@ Feature: Very first settings
 @http_proxy
   Scenario: Setup HTTP proxy
     When I am authorized as "admin" with password "admin"
-    And I follow "Admin" in the left menu
-    And I follow "Setup Wizard" in the left menu
+    When I follow the left menu "Admin > Setup Wizard"
     Then I should see a "HTTP Proxy Hostname" text
     And I should see a "HTTP Proxy Username" text
     And I should see a "HTTP Proxy Password" text

--- a/testsuite/features/core_srv_channels_add.feature
+++ b/testsuite/features/core_srv_channels_add.feature
@@ -8,12 +8,9 @@ Feature: Adding channels
 
   Background:
     Given I am authorized as "admin" with password "admin"
-    And I follow "Home" in the left menu
 
   Scenario: Add a base channel
-    When I follow "Software"
-    And I follow "Manage" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Software > Manage > Channels"
     And I follow "Create Channel"
     And I enter "Test Base Channel" as "Channel Name"
     And I enter "test_base_channel" as "Channel Label"
@@ -25,9 +22,7 @@ Feature: Adding channels
     Then I should see a "Channel Test Base Channel created." text
 
   Scenario: Add a child channel
-    When I follow "Software"
-    And I follow "Manage" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Software > Manage > Channels"
     And I follow "Create Channel"
     When I enter "Test Child Channel" as "Channel Name"
     And I enter "test_child_channel" as "Channel Label"
@@ -39,9 +34,7 @@ Feature: Adding channels
     Then I should see a "Channel Test Child Channel created." text
 
   Scenario: Add a base test channel for i586
-    When I follow "Software"
-    And I follow "Manage" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Software > Manage > Channels"
     And I follow "Create Channel"
     And I enter "Test-Channel-i586" as "Channel Name"
     And I enter "test-channel-i586" as "Channel Label"
@@ -53,9 +46,7 @@ Feature: Adding channels
     Then I should see a "Channel Test-Channel-i586 created." text
 
   Scenario: Add a child channel to the i586 test channel
-    When I follow "Software"
-    And I follow "Manage" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Software > Manage > Channels"
     And I follow "Create Channel"
     And I enter "Test-Channel-i586 Child Channel" as "Channel Name"
     And I enter "test-channel-i586-child-channel" as "Channel Label"
@@ -67,9 +58,7 @@ Feature: Adding channels
     Then I should see a "Channel Test-Channel-i586 Child Channel created." text
 
   Scenario: Add a test base channel for x86_64
-    When I follow "Software"
-    And I follow "Manage" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Software > Manage > Channels"
     And I follow "Create Channel"
     And I enter "Test-Channel-x86_64" as "Channel Name"
     And I enter "test-channel-x86_64" as "Channel Label"
@@ -81,9 +70,7 @@ Feature: Adding channels
     Then I should see a "Channel Test-Channel-x86_64 created." text
 
   Scenario: Add a child channel to the x86_64 test channel
-    When I follow "Software"
-    And I follow "Manage" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Software > Manage > Channels"
     And I follow "Create Channel"
     And I enter "Test-Channel-x86_64 Child Channel" as "Channel Name"
     And I enter "test-channel-x86_64-child-channel" as "Channel Label"
@@ -95,9 +82,7 @@ Feature: Adding channels
     Then I should see a "Channel Test-Channel-x86_64 Child Channel created." text
 
   Scenario: Add Fedora x86_64 base channel
-    When I follow "Software"
-    And I follow "Manage" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Software > Manage > Channels"
     And I follow "Create Channel"
     And I enter "Fedora x86_64 Channel" as "Channel Name"
     And I enter "fedora-x86_64-channel" as "Channel Label"
@@ -109,9 +94,7 @@ Feature: Adding channels
     Then I should see a "Channel Fedora x86_64 Channel created." text
 
   Scenario: Add Ubuntu AMD64 base channel
-    When I follow "Software"
-    And I follow "Manage" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Software > Manage > Channels"
     And I follow "Create Channel"
     And I enter "Test-Channel-Deb-AMD64" as "Channel Name"
     And I enter "test-channel-deb-amd64" as "Channel Label"
@@ -123,9 +106,7 @@ Feature: Adding channels
     Then I should see a "Channel Test-Channel-Deb-AMD64 created." text
 
   Scenario: Fail when trying to add a duplicate channel
-     When I follow "Software"
-     And I follow "Manage" in the left menu
-     And I follow "Channels" in the left menu
+     When I follow the left menu "Software > Manage > Channels"
      And I follow "Create Channel"
      And I enter "Test Base Channel" as "Channel Name"
      And I enter "test_base_channel" as "Channel Label"
@@ -137,9 +118,7 @@ Feature: Adding channels
      Then I should see a "The channel name 'Test Base Channel' is already in use, please enter a different name" text
 
   Scenario: Fail when trying to use invalid characters in the channel label
-      When I follow "Software"
-      And I follow "Manage" in the left menu
-      And I follow "Channels" in the left menu
+      When I follow the left menu "Software > Manage > Channels"
       And I follow "Create Channel"
       And I enter "test123" as "Channel Name"
       And I enter "tesT123" as "Channel Label"
@@ -148,9 +127,7 @@ Feature: Adding channels
       Then I should see a "Invalid channel label, please see the format described below" text
 
   Scenario: Fail when trying to use invalid characters in the channel name
-      When I follow "Software"
-      And I follow "Manage" in the left menu
-      And I follow "Channels" in the left menu
+      When I follow the left menu "Software > Manage > Channels"
       And I follow "Create Channel"
       And I enter "!test123" as "Channel Name"
       And I enter "test123" as "Channel Label"
@@ -159,9 +136,7 @@ Feature: Adding channels
       Then I should see a "Invalid channel name, please see the format described below" text
 
   Scenario: Fail when trying to use reserved names for channels
-    When I follow "Software"
-     And I follow "Manage" in the left menu
-     And I follow "Channels" in the left menu
+    When I follow the left menu "Software > Manage > Channels"
      And I follow "Create Channel"
      And I enter "SLE-12-Cloud-Compute5-Pool for x86_64" as "Channel Name"
      And I enter "test123" as "Channel Label"
@@ -170,9 +145,7 @@ Feature: Adding channels
     Then I should see a "The channel name 'SLE-12-Cloud-Compute5-Pool for x86_64' is reserved, please enter a different name" text
 
   Scenario: Fail when trying to use reserved labels for channels
-    When I follow "Software"
-     And I follow "Manage" in the left menu
-     And I follow "Channels" in the left menu
+    When I follow the left menu "Software > Manage > Channels"
      And I follow "Create Channel"
      And I enter "test123" as "Channel Name"
      And I enter "sle-we12-pool-x86_64-sap" as "Channel Label"
@@ -181,9 +154,7 @@ Feature: Adding channels
     Then I should see a "The channel label 'sle-we12-pool-x86_64-sap' is reserved, please enter a different name" text
 
   Scenario: Create a channel that will be changed
-    When I follow "Software"
-     And I follow "Manage" in the left menu
-     And I follow "Channels" in the left menu
+    When I follow the left menu "Software > Manage > Channels"
      And I follow "Create Channel"
      And I enter "aaaSLE-12-Cloud-Compute5-Pool for x86_64" as "Channel Name"
      And I enter "sle-we12aaa-pool-x86_64-sap" as "Channel Label"
@@ -192,9 +163,7 @@ Feature: Adding channels
     Then I should see a "Channel aaaSLE-12-Cloud-Compute5-Pool for x86_64 created." text
 
   Scenario: Fail when trying to change the channel name to a reserved name
-    When I follow "Software"
-     And I follow "Manage" in the left menu
-     And I follow "Channels" in the left menu
+    When I follow the left menu "Software > Manage > Channels"
      And I follow "aaaSLE-12-Cloud-Compute5-Pool for x86_64"
      And I enter "SLE-12-Cloud-Compute5-Pool for x86_64" as "Channel Name"
      And I click on "Update Channel"

--- a/testsuite/features/core_srv_create_activationkey.feature
+++ b/testsuite/features/core_srv_create_activationkey.feature
@@ -8,7 +8,7 @@ Feature: Be able to create and manipulate activation keys
 
   Scenario: Create an activation key
     Given I am on the Systems page
-    When I follow "Activation Keys" in the left menu
+    When I follow the left menu "Systems > Activation Keys"
     And I follow "Create Key"
     And I enter "SUSE Test Key i586" as "description"
     And I enter "SUSE-DEV-i586" as "key"
@@ -23,7 +23,7 @@ Feature: Be able to create and manipulate activation keys
 
   Scenario: Change limit of the activation key
     Given I am on the Systems page
-    When I follow "Activation Keys" in the left menu
+    When I follow the left menu "Systems > Activation Keys"
     And I follow "SUSE Test Key i586"
     And I enter "20" as "usageLimit"
     And I click on "Update Activation Key"
@@ -32,7 +32,7 @@ Feature: Be able to create and manipulate activation keys
 
   Scenario: Change the base channel of the activation key
     Given I am on the Systems page
-    When I follow "Activation Keys" in the left menu
+    When I follow the left menu "Systems > Activation Keys"
     And I follow "SUSE Test Key i586"
     And I select "Test-Channel-i586" from "selectedBaseChannel"
     And I click on "Update Activation Key"
@@ -40,7 +40,7 @@ Feature: Be able to create and manipulate activation keys
 
   Scenario: Create an activation key with a channel
     Given I am on the Systems page
-    When I follow "Activation Keys" in the left menu
+    When I follow the left menu "Systems > Activation Keys"
     And I follow "Create Key"
     And I enter "SUSE Test Key x86_64" as "description"
     And I enter "SUSE-DEV-x86_64" as "key"
@@ -57,7 +57,7 @@ Feature: Be able to create and manipulate activation keys
 
   Scenario: Create an activation key with a channel and a package list for x86_64
     Given I am on the Systems page
-    When I follow "Activation Keys" in the left menu
+    When I follow the left menu "Systems > Activation Keys"
     And I follow "Create Key"
     And I enter "SUSE Test PKG Key x86_64" as "description"
     And I enter "SUSE-PKG-x86_64" as "key"
@@ -76,7 +76,7 @@ Feature: Be able to create and manipulate activation keys
 
   Scenario: Create an activation key with a channel and a package list for i586
     Given I am on the Systems page
-    When I follow "Activation Keys" in the left menu
+    When I follow the left menu "Systems > Activation Keys"
     And I follow "Create Key"
     And I enter "SUSE Test PKG Key i586" as "description"
     And I enter "SUSE-PKG-i586" as "key"
@@ -95,7 +95,7 @@ Feature: Be able to create and manipulate activation keys
 
   Scenario: Create an activation key for Ubuntu
     Given I am on the Systems page
-    When I follow "Activation Keys" in the left menu
+    When I follow the left menu "Systems > Activation Keys"
     And I follow "Create Key"
     And I enter "Ubuntu Test Key" as "description"
     And I enter "UBUNTU-TEST" as "key"
@@ -110,7 +110,7 @@ Feature: Be able to create and manipulate activation keys
 
   Scenario: Create an activation key with a channel for salt-ssh
     Given I am on the Systems page
-    When I follow "Activation Keys" in the left menu
+    When I follow the left menu "Systems > Activation Keys"
     And I follow "Create Key"
     And I enter "SUSE SSH Test Key x86_64" as "description"
     And I enter "SUSE-SSH-DEV-x86_64" as "key"

--- a/testsuite/features/core_srv_create_repository.feature
+++ b/testsuite/features/core_srv_create_repository.feature
@@ -9,9 +9,7 @@ Feature: Add a repository to a channel
 
   Scenario: Add a test repository for x86_64
     Given I am authorized as "testing" with password "testing"
-    When I follow "Channel List"
-    And I follow "Manage" in the left menu
-    And I follow "Repositories" in the left menu
+    When I follow the left menu "Software > Manage > Repositories"
     And I follow "Create Repository"
     And I enter "Test-Repository-x86_64" as "label"
     And I enter "http://localhost/pub/TestRepo/" as "url"
@@ -21,9 +19,7 @@ Feature: Add a repository to a channel
 
   Scenario: Disable metadata check for the x86_64 test repository
     Given I am authorized as "testing" with password "testing"
-    When I follow "Channel List"
-    And I follow "Manage" in the left menu
-    And I follow "Repositories" in the left menu
+    When I follow the left menu "Software > Manage > Repositories"
     And I follow "Test-Repository-x86_64"
     And I uncheck "metadataSigned"
     And I click on "Update Repository"
@@ -32,9 +28,7 @@ Feature: Add a repository to a channel
 
   Scenario: Add the repository to the x86_64 channel
     Given I am authorized as "testing" with password "testing"
-    When I follow "Channel List"
-    And I follow "Manage" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Software > Manage > Channels"
     And I follow "Test-Channel-x86_64"
     And I follow "Repositories" in the content area
     And I select the "Test-Repository-x86_64" repo
@@ -44,10 +38,7 @@ Feature: Add a repository to a channel
   Scenario: Synchronize the repository in the x86_64 channel
     Given I am authorized as "testing" with password "testing"
     When I enable source package syncing
-    And I follow "Channel List"
-    And I follow "Manage" in the left menu
-    And I follow "Repositories" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Software > Manage > Channels"
     And I follow "Test-Channel-x86_64"
     And I follow "Repositories" in the content area
     And I follow "Sync"
@@ -56,9 +47,7 @@ Feature: Add a repository to a channel
 
   Scenario: Add a test repository for i586
     Given I am authorized as "testing" with password "testing"
-    When I follow "Channel List"
-    And I follow "Manage" in the left menu
-    And I follow "Repositories" in the left menu
+    When I follow the left menu "Software > Manage > Repositories"
     And I follow "Create Repository"
     And I enter "Test-Repository-i586" as "label"
     And I enter "file:///srv/www/htdocs/pub/TestRepo/" as "url"
@@ -68,9 +57,7 @@ Feature: Add a repository to a channel
 
   Scenario: Add the repository to the i586 channel
     Given I am authorized as "testing" with password "testing"
-    When I follow "Channel List"
-    And I follow "Manage" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Software > Manage > Channels"
     And I follow "Test-Channel-i586"
     And I follow "Repositories" in the content area
     And I select the "Test-Repository-i586" repo
@@ -80,9 +67,7 @@ Feature: Add a repository to a channel
   Scenario: Synchronize the repository in the i586 channel
     Given I am authorized as "testing" with password "testing"
     When I disable source package syncing
-    And I follow "Channel List"
-    And I follow "Manage" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Software > Manage > Channels"
     And I follow "Test-Channel-i586"
     And I follow "Repositories" in the content area
     And I follow "Sync"
@@ -92,9 +77,7 @@ Feature: Add a repository to a channel
 @ubuntu_minion
   Scenario: Add a test repository for Ubuntu
     Given I am authorized as "testing" with password "testing"
-    When I follow "Channel List"
-    And I follow "Manage" in the left menu
-    And I follow "Repositories" in the left menu
+    When I follow the left menu "Software > Manage > Repositories"
     And I follow "Create Repository"
     And I enter "Test-Repository-Deb" as "label"
     And I select "deb" from "contenttype"
@@ -105,9 +88,7 @@ Feature: Add a repository to a channel
 @ubuntu_minion
   Scenario: Add the Ubuntu repository to the AMD64 channel
     Given I am authorized as "testing" with password "testing"
-    When I follow "Channel List"
-    And I follow "Manage" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Software > Manage > Channels"
     And I follow "Test-Channel-Deb-AMD64"
     And I follow "Repositories" in the content area
     And I select the "Test-Repository-Deb" repo
@@ -117,10 +98,7 @@ Feature: Add a repository to a channel
 @ubuntu_minion
   Scenario: Synchronize the Ubuntu repository in the AMD64 channel
     Given I am authorized as "testing" with password "testing"
-    When I follow "Channel List"
-    And I follow "Manage" in the left menu
-    And I follow "Repositories" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Software > Manage > Channels"
     And I follow "Test-Channel-Deb-AMD64"
     And I follow "Repositories" in the content area
     And I follow "Sync"
@@ -129,8 +107,7 @@ Feature: Add a repository to a channel
 
   Scenario: Refresh the errata cache
     Given I am authorized as "admin" with password "admin"
-    When I follow "Admin"
-    And I follow "Task Schedules"
+    When I follow the left menu "Admin > Task Schedules"
     And I follow "errata-cache-default"
     And I follow "errata-cache-bunch"
     And I click on "Single Run Schedule"
@@ -139,9 +116,7 @@ Feature: Add a repository to a channel
 
   Scenario: Refresh the channel's repository data
     Given I am authorized as "admin" with password "admin"
-    When I follow "Admin"
-    And I follow "Task Schedules"
-    And I follow "Task Schedules"
+    When I follow the left menu "Admin > Task Schedules"
     And I follow "channel-repodata-default"
     And I follow "channel-repodata-bunch"
     And I click on "Single Run Schedule"
@@ -150,7 +125,7 @@ Feature: Add a repository to a channel
 
   Scenario: Reposync handles wrong encoding on RPM attributes
     Given I am authorized as "admin" with password "admin"
-    When I follow "Channel List"
+    When I follow the left menu "Software > Channel List"
     And I follow "Test-Channel-x86_64"
     And I follow "Packages" in the content area
     Then I should see a "blackhole-dummy" text
@@ -158,7 +133,7 @@ Feature: Add a repository to a channel
 @ubuntu_minion
   Scenario: Reposync handles wrong encoding on DEB attributes
     Given I am authorized as "admin" with password "admin"
-    When I follow "Channel List"
+    When I follow the left menu "Software > Channel List"
     And I follow "Test-Channel-Deb-AMD64"
     And I follow "Packages" in the content area
     Then I should see a "blackhole-dummy" text

--- a/testsuite/features/core_srv_docker_profiles.feature
+++ b/testsuite/features/core_srv_docker_profiles.feature
@@ -23,7 +23,7 @@ Feature: Prepare server for using Docker
 
   Scenario: Create Docker activation key
     Given I am on the Systems page
-    And I follow "Activation Keys" in the left menu
+    When I follow the left menu "Systems > Activation Keys"
     And I follow "Create Key"
     When I enter "Docker testing" as "description"
     And I enter "DOCKER-TEST" as "key"
@@ -37,8 +37,7 @@ Feature: Prepare server for using Docker
 
   Scenario: Create an image store without credentials
     Given I am authorized as "admin" with password "admin"
-    And I follow "Images" in the left menu
-    And I follow "Stores" in the left menu
+    When I follow the left menu "Images > Stores"
     And I follow "Create"
     And I enter "galaxy-registry" as "label"
     And I enter "registry.mgr.suse.de" as "uri"
@@ -48,8 +47,7 @@ Feature: Prepare server for using Docker
 
   Scenario: Create a simple image profile without activation key
     Given I am authorized as "admin" with password "admin"
-    And I follow "Images" in the left menu
-    And I follow "Profiles" in the left menu
+    When I follow the left menu "Images > Profiles"
     And I follow "Create"
     And I enter "suse_simple" as "label"
     And I select "galaxy-registry" from "imageStore"
@@ -58,8 +56,7 @@ Feature: Prepare server for using Docker
 
   Scenario: Create a simple real image profile without activation key
     Given I am authorized as "admin" with password "admin"
-    And I follow "Images" in the left menu
-    And I follow "Profiles" in the left menu
+    When I follow the left menu "Images > Profiles"
     And I follow "Create"
     And I enter "suse_real_simple" as "label"
     And I select "galaxy-registry" from "imageStore"
@@ -68,8 +65,7 @@ Feature: Prepare server for using Docker
 
   Scenario: Create an image profile with activation key
     Given I am authorized as "admin" with password "admin"
-    And I follow "Images" in the left menu
-    And I follow "Profiles" in the left menu
+    When I follow the left menu "Images > Profiles"
     And I follow "Create"
     And I enter "suse_key" as "label"
     And I select "galaxy-registry" from "imageStore"
@@ -79,8 +75,7 @@ Feature: Prepare server for using Docker
 
   Scenario: Create a simple real image profile with activation key
     Given I am authorized as "admin" with password "admin"
-    And I follow "Images" in the left menu
-    And I follow "Profiles" in the left menu
+    When I follow the left menu "Images > Profiles"
     And I follow "Create"
     And I enter "suse_real_key" as "label"
     And I select "galaxy-registry" from "imageStore"

--- a/testsuite/features/core_srv_osimage_profiles.feature
+++ b/testsuite/features/core_srv_osimage_profiles.feature
@@ -23,7 +23,7 @@ Feature: Prepare server for using Kiwi
 
   Scenario: Create Kiwi activation key
     Given I am on the Systems page
-    When I follow "Activation Keys" in the left menu
+    When I follow the left menu "Systems > Activation Keys"
     And I follow "Create Key"
     And I enter "Kiwi testing" as "description"
     And I enter "KIWI-TEST" as "key"
@@ -34,8 +34,7 @@ Feature: Prepare server for using Kiwi
 
   Scenario: Create an OS image profile with activation key
     Given I am authorized as "admin" with password "admin"
-    When I follow "Images" in the left menu
-    And I follow "Profiles" in the left menu
+    When I follow the left menu "Images > Profiles"
     And I follow "Create"
     And I enter "suse_os_image" as "label"
     And I select "Kiwi" from "imageType"

--- a/testsuite/features/core_srv_push_package.feature
+++ b/testsuite/features/core_srv_push_package.feature
@@ -8,7 +8,6 @@ Feature: Push a package with unset vendor
 
   Background:
     Given I am authorized as "admin" with password "admin"
-    And I follow "Home" in the left menu
 
   Scenario: Download the SSL certificate
     When I download the SSL certificate
@@ -16,15 +15,11 @@ Feature: Push a package with unset vendor
 
   Scenario: Push a package with unset vendor
     When I push package "/root/subscription-tools-1.0-0.noarch.rpm" into "test_base_channel" channel
-    And I follow "Software" in the left menu
-    And I follow "Channel List" in the left menu
-    And I follow "Channel List > All" in the left menu
+    And I follow the left menu "Software > Channel List > All"
     Then I should see package "subscription-tools-1.0-0.noarch" in channel "Test Base Channel"
 
   Scenario: Check vendor of package displayed in web UI
-    When I follow "Software" in the left menu
-    And I follow "Channel List" in the left menu
-    And I follow "Channel List > All" in the left menu
+    When I follow the left menu "Software > Channel List > All"
     And I follow "Test Base Channel"
     And I follow "Packages"
     And I follow "subscription-tools-1.0-0.noarch"

--- a/testsuite/features/min_action_chain.feature
+++ b/testsuite/features/min_action_chain.feature
@@ -74,9 +74,7 @@ Feature: Action chain on salt minions
 
   Scenario: Create a configuration channel for testing action chain on Salt minion
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "Create Config Channel"
     And I enter "Action Chain Channel" as "cofName"
     And I enter "actionchainchannel" as "cofLabel"
@@ -86,9 +84,7 @@ Feature: Action chain on salt minions
 
   Scenario: Add a configuration file to configuration channel for testing action chain on Salt minion
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "Action Chain Channel"
     And I follow "Create Configuration File or Directory"
     And I enter "/etc/action-chain.cnf" as "cffPath"
@@ -109,9 +105,7 @@ Feature: Action chain on salt minions
 
   Scenario: Add a configuration file deployment to the action chain on Salt minion
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "Action Chain Channel"
     And I follow "Deploy Files" in the content area
     And I click on "Deploy All Files"
@@ -297,9 +291,7 @@ Feature: Action chain on salt minions
 
   Scenario: Cleanup: remove Salt client from configuration channel
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "Action Chain Channel"
     And I follow "Systems" in the content area
     And I check the "sle-minion" client
@@ -308,9 +300,7 @@ Feature: Action chain on salt minions
 
   Scenario: Cleanup: remove configuration channel for Salt minion
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "Action Chain Channel"
     And I follow "Delete Channel"
     And I click on "Delete Config Channel"

--- a/testsuite/features/min_activationkey.feature
+++ b/testsuite/features/min_activationkey.feature
@@ -14,9 +14,7 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
 
   Scenario: Create a configuration channel for the activation key
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "Create Config Channel"
     And I enter "Key Channel" as "cofName"
     And I enter "keychannel" as "cofLabel"
@@ -26,9 +24,7 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
 
   Scenario: Add a configuration file to the key configuration channel
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "Key Channel"
     And I follow "Create Configuration File or Directory"
     And I enter "/etc/euler.conf" as "cffPath"
@@ -37,7 +33,7 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
 
   Scenario: Create a complete minion activation key
     Given I am on the Systems page
-    When I follow "Activation Keys" in the left menu
+    When I follow the left menu "Systems > Activation Keys"
     And I follow "Create Key"
     And I enter "Minion testing" as "description"
     And I enter "MINION-TEST" as "key"
@@ -117,16 +113,14 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
 
   Scenario: Cleanup: remove the key configuration channel
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "Key Channel"
     And I follow "Delete Channel"
     And I click on "Delete Config Channel"
 
   Scenario: Cleanup: delete the activation key
     Given I am on the Systems page
-    When I follow "Activation Keys" in the left menu
+    When I follow the left menu "Systems > Activation Keys"
     And I follow "Minion testing" in the content area
     And I follow "Delete Key"
     And I click on "Delete Activation Key"

--- a/testsuite/features/min_bootstrap_script.feature
+++ b/testsuite/features/min_bootstrap_script.feature
@@ -20,9 +20,7 @@ Feature: Register a Salt minion via Bootstrap-script
 
   Scenario: Create bootstrap script
     Given I am authorized as "admin" with password "admin"
-    And I follow "Admin"
-    And I follow "Manager Configuration" in the left menu
-    And I follow "Bootstrap Script" in the left menu
+    When I follow the left menu "Admin > Manager Configuration > Bootstrap Script"
     And I uncheck "Enable Client GPG checking"
     Then I should see a "$PRODUCT Configuration - Bootstrap" text
     And I should see "Bootstrap using Salt" as checked
@@ -39,8 +37,7 @@ Feature: Register a Salt minion via Bootstrap-script
     Given I am authorized as "admin" with password "admin"
     When I run "sh /root/bootstrap.sh" on "sle-minion"
     And I wait for "5" seconds
-    And I follow "Salt" in the left menu
-    And I follow "Keys" in the left menu
+    When I follow the left menu "Salt > Keys"
     And I wait until I see the name of "sle-minion", refreshing the page
     And I should see a "pending" text
     And I accept "sle-minion" key

--- a/testsuite/features/min_config_state_channel.feature
+++ b/testsuite/features/min_config_state_channel.feature
@@ -7,9 +7,7 @@ Feature: Configuration state channels
 
   Scenario: Create a state channel
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "Create State Channel"
     Then I should see a "New Config Channel" text
     When I enter "My State Channel" as "cofName"
@@ -34,9 +32,7 @@ Feature: Configuration state channels
 
   Scenario: Salt state details
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "My State Channel"
     Then I should see a "1 system subscribed" text
     When I follow "View/Edit 'init.sls' File"
@@ -56,9 +52,7 @@ Feature: Configuration state channels
 
   Scenario: Try to remove init.sls file
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "My State Channel"
     And I follow "View/Edit 'init.sls' File"
     When I follow "Delete This File Revision"
@@ -68,9 +62,7 @@ Feature: Configuration state channels
 
   Scenario: Cleanup: remove the state channel and the file
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "My State Channel"
     And I follow "Delete Channel"
     Then I should see a "Are you sure you want to delete this config channel?" text

--- a/testsuite/features/min_docker_auth_registry.feature
+++ b/testsuite/features/min_docker_auth_registry.feature
@@ -5,8 +5,7 @@ Feature: Build image with authenticated registry
 
   Scenario: Create an authenticated image store as Docker admin
     Given I am authorized as "docker" with password "docker"
-    When I follow "Images" in the left menu
-    And I follow "Stores" in the left menu
+    When I follow the left menu "Images > Stores"
     And I follow "Create"
     And I enter "portus" as "label"
     And I check "useCredentials"
@@ -15,8 +14,7 @@ Feature: Build image with authenticated registry
 
   Scenario: Create a profile for the authenticated image store as Docker admin
     Given I am authorized as "docker" with password "docker"
-    When I follow "Images" in the left menu
-    And I follow "Profiles" in the left menu
+    When I follow the left menu "Images > Profiles"
     And I follow "Create"
     And I enter "portus_profile" as "label"
     And I select "portus" from "imageStore"
@@ -39,8 +37,7 @@ Feature: Build image with authenticated registry
 
   Scenario: Cleanup: remove Docker profile for the authenticated image store
     Given I am authorized as "docker" with password "docker"
-    When I follow "Images" in the left menu
-    And I follow "Profiles" in the left menu
+    When I follow the left menu "Images > Profiles"
     And I check the row with the "portus_profile" text
     And I click on "Delete"
     And I click on the css "button.btn-danger"
@@ -48,8 +45,7 @@ Feature: Build image with authenticated registry
 
   Scenario: Cleanup: remove authenticated image store
     Given I am authorized as "docker" with password "docker"
-    When I follow "Images" in the left menu
-    And I follow "Stores" in the left menu
+    When I follow the left menu "Images > Stores"
     And I check the row with the "portus" text
     And I click on "Delete"
     And I click on the css "button.btn-danger"

--- a/testsuite/features/min_state_config_channel.feature
+++ b/testsuite/features/min_state_config_channel.feature
@@ -7,9 +7,7 @@ Feature: State Configuration channels
 
   Scenario: Create the 1st state channel
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "Create State Channel"
     Then I should see a "New Config Channel" text
     When I enter "My State Channel" as "cofName"
@@ -24,9 +22,7 @@ Feature: State Configuration channels
 
   Scenario: Create the 2nd state channel with same name
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "Create State Channel"
     Then I should see a "New Config Channel" text
     When I enter "My State Channel" as "cofName"
@@ -42,8 +38,7 @@ Feature: State Configuration channels
   Scenario: Create the 3rd state channel with spacecmd
     Given I am authorized as "admin" with password "admin"
     When I create channel "statechannel3" from spacecmd of type "state"
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     Then I should see a "statechannel3" text
     And  I update init.sls from spacecmd with content "touch /root/statechannel3:\n  cmd.run:\n    - creates: /root/statechannel3" for channel "statechannel3"
 
@@ -98,9 +93,7 @@ Feature: State Configuration channels
 
   Scenario: Cleanup: remove the 1st state channel and the deployed file
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow first "My State Channel"
     And I follow "Delete Channel"
     Then I should see a "Are you sure you want to delete this config channel?" text
@@ -110,9 +103,7 @@ Feature: State Configuration channels
 
   Scenario: Cleanup: remove the 2nd state channel and the deployed file
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow first "My State Channel"
     And I follow "Delete Channel"
     Then I should see a "Are you sure you want to delete this config channel?" text
@@ -122,9 +113,7 @@ Feature: State Configuration channels
 
   Scenario: Cleanup: remove the 3rd state channel and the deployed file
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow first "statechannel3"
     And I follow "Delete Channel"
     Then I should see a "Are you sure you want to delete this config channel?" text

--- a/testsuite/features/minssh_action_chain.feature
+++ b/testsuite/features/minssh_action_chain.feature
@@ -84,9 +84,7 @@ Feature: Salt SSH action chain
 @ssh_minion
   Scenario: Create a configuration channel for testing action chain on SSH minion
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "Create Config Channel"
     And I enter "Action Chain Channel" as "cofName"
     And I enter "actionchainchannel" as "cofLabel"
@@ -97,9 +95,7 @@ Feature: Salt SSH action chain
 @ssh_minion
   Scenario: Add a configuration file to configuration channel for testing action chain on SSH minion
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "Action Chain Channel"
     And I follow "Create Configuration File or Directory"
     And I enter "/etc/action-chain.cnf" as "cffPath"
@@ -122,9 +118,7 @@ Feature: Salt SSH action chain
 @ssh_minion
   Scenario: Add a configuration file deployment to the action chain on SSH minion
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "Action Chain Channel"
     And I follow "Deploy Files" in the content area
     And I click on "Deploy All Files"
@@ -277,9 +271,7 @@ Feature: Salt SSH action chain
 @ssh_minion
   Scenario: Cleanup: remove Salt client from configuration channel
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "Action Chain Channel"
     And I follow "Systems" in the content area
     And I check the "ssh-minion" client
@@ -289,9 +281,7 @@ Feature: Salt SSH action chain
 @ssh_minion
   Scenario: Cleanup: remove configuration channel for SSH minion
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "Action Chain Channel"
     And I follow "Delete Channel"
     And I click on "Delete Config Channel"

--- a/testsuite/features/srv_check_channels_page.feature
+++ b/testsuite/features/srv_check_channels_page.feature
@@ -8,9 +8,7 @@ Feature: The channels page
 
   Scenario: Completeness of the channels page
     Given I am authorized as "admin" with password "admin"
-    When I follow "Software" in the left menu
-    And I follow "Channel List" in the left menu
-    And I follow "Channel List > All" in the left menu
+    When I follow the left menu "Software > Channel List > All"
     Then I should see a "Full Software Channel List" text
     And I should see a "Channel List" link in the left menu
     And I should see a "All" link in the left menu
@@ -28,17 +26,12 @@ Feature: The channels page
 
   Scenario: Popular channels
     Given I am authorized as "admin" with password "admin"
-    When I follow "Software" in the left menu
-    And I follow "Channel List" in the left menu
-    And I follow "Channel List > All" in the left menu
-    And I follow "Popular" in the left menu
+    When I follow the left menu "Software > Channel List > Popular"
     Then I should see a "Popular" text
 
   Scenario: Check packages in test channel
     Given I am authorized as "admin" with password "admin"
-    When I follow "Software" in the left menu
-    And I follow "Channel List" in the left menu
-    And I follow "Channel List > All" in the left menu
+    When I follow the left menu "Software > Channel List > All"
     And I follow "Test-Channel-x86_64"
     And I follow "Packages"
     Then I should see package "andromeda-dummy-2.0-1.1.noarch"
@@ -50,9 +43,7 @@ Feature: The channels page
 
   Scenario: Check package metadata
     Given I am authorized as "admin" with password "admin"
-    When I follow "Software" in the left menu
-    And I follow "Channel List" in the left menu
-    And I follow "Channel List > All" in the left menu
+    When I follow the left menu "Software > Channel List > All"
     And I follow "Test-Channel-x86_64"
     And I follow "Packages"
     And I follow "andromeda-dummy-2.0-1.1.noarch"
@@ -65,9 +56,7 @@ Feature: The channels page
 
   Scenario: Check package dependencies page
     Given I am authorized as "admin" with password "admin"
-    When I follow "Software" in the left menu
-    And I follow "Channel List" in the left menu
-    And I follow "Channel List > All" in the left menu
+    When I follow the left menu "Software > Channel List > All"
     And I follow "Test-Channel-x86_64"
     And I follow "Packages"
     And I follow "andromeda-dummy-2.0-1.1.noarch"
@@ -78,9 +67,7 @@ Feature: The channels page
 
   Scenario: Check package change log page
     Given I am authorized as "admin" with password "admin"
-    When I follow "Software" in the left menu
-    And I follow "Channel List" in the left menu
-    And I follow "Channel List > All" in the left menu
+    When I follow the left menu "Software > Channel List > All"
     And I follow "Test-Channel-x86_64"
     And I follow "Packages"
     And I follow "andromeda-dummy-2.0-1.1.noarch"
@@ -90,9 +77,7 @@ Feature: The channels page
 
   Scenario: Check package file list page
     Given I am authorized as "admin" with password "admin"
-    When I follow "Software" in the left menu
-    And I follow "Channel List" in the left menu
-    And I follow "Channel List > All" in the left menu
+    When I follow the left menu "Software > Channel List > All"
     And I follow "Test-Channel-x86_64"
     And I follow "Packages"
     And I follow "andromeda-dummy-2.0-1.1.noarch"

--- a/testsuite/features/srv_check_sync_source_packages.feature
+++ b/testsuite/features/srv_check_sync_source_packages.feature
@@ -8,9 +8,7 @@ Feature: Check if source packages were successfully synced
 
   Background:
     Given I am authorized as "admin" with password "admin"
-    When I follow "Software" in the left menu
-    And I follow "Channel List" in the left menu
-    And I follow "Channel List > All" in the left menu
+    When I follow the left menu "Software > Channel List > All"
 
   Scenario: Check sources for noarch package
     When I follow "Test-Channel-x86_64"

--- a/testsuite/features/srv_clone_channel_npn.feature
+++ b/testsuite/features/srv_clone_channel_npn.feature
@@ -63,7 +63,7 @@ Feature: Clone a channel
 
   Scenario: Check that new patches exists
     Given I am on the patches page
-    When I follow "All" in the left menu
+    When I follow the left menu "Patches > Patch List > All"
     And I select "500" from "1154021400_PAGE_SIZE_LABEL"
     Then I should see a "CL-hoag-dummy-7890" link
     And I should see a "CL-virgo-dummy-3456" link
@@ -72,7 +72,7 @@ Feature: Clone a channel
 
   Scenario: Check CL-hoag-dummy-7890 patches
     Given I am on the patches page
-    When I follow "All" in the left menu
+    When I follow the left menu "Patches > Patch List > All"
     And I select "500" from "1154021400_PAGE_SIZE_LABEL"
     And I follow "CL-hoag-dummy-7890"
     Then I should see a "CL-hoag-dummy-7890 - Security Advisory" text
@@ -81,7 +81,7 @@ Feature: Clone a channel
 
   Scenario: Check CM-virgo-dummy-3456 patches
     Given I am on the patches page
-    When I follow "All" in the left menu
+    When I follow the left menu "Patches > Patch List > All"
     And I select "500" from "1154021400_PAGE_SIZE_LABEL"
     And I follow "CL-virgo-dummy-3456"
     Then I should see a "CL-virgo-dummy-3456 - Bug Fix Advisory" text
@@ -108,14 +108,14 @@ Feature: Clone a channel
     And I click on "Delete Channel"
     Then I should see a "Clone of Test-Channel-x86_64" text
     And I should see a "has been deleted." text
-    Given I follow "Channels" in the left menu
+    Given I follow the left menu "Software > Manage > Channels"
     When I follow "Clone 2 of Test-Channel-x86_64"
     And I follow "Delete software channel"
     And I check "unsubscribeSystems"
     And I click on "Delete Channel"
     Then I should see a "Clone 2 of Test-Channel-x86_64" text
     And I should see a "has been deleted." text
-    Given I follow "Channels" in the left menu
+    Given I follow the left menu "Software > Manage > Channels"
     When I follow "Clone 3 of Test-Channel-x86_64"
     And I follow "Delete software channel"
     And I check "unsubscribeSystems"

--- a/testsuite/features/srv_content_lifecycle.feature
+++ b/testsuite/features/srv_content_lifecycle.feature
@@ -5,8 +5,7 @@ Feature: Content lifecycle
 
   Scenario: Create a content lifecycle project
     Given I am authorized as "admin" with password "admin"
-    When I follow "Content Lifecycle"
-    And I follow "Projects"
+    When I follow the left menu "Content Lifecycle > Projects"
     Then I should see a "Content Lifecycle Projects" text
     And I should see a "There are no entries to show." text
     When I follow "Create Project"
@@ -21,8 +20,7 @@ Feature: Content lifecycle
 
   Scenario: Verify the content lifecycle project page
     Given I am authorized as "admin" with password "admin"
-    When I follow "Content Lifecycle"
-    And  I follow "Projects"
+    When I follow the left menu "Content Lifecycle > Projects"
     Then I should see a "clp_name" text
     And I should see a "clp_desc" text
     When I follow "clp_name"
@@ -34,8 +32,7 @@ Feature: Content lifecycle
 
   Scenario: Add a source to the project
     Given I am authorized as "admin" with password "admin"
-    When I follow "Content Lifecycle"
-    And I follow "Projects"
+    When I follow the left menu "Content Lifecycle > Projects"
     And I follow "clp_name"
     And I follow "Edit Sources"
     And I select "SLES12-SP4-Pool for x86_64" from "selectedBaseChannel"
@@ -50,8 +47,7 @@ Feature: Content lifecycle
 
   Scenario: Add environments to the project
     Given I am authorized as "admin" with password "admin"
-    When I follow "Content Lifecycle"
-    And I follow "Projects"
+    When I follow the left menu "Content Lifecycle > Projects"
     And I follow "clp_name"
     Then I should see a "No environments created" text
     When I follow "Add Environment"
@@ -79,8 +75,7 @@ Feature: Content lifecycle
 
   Scenario: Build the sources in the project
     Given I am authorized as "admin" with password "admin"
-    When I follow "Content Lifecycle"
-    And I follow "Projects"
+    When I follow the left menu "Content Lifecycle > Projects"
     And I follow "clp_name"
     Then I should see a "not built" text in the environment "qa_name"
     When I click on "Build (4)"
@@ -94,8 +89,7 @@ Feature: Content lifecycle
 
   Scenario: Promote promote the sources in the project
     Given I am authorized as "admin" with password "admin"
-    When I follow "Content Lifecycle"
-    And I follow "Projects"
+    When I follow the left menu "Content Lifecycle > Projects"
     Then I should see a "clp_name" text
     And I should see a "clp_desc" text
     And I should see a "dev_name - qa_name - prod_name" text
@@ -113,8 +107,7 @@ Feature: Content lifecycle
 
   Scenario: Add new sources and promote again
     Given I am authorized as "admin" with password "admin"
-    When I follow "Content Lifecycle"
-    And I follow "Projects"
+    When I follow the left menu "Content Lifecycle > Projects"
     And I follow "clp_name"
     Then I should see a "Build (0)" text
     When I follow "Edit Sources"

--- a/testsuite/features/srv_custom_system_info.feature
+++ b/testsuite/features/srv_custom_system_info.feature
@@ -5,10 +5,10 @@ Feature: Custom system info key-value pairs
 
   Background:
     Given I am authorized
-    When I follow "Systems > Overview" in the left menu
+    When I follow the left menu "Systems > Overview"
 
   Scenario: Create a new key
-    When I follow "Custom System Info" in the left menu
+    When I follow the left menu "Systems > Custom System Info"
     And I follow "Create Key"
     And I should see a "Create Custom Info Key" text
     And I enter "key-label" as "label"
@@ -37,7 +37,7 @@ Feature: Custom system info key-value pairs
     And I should see a "key-value-edited" link
 
   Scenario: Edit the key description
-    When I follow "Custom System Info" in the left menu
+    When I follow the left menu "Systems > Custom System Info"
     And I follow "key-label"
     And I enter "key-desc-edited" as "description"
     And I click on "Update Key"
@@ -45,7 +45,7 @@ Feature: Custom system info key-value pairs
     And I should see a "key-desc-edited" text
 
   Scenario: Delete the value
-    When I follow "Custom System Info" in the left menu
+    When I follow the left menu "Systems > Custom System Info"
     And I follow "key-label"
     And I follow this "sle-client" link
     And I follow "Custom Info"
@@ -55,7 +55,7 @@ Feature: Custom system info key-value pairs
     Then I should see a "No custom information defined for this system." text
 
   Scenario: Delete the key
-    When I follow "Custom System Info" in the left menu
+    When I follow the left menu "Systems > Custom System Info"
     And I follow "key-label"
     And I follow "Delete Key"
     And I click on "Delete Key"

--- a/testsuite/features/srv_cve_audit.feature
+++ b/testsuite/features/srv_cve_audit.feature
@@ -32,15 +32,13 @@ Feature: CVE Audit
 
   Scenario: Display CVE audit page
     Given I am authorized as "admin" with password "admin"
-    When I follow "Audit" in the left menu
-    And I follow "CVE Audit" in the left menu
+    When I follow the left menu "Audit > CVE Audit"
     Then I should see a "CVE Audit" link in the left menu
     And I should see a "CVE Audit" text
 
   Scenario: Search for a known CVE number
     Given I am authorized as "admin" with password "admin"
-    When I follow "Audit" in the left menu
-    And I follow "CVE Audit" in the left menu
+    When I follow the left menu "Audit > CVE Audit"
     And I select "1999" from "cveIdentifierYear"
     And I enter "9999" as "cveIdentifierId"
     And I click on "Audit Servers"
@@ -57,8 +55,7 @@ Feature: CVE Audit
 
   Scenario: Search for an unknown CVE number
     Given I am authorized as "admin" with password "admin"
-    When I follow "Audit" in the left menu
-    And I follow "CVE Audit" in the left menu
+    When I follow the left menu "Audit > CVE Audit"
     And I select "2012" from "cveIdentifierYear"
     And I enter "2806" as "cveIdentifierId"
     And I click on "Audit Servers"
@@ -66,8 +63,7 @@ Feature: CVE Audit
 
   Scenario: Select a system for the System Set Manager
     Given I am authorized as "admin" with password "admin"
-    When I follow "Audit" in the left menu
-    And I follow "CVE Audit" in the left menu
+    When I follow the left menu "Audit > CVE Audit"
     And I select "1999" from "cveIdentifierYear"
     And I enter "9999" as "cveIdentifierId"
     And I click on "Audit Servers"

--- a/testsuite/features/srv_distro_cobbler.feature
+++ b/testsuite/features/srv_distro_cobbler.feature
@@ -5,7 +5,7 @@ Feature: Cobbler and distribution autoinstallation
 
   Background:
     Given I am authorized
-    When I follow "Systems > Overview" in the left menu
+    When I follow the left menu "Systems > Overview"
 
   Scenario: Ask cobbler to create a distribution via XML-RPC
     Given cobblerd is running
@@ -17,14 +17,12 @@ Feature: Cobbler and distribution autoinstallation
     Then create profile "testprofile" as user "testing" with password "testing"
 
   Scenario: Check cobbler created distro and profile
-    When I follow "Autoinstallation" in the left menu
-    And I follow "Profiles" in the left menu
+    When I follow the left menu "Systems > Autoinstallation > Profiles"
     Then I should see a "testprofile" text
     And I should see a "testdistro" text
 
   Scenario: Create a distribution via the UI
-    When I follow "Autoinstallation" in the left menu
-    And I follow "Distributions" in the left menu
+    When I follow the left menu "Systems > Autoinstallation > Distributions"
     And I follow "Create Distribution"
     When I enter "fedora_kickstart_distro" as "label"
     And I enter "/install/Fedora_12_i386/" as "basepath"
@@ -34,8 +32,7 @@ Feature: Cobbler and distribution autoinstallation
     And I should see a "fedora_kickstart_distro" link
 
   Scenario: Create a profile via the UI
-    When I follow "Autoinstallation" in the left menu
-    And I follow "Profiles" in the left menu
+    When I follow the left menu "Systems > Autoinstallation > Profiles"
     And I follow "Create Kickstart Profile"
     When I enter "fedora_kickstart_profile" as "kickstartLabel"
     And I click on "Next"
@@ -48,12 +45,11 @@ Feature: Cobbler and distribution autoinstallation
 
   Scenario: Autoinstallation profiles page
     When I am on the Create Autoinstallation Profile page
-    And I follow "Profiles" in the left menu
+    When I follow the left menu "Systems > Autoinstallation > Profiles"
     Then I should see a "Distributions" text
 
   Scenario: Upload a profile via the UI
-    When I follow "Autoinstallation" in the left menu
-    And I follow "Profiles" in the left menu
+    When I follow the left menu "Systems > Autoinstallation > Profiles"
     And I follow "Upload Kickstart/Autoyast File"
     When I enter "fedora_kickstart_profile_upload" as "kickstartLabel"
     And I attach the file "/example.ks" to "fileUpload"
@@ -62,8 +58,7 @@ Feature: Cobbler and distribution autoinstallation
     And I should see a "Autoinstallation Details" text
 
   Scenario: Add an unprovisioned range to the created profile
-    When I follow "Autoinstallation" in the left menu
-    And I follow "Profiles" in the left menu
+    When I follow the left menu "Systems > Autoinstallation > Profiles"
     And I follow "fedora_kickstart_profile"
     And I follow "Unprovisioned Autoinstallation"
     And I enter "10" as "octet1a"
@@ -78,8 +73,7 @@ Feature: Cobbler and distribution autoinstallation
     Then I should see a "Successfully added IP Range" text
 
   Scenario: Add a variable to the uploaded profile
-    When I follow "Autoinstallation" in the left menu
-    And I follow "Profiles" in the left menu
+    When I follow the left menu "Systems > Autoinstallation > Profiles"
     And I follow "fedora_kickstart_profile_upload"
     And I follow "Variables"
     And I enter "my_var=A_Test_String" as "variables"
@@ -88,8 +82,7 @@ Feature: Cobbler and distribution autoinstallation
     Then I should see a "A_Test_String" text
 
   Scenario: Add a kernel option to the created profile
-    When I follow "Autoinstallation" in the left menu
-    And I follow "Profiles" in the left menu
+    When I follow the left menu "Systems > Autoinstallation > Profiles"
     And I follow "fedora_kickstart_profile"
     And I enter "kernel_option=a_value" as "kernel_options"
     And I click on "Update"
@@ -97,8 +90,7 @@ Feature: Cobbler and distribution autoinstallation
     And I wait until file "/srv/tftpboot/pxelinux.cfg/default" contains "kernel_option=a_value" on server
 
   Scenario: Add a kernel option to the uploaded profile
-    When I follow "Autoinstallation" in the left menu
-    And I follow "Profiles" in the left menu
+    When I follow the left menu "Systems > Autoinstallation > Profiles"
     And I follow "fedora_kickstart_profile_upload"
     And I enter "kernel_option2=a_value2" as "kernel_options"
     And I click on "Update"
@@ -106,16 +98,14 @@ Feature: Cobbler and distribution autoinstallation
     And I wait until file "/srv/tftpboot/pxelinux.cfg/default" contains "kernel_option2=a_value2" on server
 
   Scenario: Check default snippets
-    When I follow "Autoinstallation" in the left menu
-    And I follow "Autoinstallation Snippets" in the left menu
+    When I follow the left menu "Systems > Autoinstallation > Autoinstallation Snippets"
     And I follow "Default Snippets"
     And I click on "Next Page"
     And I follow "spacewalk/sles_no_signature_checks"
     Then I should see "<signature-handling>" in the textarea
 
   Scenario: Create a snippet
-    When I follow "Autoinstallation" in the left menu
-    And I follow "Autoinstallation Snippets" in the left menu
+    When I follow the left menu "Systems > Autoinstallation > Autoinstallation Snippets"
     And I follow "Create Snippet"
     And I enter "created_test_snippet" as "name"
     And I enter "<test_element>a text string</test_element>" in the editor
@@ -123,8 +113,7 @@ Feature: Cobbler and distribution autoinstallation
     Then I should see a "created_test_snippet created successfully." text
 
   Scenario: Delete a snippet
-    When I follow "Autoinstallation" in the left menu
-    And I follow "Autoinstallation Snippets" in the left menu
+    When I follow the left menu "Systems > Autoinstallation > Autoinstallation Snippets"
     And I follow "created_test_snippet"
     And I follow "delete snippet"
     And I click on "Delete Snippet"

--- a/testsuite/features/srv_docker_advanced_content_management.feature
+++ b/testsuite/features/srv_docker_advanced_content_management.feature
@@ -5,8 +5,7 @@ Feature: Advanced content management
 
   Scenario: Create an image store as Docker admin
     Given I am authorized as "docker" with password "docker"
-    And I follow "Images" in the left menu
-    And I follow "Stores" in the left menu
+    When I follow the left menu "Images > Stores"
     And I follow "Create"
     And I enter "docker_admin" as "label"
     And I enter "registry.mgr.suse.de" as "uri"
@@ -14,8 +13,7 @@ Feature: Advanced content management
 
   Scenario: Create a profile as Docker admin
     Given I am authorized as "docker" with password "docker"
-    And I follow "Images" in the left menu
-    And I follow "Profiles" in the left menu
+    When I follow the left menu "Images > Profiles"
     And I follow "Create"
     And I enter "suse_docker_admin" as "label"
     And I select "galaxy-registry" from "imageStore"
@@ -40,8 +38,7 @@ Feature: Advanced content management
 
   Scenario: Cleanup: remove Docker profile
     Given I am authorized as "docker" with password "docker"
-    When I follow "Images" in the left menu
-    And I follow "Profiles" in the left menu
+    When I follow the left menu "Images > Profiles"
     And I check the row with the "suse_docker_admin" text
     And I click on "Delete"
     And I click on the css "button.btn-danger"
@@ -49,8 +46,7 @@ Feature: Advanced content management
 
   Scenario: Cleanup: remove image store
     Given I am authorized as "docker" with password "docker"
-    When I follow "Images" in the left menu
-    And I follow "Stores" in the left menu
+    When I follow the left menu "Images > Stores"
     And I check the row with the "docker_admin" text
     And I click on "Delete"
     And I click on the css "button.btn-danger"

--- a/testsuite/features/srv_docker_cve_audit.feature
+++ b/testsuite/features/srv_docker_cve_audit.feature
@@ -8,8 +8,7 @@ Feature: CVE audit for content management
     Given I am authorized as "admin" with password "admin"
 
   Scenario: Schedule channel data refresh for content management
-    When I follow "Admin"
-    And I follow "Task Schedules"
+    When I follow the left menu "Admin > Task Schedules"
     And I follow "cve-server-channels-default"
     And I follow "cve-server-channels-bunch"
     And I click on "Single Run Schedule"
@@ -17,16 +16,14 @@ Feature: CVE audit for content management
     And I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows
 
   Scenario: Audit images, searching for a known CVE number
-    When I follow "Audit" in the left menu
-    And I follow "CVE Audit" in the left menu
+    When I follow the left menu "Audit > CVE Audit"
     And I select "1999" from "cveIdentifierYear"
     And I enter "9999" as "cveIdentifierId"
     And I click on "Audit Images"
     Then I should see a "No action required" text
 
   Scenario: Audit images, searching for an unknown CVE number
-    When I follow "Audit" in the left menu
-    And I follow "CVE Audit" in the left menu
+    When I follow the left menu "Audit > CVE Audit"
     And I select "2012" from "cveIdentifierYear"
     And I enter "2806" as "cveIdentifierId"
     And I click on "Audit Images"

--- a/testsuite/features/srv_menu.feature
+++ b/testsuite/features/srv_menu.feature
@@ -1,13 +1,24 @@
-# Copyright (c) 2010-2017 Novell, Inc.
+# Copyright (c) 2017-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-Feature: Main landing page texts and links
+Feature: Web UI - Main landing page menu, texts and links
 
   Background:
     Given I am authorized
-    And I follow "Home" in the left menu
-    And I follow "Systems" in the left menu
-    And I follow "Overview" in the left menu
+    When I follow the left menu "Systems > Overview"
+
+  Scenario: The menu direct link accesses the first submenu level only
+    When I follow the left menu "Patches > Patch List"
+    Then I should see a "Patches Relevant to Your Systems" text in the content area
+    When I follow the left menu "Configuration > Files"
+    Then I should see a "Centrally-Managed Configuration Files" text in the content area
+    And I should not see a "Locally Managed Configuration Files" text in the content area
+
+  Scenario: Idempotency of complete menu path and direct link
+    When I follow the left menu "Software > Manage"
+    Then I should see a " Software Channel Management" text in the content area
+    When I follow the left menu "Software > Manage > Channels"
+    Then I should see a " Software Channel Management" text in the content area
 
   Scenario: Completeness of the side navigation bar and the content frame
     Then I should see a "System Overview" text
@@ -26,8 +37,8 @@ Feature: Main landing page texts and links
     And I should see a "Download CSV" link
     And I should see a Sign Out link
 
-  Scenario: Check sidebar link destination for Systems
-    When I click System List, under Systems node
+  Scenario: Sidebar link destination for Systems
+    When I follow the left menu "Systems > System List"
     Then I should see a "All" link in the left menu
     And I should see a "Physical Systems" link in the left menu
     And I should see a "Virtual Systems" link in the left menu
@@ -44,80 +55,69 @@ Feature: Main landing page texts and links
     And I should see a "System Types" link in the left menu
     And I should see a "Systems" text
 
-  Scenario: Check sidebar link destination for Systems => Physical Systems
-    When I click System List, under Systems node
-    And I follow "Physical Systems" in the left menu
+  Scenario: Sidebar link destination for Systems => Physical Systems
+    When I follow the left menu "Systems > System List > Physical Systems"
     Then I should see a "Physical Systems" text
     And I should see a "No systems." text
     And the current path is "/rhn/systems/PhysicalList.do"
 
-  Scenario: Check sidebar link destination for Systems => Virtual Systems
-    When I click System List, under Systems node
-    And I follow "Virtual Systems" in the left menu
+  Scenario: Sidebar link destination for Systems => Virtual Systems
+    When I follow the left menu "Systems > System List > Virtual Systems"
     Then I should see a "Virtual Systems" text
     And I should see a "No Virtual Systems." text
     And the current path is "/rhn/systems/VirtualList.do"
 
-  Scenario: Check sidebar link destination for Systems => Out of Date
-    When I click System List, under Systems node
-    And I follow "Out of Date" in the left menu
+  Scenario: Sidebar link destination for Systems => Out of Date
+    When I follow the left menu "Systems > System List > Out of Date"
     Then I should see a "Out of Date Systems" text
     And I should see a "No systems." text
     And the current path is "/rhn/systems/OutOfDate.do"
 
-  Scenario: Check sidebar link destination for Systems => Requiring Reboot
-    When I click System List, under Systems node
-    And I follow "Requiring Reboot" in the left menu
+  Scenario: Sidebar link destination for Systems => Requiring Reboot
+    When I follow the left menu "Systems > System List > Requiring Reboot"
     Then I should see a "Systems Requiring Reboot" text
     And I should see a "No systems." text
     And the current path is "/rhn/systems/RequiringReboot.do"
 
-  Scenario: Check sidebar link destination for Systems => Non Compliant
-    When I click System List, under Systems node
-    And I follow "Non Compliant" in the left menu
+  Scenario: Sidebar link destination for Systems => Non Compliant
+    When I follow the left menu "Systems > System List > Non Compliant"
     Then I should see a "Non Compliant Systems" text
     And I should see a "No systems." text
     And the current path is "/rhn/systems/ExtraPackagesSystems.do"
 
-  Scenario: Check sidebar link destination for Systems => Without System Type
-    When I click System List, under Systems node
-    And I follow "Without System Type" in the left menu
+  Scenario: Sidebar link destination for Systems => Without System Type
+    When I follow the left menu "Systems > System List > Without System Type"
     Then I should see a "Systems without System Type" text
     And I should see a "No systems." text
     And the current path is "/rhn/systems/Unentitled.do"
 
-  Scenario: Check sidebar link destination for Systems => Ungrouped
-    When I click System List, under Systems node
-    And I follow "Ungrouped" in the left menu
+  Scenario: Sidebar link destination for Systems => Ungrouped
+    When I follow the left menu "Systems > System List > Ungrouped"
     Then I should see a "Ungrouped Systems" text
     And I should see a "No systems." text
     And the current path is "/rhn/systems/Ungrouped.do"
 
-  Scenario: Check sidebar link destination for Systems => Inactive
-    When I click System List, under Systems node
-    And I follow "Inactive" in the left menu
+  Scenario: Sidebar link destination for Systems => Inactive
+    When I follow the left menu "Systems > System List > Inactive"
     Then I should see a "Inactive Systems" text
     And I should see a "No systems." text
     And the current path is "/rhn/systems/Inactive.do"
 
-  Scenario: Check sidebar link destination for Systems => Recently Registered
-    When I click System List, under Systems node
-    And I follow "Recently Registered" in the left menu
+  Scenario: Sidebar link destination for Systems => Recently Registered
+    When I follow the left menu "Systems > System List > Recently Registered"
     Then I should see a "Recently Registered Systems" text
     And I should see a "No systems." text
     And I should see a "View systems registered:" text
     And the current path is "/rhn/systems/Registered.do"
 
-  Scenario: Check sidebar link destination for Systems => Proxy
-    When I click System List, under Systems node
-    And I follow "Proxy" in the left menu
+  Scenario: Sidebar link destination for Systems => Proxy
+    When I follow the left menu "Systems > System List > Proxy"
     Then I should see a "Proxy Servers" text
     And I should see a "No systems." text
     And the current path is "/rhn/systems/ProxyList.do"
 
-  Scenario: Check sidebar link destination for Systems => Duplicate Systems
-    When I click System List, under Systems node
-    And I follow "Duplicate Systems" in the left menu
+  Scenario: Sidebar link destination for Systems => Duplicate Systems
+    When I follow the left menu "Systems > System List > Duplicate Systems"
     Then I should see a "Duplicate Systems" text
     And I should see a "No systems." text
     And the current path is "/rhn/systems/DuplicateIPList.do"
@@ -126,16 +126,14 @@ Feature: Main landing page texts and links
     And I should see a "Duplicate IPv6 Address" link
     And I should see a "Duplicate MAC Address" link
 
-  Scenario: Check sidebar link destination for Systems => System Currency
-    When I click System List, under Systems node
-    And I follow "System Currency" in the left menu
+  Scenario: Sidebar link destination for Systems => System Currency
+    When I follow the left menu "Systems > System List > System Currency"
     Then I should see a "System Currency Report" text
     And I should see a "No systems." text
     And the current path is "/rhn/systems/SystemCurrency.do"
 
-  Scenario: Check sidebar link destination for Systems => System Types
-    When I click System List, under Systems node
-    And I follow "System Types" in the left menu
+  Scenario: Sidebar link destination for Systems => System Types
+    When I follow the left menu "Systems > System List > System Types"
     Then I should see a "System Types" text
     And I should see a "Management:" text
     And I should see a "Salt:" text
@@ -143,13 +141,13 @@ Feature: Main landing page texts and links
     And I should see a "Virtualization Host:" text
     And the current path is "/rhn/systems/SystemEntitlements.do"
 
-  Scenario: Check sidebar link destination for Systems => System Groups
-    When I follow "System Groups" in the left menu
+  Scenario: Sidebar link destination for Systems => System Groups
+    When I follow the left menu "Systems > System Groups"
     Then I should see a "System Groups" text
     And I should see a "Create Group" link
     And I should see a "Your organization has no system groups." text
 
-  Scenario: Check sidebar link destination for Systems => System Set Manager
+  Scenario: Sidebar link destination for Systems => System Set Manager
     When I am on System Set Manager Overview
     Then I should see a "System Set Manager" text
     And I should see a "Task Log" link in the left menu
@@ -163,28 +161,28 @@ Feature: Main landing page texts and links
     And I should see a "Provisioning" link in the content area
     And I should see a "Misc" link in the content area
 
-  Scenario: Check sidebar link destination for Systems => Advanced Search
-    When I follow "Advanced Search" in the left menu
+  Scenario: Sidebar link destination for Systems => Advanced Search
+    When I follow the left menu "Systems > Advanced Search"
     Then I should see a "Advanced Search" text
 
-  Scenario: Check sidebar link destination for Systems => Activation Keys
-    When I follow "Activation Keys" in the left menu
+  Scenario: Sidebar link destination for Systems => Activation Keys
+    When I follow the left menu "Systems > Activation Keys"
     Then I should see a "Activation Keys" text
     And I should see a "Create Key" link
-    And I should see a "No activation keys available" text
+    And I should see a "The following activation keys have been created for use by your organization." text
 
-  Scenario: Check sidebar link destination for Systems => Stored Profiles
-    When I follow "Stored Profiles" in the left menu
+  Scenario: Sidebar link destination for Systems => Stored Profiles
+    When I follow the left menu "Systems > Stored Profiles"
     Then I should see a "Stored Profiles" text
     And I should see a "No stored profiles." text
 
-  Scenario: Check sidebar link destination for Systems => Custom System Info
-    When I follow "Custom System Info" in the left menu
+  Scenario: Sidebar link destination for Systems => Custom System Info
+    When I follow the left menu "Systems > Custom System Info"
     Then I should see a "Custom System Info Keys" text
     And I should see a "Create Key" link
     And I should see a "No Custom Info Keys Found" text
 
-  Scenario: Check sidebar link destination for Systems => Autoinstallation
+  Scenario: Sidebar link destination for Systems => Autoinstallation
     When I am on Autoinstallation Overview page
     Then I should see a "Autoinstallation Overview" text
     And I should see a "Profiles" link in the left menu
@@ -199,44 +197,38 @@ Feature: Main landing page texts and links
     And I should see a "Create a New Kickstart Profile" link
     And I should see a "Upload a New Kickstart/AutoYaST File" link
 
-  Scenario: Check sidebar link destination for Systems => Autoinstallation => Profiles
-    When I follow "Autoinstallation" in the left menu
-    And I follow "Profiles" in the left menu
+  Scenario: Sidebar link destination for Systems => Autoinstallation => Profiles
+    When I follow the left menu "Systems > Autoinstallation > Profiles"
     Then I should see a "Autoinstallation Profiles" text
     And I should see a "Create Kickstart Profile" link
     And I should see a "Upload Kickstart/Autoyast File" link
 
-  Scenario: Check sidebar link destination for Systems => Autoinstallation => Unprovisioned
-    When I follow "Autoinstallation" in the left menu
-    And I follow "Unprovisioned" in the left menu
+  Scenario: Sidebar link destination for Systems => Autoinstallation => Unprovisioned
+    When I follow the left menu "Systems > Autoinstallation > Unprovisioned"
     Then I should see a "Unprovisioned Autoinstallation By IP" text
     And I should see a "No Ip Ranges Found" text
 
-  Scenario: Check sidebar link destination for Systems => Autoinstallation => GPG and SSL Keys
-    When I follow "Autoinstallation" in the left menu
-    And I follow "GPG and SSL Keys" in the left menu
+  Scenario: Sidebar link destination for Systems => Autoinstallation => GPG and SSL Keys
+    When I follow the left menu "Systems > Autoinstallation > GPG and SSL Keys"
     Then I should see a "GPG Public Keys and SSL Certificates" text
     And I should see a "Create Stored Key/Cert" link
     And I should see a "Reference Guide" link
     And I should see a "RHN-ORG-TRUSTED-SSL-CERT" link
 
-  Scenario: Check sidebar link destination for Systems => Autoinstallation => Distributions
-    When I follow "Autoinstallation" in the left menu
-    And I follow "Distributions" in the left menu
+  Scenario: Sidebar link destination for Systems => Autoinstallation => Distributions
+    When I follow the left menu "Systems > Autoinstallation > Distributions"
     Then I should see a "Autoinstallable Distributions" text
     And I should see a "No autoinstallable distributions available." text
     And I should see a "Create Distribution" link
 
-  Scenario: Check sidebar link destination for Systems => Autoinstallation => File Preservation
-    When I follow "Autoinstallation" in the left menu
-    And I follow "File Preservation" in the left menu
+  Scenario: Sidebar link destination for Systems => Autoinstallation => File Preservation
+    When I follow the left menu "Systems > Autoinstallation > File Preservation"
     Then I should see a "File Preservation" text
     And I should see a "Reference Guide" link
     And I should see a "Create File Preservation List" link
 
-  Scenario: Check sidebar link destination for Systems => Autoinstallation => Autoinstallation Snippets
-    When I follow "Autoinstallation" in the left menu
-    And I follow "Autoinstallation Snippets" in the left menu
+  Scenario: Sidebar link destination for Systems => Autoinstallation => Autoinstallation Snippets
+    When I follow the left menu "Systems > Autoinstallation > Autoinstallation Snippets"
     Then I should see a "Autoinstallation Snippets" text
     And I should see a "No autoinstallation snippets found." text
     And I should see a "Create Snippet" link
@@ -244,23 +236,20 @@ Feature: Main landing page texts and links
     And I should see a "Custom Snippets" link in the content area
     And I should see a "All Snippets" link in the content area
 
-  Scenario: Check "Create Kickstart Profile" page Systems => Autoinstallation => Profiles => Create Kickstart Profile
-    When I follow "Autoinstallation" in the left menu
-    And I follow "Profiles" in the left menu
+  Scenario: "Create Kickstart Profile" page Systems => Autoinstallation => Profiles => Create Kickstart Profile
+    When I follow the left menu "Systems > Autoinstallation > Profiles"
     And I follow "Create Kickstart Profile"
     Then I should see a "Step 1: Create Kickstart Profile" text
 
-  Scenario: Check "Upload Kickstart/Autoyast File" page Systems => Autoinstallation => Profiles => Upload Kickstart/Autoyast File
-    When I follow "Autoinstallation" in the left menu
-    And I follow "Profiles" in the left menu
+  Scenario: "Upload Kickstart/Autoyast File" page Systems => Autoinstallation => Profiles => Upload Kickstart/Autoyast File
+    When I follow the left menu "Systems > Autoinstallation > Profiles"
     And I follow "Upload Kickstart/Autoyast File"
     Then I should see a "Create Autoinstallation Profile" text
     And I should see a "File Contents:" text
     And I should see a "Autoinstallation Details" text
 
-  Scenario: Check "create kickstart distribution" page Systems => Autoinstallation => Distributions => create new kickstart distribution
-    When I follow "Autoinstallation" in the left menu
-    And I follow "Distributions" in the left menu
+  Scenario: "Create kickstart distribution" page Systems => Autoinstallation => Distributions => create new kickstart distribution
+    When I follow the left menu "Systems > Autoinstallation > Distributions"
     And I follow "Create Distribution"
     Then I should see a "Create Autoinstallable Distribution" text
     And I should see a "Distribution Label" text

--- a/testsuite/features/srv_notifications.feature
+++ b/testsuite/features/srv_notifications.feature
@@ -5,14 +5,14 @@ Feature: Test the notification/notification-messages feature
   
   Scenario: Check the unread notification counter is correct
     Given I am authorized as "admin" with password "admin"
-    When I follow "Notification Messages" in the left menu
+    When I follow the left menu "Home > Notification Messages"
     And I wait until I see "The server has collected the following notification messages." text
     Then I follow "Unread Messages"
     And the notification badge and the table should count the same amount of messages
 
   Scenario: Delete notification-messages
     Given I am authorized as "admin" with password "admin"
-    When I follow "Notification Messages" in the left menu
+    When I follow the left menu "Home > Notification Messages"
     And I wait until I see "The server has collected the following notification messages." text
     Then I follow "All Messages"
     Then I check the first notification message
@@ -20,7 +20,7 @@ Feature: Test the notification/notification-messages feature
 
   Scenario: Flag a notification-message as read
     Given I am authorized as "admin" with password "admin"
-    When I follow "Notification Messages" in the left menu
+    When I follow the left menu "Home > Notification Messages"
     And I wait until I see "The server has collected the following notification messages." text
     Then I follow "All Messages"
     Then I check the first notification message

--- a/testsuite/features/srv_patches_page.feature
+++ b/testsuite/features/srv_patches_page.feature
@@ -21,8 +21,7 @@ Feature: Patches page
 
   Scenario: Create new bugfix patch with bnc URL
     Given I am on the patches page
-    And I follow "Manage Patches" in the left menu
-    And I follow "Published" in the left menu
+    When I follow the left menu "Patches > Manage Patches > Published"
     And I follow "Create Patch"
     When I enter "Test Patch" as "synopsis"
     And I enter "Test Advisory" as "advisoryName"
@@ -42,8 +41,7 @@ Feature: Patches page
 
   Scenario: Create new enhancement patch with no bnc URL
     Given I am on the patches page
-    And I follow "Manage Patches" in the left menu
-    And I follow "Published" in the left menu
+    When I follow the left menu "Patches > Manage Patches > Published"
     And I follow "Create Patch"
     When I enter "Enhancement Patch" as "synopsis"
     And I enter "Enhancement Advisory" as "advisoryName"
@@ -62,8 +60,7 @@ Feature: Patches page
 
   Scenario: Delete enhancement patch
     Given I am on the patches page
-    And I follow "Manage Patches" in the left menu
-    And I follow "Unpublished" in the left menu
+    When I follow the left menu "Patches > Manage Patches > Unpublished"
     And I check "Enhancement Advisory" patch
     And I click on "Delete Patches"
     And I click on "Confirm"
@@ -71,8 +68,7 @@ Feature: Patches page
 
   Scenario: Publish patch called "Test advisory"
     Given I am on the patches page
-    And I follow "Manage Patches" in the left menu
-    And I follow "Unpublished" in the left menu
+    When I follow the left menu "Patches > Manage Patches > Unpublished"
     And I follow "Test Advisory"
     And I click on "Publish Patch"
     And I check test channel
@@ -81,7 +77,7 @@ Feature: Patches page
 
   Scenario: Verify patch presence in web UI
     Given I am on the patches page
-    And I follow "All" in the left menu
+    When I follow the left menu "Patches > Patch List > All"
     And I follow "Bugfix Patches" in the content area
     And I enter "Test Patch" in the css "input[placeholder='Filter by Synopsis: ']"
     And I click on the css "button.spacewalk-button-filter"
@@ -99,17 +95,14 @@ Feature: Patches page
 
   Scenario: Assert that patch is now in test base channel
     Given I am on the patches page
-    And I follow "Software" in the left menu
-    And I follow "Channel List" in the left menu
-    And I follow "Channel List > All" in the left menu
+    When I follow the left menu "Software > Channel List > All"
     And I follow "Test Base Channel"
     And I follow "Patches" in the content area
     Then I should see a "Test Patch" text
 
   Scenario: Delete patch
     Given I am on the patches page
-    And I follow "Manage Patches" in the left menu
-    And I follow "Published" in the left menu
+    When I follow the left menu "Patches > Manage Patches > Published"
     And I check "Test Advisory" patch
     And I click on "Delete Patches"
     And I click on "Confirm"

--- a/testsuite/features/srv_virtual_host_manager.feature
+++ b/testsuite/features/srv_virtual_host_manager.feature
@@ -34,7 +34,7 @@ Feature: Virtual host manager web UI
 
   Scenario: Run virtual-host-gatherer
    Given I am authorized as "admin" with password "admin"
-    When I follow "Systems" in the left menu
+    When I follow the left menu "Systems"
      And I follow "Virtual Host Managers"
      And I follow "file-vmware"
     Then I should see a "file:///var/tmp/vCenter.json" text
@@ -47,14 +47,13 @@ Feature: Virtual host manager web UI
     And I wait until I see "10.162.186.111" text, refreshing the page
     When I follow "10.162.186.111"
     Then I should see a "OS: VMware ESXi" text
-    When I click System List, under Systems node
-    And I follow "Virtual Systems" in the left menu
+    When I follow the left menu "Systems > System List > Virtual Systems"
     Then I should see a "vCenter" text
      And I should see a "NSX-l3gateway" text
 
   Scenario: Delete Virtual Host Manager
     Given I am on the Systems page
-    When I follow "Virtual Host Managers"
+    When I follow the left menu "Systems > Virtual Host Managers"
     And I follow "file-vmware"
     And I click on "Delete"
     And I wait for "1" second

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -216,7 +216,7 @@ end
 Given(/^I am on the Systems page$/) do
   steps %(
     When I am authorized as "admin" with password "admin"
-    And I follow "Systems > Overview" in the left menu
+    When I follow the left menu "Systems > Overview"
   )
 end
 
@@ -373,7 +373,7 @@ end
 
 Then(/^I should see package "([^"]*)" in channel "([^"]*)"$/) do |pkg, channel|
   steps %(
-    And I follow "Channel List > All" in the left menu
+    When I follow the left menu "Software > Channel List > All"
     And I follow "#{channel}"
     And I follow "Packages"
     Then I should see package "#{pkg}"

--- a/testsuite/features/trad_action_chain.feature
+++ b/testsuite/features/trad_action_chain.feature
@@ -84,9 +84,7 @@ Feature: Action chain on traditional clients
 
   Scenario: Create a configuration channel for testing action chain on traditional client
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "Create Config Channel"
     And I enter "Action Chain Channel" as "cofName"
     And I enter "actionchainchannel" as "cofLabel"
@@ -96,9 +94,7 @@ Feature: Action chain on traditional clients
 
   Scenario: Add a configuration file to configuration channel for testing action chain on traditional client
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "Action Chain Channel"
     And I follow "Create Configuration File or Directory"
     And I enter "/etc/action-chain.cnf" as "cffPath"
@@ -119,9 +115,7 @@ Feature: Action chain on traditional clients
 
   Scenario: Add a configuration file deployment to the action chain on traditional client
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "Action Chain Channel"
     And I follow "Deploy Files" in the content area
     And I click on "Deploy All Files"
@@ -245,9 +239,7 @@ Feature: Action chain on traditional clients
 
   Scenario: Cleanup: remove traditional client from configuration channel
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "Action Chain Channel"
     And I follow "Systems" in the content area
     And I check the "sle-client" client
@@ -256,9 +248,7 @@ Feature: Action chain on traditional clients
 
   Scenario: Cleanup: remove configuration channel for traditional client
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "Action Chain Channel"
     And I follow "Delete Channel"
     And I click on "Delete Config Channel"

--- a/testsuite/features/trad_baremetal_discovery.feature
+++ b/testsuite/features/trad_baremetal_discovery.feature
@@ -14,9 +14,7 @@ Feature: Bare metal discovery
 
   Scenario: Enable bare metal discovery
     Given I am authorized as "admin" with password "admin"
-    And I follow "Admin"
-    And I follow "Manager Configuration" in the left menu
-    And I follow "General" in the left menu
+    When I follow the left menu "Admin > Manager Configuration > General"
     When I follow "Bare-metal systems" in the content area
     Then I should see a "Allows $PRODUCT to automatically add bare-metal systems capable of PXE booting to an organization." text
     And I should see a "Enable adding to this organization" button
@@ -36,8 +34,7 @@ Feature: Bare metal discovery
 
   Scenario: See the client in unprovisioned systems list
     Given I am on the Systems page
-    And I click System List, under Systems node 
-    And I follow "Unprovisioned Systems" in the left menu
+    When I follow the left menu "Systems > System List > Unprovisioned Systems"
     Then I should see a "Unprovisioned Systems" text
     And I should see a "Detected on" text
     And I should see a "Number of CPUs" text
@@ -53,7 +50,7 @@ Feature: Bare metal discovery
 
   Scenario: Check unprovisioned system details
     Given I am on the Systems page
-    And I click System List, under Systems node 
+    When I follow the left menu "Systems > System List"
     When I follow this "sle-client" link
     Then I should see a "Details" link in the content area
     And I should not see a "Software" link in the content area
@@ -111,9 +108,7 @@ Feature: Bare metal discovery
 
   Scenario: Cleanup: disable bare metal discovery
     Given I am authorized as "admin" with password "admin"
-    And I follow "Admin"
-    And I follow "Manager Configuration" in the left menu
-    And I follow "General" in the left menu
+    When I follow the left menu "Admin > Manager Configuration > General"
     When I follow "Bare-metal systems" in the content area
     Then I should see a "Allows $PRODUCT to automatically add bare-metal systems capable of PXE booting to an organization." text
     And I should see a "Disable adding to this organization" button

--- a/testsuite/features/trad_check_patches_install.feature
+++ b/testsuite/features/trad_check_patches_install.feature
@@ -20,7 +20,7 @@ Feature: Patches display
 
   Scenario: Check all patches exist
     Given I am on the patches page
-    When I follow "Relevant" in the left menu
+    When I follow the left menu "Patches > Patch List > Relevant"
     Then I should see an update in the list
     And I should see a "virgo-dummy-3456" link
 

--- a/testsuite/features/trad_config_channel.feature
+++ b/testsuite/features/trad_config_channel.feature
@@ -5,9 +5,7 @@ Feature: Configuration management of traditional clients
 
   Scenario: Successfully create configuration channel
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "Create Config Channel"
     And I enter "Test Channel" as "cofName"
     And I enter "testchannel" as "cofLabel"
@@ -26,9 +24,7 @@ Feature: Configuration management of traditional clients
 
   Scenario: Try to create same channel again; this should fail
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "Create Config Channel"
     And I enter "Test Channel" as "cofName"
     And I enter "testchannel" as "cofLabel"
@@ -39,9 +35,7 @@ Feature: Configuration management of traditional clients
 
   Scenario: Try to create a channel with an invalid label
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "Create Config Channel"
     And I enter "Test Channel2" as "cofName"
     And I enter "!testchannel" as "cofLabel"
@@ -52,9 +46,7 @@ Feature: Configuration management of traditional clients
 
   Scenario: Successfully create a new configuration channel
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "Create Config Channel"
     And I enter "New Test Channel" as "cofName"
     And I enter "newtestchannel" as "cofLabel"
@@ -73,9 +65,7 @@ Feature: Configuration management of traditional clients
 
   Scenario: Add a configuration file to new configuration channel
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "New Test Channel"
     And I follow "Create Configuration File or Directory"
     And I enter "/etc/mgr-test-file.cnf" as "cffPath"
@@ -96,10 +86,7 @@ Feature: Configuration management of traditional clients
 
   Scenario: Check centrally managed files
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Files" in the left menu
-    And I follow "Centrally Managed" in the left menu
+    When I follow the left menu "Configuration > Files > Centrally Managed"
     Then I should see a table line with "/etc/mgr-test-file.cnf", "New Test Channel", "1 system"
 
   Scenario: Check centrally managed files of SLES client
@@ -111,10 +98,8 @@ Feature: Configuration management of traditional clients
 
   Scenario: Deploy centrally managed files
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I run "rhn-actions-control --enable-all" on "sle-client"
-    And I follow "Channels" in the left menu
+    When I run "rhn-actions-control --enable-all" on "sle-client"
+    And I follow the left menu "Configuration > Channels"
     And I follow "New Test Channel"
     And I follow "Deploy all configuration files to all subscribed systems"
     Then I should see a "/etc/mgr-test-file.cnf" link
@@ -196,9 +181,7 @@ Feature: Configuration management of traditional clients
 
   Scenario: Add another configure file to new test channel
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "New Test Channel"
     And I follow "Create Configuration File or Directory"
     And I enter "/tmp/mycache.txt" as "cffPath"
@@ -232,9 +215,7 @@ Feature: Configuration management of traditional clients
 
   Scenario: Check configuration page content
    Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Overview" in the left menu
+    When I follow the left menu "Configuration > Overview"
     Then I should see a "Configuration Overview" text
     And I should see a "Configuration Summary" text
     And I should see a "Configuration Actions" text
@@ -254,44 +235,34 @@ Feature: Configuration management of traditional clients
 
   Scenario: Show Systems with Managed Configuration Files page
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Overview" in the left menu
+    When I follow the left menu "Configuration > Overview"
     And I follow "View Systems with Managed Configuration Files"
     Then I should see a "Managed" link in the left menu
     And I should see a "Target" link in the left menu
 
   Scenario: Show All Managed Configuration Files page
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Overview" in the left menu
+    When I follow the left menu "Configuration > Overview"
     And I follow "View All Managed Configuration Files"
     Then I should see a "Centrally Managed" link in the left menu
     And I should see a "Locally Managed" link in the left menu
 
   Scenario: Show All Managed Configuration Channels page
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Overview" in the left menu
+    When I follow the left menu "Configuration > Overview"
     And I follow "View All Managed Configuration Channels"
     Then I should see a "Create Config Channel" link
 
   Scenario: Show Enable Configuration Management on Systems page
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Overview" in the left menu
+    When I follow the left menu "Configuration > Overview"
     And I follow "Enable Configuration Management on Systems"
     Then I should see a "Managed" link in the left menu
     And I should see a "Target" link in the left menu
 
   Scenario: Cleanup: remove system from new configuration channel
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "New Test Channel"
     And I follow "Systems" in the content area
     And I check the "sle-client" client
@@ -300,18 +271,14 @@ Feature: Configuration management of traditional clients
 
   Scenario: Cleanup: remove test configuration channel
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "Test Channel"
     And I follow "Delete Channel"
     And I click on "Delete Config Channel"
 
   Scenario: Cleanup: remove new configuration channel
     Given I am authorized as "admin" with password "admin"
-    When I follow "Home" in the left menu
-    And I follow "Configuration" in the left menu
-    And I follow "Channels" in the left menu
+    When I follow the left menu "Configuration > Channels"
     And I follow "New Test Channel"
     And I follow "Delete Channel"
     And I click on "Delete Config Channel"

--- a/testsuite/features/trad_cve_id_new_syntax.feature
+++ b/testsuite/features/trad_cve_id_new_syntax.feature
@@ -5,7 +5,7 @@ Feature: Support for new CVE-ID syntax
 
   Scenario: Check perseus-dummy-7891 patches
     Given I am on the patches page
-    When I follow "All" in the left menu
+    When I follow the left menu "Patches > Patch List > All"
     And I follow "perseus-dummy-7891"
     Then I should see a "perseus-dummy-7891 - Security Advisory" text
     And I should see a "CVE-1999-12345" link

--- a/testsuite/features/trad_migrate_to_sshminion.feature
+++ b/testsuite/features/trad_migrate_to_sshminion.feature
@@ -20,8 +20,7 @@ Feature: Migrate a traditional client into a Salt SSH minion
 
   Scenario: Change contact method of activation key to ssh-push
     Given I am authorized as "admin" with password "admin"
-    And I follow "Systems" in the left menu
-    And I follow "Activation Keys"
+    When I follow the left menu "Systems > Activation Keys"
     And I follow "SUSE Test PKG Key x86_64" in the content area
     And I select "Push via SSH" from "contactMethodId"
     And I click on "Update Activation Key"
@@ -123,8 +122,7 @@ Feature: Migrate a traditional client into a Salt SSH minion
 
   Scenario: Cleanup: change contact method of activation key back to default
     Given I am authorized as "admin" with password "admin"
-    When I follow "Systems" in the left menu
-    And I follow "Activation Keys"
+    When I follow the left menu "Systems > Activation Keys"
     And I follow "SUSE Test PKG Key x86_64" in the content area
     And I select "Default" from "contactMethodId"
     And I click on "Update Activation Key"

--- a/testsuite/features/trad_need_reboot.feature
+++ b/testsuite/features/trad_need_reboot.feature
@@ -6,14 +6,9 @@ Feature: Reboot required after patch
   As an authorized user
   I want to see systems that need a reboot
 
-  Scenario: Check requiring reboot in the web UI
+  Scenario: Check requiring reboot link in the web UI
     Given I am authorized
-    When I follow "Home" in the left menu
-    And I follow "Systems" in the left menu
-    And I follow "Overview" in the left menu
-    And I click System List, under Systems node
-    Then I should see a "All" link in the left menu
-    When I follow "All" in the left menu
+    When I follow the left menu "Systems > System List"
     Then I should see a "Requiring Reboot" link in the left menu
 
   Scenario: No reboot notice if no need to reboot
@@ -42,14 +37,10 @@ Feature: Reboot required after patch
     And I click on "Apply Patches"
     And I click on "Confirm"
     And I run "rhn_check -vvv" on "sle-client"
-    And I follow "Software" in the left menu
-    And I click System List, under Systems node
-    And I follow "All" in the left menu
+    When I follow the left menu "Systems > System List > All"
     And I follow this "sle-client" link
     Then I should see a "The system requires a reboot" text
-    And I follow "Software" in the left menu
-    And I click System List, under Systems node
-    And I follow "Requiring Reboot" in the left menu
+    When I follow the left menu "Systems > System List > Requiring Reboot"
     Then I should see "sle-client" as link
 
   Scenario: Cleanup: remove packages and restore non-update repo after needing reboot tests

--- a/testsuite/features/trad_ssh_push.feature
+++ b/testsuite/features/trad_ssh_push.feature
@@ -13,7 +13,7 @@ Feature: Register a traditional system to be managed via SSH push
 
   Scenario: Create an activation key for SSH push
     Given I am on the Systems page
-    When I follow "Activation Keys" in the left menu
+    When I follow the left menu "Systems > Activation Keys"
     And I follow "Create Key"
     And I enter "SSH push key" as "description"
     And I enter "ssh-push" as "key"
@@ -23,7 +23,7 @@ Feature: Register a traditional system to be managed via SSH push
 
   Scenario: Create an activation key for SSH push via tunnel
     Given I am on the Systems page
-    When I follow "Activation Keys" in the left menu
+    When I follow the left menu "Systems > Activation Keys"
     And I follow "Create Key"
     And I enter "SSH push via tunnel key" as "description"
     And I enter "ssh-push-tunnel" as "key"
@@ -54,7 +54,7 @@ Feature: Register a traditional system to be managed via SSH push
 
   Scenario: Cleanup: delete the activation key for SSH push
     Given I am on the Systems page
-    And I follow "Activation Keys" in the left menu
+    When I follow the left menu "Systems > Activation Keys"
     And I follow "SSH push key" in the content area
     And I follow "Delete Key"
     And I click on "Delete Activation Key"
@@ -62,7 +62,7 @@ Feature: Register a traditional system to be managed via SSH push
 
   Scenario: Cleanup: delete the activation key for SSH push via tunnel
     Given I am on the Systems page
-    And I follow "Activation Keys" in the left menu
+    When I follow the left menu "Systems > Activation Keys"
     And I follow "SSH push via tunnel key" in the content area
     And I follow "Delete Key"
     And I click on "Delete Activation Key"

--- a/testsuite/features/trad_weak_deps.feature
+++ b/testsuite/features/trad_weak_deps.feature
@@ -5,9 +5,7 @@ Feature: Weak dependencies in the package page and in the metadata on the client
 
   Background:
     Given I am authorized as "admin" with password "admin"
-    When I follow "Software" in the left menu
-    And I follow "Channel List" in the left menu
-    And I follow "Channel List > All" in the left menu
+    When I follow the left menu "Software > Channel List > All"
 
   Scenario: Pre-requisite: remove packages before weak-dependancies test
    When I run "zypper -n in virgo-dummy" on "sle-client" without error control

--- a/testsuite/run_sets/refhost.yml
+++ b/testsuite/run_sets/refhost.yml
@@ -13,7 +13,6 @@
 - features/core_srv_channels_add.feature
 - features/core_srv_push_package.feature
 - features/core_srv_create_repository.feature
-- features/core_srv_systemspage.feature
 - features/core_srv_users.feature
 - features/core_srv_create_activationkey.feature
 - features/core_srv_docker_profiles.feature
@@ -36,6 +35,7 @@
 
 # IDEMPOTENT
 
+- features/srv_menu.feature
 - features/srv_clone_channel_npn.feature
 - features/srv_distro_cobbler.feature
 - features/trad_config_channel.feature

--- a/testsuite/run_sets/testsuite.yml
+++ b/testsuite/run_sets/testsuite.yml
@@ -13,7 +13,6 @@
 - features/core_srv_channels_add.feature
 - features/core_srv_push_package.feature
 - features/core_srv_create_repository.feature
-- features/core_srv_systemspage.feature
 - features/core_srv_users.feature
 - features/core_srv_create_activationkey.feature
 - features/core_srv_osimage_profiles.feature
@@ -41,6 +40,7 @@
 
 # IDEMPOTENT
 
+- features/srv_menu.feature
 - features/allcli_reboot.feature
 - features/trad_config_channel.feature
 - features/trad_lock_packages.feature

--- a/testsuite/run_sets/virtualization.yml
+++ b/testsuite/run_sets/virtualization.yml
@@ -13,7 +13,6 @@
 - features/core_srv_channels_add.feature
 - features/core_srv_push_package.feature
 - features/core_srv_create_repository.feature
-- features/core_srv_systemspage.feature
 - features/core_srv_users.feature
 - features/core_srv_create_activationkey.feature
 - features/core_srv_osimage_profiles.feature
@@ -28,6 +27,7 @@
 ## Secondary features BEGIN ##
 
 # IDEMPOTENT
+- features/srv_menu.feature
 - features/minkvm_guests.feature
 - features/minxen_guests.feature
 ## Secondary features END ##


### PR DESCRIPTION
## What does this PR change?

#### tl;dr
Standardize reaching the menu in the testsuite: migrate to one single way of following menu links, and separate menu steps in a proper file.

#### The long explanation
The shape of the menu is changed, and the behavior as well.
At the moment in the testsuite we have a *mixed flavor* ways of reaching menu links, and with the new changes some are failing and some other don't. To fix failures we can choose to fix case by case where they fail (and this will happen again ad again in the future as soon as something changes), or start using one and only one way for doing it.
This PR propose a single and dedicated approach for the testsuite menu steps.

Usage example: `When I follow the left menu "Configuration > Systems > Target"`

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: it's only about the testsuite

- [x] **DONE**

## Test coverage
- Cucumber tests were added: it is about the testsuite

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop" 
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
