### PR TITLE
Fix TypeError for 'errata.getErrataInfo' XMLRPC handler (bsc#1132346)

### DIFF
--- a/backend/server/handlers/xmlrpc/errata.py
+++ b/backend/server/handlers/xmlrpc/errata.py
@@ -190,7 +190,7 @@ class Errata(rhnHandler):
         cap_info = None
         if client_caps and 'packages.update' in client_caps:
             cap_info = client_caps['packages.update']
-        if cap_info and cap_info['version'] > 1:
+        if cap_info and int(cap_info['version']) > 1:
             multiarch = 1
 
         statement = """

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Fix TypeError for 'errata.getErrataInfo' XMLRPC handler (bsc#1132346)
 - fix typo in syncing product extensions (bsc#1118492)
 - Fix mgr-sign-metadata-ctl checking of exported keys.
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue when trying to install a patch on a RES6/RES7 traditional client.

Currently, the 'errata.getErrataInfo' XMLRPC handler located on the server is raising an exception because a wrong `>` operation between `int` and `str`.

On Python3, comparison between `int` and `str` is not longer supported.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **tested by QA**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/salt-board/issues/323

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
