### PR TITLE
Remove workaround for bsc#1132908

### DIFF
--- a/testsuite/features/core_proxy_branch_network.feature
+++ b/testsuite/features/core_proxy_branch_network.feature
@@ -41,6 +41,8 @@ Feature: Setup SUSE Manager for Retail branch network
     And I follow first "Branch Network" in the content area
     And I enter "eth1" in NIC field
     And I enter the local IP address of "proxy" in IP field
+    # bsc#1132908 - Branch network formula closes IPv6 default route, potentially making further networking fail
+    And I check enable SLAAC with routing box
     And I click on "Save Formula"
     Then I should see a "Formula saved" text
 
@@ -125,9 +127,6 @@ Feature: Setup SUSE Manager for Retail branch network
 @private_net
   Scenario: Let avahi work on the branch server
     When I open avahi port on the proxy
-    # WORKAROUND
-    # bsc#1132908 - Branch network formula closes IPv6 default route, potentially making further networking fail
-    And I enable SLAAC on the proxy
 
 @proxy
 @private_net

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -627,14 +627,6 @@ When(/^I open avahi port on the proxy$/) do
   $proxy.run('firewall-offline-cmd --zone=public --add-service=mdns')
 end
 
-# WORKAROUND
-# bsc#1132908 - Branch network formula closes IPv6 default route, potentially making further networking fail
-When(/^I enable SLAAC on the proxy$/) do
-  cmd = 'echo "net.ipv6.conf.eth0.accept_ra = 2" > /etc/sysctl.d/98-slaac.conf && '
-  cmd += 'sysctl -p /etc/sysctl.d/98-slaac.conf'
-  $proxy.run(cmd)
-end
-
 When(/^I copy server\'s keys to the proxy$/) do
   ['RHN-ORG-PRIVATE-SSL-KEY', 'RHN-ORG-TRUSTED-SSL-CERT', 'rhn-ca-openssl.cnf'].each do |file|
     return_code = file_extract($server, '/root/ssl-build/' + file, '/tmp/' + file)

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -489,7 +489,8 @@ When(/^I press "Remove Item" in (.*) section$/) do |section|
 end
 
 When(/^I check (.*) box$/) do |box|
-  boxids = { 'include forwarders' => 'bind#config#include_forwarders' }
+  boxids = { 'enable SLAAC with routing' => 'branch_network#firewall#enable_SLAAC_with_routing',
+             'include forwarders'        => 'bind#config#include_forwarders' }
   check boxids[box]
 end
 


### PR DESCRIPTION
## What does this PR change?

This PR removes the workaround in the test suite against 

   https://bugzilla.suse.com/show_bug.cgi?id=1132908
   Branch network formula closes IPv6 default route, potentially making further networking fail

and replaces it with a permanent solution, ticking the new "force SLAAC for routing" checkbox provided by the branch network formula.

As a side effect, this should also fix the problem of migration from traditional client to proxy we were seeing in the test suite.


uyuni only.


- [x] No changelog needed
