### PR TITLE
PGEventStream: handle the last notification queue

### DIFF
--- a/java/code/src/com/suse/manager/reactor/PGEventStream.java
+++ b/java/code/src/com/suse/manager/reactor/PGEventStream.java
@@ -163,7 +163,7 @@ public class PGEventStream extends AbstractEventStream implements PGNotification
         LOG.trace("Got notification: " + counts);
         // compute the number of jobs we need to do - each job COMMITs individually
         // jobs = events / MAX_EVENTS_PER_COMMIT (rounded up)
-        IntStream.range(0, THREAD_POOL_SIZE).forEach(queue -> {
+        IntStream.range(0, THREAD_POOL_SIZE + 1).forEach(queue -> {
             long jobs = (counts.get(queue) + MAX_EVENTS_PER_COMMIT - 1) / MAX_EVENTS_PER_COMMIT;
 
             // queue one handlingTransaction(processEvents) call per job

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix handling of the last Salt event queue (bsc#1135896)
 - Add state EDITED to filters in the Content Lifecycle Environments
 - Add built time date to the Content Lifecycle Environments
 - Update ServerArch on each ImageDeployedEvent (bsc#1134621)


### PR DESCRIPTION
## What does this PR change?

Fix recurring messages like this one:

> 2019-05-22 06:01:25,568 [salt-event-connection-watchdog] WARN       com.suse.manager.reactor.PGEventStream - Found [0, 0, 0, 0, 0, 0, 0, 0, 14] 
    events without a job. Scheduling...

In fact the last queue was never handled due to a forgotten `+1`

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: bug fix

- [X] **DONE**

## Test coverage
- No tests: tiny trivial fix

- [X] **DONE**

## Links

Fixes [bsc#1135896](https://bugzilla.suse.com/show_bug.cgi?id=1135896)
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
