### PR TITLE
Add scc credentials via setup wizard

### DIFF
--- a/testsuite/documentation/optional.md
+++ b/testsuite/documentation/optional.md
@@ -172,6 +172,18 @@ Inside of the testsuite, the scenarios that are tagged with
 ```
 are executed only if you don't use a mirror.
 
+### Testing with a SCC crendentials
+
+Using the SCC crendentials with the testsuite is not mandatory.
+
+If you do not want to use SCC, do not define `scc_credentials` environment
+variable before you run the testsuite. That's all.
+If you want to use SCC, let this variable be equal to
+`"username|password"`:
+```bash
+export scc_credentials="username|password"
+```
+and then run the testsuite.
 
 ### Testing with external Docker or Kiwi profiles
 

--- a/testsuite/features/allcli_software_channels_dependencies.feature
+++ b/testsuite/features/allcli_software_channels_dependencies.feature
@@ -1,9 +1,10 @@
-# Copyright (c) 2018 SUSE LLC
+# Copyright (c) 2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Chanel subscription with recommended/required dependencies
 
 @sle15_minion
+@scc_credentials
   Scenario: Play with recommended and required child channels selection for a single system
     Given I am on the Systems overview page of this "sle-minion"
     When I follow "Software" in the content area
@@ -24,6 +25,7 @@ Feature: Chanel subscription with recommended/required dependencies
     Then I should see the child channel "SLE-Module-Server-Applications15-Pool for x86_64" "selected"
 
 @sle15_minion
+@scc_credentials
   Scenario: Play with recommended and required child channels selection in SSM
     Given I am authorized as "admin" with password "admin"
     When I am on the System Overview page

--- a/testsuite/features/core_srv_products_page.feature
+++ b/testsuite/features/core_srv_products_page.feature
@@ -3,6 +3,7 @@
 
 Feature: Synchronize products in the products page of the Setup Wizard
 
+@scc_credentials
   Scenario: Let the products page appear
     Given I am on the Admin page
     # Order matters here, refresh first
@@ -13,6 +14,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I should see a "Channels" text
     And I should not see a "WebYaST 1.3" text
 
+@scc_credentials
   Scenario: Use the products filter
     Given I am on the Admin page
     When I follow "SUSE Products" in the content area
@@ -20,6 +22,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I enter "RHEL Expanded Support 7" in the css "input[name='product-description-filter']"
     Then I should see a "RHEL Expanded Support 7" text
 
+@scc_credentials
   Scenario: View the channels list in the products page
     Given I am on the Admin page
     When I follow "SUSE Products" in the content area
@@ -30,6 +33,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I should see a "Mandatory Channels" text
     And I should see a "Optional Channels" text
 
+@scc_credentials
   Scenario: Add a product and one of its modules
     Given I am on the Admin page
     When I follow "SUSE Products" in the content area
@@ -47,6 +51,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I wait until I see "SUSE Linux Enterprise Server 12 SP2 x86_64" product has been added
     Then the SLE12 products should be added
 
+@scc_credentials
   Scenario: Add a product with recommended enabled
     Given I am on the Admin page
     When I follow "SUSE Products" in the content area

--- a/testsuite/features/core_srv_sync_channels.feature
+++ b/testsuite/features/core_srv_sync_channels.feature
@@ -6,11 +6,13 @@ Feature: Be able to list available channels and enable them
   As root user
   I want to be able to list available channels and enable them
 
+@scc_credentials
   Scenario: List available channels
     When I execute mgr-sync "list channels -e" with user "admin" and password "admin"
     Then I should get "[ ] SLES11-SP1-Pool for x86_64 SUSE Linux Enterprise Server 11 SP1 x86_64 [sles11-sp1-pool-x86_64]"
     And I should get "    [ ] SLE11-SDK-SP1-Updates for x86_64 SUSE Linux Enterprise Software Development Kit 11 SP1 [sle11-sdk-sp1-updates-x86_64]"
 
+@scc_credentials
   Scenario: List available mandatory channels
     When I execute mgr-sync "list channels -e --no-optional"
     Then I should get "[ ] SLES11-SP1-Pool for x86_64 SUSE Linux Enterprise Server 11 SP1 x86_64 [sles11-sp1-pool-x86_64]"
@@ -18,11 +20,13 @@ Feature: Be able to list available channels and enable them
     And I shouldn't get "debuginfo"
     And I shouldn't get "sles11-extras"
 
+@scc_credentials
   Scenario: List products
     When I execute mgr-sync "list products"
     Then I should get "[ ] SUSE Linux Enterprise Server 12 x86_64"
     And I should get "[ ] SUSE Manager Proxy 2.1 x86_64"
 
+@scc_credentials
   Scenario: List all products
     When I execute mgr-sync "list products --expand"
     Then I should get "[ ] SUSE Linux Enterprise Server 12 x86_64"
@@ -30,12 +34,14 @@ Feature: Be able to list available channels and enable them
     And I should get "  [ ] SUSE Cloud 4 x86_64"
     And I should get "  [ ] SUSE Linux Enterprise High Availability Extension 12 x86_64"
 
+@scc_credentials
   Scenario: List products with filter
     When I execute mgr-sync "list products --expand --filter x86_64"
     Then I should get "[ ] SUSE Linux Enterprise Server for SAP All-in-One 11 SP4 x86_64"
     And I shouldn't get "ppc64"
     And I shouldn't get "s390x"
 
+@scc_credentials
   Scenario: Run spacewalk-repo-sync with custom URLs
     When I call spacewalk-repo-sync for channel "test_base_channel" with a custom url "http://localhost/pub/TestRepo/"
     Then I should see "Channel: test_base_channel" in the output
@@ -43,6 +49,7 @@ Feature: Be able to list available channels and enable them
     And I should see "Total time:" in the output
     And I should see "Repo URL:" in the output
 
+@scc_credentials
   Scenario: Enable sles12-sp4-pool-x86_64
     # This automaticaly enables all required channels
     When I execute mgr-sync "add channel sles12-sp4-pool-x86_64"
@@ -51,6 +58,7 @@ Feature: Be able to list available channels and enable them
     And I should get "    [I] SLES12-SP4-Updates for x86_64 SUSE Linux Enterprise Server 12 SP4 x86_64 [sles12-sp4-updates-x86_64]"
     And I should get "    [ ] SLE-Module-Containers12-Pool for x86_64 Containers Module 12 x86_64 [sle-module-containers12-pool-x86_64-sp4]"
 
+@scc_credentials
   Scenario: Enable sle-module-containers12-pool-x86_64-sp4
     # This automatically enables all required channels
     When I execute mgr-sync "add channel sle-module-containers12-pool-x86_64-sp4"
@@ -59,6 +67,7 @@ Feature: Be able to list available channels and enable them
     And I should get "    [I] SLE-Module-Containers12-Pool for x86_64 Containers Module 12 x86_64 [sle-module-containers12-pool-x86_64-sp4]"
     And I should get "    [I] SLE-Module-Containers12-Updates for x86_64 Containers Module 12 x86_64 [sle-module-containers12-updates-x86_64-sp4]"
 
+@scc_credentials
   Scenario: Let mgr-sync time out
     When I remove the mgr-sync cache file
     And I execute mgr-sync refresh

--- a/testsuite/features/srv_content_lifecycle.feature
+++ b/testsuite/features/srv_content_lifecycle.feature
@@ -3,6 +3,7 @@
 
 Feature: Content lifecycle
 
+@scc_credentials
   Scenario: Create a content lifecycle project
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Content Lifecycle > Projects"
@@ -17,6 +18,7 @@ Feature: Content lifecycle
     And I click on "Create"
     Then I wait until I see "Content Lifecycle Project - clp_name" text
 
+@scc_credentials
   Scenario: Verify the content lifecycle project page
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Content Lifecycle > Projects"
@@ -29,6 +31,7 @@ Feature: Content lifecycle
     And I should see a "Filters" text
     And I should see a "Environment Lifecycle" text
 
+@scc_credentials
   Scenario: Add a source to the project
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Content Lifecycle > Projects"
@@ -41,6 +44,7 @@ Feature: Content lifecycle
     And I should see a "Build (2)" text
     And I should see a "Version 1: (draft - not built) - Check the changes below" text
 
+@scc_credentials
   Scenario: Add environments to the project
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Content Lifecycle > Projects"
@@ -66,6 +70,7 @@ Feature: Content lifecycle
     Then I wait until I see "qa_name" text
     And I should see a "qa_desc" text
 
+@scc_credentials
   Scenario: Build the sources in the project
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Content Lifecycle > Projects"
@@ -79,6 +84,7 @@ Feature: Content lifecycle
     And I should see a "Version 1: test version message 1" text
     And I wait until I see "Built" text
 
+@scc_credentials
   Scenario: Promote promote the sources in the project
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Content Lifecycle > Projects"
@@ -95,6 +101,7 @@ Feature: Content lifecycle
     And I click on "Promote environment" in "Promote version 1 into prod_name" modal
     Then I wait until I see "Version 1: test version message 1" text in the environment "prod_name"
 
+@scc_credentials
   Scenario: Add new sources and promote again
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Content Lifecycle > Projects"
@@ -118,6 +125,7 @@ Feature: Content lifecycle
     And I click on "Promote environment" in "Promote version 2 into prod_name" modal
     Then I wait until I see "Version 2: test version message 2" text in the environment "prod_name"
 
+@scc_credentials
   Scenario: Clean up the Content Lifecycle Management feature
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Content Lifecycle > Projects"

--- a/testsuite/features/srv_organization_credentials.feature
+++ b/testsuite/features/srv_organization_credentials.feature
@@ -3,6 +3,12 @@
 
 Feature: Organization credentials in the Setup Wizard
 
+@scc_credentials
+  Scenario: Enter valid SCC credentials
+    Given I am on the Admin page
+    When I follow "Organization Credentials" in the content area
+    And I enter the SCC credentials
+
 @no_mirror
   Scenario: Create some organization credentials
     Given I am on the Admin page

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -973,3 +973,16 @@ And(/I should see a list item with text "([^"]*)" and bullet with "([^"]*)" icon
   item_xpath = "//ul/li[text()='#{text}']/i[contains(@class, 'text-#{class_name}')]"
   find(:xpath, item_xpath)
 end
+
+When(/^I enter the SCC credentials$/) do
+  user = ENV['scc_credentials'].split('|')[0]
+  password = ENV['scc_credentials'].split('|')[1]
+  unless page.has_content?(user)
+    steps %(
+      And I want to add a new credential
+      And I enter "#{user}" as "edit-user"
+      And I enter "#{password}" as "edit-password"
+      And I click on "Save"
+    )
+  end
+end

--- a/testsuite/features/support/setup_browser.rb
+++ b/testsuite/features/support/setup_browser.rb
@@ -88,7 +88,7 @@ end
 
 # do we have scc credentials
 Before('@scc_credentials') do |scenario|
-  scenario.skip_invoke! unless ENV['scc_credentials']
+  scenario.skip_invoke! unless $scc_credentials
 end
 
 # do some tests only if there is a private network

--- a/testsuite/features/support/setup_browser.rb
+++ b/testsuite/features/support/setup_browser.rb
@@ -86,6 +86,11 @@ Before('@sle15_minion') do |scenario|
   scenario.skip_invoke! unless $sle15_minion
 end
 
+# do we have scc credentials
+Before('@scc_credentials') do |scenario|
+  scenario.skip_invoke! unless ENV['scc_credentials']
+end
+
 # do some tests only if there is a private network
 Before('@private_net') do |scenario|
   scenario.skip_invoke! unless $private_net

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -128,3 +128,4 @@ $mirror = ENV['MIRROR']
 $git_profiles = ENV['GITPROFILES']
 $product = product
 $server_http_proxy = ENV['SERVER_HTTP_PROXY'] if ENV['SERVER_HTTP_PROXY']
+$scc_credentials = ENV['scc_credentials'] if ENV['scc_credentials']


### PR DESCRIPTION
## What does this PR change?
Add scc credentials via setup wizard

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/7010
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test" 
- [ ] Re-run test "backend_unittests_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "java_lint_checkstyle" (Test skipped, there are no changes to test)		 
- [ ] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)		 
- [ ] Re-run test "ruby_rubocop" 
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
