### PR TITLE
Cucumber output: let it be generated in a JSON format as well

### DIFF
--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -4,11 +4,15 @@ require 'cucumber/rake/task'
 
 outputfile = 'output.html'
 html_results = "--format html -o #{outputfile}"
+
+outputfile_json = 'output.json'
+json_results = "--format json_pretty -o #{outputfile_json}"
+
 junit_results = '--format junit -o results_junit'
 Dir.glob(File.join(Dir.pwd, 'run_sets', '*.yml')).each do |entry|
   namespace :cucumber do
     Cucumber::Rake::Task.new(File.basename(entry, '.yml').to_sym) do |t|
-      cucumber_opts = %W[#{html_results} #{junit_results} -f rerun --out failed.txt --format pretty]
+      cucumber_opts = %W[#{html_results} #{json_results} #{junit_results} -f rerun --out failed.txt --format pretty]
       features = YAML.safe_load(File.read(entry))
       t.cucumber_opts = cucumber_opts + features
     end


### PR DESCRIPTION
## What does this PR change?

Let cucumber run and save the output data results in a `JSON` file format as well. This allow a more *code oriented analysis* approach and data can be compared and manipulated easily from the `JSON` format instead of parsing the `HTML` ouput result.

#### Notes
The only *not so nice* but also *nothing can be done* about the it is that if the testsuite run is stopped or it fails before the complete run ends, the `JSON` file results empty because Cucumber is not able to write and close it properly.

## GUI diff

Before:

The current output results folder contains the `HTML` output file among other files.
```
- spacewalk/testsuite/
  - output.html
```

After:

The new `JSON` file will be saved a the same path level of the `HTML` one.
```
- spacewalk/testsuite/
  - output.html
  - output.json
```


- [x] **DONE**

## Documentation
- No documentation needed: internal tool

- [x] **DONE**

## Test coverage
- No tests: internal tool changes on the cucumber testsuite itself

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
