### PR TITLE
 CLM - small text fixes. Attach/Detach Sources and draft message 

### DIFF
--- a/testsuite/features/srv_content_lifecycle.feature
+++ b/testsuite/features/srv_content_lifecycle.feature
@@ -34,7 +34,7 @@ Feature: Content lifecycle
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Content Lifecycle > Projects"
     And I follow "clp_name"
-    And I follow "Edit Sources"
+    And I follow "Attach/Detach Sources"
     And I select "SLES12-SP4-Pool for x86_64" from "selectedBaseChannel"
     And I click on "Save"
     Then I should see a "Sources edited successfully" text
@@ -110,7 +110,7 @@ Feature: Content lifecycle
     When I follow the left menu "Content Lifecycle > Projects"
     And I follow "clp_name"
     Then I should see a "Build (0)" text
-    When I follow "Edit Sources"
+    When I follow "Attach/Detach Sources"
     And I add the "Test Base Channel" channel to sources
     And I click on "Save"
     Then I should see a "Sources edited successfully" text

--- a/web/html/src/manager/content-management/shared/components/panels/properties/properties-edit.js
+++ b/web/html/src/manager/content-management/shared/components/panels/properties/properties-edit.js
@@ -29,7 +29,7 @@ const PropertiesEdit = (props: Props) => {
 
   const defaultDraftHistory = {
     version: props.currentHistoryEntry ? props.currentHistoryEntry.version + 1 : 1 ,
-    message:'(draft - not built) - Check the colors below for all the changes'
+    message:'(draft - not built) - Check the changes below'
   };
 
   let propertiesToShow = produce(props.properties, draftProperties => {

--- a/web/html/src/manager/content-management/shared/components/panels/sources/sources.js
+++ b/web/html/src/manager/content-management/shared/components/panels/sources/sources.js
@@ -85,7 +85,7 @@ const Sources = (props: SourcesProps) => {
     <CreatorPanel
       id="sources"
       title="Sources"
-      creatingText="Edit Sources"
+      creatingText="Attach/Detach Sources"
       panelLevel="2"
       disableEditing={!hasEditingPermissions}
       collapsible


### PR DESCRIPTION
## What does this PR change?
 CLM - small text fixes. Attach/Detach Sources and draft message 

## GUI diff

![Screenshot from 2019-05-14 14-02-01](https://user-images.githubusercontent.com/1140720/57699967-e1d7fa80-7650-11e9-822e-c77f9f7b525d.png)

- [x] **DONE**

## Documentation

- Not needed 

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Fixes #https://github.com/SUSE/spacewalk/issues/7795

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
