### PR TITLE
Add new packages names to instructions for adding remote configuration support for traditional clients

### DIFF
--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -833,10 +833,13 @@ if [ $ALLOW_CONFIG_ACTIONS -eq 1 ] ; then
     echo "  NOTE: use an activation key to subscribe to the tools"
     if [ "$INSTALLER" == zypper ] ; then
         echo "        channel and zypper install/update rhncfg-actions"
+        echo "        or zypper install/update mgr-cfg-actions starting with 4.0"
     elif [ "$INSTALLER" == yum ] ; then
         echo "        channel and yum upgrade rhncfg-actions"
+        echo "        or yum upgrade mgr-cfg-actions starting with 4.0"
     else
         echo "        channel and up2date rhncfg-actions"
+        echo "        or up2date mgr-cfg-actions starting with 4.0"
     fi
     if [ -x "/usr/bin/rhn-actions-control" ] ; then
         rhn-actions-control --enable-all
@@ -845,11 +848,14 @@ if [ $ALLOW_CONFIG_ACTIONS -eq 1 ] ; then
         echo "Error setting permissions for configuration management."
         echo "    Please ensure that the activation key subscribes the"
         if [ "$INSTALLER" == zypper ] ; then
-            echo "    system to the tools channel and zypper install/update rhncfg-actions."
+            echo "    system to the tools channel and zypper install/update rhncfg-actions"
+            echo "    or zypper install/update mgr-cfg-actions starting with 4.0."
         elif [ "$INSTALLER" == yum ] ; then
-            echo "    system to the tools channel and yum updates rhncfg-actions."
+            echo "    system to the tools channel and yum updates rhncfg-actions"
+            echo "    or yum update mgr-cfg-actions starting with 4.0.
         else
-            echo "    system to the tools channel and up2dates rhncfg-actions."
+            echo "    system to the tools channel and up2date rhncfg-actions"
+            echo "    or up2date mgr-cfg-actions starting with 4.0."
         fi
         exit
     fi

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,5 @@
+- Add new packages names to instructions for adding remote configuration
+  support for traditional clients
 - Print error message instead of stacktrace for client_config_update.py
 
 -------------------------------------------------------------------


### PR DESCRIPTION
Add new packages names to instructions for adding remote configuration support for traditional clients

## What does this PR change?

As discussed at https://github.com/uyuni-project/uyuni/pull/950

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Requested at https://github.com/SUSE/spacewalk/issues/7805

- [x] **DONE**

## Test coverage
- No tests: Only text, not covered by tests

- [x] **DONE**

## Links

Related: https://github.com/SUSE/spacewalk/issues/7805

Should be ported to 3.2 IMHO.

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
