### PR TITLE
Empty repos fix

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/content/MgrSyncUtils.java
+++ b/java/code/src/com/redhat/rhn/manager/content/MgrSyncUtils.java
@@ -33,6 +33,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
@@ -200,8 +201,12 @@ public class MgrSyncUtils {
             URL url = new URL(urlString);
             host = url.getHost();
             path = url.getPath();
+
+            if ("localhost".equals(host)) {
+                return url.toURI();
+            }
         }
-        catch (MalformedURLException e) {
+        catch (MalformedURLException | URISyntaxException e) {
             log.warn("Unable to parse URL: " + urlString);
         }
         String sccDataPath = Config.get().getString(ContentSyncManager.RESOURCE_PATH, null);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Don't convert localhost repositories URL in mirror case (bsc#1135957)
 - Add state EDITED to filters in the Content Lifecycle Environments
 - Add built time date to the Content Lifecycle Environments
 - Update ServerArch on each ImageDeployedEvent (bsc#1134621)


### PR DESCRIPTION
## What does this PR change?

Show the empty base repos for RHEL and Ubuntu in the mirror case.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: no UI change at all

- [X] **DONE**

## Test coverage
- No tests: tiny easy fix.

- [X] **DONE**

## Links

Fixes [bsc#1135957](https://bugzilla.suse.com/show_bug.cgi?id=1135957)

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
