### PR TITLE
250s -> 500s to build containers on slow machines

### DIFF
--- a/testsuite/features/min_docker_build_image.feature
+++ b/testsuite/features/min_docker_build_image.feature
@@ -9,11 +9,11 @@ Feature: Build container images
   Scenario: Build the images with and without activation key
     Given I am on the Systems overview page of this "sle-minion"
     When I schedule the build of image "suse_key" via XML-RPC calls
-    Then I wait until event "Image Build suse_key scheduled by admin" is completed
-    When I schedule the build of image "suse_simple" via XML-RPC calls
-    Then I wait until event "Image Build suse_simple scheduled by admin" is completed
-    When I schedule the build of image "suse_real_key" via XML-RPC calls
-    Then I wait until event "Image Build suse_real_key scheduled by admin" is completed
+    And I wait at most 500 seconds until event "Image Build suse_key scheduled by admin" is completed
+    And I schedule the build of image "suse_simple" via XML-RPC calls
+    And I wait at most 500 seconds until event "Image Build suse_simple scheduled by admin" is completed
+    And I schedule the build of image "suse_real_key" via XML-RPC calls
+    And I wait at most 500 seconds until event "Image Build suse_real_key scheduled by admin" is completed
 
   Scenario: Build same images with different versions
     Given I am authorized as "admin" with password "admin"


### PR DESCRIPTION
## What does this PR change?

This PR gives the test suite more time to build container images for the case where we use slow test machines.

Measured time:
 * real_key on ix64ph1078: 285 seconds
 * real_key on ix64ph1074: 395 seconds
 * suse_simple on ix64ph1074: 395 seconds

Previous timeout was 250 seconds, increasing it to 500 seconds.

## Links

* 3.1: SUSE/spacewalk#7859
* 3.2: SUSE/spacewalk#7860

- [x] No changelog needed
