### PR TITLE
Check bootstrap events in chronological order

### DIFF
--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -97,8 +97,9 @@ When(/^I wait until onboarding is completed for "([^"]*)"$/) do |host|
     When I navigate to "rhn/systems/Overview.do" page
     And I wait until I see the name of "#{host}", refreshing the page
     And I follow this "#{host}" link
-    And I wait until event "Package List Refresh scheduled by (none)" is completed
-    Then I wait until event "Apply states" is completed
+    And I wait until event "Hardware List Refresh" is completed
+    And I wait until event "Apply states" is completed
+    And I wait until event "Package List Refresh" is completed
   )
 end
 


### PR DESCRIPTION
## What does this PR change?

This PR waits for the events at bootstrap in chronological order.

An expected side effect is to give it a bit more time, by not waiting last event first :smile_cat: .

Ported to:
 * 3.1 SUSE/spacewalk#7902
 * 3.2 SUSE/spacewalk#7903


- [x] No changelog needed
