### PR TITLE
Let softwarechannel_errata_sync fallback on vendor errata (bsc#1132914)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandler.java
@@ -1388,7 +1388,7 @@ public class ErrataHandler extends BaseHandler {
     public Errata publish(User loggedInUser, String advisory, List<String> channelLabels)
             throws InvalidChannelRoleException {
         List<Channel> channels = verifyChannelList(channelLabels, loggedInUser);
-        Errata toPublish = lookupErrata(advisory, loggedInUser.getOrg());
+        Errata toPublish = lookupErratumByAdvisoryAndOrg(advisory, loggedInUser.getOrg());
         return publish(toPublish, channels, loggedInUser, false);
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/test/ErrataHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/test/ErrataHandlerTest.java
@@ -840,20 +840,41 @@ public class ErrataHandlerTest extends BaseHandlerTestCase {
                 errata.getAdvisoryRel().longValue());
     }
 
-    public void testPublish() throws Exception {
-
-        Errata unpublished = ErrataFactoryTest.createTestUnpublishedErrata(
-                admin.getOrg().getId());
+    /**
+     * Note:
+     * custom errata --> orgId != null
+     * vendor errata --> orgId == null
+     **/
+    public void testPublishCustomErrata() throws Exception {
+        // publish a custom errata
+        Errata unpublished = ErrataFactoryTest.createTestUnpublishedErrata(admin.getOrg().getId());
         Channel channel = ChannelFactoryTest.createBaseChannel(admin);
         channel.setOrg(admin.getOrg());
         ArrayList channels = new ArrayList();
         channels.add(channel.getLabel());
-        Errata published = handler.publish(admin, unpublished.getAdvisoryName(),
-                channels);
+        Errata published = handler.publish(admin, unpublished.getAdvisoryName(), channels);
 
         assertTrue(published.isPublished());
         assertEquals(unpublished.getAdvisory(), published.getAdvisory());
+    }
 
+    /**
+     * Note:
+     * custom errata --> orgId != null
+     * vendor errata --> orgId == null
+     **/
+    public void testPublishVendorErrata() throws Exception {
+        // publish a custom errata
+        Errata unpublished = ErrataFactoryTest.createTestUnpublishedErrata(admin.getOrg().getId());
+        unpublished.setOrg(null); // let the errata be a vendor one
+        Channel channel = ChannelFactoryTest.createBaseChannel(admin);
+        channel.setOrg(admin.getOrg());
+        ArrayList channels = new ArrayList();
+        channels.add(channel.getLabel());
+        Errata published = handler.publish(admin, unpublished.getAdvisoryName(), channels);
+
+        assertTrue(published.isPublished());
+        assertEquals(unpublished.getAdvisory(), published.getAdvisory());
     }
 
     public void testListByDate() throws Exception {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Let softwarechannel_errata_sync fallback on vendor errata (bsc#1132914)
 - Don't convert localhost repositories URL in mirror case (bsc#1135957)
 - Add state EDITED to filters in the Content Lifecycle Environments
 - Add built time date to the Content Lifecycle Environments


### PR DESCRIPTION
## What does this PR change?

Bugfix: on syncing erratas from a channel to another, let it lookup and publish in the target channel the custom errata first, but fallback on the vendor errata as well.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes #
Tracks  https://github.com/SUSE/spacewalk/pull/7872

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
