### PR TITLE
Fix: bug in spacecmd with _listrepos

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- Fix: bug in spacecmd with _listrepos
 - Bugfix: 'dict' object has no attribute 'iteritems' (bsc#1135881)
 - Add unit tests for custominfo, snippet, scap, ssm, cryptokey and distribution
 

--- a/spacecmd/src/spacecmd/softwarechannel.py
+++ b/spacecmd/src/spacecmd/softwarechannel.py
@@ -2776,8 +2776,8 @@ def do_softwarechannel_listrepos(self, args):
         details = self.client.channel.software.getDetails(self.session, args[0])
         repos = [r.get('label') for r in details.get('contentSources')]
 
-    if repos:
-        print('\n'.join(sorted(repos)))
+        if repos:
+            print('\n'.join(sorted(repos)))
     else:
         self.help_softwarechannel_listrepos()
 


### PR DESCRIPTION
## What does this PR change?

Before:

```
spacecmd {SSM:0}> softwarechannel_listrepos
ERROR: local variable 'repos' referenced before assignment

spacecmd {SSM:0}> softwarechannel_listrepos fedora-x86_64-channel
softwarechannel_listrepos: List the repos for a software channel
usage: softwarechannel_listrepos CHANNEL
```

After:

```
spacecmd {SSM:0}> softwarechannel_listrepos
softwarechannel_listrepos: List the repos for a software channel
usage: softwarechannel_listrepos CHANNEL

spacecmd {SSM:0}> softwarechannel_listrepos fedora-x86_64-channel
spacecmd {SSM:0}>
```

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: internal

- [X] **DONE**

## Test coverage
- No tests: there were none

- [X] **DONE**

## Links

- Manager-4.0 PR: TBD
- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
