### PR TITLE
Update link to documentation in server monitoring UI

### DIFF
--- a/web/html/src/manager/admin/config/monitoring-admin.js
+++ b/web/html/src/manager/admin/config/monitoring-admin.js
@@ -84,7 +84,7 @@ const HelpPanel = (props) => {
       The server uses <a href="https://prometheus.io" target="_blank" rel="noopener noreferrer">Prometheus</a> exporters to expose metrics about your environment.
       </p>
       <p>
-      Refer to the <a href="/docs/index.html" target="_blank">documentation</a> to learn how to to consume these metrics.
+      Refer to the <a href="/docs/administration/pages/prometheus.html" target="_blank">documentation</a> to learn how to to consume these metrics.
       </p>
   </div>);
 }


### PR DESCRIPTION
## What does this PR change?

Update link to docs in `Admin > Config > Monitoring`.

## GUI diff

No difference.

## Documentation
- No documentation needed

## Test coverage
- No tests

## Links

Fixes https://github.com/SUSE/spacewalk/issues/7846

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
