### PR TITLE
Removing the 'returning' clause because oracle doesn't support it

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
@@ -867,16 +867,15 @@ public class ActionFactory extends HibernateFactory {
      * @param status {@link ActionStatus} object that needs to be set
      */
     public static void updateServerActions(Action actionIn, List<Long> serverIds, ActionStatus status) {
-        List list = HibernateFactory.getSession()
+        if (log.isDebugEnabled()) {
+            log.debug("Action status " + status.getName() + " is going to b set for these servers: " + serverIds);
+        }
+        HibernateFactory.getSession()
                 .getNamedQuery("Action.updateServerActions")
                 .setParameter("action_id", actionIn.getId())
                 .setParameter("server_ids", serverIds)
                 .setParameter("status", status.getId())
-                .list();
-        if (log.isDebugEnabled()) {
-            log.debug("Updated number of serverActions " + list.size() + " for action " + actionIn.getId());
-            log.debug("Action status" + status.getName() + " set for these servers: " + list);
-        }
+                .executeUpdate();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
@@ -622,14 +622,12 @@ select sa.server_id
     </sql-query>
 
     <sql-query name="Action.updateServerActions">
-        <return-scalar column="server_id" type="long"/>
         <![CDATA[
             UPDATE rhnServerAction
                 SET status = :status
             WHERE action_id  = :action_id
                 AND server_id  IN (:server_ids)
                 AND status NOT IN(2,3)
-            RETURNING server_id;
         ]]>
     </sql-query>
 </hibernate-mapping>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Remove the 'Returning' clause from the query as oracle doesn't support it (bsc#1135166)
 - Display warning if product catalog refresh is already in progress (bsc#1132234)
 - Fix apidoc return order on mergePackages
 - Explicitly mention country code in the advanced search (bsc#1131892)


### PR DESCRIPTION
## What does this PR change?
Removing the 'returning' clause because Oracle doesn't support it.

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: **Bug fixed**

- [x] **DONE**

## Test coverage
- No tests: **Existing tests should be enoug**


- [x] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/7834
Tracks # **https://github.com/SUSE/spacewalk/pull/7840**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
