### PR TITLE
virt tests: cleanup all remaining disk images

### DIFF
--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -686,6 +686,11 @@ Then "test-vm" virtual machine on "virt-server" should have a virtio cdrom
 Then "test-vm" virtual machine on "virt-server" should have no cdrom
 ```
 
+* Remove disk images from a storage pool
+
+```cucumber
+When I delete all "test-vm.*" volumes from "default" pool on "kvm-server" without error control
+```
 
 <a name="c" />
 

--- a/testsuite/features/minkvm_guests.feature
+++ b/testsuite/features/minkvm_guests.feature
@@ -196,5 +196,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I run "virsh undefine --remove-all-storage test-vm2" on "kvm-server" without error control
     And I run "virsh net-destroy test-net0" on "kvm-server" without error control
     And I run "virsh net-undefine test-net0" on "kvm-server" without error control
+    And I delete all "test-vm.*" volumes from "default" pool on "kvm-server" without error control
     # Remove the virtpoller cache to avoid problems
     And I run "rm /var/cache/virt_state.cache" on "kvm-server" without error control

--- a/testsuite/features/minxen_guests.feature
+++ b/testsuite/features/minxen_guests.feature
@@ -212,5 +212,6 @@ Feature: Be able to manage XEN virtual machines via the GUI
     And I run "virsh undefine --remove-all-storage test-vm3" on "xen-server" without error control
     And I run "virsh net-destroy test-net0" on "xen-server" without error control
     And I run "virsh net-undefine test-net0" on "xen-server" without error control
+    And I delete all "test-vm.*" volumes from "default" pool on "kvm-server" without error control
     # Remove the virtpoller cache to avoid problems
     And I run "rm /var/cache/virt_state.cache" on "xen-server" without error control

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -956,6 +956,12 @@ Then(/^"([^"]*)" virtual machine on "([^"]*)" should have (no|a) ([^ ]*) ?cdrom$
   end
 end
 
+When(/^I delete all "([^"]*)" volumes from "([^"]*)" pool on "([^"]*)" without error control$/) do |volumes, pool, host|
+  node = get_target(host)
+  output, _code = node.run("virsh vol-list #{pool} | sed -n -e 's/^[[:space:]]*\([^[:space:]]\+\).*$/\1/;/#{volumes}/p'", false)
+  output.each_line { |volume| node.run("virsh vol-delete #{volume} #{pool}", false) }
+end
+
 When(/^I reduce virtpoller run interval on "([^"]*)"$/) do |host|
   node = get_target(host)
   source = File.dirname(__FILE__) + '/../upload_files/susemanager-virtpoller.conf'


### PR DESCRIPTION
## What does this PR change?

Some disks images are left over in the default pool after the KVM or Xen tests. Ensure those are removed at the end of the test.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: test suite enhancement

- [X] **DONE**

## Test coverage
- No tests: tests fix

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
