### PR TITLE
TESTSUITE: wait for all events to complete when rolling back action chain effects

### DIFF
--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -546,6 +546,7 @@ The check box can be identified by name, id or label text.
 ```cucumber
   When I wait until onboarding is completed for "ceos-minion"
   When I wait until event "Package Install/Upgrade scheduled by admin" is completed
+  When I wait until all events in history are completed
 ```
 
 

--- a/testsuite/features/min_action_chain.feature
+++ b/testsuite/features/min_action_chain.feature
@@ -247,6 +247,7 @@ Feature: Action chain on salt minions
     And I run "zypper -n rm virgo-dummy" on "sle-minion" without error control
     And I run "zypper -n in milkyway-dummy" on "sle-minion" without error control
     And I run "zypper -n in --oldpackage andromeda-dummy-1.0" on "sle-minion"
+    And I wait until all events in history are completed
     When I follow "Software" in the content area
     And I follow "List / Remove" in the content area
     And I enter "andromeda-dummy" in the css "input[placeholder='Filter by Package Name: ']"

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -936,3 +936,30 @@ And(/^I check for failed events on history event page$/) do
   count_failures = failings.length
   raise "\nFailures in event history found:\n\n#{failings}" if count_failures.nonzero?
 end
+
+When(/^I wait until all events in history are completed$/) do
+  steps %(
+    When I follow "Events" in the content area
+    And I follow "History" in the content area
+    Then I should see a "System History" text
+  )
+  begin
+    events_icons = "//div[@class='table-responsive']/table/tbody/tr/td[2]/i"
+    Timeout.timeout(DEFAULT_TIMEOUT) do
+      loop do
+        pickedup = false
+        events = all(:xpath, events_icons)
+        events.each do |ev|
+          if ev[:class].include?('fa-exchange')
+            pickedup = true
+            break
+          end
+        end
+        break if not pickedup
+        sleep 1
+      end
+    end
+  rescue Timeout::Error
+    raise "Timed out waiting for the system events to complete."
+  end
+end


### PR DESCRIPTION
## What does this PR change?

Wait for all events in the history tab to complete before (in this case package refresh) before checking for package.

## GUI diff

No difference.

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**


## Test coverage
- Cucumber tests were added

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
