### PR TITLE
Fix channel sync status logic in products page (bsc#1131721)

### DIFF
--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix channel sync status logic in products page (bsc#1131721)
 - Report Monitoring products to subscription-matcher
 - Update help URLs in the UI
 - Fix SSM package upgrade list item selection (bsc#1133421)


### PR DESCRIPTION
At the time of page load, if the reposync task for a channel is already finished but the metadata file has not been generated yet (via channel-repodata task), the page incorrectly reports the sync as failed.

This PR fixes the logic for channel sync status report.

Follow-up to #812 for [bsc#1131721](https://bugzilla.suse.com/1131721)

## Documentation
- No documentation needed: Bugfix

## Test coverage
- Existing unit tests: https://github.com/uyuni-project/uyuni/blob/master/java/code/src/com/redhat/rhn/manager/setup/test/ProductSyncManagerTest.java

## Ports
- https://github.com/SUSE/spacewalk/pull/7890

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
