### PR TITLE
Fix SSM package upgrade list item selection (bsc#1133421)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/dto/SsmUpgradablePackageListItem.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/SsmUpgradablePackageListItem.java
@@ -29,8 +29,9 @@ public class SsmUpgradablePackageListItem extends PackageListItem {
     private boolean errataRestart;
 
     /** {@inheritDoc} */
+    @Override
     public String getSelectionKey() {
-        return getIdCombo() + "~*~" + getEpoch() + "-" + getVersion() + "-" + getRelease();
+        return getIdCombo() + "~*~" + getEpoch() + "-" + getVersion() + "-" + getRelease() + "@" + getAdvisoryId();
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix SSM package upgrade list item selection (bsc#1133421)
 - Support system groups with the prometheus-exporters-formula and monitoring entitlements
 - Let softwarechannel_errata_sync fallback on vendor errata (bsc#1132914)
 - Don't convert localhost repositories URL in mirror case (bsc#1135957)


### PR DESCRIPTION
Fix SSM package upgrade list item selection for multiple entries with the same package version by adding the advisory id to the composite list selection key.

https://bugzilla.suse.com/1133421

Port of https://github.com/SUSE/spacewalk/pull/7892

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
