### PR TITLE
Fix CLM testsuite after changing draft version message

### DIFF
--- a/testsuite/features/srv_content_lifecycle.feature
+++ b/testsuite/features/srv_content_lifecycle.feature
@@ -43,7 +43,7 @@ Feature: Content lifecycle
     And I should see a "SLES12-SP4-Updates for x86_64" text
     And I should see a "SLE-Manager-Tools12-Pool for x86_64 SP4" text
     And I should see a "Build (4)" text
-    And I should see a "Version 1: (draft - not built) - Check the colors below for all the changes" text
+    And I should see a "Version 1: (draft - not built) - Check the changes below" text
 
   Scenario: Add environments to the project
     Given I am authorized as "admin" with password "admin"
@@ -116,7 +116,7 @@ Feature: Content lifecycle
     Then I should see a "Sources edited successfully" text
     And I should see a "Test Base Channel" text
     And I should see a "Build (1)" text
-    And I should see a "Version 2: (draft - not built) - Check the colors below for all the changes" text
+    And I should see a "Version 2: (draft - not built) - Check the changes below" text
     When I click on "Build (1)"
     Then I should see a "Version 2 history" text
     When I enter "test version message 2" as "message"


### PR DESCRIPTION
## What does this PR change?

Fix CLM testsuite after changing draft version message. Related with https://github.com/uyuni-project/uyuni/pull/970

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests:

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test" 
- [ ] Re-run test "backend_unittests_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "java_lint_checkstyle" (Test skipped, there are no changes to test)		 
- [ ] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)		 
- [ ] Re-run test "ruby_rubocop" 
- [x] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql" (Test skipped, there are no changes to test)		 
- [ ] Re-run test "susemanager_unittests" (Test skipped, there are no changes to test)
- [ ] Re-run test "javascript_lint" (Test skipped, there are no changes to test)		 
