### PR TITLE
testsuite harden /^I wait until I see "([^"]*)" text$/

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -33,29 +33,11 @@ Then(/^the current path is "([^"]*)"$/) do |arg1|
 end
 
 When(/^I wait until I see "([^"]*)" text$/) do |text|
-  begin
-    Timeout.timeout(DEFAULT_TIMEOUT) do
-      loop do
-        break if page.has_content?(text)
-        sleep 3
-      end
-    end
-  rescue Timeout::Error
-    raise "Couldn't find the #{text} in webpage"
-  end
+  raise unless page.has_text?(text, wait: DEFAULT_TIMEOUT)
 end
 
 When(/^I wait until I do not see "([^"]*)" text$/) do |text|
-  begin
-    Timeout.timeout(DEFAULT_TIMEOUT) do
-      loop do
-        break unless page.has_content?(text)
-        sleep 3
-      end
-    end
-  rescue Timeout::Error
-    raise "The #{text} was always there in webpage"
-  end
+  raise unless page.has_no_text?(text, wait: DEFAULT_TIMEOUT)
 end
 
 When(/^I wait at most (\d+) seconds until I see "([^"]*)" text$/) do |seconds, text|


### PR DESCRIPTION
## What does this PR change?

`/^I wait until I see "([^"]*)" text$/` implementation may throw
`capybara::ElementNotFound exception`. Catch it and sleep again since it means
the page has been fully loaded. An example failure follows:

```
Then I wait until I see "has been deleted" text
features/step_definitions/navigation_steps.rb:29

Unable to find visible xpath "/html" (Capybara::ElementNotFound)
```

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: testsuite fixes

- [X] **DONE**

## Test coverage
- No tests: testsuite fixes

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
