### PR TITLE
Allow adding monitoring entitlement to openSUSE Leap 15.x

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
@@ -155,7 +155,7 @@ public class MinionServer extends Server implements SaltConfigurable {
 
     @Override
     public boolean doesOsSupportsMonitoring() {
-        return isSLES12() || isSLES15();
+        return isSLES12() || isSLES15() || isLeap15();
     }
 
     /**
@@ -184,6 +184,10 @@ public class MinionServer extends Server implements SaltConfigurable {
      */
     private boolean isSLES15() {
         return ServerConstants.SLES.equals(getOs()) && getRelease().startsWith("15");
+    }
+
+    private boolean isLeap15() {
+        return ServerConstants.LEAP.equalsIgnoreCase(getOs()) && getRelease().startsWith("15");
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/server/ServerConstants.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerConstants.java
@@ -25,6 +25,7 @@ public class ServerConstants {
      */
     public static final String FEATURE_KICKSTART = "ftr_kickstart";
     public static final String SLES = "SLES";
+    public static final String LEAP = "Leap";
 
     private ServerConstants() {
 

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerTest.java
@@ -148,6 +148,28 @@ public class ServerTest extends BaseTestCaseWithUser {
     /**
      * Test for {@link Server#doesOsSupportsOSImageBuilding()}.
      */
+    public void testOsSupportsMonitoring() throws Exception {
+        Server s = ServerFactoryTest.createTestServer(user, true,
+                ServerConstants.getServerGroupTypeSaltEntitled(),
+                ServerFactoryTest.TYPE_SERVER_MINION);
+        s.setOs("SLES");
+        s.setRelease("12.1");
+        assertTrue(s.doesOsSupportsMonitoring());
+    }
+    /**
+     * Test for {@link Server#doesOsSupportsOSImageBuilding()}.
+     */
+    public void testOsSupportsMonitoringLeap() throws Exception {
+        Server s = ServerFactoryTest.createTestServer(user, true,
+                ServerConstants.getServerGroupTypeSaltEntitled(),
+                ServerFactoryTest.TYPE_SERVER_MINION);
+        s.setOs("Leap");
+        s.setRelease("15.0");
+        assertTrue(s.doesOsSupportsMonitoring());
+    }
+    /**
+     * Test for {@link Server#doesOsSupportsOSImageBuilding()}.
+     */
     public void testOsDoesNotSupportsOSImageBuilding() throws Exception {
         Server s = ServerFactoryTest.createTestServer(user, true,
                 ServerConstants.getServerGroupTypeSaltEntitled(),
@@ -156,7 +178,17 @@ public class ServerTest extends BaseTestCaseWithUser {
         s.setRelease("11.4");
         assertFalse(s.doesOsSupportsContainerization());
     }
-
+    /**
+     * Test for {@link Server#doesOsSupportsOSImageBuilding()}.
+     */
+    public void testOsDoesNotSupportsMonitoring() throws Exception {
+        Server s = ServerFactoryTest.createTestServer(user, true,
+                ServerConstants.getServerGroupTypeSaltEntitled(),
+                ServerFactoryTest.TYPE_SERVER_MINION);
+        s.setOs("Ubuntu");
+        s.setRelease("18.04");
+        assertFalse(s.doesOsSupportsMonitoring());
+    }
     public void testGetIpAddress() throws Exception {
         Server s = ServerTestUtils.createTestSystem(user);
         assertNull(s.getIpAddress());

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Allow adding monitoring entitlement to openSUSE Leap 15.x
 - Add support for Salt Formulas to be used with standalone Salt
 - Fix channel sync status logic in products page (bsc#1131721)
 - Report Monitoring products to subscription-matcher


### PR DESCRIPTION
## What does this PR change?

Allow adding monitoring entitlement to openSUSE Leap 15.x

## GUI diff

No difference.

## Documentation
- No documentation needed

## Test coverage
- No tests

## Links

Fixes #


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
