### PR TITLE
Fix error messages on image profile page

### DIFF
--- a/web/html/src/manager/images/image-profile-edit.js
+++ b/web/html/src/manager/images/image-profile-edit.js
@@ -23,7 +23,9 @@ const typeMap = {
 };
 
 const msgMap = {
-  "invalid_type": "Invalid image type."
+  "invalid_type": "Invalid image type.",
+  "activation_key_required": "Please give an activation key",
+  "": "There was an error."
 };
 
 class CreateImageProfile extends React.Component {
@@ -304,7 +306,7 @@ class CreateImageProfile extends React.Component {
     );
 
     return (
-      <Select name="activationKey" label={t("Activation Key")}
+      <Select name="activationKey" label={t("Activation Key")} invalidHint={t("Activation key is required for kiwi images.")}
         onChange={this.handleTokenChange} labelClass="col-md-3" divClass="col-md-6"
         hint={hint} required={isRequired}>
         <option key="0" value="">None</option>

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- add error messages, hints for image profile edit page (bsc#1127319) 
 - Allow virtualization tab for foreign systems (bsc#1116869)
 - Add checks for empty required entries on formula forms (bsc#1109639)
 - Fix big formula checkbox not supported in Firefox


### PR DESCRIPTION
## What does this PR change?
This is part of a fix for bsc#1127319 https://bugzilla.suse.com/show_bug.cgi?d=1127319&GoAheadAndLogIn=1  

This adds the right error messages and adds a invalidHint for the activationKey.

@lneves12 Fixed a part of the issue in #989   and issue 7410
**add description**
bsc#1127319
## GUI diff


Before:
![no_error_text_image_profile](https://user-images.githubusercontent.com/729087/57915811-d3c4ec80-7891-11e9-97eb-a38fce2136e8.png)

After:
![correct_error_image_profile](https://user-images.githubusercontent.com/729087/57915824-db849100-7891-11e9-882d-c2c613e24624.png)

- [ ] **DONE**

## Documentation
- No documentation needed

## Test coverage
- No tests:  Not needed



## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
