### PR TITLE
Testsuite fixes

### DIFF
--- a/testsuite/features/core_proxy_branch_network.feature
+++ b/testsuite/features/core_proxy_branch_network.feature
@@ -42,7 +42,7 @@ Feature: Setup SUSE Manager for Retail branch network
     And I enter "eth1" in NIC field
     And I enter the local IP address of "proxy" in IP field
     And I click on "Save Formula"
-    Then I should see a "Formula saved!" text
+    Then I should see a "Formula saved" text
 
 @proxy
 @private_net
@@ -68,7 +68,7 @@ Feature: Setup SUSE Manager for Retail branch network
     And I enter the local IP address of "minion" in second reserved IP field
     And I enter the MAC address of "sle-minion" in second reserved MAC field
     And I click on "Save Formula"
-    Then I should see a "Formula saved!" text
+    Then I should see a "Formula saved" text
 
 @proxy
 @private_net
@@ -113,7 +113,7 @@ Feature: Setup SUSE Manager for Retail branch network
     And I enter "example.org" in second for zones field
     # end
     And I click on "Save Formula"
-    Then I should see a "Formula saved!" text
+    Then I should see a "Formula saved" text
 
 @proxy
 @private_net

--- a/testsuite/features/min_salt_formulas.feature
+++ b/testsuite/features/min_salt_formulas.feature
@@ -35,7 +35,7 @@ Feature: Use salt formulas
      And I select "French" in language field
      And I select "French (Canada)" in keyboard layout field
      And I click on "Save Formula"
-     Then I should see a "Formula saved!" text
+     Then I should see a "Formula saved" text
 
   Scenario: Check the pillar data after saving the formula
      When I refresh the pillar data
@@ -75,7 +75,7 @@ Feature: Use salt formulas
      And I follow first "Locale" in the content area
      And I click on "Clear values" and confirm
      And I click on "Save Formula"
-     Then I should see a "Formula saved!" text
+     Then I should see a "Formula saved" text
 
   Scenario: Check the pillar data after resetting the formula
      When I refresh the pillar data

--- a/testsuite/features/min_salt_formulas_advanced.feature
+++ b/testsuite/features/min_salt_formulas_advanced.feature
@@ -78,7 +78,7 @@ Feature: Use advanced features of Salt formulas
      And I enter "pw2" as "testing#pw_or_null"
      And I enter "pw3" as "testing#pw_opt"
      And I click on "Save Formula"
-     Then I should see a "Formula saved!" text
+     Then I should see a "Formula saved" text
      And the pillar data for "testing:str" should be "text1" on "sle-minion"
      And the pillar data for "testing:str_def" should be "text2" on "sle-minion"
      And the pillar data for "testing:str_or_null" should be "text3" on "sle-minion"
@@ -98,7 +98,7 @@ Feature: Use advanced features of Salt formulas
      And I follow first "Testform" in the content area
      And I click on "Clear values" and confirm
      And I click on "Save Formula"
-     Then I should see a "Formula saved!" text
+     Then I should see a "Formula saved" text
      And the pillar data for "testing:str" should be "" on "sle-minion"
      And the pillar data for "testing:str_def" should be "defvalue" on "sle-minion"
      And the pillar data for "testing:str_or_null" should be "None" on "sle-minion"
@@ -134,7 +134,7 @@ Feature: Use advanced features of Salt formulas
      And I enter "2" as "testing#num_def"
      And I enter "pw1" as "testing#pw"
      And I click on "Save Formula"
-     Then I should see a "Formula saved!" text
+     Then I should see a "Formula saved" text
      And the pillar data for "testing:str" should be "text1" on "sle-minion"
      And the pillar data for "testing:str_def" should be "defvalue" on "sle-minion"
      And the pillar data for "testing:str_or_null" should be "None" on "sle-minion"
@@ -152,7 +152,7 @@ Feature: Use advanced features of Salt formulas
      When I follow "Formulas" in the content area
      And I follow first "Testform" in the content area
      And I click on "Save Formula"
-     Then I should see a "Formula saved!" text
+     Then I should see a "Formula saved" text
      Then the pillar data for "testing:str" should be "text1" on "sle-minion"
      And the pillar data for "testing:str_def" should be "defvalue" on "sle-minion"
      And the pillar data for "testing:str_or_null" should be "None" on "sle-minion"
@@ -181,7 +181,7 @@ Feature: Use advanced features of Salt formulas
      And I enter "min_pw2" as "testing#pw_or_null"
      And I enter "min_pw3" as "testing#pw_opt"
      And I click on "Save Formula"
-     Then I should see a "Formula saved!" text
+     Then I should see a "Formula saved" text
      And the pillar data for "testing:str" should be "min_text1" on "sle-minion"
      And the pillar data for "testing:str_def" should be "min_text2" on "sle-minion"
      And the pillar data for "testing:str_or_null" should be "min_text3" on "sle-minion"
@@ -201,7 +201,7 @@ Feature: Use advanced features of Salt formulas
      And I follow first "Testform" in the content area
      And I click on "Clear values" and confirm
      And I click on "Save Formula"
-     Then I should see a "Formula saved!" text
+     Then I should see a "Formula saved" text
      Then the pillar data for "testing:str" should be "text1" on "sle-minion"
      And the pillar data for "testing:str_def" should be "defvalue" on "sle-minion"
      And the pillar data for "testing:str_or_null" should be "None" on "sle-minion"

--- a/testsuite/features/proxy_retail_pxeboot.feature
+++ b/testsuite/features/proxy_retail_pxeboot.feature
@@ -76,7 +76,7 @@ Feature: PXE boot a Retail terminal
     And I enter the hostname of "proxy" in third NS field
     # end
     And I click on "Save Formula"
-    Then I should see a "Formula saved!" text
+    Then I should see a "Formula saved" text
 
 @proxy
 @private_net
@@ -92,7 +92,7 @@ Feature: PXE boot a Retail terminal
     And I enter the local IP address of "pxeboot" in third reserved IP field
     And I enter the MAC address of "pxeboot-minion" in third reserved MAC field
     And I click on "Save Formula"
-    Then I should see a "Formula saved!" text
+    Then I should see a "Formula saved" text
 
 @proxy
 @private_net
@@ -104,7 +104,7 @@ Feature: PXE boot a Retail terminal
     And I enter the local IP address of "proxy" in internal network address field
     And I enter "/srv/saltboot" in TFTP base directory field
     And I click on "Save Formula"
-    Then I should see a "Formula saved!" text
+    Then I should see a "Formula saved" text
 
 @proxy
 @private_net
@@ -116,7 +116,7 @@ Feature: PXE boot a Retail terminal
     And I enter the local IP address of "proxy" in vsftpd internal network address field
     And I enter "/srv/saltboot" in FTP server directory field
     And I click on "Save Formula"
-    Then I should see a "Formula saved!" text
+    Then I should see a "Formula saved" text
 
 @proxy
 @private_net
@@ -127,7 +127,7 @@ Feature: PXE boot a Retail terminal
     And I follow first "Pxe" in the content area
     And I enter "example" in branch id field
     And I click on "Save Formula"
-    Then I should see a "Formula saved!" text
+    Then I should see a "Formula saved" text
 
 @proxy
 @private_net
@@ -217,7 +217,7 @@ Feature: PXE boot a Retail terminal
     And I enter "/" in second mount point field
     And I enter "POS_Image_JeOS6" in second OS image field
     And I click on "Save Formula"
-    Then I should see a "Formula saved!" text
+    Then I should see a "Formula saved" text
 
 @proxy
 @private_net
@@ -295,7 +295,7 @@ Feature: PXE boot a Retail terminal
     And I press "Remove Item" in second CNAME section
     And I press "Remove Item" in first CNAME section
     And I click on "Save Formula"
-    Then I should see a "Formula saved!" text
+    Then I should see a "Formula saved" text
 
 @proxy
 @private_net

--- a/testsuite/features/srv_change_password.feature
+++ b/testsuite/features/srv_change_password.feature
@@ -8,8 +8,7 @@ Feature: Change the user's password
 
   Scenario: Change the password to a new password
     Given I am authorized as "admin" with password "admin"
-    When I follow "User Account"
-    And I follow "Your Account"
+    When I follow the left menu "User Account > Your Account"
     And I enter "GoodPass" as "desiredpassword"
     And I enter "GoodPass" as "desiredpasswordConfirm"
     And I click on "Update"
@@ -22,8 +21,7 @@ Feature: Change the user's password
 
   Scenario: Revert the new password to a valid standard password
     Given I am authorized as "admin" with password "GoodPass"
-    When I follow "User Account"
-    And I follow "Your Account"
+    When I follow the left menu "User Account > Your Account"
     And I enter "admin" as "desiredpassword"
     And I enter "admin" as "desiredpasswordConfirm"
     And I click on "Update"
@@ -36,8 +34,7 @@ Feature: Change the user's password
 
   Scenario: Try an invalid password
     Given I am authorized as "admin" with password "admin"
-    When I follow "User Account"
-    And I follow "Your Account"
+    When I follow the left menu "User Account > Your Account"
     And I enter "A" as "desiredpassword"
     And I enter "A" as "desiredpasswordConfirm"
     And I click on "Update"

--- a/testsuite/features/srv_change_task_schedule.feature
+++ b/testsuite/features/srv_change_task_schedule.feature
@@ -5,8 +5,7 @@ Feature: Change the schedule of a task
 
   Scenario: Change the schedule of task mgr-sync-refresh-default to weekly
     Given I am authorized as "admin" with password "admin"
-    When I follow "Admin"
-    And I follow "Task Schedules"
+    When I follow the left menu "Admin > Task Schedules"
     And I follow "mgr-sync-refresh-default"
     And I check radio button "weekly"
     And I select "Friday" from "date_day_week"
@@ -19,8 +18,7 @@ Feature: Change the schedule of a task
 
   Scenario: Change the schedule of task mgr-sync-refresh-default to monthly
     Given I am authorized as "admin" with password "admin"
-    When I follow "Admin"
-    And I follow "Task Schedules"
+    When I follow the left menu "Admin > Task Schedules"
     And I follow "mgr-sync-refresh-default"
     And I check radio button "monthly"
     And I select "17" from "date_day_month"
@@ -32,8 +30,7 @@ Feature: Change the schedule of a task
 
   Scenario: Change the schedule of task mgr-sync-refresh-default back to daily
     Given I am authorized as "admin" with password "admin"
-    When I follow "Admin"
-    And I follow "Task Schedules"
+    When I follow the left menu "Admin > Task Schedules"
     And I follow "mgr-sync-refresh-default"
     And I check radio button "daily"
     And I click on "Update Schedule"

--- a/testsuite/features/srv_cve_audit.feature
+++ b/testsuite/features/srv_cve_audit.feature
@@ -12,8 +12,7 @@ Feature: CVE Audit
     And I run "zypper -n in --oldpackage milkyway-dummy-1.0" on "sle-client"
     And I run "zypper -n ref" on "sle-client"
     And I run "rhn_check -vvv" on "sle-client"
-    And I follow "Admin"
-    And I follow "Task Schedules"
+    And I follow the left menu "Admin > Task Schedules"
     And I follow "errata-cache-default"
     And I follow "errata-cache-bunch"
     And I click on "Single Run Schedule"
@@ -22,8 +21,7 @@ Feature: CVE Audit
 
   Scenario: Schedule channel data refresh
     Given I am authorized as "admin" with password "admin"
-    When I follow "Admin"
-    And I follow "Task Schedules"
+    And I follow the left menu "Admin > Task Schedules"
     And I follow "cve-server-channels-default"
     And I follow "cve-server-channels-bunch"
     And I click on "Single Run Schedule"

--- a/testsuite/features/srv_menu.feature
+++ b/testsuite/features/srv_menu.feature
@@ -21,8 +21,7 @@ Feature: Web UI - Main landing page menu, texts and links
     Then I should see a " Software Channel Management" text in the content area
 
   Scenario: Completeness of the side navigation bar and the content frame
-    Then I should see a "System Overview" text
-    And I should see a "No systems." text
+    Then I should see a "System Overview" text in the content area
     And I should see a "Overview" link in the left menu
     And I should see a "Systems" link in the left menu
     And I should see a "System Groups" link in the left menu
@@ -58,68 +57,57 @@ Feature: Web UI - Main landing page menu, texts and links
   Scenario: Sidebar link destination for Systems => Physical Systems
     When I follow the left menu "Systems > System List > Physical Systems"
     Then I should see a "Physical Systems" text
-    And I should see a "No systems." text
     And the current path is "/rhn/systems/PhysicalList.do"
 
   Scenario: Sidebar link destination for Systems => Virtual Systems
     When I follow the left menu "Systems > System List > Virtual Systems"
     Then I should see a "Virtual Systems" text
-    And I should see a "No Virtual Systems." text
     And the current path is "/rhn/systems/VirtualList.do"
 
   Scenario: Sidebar link destination for Systems => Out of Date
     When I follow the left menu "Systems > System List > Out of Date"
     Then I should see a "Out of Date Systems" text
-    And I should see a "No systems." text
     And the current path is "/rhn/systems/OutOfDate.do"
 
   Scenario: Sidebar link destination for Systems => Requiring Reboot
     When I follow the left menu "Systems > System List > Requiring Reboot"
     Then I should see a "Systems Requiring Reboot" text
-    And I should see a "No systems." text
     And the current path is "/rhn/systems/RequiringReboot.do"
 
   Scenario: Sidebar link destination for Systems => Non Compliant
     When I follow the left menu "Systems > System List > Non Compliant"
     Then I should see a "Non Compliant Systems" text
-    And I should see a "No systems." text
     And the current path is "/rhn/systems/ExtraPackagesSystems.do"
 
   Scenario: Sidebar link destination for Systems => Without System Type
     When I follow the left menu "Systems > System List > Without System Type"
     Then I should see a "Systems without System Type" text
-    And I should see a "No systems." text
     And the current path is "/rhn/systems/Unentitled.do"
 
   Scenario: Sidebar link destination for Systems => Ungrouped
     When I follow the left menu "Systems > System List > Ungrouped"
     Then I should see a "Ungrouped Systems" text
-    And I should see a "No systems." text
     And the current path is "/rhn/systems/Ungrouped.do"
 
   Scenario: Sidebar link destination for Systems => Inactive
     When I follow the left menu "Systems > System List > Inactive"
     Then I should see a "Inactive Systems" text
-    And I should see a "No systems." text
     And the current path is "/rhn/systems/Inactive.do"
 
   Scenario: Sidebar link destination for Systems => Recently Registered
     When I follow the left menu "Systems > System List > Recently Registered"
     Then I should see a "Recently Registered Systems" text
-    And I should see a "No systems." text
     And I should see a "View systems registered:" text
     And the current path is "/rhn/systems/Registered.do"
 
   Scenario: Sidebar link destination for Systems => Proxy
     When I follow the left menu "Systems > System List > Proxy"
     Then I should see a "Proxy Servers" text
-    And I should see a "No systems." text
     And the current path is "/rhn/systems/ProxyList.do"
 
   Scenario: Sidebar link destination for Systems => Duplicate Systems
     When I follow the left menu "Systems > System List > Duplicate Systems"
     Then I should see a "Duplicate Systems" text
-    And I should see a "No systems." text
     And the current path is "/rhn/systems/DuplicateIPList.do"
     And I should see a "Duplicate IP Address" link
     And I should see a "Duplicate Hostname" link
@@ -129,7 +117,6 @@ Feature: Web UI - Main landing page menu, texts and links
   Scenario: Sidebar link destination for Systems => System Currency
     When I follow the left menu "Systems > System List > System Currency"
     Then I should see a "System Currency Report" text
-    And I should see a "No systems." text
     And the current path is "/rhn/systems/SystemCurrency.do"
 
   Scenario: Sidebar link destination for Systems => System Types

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -604,15 +604,13 @@ end
 
 When(/^I go to the minion onboarding page$/) do
   steps %(
-    And I follow "Salt"
-    And I follow "Keys"
+    When I follow the left menu "Salt > Keys"
     )
 end
 
 When(/^I go to the bootstrapping page$/) do
   steps %(
-    And I follow "Systems"
-    And I follow "Bootstrapping"
+    When I follow the left menu "Systems > Bootstrapping"
     )
 end
 


### PR DESCRIPTION
## What does this PR change?

Referring to [this testsuite run](https://ci.suse.de/job/manager-Head-cucumber/ws/results/output-2019-05-10-00-39-45-2273.html)

Fixes:

Due to moving down in the order of features test scenarios, those tests were assuming `no system registered`, and that assumption is not true anymore.
  - Scenario: Completeness of the side navigation bar and the content frame
  - Scenario: Sidebar link destination for Systems => Virtual Systems
  - Scenario: Sidebar link destination for Systems => Out of Date
  - Scenario: Sidebar link destination for Systems => Non Compliant
  - Scenario: Sidebar link destination for Systems => Ungrouped
  - Scenario: Sidebar link destination for Systems => Recently Registered
  - Scenario: Sidebar link destination for Systems => Proxy
  - Scenario: Sidebar link destination for Systems => System Currency


Due to a message change to the bubble text on saving a formula, those tests were relying on the old text.
  - Scenario: Parametrize the formula on the minion
  - Scenario: Reset the formula on the minion
  - Scenario: Fill in and verify non-default values in group formula
  - Scenario: Clear values in group formula and verify the defaults again
  - Scenario: Fill in and verify mix of default and non-default values in group formula
  - Scenario: Verify that minion form inherits the values from group form
  - Scenario: Fill in and verify non-default values in minion formula
  - Scenario: Clear values in minion formula and verify that the pillar is set to group values
  - Scenario: Cleanup: remove "Testform" formula from "test-formula-group"
  - Scenario: Configure PXE part of DNS on the branch server
  - Scenario: Configure PXE part of DHCP on the branch server
  - Scenario: Parametrize TFTP on the branch server
  - Scenario: Parametrize vsFTPd on the branch server
  - Scenario: Configure PXE itself on the branch server
  - Scenario: Parametrize the Saltboot formula
  - Scenario: Cleanup: undo CNAME aliases


Due to a recent pattern change to use the menu in test scenarios, those steps were failing founding more than one link.
  - Scenario: Check the new bootstrapped minion in System Overview page
  - Scenario: Check new minion bootstrapped via XML-RPC in System Overview page
  - Scenario: Verify that minion bootstrapped with Salt key and packages
  - Scenario: Change the password to a new password
    - Scenario: Change the password to a new password
    - Scenario: Try an invalid password
  - Scenario: List systems by patch status via XML-RPC before patch
  - Scenario: Completeness of the onboarding page
  - Scenario: Minion is visible in the Pending section
  - Scenario: Reject and delete the pending key
  - Scenario: Accepted minion shows up as a registered system
  - Scenario: Change the schedule of task mgr-sync-refresh-default to weekly
  - Scenario: Change the schedule of task mgr-sync-refresh-default to monthly
  - Scenario: Change the schedule of task mgr-sync-refresh-default back to daily

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: it's about the testsuite

- [x] **DONE**

## Test coverage
- No tests: it's about the testsuite

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
