### PR TITLE
Cucumber output: let it be generated by cucumber-html-reporter

### DIFF
--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -5,8 +5,8 @@ require 'cucumber/rake/task'
 outputfile = 'output.html'
 html_results = "--format html -o #{outputfile}"
 junit_results = '--format junit -o results_junit'
-Dir.glob(File.join(Dir.pwd, 'run_sets', '*.yml')).each do |entry|
-  namespace :cucumber do
+namespace :cucumber do
+  Dir.glob(File.join(Dir.pwd, 'run_sets', '*.yml')).each do |entry|
     Cucumber::Rake::Task.new(File.basename(entry, '.yml').to_sym) do |t|
       cucumber_opts = %W[#{html_results} #{junit_results} -f rerun --out failed.txt --format pretty]
       features = YAML.safe_load(File.read(entry))

--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -13,6 +13,11 @@ namespace :cucumber do
       t.cucumber_opts = cucumber_opts + features
     end
   end
+  at_exit { post_nodejs_report }
+end
+
+def post_nodejs_report
+  `node index.js`
 end
 
 task :cucumber do

--- a/testsuite/index.js
+++ b/testsuite/index.js
@@ -1,0 +1,29 @@
+/**
+ * https://github.com/gkushang/cucumber-html-reporter
+ */
+
+var reporter = require('cucumber-html-reporter');
+
+var options = {
+  theme: 'bootstrap',
+  jsonFile: 'output.json',
+  output: './cucumber_report/cucumber_report.html',
+  reportSuiteAsScenarios: true,
+  launchReport: false,
+  columnLayout: 1,
+  screenshotsDirectory: './cucumber_report/',
+  storeScreenshots: true,
+  noInlineScreenshots: true,
+  name: 'SUSE Manager Testsuite',
+  brandTitle: ' ',
+  // metadata: {
+  //   "App Version":"",
+  //   "Test Environment": "",
+  //   "Browser": "",
+  //   "Platform": "",
+  //   "Parallel": "",
+  //   "Executed": ""
+  // }
+};
+
+reporter.generate(options);

--- a/testsuite/index.js
+++ b/testsuite/index.js
@@ -11,7 +11,7 @@ var options = {
   reportSuiteAsScenarios: true,
   launchReport: false,
   columnLayout: 1,
-  screenshotsDirectory: './cucumber_report/',
+  screenshotsDirectory: './cucumber_report/screenshots/',
   storeScreenshots: true,
   noInlineScreenshots: true,
   name: 'SUSE Manager Testsuite',


### PR DESCRIPTION
## What does this PR change?

Let the output go through the [cucumber-html-reporter](https://github.com/gkushang/cucumber-html-reporter) `js` module library **in order to** have a faster, readable, usable and better styled `HTML` report (see screenshots in the "GUI diff" section).

#### Requirements

This PR should come **after** [this PR](https://github.com/uyuni-project/uyuni/pull/1007) because in order to have screenshots generated and visible for the new `cucumber-html-reporter` module, it is needed that original screenshots taken during the Cucumber run those are saved and kept in the output dir [addressed in the required PR](https://github.com/uyuni-project/uyuni/pull/1007). From those images the new module will generate its own screenshots in a separate and proper subfolder.

[sumaform specific] This PR should come **after** [this PR](https://github.com/moio/sumaform/pull/541) because the latter lets the controller have installed early and by default the new js module at the highstate apply time.

#### Notes
This PR is not preventing the old `output.html` generation, it is still generated there, but at the same time the new `cucumber-html-generator` module will generate the new report in a subfolder.


The new js module is a *cucumber result output generator* based on the `JSON` output generated by Cucumber itself. For details how the [cucumber-html-reporter](https://github.com/gkushang/cucumber-html-reporter) works please refer to the plugin project itself.
The basic usage of this module is simple:
- let Cucumber produce `JSON` output data
- have an `index.js` file to set properties and drive the module
- run `node index.js` to generate the cucumber output `HTML` result

## GUI diff

Before:

![Screenshot from 2019-05-19 18-25-09](https://user-images.githubusercontent.com/7080830/57985110-80a29380-7a63-11e9-846f-b7af3834c440.png)

After:

![Screenshot from 2019-05-19 18-24-54](https://user-images.githubusercontent.com/7080830/57985111-839d8400-7a63-11e9-967e-1c448a1d9e63.png)

---

Before:

The current output results folder from the filesystem POV looks like this at the moment (a simple example of one Feature of one Scenario with one failure screenshot only):
```
- spacewalk/testsuite/
  - output.html [199K]
```

After:

The output results folder will look like the following instead:
```
- spacewalk/testsuite/
  - output.html [90K]
  - screenshots/
    - output_screenshot.png [81K]
  - output.json [119K]
  - cucumber_report/
    - cucumber_report.html [29K]
    - screenshots/
      - cucumber_report_screenshot.png [81K]
```


- [x] **DONE**

## Documentation
- No documentation needed: internal tool

- [x] **DONE**

## Test coverage
- No tests: internal tool changes on the cucumber testsuite itself

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"  
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
