### PR TITLE
Apache configuration: cache vendors folder

### DIFF
--- a/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-www.conf
+++ b/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-www.conf
@@ -140,6 +140,7 @@ SetEnvIf Request_URI "/img" susemanager_static
 SetEnvIf Request_URI "/css" susemanager_static
 SetEnvIf Request_URI "/fonts" susemanager_static
 SetEnvIf Request_URI "/javascript" susemanager_static
+SetEnvIf Request_URI "/vendors" susemanager_static
 SetEnvIf Request_URI "/pub" susemanager_static
 SetEnvIf Request_URI "/errors" susemanager_static
 SetEnvIf Request_URI "/rhn/manager/download" susemanager_static


### PR DESCRIPTION
## What does this PR change?

Add the new folder "vendors" to the apache whitelist of folders that should be cached.

@mcalmer For 4.0, if it's merged before Friday, I believe we don't need an upgrade script for the apache configuration since everything will be installed from scratch. 

This configuration would also be nice to have on 3.2. Can you point me to an example where this kind of apache configuration upgrade was done?

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
