### PR TITLE
CLM - Filters: Add new state EDITED

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
@@ -509,6 +509,9 @@ public class ContentProjectFactory extends HibernateFactory {
         name.ifPresent(n -> filter.setName(n));
         rule.ifPresent(r -> filter.setRule(r));
         criteria.ifPresent(c -> filter.setCriteria(c));
+        listFilterProjectsRelation(filter).stream()
+                .filter(projectFilter -> projectFilter.getState() == ContentProjectFilter.State.BUILT)
+                .forEach(projectFilter -> projectFilter.setState(ContentProjectFilter.State.EDITED));
         return filter;
     }
 
@@ -531,8 +534,22 @@ public class ContentProjectFactory extends HibernateFactory {
     public static List<ContentProject> listFilterProjects(ContentFilter filter) {
         return HibernateFactory.getSession()
                 .createQuery("SELECT cp FROM ContentProject cp " +
-                                "WHERE cp.id IN (SELECT cpf.project.id FROM ContentProjectFilter cpf " +
-                                                 "WHERE cpf.filter.id = :fid)")
+                        "WHERE cp.id IN (SELECT cpf.project.id FROM ContentProjectFilter cpf " +
+                        "WHERE cpf.filter.id = :fid)")
+                .setParameter("fid", filter.getId())
+                .list();
+    }
+
+    /**
+     * List {@link ContentProjectFilter}s using given {@link ContentFilter}
+     *
+     * @param filter the Filter
+     * @return list of Projects
+     */
+    public static List<ContentProjectFilter> listFilterProjectsRelation(ContentFilter filter) {
+        return HibernateFactory.getSession()
+                .createQuery("SELECT cpf FROM ContentProjectFilter cpf " +
+                        "WHERE cpf.filter.id = :fid")
                 .setParameter("fid", filter.getId())
                 .list();
     }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFilter.java
@@ -47,7 +47,8 @@ public class ContentProjectFilter {
     public enum State {
         ATTACHED,
         DETACHED,
-        BUILT
+        BUILT,
+        EDITED
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -584,6 +584,8 @@ public class ContentManager {
         // newly attached filters get built
         filtersToHandle.getOrDefault(ContentProjectFilter.State.ATTACHED, emptyList()).stream()
                 .forEach(f -> f.setState(ContentProjectFilter.State.BUILT));
+        filtersToHandle.getOrDefault(ContentProjectFilter.State.EDITED, emptyList()).stream()
+                .forEach(f -> f.setState(ContentProjectFilter.State.BUILT));
         // remove the detached filters
         filtersToHandle.getOrDefault(ContentProjectFilter.State.DETACHED, emptyList()).stream()
                 .forEach(f -> removeFilter(f));

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add state EDITED to filters in the Content Lifecycle Environments
 - Add built time date to the Content Lifecycle Environments
 - Update ServerArch on each ImageDeployedEvent (bsc#1134621)
 - Remove the 'Returning' clause from the query as oracle doesn't support it (bsc#1135166)

--- a/web/html/src/manager/content-management/list-filters/filter-form.js
+++ b/web/html/src/manager/content-management/list-filters/filter-form.js
@@ -26,6 +26,13 @@ const FilterForm = (props: Props) => {
       }}
     >
       <React.Fragment>
+        {
+          props.editing &&
+          <div className="alert alert-info" style={{marginTop: "0px"}}>
+            {t("Bear in mind that all the associated projects need to be rebuilt after a filter update")}
+          </div>
+
+        }
         <div className="row">
           <Text
             name="name"

--- a/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project.js
+++ b/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project.js
@@ -44,6 +44,17 @@ const renderFilterEntry = (filter, projectId) => {
       </li>
     );
   }
+  if (filter.state === statesEnum.enum.EDITED.key) {
+    return (
+      <li
+        key={`filter_list_item_${filter.id}`}
+        className={`list-group-item text-warning ${styles.wrapper}`}>
+        <i className='fa fa-edit'/>
+        <b>{descr}</b>
+        {filterButton}
+      </li>
+    );
+  }
   if (filter.state === statesEnum.enum.DETACHED.key) {
     return (
       <li

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Add state EDITED to filters in the Content Lifecycle
 - Add built time date to the Content Lifecycle Environments
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Whenever a filter is edited, mark all the projects using that filter as EDITED as show it with a yellow color

This PR depends on: https://github.com/uyuni-project/uyuni/pull/993

Only the last commit matters. All the others are from https://github.com/uyuni-project/uyuni/pull/993

## GUI diff

![Screenshot from 2019-05-20 15-19-57](https://user-images.githubusercontent.com/1140720/58028525-d41fea80-7b12-11e9-9dbc-024eb7c9a10c.png)

- [x] **DONE**

## Documentation

- [x] **DONE**

## Test coverage 

- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 