### PR TITLE
Fix for import error and removal of mimetools

### DIFF
--- a/tftpsync/susemanager-tftpsync/susemanager-tftpsync.changes
+++ b/tftpsync/susemanager-tftpsync/susemanager-tftpsync.changes
@@ -1,3 +1,7 @@
+- Fixes import error for sync_post_tftpd_proxies and
+  MultipartPostHandler. Replacing usage of mimetools, which is
+  Python2 only. (bsc#1134450)
+
 -------------------------------------------------------------------
 Mon Apr 22 12:27:16 CEST 2019 - jgonzalez@suse.com
 

--- a/tftpsync/susemanager-tftpsync/sync_post_tftpd_proxies.py
+++ b/tftpsync/susemanager-tftpsync/sync_post_tftpd_proxies.py
@@ -17,14 +17,13 @@
 #    License along with this library; if not, write to the Free Software
 #    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
-import sys
+
 import os
-import traceback
 import cobbler.utils as utils
 import time
-import MultipartPostHandler
+import cobbler.MultipartPostHandler as MultipartPostHandler
 import simplejson
-import clogger
+import cobbler.clogger as clogger
 import threading
 
 try:


### PR DESCRIPTION
## What does this PR change?

Fixes import error for sync_post_tftpd_proxies and MultipartPostHandler. Replacing usage of mimetools, which is Python2 only.

See: https://bugzilla.suse.com/show_bug.cgi?id=1134450

## GUI diff

No difference.

Before:

Import error during (re)start of cobblerd in `/var/log/cobbler/cobbler.log`.

```
Wed May  8 15:08:23 2019 - INFO | Exception Info:
  File "/usr/lib/python3.6/site-packages/cobbler/module_loader.py", line 72, in load_modules
    blip = __import__("cobbler.modules.%s" % (modname), globals(), locals(), [modname])

  File "/usr/lib/python3.6/site-packages/cobbler/modules/sync_post_tftpd_proxies.py", line 25, in <module>
    import MultipartPostHandler
```

After:

Error should be gone.
- [ ] **DONE**

## Documentation
- No documentation needed: No. It's an error.


- [ ] **DONE**

## Test coverage
- No tests: No

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
