### PR TITLE
Display warning message that another refresh is already in progress(bsc#1132234)

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/ProductsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/ProductsController.java
@@ -61,6 +61,7 @@ public class ProductsController {
     private static final String ISS_MASTER = "issMaster";
     private static final String REFRESH_NEEDED = "refreshNeeded";
     private static final String REFRESH_RUNNING = "refreshRunning";
+    private static final String REFRESH_FILE_LOCKED = "refreshFileLocked";
 
     private static Logger log = Logger.getLogger(ProductsController.class);
 
@@ -82,6 +83,7 @@ public class ProductsController {
         data.put(ISS_MASTER, String.valueOf(IssFactory.getCurrentMaster() == null));
         data.put(REFRESH_NEEDED, String.valueOf(SCCCachingFactory.refreshNeeded()));
         data.put(REFRESH_RUNNING, String.valueOf(latestRun != null && latestRun.getEndTime() == null));
+        data.put(REFRESH_FILE_LOCKED, String.valueOf(SCCRefreshLock.isAlreadyLocked()));
 
         return new ModelAndView(data, "templates/products/show.jade");
     }

--- a/java/code/src/com/suse/manager/webui/templates/products/show.jade
+++ b/java/code/src/com/suse/manager/webui/templates/products/show.jade
@@ -6,6 +6,7 @@ script(type='text/javascript').
     const issMaster_flag_from_backend = #{issMaster};
     const refreshNeeded_flag_from_backend = #{refreshNeeded};
     const refreshRunning_flag_from_backend = #{refreshRunning};
+    const scc_refresh_file_locked_status = #{refreshFileLocked};
 
 +userPreferences
 script(src='/javascript/manager/products.bundle.js?cb=#{webVersion}', type='text/javascript')

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Display warning if product catalog refresh is already in progress (bsc#1132234)
 - Fix apidoc return order on mergePackages
 - Explicitly mention country code in the advanced search (bsc#1131892)
 

--- a/web/html/src/manager/products.js
+++ b/web/html/src/manager/products.js
@@ -76,7 +76,7 @@ class ProductsPageWrapper extends React.Component {
   state = {
     issMaster: issMaster_flag_from_backend,
     refreshNeeded: refreshNeeded_flag_from_backend,
-    refreshRunning: refreshRunning_flag_from_backend,
+    refreshRunning: refreshRunning_flag_from_backend || scc_refresh_file_locked_status,
     serverData: {_DATA_ROOT_ID : []},
     errors: [],
     loading: true,


### PR DESCRIPTION
## What does this PR change?

Currently locking mechanism that we have for locking scc `sccrefresh.lock` file is not very sophisticated. To fix that properly need more time and bit of research.

This PR is limited to web UI and check if the `sccrefresh.lock` file is already locked, display a reasonable message that refresh is already in progress and disable the `Refresh` button.



## GUI diff

Before:
![Screenshot from 2019-05-14 18-27-05](https://user-images.githubusercontent.com/12951268/57714972-f8447d00-7675-11e9-9be2-6cfbf8f939f6.png)


After:
![Screenshot from 2019-05-16 13-23-01](https://user-images.githubusercontent.com/12951268/57850281-d403b000-77dd-11e9-9304-2a77579912ea.png)


- [x] **DONE**

## Documentation
- No documentation needed: **Not sure, if something needs to be documented here**


- [x] **DONE**

## Test coverage
- No tests: UI changed

- [x] **DONE**

## Links

Fixes #  https://github.com/SUSE/spacewalk/issues/7602
Tracks # **https://github.com/SUSE/spacewalk/pull/7831**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
