### PR TITLE
Explicitly mention in API docs that to preserve LF/CR, user needs to encode the data

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/configchannel/ConfigChannelHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/configchannel/ConfigChannelHandler.java
@@ -449,8 +449,8 @@ public class ConfigChannelHandler extends BaseHandler {
      * @xmlrpc.param
      *  #struct("path info")
      *      #prop_desc("string","contents",
-     *              "Contents of the file (text or base64 encoded if binary).
-     *                   (only for non-directories)")
+     *              "Contents of the file (text or base64 encoded if binary or want to preserve
+     *                         control characters like LF, CR etc.)(only for non-directories)")
      *      #prop_desc("boolean","contents_enc64", "Identifies base64 encoded content
      *                   (default: disabled, only for non-directories)")
      *      #prop_desc("string", "owner", "Owner of the file/directory.")

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Explicitly mention in API docs that to preserve LF/CR, user needs to encode the data(bsc#1135442)
 - Switch menu links and adjust title icons
 - Add XML-RPC API calls to manage server monitoring
 - Allow adding monitoring entitlement to openSUSE Leap 15.x


### PR DESCRIPTION
## What does this PR change?
Update the API documentation to explicitly mention that to preserve control characters liks LF/CR, the user needs to encode the data

**add description**

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: ** API doc which is generated automatically from this**


- [x] **DONE**

## Test coverage
- No tests: **only documentation is updated**

- [x] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/7870
Tracks # 
3.2 https://github.com/SUSE/spacewalk/pull/7938**
4.0  https://github.com/SUSE/spacewalk/pull/7939

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
