### PR TITLE
HTTP proxy variable renamed

### DIFF
--- a/testsuite/documentation/optional.md
+++ b/testsuite/documentation/optional.md
@@ -312,15 +312,15 @@ are executed only if the PXE boot minion is available.
 
 ## HTTP Proxy setting
 
-If you need to specify HTTP Proxy on SUSE Manager "Setup Wizard" page, you can use 
-variable `http_proxy` from `controller` module in your `main.tf` file with following syntax:
+If you need to specify HTTP proxy on SUSE Manager "Setup Wizard" page, you can use 
+variable `server_http_proxy` from `controller` module in your `main.tf` file with following syntax:
 ```
-http_proxy = "hostname:port"
+server_http_proxy = "hostname:port"
 ```
 It is set to `galaxy-proxy.mgr.suse.de:3128` by default.
 
-Sumaform creates `$SUMA_HTTP_PROXY` variable with corresponding settings in `/root/.bashrc` file
+Sumaform creates `$SERVER_HTTP_PROXY` variable with corresponding settings in `/root/.bashrc` file
 on the controller. It is also possible to tag the scenarios with:
 ```
-@http_proxy
+@server_http_proxy
 ```

--- a/testsuite/features/core_first_settings.feature
+++ b/testsuite/features/core_first_settings.feature
@@ -76,7 +76,7 @@ Feature: Very first settings
     And service "tomcat" is enabled on "server"
     And service "tomcat" is active on "server"
 
-@http_proxy
+@server_http_proxy
   Scenario: Setup HTTP proxy
     When I am authorized as "admin" with password "admin"
     When I follow the left menu "Admin > Setup Wizard"

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -476,7 +476,7 @@ Then(/^I see verification succeeded/) do
 end
 
 When(/^I enter the address of the HTTP proxy as "([^"]*)"/) do |hostname|
-  step %(I enter "#{$http_proxy}" as "#{hostname}")
+  step %(I enter "#{$server_http_proxy}" as "#{hostname}")
 end
 
 # configuration management steps

--- a/testsuite/features/support/setup_browser.rb
+++ b/testsuite/features/support/setup_browser.rb
@@ -104,8 +104,8 @@ Before('@susemanager') do |scenario|
 end
 
 # do test only if HTTP proxy for SUSE Manager is defined
-Before('@http_proxy') do |scenario|
-  scenario.skip_invoke! unless $http_proxy
+Before('@server_http_proxy') do |scenario|
+  scenario.skip_invoke! unless $server_http_proxy
 end
 
 # have more infos about the errors

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -127,4 +127,4 @@ $private_net = ENV['PRIVATENET'] if ENV['PRIVATENET']
 $mirror = ENV['MIRROR']
 $git_profiles = ENV['GITPROFILES']
 $product = product
-$http_proxy = ENV['SUMA_HTTP_PROXY'] if ENV['SUMA_HTTP_PROXY']
+$server_http_proxy = ENV['SERVER_HTTP_PROXY'] if ENV['SERVER_HTTP_PROXY']


### PR DESCRIPTION
## What does this PR change?

PR renames HTTP proxy variable to more suitable (product neutral) name.

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
