### PR TITLE
Make swap files readable only by root (bsc#1131954, CVE-2019-3684)

### DIFF
--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- Make swap files readable only by root (bsc#1131954, CVE-2019-3684)
 - convert cobbler files to new format during migration
 - add dbus-lib to RES6 bootstrap repo (bsc#1132343)
 - create bootstrap repo for new Red Hat channels (bsc#1133587)

--- a/susemanager/susemanager.spec
+++ b/susemanager/susemanager.spec
@@ -230,6 +230,10 @@ if [ $POST_ARG -eq 2 ] ; then
     fi
 fi
 # else new install and the systems dir should be created by spacewalk-setup
+# Fix permissions for existing swapfiles (bsc#1131954, CVE-2019-3684)
+if [[ -f /SWAPFILE && $(stat -c "%a" "/SWAPFILE") != "600" ]]; then
+    chmod 600 /SWAPFILE
+fi
 
 %posttrans
 # make sure our database will use correct encoding


### PR DESCRIPTION
## What does this PR change?

Make swap files readable only by root (bsc#1131954, CVE-2019-3684)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Bugfix

- [x] **DONE**

## Test coverage
- No tests: Not covered

- [x] **DONE**

## Links

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1131954

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
