### PR TITLE
Fix: Required fields for image-profiles when form props change (regression)

### DIFF
--- a/web/html/src/components/input/Form.js
+++ b/web/html/src/components/input/Form.js
@@ -60,7 +60,7 @@ class Form extends React.Component<Props, State> {
     this.setState({
       model,
     },
-    () => this.validate(component));
+    () => this.validate(component, component.props));
 
     if (this.props.onChange) {
       this.props.onChange(this.state.model, this.state.isValid);
@@ -85,8 +85,7 @@ class Form extends React.Component<Props, State> {
     }
   }
 
-  validate(component: React.ElementRef<any>) {
-    const { props } = component;
+  validate(component: React.ElementRef<any>, props: Object) {
     const { name } = props;
     const results = [];
     let isValid = true;
@@ -133,7 +132,7 @@ class Form extends React.Component<Props, State> {
         model[component.props.name] = component.props.value;
         return { model };
       },
-      () => this.validate(component));
+      () => this.validate(component, component.props));
     }
   }
 

--- a/web/html/src/components/input/InputBase.js
+++ b/web/html/src/components/input/InputBase.js
@@ -64,10 +64,10 @@ class InputBase extends React.Component<Props, State> {
   }
 
   // eslint-disable-next-line
-  UNSAFE_componentWillReceiveProps(props) {
-    if (!(props.value === this.props.value && props.disabled === this.props.disabled
-              && props.required === this.props.required)) {
-      if (this.props.validate) this.props.validate(this, props);
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    if (!(nextProps.value === this.props.value && nextProps.disabled === this.props.disabled
+              && nextProps.required === this.props.required)) {
+      if (this.props.validate) this.props.validate(this, nextProps);
       this.setState({
         showErrors: false,
       });


### PR DESCRIPTION
## What does this PR change?

Required fields for image-profiles when form props change (regression)

Regression of: 

Before: https://github.com/uyuni-project/uyuni/commit/e65b6865c3e4172e46e549fe3cc61966b698bd38#diff-41a8895c49b98aec882aaa7fb2e88fbaL96

After: https://github.com/uyuni-project/uyuni/commit/e65b6865c3e4172e46e549fe3cc61966b698bd38#diff-0a6ed3fb865de44349e0039fb2cd5643R84

If we trigger a validation during the lifecycle componentWillReceiveProps we can't use the component props but have to use the next props instead. The component props will still be the old ones.


Although I really like our forms implementation, this makes me wonder if we have enough frontend devs bandwidth to maintain our own implementation of forms. 

It might be interesting to try a POC using this forms library: https://jaredpalmer.com/formik/ (I will create an issue for that). It  looks stable and used by a lot of big companies 

From all the forms libraries implementation I have seen and used this is the only one that pleases me :) 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: 
- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/7410

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle" (Test skipped, there are no changes to test)		 
- [ ] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)		 
- [ ] Re-run test "ruby_rubocop" (Test skipped, there are no changes to test)
- [x] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql" (Test skipped, there are no changes to test)		 
- [ ] Re-run test "susemanager_unittests" (Test skipped, there are no changes to test)
- [ ] Re-run test "javascript_lint" (Test skipped, there are no changes to test)		 
