### PR TITLE
Fixing an error when row element is null

### DIFF
--- a/testsuite/documentation/optional.md
+++ b/testsuite/documentation/optional.md
@@ -312,15 +312,15 @@ are executed only if the PXE boot minion is available.
 
 ## HTTP Proxy setting
 
-If you need to specify HTTP Proxy on SUSE Manager "Setup Wizard" page, you can use 
-variable `http_proxy` from `controller` module in your `main.tf` file with following syntax:
+If you need to specify HTTP proxy on SUSE Manager "Setup Wizard" page, you can use 
+variable `server_http_proxy` from `controller` module in your `main.tf` file with following syntax:
 ```
-http_proxy = "hostname:port"
+server_http_proxy = "hostname:port"
 ```
 It is set to `galaxy-proxy.mgr.suse.de:3128` by default.
 
-Sumaform creates `$SUMA_HTTP_PROXY` variable with corresponding settings in `/root/.bashrc` file
+Sumaform creates `$SERVER_HTTP_PROXY` variable with corresponding settings in `/root/.bashrc` file
 on the controller. It is also possible to tag the scenarios with:
 ```
-@http_proxy
+@server_http_proxy
 ```

--- a/testsuite/features/core_first_settings.feature
+++ b/testsuite/features/core_first_settings.feature
@@ -76,7 +76,7 @@ Feature: Very first settings
     And service "tomcat" is enabled on "server"
     And service "tomcat" is active on "server"
 
-@http_proxy
+@server_http_proxy
   Scenario: Setup HTTP proxy
     When I am authorized as "admin" with password "admin"
     When I follow the left menu "Admin > Setup Wizard"

--- a/testsuite/features/min_docker_build_image.feature
+++ b/testsuite/features/min_docker_build_image.feature
@@ -9,11 +9,11 @@ Feature: Build container images
   Scenario: Build the images with and without activation key
     Given I am on the Systems overview page of this "sle-minion"
     When I schedule the build of image "suse_key" via XML-RPC calls
-    Then I wait until event "Image Build suse_key scheduled by admin" is completed
-    When I schedule the build of image "suse_simple" via XML-RPC calls
-    Then I wait until event "Image Build suse_simple scheduled by admin" is completed
-    When I schedule the build of image "suse_real_key" via XML-RPC calls
-    Then I wait until event "Image Build suse_real_key scheduled by admin" is completed
+    And I wait at most 500 seconds until event "Image Build suse_key scheduled by admin" is completed
+    And I schedule the build of image "suse_simple" via XML-RPC calls
+    And I wait at most 500 seconds until event "Image Build suse_simple scheduled by admin" is completed
+    And I schedule the build of image "suse_real_key" via XML-RPC calls
+    And I wait at most 500 seconds until event "Image Build suse_real_key scheduled by admin" is completed
 
   Scenario: Build same images with different versions
     Given I am authorized as "admin" with password "admin"

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -476,7 +476,7 @@ Then(/^I see verification succeeded/) do
 end
 
 When(/^I enter the address of the HTTP proxy as "([^"]*)"/) do |hostname|
-  step %(I enter "#{$http_proxy}" as "#{hostname}")
+  step %(I enter "#{$server_http_proxy}" as "#{hostname}")
 end
 
 # configuration management steps

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -797,7 +797,7 @@ When(/^I check "([^"]*)" in the list$/) do |arg1|
       $stderr.puts 'ERROR - try again'
       row = first(:xpath, "//div[@class=\"table-responsive\"]/table/tbody/tr[.//td[contains(.,'#{arg1}')]]")
     end
-    row.first(:xpath, './/input[@type="checkbox"]').set(true)
+    row.first(:xpath, './/input[@type="checkbox"]').set(true) unless row.nil?
   end
 end
 
@@ -811,7 +811,7 @@ When(/^I uncheck "([^"]*)" in the list$/) do |arg1|
       $stderr.puts 'ERROR - try again'
       row = first(:xpath, top_level_xpath_query)
     end
-    row.first(:xpath, './/input[@type="checkbox"]').set(false)
+    row.first(:xpath, './/input[@type="checkbox"]').set(false) unless row.nil?
   end
 end
 

--- a/testsuite/features/support/setup_browser.rb
+++ b/testsuite/features/support/setup_browser.rb
@@ -104,8 +104,8 @@ Before('@susemanager') do |scenario|
 end
 
 # do test only if HTTP proxy for SUSE Manager is defined
-Before('@http_proxy') do |scenario|
-  scenario.skip_invoke! unless $http_proxy
+Before('@server_http_proxy') do |scenario|
+  scenario.skip_invoke! unless $server_http_proxy
 end
 
 # have more infos about the errors

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -127,4 +127,4 @@ $private_net = ENV['PRIVATENET'] if ENV['PRIVATENET']
 $mirror = ENV['MIRROR']
 $git_profiles = ENV['GITPROFILES']
 $product = product
-$http_proxy = ENV['SUMA_HTTP_PROXY'] if ENV['SUMA_HTTP_PROXY']
+$server_http_proxy = ENV['SERVER_HTTP_PROXY'] if ENV['SERVER_HTTP_PROXY']


### PR DESCRIPTION

<img width="964" alt="Captura de pantalla 2019-05-17 a las 13 41 59" src="https://user-images.githubusercontent.com/2827771/57925747-9a987680-78a9-11e9-951a-a102f9f39513.png">

## What does this PR change?

Fix a possible problem in navigation_steps when we try to call the method find, on a "row" element which is null.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
