### PR TITLE
Changes setting of Kickstart template to pseudo absolute path

### DIFF
--- a/java/code/src/org/cobbler/Profile.java
+++ b/java/code/src/org/cobbler/Profile.java
@@ -302,7 +302,7 @@ public class Profile extends CobblerObject {
       * @param kickstartIn the Kickstart
       */
       public void  setKickstart(String kickstartIn) {
-          modify(KICKSTART, getRelativeAutoinstallPath(kickstartIn));
+          modify(KICKSTART, "/" + getRelativeAutoinstallPath(kickstartIn));
       }
 
       /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Saving cobbler autoinstall templates with a leading slash.
 - Implement NEVR(A) filtering in Content Lifecycle Management
 - Adjust product tree tag according to the base OS
 - Add a link to the highstate page after formula was saved


### PR DESCRIPTION
## What does this PR change?

In order to make an old version of Koan happy, we need an absolute path here. Cobbler itself still treats this as a relative path, so this should also work this way.

## GUI diff

No difference.

Before:

The kickstart template was saved as a relative path like `upload/testp4--1.cfg`.

After:

The kickstart template will be saved as an absolute path like `/upload/testp4--1.cfg`.

- [ ] **DONE**

## Documentation
- No documentation needed: The user shouldn't see this.


- [ ] **DONE**

## Test coverage
- No tests: Don't know where… ¯\_(ツ)_/¯

- [ ] **DONE**

## Links

Relates to this PR: https://github.com/uyuni-project/uyuni/pull/736

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"  
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
