### PR TITLE
Remove useless background steps

### DIFF
--- a/testsuite/features/srv_custom_system_info.feature
+++ b/testsuite/features/srv_custom_system_info.feature
@@ -5,7 +5,6 @@ Feature: Custom system info key-value pairs
 
   Background:
     Given I am authorized
-    When I follow the left menu "Systems > Overview"
 
   Scenario: Create a new key
     When I follow the left menu "Systems > Custom System Info"
@@ -17,6 +16,7 @@ Feature: Custom system info key-value pairs
     Then I should see a "Successfully added 1 custom key." text
 
   Scenario: Add a value to a system
+    When I follow the left menu "Systems > Overview"
     When I follow this "sle-client" link
     And I follow "Custom Info"
     And I follow "Create Value"
@@ -27,6 +27,7 @@ Feature: Custom system info key-value pairs
     And I should see a "key-value" link
 
   Scenario: Edit the value
+    When I follow the left menu "Systems > Overview"
     When I follow this "sle-client" link
     And I follow "Custom Info"
     And I follow "key-value"

--- a/testsuite/features/srv_distro_cobbler.feature
+++ b/testsuite/features/srv_distro_cobbler.feature
@@ -5,7 +5,6 @@ Feature: Cobbler and distribution autoinstallation
 
   Background:
     Given I am authorized
-    When I follow the left menu "Systems > Overview"
 
   Scenario: Ask cobbler to create a distribution via XML-RPC
     Given cobblerd is running

--- a/testsuite/features/srv_menu.feature
+++ b/testsuite/features/srv_menu.feature
@@ -5,7 +5,6 @@ Feature: Web UI - Main landing page menu, texts and links
 
   Background:
     Given I am authorized
-    When I follow the left menu "Systems > Overview"
 
   Scenario: The menu direct link accesses the first submenu level only
     When I follow the left menu "Patches > Patch List"
@@ -21,6 +20,7 @@ Feature: Web UI - Main landing page menu, texts and links
     Then I should see a " Software Channel Management" text in the content area
 
   Scenario: Completeness of the side navigation bar and the content frame
+    When I follow the left menu "Systems > Overview"
     Then I should see a "System Overview" text in the content area
     And I should see a "Overview" link in the left menu
     And I should see a "Systems" link in the left menu


### PR DESCRIPTION
## What does this PR change?

Remove Background steps loading pages that are not used in the most of the Feature Scenarios

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed:

- [x] **DONE**

## Test coverage
- No tests:

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint" (Test skipped, there are no changes to test)		 
