### PR TITLE
python3-pytest is common for koan and cobbler containers, move it to root

### DIFF
--- a/susemanager-utils/testing/docker/master/uyuni-master-pgsql/Dockerfile
+++ b/susemanager-utils/testing/docker/master/uyuni-master-pgsql/Dockerfile
@@ -21,5 +21,3 @@ ADD postgresql.conf /var/lib/pgsql/data/postgresql.conf
 RUN zypper in -y python3-pip python3-solv python3-salt
 
 RUN pip3 install --upgrade pylint==1.8 astroid==1.6.5
-
-RUN zypper in -y python3-pytest

--- a/susemanager-utils/testing/docker/master/uyuni-master-root/add_packages.sh
+++ b/susemanager-utils/testing/docker/master/uyuni-master-root/add_packages.sh
@@ -10,7 +10,8 @@ zypper in -y  make \
               python3-devel \
               python3-mock \
 	      python3-nose \
-              python3-pylint
+              python3-pylint \
+              python3-pytest
 
 # python3-urlgabber is not part of neither SLE or openSUSE 15.X
 curl https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/openSUSE_Leap_15.0/noarch/python3-urlgrabber.rpm -o /tmp/python3-urlgrabber.rpm && \


### PR DESCRIPTION
## Maintenance Update status

Check http://ramrod.mgr.suse.de/pub/mu-badges/ and if any of the versions has an active Maintenance Update, please consider if this PR should be ported to the Maintenance Update branch.

## What does this PR change?

python3-pytest is common for koan and cobbler containers, move it to root

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Tests

- [x] **DONE**

## Test coverage
- No tests: Tests

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
