### PR TITLE
CLM -  Add built time column to the content environment target and show it on the UI

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentEnvironment.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentEnvironment.java
@@ -15,17 +15,24 @@
 
 package com.redhat.rhn.domain.contentmgmt;
 
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+import static java.util.Optional.ofNullable;
+
 import com.redhat.rhn.domain.BaseDomainHelper;
 import com.redhat.rhn.domain.contentmgmt.EnvironmentTarget.Status;
+
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -40,10 +47,6 @@ import javax.persistence.OneToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.persistence.Transient;
-
-import static java.util.Optional.empty;
-import static java.util.Optional.of;
-import static java.util.Optional.ofNullable;
 
 /**
  * A Content Environment
@@ -337,5 +340,22 @@ public class ContentEnvironment extends BaseDomainHelper {
         }
 
         return of(Status.BUILT);
+    }
+
+    /**
+     * Computes the built time of the {@link ContentEnvironment} based on the built times of its
+     * {@link EnvironmentTarget}
+     * Most recent built time of all the environment targets
+     *
+     * @return the built time
+     */
+    public Optional<Date> computeBuiltTime() {
+        return computeStatus()
+                .filter(envStatus -> envStatus == Status.BUILT)
+                .map(envStatus -> getTargets().stream()
+                        .map(t -> t.getBuiltTime())
+                        .filter(value -> value != null)
+                        .max(Date::compareTo))
+                .orElse(Optional.empty());
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/EnvironmentTarget.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/EnvironmentTarget.java
@@ -17,7 +17,9 @@ package com.redhat.rhn.domain.contentmgmt;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
+import java.util.Date;
 import java.util.Optional;
+
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorColumn;
 import javax.persistence.Entity;
@@ -46,6 +48,7 @@ public abstract class EnvironmentTarget {
     private Long id;
     private ContentEnvironment contentEnvironment;
     private Status status;
+    private Date builtTime;
 
     /**
      * Status of the {@link EnvironmentTarget}
@@ -162,6 +165,24 @@ public abstract class EnvironmentTarget {
                 .append("id", id)
                 .append("contentEnvironment", contentEnvironment)
                 .append("status", status);
+    }
+
+
+    /**
+     * Gets the time of latest build
+     * @return Date of latest build
+     */
+    @Column(name = "built_time")
+    public Date getBuiltTime() {
+        return this.builtTime;
+    }
+
+    /**
+     * Sets the time of latest build
+     * @param builtTimeIn New value for build time
+     */
+    public void setBuiltTime(Date builtTimeIn) {
+        this.builtTime = builtTimeIn;
     }
 
     @Override

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/ChannelRepodataWorker.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/ChannelRepodataWorker.java
@@ -30,6 +30,7 @@ import com.redhat.rhn.taskomatic.task.threaded.QueueWorker;
 import com.redhat.rhn.taskomatic.task.threaded.TaskQueue;
 import org.apache.log4j.Logger;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -153,6 +154,7 @@ public class ChannelRepodataWorker implements QueueWorker {
                 .filter(t -> t.getStatus() == GENERATING_REPODATA)
                 .ifPresent(t -> {
                     t.setStatus(built);
+                    t.setBuiltTime(new Date());
                     ContentProjectFactory.save(t);
                 });
     }

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/ContentManagementViewsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/ContentManagementViewsController.java
@@ -25,10 +25,10 @@ import com.redhat.rhn.domain.contentmgmt.ContentProjectFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.contentmgmt.ContentManager;
 
+import com.suse.manager.webui.controllers.contentmanagement.handlers.ControllerApiUtils;
 import com.suse.manager.webui.controllers.contentmanagement.mappers.ResponseMappers;
 import com.suse.manager.webui.controllers.contentmanagement.response.FilterResponse;
 import com.suse.manager.webui.utils.FlashScopeHelper;
-import com.suse.utils.Json;
 
 import com.google.gson.Gson;
 
@@ -51,7 +51,7 @@ import spark.template.jade.JadeTemplateEngine;
 public class ContentManagementViewsController {
 
     private static Logger log = Logger.getLogger(ContentManagementViewsController.class);
-    private static final Gson GSON = Json.GSON;
+    private static final Gson GSON = ControllerApiUtils.GSON;
 
     private ContentManagementViewsController() {
     }

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ControllerApiUtils.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ControllerApiUtils.java
@@ -23,12 +23,14 @@ import com.redhat.rhn.domain.contentmgmt.ContentProjectFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.contentmgmt.ContentManager;
 
+import com.suse.manager.webui.controllers.ECMAScriptDateAdapter;
 import com.suse.manager.webui.controllers.contentmanagement.mappers.ResponseMappers;
 import com.suse.manager.webui.utils.gson.ResultJson;
-import com.suse.utils.Json;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -39,7 +41,11 @@ import spark.Response;
  * Utility class to all the api Controllers
  */
 public class ControllerApiUtils {
-    private static final Gson GSON = Json.GSON;
+    public static final Gson GSON = new GsonBuilder()
+            .registerTypeAdapter(Date.class, new ECMAScriptDateAdapter())
+            .serializeNulls()
+            .create();
+
 
     private ControllerApiUtils() { }
 

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/EnvironmentApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/EnvironmentApiController.java
@@ -25,7 +25,6 @@ import com.redhat.rhn.manager.contentmgmt.ContentManager;
 
 import com.suse.manager.webui.controllers.contentmanagement.request.EnvironmentRequest;
 import com.suse.manager.webui.utils.gson.ResultJson;
-import com.suse.utils.Json;
 
 import com.google.gson.Gson;
 
@@ -43,7 +42,7 @@ import spark.Response;
  */
 public class EnvironmentApiController {
 
-    private static final Gson GSON = Json.GSON;
+    private static final Gson GSON = ControllerApiUtils.GSON;
 
     private EnvironmentApiController() {
     }

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/FilterApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/FilterApiController.java
@@ -33,7 +33,6 @@ import com.suse.manager.webui.controllers.contentmanagement.request.FilterReques
 import com.suse.manager.webui.controllers.contentmanagement.request.ProjectFiltersUpdateRequest;
 import com.suse.manager.webui.utils.FlashScopeHelper;
 import com.suse.manager.webui.utils.gson.ResultJson;
-import com.suse.utils.Json;
 
 import com.google.gson.Gson;
 
@@ -54,7 +53,7 @@ import spark.Response;
  */
 public class FilterApiController {
 
-    private static final Gson GSON = Json.GSON;
+    private static final Gson GSON = ControllerApiUtils.GSON;
 
     private FilterApiController() {
     }

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ProjectActionsApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ProjectActionsApiController.java
@@ -25,7 +25,6 @@ import com.redhat.rhn.manager.contentmgmt.ContentManager;
 import com.suse.manager.webui.controllers.contentmanagement.request.ProjectBuildRequest;
 import com.suse.manager.webui.controllers.contentmanagement.request.ProjectPromoteRequest;
 import com.suse.manager.webui.utils.gson.ResultJson;
-import com.suse.utils.Json;
 
 import com.google.gson.Gson;
 
@@ -43,7 +42,7 @@ import spark.Response;
  */
 public class ProjectActionsApiController {
 
-    private static final Gson GSON = Json.GSON;
+    private static final Gson GSON = ControllerApiUtils.GSON;
 
     private ProjectActionsApiController() {
     }

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ProjectApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ProjectApiController.java
@@ -31,7 +31,6 @@ import com.suse.manager.webui.controllers.contentmanagement.request.NewProjectRe
 import com.suse.manager.webui.controllers.contentmanagement.request.ProjectPropertiesRequest;
 import com.suse.manager.webui.utils.FlashScopeHelper;
 import com.suse.manager.webui.utils.gson.ResultJson;
-import com.suse.utils.Json;
 
 import com.google.gson.Gson;
 
@@ -49,7 +48,7 @@ import spark.Response;
  */
 public class ProjectApiController {
 
-    private static final Gson GSON = Json.GSON;
+    private static final Gson GSON = ControllerApiUtils.GSON;
 
     private ProjectApiController() {
     }

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ProjectSourcesApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ProjectSourcesApiController.java
@@ -24,9 +24,6 @@ import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.contentmgmt.ContentManager;
 
 import com.suse.manager.webui.controllers.contentmanagement.request.ProjectSourcesRequest;
-import com.suse.utils.Json;
-
-import com.google.gson.Gson;
 
 import java.util.Collections;
 import java.util.List;
@@ -40,8 +37,6 @@ import spark.Response;
  * Spark controller class for content management sources API endpoints.
  */
 public class ProjectSourcesApiController {
-
-    private static final Gson GSON = Json.GSON;
 
     private ProjectSourcesApiController() {
     }

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/mappers/ResponseMappers.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/mappers/ResponseMappers.java
@@ -112,6 +112,7 @@ public class ResponseMappers {
                                     .map(status -> status.getLabel())
                                     .orElse(null)
                     );
+                    environmentResponse.setBuiltTime(envDB.computeBuiltTime().orElse(null));
                     return environmentResponse;
                 })
                 .collect(Collectors.toList());

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/response/EnvironmentResponse.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/response/EnvironmentResponse.java
@@ -14,6 +14,8 @@
  */
 package com.suse.manager.webui.controllers.contentmanagement.response;
 
+import java.util.Date;
+
 /**
  * JSON response wrapper for an environment of a content project.
  */
@@ -25,6 +27,7 @@ public class EnvironmentResponse {
     private String description;
     private Long version;
     private String status;
+    private Date builtTime;
 
     public void setStatus(String statusIn) {
         this.status = statusIn;
@@ -48,5 +51,9 @@ public class EnvironmentResponse {
 
     public void setVersion(Long versionIn) {
         this.version = versionIn;
+    }
+
+    public void setBuiltTime(Date builtTimeIn) {
+        this.builtTime = builtTimeIn;
     }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add built time date to the Content Lifecycle Environments
 - Update ServerArch on each ImageDeployedEvent (bsc#1134621)
 - Remove the 'Returning' clause from the query as oracle doesn't support it (bsc#1135166)
 - Display warning if product catalog refresh is already in progress (bsc#1132234)

--- a/schema/spacewalk/common/tables/suseContentEnvironmentTarget.sql
+++ b/schema/spacewalk/common/tables/suseContentEnvironmentTarget.sql
@@ -24,7 +24,8 @@ CREATE TABLE suseContentEnvironmentTarget(
     status     VARCHAR2(32) NOT NULL DEFAULT 'NEW',
     channel_id NUMBER
                    CONSTRAINT suse_ct_env_tgt_chanid_fk
-                       REFERENCES rhnChannel(id)
+                       REFERENCES rhnChannel(id),
+    built_time TIMESTAMP WITH LOCAL TIME ZONE
 )
 ENABLE ROW MOVEMENT
 ;

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,5 @@
+- Add built time column to suseContentEnvironmentTarget
+
 -------------------------------------------------------------------
 Wed May 15 15:34:53 CEST 2019 - jgonzalez@suse.com
 

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.12-to-susemanager-schema-4.0.13/051-suseContentEnvironmentTarget.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.12-to-susemanager-schema-4.0.13/051-suseContentEnvironmentTarget.sql.oracle
@@ -1,0 +1,2 @@
+-- intentionally left empty
+

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.12-to-susemanager-schema-4.0.13/051-suseContentEnvironmentTarget.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.12-to-susemanager-schema-4.0.13/051-suseContentEnvironmentTarget.sql.postgresql
@@ -1,0 +1,3 @@
+-- oracle equivalent source sha1 98c02e574d4346f7eecade4697a2b26a13abaa28
+
+ALTER TABLE suseContentEnvironmentTarget ADD COLUMN IF NOT EXISTS built_time TIMESTAMPTZ;

--- a/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-view.js
+++ b/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-view.js
@@ -1,4 +1,5 @@
 //@flow
+// globals moment
 import React from 'react';
 import _isEmpty from "lodash/isEmpty"
 
@@ -6,6 +7,8 @@ import type {ProjectEnvironmentType} from '../../../type/project.type.js';
 import type {ProjectHistoryEntry} from "../../../type/project.type";
 import {getVersionMessageByNumber} from "../properties/properties.utils";
 import {objectDefaultValueHandler} from "core/utils/objects";
+
+declare var moment: any;
 
 type Props = {
   environment: ProjectEnvironmentType,
@@ -68,7 +71,7 @@ const EnvironmentView = React.memo((props: Props) => {
           <dl className="row">
             <dt className="col-xs-3">Built time:</dt>
             <dd className="col-xs-9">
-              {props.environment.builtTime}
+              {moment(props.environment.builtTime).format("YYYY-MM-DD HH:mm:ss")}
             </dd>
           </dl>
           : null

--- a/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-view.js
+++ b/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-view.js
@@ -1,5 +1,6 @@
 //@flow
 import React from 'react';
+import _isEmpty from "lodash/isEmpty"
 
 import type {ProjectEnvironmentType} from '../../../type/project.type.js';
 import type {ProjectHistoryEntry} from "../../../type/project.type";
@@ -13,17 +14,18 @@ type Props = {
 
 type EnvironmentStatusEnumType = {
   [key:string]: {
+    key: string,
     text: string,
     isBuilding: boolean
   }
 }
 
 const environmentStatusEnum: EnvironmentStatusEnumType = new Proxy({
-    'new': {text: "New", isBuilding: false},
-    'building': {text: "Cloning channels", isBuilding: true},
-    'generating_repodata': {text: "Generating repositories data", isBuilding: true},
-    'built': {text: "Built", isBuilding: false},
-    'failed': {text: "Failed", isBuilding: false},
+    new: {key: "new", text: "New", isBuilding: false},
+    building: {key: "building", text: "Cloning channels", isBuilding: true},
+    generating_repodata: {key: "generating_repodata", text: "Generating repositories data", isBuilding: true},
+    built: {key: "built", text: "Built", isBuilding: false},
+    failed: {key: "failed", text: "Failed", isBuilding: false},
   },
   objectDefaultValueHandler({text: '', isBuilding: false})
 );
@@ -55,8 +57,18 @@ const EnvironmentView = React.memo((props: Props) => {
               &nbsp;
               {
                 environmentStatusEnum[props.environment.status].isBuilding &&
-                  <i className="fa fa-spinner fa-spin fa-1-5x" />
+                <i className="fa fa-spinner fa-spin fa-1-5x" />
               }
+            </dd>
+          </dl>
+          : null
+      }
+      {
+        props.environment.status === environmentStatusEnum.built.key && !_isEmpty(props.environment.builtTime) ?
+          <dl className="row">
+            <dt className="col-xs-3">Built time:</dt>
+            <dd className="col-xs-9">
+              {props.environment.builtTime}
             </dd>
           </dl>
           : null

--- a/web/html/src/manager/content-management/shared/type/project.type.js
+++ b/web/html/src/manager/content-management/shared/type/project.type.js
@@ -26,7 +26,8 @@ export type ProjectEnvironmentType = {
   name: string,
   description: string,
   status: string,
-  version: number
+  version: number,
+  builtTime: ?string
 }
 
 export type ProjectFilterServerType = {

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- Add built time date to the Content Lifecycle Environments
+
 -------------------------------------------------------------------
 Wed May 15 15:23:06 CEST 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

CLM -  Add built time column to the content environment target and show it on the UI

## GUI diff

![Screenshot from 2019-05-17 17-18-22](https://user-images.githubusercontent.com/1140720/57941900-0f7aa900-78c8-11e9-86c6-32396b18d54e.png)


- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/7808

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests" 		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
