### PR TITLE
Fix spacewalk-setup.spec syntax and make dirs readable

### DIFF
--- a/spacewalk/setup/spacewalk-setup.spec
+++ b/spacewalk/setup/spacewalk-setup.spec
@@ -199,7 +199,7 @@ mkdir -p $RPM_BUILD_ROOT%{_mandir}/man8
 install -Dd -m 0750 %{buildroot}%{_prefix}/share/salt-formulas
 install -Dd -m 0750 %{buildroot}%{_prefix}/share/salt-formulas/states
 install -Dd -m 0750 %{buildroot}%{_prefix}/share/salt-formulas/metadata
-%
+
 %post
 if [ $1 = 2 -a -e /etc/tomcat6/tomcat6.conf ]; then
     # in case of upgrade

--- a/spacewalk/setup/spacewalk-setup.spec
+++ b/spacewalk/setup/spacewalk-setup.spec
@@ -196,9 +196,9 @@ mkdir -p $RPM_BUILD_ROOT%{_mandir}/man8
 /usr/bin/pod2man --section=1 $RPM_BUILD_ROOT/%{_bindir}/spacewalk-setup-ipa-authentication| gzip > $RPM_BUILD_ROOT%{_mandir}/man1/spacewalk-setup-ipa-authentication.1.gz
 
 # Standalone Salt formulas configuration
-install -Dd -m 0750 %{buildroot}%{_prefix}/share/salt-formulas
-install -Dd -m 0750 %{buildroot}%{_prefix}/share/salt-formulas/states
-install -Dd -m 0750 %{buildroot}%{_prefix}/share/salt-formulas/metadata
+install -Dd -m 0755 %{buildroot}%{_prefix}/share/salt-formulas
+install -Dd -m 0755 %{buildroot}%{_prefix}/share/salt-formulas/states
+install -Dd -m 0755 %{buildroot}%{_prefix}/share/salt-formulas/metadata
 
 %post
 if [ $1 = 2 -a -e /etc/tomcat6/tomcat6.conf ]; then
@@ -297,9 +297,9 @@ pylint --rcfile /etc/spacewalk-python3-pylint.rc \
 %{_bindir}/spacewalk-setup-db-ssl-certificates
 %{_bindir}/cobbler20-setup
 %{_mandir}/man[13]/*.[13]*
-%dir %attr(0750, root, root) %{_prefix}/share/salt-formulas/
-%dir %attr(0750, root, root) %{_prefix}/share/salt-formulas/states/
-%dir %attr(0750, root, root) %{_prefix}/share/salt-formulas/metadata/
+%dir %attr(0755, root, root) %{_prefix}/share/salt-formulas/
+%dir %attr(0755, root, root) %{_prefix}/share/salt-formulas/states/
+%dir %attr(0755, root, root) %{_prefix}/share/salt-formulas/metadata/
 %dir %{_datadir}/spacewalk
 %{_datadir}/spacewalk/*
 %attr(755, %{apache_user}, root) %{misc_path}/spacewalk


### PR DESCRIPTION
## What does this PR change?

This patch fixes a syntax error in `spacewalk-setup.spec` and make the Formula directories readable for everyone.

## GUI diff

No difference.

## Documentation

- No documentation needed.

## Test coverage

- No tests needed: only spec file was changed.

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
