### PR TITLE
Revert "PGEventStream: handle the last notification queue"

### DIFF
--- a/java/code/src/com/suse/manager/reactor/PGEventStream.java
+++ b/java/code/src/com/suse/manager/reactor/PGEventStream.java
@@ -163,7 +163,7 @@ public class PGEventStream extends AbstractEventStream implements PGNotification
         LOG.trace("Got notification: " + counts);
         // compute the number of jobs we need to do - each job COMMITs individually
         // jobs = events / MAX_EVENTS_PER_COMMIT (rounded up)
-        IntStream.range(0, THREAD_POOL_SIZE + 1).forEach(queue -> {
+        IntStream.range(0, THREAD_POOL_SIZE).forEach(queue -> {
             long jobs = (counts.get(queue) + MAX_EVENTS_PER_COMMIT - 1) / MAX_EVENTS_PER_COMMIT;
 
             // queue one handlingTransaction(processEvents) call per job

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,4 +1,3 @@
-- Fix handling of the last Salt event queue (bsc#1135896)
 - Add state EDITED to filters in the Content Lifecycle Environments
 - Add built time date to the Content Lifecycle Environments
 - Update ServerArch on each ImageDeployedEvent (bsc#1134621)


### PR DESCRIPTION
This reverts commit e3e0733f9a2c83feb2bc99dcf0f91843fb944e99 in order to help tagging 4.0-rc1

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
