### PR TITLE
Update ServerArch on each ImageDeployedEvent (bsc#1134621)

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/ImageDeployedEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/ImageDeployedEventMessageAction.java
@@ -17,6 +17,7 @@ package com.suse.manager.reactor.messaging;
 
 import com.redhat.rhn.common.messaging.EventMessage;
 import com.redhat.rhn.common.messaging.MessageAction;
+import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.MinionServerFactory;
 import com.redhat.rhn.domain.token.ActivationKey;
@@ -75,6 +76,11 @@ public class ImageDeployedEventMessageAction implements MessageAction {
             LOG.info("System image of minion id '" + m.getId() + "' has changed. Re-applying activation key," +
                     " subscribing to channels and executing post-registration tasks.");
             ValueMap grains = imageDeployedEvent.getGrains();
+
+            grains.getOptionalAsString("osarch").ifPresent(osarch -> {
+                m.setServerArch(ServerFactory.lookupServerArchByLabel(osarch + "-redhat-linux"));
+            });
+
             Optional<String> activationKeyLabel = grains
                     .getMap("susemanager")
                     .flatMap(suma -> suma.getOptionalAsString("activation_key"));

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Update ServerArch on each ImageDeployedEvent (bsc#1134621)
 - Remove the 'Returning' clause from the query as oracle doesn't support it (bsc#1135166)
 - Display warning if product catalog refresh is already in progress (bsc#1132234)
 - Fix apidoc return order on mergePackages


### PR DESCRIPTION
## What does this PR change?

Update ServerArch on each ImageDeployedEvent

OS architecture depends on the image, so it must be updated every time the image is changed.
http://bugzilla.suse.com/show_bug.cgi?id=1134621

## GUI diff

No difference.


## Documentation
- No documentation needed: expected behavior

## Test coverage
- tested manually
- will be covered in Retail OpenQA tests


## Links

Fixes: http://bugzilla.suse.com/show_bug.cgi?id=1134621

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
