### PR TITLE
Explicitly mention country code in the advanced search (bsc#1131892)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/systems/SystemSearchAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/SystemSearchAction.java
@@ -95,7 +95,7 @@ public class SystemSearchAction extends BaseSearchAction implements Listable {
                     { SystemSearchHelper.INSTALLED_PACKAGES,
                                     SystemSearchHelper.NEEDED_PACKAGES },
                     /* location */
-                    { SystemSearchHelper.LOC_COUNTRY, SystemSearchHelper.LOC_STATE,
+                    { SystemSearchHelper.LOC_COUNTRY_CODE, SystemSearchHelper.LOC_STATE,
                                     SystemSearchHelper.LOC_CITY,
                                     SystemSearchHelper.LOC_ADDRESS,
                                     SystemSearchHelper.LOC_BUILDING,

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/SystemSearchHelper.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/SystemSearchHelper.java
@@ -83,7 +83,7 @@ public class SystemSearchHelper {
     public static final String INSTALLED_PACKAGES = "systemsearch_installed_packages";
     public static final String NEEDED_PACKAGES = "systemsearch_needed_packages";
     public static final String RUNNING_KERNEL = "systemsearch_running_kernel";
-    public static final String LOC_COUNTRY = "systemsearch_location_country";
+    public static final String LOC_COUNTRY_CODE = "systemsearch_location_country_code";
     public static final String LOC_STATE = "systemsearch_location_state";
     public static final String LOC_CITY = "systemsearch_location_city";
     public static final String LOC_ADDRESS = "systemsearch_location_address";
@@ -142,7 +142,7 @@ public class SystemSearchHelper {
                     { SystemSearchHelper.INSTALLED_PACKAGES,
                                     SystemSearchHelper.NEEDED_PACKAGES },
                     /* location */
-                    { SystemSearchHelper.LOC_COUNTRY, SystemSearchHelper.LOC_STATE,
+                    { SystemSearchHelper.LOC_COUNTRY_CODE, SystemSearchHelper.LOC_STATE,
                                     SystemSearchHelper.LOC_CITY,
                                     SystemSearchHelper.LOC_ADDRESS,
                                     SystemSearchHelper.LOC_BUILDING,
@@ -415,7 +415,7 @@ public class SystemSearchHelper {
             query = "runningKernel:(" + terms + ")";
             index = SERVER_INDEX;
         }
-        else if (LOC_COUNTRY.equals(mode)) {
+        else if (LOC_COUNTRY_CODE.equals(mode)) {
             query = "country:(" + terms + ")";
             index = SERVER_INDEX;
         }

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemDetailsEditAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemDetailsEditAction.java
@@ -409,7 +409,7 @@ public class SystemDetailsEditAction extends RhnAction {
         while (i.hasNext()) {
             String name = (String) i.next();
             String code = (String) cmap.get(name);
-            countries.add(new LabelValueBean(name, code));
+            countries.add(new LabelValueBean(String.format("%s (%s)", name, code), code));
         }
         return countries;
     }

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -2881,8 +2881,8 @@ and try again.
           <context context-type="sourcefile">/systems/Search</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="systemsearch_location_country">
-        <source>Country</source>
+      <trans-unit id="systemsearch_location_country_code">
+        <source>Country Code</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/systems/Search</context>
         </context-group>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Explicitly mention country code in the advanced search (bsc#1131892)
+
 -------------------------------------------------------------------
 Wed May 15 17:05:45 CEST 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
The search server indexes the country attribute of servers using country code
(not country name (which wouldn't be cannonical, because of the localization)).

This PR changes the UI so that it's explicit that search in 'Advanced search'
is based on country code and not country name.

XMLRPC has always worked on country code, therefore it's unaffected by this "bug".

## Screenshots
Before:
![ss-before](https://user-images.githubusercontent.com/1412268/57785634-6babc480-7732-11e9-9165-13a0b31f1744.png)

![ss-before2](https://user-images.githubusercontent.com/1412268/57785633-6babc480-7732-11e9-8e90-fbad4a53dd67.png)


After:
![ss-bsc1](https://user-images.githubusercontent.com/1412268/57785540-3d2de980-7732-11e9-8302-03c5509fa78b.png)
![ss-bsc2](https://user-images.githubusercontent.com/1412268/57785541-3d2de980-7732-11e9-8856-3aa398ec4f69.png)


- [x] **DONE**

## Docs
- No documentation needed: bugfix

- [x] **DONE**

## Tests
- No tests: No tests for frontend

- [x] **DONE**

## Links
Tracks https://github.com/SUSE/spacewalk/issues/7562

- [x] **DONE**

## Changelog
If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)



If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"