### PR TITLE
spacecmd: bsc1135881

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- Bugfix: 'dict' object has no attribute 'iteritems' (bsc#1135881)
 - Add unit tests for custominfo, snippet, scap, ssm, cryptokey and distribution
 
 -------------------------------------------------------------------

--- a/spacecmd/src/spacecmd/misc.py
+++ b/spacecmd/src/spacecmd/misc.py
@@ -585,12 +585,12 @@ def generate_package_cache(self, force=False):
     # We assume that package IDs are unique, so one ID is only
     # refering one package.
     self.all_packages_by_id = {}
-    for (k, v) in self.all_packages.iteritems():
+    for k, v in self.all_packages.items():
         for i in v:
             # Alert in case of non-unique ID is detected.
             if i in self.all_packages_by_id:
                 logging.debug(
-                    'Non-unique package id "%s" is detected. Taking "%s" ' \
+                    'Non-unique package id "%s" is detected. Taking "%s" '
                     'instead of "%s"' % (i, k, self.all_packages_by_id[i]))
 
             self.all_packages_by_id[i] = k


### PR DESCRIPTION
## What does this PR change?

Bugfix.

Before:

```
spacecmd {SSM:0}> package_details vim
** Generating package cache **ERROR: 'dict' object has no attribute 'iteritems'
spacecmd {SSM:0}>
```

After:

Bug no longer appears, works as designed.

## Test coverage

Coming as part of https://github.com/uyuni-project/uyuni/pull/1005
