### PR TITLE
Idempotency test fix

### DIFF
--- a/susemanager-utils/testing/docker/scripts/schema_idempotency_test_pgsql.py
+++ b/susemanager-utils/testing/docker/scripts/schema_idempotency_test_pgsql.py
@@ -5,6 +5,7 @@ import distutils.version as DV
 import glob
 import json
 import os
+import os.path
 import re
 import shutil
 import subprocess
@@ -86,8 +87,10 @@ def create_fake_migration_path(schema_path, new_version, pr_file=None, version=N
     print("Creating: " + fake_path)
     os.mkdir(fake_path)
     for migration_file in files:
-        print("Copying %s to %s.." %(migration_file, fake_path))
-        shutil.copy(migration_file, fake_path)
+        m = re.search('susemanager-schema-\d+\.\d+[\d|.]*-to-susemanager-schema-(\d+\.\d+[\d|.]*)', migration_file)
+        dest_file = os.path.join(fake_path, "%s-%s" %(m.group(1), os.path.basename(migration_file)))
+        print("Copying %s to %s..." %(migration_file, dest_file))
+        shutil.copy(migration_file, dest_file)
 
 
 def run_command(command):

--- a/susemanager-utils/testing/docker/scripts/schema_idempotency_test_pgsql.py
+++ b/susemanager-utils/testing/docker/scripts/schema_idempotency_test_pgsql.py
@@ -159,7 +159,7 @@ def diff_dumps(initial_dump, migrated_dump):
     """ Perform a diff of two database dumps """
     file_initial = open(initial_dump)
     file_migrated = open(migrated_dump)
-    return difflib.context_diff(file_initial.readlines(), file_migrated.readlines())
+    return difflib.unified_diff(file_initial.readlines(), file_migrated.readlines())
 
 
 def argparser():


### PR DESCRIPTION
## What does this PR change?
The problem that is fixed happens when an upgrade script changes the
same thing than another update script in an earlier version, but has a
filename that comes first in the lexicographical order.

As an example, we have the two scripts changing the same index:

  * susemanager-schema-4.0.10-to-susemanager-schema-4.0.11/002-alter-susesaltevent.sql.postgresql
  * susemanager-schema-4.0.11-to-susemanager-schema-4.0.12/001-alter-susesaltevent.sql.postgresql

Obviously the first one needs to be processed first or we would miss
some part of the index after the idempotency test.

The idempotency test copies all the scripts to test into a fake upgrade
folder and applies them all. However here the one named '001-*' will be
applied first independently of the version it has been introduced in.

In order to solve this problem, we now prefix the copied file names with
the version they have been introduced in. For our example we would then
get files:

  * 4.0.11-002-alter-susesaltevent.sql.postgresql
  * 4.0.12-001-alter-susesaltevent.sql.postgresql

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: test fix

- [X] **DONE**

## Test coverage
- No tests: test fix

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
