### PR TITLE
Manager cobbler migrate

### DIFF
--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -397,6 +397,31 @@ upgrade_schema() {
     fi
 }
 
+convert_cobbler_files() {
+    OLD_COBBLER_DIR=/var/lib/cobbler/config
+    NEW_COBBLER_DIR=/var/lib/cobbler/collections
+
+    for OLDDIR in $OLD_COBBLER_DIR/*.d
+    do
+        if [ ! -z "$(ls $OLDDIR)" ]; then
+            NEWDIR=$NEW_COBBLER_DIR/`basename $OLDDIR | sed -e "s/\.d$//"`
+            if [ ! -d $NEWDIR ]; then
+                mkdir $NEWDIR
+            fi
+            echo "`date +"%H:%M:%S"`   Converting $OLDDIR --> $NEWDIR"
+            for FILE in $OLDDIR/*
+            do
+                sed -e "s/kickstart/autoinstall/" \
+                    -e "s/ks_meta/autoinstall_meta/" \
+                    -e "s/ksmeta/autoinstall_meta/" \
+                    -e "s/kopts/kernel_options/" \
+                    -e "s/kopts_post/kernel_options_post/" \
+                $FILE > $NEWDIR/`basename $FILE`
+            done
+        fi
+    done
+}
+
 copy_remote_files() {
     SUMAFILES="/etc/salt
                /root/ssl-build
@@ -409,7 +434,7 @@ copy_remote_files() {
                /srv/www/os-images
                /var/cache/rhn
                /var/cache/salt
-               /var/lib/cobbler
+               /var/lib/cobbler/config
                /var/lib/Kiwi
                /var/lib/rhn
                /var/lib/salt
@@ -449,6 +474,7 @@ copy_remote_files() {
     chown -R wwwrun.www /var/spacewalk
     ln -sf /srv/www/htdocs/pub/RHN-ORG-TRUSTED-SSL-CERT /etc/pki/trust/anchors
     update-ca-certificates
+    convert_cobbler_files
 }
 
 create_ssh_key() {

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- convert cobbler files to new format during migration
 - add dbus-lib to RES6 bootstrap repo (bsc#1132343)
 - create bootstrap repo for new Red Hat channels (bsc#1133587)
 


### PR DESCRIPTION
## What does this PR change?

The new cobbler has some keywords renamed. During migration, we need to rename the respective data of already existing files and also need to take into account the new directory structure (some directories have been renamed).

So far I just tested that the script will process existing files in a way that they are syntactically correct so cobbler does not complain loading them.

All the possible scenarios need to be tested of course (before and after migration). But chances are this is already enough.

I'm still pondering whether we should delete the old data (/var/lib/cobbler/config) after processing them or leave them for reference. They do not upset cobbler as they are located in an old-named directory and they also do not need very much space. So for now I'm leaving them. Can be changed later trivially.