### PR TITLE
Hide disabled activation keys in form drop-downs (bsc#1101706)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/token/ActivationKey.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/token/ActivationKey.hbm.xml
@@ -61,6 +61,14 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                      and ak.bootstrap = 'N']]>
     </query>
 
+    <query name="ActivationKey.findActiveByOrg">
+        <![CDATA[from com.redhat.rhn.domain.token.ActivationKey as ak
+                   where ak.token.org = :org
+                     and ak.kickstartSession = null
+                     and ak.token.server = null
+                     and ak.bootstrap = 'N'
+                     and ak.token.disabled = 0]]>
+    </query>
 
      <query name="ActivationKey.listAssociatedKickstarts">
         <![CDATA[from com.redhat.rhn.domain.kickstart.KickstartData as k where :token member of k.defaultRegTokens]]>

--- a/java/code/src/com/redhat/rhn/manager/token/ActivationKeyManager.java
+++ b/java/code/src/com/redhat/rhn/manager/token/ActivationKeyManager.java
@@ -326,6 +326,19 @@ public class ActivationKeyManager {
     }
 
     /**
+     * Finds all activation keys visible to user,
+     * excluding disabled ones.
+     * @param requester User requesting the list.
+     * @return All activation keys visible to user.
+     */
+    public List<ActivationKey> findAllActive(User requester) {
+        Session session = HibernateFactory.getSession();
+        return session.getNamedQuery("ActivationKey.findActiveByOrg")
+            .setParameter("org", requester.getOrg())
+            .list();
+    }
+
+    /**
      * Returns true if the the given user can
      * administer activation keys..
      * This should be the baseline for us to load activation keys.

--- a/java/code/src/com/suse/manager/webui/Router.java
+++ b/java/code/src/com/suse/manager/webui/Router.java
@@ -21,7 +21,6 @@ import static com.suse.manager.webui.utils.SparkApplicationHelper.withOrgAdmin;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.withProductAdmin;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.withUser;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.withUserPreferences;
-import static spark.Spark.delete;
 import static spark.Spark.exception;
 import static spark.Spark.get;
 import static spark.Spark.head;
@@ -92,6 +91,9 @@ public class Router implements SparkApplication {
         get("/manager/api/audit/cve.csv", withUser(CVEAuditController::cveAuditCSV));
 
         initContentManagementRoutes(jade);
+
+        // Virtual Host Managers
+        VirtualHostManagerController.initRoutes(jade);
 
         // Virtualization Routes
         initVirtualizationRoutes(jade);
@@ -183,37 +185,6 @@ public class Router implements SparkApplication {
         get("/manager/api/states/packages/match", StatesAPI::matchPackages);
         get("/manager/api/states/highstate", StatesAPI::showHighstate);
         get("/manager/api/states/:channelId/content", withUser(StatesAPI::stateContent));
-
-        // Virtual Host Managers
-        get("/manager/vhms",
-                withUserPreferences(withCsrfToken(withOrgAdmin(VirtualHostManagerController::list))),
-                jade);
-        post("/manager/api/vhms/kubeconfig/validate",
-                withOrgAdmin(VirtualHostManagerController::validateKubeconfig));
-        post("/manager/api/vhms/create/kubernetes",
-                withUser(VirtualHostManagerController::createKubernetes));
-        post("/manager/api/vhms/update/kubernetes",
-                withUser(VirtualHostManagerController::updateKubernetes));
-        get("/manager/api/vhms/kubeconfig/:id/contexts",
-                withOrgAdmin(VirtualHostManagerController::getKubeconfigContexts));
-        post("/manager/api/vhms/:id/refresh",
-                withOrgAdmin(VirtualHostManagerController::refresh));
-        get("/manager/api/vhms/:id/nodes",
-                withOrgAdmin(VirtualHostManagerController::getNodes));
-        get("/manager/api/vhms/modules",
-                withOrgAdmin(VirtualHostManagerController::getModules));
-        get("/manager/api/vhms/module/:name/params",
-                withOrgAdmin(VirtualHostManagerController::getModuleParams));
-        get("/manager/api/vhms",
-                withOrgAdmin(VirtualHostManagerController::get));
-        get("/manager/api/vhms/:id",
-                withOrgAdmin(VirtualHostManagerController::getSingle));
-        post("/manager/api/vhms/create",
-                withOrgAdmin(VirtualHostManagerController::create));
-        post("/manager/api/vhms/update/:id",
-                withOrgAdmin(VirtualHostManagerController::update));
-        delete("/manager/api/vhms/delete/:id",
-                withOrgAdmin(VirtualHostManagerController::delete));
 
         // Subscription Matching
         get("/manager/subscription-matching",

--- a/java/code/src/com/suse/manager/webui/controllers/ImageProfileController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/ImageProfileController.java
@@ -410,17 +410,14 @@ public class ImageProfileController {
      * @return a JSON string of the list of activation keys
      */
     private static String getActivationKeys(User user) {
-        ActivationKeyManager akm = ActivationKeyManager.getInstance();
-        return GSON.toJson(akm.findAll(user).stream()
-                .filter(ak -> ak.getBaseChannel() != null)
-                .map(ActivationKey::getKey)
-                .collect(Collectors.toList()));
+        return GSON.toJson(getActivationKeyNames(user));
     }
 
     private static List<String> getActivationKeyNames(User user) {
         return ActivationKeyManager.getInstance()
-                .findAll(user)
-                .stream().map(ActivationKey::getKey)
+                .findAllActive(user).stream()
+                .filter(ak -> ak.getBaseChannel() != null)
+                .map(ActivationKey::getKey)
                 .collect(Collectors.toList());
     }
 
@@ -523,9 +520,7 @@ public class ImageProfileController {
 
         // Remove deleted values
         oldVals.stream()
-                .filter(oldVal -> !newValues.stream()
-                        .filter(newVal -> oldVal.getId().equals(newVal.getId())).findAny()
-                        .isPresent())
+                .filter(oldVal -> newValues.stream().noneMatch(newVal -> oldVal.getId().equals(newVal.getId())))
                 .forEach(ImageProfileFactory::delete);
     }
 }

--- a/java/code/src/com/suse/manager/webui/controllers/MinionController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/MinionController.java
@@ -257,8 +257,8 @@ public class MinionController {
     public static ModelAndView bootstrap(Request request, Response response, User user) {
         Map<String, Object> data = new HashMap<>();
         ActivationKeyManager akm = ActivationKeyManager.getInstance();
-        List<String> visibleBootstrapKeys = akm.findAll(user)
-                .stream().map(ActivationKey::getKey)
+        List<String> visibleBootstrapKeys = akm.findAllActive(user).stream()
+                .map(ActivationKey::getKey)
                 .collect(Collectors.toList());
         List<Map<String, Object>> proxies = ServerFactory.lookupProxiesByOrg(user)
                 .stream()

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Hide disabled activation keys in form drop-downs (bsc#1101706)
 - Implement Errata filtering based on advisory name in Content Lifecycle Management
 - UI to enable / disable server monitoring
 - Add monitoring entitlement


### PR DESCRIPTION
Hide disabled keys in activation key drop-downs in the following forms:
 - Bootstrap
 - Image profile
 - Image import

## Documentation
- No documentation needed: Bugfix

## Links

Fixes [bsc#1101706](https://bugzilla.suse.com/show_bug.cgi?id=1101706)

## Ports
 - [ ] Manager 3.2

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"  		 
- [ ] Re-run test "java_pgsql_tests"  		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
