### PR TITLE
More thorougly disable the Salt mine in util.mgr_mine_config_clean_up…

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/util/mgr_mine_config_clean_up.sls
+++ b/susemanager-utils/susemanager-sls/salt/util/mgr_mine_config_clean_up.sls
@@ -1,5 +1,14 @@
 {%- if salt['pillar.get']('contact_method') not in ['ssh-push', 'ssh-push-tunnel'] %}
-mgr_mine_config_clean_up:
-  file.absent:
+mgr_disable_mine:
+  file.managed:
     - name: /etc/salt/minion.d/susemanager-mine.conf
+    - contents: "mine_enabled: False"
+
+mgr_salt_minion:
+  service.running:
+   - name: salt-minion
+   - enable: True
+   - order: last
+   - watch:
+     - file: mgr_disable_mine
 {% endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- More thorougly disable the Salt mine in util.mgr_mine_config_clean_up (bsc#1135075)
+
 -------------------------------------------------------------------
 Wed May 15 15:35:23 CEST 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

It changes the way the Salt Mine is disabled in the utility state util.mgr_mine_config_clean_up ([documentation pending](https://github.com/SUSE/spacewalk/issues/7731)).

Before this patch the Mine was kept active but job reporting to the salt-master was disabled, now it is completely disabled.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
[Documentation pending](https://github.com/SUSE/spacewalk/issues/7731).

- [x] **DONE**

## Test coverage
- No tests: **one-shot utility script**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/7850

- [x] **DONE**

