### PR TITLE
Cucumber tests for the server monitoring UI

### DIFF
--- a/testsuite/features/srv_monitoring.feature
+++ b/testsuite/features/srv_monitoring.feature
@@ -1,0 +1,41 @@
+# Copyright (c) 2019 SUSE LLC
+# Licensed under the terms of the MIT license.
+#
+
+Feature: Monitor SUSE Manager server
+
+  Scenario: Check that monitoring is disabled using the UI
+    Given I am authorized as "admin" with password "admin"
+    When I follow the left menu "Admin > Manager Configuration > Monitoring"
+    And I wait until I do not see "Checking services..." text
+    Then I should see a list item with text "System" and bullet with "danger" icon
+    And I should see a list item with text "Taskomatic (Java JMX)" and bullet with "danger" icon
+    And I should see a list item with text "Tomcat (Java JMX)" and bullet with "danger" icon
+    And I should see a list item with text "PostgreSQL database" and bullet with "danger" icon
+    And I should see a "Enable services" button
+
+  Scenario: Enable monitoring from the UI
+    Given I am authorized as "admin" with password "admin"
+    When I follow the left menu "Admin > Manager Configuration > Monitoring"
+    And I wait until I do not see "Checking services..." text
+    And I click on "Enable services"
+    And I wait until I do not see "Enabling services..." text
+    Then I should see a "Monitoring enabled successfully." text
+    And I should see a list item with text "System" and bullet with "success" icon
+    And I should see a list item with text "Taskomatic (Java JMX)" and bullet with "success" icon
+    And I should see a list item with text "Tomcat (Java JMX)" and bullet with "success" icon
+    And I should see a list item with text "PostgreSQL database" and bullet with "success" icon
+    And I should see a "Disable services" button
+
+  Scenario: Disable monitoring from the UI
+    Given I am authorized as "admin" with password "admin"
+    When I follow the left menu "Admin > Manager Configuration > Monitoring"
+    And I wait until I do not see "Checking services..." text
+    And I click on "Disable services"
+    And I wait until I do not see "Disabling services..." text
+    Then I should see a "Monitoring disabled successfully." text
+    And I should see a list item with text "System" and bullet with "danger" icon
+    And I should see a list item with text "Taskomatic (Java JMX)" and bullet with "danger" icon
+    And I should see a list item with text "Tomcat (Java JMX)" and bullet with "danger" icon
+    And I should see a list item with text "PostgreSQL database" and bullet with "danger" icon
+    And I should see a "Enable services" button

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -947,3 +947,8 @@ When(/^I wait until all events in history are completed$/) do
     sleep 1
   end
 end
+
+And(/I should see a list item with text "([^"]*)" and bullet with "([^"]*)" icon/) do |text, class_name|
+  item_xpath = "//ul/li[text()='#{text}']/i[contains(@class, 'text-#{class_name}')]"
+  find(:xpath, item_xpath)
+end

--- a/testsuite/run_sets/testsuite.yml
+++ b/testsuite/run_sets/testsuite.yml
@@ -126,6 +126,7 @@
 - features/minxen_guests.feature
 - features/min_empty_system_profiles.feature
 - features/min_custom_pkg_download_endpoint.feature
+- features/srv_monitoring.feature
 
 ## Secondary features END ##
 


### PR DESCRIPTION
## What does this PR change?

Cucumber tests for the server monitoring UI.

## GUI diff

No difference.

## Documentation
- No documentation needed

## Test coverage
- Cucumber tests were added

## Links

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
