### PR TITLE
ubuntu: spacewalk-repo-sync needs to handle the file:// scheme

### DIFF
--- a/backend/satellite_tools/repo_plugins/deb_src.py
+++ b/backend/satellite_tools/repo_plugins/deb_src.py
@@ -16,6 +16,7 @@
 import sys
 import os.path
 from shutil import rmtree
+from shutil import copyfile
 import time
 import re
 import fnmatch
@@ -28,11 +29,13 @@ from spacewalk.satellite_tools.repo_plugins import ContentPackage, CACHE_DIR
 from spacewalk.satellite_tools.syncLib import log2
 from spacewalk.common.rhnConfig import CFG, initCFG
 try:
-    #  python 2
+    #  python 2 
+    from urllib import unquote
     import urlparse
 except ImportError:
     #  python3
     import urllib.parse as urlparse # pylint: disable=F0401,E0611
+    from urllib.parse import unquote
 
 RETRIES = 10
 RETRY_DELAY = 1
@@ -87,6 +90,13 @@ class DebRepo(object):
         self.http_headers = {}
 
     def _download(self, url):
+        if url.startswith('file://'):
+            srcpath = unquote(url[len('file://'):])
+            if not os.path.exists(srcpath):
+                return ''
+            filename = self.basecachedir + '/' + os.path.basename(url)
+            copyfile(srcpath, filename)
+            return filename
         for _ in range(0, RETRIES):
             try:
                 proxies=""

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Fix spacewalk-repo-sync for Ubuntu repositories in mirror case (bsc#1136029)
 - Add support for ULN repositories on new Zypper based reposync.
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

In the ubuntu plugin, the _download function uses the Requests library
to fetch the files from the repository. However in the mirror case,
those are designated by a file:// URL which is not handled by requests.

Handle this case by performing a simple file copy.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: reposync fix

- [X] **DONE**

## Test coverage
- No tests: reposync fix

- [X] **DONE**

## Links

Fixes [bsc#1136029](https://bugzilla.suse.com/show_bug.cgi?id=1136029)

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
