### PR TITLE
Content Lifecycle Management: Minor improvements in channel alignment

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/events/AlignSoftwareTargetAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/AlignSoftwareTargetAction.java
@@ -25,7 +25,7 @@ import com.redhat.rhn.domain.contentmgmt.ContentProjectFactory;
 import com.redhat.rhn.domain.contentmgmt.EnvironmentTarget.Status;
 import com.redhat.rhn.domain.contentmgmt.SoftwareEnvironmentTarget;
 import com.redhat.rhn.manager.EntityNotExistsException;
-import com.redhat.rhn.manager.channel.ChannelManager;
+import com.redhat.rhn.manager.contentmgmt.ContentManager;
 import com.redhat.rhn.manager.user.UserManager;
 import org.apache.log4j.Logger;
 
@@ -61,7 +61,7 @@ public class AlignSoftwareTargetAction implements MessageAction {
 
             LOG.info("Asynchronously aligning: " + msg);
             Instant start = Instant.now();
-            ChannelManager.alignEnvironmentTargetSync(filters, sourceChannel, targetChannel, msg.getUser());
+            ContentManager.alignEnvironmentTargetSync(filters, sourceChannel, targetChannel, msg.getUser());
             target.setStatus(Status.GENERATING_REPODATA);
             LOG.info("Finished aligning " + msg + " in " + Duration.between(start, Instant.now()));
         }

--- a/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
@@ -24,7 +24,6 @@ import com.redhat.rhn.common.db.datasource.WriteMode;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.hibernate.LookupException;
 import com.redhat.rhn.common.localization.LocalizationService;
-import com.redhat.rhn.common.messaging.MessageQueue;
 import com.redhat.rhn.common.security.PermissionException;
 import com.redhat.rhn.common.validator.ValidatorException;
 import com.redhat.rhn.domain.channel.Channel;
@@ -39,12 +38,6 @@ import com.redhat.rhn.domain.channel.DistChannelMap;
 import com.redhat.rhn.domain.channel.InvalidChannelRoleException;
 import com.redhat.rhn.domain.channel.ProductName;
 import com.redhat.rhn.domain.channel.ReleaseChannelMap;
-import com.redhat.rhn.domain.contentmgmt.ContentFilter;
-import com.redhat.rhn.domain.contentmgmt.ContentProjectFactory;
-import com.redhat.rhn.domain.contentmgmt.EnvironmentTarget;
-import com.redhat.rhn.domain.contentmgmt.ErrataFilter;
-import com.redhat.rhn.domain.contentmgmt.PackageFilter;
-import com.redhat.rhn.domain.contentmgmt.SoftwareEnvironmentTarget;
 import com.redhat.rhn.domain.errata.Errata;
 import com.redhat.rhn.domain.kickstart.KickstartData;
 import com.redhat.rhn.domain.org.Org;
@@ -52,7 +45,6 @@ import com.redhat.rhn.domain.product.SUSEProduct;
 import com.redhat.rhn.domain.product.SUSEProductChannel;
 import com.redhat.rhn.domain.product.SUSEProductExtension;
 import com.redhat.rhn.domain.product.SUSEProductFactory;
-import com.redhat.rhn.domain.rhnpackage.Package;
 import com.redhat.rhn.domain.rhnpackage.PackageEvr;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.server.MinionServer;
@@ -70,15 +62,12 @@ import com.redhat.rhn.frontend.dto.PackageDto;
 import com.redhat.rhn.frontend.dto.PackageListItem;
 import com.redhat.rhn.frontend.dto.PackageOverview;
 import com.redhat.rhn.frontend.dto.SystemsPerChannelDto;
-import com.redhat.rhn.frontend.events.AlignSoftwareTargetAction;
-import com.redhat.rhn.frontend.events.AlignSoftwareTargetMsg;
 import com.redhat.rhn.frontend.listview.ListControl;
 import com.redhat.rhn.frontend.listview.PageControl;
 import com.redhat.rhn.frontend.xmlrpc.NoSuchChannelException;
 import com.redhat.rhn.frontend.xmlrpc.ProxyChannelNotFoundException;
 import com.redhat.rhn.manager.BaseManager;
 import com.redhat.rhn.manager.action.ActionManager;
-import com.redhat.rhn.manager.errata.ErrataManager;
 import com.redhat.rhn.manager.errata.cache.ErrataCacheManager;
 import com.redhat.rhn.manager.rhnpackage.PackageManager;
 import com.redhat.rhn.manager.rhnset.RhnSetDecl;
@@ -99,7 +88,6 @@ import java.sql.Types;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -110,7 +98,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -2753,130 +2740,6 @@ public class ChannelManager extends BaseManager {
         params.put("from", fromCid);
         params.put("to", toCid);
         return m.executeUpdate(params);
-    }
-
-    /**
-     * Align packages and errata of the {@link SoftwareEnvironmentTarget} to the source {@link Channel}
-     *
-     * @param src the source {@link Channel}
-     * @param tgt the target {@link SoftwareEnvironmentTarget}
-     * @param filters the {@link ContentFilter}s
-     * @param async run this operation asynchronously?
-     * @param user the user
-     */
-    public static void alignEnvironmentTarget(Channel src, SoftwareEnvironmentTarget tgt, List<ContentFilter> filters,
-            boolean async, User user) {
-        // adjust the target status
-        tgt.setStatus(EnvironmentTarget.Status.BUILDING);
-        ContentProjectFactory.save(tgt);
-
-        AlignSoftwareTargetMsg msg = new AlignSoftwareTargetMsg(src, tgt, filters, user);
-        if (async) {
-            MessageQueue.publish(msg);
-        }
-        else {
-            new AlignSoftwareTargetAction().execute(msg);
-        }
-    }
-
-    /**
-     * Synchronously align packages and errata of the {@link SoftwareEnvironmentTarget} to the source {@link Channel}
-     * This method is potentially time-expensive and should be run asynchronously (@see alignEnvironmentTarget)
-     *
-     * @param filters the filters
-     * @param src the source {@link Channel}
-     * @param tgt the target {@link SoftwareEnvironmentTarget}
-     * @param user the user
-     */
-    public static void alignEnvironmentTargetSync(Collection<ContentFilter> filters, Channel src, Channel tgt,
-            User user) {
-        // align packages and the cache (rhnServerNeededCache)
-        List<PackageFilter> packageFilters = filters.stream()
-                .flatMap(f -> Opt.stream((Optional<PackageFilter>) f.asPackageFilter()))
-                .collect(Collectors.toList());
-        List<ErrataFilter> errataFilters = filters.stream()
-                .flatMap(f -> Opt.stream((Optional<ErrataFilter>) f.asErrataFilter()))
-                .collect(Collectors.toList());
-
-        alignPackages(src, tgt, packageFilters);
-
-        // align errata and the cache (rhnServerNeededCache)
-        alignErrata(src, tgt, errataFilters, user);
-
-        // update the channel newest packages cache
-        ChannelFactory.refreshNewestPackageCache(tgt, "java::alignPackages");
-
-        // now request repo regen
-        tgt.setLastModified(new Date());
-        HibernateFactory.getSession().saveOrUpdate(tgt);
-        ChannelManager.queueChannelChange(tgt.getLabel(), "java::alignChannel", "Channel aligned");
-    }
-
-    private static void alignPackages(Channel srcChannel, Channel tgtChannel, Collection<PackageFilter> filters) {
-        Set<Package> oldTgtPackages = new HashSet<>(tgtChannel.getPackages());
-        Set<Package> onlyInSrc = new HashSet<>(srcChannel.getPackages());
-        onlyInSrc.removeAll(tgtChannel.getPackages());
-
-        // align the packages
-        tgtChannel.getPackages().clear();
-        Set<Package> newPackages = filterPackages(srcChannel.getPackages(), filters);
-        tgtChannel.getPackages().addAll(newPackages);
-
-        // remove cache entries for only in tgt
-        oldTgtPackages.removeAll(newPackages);
-        ErrataCacheManager.deleteCacheEntriesForChannelPackages(tgtChannel.getId(), extractPackageIds(oldTgtPackages));
-
-        // add cache entries for new ones
-        ErrataCacheManager.insertCacheForChannelPackages(tgtChannel.getId(), null,
-                extractPackageIds(filterPackages(onlyInSrc, filters)));
-    }
-
-    /**
-     * Align {@link Errata} of a target {@link Channel} to the source {@link Channel}
-     *
-     * Alignment has 4 steps:
-     * 1. Compute included and excluded errata based on given source channel and {@link ErrataFilter}s
-     * 2. Remove (truncate) those errata in target channel, which are not in included errata (or which do not have
-     * original in the included errata)
-     * 3. Remove the {@link Package}s from excluded errata from target channel
-     * 4. Merge the included errata to target channel
-     *
-     * @param src the source {@link Channel}
-     * @param tgt the target {@link Channel}
-     * @param errataFilters the {@link ErrataFilter}s
-     * @param user the {@link User}
-     */
-    private static void alignErrata(Channel src, Channel tgt, Collection<ErrataFilter> errataFilters, User user) {
-        Predicate<Errata> compositePredicate = errataFilters.stream()
-                .map(f -> (Predicate) f)
-                .reduce((f1, f2) -> f1.and(f2))
-                .orElse(p -> true);
-
-        Map<Boolean, List<Errata>> partitionedErrata = src.getErratas().stream()
-                .collect(Collectors.partitioningBy(compositePredicate));
-        Set<Errata> includedErrata = new HashSet<>(partitionedErrata.get(true));
-        List<Errata> excludedErrata = partitionedErrata.get(false);
-
-        // Truncate extra errata in target channel
-        ErrataManager.truncateErrata(includedErrata, tgt, user);
-        // Remove packages from excluded errata
-        excludedErrata.forEach(e -> ErrataManager.removeErratumAndPackagesFromChannel(e, tgt, user));
-        // Merge the included errata
-        ErrataManager.mergeErrataToChannel(user, includedErrata, tgt, src, false, false);
-    }
-
-    private static List<Long> extractPackageIds(Collection<Package> packages) {
-        return packages.stream().map(p -> p.getId()).collect(Collectors.toList());
-    }
-
-    private static Set<Package> filterPackages(Set<Package> packages, Collection<PackageFilter> packageFilters) {
-        Predicate<Package> compositePredicate = packageFilters.stream()
-                .map(f -> (Predicate) f)
-                .reduce((f1, f2) -> f1.and(f2))
-                .orElse(p -> true);
-        return packages.stream()
-                .filter(compositePredicate)
-                .collect(Collectors.toSet());
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -769,12 +769,12 @@ public class ContentManager {
     }
 
     /**
-     * Synchronously align packages and errata of the {@link SoftwareEnvironmentTarget} to the source {@link Channel}
+     * Synchronously align packages and errata of the {@link Channel} to the source {@link Channel}
      * This method is potentially time-expensive and should be run asynchronously (@see alignEnvironmentTarget)
      *
      * @param filters the filters
      * @param src the source {@link Channel}
-     * @param tgt the target {@link SoftwareEnvironmentTarget}
+     * @param tgt the target {@link Channel}
      * @param user the user
      */
     public static void alignEnvironmentTargetSync(Collection<ContentFilter> filters, Channel src, Channel tgt,

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -15,6 +15,50 @@
 
 package com.redhat.rhn.manager.contentmgmt;
 
+import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.common.hibernate.LookupException;
+import com.redhat.rhn.common.messaging.MessageQueue;
+import com.redhat.rhn.common.security.PermissionException;
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.channel.ChannelFactory;
+import com.redhat.rhn.domain.contentmgmt.ContentEnvironment;
+import com.redhat.rhn.domain.contentmgmt.ContentFilter;
+import com.redhat.rhn.domain.contentmgmt.ContentManagementException;
+import com.redhat.rhn.domain.contentmgmt.ContentProject;
+import com.redhat.rhn.domain.contentmgmt.ContentProjectFactory;
+import com.redhat.rhn.domain.contentmgmt.ContentProjectFilter;
+import com.redhat.rhn.domain.contentmgmt.ContentProjectHistoryEntry;
+import com.redhat.rhn.domain.contentmgmt.EnvironmentTarget;
+import com.redhat.rhn.domain.contentmgmt.ErrataFilter;
+import com.redhat.rhn.domain.contentmgmt.FilterCriteria;
+import com.redhat.rhn.domain.contentmgmt.PackageFilter;
+import com.redhat.rhn.domain.contentmgmt.ProjectSource;
+import com.redhat.rhn.domain.contentmgmt.ProjectSource.Type;
+import com.redhat.rhn.domain.contentmgmt.SoftwareEnvironmentTarget;
+import com.redhat.rhn.domain.contentmgmt.SoftwareProjectSource;
+import com.redhat.rhn.domain.errata.Errata;
+import com.redhat.rhn.domain.rhnpackage.Package;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.events.AlignSoftwareTargetAction;
+import com.redhat.rhn.frontend.events.AlignSoftwareTargetMsg;
+import com.redhat.rhn.manager.EntityExistsException;
+import com.redhat.rhn.manager.EntityNotExistsException;
+import com.redhat.rhn.manager.channel.ChannelManager;
+import com.redhat.rhn.manager.channel.CloneChannelCommand;
+import com.redhat.rhn.manager.errata.ErrataManager;
+import com.redhat.rhn.manager.errata.cache.ErrataCacheManager;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
 import static com.redhat.rhn.domain.contentmgmt.ProjectSource.State.ATTACHED;
 import static com.redhat.rhn.domain.contentmgmt.ProjectSource.State.BUILT;
 import static com.redhat.rhn.domain.contentmgmt.ProjectSource.State.DETACHED;
@@ -30,36 +74,6 @@ import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.partitioningBy;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
-
-import com.redhat.rhn.common.hibernate.LookupException;
-import com.redhat.rhn.common.security.PermissionException;
-import com.redhat.rhn.domain.channel.Channel;
-import com.redhat.rhn.domain.channel.ChannelFactory;
-import com.redhat.rhn.domain.contentmgmt.ContentEnvironment;
-import com.redhat.rhn.domain.contentmgmt.ContentFilter;
-import com.redhat.rhn.domain.contentmgmt.ContentManagementException;
-import com.redhat.rhn.domain.contentmgmt.ContentProject;
-import com.redhat.rhn.domain.contentmgmt.ContentProjectFactory;
-import com.redhat.rhn.domain.contentmgmt.ContentProjectFilter;
-import com.redhat.rhn.domain.contentmgmt.ContentProjectHistoryEntry;
-import com.redhat.rhn.domain.contentmgmt.FilterCriteria;
-import com.redhat.rhn.domain.contentmgmt.ProjectSource;
-import com.redhat.rhn.domain.contentmgmt.ProjectSource.Type;
-import com.redhat.rhn.domain.contentmgmt.SoftwareEnvironmentTarget;
-import com.redhat.rhn.domain.contentmgmt.SoftwareProjectSource;
-import com.redhat.rhn.domain.user.User;
-import com.redhat.rhn.manager.EntityExistsException;
-import com.redhat.rhn.manager.EntityNotExistsException;
-import com.redhat.rhn.manager.channel.ChannelManager;
-import com.redhat.rhn.manager.channel.CloneChannelCommand;
-
-import org.apache.commons.lang3.tuple.Pair;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Stream;
 
 /**
  * Content Management functionality
@@ -627,7 +641,7 @@ public class ContentManager {
                 .forEach(toRemove -> ContentProjectFactory.purgeTarget(toRemove));
 
         // align the contents
-        newSrcTgtPairs.forEach(srcTgt -> ChannelManager.
+        newSrcTgtPairs.forEach(srcTgt ->
                 alignEnvironmentTarget(srcTgt.getLeft(), srcTgt.getRight(), filters, async, user));
     }
 
@@ -728,6 +742,130 @@ public class ContentManager {
         entry.setMessage(message.orElse("Content Project build"));
         ContentProjectFactory.addHistoryEntryToProject(project, entry);
         return entry;
+    }
+
+    /**
+     * Align packages and errata of the {@link SoftwareEnvironmentTarget} to the source {@link Channel}
+     *
+     * @param src the source {@link Channel}
+     * @param tgt the target {@link SoftwareEnvironmentTarget}
+     * @param filters the {@link ContentFilter}s
+     * @param async run this operation asynchronously?
+     * @param user the user
+     */
+    public static void alignEnvironmentTarget(Channel src, SoftwareEnvironmentTarget tgt, List<ContentFilter> filters,
+            boolean async, User user) {
+        // adjust the target status
+        tgt.setStatus(EnvironmentTarget.Status.BUILDING);
+        ContentProjectFactory.save(tgt);
+
+        AlignSoftwareTargetMsg msg = new AlignSoftwareTargetMsg(src, tgt, filters, user);
+        if (async) {
+            MessageQueue.publish(msg);
+        }
+        else {
+            new AlignSoftwareTargetAction().execute(msg);
+        }
+    }
+
+    /**
+     * Synchronously align packages and errata of the {@link SoftwareEnvironmentTarget} to the source {@link Channel}
+     * This method is potentially time-expensive and should be run asynchronously (@see alignEnvironmentTarget)
+     *
+     * @param filters the filters
+     * @param src the source {@link Channel}
+     * @param tgt the target {@link SoftwareEnvironmentTarget}
+     * @param user the user
+     */
+    public static void alignEnvironmentTargetSync(Collection<ContentFilter> filters, Channel src, Channel tgt,
+            User user) {
+        // align packages and the cache (rhnServerNeededCache)
+        List<PackageFilter> packageFilters = filters.stream()
+                .flatMap(f -> stream((Optional<PackageFilter>) f.asPackageFilter()))
+                .collect(toList());
+        List<ErrataFilter> errataFilters = filters.stream()
+                .flatMap(f -> stream((Optional<ErrataFilter>) f.asErrataFilter()))
+                .collect(toList());
+
+        alignPackages(src, tgt, packageFilters);
+
+        // align errata and the cache (rhnServerNeededCache)
+        alignErrata(src, tgt, errataFilters, user);
+
+        // update the channel newest packages cache
+        ChannelFactory.refreshNewestPackageCache(tgt, "java::alignPackages");
+
+        // now request repo regen
+        tgt.setLastModified(new Date());
+        HibernateFactory.getSession().saveOrUpdate(tgt);
+        ChannelManager.queueChannelChange(tgt.getLabel(), "java::alignChannel", "Channel aligned");
+    }
+
+    private static void alignPackages(Channel srcChannel, Channel tgtChannel, Collection<PackageFilter> filters) {
+        Set<Package> oldTgtPackages = new HashSet<>(tgtChannel.getPackages());
+        Set<Package> onlyInSrc = new HashSet<>(srcChannel.getPackages());
+        onlyInSrc.removeAll(tgtChannel.getPackages());
+
+        // align the packages
+        tgtChannel.getPackages().clear();
+        Set<Package> newPackages = filterPackages(srcChannel.getPackages(), filters);
+        tgtChannel.getPackages().addAll(newPackages);
+
+        // remove cache entries for only in tgt
+        oldTgtPackages.removeAll(newPackages);
+        ErrataCacheManager.deleteCacheEntriesForChannelPackages(tgtChannel.getId(), extractPackageIds(oldTgtPackages));
+
+        // add cache entries for new ones
+        ErrataCacheManager.insertCacheForChannelPackages(tgtChannel.getId(), null,
+                extractPackageIds(filterPackages(onlyInSrc, filters)));
+    }
+
+    /**
+     * Align {@link Errata} of a target {@link Channel} to the source {@link Channel}
+     *
+     * Alignment has 4 steps:
+     * 1. Compute included and excluded errata based on given source channel and {@link ErrataFilter}s
+     * 2. Remove (truncate) those errata in target channel, which are not in included errata (or which do not have
+     * original in the included errata)
+     * 3. Remove the {@link Package}s from excluded errata from target channel
+     * 4. Merge the included errata to target channel
+     *
+     * @param src the source {@link Channel}
+     * @param tgt the target {@link Channel}
+     * @param errataFilters the {@link ErrataFilter}s
+     * @param user the {@link User}
+     */
+    private static void alignErrata(Channel src, Channel tgt, Collection<ErrataFilter> errataFilters, User user) {
+        Predicate<Errata> compositePredicate = errataFilters.stream()
+                .map(f -> (Predicate) f)
+                .reduce((f1, f2) -> f1.and(f2))
+                .orElse(p -> true);
+
+        Map<Boolean, List<Errata>> partitionedErrata = src.getErratas().stream()
+                .collect(partitioningBy(compositePredicate));
+        Set<Errata> includedErrata = new HashSet<>(partitionedErrata.get(true));
+        List<Errata> excludedErrata = partitionedErrata.get(false);
+
+        // Truncate extra errata in target channel
+        ErrataManager.truncateErrata(includedErrata, tgt, user);
+        // Remove packages from excluded errata
+        excludedErrata.forEach(e -> ErrataManager.removeErratumAndPackagesFromChannel(e, tgt, user));
+        // Merge the included errata
+        ErrataManager.mergeErrataToChannel(user, includedErrata, tgt, src, false, false);
+    }
+
+    private static List<Long> extractPackageIds(Collection<Package> packages) {
+        return packages.stream().map(p -> p.getId()).collect(toList());
+    }
+
+    private static Set<Package> filterPackages(Set<Package> packages, Collection<PackageFilter> packageFilters) {
+        Predicate<Package> compositePredicate = packageFilters.stream()
+                .map(f -> (Predicate) f)
+                .reduce((f1, f2) -> f1.and(f2))
+                .orElse(p -> true);
+        return packages.stream()
+                .filter(compositePredicate)
+                .collect(toSet());
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerChannelAlignmentTest.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerChannelAlignmentTest.java
@@ -15,6 +15,16 @@
 
 package com.redhat.rhn.manager.contentmgmt.test;
 
+import static com.redhat.rhn.domain.contentmgmt.ContentFilter.EntityType.ERRATUM;
+import static com.redhat.rhn.domain.contentmgmt.ContentFilter.EntityType.PACKAGE;
+import static com.redhat.rhn.domain.contentmgmt.ContentFilter.Rule.DENY;
+import static com.redhat.rhn.domain.role.RoleFactory.ORG_ADMIN;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singleton;
+import static java.util.Optional.of;
+import static java.util.stream.Collectors.toSet;
+
+import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.ChannelFactory;
@@ -44,15 +54,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
-import static com.redhat.rhn.domain.contentmgmt.ContentFilter.EntityType.ERRATUM;
-import static com.redhat.rhn.domain.contentmgmt.ContentFilter.EntityType.PACKAGE;
-import static com.redhat.rhn.domain.contentmgmt.ContentFilter.Rule.DENY;
-import static com.redhat.rhn.domain.role.RoleFactory.ORG_ADMIN;
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singleton;
-import static java.util.Optional.of;
-import static java.util.stream.Collectors.toSet;
 
 /**
  * Test for the content-management related methods in {@link ChannelManager}

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerChannelAlignmentTest.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerChannelAlignmentTest.java
@@ -13,7 +13,7 @@
  * in this software or its documentation.
  */
 
-package com.redhat.rhn.manager.channel.test;
+package com.redhat.rhn.manager.contentmgmt.test;
 
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.channel.Channel;
@@ -57,7 +57,7 @@ import static java.util.stream.Collectors.toSet;
 /**
  * Test for the content-management related methods in {@link ChannelManager}
  */
-public class ChannelManagerContentAlignmentTest extends BaseTestCaseWithUser {
+public class ContentManagerChannelAlignmentTest extends BaseTestCaseWithUser {
 
     private Channel srcChannel;
     private Channel tgtChannel;
@@ -99,7 +99,7 @@ public class ChannelManagerContentAlignmentTest extends BaseTestCaseWithUser {
     public void testAlignEntities() throws Exception {
         // let's add a package to the target. it should be removed after aligning
         tgtChannel.getPackages().add(PackageTest.createTestPackage(user.getOrg()));
-        ChannelManager.alignEnvironmentTargetSync(emptyList(), srcChannel, tgtChannel, user);
+        ContentManager.alignEnvironmentTargetSync(emptyList(), srcChannel, tgtChannel, user);
 
         // check that newest packages cache has been updated
         assertEquals(
@@ -127,7 +127,7 @@ public class ChannelManagerContentAlignmentTest extends BaseTestCaseWithUser {
         assertEquals(pack2.getId(), ChannelManager.getLatestPackageEqual(tgtChannel.getId(), pack2.getPackageName().getName()));
         assertNull(ChannelManager.getLatestPackageEqual(tgtChannel.getId(), pkg.getPackageName().getName()));
 
-        ChannelManager.alignEnvironmentTargetSync(emptyList(), srcChannel, tgtChannel, user);
+        ContentManager.alignEnvironmentTargetSync(emptyList(), srcChannel, tgtChannel, user);
         assertEquals(pkg.getId(), ChannelManager.getLatestPackageEqual(tgtChannel.getId(), pkg.getPackageName().getName()));
         assertNull(ChannelManager.getLatestPackageEqual(tgtChannel.getId(), pack2.getPackageName().getName()));
     }
@@ -167,7 +167,7 @@ public class ChannelManagerContentAlignmentTest extends BaseTestCaseWithUser {
         FilterCriteria criteria2 = new FilterCriteria(FilterCriteria.Matcher.CONTAINS, "name", pack2.getPackageName().getName());
         ContentFilter filter2 = ContentManager.createFilter("test-filter-12345", DENY, PACKAGE, criteria2, user);
 
-        ChannelManager.alignEnvironmentTargetSync(Arrays.asList(filter, filter2), srcChannel, tgtChannel, user);
+        ContentManager.alignEnvironmentTargetSync(Arrays.asList(filter, filter2), srcChannel, tgtChannel, user);
         List<Long> ids = ChannelManager.latestPackagesInChannel(tgtChannel).stream()
                 .map(p -> (Long) p.get("id"))
                 .collect(Collectors.toList());
@@ -191,7 +191,7 @@ public class ChannelManagerContentAlignmentTest extends BaseTestCaseWithUser {
 
         SystemManager.subscribeServerToChannel(user, server, tgtChannel);
 
-        ChannelManager.alignEnvironmentTargetSync(emptyList(), srcChannel, tgtChannel, user);
+        ContentManager.alignEnvironmentTargetSync(emptyList(), srcChannel, tgtChannel, user);
         assertEquals(errata.getId(), SystemManager.relevantErrata(user, server.getId()).get(0).getId());
     }
 
@@ -213,7 +213,7 @@ public class ChannelManagerContentAlignmentTest extends BaseTestCaseWithUser {
         List<SystemOverview> systemsWithNeededPackage = SystemManager.listSystemsWithNeededPackage(user, pkg.getId());
         assertTrue(systemsWithNeededPackage.isEmpty());
 
-        ChannelManager.alignEnvironmentTargetSync(emptyList(), srcChannel, tgtChannel, user);
+        ContentManager.alignEnvironmentTargetSync(emptyList(), srcChannel, tgtChannel, user);
         systemsWithNeededPackage = SystemManager.listSystemsWithNeededPackage(user, pkg.getId());
         assertEquals(1, systemsWithNeededPackage.size());
         assertEquals(server.getId(), systemsWithNeededPackage.get(0).getId());
@@ -243,7 +243,7 @@ public class ChannelManagerContentAlignmentTest extends BaseTestCaseWithUser {
         assertEquals(1, systemsWithNeededPackage.size());
         assertEquals(server.getId(), systemsWithNeededPackage.get(0).getId());
 
-        ChannelManager.alignEnvironmentTargetSync(emptyList(), srcChannel, tgtChannel, user);
+        ContentManager.alignEnvironmentTargetSync(emptyList(), srcChannel, tgtChannel, user);
         systemsWithNeededPackage = SystemManager.listSystemsWithNeededPackage(user, otherPkg.getId());
         assertTrue(systemsWithNeededPackage.isEmpty());
     }
@@ -259,7 +259,7 @@ public class ChannelManagerContentAlignmentTest extends BaseTestCaseWithUser {
         Errata toRemove = ErrataFactoryTest.createTestPublishedErrata(user.getOrg().getId());;
         tgtChannel.addErrata(toRemove);
 
-        ChannelManager.alignEnvironmentTargetSync(emptyList(), srcChannel, tgtChannel, user);
+        ContentManager.alignEnvironmentTargetSync(emptyList(), srcChannel, tgtChannel, user);
 
         // check that packages and errata have been aligned
         assertEquals(srcChannel.getPackages(), tgtChannel.getPackages());
@@ -274,7 +274,7 @@ public class ChannelManagerContentAlignmentTest extends BaseTestCaseWithUser {
         FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.EQUALS, "advisory_name", errata.getAdvisoryName());
         ContentFilter filter = ContentManager.createFilter("test-filter-123", DENY, ERRATUM, criteria, user);
 
-        ChannelManager.alignEnvironmentTargetSync(singleton(filter), srcChannel, tgtChannel, user);
+        ContentManager.alignEnvironmentTargetSync(singleton(filter), srcChannel, tgtChannel, user);
 
         assertTrue(tgtChannel.getErratas().isEmpty());
     }
@@ -320,7 +320,7 @@ public class ChannelManagerContentAlignmentTest extends BaseTestCaseWithUser {
         FilterCriteria criteria2 = new FilterCriteria(FilterCriteria.Matcher.EQUALS, "advisory_name", e6.getAdvisoryName());
         ContentFilter filter2 = ContentManager.createFilter("test-filter-1235", DENY, ERRATUM, criteria2, user);
 
-        ChannelManager.alignEnvironmentTargetSync(Arrays.asList(filter, filter2), srcChan, tgtChan, user);
+        ContentManager.alignEnvironmentTargetSync(Arrays.asList(filter, filter2), srcChan, tgtChan, user);
 
         assertEquals(2, tgtChan.getErrataCount());
         tgtChan = (Channel) HibernateFactory.reload(tgtChan);
@@ -343,7 +343,7 @@ public class ChannelManagerContentAlignmentTest extends BaseTestCaseWithUser {
         FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.EQUALS, "advisory_name", errata.getAdvisoryName());
         ContentFilter filter = ContentManager.createFilter("test-filter-1234", DENY, ERRATUM, criteria, user);
 
-        ChannelManager.alignEnvironmentTargetSync(singleton(filter), srcChannel, tgtChannel, user);
+        ContentManager.alignEnvironmentTargetSync(singleton(filter), srcChannel, tgtChannel, user);
 
         tgtChannel = (Channel) HibernateFactory.reload(tgtChannel);
 

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerChannelAlignmentTest.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerChannelAlignmentTest.java
@@ -187,8 +187,7 @@ public class ContentManagerChannelAlignmentTest extends BaseTestCaseWithUser {
         // server will have an older package installed -> after the alignment, the rhnServerNeededCache
         // must contain the entry corresponding to the the newer package
         InstalledPackage olderPack = copyPackage(pkg, of("0.9.9"));
-        olderPack.setServer(server);
-        server.getPackages().add(olderPack);
+        setInstalledPackage(server, olderPack);
 
         SystemManager.subscribeServerToChannel(user, server, tgtChannel);
 
@@ -208,8 +207,7 @@ public class ContentManagerChannelAlignmentTest extends BaseTestCaseWithUser {
         srcChannel.getErratas().clear();
 
         InstalledPackage olderPkg = copyPackage(pkg, of("0.9.9"));
-        olderPkg.setServer(server);
-        server.getPackages().add(olderPkg);
+        setInstalledPackage(server, olderPkg);
 
         List<SystemOverview> systemsWithNeededPackage = SystemManager.listSystemsWithNeededPackage(user, pkg.getId());
         assertTrue(systemsWithNeededPackage.isEmpty());
@@ -235,8 +233,7 @@ public class ContentManagerChannelAlignmentTest extends BaseTestCaseWithUser {
         SystemManager.subscribeServerToChannel(user, server, tgtChannel);
 
         InstalledPackage olderPkg = copyPackage(otherPkg, of("0.9.9"));
-        olderPkg.setServer(server);
-        server.getPackages().add(olderPkg);
+        setInstalledPackage(server, olderPkg);
 
         // we fake the cache entry here
         ErrataCacheManager.insertCacheForChannelPackages(tgtChannel.getId(), null, Collections.singletonList(otherPkg.getId()));
@@ -376,5 +373,10 @@ public class ContentManagerChannelAlignmentTest extends BaseTestCaseWithUser {
         olderPkg.setArch(otherPkg.getPackageArch());
         olderPkg.setName(otherPkg.getPackageName());
         return olderPkg;
+    }
+
+    private void setInstalledPackage(Server server, InstalledPackage olderPack) {
+        olderPack.setServer(server);
+        server.getPackages().add(olderPack);
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -1521,6 +1521,9 @@ public class ErrataManager extends BaseManager {
         eList.add(errata.getId());
         //First delete the cache entries
         ErrataCacheManager.deleteCacheEntriesForChannelErrata(chan.getId(), eList);
+        ErrataCacheManager.deleteCacheEntriesForChannelPackages(
+                chan.getId(),
+                errata.getPackages().stream().map(p -> p.getId()).collect(toList()));
 
         // remove packages
         errata.getPackages().stream().forEach(p -> chan.getPackages().remove(p));


### PR DESCRIPTION
## What does this PR change?
 
This PR contains 3 things:
1. Refactoring part - move aligning logic to better location
1. Test part  - more content alignment tests
1. Fixing part - when removing an errata, make sure the cache with available server updates (`rhnServerNeededCache`) is updated correctly (previously, when filtering out an erratum with a package, the cache still contained a row with an information about update of the removed package)
 
 ## GUI diff
 
 No difference.
 
 - [x] **DONE**
 
 ## Documentation
 - No documentation needed: Refactoring/testing/bugfixing

 
 - [x] **DONE**
 
 ## Test coverage
 - Unit tests were added
 
 - [x] **DONE**
 
 ## Links
 
 Tracks https://github.com/SUSE/spacewalk/issues/7653
 
 - [x] **DONE**
 
 ## Changelogs
 
 If you don't need a changelog check, please mark this checkbox:
 
 - [x] No changelog needed
 
 If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
 
 
 ## Re-run a test
 
 If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:
 
 - [ ] Re-run test "changelog_test" 
 - [ ] Re-run test "backend_unittests_pgsql"
 - [ ] Re-run test "java_lint_checkstyle"		 
 - [ ] Re-run test "java_pgsql_tests"		 
 - [ ] Re-run test "ruby_rubocop"
 - [ ] Re-run test "schema_migration_test_oracle"
 - [ ] Re-run test "schema_migration_test_pgsql"		 
 - [ ] Re-run test "susemanager_unittests"
 - [ ] Re-run test "javascript_lint"