### PR TITLE
Cucumber output: do not embed screenshots, save files instead

### DIFF
--- a/testsuite/features/support/setup_browser.rb
+++ b/testsuite/features/support/setup_browser.rb
@@ -47,12 +47,10 @@ Capybara.app_host = "https://#{server}"
 # embed a screenshot after each failed scenario
 After do |scenario|
   if scenario.failed?
-    img_name = "#{SecureRandom.urlsafe_base64}.png"
+    img_name = "#{scenario.name.tr(' ', '_')}.png"
     save_screenshot(img_name)
-    encoded_img = Base64.encode64(File.read(img_name))
-    FileUtils.rm_rf(img_name)
-    # embed the base64 image in the cucumber HTML report
-    embed("data:image/png;base64,#{encoded_img}", 'image/png')
+    # embed the image name in the cucumber HTML report
+    embed(img_name, 'image/png')
     debug_server_on_realtime_failure
   end
 end

--- a/testsuite/features/support/setup_browser.rb
+++ b/testsuite/features/support/setup_browser.rb
@@ -48,9 +48,9 @@ Capybara.app_host = "https://#{server}"
 After do |scenario|
   if scenario.failed?
     img_name = "#{scenario.name.tr(' ', '_')}.png"
-    save_screenshot(img_name)
+    save_screenshot('screenshots/' + img_name)
     # embed the image name in the cucumber HTML report
-    embed(img_name, 'image/png')
+    embed('screenshots/' + img_name, 'image/png')
     debug_server_on_realtime_failure
   end
 end


### PR DESCRIPTION
## What does this PR change?

Save screenshots and keep them in the filesystem instead of embedding the `PNG` data into the `HTML` output **in order to** have a lighter and fast-loading `output.html` report

#### Requirements
[SUSE internal specific] This PR should come only **after** [this MR](https://gitlab.suse.de/galaxy/sumaform-test-runner/merge_requests/123) otherwise all generated screenshots would not be copied to the `CI` destination folder `...../ws/results/`, and without the new proposed structure in the MR mentioned, that folder could become a bit messy with all screenshots at the same folder level not nested into the proper `build run` path.


## GUI diff

Before:

The current output results folder from the filesystem POV looks like this at the moment (a simple example of one Feature of one Scenario with one failure screenshot only):
```
- spacewalk/testsuite/
  - output.html [199K]
```

After:

The output results folder will look like the following instead:
```
- spacewalk/testsuite/
  - output.html [90K]
  - screenshots/
    - output_screenshot.png [81K]
```
- [x] **DONE**

## Documentation
- No documentation needed: structural changes for the testsuite

- [x] **DONE**

## Test coverage
- No tests: nothing to test

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"    
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint" (Test skipped, there are no changes to test)		 
