### PR TITLE
Explicitly check that channel entry has been removed from system after unsubscribing

### DIFF
--- a/testsuite/features/allcli_software_channels.feature
+++ b/testsuite/features/allcli_software_channels.feature
@@ -194,6 +194,7 @@ Feature: Chanel subscription via SSM
     Then I should see a "Changing the channels has been scheduled." text
     When I follow "scheduled" in the content area
     And I wait until I see "1 system successfully completed this action." text, refreshing the page
+    Then channel "Test-Channel-x86_64 Child Channel" should not be enabled on "sle-minion"
 
   Scenario: Cleanup: subscribe the SLES client back to previous channels
     Given I am on the Systems overview page of this "sle-client"
@@ -210,6 +211,7 @@ Feature: Chanel subscription via SSM
     Then I should see a "Changing the channels has been scheduled." text
     When I follow "scheduled" in the content area
     And I wait until I see "1 system successfully completed this action." text, refreshing the page
+    Then channel "Test-Channel-x86_64 Child Channel" should not be enabled on "sle-client"
 
   Scenario: Cleanup: remove remaining systems from SSM
     Given I am authorized as "admin" with password "admin"

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -305,6 +305,12 @@ Then(/^channel "([^"]*)" should be enabled on "([^"]*)"$/) do |channel, host|
   node.run("zypper lr -E | grep '#{channel}'")
 end
 
+Then(/^channel "([^"]*)" should not be enabled on "([^"]*)"$/) do |channel, host|
+  node = get_target(host)
+  _out, code = node.run("zypper lr -E | grep '#{channel}'", false)
+  raise "'#{channel}' was not expected but was found." if code.to_i.zero?
+end
+
 Then(/^"(\d+)" channels should be enabled on "([^"]*)"$/) do |count, host|
   node = get_target(host)
   _out, code = node.run("zypper lr -E | tail -n +5 | wc -l")


### PR DESCRIPTION

## What does this PR change?
Explicitly check that channel entry has been removed from the system after unsubscribing channel


- [x] **DONE**

## Documentation
- No documentation needed: **just extending cucumber test**


- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #
https://github.com/SUSE/spacewalk/issues/6783
Relevant branches (GitHub automatic links expected below):

 - 3.2  https://github.com/SUSE/spacewalk/pull/7718

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
