### PR TITLE
Testsuite - skip scenario when http_proxy is not defined

### DIFF
--- a/testsuite/features/support/setup_browser.rb
+++ b/testsuite/features/support/setup_browser.rb
@@ -103,6 +103,11 @@ Before('@susemanager') do |scenario|
   scenario.skip_invoke! unless $product == 'SUSE Manager'
 end
 
+# do test only if HTTP proxy for SUSE Manager is defined
+Before('@http_proxy') do |scenario|
+  scenario.skip_invoke! unless $http_proxy
+end
+
 # have more infos about the errors
 def debug_server_on_realtime_failure
   puts


### PR DESCRIPTION
## What does this PR change?

PR adds skipping of scenario when `http_proxy` variable is not defined by cucumber.


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
