### PR TITLE
remove 'apt-transport-spacewalk' and spacewalk 'sources' on Debian...

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/bootstrap/remove_traditional_stack.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/remove_traditional_stack.sls
@@ -32,6 +32,8 @@ remove_traditional_stack:
       - rhn-check
       - rhn-setup
       - rhn-client-tools
+{%- elif grains['os_family'] == 'Debian' %}
+      - apt-transport-spacewalk
 {%- endif %}
       - osad
       - osa-common
@@ -44,6 +46,16 @@ remove_traditional_stack:
       - module: disable_repo*
 {%- endif %}
     - unless: rpm -q spacewalk-proxy-common
+
+# only removing apt-transport-spacewalk above
+# causes apt-get update to 'freeze' if this
+# file is still present and referencing a
+# method not present anymore.
+{%- if grains['os_family'] == 'Debian' %}
+remove_spacewalk_sources:
+  file.absent:
+    - name: /etc/apt/sources.list.d/spacewalk.list
+{%- endif %}
 
 # Remove suseRegisterInfo in a separate yum transaction to avoid being called by
 # the yum plugin.


### PR DESCRIPTION
## What does this PR change?

**'apt-transport-spacewalk' is normally installed on Spacewalk managed systems
which installs 2 hooks into APT to always update the 'spacewalk.list' sources
file. Keeping this package causes the - possibly disabled - spacewalk repos
to be reenabled. Therefore, remove the package and also the sources file
which also might cause a 'hang' of 'apt-get update' if a sources file is present
referencing a 'method' not available anymore.**

## GUI diff

No difference.

Before:

After:

- [X] **DONE**

## Documentation
- No documentation needed: **Minor bugfix**

- [X] **DONE**

## Test coverage
- No tests: **minor bugfix**

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"  
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
