### PR TITLE
Allow virtualization tab for foreign systems (bsc#1116869)

### DIFF
--- a/java/code/src/com/redhat/rhn/common/security/acl/Access.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/Access.java
@@ -247,6 +247,27 @@ public class Access extends BaseHandler {
     }
 
     /**
+     * Check if any system has a Foreign entitlement.
+     * @param ctx Context map to pass in.
+     * @param params Parameters to use to fetch from context.
+     * @return True if system has foreign entitlement, false otherwise.
+     */
+    public boolean aclSystemHasForeignEntitlement(Object ctx, String[] params) {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> map = (Map<String, Object>) ctx;
+        Long sid = getAsLong(map.get("sid"));
+        boolean ret = false;
+        if (sid != null) {
+            User user = (User) map.get("user");
+            Server server = SystemManager.lookupByIdAndUser(sid, user);
+            if (server != null) {
+                ret = server.hasEntitlement(EntitlementManager.FOREIGN);
+            }
+        }
+        return ret;
+    }
+
+    /**
      * Check if a system is a {@link com.redhat.rhn.domain.server.MinionServer} which has a bootstrap entitlement
      * @param ctx Context map to pass in.
      * @param params Parameters to use to fetch from context.

--- a/java/code/src/com/suse/manager/webui/controllers/VirtualGuestsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/VirtualGuestsController.java
@@ -156,6 +156,7 @@ public class VirtualGuestsController {
 
         /* For the rest of the template */
         data.put("salt_entitled", server.hasEntitlement(EntitlementManager.SALT));
+        data.put("foreign_entitled", server.hasEntitlement(EntitlementManager.FOREIGN));
         data.put("is_admin", user.hasRole(RoleFactory.ORG_ADMIN));
 
         return new ModelAndView(data, "templates/virtualization/guests/show.jade");
@@ -596,6 +597,10 @@ public class VirtualGuestsController {
                                              ActionType actionType,
                                              User user,
                                              Map<String, String> context) {
+        if (host.hasEntitlement(EntitlementManager.FOREIGN)) {
+            LOG.warn("Foreign systems don't support virtual guest actions");
+            return null;
+        }
         // Traditionally registered systems aren't able to really delete the VM: fail
         // the delete action for them
         if (host.hasEntitlement(EntitlementManager.MANAGEMENT) &&

--- a/java/code/src/com/suse/manager/webui/templates/virtualization/guests/show.jade
+++ b/java/code/src/com/suse/manager/webui/templates/virtualization/guests/show.jade
@@ -13,6 +13,7 @@ script(type='text/javascript').
         {
             serverId: "#{server.id}",
             saltEntitled: #{salt_entitled},
+            foreignEntitled: #{foreign_entitled},
             isAdmin: #{is_admin}
         }
     );

--- a/java/code/webapp/WEB-INF/nav/system_detail.xml
+++ b/java/code/webapp/WEB-INF/nav/system_detail.xml
@@ -185,7 +185,7 @@
     <rhn-tab name="Join" url="/rhn/systems/details/groups/Add.do"/>
   </rhn-tab>
 
-  <rhn-tab name="Virtualization" acl="system_has_virtualization_entitlement()">
+  <rhn-tab name="Virtualization" acl="system_has_virtualization_entitlement() or system_has_foreign_entitlement()">
     <rhn-tab-url>/rhn/manager/systems/details/virtualization/guests/${sid}</rhn-tab-url>
     <rhn-tab name="Guests" url="/rhn/manager/systems/details/virtualization/guests/${sid}"/>
     <rhn-tab name="Provisioning" url="/rhn/systems/details/virtualization/ProvisionVirtualizationWizard.do" acl="system_feature(ftr_kickstart) or system_feature(ftr_snapshotting)"/>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Allow virtualization tab for foreign systems (bsc#1116869)
 - Keep querystring on ListTag parent_url for actions that have the cid param (bsc#1134677)
 - Allow forcing off or resetting VMs
 - Fix profiles package scheduling when epoch is null (bsc#1137144)

--- a/web/html/src/manager/virtualization/guests/list/guests-list.js
+++ b/web/html/src/manager/virtualization/guests/list/guests-list.js
@@ -25,6 +25,7 @@ type Props = {
   serverId: string,
   refreshInterval: number,
   saltEntitled: boolean,
+  foreignEntitled: boolean,
   isAdmin: boolean,
 };
 
@@ -226,6 +227,7 @@ class GuestsList extends React.Component<Props, State> {
                 type: 'delete', name: t('Delete'), icon: 'fa-trash', bulkonly: false,
               },
             ];
+            const isActionVisible = (action, props) => !props.foreignEntitled && (action.type !== 'delete' || props.saltEntitled);
             const panelButtons = (
               <div className="pull-right btn-group">
                 {this.props.saltEntitled
@@ -239,7 +241,7 @@ class GuestsList extends React.Component<Props, State> {
                   />)
                 }
                 {modalsData
-                  .filter(action => action.type !== 'delete' || this.props.saltEntitled)
+                  .filter(action => isActionVisible(action, this.props))
                   .map(action => this.createSelectedModalButton(action))}
               </div>);
 
@@ -362,8 +364,9 @@ class GuestsList extends React.Component<Props, State> {
                             }
                             return '-';
                           }}
-                        />)}
-                        <Column
+                            />)}
+                        {!this.props.foreignEntitled &&
+                         (<Column
                           header={t('Actions')}
                           columnClass="text-right"
                           headerClass="text-right"
@@ -404,11 +407,12 @@ class GuestsList extends React.Component<Props, State> {
                               </div>
                             );
                           }}
-                        />
+                          />)
+                        }
                       </Table>
 
                       {modalsData
-                        .filter(action => action.type !== 'delete' || this.props.saltEntitled)
+                        .filter(action => isActionVisible(action, this.props))
                         .map(action => this.createConfirmModal(action, onAction).map(modal => modal))}
                     </div>
                   )

--- a/web/html/src/manager/virtualization/guests/list/guests-list.renderer.js
+++ b/web/html/src/manager/virtualization/guests/list/guests-list.renderer.js
@@ -5,12 +5,13 @@ const { GuestsList } = require('./guests-list');
 window.pageRenderers = window.pageRenderers || {};
 window.pageRenderers.guests = window.pageRenderers.guests || {};
 window.pageRenderers.guests.list = window.pageRenderers.guests.list || {};
-window.pageRenderers.guests.list.renderer = (id, { serverId, saltEntitled, isAdmin }) => {
+window.pageRenderers.guests.list.renderer = (id, { serverId, saltEntitled, foreignEntitled, isAdmin }) => {
   ReactDOM.render(
     <GuestsList
       refreshInterval={5 * 1000}
       serverId={serverId}
       saltEntitled={saltEntitled}
+      foreignEntitled={foreignEntitled}
       isAdmin={isAdmin}
     />,
     document.getElementById(id),

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Allow virtualization tab for foreign systems (bsc#1116869)
 - Add checks for empty required entries on formula forms (bsc#1109639)
 - Fix big formula checkbox not supported in Firefox
 - Allow forcing off or resetting VMs


### PR DESCRIPTION
Fix the virtualization tab for `foreign` systems.

When in Systems -> Virtual systems, after clicking the "Show all" link for
virtualization host, user is forwarded to the "System detail -> Virtualizationa
-> Guests" page. This page loads fine, but it's not enabled in the tree
navigation of spacewalk, which means the tab "headers" (Virtualization ->
Guests) are missing for `foreign` systems). This PR fixes that.

Moreover, actions for virtual guests are forbidden in case the host system is
`foreign`. The PR forbids them in the UI as well.

## TODO
- [ ] Port to 4.0 after merging this.

## Screenshots
No difference.

Before:
![ss-pr1](https://user-images.githubusercontent.com/1412268/58535677-d3601600-81ee-11e9-985a-7dc3f8e9a49e.png)
After:
![ss-pr2](https://user-images.githubusercontent.com/1412268/58535678-d3601600-81ee-11e9-9974-cb503d8d774f.png)

- [x] **DONE**

## Docs
- No documentation needed: bugfix

- [x] **DONE**

## Tests
- No tests

- [x] **DONE**

## Refs
Tracks https://github.com/SUSE/spacewalk/issues/6425

- [x] **DONE**

