### PR TITLE
Changed traditional pkg names

### DIFF
--- a/backend/server/action/kickstart_host.py
+++ b/backend/server/action/kickstart_host.py
@@ -42,8 +42,8 @@ def schedule_virt_host_pkg_install(server_id, action_id, dry_run=0):
     """
     log_debug(3)
 
-    virt_host_package_name = "rhn-virtualization-host"
-    messaging_package_name = "osad"
+    virt_host_package_name = "mgr-virtualization-host"
+    messaging_package_name = "mgr-osad"
 
     tools_channel = SubscribedChannel(server_id, "rhn-tools")
     found_tools_channel = tools_channel.is_subscribed_to_channel()
@@ -54,12 +54,12 @@ def schedule_virt_host_pkg_install(server_id, action_id, dry_run=0):
     rhn_v12n_package = ChannelPackage(server_id, virt_host_package_name)
 
     if not rhn_v12n_package.exists():
-        raise InvalidAction("Could not find the rhn-virtualization-host package.")
+        raise InvalidAction("Could not find the mgr-virtualization-host package.")
 
     messaging_package = ChannelPackage(server_id, messaging_package_name)
 
     if not messaging_package.exists():
-        raise InvalidAction("Could not find the osad package.")
+        raise InvalidAction("Could not find the mgr-osad package.")
 
     try:
         rhn_v12n_install_scheduler = PackageInstallScheduler(server_id, action_id, rhn_v12n_package)
@@ -79,5 +79,5 @@ def schedule_virt_host_pkg_install(server_id, action_id, dry_run=0):
         e = sys.exc_info()[1]
         raise_with_tb(InvalidAction(str(e)), sys.exc_info()[2])
 
-    log_debug(3, "Completed scheduling install of rhn-virtualization-host and osad!")
+    log_debug(3, "Completed scheduling install of mgr-virtualization-host and mgr-osad!")
     raise ShadowAction("Scheduled installation of Virtualization Host packages.")

--- a/backend/server/rhnServer/server_kickstart.py
+++ b/backend/server/rhnServer/server_kickstart.py
@@ -296,7 +296,7 @@ def schedule_virt_pkg_install(server_id, kickstart_session_id):
         action_id = rhnAction.schedule_server_action(
             server_id,
             action_type='kickstart_host.schedule_virt_host_pkg_install',
-            action_name="Schedule install of rhn-virtualization-host package.",
+            action_name="Schedule install of mgr-virtualization-host package.",
             delta_time=0, scheduler=scheduler, org_id=org_id,
         )
     elif ks_type == 'para_guest':
@@ -304,7 +304,7 @@ def schedule_virt_pkg_install(server_id, kickstart_session_id):
         action_id = rhnAction.schedule_server_action(
             server_id,
             action_type='kickstart_guest.schedule_virt_guest_pkg_install',
-            action_name="Schedule install of rhn-virtualization-guest package.",
+            action_name="Schedule install of mgr-virtualization-guest package.",
             delta_time=0, scheduler=scheduler, org_id=org_id,
         )
     else:

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- use new names in code for client tool packages which were renamed (bsc#1134876)
+
 -------------------------------------------------------------------
 Wed May 15 15:07:45 CEST 2019 - jgonzalez@suse.com
 

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/config_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/config_queries.xml
@@ -398,7 +398,7 @@ SELECT  S.id,
                  FROM  rhnServerPackage SP, rhnPackageName PN
                 WHERE  S.id = SP.server_id
                   AND  SP.name_id = PN.id
-                  AND  PN.name = 'rhncfg') is not null then 'Y'
+                  AND  (PN.name = 'rhncfg' OR PN.name = 'mgr-cfg')) is not null then 'Y'
                  when (SELECT  DISTINCT 1
                           FROM  rhnServerAction SA, rhnActionPackage AP,
                                 rhnPackageName PN, rhnActionStatus PAS
@@ -407,12 +407,12 @@ SELECT  S.id,
                            AND  PAS.name IN ('Queued', 'Picked Up')
                            AND  SA.action_id = AP.action_id
                            AND  AP.name_id = PN.id
-                           AND  PN.name = 'rhncfg') is not null then 'P' else 'N' end AS rhncfg,
+                           AND  (PN.name = 'rhncfg' OR PN.name = 'mgr-cfg')) is not null then 'P' else 'N' end AS rhncfg,
         case when (SELECT  DISTINCT 1
                  FROM  rhnServerPackage SP, rhnPackageName PN
                 WHERE  S.id = SP.server_id
                   AND  SP.name_id = PN.id
-                  AND  PN.name = 'rhncfg-actions') is not null then 'Y'
+                  AND  (PN.name = 'rhncfg-actions' OR PN.name = 'mgr-cfg-actions')) is not null then 'Y'
                  when (SELECT  DISTINCT 1
                           FROM  rhnServerAction SA, rhnActionPackage AP,
                                 rhnPackageName PN, rhnActionStatus PAS
@@ -421,12 +421,12 @@ SELECT  S.id,
                            AND  PAS.name IN ('Queued', 'Picked Up')
                            AND  SA.action_id = AP.action_id
                            AND  AP.name_id = PN.id
-                           AND  PN.name = 'rhncfg-actions') is not null then 'P' else 'N' end AS rhncfg_actions,
+                           AND  (PN.name = 'rhncfg-actions' Or PN.name = 'mgr-cfg-actions')) is not null then 'P' else 'N' end AS rhncfg_actions,
         case when (SELECT  DISTINCT 1
                  FROM  rhnServerPackage SP, rhnPackageName PN
                 WHERE  S.id = SP.server_id
                   AND  SP.name_id = PN.id
-                  AND  PN.name = 'rhncfg-client') is not null then 'Y'
+                  AND  (PN.name = 'rhncfg-client' OR PN.name = 'mgr-cfg-client')) is not null then 'Y'
                  when (SELECT  DISTINCT 1
                           FROM  rhnServerAction SA, rhnActionPackage AP,
                                 rhnPackageName PN, rhnActionStatus PAS
@@ -435,7 +435,7 @@ SELECT  S.id,
                            AND  PAS.name IN ('Queued', 'Picked Up')
                            AND  SA.action_id = AP.action_id
                            AND  AP.name_id = PN.id
-                           AND  PN.name = 'rhncfg-client') is not null then 'P' else 'N' end AS rhncfg_client,
+                           AND  (PN.name = 'rhncfg-client' OR PN.name = 'rhncfg-client')) is not null then 'P' else 'N' end AS rhncfg_client,
         case when (SELECT  DISTINCT 1
                  FROM  rhnServerChannel SC, rhnChannel C
                 WHERE  S.id = SC.server_id

--- a/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
@@ -151,7 +151,7 @@ public class ChannelManager extends BaseManager {
      * Key used to identify the rhn-tools channel.  Used in searches to find the channel
      */
     public static final String TOOLS_CHANNEL_PACKAGE_NAME =
-        Config.get().getString("tools_channel.package_name", "rhncfg");
+        Config.get().getString("tools_channel.package_name", "mgr-cfg");
 
 
     /**
@@ -166,7 +166,7 @@ public class ChannelManager extends BaseManager {
      */
     public static final String RHN_VIRT_HOST_PACKAGE_NAME =
         Config.get().getString("tools_channel.virt_package_name",
-                "rhn-virtualization-host");
+                "mgr-virtualization-host");
 
     /**
      * OS name for the virt child channel.  rhnDistChannelMap.OS field.

--- a/java/code/src/com/redhat/rhn/manager/rhnpackage/PackageManager.java
+++ b/java/code/src/com/redhat/rhn/manager/rhnpackage/PackageManager.java
@@ -77,9 +77,9 @@ import com.redhat.rhn.manager.system.IncompatibleArchException;
  */
 public class PackageManager extends BaseManager {
     private static final Logger LOG = Logger.getLogger(PackageManager.class);
-    public static final String RHNCFG = "rhncfg";
-    public static final String RHNCFG_CLIENT = "rhncfg-client";
-    public static final String RHNCFG_ACTIONS = "rhncfg-actions";
+    public static final String RHNCFG = "mgr-cfg";
+    public static final String RHNCFG_CLIENT = "mgr-cfg-client";
+    public static final String RHNCFG_ACTIONS = "mgr-cfg-actions";
 
     // Valid dependency types
     public static final String[]

--- a/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
@@ -73,7 +73,8 @@ import java.util.stream.Stream;
 public class RegistrationUtils {
 
     private static final List<String> BLACKLIST = Collections.unmodifiableList(
-       Arrays.asList("rhncfg", "rhncfg-actions", "rhncfg-client", "rhn-virtualization-host", "osad")
+       Arrays.asList("rhncfg", "rhncfg-actions", "rhncfg-client", "rhn-virtualization-host", "osad",
+               "mgr-cfg", "mgr-cfg-actions", "mgr-cfg-client", "mgr-virtualization-host", "mgr-osad")
     );
 
     private static final String OS = "os";

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- use new names in code for client tool packages which were renamed (bsc#1134876)
+
 -------------------------------------------------------------------
 Wed May 15 15:11:15 CEST 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

In uyuni we renamed client tools packages which are also used in the code.
Use the new names everywhere. At some places check for old and new names.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- https://github.com/SUSE/doc-susemanager/issues/458

- [x] **DONE**

## Test coverage
- No tests: **add explanation**

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"   
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests" 		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
