### PR TITLE
Removed workaround for bsc#1131846, now fixed

### DIFF
--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -289,10 +289,6 @@ When(/^I manually uninstall the "([^"]*)" formula from the server$/) do |package
 end
 
 When(/^I synchronize all Salt dynamic modules on "([^"]*)"$/) do |host|
-  # WORKAROUND - remove me when fixed
-  # bsc#1131846 - salt chokes on ipv6 addresses when synchronizing client exec execution modules
-  $server.run("sed -i \"s/'ss', '-ant'/'ss', '-ant4'/\" /usr/lib/python3.6/site-packages/salt/utils/network.py", false)
-  # ---------------------------------
   system_name = get_system_name(host)
   $server.run("salt #{system_name} saltutil.sync_all")
 end


### PR DESCRIPTION
## What does this PR change?

This PR removes a workaround for bsc#1131846 / bsc#1130784

"salt chokes on ipv6 addresses when synchronizing client exec execution modules"

that appears when converting the proxy in a Retail branch server, now that the problem is fixed in Salt.

uyuni only.

- [x] No changelog needed
