### PR TITLE
Fix metadata signing

### DIFF
--- a/backend/satellite_tools/mgr-sign-metadata
+++ b/backend/satellite_tools/mgr-sign-metadata
@@ -38,14 +38,14 @@ else
 fi
 
 rm -f $SIGFILE
-echo "$GPGPASS" | gpg -sab --batch -u $KEYID --passphrase-fd 0 $DIGESTOPT -o $SIGFILE $FILETOSIGN
+echo "$GPGPASS" | gpg -sab --batch -u $KEYID --passphrase-fd 0 --pinentry-mode loopback $DIGESTOPT -o $SIGFILE $FILETOSIGN
 
 rm -f $KEYFILE
 gpg --batch --export -a -o $KEYFILE $KEYID
 
 if [ ! -z "$CLRSIGNEDFILE" ]; then
   rm -f $CLRSIGNEDFILE
-  echo "$GPGPASS" | gpg --batch -u $KEYID --passphrase-fd 0 $DIGESTOPT --clearsign -o $CLRSIGNEDFILE $FILETOSIGN
+  echo "$GPGPASS" | gpg --batch -u $KEYID --passphrase-fd 0 --pinentry-mode loopback $DIGESTOPT --clearsign -o $CLRSIGNEDFILE $FILETOSIGN
 fi
 
 exit 0

--- a/backend/satellite_tools/mgr-sign-metadata-ctl
+++ b/backend/satellite_tools/mgr-sign-metadata-ctl
@@ -147,7 +147,7 @@ if [[  $ACTION = "enable" ]]; then
         mkdir -p $GPG_SALT_EXPORT_DIR
         chown salt:salt $GPG_SALT_EXPORT_DIR
         chmod 775 $GPG_SALT_EXPORT_DIR
-        gpg --export $KEYID > $GPG_SALT_EXPORT_FILE
+        gpg --export $ENABLE_KEYID > $GPG_SALT_EXPORT_FILE
         chmod 644 $GPG_SALT_EXPORT_FILE
         echo "DONE. Exported key ${ENABLE_KEYID} to ${GPG_SALT_EXPORT_FILE}."
     fi
@@ -155,14 +155,14 @@ if [[  $ACTION = "enable" ]]; then
     # check if key was exported to the http pub dir
     EXPORT_WWW_PUB_KEY=true
     if [ -f $GPG_PUB_EXPORT_FILE ]; then
-        if gpg --with-fingerprint $GPG_PUB_EXPORT_FILE | grep --quiet $ENABLE_KEYID; then
+        if cat $GPG_PUB_EXPORT_FILE | gpg -q --with-colons --import-options show-only --import | grep --quiet $ENABLE_KEYID; then
             echo "OK. Key ${ENABLE_KEYID} was exported to ${GPG_PUB_EXPORT_FILE}."
             EXPORT_WWW_PUB_KEY=false
         fi
     fi
     if [ "$EXPORT_WWW_PUB_KEY" = true ]; then
         rm -f $GPG_PUB_EXPORT_FILE
-        gpg --batch --export --armor --output $GPG_PUB_EXPORT_FILE
+        gpg --batch --export --armor --output $GPG_PUB_EXPORT_FILE $ENABLE_KEYID
         chmod 644 $GPG_PUB_EXPORT_FILE
         echo "DONE. Exported key ${ENABLE_KEYID} to ${GPG_PUB_EXPORT_FILE}."
     fi

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Fix password prompt within mgr-sign-metadata
 - Fix TypeError for 'errata.getErrataInfo' XMLRPC handler (bsc#1132346)
 - fix typo in syncing product extensions (bsc#1118492)
 - Fix mgr-sign-metadata-ctl checking of exported keys.


### PR DESCRIPTION
## What does this PR change?

This PR fixes 3 small issues which the ```mgr-sign-metadata``` and ```mgr-sign-metadata-ctl``` tools.
- Since gpg v2.1, also ```--pinentry-mode loopback``` is needed for ```--passphrase-fd``` to work
- Only export the one key requested, and not the whole keyring
- Also use the new gpg options to check the armored public key while in ```enable``` mode.

## GUI diff

No difference.

Before:

After:

- [X] **DONE**

## Documentation
- No documentation needed: **No change in overall functionality**

- [X] **DONE**

## Test coverage
- No tests: **No new functionality implemented**

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test" 
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
