### PR TITLE
Report Monitoring products to subscription matcher

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/product/test/SUSEProductTestUtils.java
+++ b/java/code/src/com/redhat/rhn/domain/product/test/SUSEProductTestUtils.java
@@ -387,6 +387,30 @@ public class SUSEProductTestUtils extends HibernateFactory {
         product.setProductId(1097);
         product.setReleaseStage(ReleaseStage.released);
         TestUtils.saveAndFlush(product);
+
+        product = new SUSEProduct();
+        product.setName("suse-manager-mon-single");
+        product.setVersion("1.2");
+        product.setFriendlyName("SUSE Manager Monitoring Single 1.2");
+        product.setProductId(1201);
+        product.setReleaseStage(ReleaseStage.released);
+        TestUtils.saveAndFlush(product);
+
+        product = new SUSEProduct();
+        product.setName("suse-manager-mon-unlimited-virtual");
+        product.setVersion("1.2");
+        product.setFriendlyName("SUSE Manager Monitoring Unlimited Virtual 1.2");
+        product.setProductId(1202);
+        product.setReleaseStage(ReleaseStage.released);
+        TestUtils.saveAndFlush(product);
+
+        product = new SUSEProduct();
+        product.setName("suse-manager-mon-unlimited-virtual-z");
+        product.setVersion("1.2");
+        product.setFriendlyName("SUSE Manager Monitoring Unlimited Virtual Z 1.2");
+        product.setProductId(1203);
+        product.setReleaseStage(ReleaseStage.released);
+        TestUtils.saveAndFlush(product);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/server/test/VirtualInstanceManufacturer.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/VirtualInstanceManufacturer.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.domain.server.test;
 
+import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.VirtualInstance;
 import com.redhat.rhn.domain.server.VirtualInstanceFactory;
 import com.redhat.rhn.domain.server.VirtualInstanceState;
@@ -62,6 +63,16 @@ public class VirtualInstanceManufacturer {
         VirtualInstance guest = createVirtualInstance(
                 VirtualInstanceFactory.getInstance().getRunningState());
         guest.setGuestSystem(ServerFactoryTest.createTestServer(user));
+        return guest;
+    }
+
+    public VirtualInstance newRegisteredGuestWithoutHost(boolean salt) throws Exception {
+        VirtualInstance guest = createVirtualInstance(
+                VirtualInstanceFactory.getInstance().getRunningState());
+        Server server = salt
+                ? MinionServerFactoryTest.createTestMinionServer(user)
+                : ServerFactoryTest.createTestServer(user);
+        guest.setGuestSystem(server);
         return guest;
     }
 

--- a/java/code/src/com/redhat/rhn/manager/content/test/sccdata_lifecycle_products/organizations_orders.json
+++ b/java/code/src/com/redhat/rhn/manager/content/test/sccdata_lifecycle_products/organizations_orders.json
@@ -21,6 +21,29 @@
             "start_date" : "2013-01-01T00:00:00.000Z"
          }
       ]
+   },
+   {
+      "order_number" : 98765433,
+      "order_items" : [
+         {
+            "quantity" : 1,
+            "subscription_id" : 3,
+            "id" : 13,
+            "end_date" : "2017-01-01T00:00:00.000Z",
+            "sku" : "874-005119",
+            "fulfillid" : 555555557,
+            "start_date" : "2013-01-01T00:00:00.000Z"
+         },
+         {
+            "quantity" : 1,
+            "subscription_id" : 4,
+            "id" : 14,
+            "end_date" : "2017-01-01T00:00:00.000Z",
+            "sku" : "874-005120",
+            "fulfillid" : 555555558,
+            "start_date" : "2013-01-01T00:00:00.000Z"
+         }
+      ]
    }
 ]
 

--- a/java/code/src/com/redhat/rhn/manager/content/test/sccdata_lifecycle_products/organizations_subscriptions.json
+++ b/java/code/src/com/redhat/rhn/manager/content/test/sccdata_lifecycle_products/organizations_subscriptions.json
@@ -46,5 +46,53 @@
       "product_ids" : [
          1078
       ]
+   },
+   {
+      "systems" : [
+         {
+            "password" : "secret",
+            "id" : 1245678,
+            "login" : "1234567890945aaa14fa3ba67b1f83b"
+         }
+      ],
+      "id" : 3,
+      "regcode" : "55REGCODE182",
+      "status" : "ACTIVE",
+      "product_classes" : [
+      ],
+      "system_limit" : 1,
+      "type" : "full",
+      "systems_count" : 1,
+      "expires_at" : "2017-12-31T00:00:00.000Z",
+      "virtual_count" : null,
+      "name" : "Mock monitoring subscription - Single",
+      "starts_at" : "2012-01-01T00:00:00.000Z",
+      "product_ids" : [
+         1201
+      ]
+   },
+{
+      "systems" : [
+         {
+            "password" : "secret",
+            "id" : 1245678,
+            "login" : "1234567890945aaa14fa3ba67b1f83b"
+         }
+      ],
+      "id" : 4,
+      "regcode" : "55REGCODE183",
+      "status" : "ACTIVE",
+      "product_classes" : [
+      ],
+      "system_limit" : 1,
+      "type" : "full",
+      "systems_count" : 1,
+      "expires_at" : "2017-12-31T00:00:00.000Z",
+      "virtual_count" : null,
+      "name" : "Mock monitoring subscription - Unlimited Virtual",
+      "starts_at" : "2012-01-01T00:00:00.000Z",
+      "product_ids" : [
+         1202
+      ]
    }
 ]

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -2045,7 +2045,7 @@ public class SystemManager extends BaseManager {
                     !wasVirtEntitled && EntitlementManager.VIRTUALIZATION.equals(ent)) {
                 SystemManager.updateLibvirtEngine(minion);
             }
-            else if (EntitlementManager.MONITORING.equals(ent)) {
+            if (EntitlementManager.MONITORING.equals(ent)) {
                 try {
                     // Assign the monitoring formula to the system
                     // unless the system belongs to a group having monitoring already enabled

--- a/java/code/src/com/redhat/rhn/testing/ServerTestUtils.java
+++ b/java/code/src/com/redhat/rhn/testing/ServerTestUtils.java
@@ -157,7 +157,7 @@ public class ServerTestUtils {
      *
      * @param user to own system
      * @param numberOfGuests number of guests to create
-     * @param salt true to create a salt-managed host
+     * @param salt true to create a salt-managed systems
      * @return Server with guest.
      * @throws Exception if error
      */
@@ -181,8 +181,7 @@ public class ServerTestUtils {
         SystemManager.entitleServer(s, EntitlementManager.VIRTUALIZATION);
 
         for (int i = 0; i < numberOfGuests; i++) {
-            VirtualInstance vi = new VirtualInstanceManufacturer(user).
-                newRegisteredGuestWithoutHost();
+            VirtualInstance vi = new VirtualInstanceManufacturer(user).newRegisteredGuestWithoutHost(salt);
             vi.setConfirmed((long) 0);
             s.addGuest(vi);
         }

--- a/java/code/src/com/suse/manager/matcher/MatcherJsonIO.java
+++ b/java/code/src/com/suse/manager/matcher/MatcherJsonIO.java
@@ -76,10 +76,10 @@ public class MatcherJsonIO {
     /** Cached instance of the s390x ServerArch object. */
     private final ServerArch s390arch;
 
-    /** Cached list of mandatory product IDs for an s390x system. */
+    /** Cached mandatory product ID for an s390x system. */
     private final Optional<Long> productIdForS390xSystem;
 
-    /** Cached list of mandatory product IDs for a regular system. */
+    /** Cached mandatory product ID for a regular system. */
     private final Optional<Long> productIdForSystem;
 
     /** Translation of unlimited virtual lifecycle products to single variant. **/

--- a/java/code/src/com/suse/manager/matcher/MatcherJsonIO.java
+++ b/java/code/src/com/suse/manager/matcher/MatcherJsonIO.java
@@ -119,6 +119,9 @@ public class MatcherJsonIO {
 
         monitoringProductId = productIdForEntitlement("SUSE-Manager-Mon-Single");
         monitoringProductIdS390x = productIdForEntitlement("SUSE-Manager-Mon-Unlimited-Virtual-Z");
+        productIdForEntitlement("SUSE-Manager-Mon-Unlimited-Virtual").ifPresent(
+                from -> monitoringProductId.ifPresent(to -> lifecycleProductsTranslation.put(from, to)));
+
         productFactory = new CachingSUSEProductFactory();
     }
 

--- a/java/code/src/com/suse/manager/matcher/MatcherJsonIO.java
+++ b/java/code/src/com/suse/manager/matcher/MatcherJsonIO.java
@@ -76,6 +76,7 @@ public class MatcherJsonIO {
     /** Architecture strings **/
     private static final String AMD64_ARCH_STR = "amd64";
     private static final String S390_ARCH_STR = "s390";
+    private static final String PPC64LE_ARCH_STR = "ppc64le";
 
     /** (De)serializer instance. */
     private Gson gson;
@@ -136,12 +137,14 @@ public class MatcherJsonIO {
                 from -> monitoringProductId.ifPresent(to -> lifecycleProductsTranslation.put(from, to)));
 
         selfProductsByArch = new HashMap<>();
-        selfProductsByArch.put(AMD64_ARCH_STR, 1899L); // SUSE Manager Server 4.0 x86_64
-        selfProductsByArch.put(S390_ARCH_STR, 1898L); // SUSE Manager Server 4.0 s390
+        selfProductsByArch.put(AMD64_ARCH_STR, 1899L);   // SUSE Manager Server 4.0 x86_64
+        selfProductsByArch.put(S390_ARCH_STR, 1898L);    // SUSE Manager Server 4.0 s390
+        selfProductsByArch.put(PPC64LE_ARCH_STR, 1897L); // SUSE Manager Server 4.0 ppc64le
 
         monitoringProductByArch = new HashMap<>();
-        monitoringProductByArch.put(AMD64_ARCH_STR, 1201L); // SUSE Manager Monitoring Single
-        monitoringProductByArch.put(S390_ARCH_STR, 1203L); // SUSE Manager Monitoring Unlimited Virtual Z
+        monitoringProductByArch.put(AMD64_ARCH_STR, 1201L);   // SUSE Manager Monitoring Single
+        monitoringProductByArch.put(S390_ARCH_STR, 1203L);    // SUSE Manager Monitoring Unlimited Virtual Z
+        monitoringProductByArch.put(PPC64LE_ARCH_STR, 1201L); // SUSE Manager Monitoring Single
 
         productFactory = new CachingSUSEProductFactory();
     }
@@ -311,7 +314,7 @@ public class MatcherJsonIO {
     private Set<Long> computeSelfProductIds(boolean includeSelf, boolean selfMonitoringEnabled, String arch) {
         Set<Long> result = new LinkedHashSet<>();
 
-        if (!arch.equals(S390_ARCH_STR) && !arch.equals(AMD64_ARCH_STR)) {
+        if (!Arrays.asList(AMD64_ARCH_STR, S390_ARCH_STR, PPC64LE_ARCH_STR).contains(arch)) {
             logger.warn(String.format("Couldn't determine products for SUMA server itself" +
                     " for architecture %s. Master SUSE Manager Server system products" +
                     " won't be reported to the subscription matcher.", arch));

--- a/java/code/src/com/suse/manager/matcher/MatcherJsonIO.java
+++ b/java/code/src/com/suse/manager/matcher/MatcherJsonIO.java
@@ -107,7 +107,7 @@ public class MatcherJsonIO {
     private static Logger logger = Logger.getLogger(MatcherJsonIO.class);
 
     /** SUSE Manager server products (by arch) installed on self **/
-    private Map<String, List<Long>> selfProductsByArch;
+    private Map<String, Long> selfProductsByArch;
 
     /** Monitoring products by arch **/
     private Map<String, Long> monitoringProductByArch;
@@ -136,10 +136,8 @@ public class MatcherJsonIO {
                 from -> monitoringProductId.ifPresent(to -> lifecycleProductsTranslation.put(from, to)));
 
         selfProductsByArch = new HashMap<>();
-        // SUSE Manager Server 4.0 x86_64 & SUSE Linux Enterprise Server 15 SP1 x86_64
-        selfProductsByArch.put(AMD64_ARCH_STR, Arrays.asList(1899L, 1763L));
-        // SUSE Manager Server 4.0 x86_64 & SUSE Linux Enterprise Server 15 SP1 s390
-        selfProductsByArch.put(S390_ARCH_STR, Arrays.asList(1898L, 1762L));
+        selfProductsByArch.put(AMD64_ARCH_STR, 1899L); // SUSE Manager Server 4.0 x86_64
+        selfProductsByArch.put(S390_ARCH_STR, 1898L); // SUSE Manager Server 4.0 s390
 
         monitoringProductByArch = new HashMap<>();
         monitoringProductByArch.put(AMD64_ARCH_STR, 1201L); // SUSE Manager Monitoring Single
@@ -321,7 +319,7 @@ public class MatcherJsonIO {
         }
 
         if (includeSelf) {
-            result.addAll(selfProductsByArch.get(arch));
+            result.add(selfProductsByArch.get(arch));
         }
 
         if (selfMonitoringEnabled) {

--- a/java/code/src/com/suse/manager/matcher/MatcherJsonIO.java
+++ b/java/code/src/com/suse/manager/matcher/MatcherJsonIO.java
@@ -136,10 +136,10 @@ public class MatcherJsonIO {
                 from -> monitoringProductId.ifPresent(to -> lifecycleProductsTranslation.put(from, to)));
 
         selfProductsByArch = new HashMap<>();
-        // SUSE Manager Server 3.1 x86_64 & SUSE Linux Enterprise Server 12 SP2 x86_64
-        selfProductsByArch.put(AMD64_ARCH_STR, Arrays.asList(1518L, 1357L));
-        // SUSE Manager Server 3.1 s390 & SUSE Linux Enterprise Server 12 SP2 s390
-        selfProductsByArch.put(S390_ARCH_STR, Arrays.asList(1519L, 1356L)); // SUSE Manager Server 3.1 x86_64
+        // SUSE Manager Server 4.0 x86_64 & SUSE Linux Enterprise Server 15 SP1 x86_64
+        selfProductsByArch.put(AMD64_ARCH_STR, Arrays.asList(1899L, 1763L));
+        // SUSE Manager Server 4.0 x86_64 & SUSE Linux Enterprise Server 15 SP1 s390
+        selfProductsByArch.put(S390_ARCH_STR, Arrays.asList(1898L, 1762L));
 
         monitoringProductByArch = new HashMap<>();
         monitoringProductByArch.put(AMD64_ARCH_STR, 1201L); // SUSE Manager Monitoring Single

--- a/java/code/src/com/suse/manager/matcher/MatcherRunner.java
+++ b/java/code/src/com/suse/manager/matcher/MatcherRunner.java
@@ -19,6 +19,9 @@ import com.redhat.rhn.domain.iss.IssFactory;
 import com.redhat.rhn.domain.matcher.MatcherRunData;
 import com.redhat.rhn.domain.matcher.MatcherRunDataFactory;
 import com.redhat.rhn.domain.server.PinnedSubscriptionFactory;
+
+import com.suse.manager.webui.services.impl.MonitoringService;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 
@@ -67,9 +70,10 @@ public class MatcherRunner {
             Process p = r.exec(args.toArray(new String[0]));
             PrintWriter stdin = new PrintWriter(p.getOutputStream());
             boolean isISSMaster = IssFactory.getCurrentMaster() == null;
+            boolean isSelfMonitoringEnabled = MonitoringService.isMonitoringEnabled();
             String arch = System.getProperty("os.arch");
             PinnedSubscriptionFactory.getInstance().cleanStalePins();
-            String s = new MatcherJsonIO().generateMatcherInput(isISSMaster, arch);
+            String s = new MatcherJsonIO().generateMatcherInput(isISSMaster, arch, isSelfMonitoringEnabled);
             stdin.println(s);
             stdin.flush();
             stdin.close();

--- a/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
+++ b/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
@@ -145,7 +145,6 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
         assertEquals("SUSE Manager Server system", sumaItself.getName());
         assertTrue(sumaItself.getPhysical());
         assertTrue(sumaItself.getProductIds().contains(1899L));
-        assertTrue(sumaItself.getProductIds().contains(1763L));
     }
 
     public void testSystemsToJsonIssSlave() {
@@ -172,14 +171,14 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
         // x86_64
         List<SystemJson> result = new MatcherJsonIO().getJsonSystems(true, AMD64_ARCH, true);
         SystemJson sumaItself = findSystem(MatcherJsonIO.SELF_SYSTEM_ID, result);
-        assertEquals(3, sumaItself.getProductIds().size());
-        assertEquals(new HashSet<>(Arrays.asList(1899L, 1763L, 1201L)), sumaItself.getProductIds());
+        assertEquals(2, sumaItself.getProductIds().size());
+        assertEquals(new HashSet<>(Arrays.asList(1899L, 1201L)), sumaItself.getProductIds());
 
         // s390
         result = new MatcherJsonIO().getJsonSystems(true, S390_ARCH, true);
         sumaItself = findSystem(MatcherJsonIO.SELF_SYSTEM_ID, result);
-        assertEquals(3, sumaItself.getProductIds().size());
-        assertEquals(new HashSet<>(Arrays.asList(1898L, 1762L, 1203L)), sumaItself.getProductIds());
+        assertEquals(2, sumaItself.getProductIds().size());
+        assertEquals(new HashSet<>(Arrays.asList(1898L, 1203L)), sumaItself.getProductIds());
     }
 
     public void testProductsToJson() throws Exception {

--- a/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
+++ b/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
@@ -117,14 +117,12 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
         List<SystemJson> result = new MatcherJsonIO().getJsonSystems(true, AMD64_ARCH, false);
         assertNotNull(result);
 
-        SystemJson resultH1 =
-                result.stream().filter(s -> s.getId().equals(h1.getId())).findFirst().get();
+        SystemJson resultH1 = findSystem(h1.getId(), result);
         assertNotNull(resultH1);
         assertEquals("host1.example.com", resultH1.getName());
         assertEquals(0, resultH1.getProductIds().size());
 
-        SystemJson resultG1 =
-                result.stream().filter(s -> s.getId().equals(g1.getId())).findFirst().get();
+        SystemJson resultG1 = findSystem(g1.getId(), result);
         assertNotNull(resultG1);
         assertEquals("guest1.example.com", resultG1.getName());
         assertEquals(3, resultG1.getProductIds().size());
@@ -132,8 +130,7 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
         assertTrue(resultG1.getProductIds().contains(MGMT_SINGLE_PROD_ID));
         assertTrue(resultG1.getProductIds().contains(1324L));
 
-        SystemJson resultG2 =
-                result.stream().filter(s -> s.getId().equals(g2.getId())).findFirst().get();
+        SystemJson resultG2 = findSystem(g2.getId(), result);
         assertNotNull(resultG2);
         assertEquals("guest2.example.com", resultG2.getName());
         assertEquals(3, resultG2.getProductIds().size());
@@ -142,9 +139,7 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
         assertTrue(resultG2.getProductIds().contains(1324L));
 
         // ISS Master should add itself
-        SystemJson sumaItself = result.stream().filter(
-                s -> s.getId().equals(MatcherJsonIO.SELF_SYSTEM_ID))
-                .findFirst().get();
+        SystemJson sumaItself = findSystem(MatcherJsonIO.SELF_SYSTEM_ID, result);
         assertNotNull(sumaItself);
         assertEquals(1L, sumaItself.getCpus().longValue());
         assertEquals("SUSE Manager Server system", sumaItself.getName());
@@ -162,17 +157,13 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
     public void testSystemsToJsonMonitoringEnabled() {
         // x86_64
         List<SystemJson> result = new MatcherJsonIO().getJsonSystems(false, AMD64_ARCH, true);
-        SystemJson sumaItself = result.stream().filter(
-                s -> s.getId().equals(MatcherJsonIO.SELF_SYSTEM_ID))
-                .findFirst().get();
+        SystemJson sumaItself = findSystem(MatcherJsonIO.SELF_SYSTEM_ID, result);
         assertEquals(1, sumaItself.getProductIds().size());
         assertEquals(1201L, sumaItself.getProductIds().iterator().next().longValue());
 
         // s390
         result = new MatcherJsonIO().getJsonSystems(false, S390_ARCH, true);
-        sumaItself = result.stream().filter(
-                s -> s.getId().equals(MatcherJsonIO.SELF_SYSTEM_ID))
-                .findFirst().get();
+        sumaItself = findSystem(MatcherJsonIO.SELF_SYSTEM_ID, result);
         assertEquals(1, sumaItself.getProductIds().size());
         assertEquals(1203L, sumaItself.getProductIds().iterator().next().longValue());
     }
@@ -180,17 +171,13 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
     public void testSystemsToJsonIssMasterWithMonitoring() {
         // x86_64
         List<SystemJson> result = new MatcherJsonIO().getJsonSystems(true, AMD64_ARCH, true);
-        SystemJson sumaItself = result.stream().filter(
-                s -> s.getId().equals(MatcherJsonIO.SELF_SYSTEM_ID))
-                .findFirst().get();
+        SystemJson sumaItself = findSystem(MatcherJsonIO.SELF_SYSTEM_ID, result);
         assertEquals(3, sumaItself.getProductIds().size());
         assertEquals(new HashSet<>(Arrays.asList(1899L, 1763L, 1201L)), sumaItself.getProductIds());
 
         // s390
         result = new MatcherJsonIO().getJsonSystems(true, S390_ARCH, true);
-        sumaItself = result.stream().filter(
-                s -> s.getId().equals(MatcherJsonIO.SELF_SYSTEM_ID))
-                .findFirst().get();
+        sumaItself = findSystem(MatcherJsonIO.SELF_SYSTEM_ID, result);
         assertEquals(3, sumaItself.getProductIds().size());
         assertEquals(new HashSet<>(Arrays.asList(1898L, 1762L, 1203L)), sumaItself.getProductIds());
     }
@@ -234,8 +221,8 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
         List<SystemJson> systems = matcherInput.getJsonSystems(false, AMD64_ARCH, false);
         assertEquals(1, systems.stream().filter(s -> s.getId().equals(hostServer.getId())).count());
         assertEquals(1, systems.stream().filter(s -> s.getId().equals(guestServer.getId())).count());
-        SystemJson host = systems.stream().filter(s -> s.getId().equals(hostServer.getId())).findFirst().get();
-        SystemJson guest = systems.stream().filter(s -> s.getId().equals(guestServer.getId())).findFirst().get();
+        SystemJson host = findSystem(hostServer.getId(), systems);
+        SystemJson guest = findSystem(guestServer.getId(), systems);
 
         assertTrue(host.getProductIds().contains(MGMT_SINGLE_PROD_ID));
         assertFalse(host.getProductIds().contains(MGMT_UNLIMITED_VIRT_PROD_ID));
@@ -273,8 +260,8 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
         List<SystemJson> systems = matcherInput.getJsonSystems(false, AMD64_ARCH, selfMonitoringEnabled);
         assertEquals(1, systems.stream().filter(s -> s.getId().equals(hostServer.getId())).count());
         assertEquals(1, systems.stream().filter(s -> s.getId().equals(guestServer.getId())).count());
-        SystemJson host = systems.stream().filter(s -> s.getId().equals(hostServer.getId())).findFirst().get();
-        SystemJson guest = systems.stream().filter(s -> s.getId().equals(guestServer.getId())).findFirst().get();
+        SystemJson host = findSystem(hostServer.getId(), systems);
+        SystemJson guest = findSystem(guestServer.getId(), systems);
 
         // let's check that monitoring products are NOT reported when the servers are not Monitoring-entitled
         assertFalse(host.getProductIds().contains(MONITORING_SINGLE_PROD_ID));
@@ -288,8 +275,8 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
         HibernateFactory.getSession().clear();
 
         systems = matcherInput.getJsonSystems(false, AMD64_ARCH, selfMonitoringEnabled);
-        host = systems.stream().filter(s -> s.getId().equals(hostServer.getId())).findFirst().get();
-        guest = systems.stream().filter(s -> s.getId().equals(guestServer.getId())).findFirst().get();
+        host = findSystem(hostServer.getId(), systems);
+        guest = findSystem(guestServer.getId(), systems);
         assertTrue(host.getProductIds().contains(MONITORING_SINGLE_PROD_ID));
         assertFalse(host.getProductIds().contains(MONITORING_UNLIMITED_VIRT_PROD_ID));
         assertTrue(guest.getProductIds().contains(MONITORING_SINGLE_PROD_ID));
@@ -327,8 +314,7 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
         testSystem.setInstalledProducts(installedProducts);
 
         MatcherJsonIO matcherInput = new MatcherJsonIO();
-        SystemJson system = matcherInput.getJsonSystems(false, AMD64_ARCH, false).stream()
-                .filter(s -> s.getId().equals(testSystem.getId())).findFirst().get();
+        SystemJson system = findSystem(testSystem.getId(), matcherInput.getJsonSystems(false, AMD64_ARCH, false));
 
         assertFalse(system.getProductIds().contains(instPrd.getSUSEProduct().getProductId()));
     }
@@ -542,5 +528,12 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
         instProd.setArch(PackageFactory.lookupPackageArchByLabel(archLabel));
         instProd.setBaseproduct(base);
         return instProd;
+    }
+
+    // helper method for finding system in a list
+    private SystemJson findSystem(long systemId, List<SystemJson> result) {
+        return result.stream().filter(
+                s -> s.getId().equals(systemId))
+                .findFirst().get();
     }
 }

--- a/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
+++ b/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
@@ -64,6 +64,7 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
 
     private static final String AMD64_ARCH = "amd64";
     private static final String S390_ARCH = "s390";
+    private static final String PPC64LE_ARCH = "ppc64le";
 
     @Override
     public void setUp() throws Exception {
@@ -165,6 +166,12 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
         sumaItself = findSystem(MatcherJsonIO.SELF_SYSTEM_ID, result);
         assertEquals(1, sumaItself.getProductIds().size());
         assertEquals(1203L, sumaItself.getProductIds().iterator().next().longValue());
+
+        // ppc64le
+        result = new MatcherJsonIO().getJsonSystems(false, PPC64LE_ARCH, true);
+        sumaItself = findSystem(MatcherJsonIO.SELF_SYSTEM_ID, result);
+        assertEquals(1, sumaItself.getProductIds().size());
+        assertEquals(1201L, sumaItself.getProductIds().iterator().next().longValue());
     }
 
     public void testSystemsToJsonIssMasterWithMonitoring() {
@@ -179,6 +186,12 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
         sumaItself = findSystem(MatcherJsonIO.SELF_SYSTEM_ID, result);
         assertEquals(2, sumaItself.getProductIds().size());
         assertEquals(new HashSet<>(Arrays.asList(1898L, 1203L)), sumaItself.getProductIds());
+
+        // ppc64le
+        result = new MatcherJsonIO().getJsonSystems(true, PPC64LE_ARCH, true);
+        sumaItself = findSystem(MatcherJsonIO.SELF_SYSTEM_ID, result);
+        assertEquals(2, sumaItself.getProductIds().size());
+        assertEquals(new HashSet<>(Arrays.asList(1897L, 1201L)), sumaItself.getProductIds());
     }
 
     public void testProductsToJson() throws Exception {

--- a/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
+++ b/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
@@ -312,13 +312,19 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
         withSetupContentSyncManager("/com/redhat/rhn/manager/content/test/sccdata_lifecycle_products", () -> {
             List<SubscriptionJson> subscriptions = new MatcherJsonIO().getJsonSubscriptions();
 
-            assertEquals(2, subscriptions.size());
+            assertEquals(4, subscriptions.size());
 
             subscriptions.stream()
                     .filter(s -> s.getId() == 11 || s.getId() == 12) // Management
                     .forEach(s -> {
                         assertTrue(s.getProductIds().contains(MGMT_SINGLE_PROD_ID));
                         assertFalse(s.getProductIds().contains(MGMT_UNLIMITED_VIRT_PROD_ID));
+                    });
+            subscriptions.stream()
+                    .filter(s -> s.getId() == 13 || s.getId() == 14) // Monitoring
+                    .forEach(s -> {
+                        assertTrue(s.getProductIds().contains(MONITORING_SINGLE_PROD_ID));
+                        assertFalse(s.getProductIds().contains(MONITORING_UNLIMITED_VIRT_PROD_ID));
                     });
         });
     }

--- a/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
+++ b/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
@@ -162,29 +162,37 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
     public void testSystemsToJsonMonitoringEnabled() {
         // x86_64
         List<SystemJson> result = new MatcherJsonIO().getJsonSystems(false, AMD64_ARCH, true);
-        assertEquals(1, result.size());
-        assertEquals(1, result.get(0).getProductIds().size());
-        assertEquals(1201L, result.get(0).getProductIds().iterator().next().longValue());
+        SystemJson sumaItself = result.stream().filter(
+                s -> s.getId().equals(MatcherJsonIO.SELF_SYSTEM_ID))
+                .findFirst().get();
+        assertEquals(1, sumaItself.getProductIds().size());
+        assertEquals(1201L, sumaItself.getProductIds().iterator().next().longValue());
 
         // s390
         result = new MatcherJsonIO().getJsonSystems(false, S390_ARCH, true);
-        assertEquals(1, result.size());
-        assertEquals(1, result.get(0).getProductIds().size());
-        assertEquals(1203L, result.get(0).getProductIds().iterator().next().longValue());
+        sumaItself = result.stream().filter(
+                s -> s.getId().equals(MatcherJsonIO.SELF_SYSTEM_ID))
+                .findFirst().get();
+        assertEquals(1, sumaItself.getProductIds().size());
+        assertEquals(1203L, sumaItself.getProductIds().iterator().next().longValue());
     }
 
     public void testSystemsToJsonIssMasterWithMonitoring() {
         // x86_64
         List<SystemJson> result = new MatcherJsonIO().getJsonSystems(true, AMD64_ARCH, true);
-        assertEquals(1, result.size());
-        assertEquals(3, result.get(0).getProductIds().size());
-        assertEquals(new HashSet<>(Arrays.asList(1899L, 1763L, 1201L)), result.get(0).getProductIds());
+        SystemJson sumaItself = result.stream().filter(
+                s -> s.getId().equals(MatcherJsonIO.SELF_SYSTEM_ID))
+                .findFirst().get();
+        assertEquals(3, sumaItself.getProductIds().size());
+        assertEquals(new HashSet<>(Arrays.asList(1899L, 1763L, 1201L)), sumaItself.getProductIds());
 
         // s390
         result = new MatcherJsonIO().getJsonSystems(true, S390_ARCH, true);
-        assertEquals(1, result.size());
-        assertEquals(3, result.get(0).getProductIds().size());
-        assertEquals(new HashSet<>(Arrays.asList(1898L, 1762L, 1203L)), result.get(0).getProductIds());
+        sumaItself = result.stream().filter(
+                s -> s.getId().equals(MatcherJsonIO.SELF_SYSTEM_ID))
+                .findFirst().get();
+        assertEquals(3, sumaItself.getProductIds().size());
+        assertEquals(new HashSet<>(Arrays.asList(1898L, 1762L, 1203L)), sumaItself.getProductIds());
     }
 
     public void testProductsToJson() throws Exception {

--- a/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
+++ b/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
@@ -24,7 +24,6 @@ import com.redhat.rhn.testing.ServerTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 
 import com.suse.manager.matcher.MatcherJsonIO;
-import com.suse.manager.virtualization.VirtManager;
 import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.matcher.json.MatchJson;
 import com.suse.matcher.json.ProductJson;
@@ -64,6 +63,20 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
     private static final long MONITORING_UNLIMITED_VIRT_PROD_ID = 1202L;
 
     private static final String AMD64_ARCH = "amd64";
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        setImposteriser(ClassImposteriser.INSTANCE);
+
+        SaltService saltServiceMock = context().mock(SaltService.class);
+        context().checking(new Expectations() {{
+            allowing(saltServiceMock).callSync(
+                    with(any(LocalCall.class)),
+                    with(any(String.class)));
+        }});
+        SystemManager.mockSaltService(saltServiceMock);
+    }
 
     public void testSystemsToJson() throws Exception {
         SUSEProductTestUtils.clearAllProducts();

--- a/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
+++ b/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
@@ -149,8 +149,8 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
         assertEquals(1L, sumaItself.getCpus().longValue());
         assertEquals("SUSE Manager Server system", sumaItself.getName());
         assertTrue(sumaItself.getPhysical());
-        assertTrue(sumaItself.getProductIds().contains(1518L));
-        assertTrue(sumaItself.getProductIds().contains(1357L));
+        assertTrue(sumaItself.getProductIds().contains(1899L));
+        assertTrue(sumaItself.getProductIds().contains(1763L));
     }
 
     public void testSystemsToJsonIssSlave() {
@@ -178,13 +178,13 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
         List<SystemJson> result = new MatcherJsonIO().getJsonSystems(true, AMD64_ARCH, true);
         assertEquals(1, result.size());
         assertEquals(3, result.get(0).getProductIds().size());
-        assertEquals(new HashSet<>(Arrays.asList(1518L, 1357L, 1201L)), result.get(0).getProductIds());
+        assertEquals(new HashSet<>(Arrays.asList(1899L, 1763L, 1201L)), result.get(0).getProductIds());
 
         // s390
         result = new MatcherJsonIO().getJsonSystems(true, S390_ARCH, true);
         assertEquals(1, result.size());
         assertEquals(3, result.get(0).getProductIds().size());
-        assertEquals(new HashSet<>(Arrays.asList(1519L, 1356L, 1203L)), result.get(0).getProductIds());
+        assertEquals(new HashSet<>(Arrays.asList(1898L, 1762L, 1203L)), result.get(0).getProductIds());
     }
 
     public void testProductsToJson() throws Exception {

--- a/java/code/src/com/suse/manager/webui/services/impl/MonitoringService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/MonitoringService.java
@@ -95,6 +95,17 @@ public class MonitoringService {
     }
 
     /**
+     * Check if at least one exporter is running
+     *
+     * @return true if at least one exporter is running, false otherwise
+     */
+    public static boolean isMonitoringEnabled() {
+        return getStatus()
+                .map(status -> status.values().contains(true))
+                .orElse(false);
+    }
+
+    /**
      * Get the status of Prometheus exporters.
      * @return a {@link Map} with the status of each Prometheus exporter
      */

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Report Monitoring products to subscription-matcher
 - Update help URLs in the UI
 - Fix SSM package upgrade list item selection (bsc#1133421)
 - Support system groups with the prometheus-exporters-formula and monitoring entitlements


### PR DESCRIPTION
## What does this PR change?
 
 In a similar fashion as the Management products, report Monitoring products
 too. The products are reported based on whether the system has Monitoring
 entitlement assigned.

**Review commit-by-commit** please.

 TODO:
 - [x] Monitoring SUMA instance itself (** Also take into account the ISS slave scenario ** )
 - [x] Adjust the suma server reported products (now we still report 3.1 and sle 12 sp2)
 - [x] ~Monitoring other Prometheus instances (I don't know what they are and how to
 detect them)~
 - [x] Fix the formula assignment bug in `SystemManager.entitleServer`
 - [x] In `Tests for Monitoring products reporting ` commit: there are 2 todos (re-assignment of server arch to be able to assign the Monitoring entitlement (it failed when the server arch was `i386`))
- [x] Answer this: Do we want to report Monitoring product even when no base product is installed on the machine (currently it's not reported in such case). Let's keep it that way.
 
 ## GUI diff
 
 No difference.
 
 - [x] **DONE**
 
 ## Documentation
 - [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)
 
 - [ ] **DONE**
 
 ## Test coverage
 - Unit tests were added
 
 - [x] **DONE**
 
 ## Links
 
 Tracks https://github.com/SUSE/spacewalk/issues/6675
 
 - [x] **DONE**
 
 ## Changelogs
 
 If you don't need a changelog check, please mark this checkbox:
 
 - [ ] No changelog needed
 
 If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
 
 
 ## Re-run a test
 
 If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:
 
 - [ ] Re-run test "changelog_test"
 - [ ] Re-run test "backend_unittests_pgsql"
 - [ ] Re-run test "java_lint_checkstyle" 		 
 - [ ] Re-run test "java_pgsql_tests"  		 
 - [ ] Re-run test "ruby_rubocop"
 - [ ] Re-run test "schema_migration_test_oracle"
 - [ ] Re-run test "schema_migration_test_pgsql"		 
 - [ ] Re-run test "susemanager_unittests"
 - [ ] Re-run test "javascript_lint"