### PR TITLE
Chore: list JARs dependencies for SSO in ant

### DIFF
--- a/java/buildconf/build-props.xml
+++ b/java/buildconf/build-props.xml
@@ -133,7 +133,7 @@
              regexp ${jmock-jars} strutstest" / -->
 
   <!-- SUSE extra dependencies: build and runtime -->
-  <property name="suse-common-jars" value="jade4j jose4j salt-netapi-client spark-core spark-template-jade httpclient httpcore httpasyncclient httpcore-nio simpleclient simpleclient_common simpleclient_servlet simpleclient_httpserver pgjdbc-ng netty-common netty-buffer netty-resolver netty-transport netty-codec netty-handler" />
+  <property name="suse-common-jars" value="jade4j jose4j salt-netapi-client spark-core spark-template-jade httpclient httpcore httpasyncclient httpcore-nio simpleclient simpleclient_common simpleclient_servlet simpleclient_httpserver pgjdbc-ng netty-common netty-buffer netty-resolver netty-transport netty-codec netty-handler java-saml java-saml-core joda-time woodstox-core-asl xmlsec" />
 
   <!-- SUSE extra dependencies: runtime only -->
   <property name="suse-runtime-jars" value="commons-jexl ${commons-lang} concurrentlinkedhashmap-lru


### PR DESCRIPTION
## What does this PR change?

List JARs dependencies in ant

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: internal

- [X] **DONE**

## Test coverage
- No tests: internal

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"   
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
