### PR TITLE
Support system groups with the prometheus-exporters-formula and monitoring entitlements

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/formula/FormulaManager.java
+++ b/java/code/src/com/redhat/rhn/manager/formula/FormulaManager.java
@@ -100,7 +100,7 @@ public class FormulaManager {
 
         ManagedServerGroup group = ServerGroupFactory.lookupByIdAndOrg(groupId, user.getOrg());
         checkUserHasPermissionsOnServerGroup(user, group);
-        FormulaFactory.saveGroupFormulaData(content, groupId, formulaName);
+        FormulaFactory.saveGroupFormulaData(content, groupId, user.getOrg(), formulaName);
         List<String> minionIds = group.getServers().stream()
                 .flatMap(s -> Opt.stream(s.asMinionServer()))
                 .map(MinionServer::getMinionId).collect(Collectors.toList());

--- a/java/code/src/com/redhat/rhn/manager/system/test/prometheus/pillar.example
+++ b/java/code/src/com/redhat/rhn/manager/system/test/prometheus/pillar.example
@@ -1,0 +1,6 @@
+node_exporter:
+  enabled: False
+
+postgres_exporter:
+  enabled: False
+  data_source_name: postgresql://user:passwd@localhost:5432/database?sslmode=disable

--- a/java/code/src/com/suse/manager/webui/controllers/FormulaController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/FormulaController.java
@@ -205,7 +205,7 @@ public class FormulaController {
                     if (!checkUserHasPermissionsOnServerGroup(user, group)) {
                         return deniedResponse(response);
                     }
-                    FormulaFactory.saveGroupFormulaData(formData, id, formulaName);
+                    FormulaFactory.saveGroupFormulaData(formData, id, user.getOrg(), formulaName);
                     List<String> minionIds = group.getServers().stream()
                             .flatMap(s -> Opt.stream(s.asMinionServer()))
                             .map(MinionServer::getMinionId).collect(Collectors.toList());

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Support system groups with the prometheus-exporters-formula and monitoring entitlements
 - Let softwarechannel_errata_sync fallback on vendor errata (bsc#1132914)
 - Don't convert localhost repositories URL in mirror case (bsc#1135957)
 - Add state EDITED to filters in the Content Lifecycle Environments


### PR DESCRIPTION
## What does this PR change?

Add/remove monitoring entitlement to servers when monitoring formula is activated/deactivated in a system group. 

## GUI diff

No difference.

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/7717

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
