### PR TITLE
decide rhel product based on availability of RES (bsc#1136301)

### DIFF
--- a/java/code/src/com/suse/manager/reactor/utils/RhelUtils.java
+++ b/java/code/src/com/suse/manager/reactor/utils/RhelUtils.java
@@ -202,6 +202,7 @@ public class RhelUtils {
 
             Optional<SUSEProduct> suseProduct = Optional.ofNullable(SUSEProductFactory
                     .findSUSEProduct("RES", majorVersion, release, arch, true));
+
             return Optional.of(new RhelProduct(suseProduct, name,
                     majorVersion, release, arch));
         }
@@ -283,7 +284,11 @@ public class RhelUtils {
         String majorVersion = releaseFile.map(ReleaseFile::getMajorVersion)
                 .orElse("unknown");
         String release = releaseFile.map(ReleaseFile::getRelease).orElse("unknown");
-        return new RhelProduct(Optional.empty(), name, majorVersion, release, arch);
+        Optional<SUSEProduct> suseProduct = defaultName.equals("RedHatEnterprise") ?
+                Optional.ofNullable(SUSEProductFactory
+                        .findSUSEProduct("rhel-base", majorVersion, release, arch, true)) :
+                Optional.empty();
+        return new RhelProduct(suseProduct, name, majorVersion, release, arch);
     }
 
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Enable product detection for plain rhel systems (bsc#1136301)
 - For orphan contentsources, look also in susesccrepositoryauth to make sure they are not being referenced (bsc#1138275)
 - Fallback to logged-in-user org and then vendor errata when looking up erratum on cloning (bsc#1137308)
 - Add new validation to avoid creating content lifecycle projects starting with a number (bsc#1139493)

--- a/susemanager-sync-data/additional_products.json
+++ b/susemanager-sync-data/additional_products.json
@@ -1,5 +1,196 @@
 [
     {
+        "id" : 1232,
+        "name" : "Novell Open Enterprise Server 2 11",
+        "identifier" : "Open_Enterprise_Server",
+        "former_identifier" : "",
+        "version" : "11",
+        "release_type" : null,
+        "arch" : null,
+        "friendly_name" : "Novell Open Enterprise Server 2 11",
+        "product_class" : "OES2",
+        "cpe" : null,
+        "free" : false,
+        "description" : null,
+        "release_stage" : "released",
+        "eula_url" : "",
+        "product_type" : "extension",
+        "offline_predecessor_ids" : [
+        ],
+        "online_predecessor_ids" : [
+        ],
+        "shortname" : null,
+        "recommended" : false,
+        "extensions" : [
+        ],
+        "repositories" : [
+            {
+                "id" : -1,
+                "url" : "https://nu.novell.com/repo/$RCE/OES11-Pool/sle-11-x86_64/",
+                "name" : "OES11-Pool",
+                "distro_target" : "sle-11-x86_64",
+                "description" : "Novell Open Enterprise Server 11",
+                "enabled" : true,
+                "autorefresh" : false,
+                "installer_updates" : false
+            },
+            {
+                "id" : -2,
+                "url" : "https://nu.novell.com/repo/$RCE/OES11-Updates/sle-11-x86_64/",
+                "name" : "OES11-Updates",
+                "distro_target" : "sle-11-x86_64",
+                "description" : "Novell Open Enterprise Server 11",
+                "enabled" : true,
+                "autorefresh" : true,
+                "installer_updates" : false
+            }
+        ]
+    },
+    {
+        "id" : 1241,
+        "name" : "Novell Open Enterprise Server 2 11.1",
+        "identifier" : "Open_Enterprise_Server",
+        "former_identifier" : "",
+        "version" : "11.1",
+        "release_type" : null,
+        "arch" : null,
+        "friendly_name" : "Novell Open Enterprise Server 2 11.1",
+        "product_class" : "OES2",
+        "cpe" : null,
+        "free" : false,
+        "description" : null,
+        "release_stage" : "released",
+        "eula_url" : "",
+        "product_type" : "extension",
+        "offline_predecessor_ids" : [
+        ],
+        "online_predecessor_ids" : [
+            1232
+        ],
+        "shortname" : null,
+        "recommended" : false,
+        "extensions" : [
+        ],
+        "repositories" : [
+            {
+                "id" : -3,
+                "url" : "https://nu.novell.com/repo/$RCE/OES11-SP1-Pool/sle-11-x86_64/",
+                "name" : "OES11-SP1-Pool",
+                "distro_target" : "sle-11-x86_64",
+                "description" : "Novell Open Enterprise Server 11.1",
+                "enabled" : true,
+                "autorefresh" : false,
+                "installer_updates" : false
+            },
+            {
+                "id" : -4,
+                "url" : "https://nu.novell.com/repo/$RCE/OES11-SP1-Updates/sle-11-x86_64/",
+                "name" : "OES11-SP1-Updates",
+                "distro_target" : "sle-11-x86_64",
+                "description" : "Novell Open Enterprise Server 11.1",
+                "enabled" : true,
+                "autorefresh" : true,
+                "installer_updates" : false
+            }
+        ]
+    },
+    {
+        "id" : 1242,
+        "name" : "Novell Open Enterprise Server 2 11.2",
+        "identifier" : "Open_Enterprise_Server",
+        "former_identifier" : "",
+        "version" : "11.2",
+        "release_type" : null,
+        "arch" : "x86_64",
+        "friendly_name" : "Novell Open Enterprise Server 2 11.2",
+        "product_class" : "OES2",
+        "cpe" : null,
+        "free" : false,
+        "description" : null,
+        "release_stage" : "released",
+        "eula_url" : "",
+        "product_type" : "extension",
+        "offline_predecessor_ids" : [
+        ],
+        "online_predecessor_ids" : [
+            1241
+        ],
+        "shortname" : null,
+        "recommended" : false,
+        "extensions" : [
+        ],
+        "repositories" : [
+            {
+                "id" : -5,
+                "url" : "https://nu.novell.com/repo/$RCE/OES11-SP2-Pool/sle-11-x86_64/",
+                "name" : "OES11-SP2-Pool",
+                "distro_target" : "sle-11-x86_64",
+                "description" : "Novell Open Enterprise Server 11.2",
+                "enabled" : true,
+                "autorefresh" : false,
+                "installer_updates" : false
+            },
+            {
+                "id" : -6,
+                "url" : "https://nu.novell.com/repo/$RCE/OES11-SP2-Updates/sle-11-x86_64/",
+                "name" : "OES11-SP2-Updates",
+                "distro_target" : "sle-11-x86_64",
+                "description" : "Novell Open Enterprise Server 11.2",
+                "enabled" : true,
+                "autorefresh" : true,
+                "installer_updates" : false
+            }
+        ]
+    },
+    {
+        "id" : 44,
+        "name" : "Open Enterprise Server 11 SP3",
+        "identifier" : "Open_Enterprise_Server",
+        "former_identifier" : "",
+        "version" : "11.3",
+        "release_type" : null,
+        "arch" : "x86_64",
+        "friendly_name" : "Open Enterprise Server 11 SP3",
+        "product_class" : "OES2",
+        "cpe" : null,
+        "free" : false,
+        "description" : null,
+        "release_stage" : "released",
+        "eula_url" : "",
+        "product_type" : "extension",
+        "offline_predecessor_ids" : [
+        ],
+        "online_predecessor_ids" : [
+            1242
+        ],
+        "shortname" : null,
+        "recommended" : false,
+        "extensions" : [
+        ],
+        "repositories" : [
+            {
+                "id" : -7,
+                "url" : "https://nu.novell.com/repo/$RCE/OES11-SP3-Pool/sle-11-x86_64/",
+                "name" : "OES11-SP3-Pool",
+                "distro_target" : "sle-11-x86_64",
+                "description" : "Open Enterprise Server 11 SP3",
+                "enabled" : true,
+                "autorefresh" : false,
+                "installer_updates" : false
+            },
+            {
+                "id" : -8,
+                "url" : "https://nu.novell.com/repo/$RCE/OES11-SP3-Updates/sle-11-x86_64/",
+                "name" : "OES11-SP3-Updates",
+                "distro_target" : "sle-11-x86_64",
+                "description" : "Open Enterprise Server 11 SP3",
+                "enabled" : true,
+                "autorefresh" : true,
+                "installer_updates" : false
+            }
+        ]
+    },
+    {
         "id" : 42,
         "name" : "Open Enterprise Server 2015",
         "identifier" : "Open_Enterprise_Server",
@@ -88,54 +279,6 @@
                 "name" : "OES2015-SP1-Updates",
                 "distro_target" : "sle-11-x86_64",
                 "description" : "Open Enterprise Server 2015 SP1",
-                "enabled" : true,
-                "autorefresh" : true,
-                "installer_updates" : false
-            }
-        ]
-    },
-    {
-        "id" : 44,
-        "name" : "Open Enterprise Server 11 SP3",
-        "identifier" : "Open_Enterprise_Server",
-        "former_identifier" : "",
-        "version" : "11.3",
-        "release_type" : null,
-        "arch" : "x86_64",
-        "friendly_name" : "Open Enterprise Server 11 SP3",
-        "product_class" : "OES2",
-        "cpe" : null,
-        "free" : false,
-        "description" : null,
-        "release_stage" : "released",
-        "eula_url" : "",
-        "product_type" : "extension",
-        "offline_predecessor_ids" : [
-        ],
-        "online_predecessor_ids" : [
-            1242
-        ],
-        "shortname" : null,
-        "recommended" : false,
-        "extensions" : [
-        ],
-        "repositories" : [
-            {
-                "id" : -7,
-                "url" : "https://nu.novell.com/repo/$RCE/OES11-SP3-Pool/sle-11-x86_64/",
-                "name" : "OES11-SP3-Pool",
-                "distro_target" : "sle-11-x86_64",
-                "description" : "Open Enterprise Server 11 SP3",
-                "enabled" : true,
-                "autorefresh" : false,
-                "installer_updates" : false
-            },
-            {
-                "id" : -8,
-                "url" : "https://nu.novell.com/repo/$RCE/OES11-SP3-Updates/sle-11-x86_64/",
-                "name" : "OES11-SP3-Updates",
-                "distro_target" : "sle-11-x86_64",
-                "description" : "Open Enterprise Server 11 SP3",
                 "enabled" : true,
                 "autorefresh" : true,
                 "installer_updates" : false
@@ -698,149 +841,6 @@
         ]
     },
     {
-        "id" : 1232,
-        "name" : "Novell Open Enterprise Server 2 11",
-        "identifier" : "Open_Enterprise_Server",
-        "former_identifier" : "",
-        "version" : "11",
-        "release_type" : null,
-        "arch" : null,
-        "friendly_name" : "Novell Open Enterprise Server 2 11",
-        "product_class" : "OES2",
-        "cpe" : null,
-        "free" : false,
-        "description" : null,
-        "release_stage" : "released",
-        "eula_url" : "",
-        "product_type" : "extension",
-        "offline_predecessor_ids" : [
-        ],
-        "online_predecessor_ids" : [
-        ],
-        "shortname" : null,
-        "recommended" : false,
-        "extensions" : [
-        ],
-        "repositories" : [
-            {
-                "id" : -1,
-                "url" : "https://nu.novell.com/repo/$RCE/OES11-Pool/sle-11-x86_64/",
-                "name" : "OES11-Pool",
-                "distro_target" : "sle-11-x86_64",
-                "description" : "Novell Open Enterprise Server 11",
-                "enabled" : true,
-                "autorefresh" : false,
-                "installer_updates" : false
-            },
-            {
-                "id" : -2,
-                "url" : "https://nu.novell.com/repo/$RCE/OES11-Updates/sle-11-x86_64/",
-                "name" : "OES11-Updates",
-                "distro_target" : "sle-11-x86_64",
-                "description" : "Novell Open Enterprise Server 11",
-                "enabled" : true,
-                "autorefresh" : true,
-                "installer_updates" : false
-            }
-        ]
-    },
-    {
-        "id" : 1241,
-        "name" : "Novell Open Enterprise Server 2 11.1",
-        "identifier" : "Open_Enterprise_Server",
-        "former_identifier" : "",
-        "version" : "11.1",
-        "release_type" : null,
-        "arch" : null,
-        "friendly_name" : "Novell Open Enterprise Server 2 11.1",
-        "product_class" : "OES2",
-        "cpe" : null,
-        "free" : false,
-        "description" : null,
-        "release_stage" : "released",
-        "eula_url" : "",
-        "product_type" : "extension",
-        "offline_predecessor_ids" : [
-        ],
-        "online_predecessor_ids" : [
-            1232
-        ],
-        "shortname" : null,
-        "recommended" : false,
-        "extensions" : [
-        ],
-        "repositories" : [
-            {
-                "id" : -3,
-                "url" : "https://nu.novell.com/repo/$RCE/OES11-SP1-Pool/sle-11-x86_64/",
-                "name" : "OES11-SP1-Pool",
-                "distro_target" : "sle-11-x86_64",
-                "description" : "Novell Open Enterprise Server 11.1",
-                "enabled" : true,
-                "autorefresh" : false,
-                "installer_updates" : false
-            },
-            {
-                "id" : -4,
-                "url" : "https://nu.novell.com/repo/$RCE/OES11-SP1-Updates/sle-11-x86_64/",
-                "name" : "OES11-SP1-Updates",
-                "distro_target" : "sle-11-x86_64",
-                "description" : "Novell Open Enterprise Server 11.1",
-                "enabled" : true,
-                "autorefresh" : true,
-                "installer_updates" : false
-            }
-        ]
-    },
-    {
-        "id" : 1242,
-        "name" : "Novell Open Enterprise Server 2 11.2",
-        "identifier" : "Open_Enterprise_Server",
-        "former_identifier" : "",
-        "version" : "11.2",
-        "release_type" : null,
-        "arch" : "x86_64",
-        "friendly_name" : "Novell Open Enterprise Server 2 11.2",
-        "product_class" : "OES2",
-        "cpe" : null,
-        "free" : false,
-        "description" : null,
-        "release_stage" : "released",
-        "eula_url" : "",
-        "product_type" : "extension",
-        "offline_predecessor_ids" : [
-        ],
-        "online_predecessor_ids" : [
-            1241
-        ],
-        "shortname" : null,
-        "recommended" : false,
-        "extensions" : [
-        ],
-        "repositories" : [
-            {
-                "id" : -5,
-                "url" : "https://nu.novell.com/repo/$RCE/OES11-SP2-Pool/sle-11-x86_64/",
-                "name" : "OES11-SP2-Pool",
-                "distro_target" : "sle-11-x86_64",
-                "description" : "Novell Open Enterprise Server 11.2",
-                "enabled" : true,
-                "autorefresh" : false,
-                "installer_updates" : false
-            },
-            {
-                "id" : -6,
-                "url" : "https://nu.novell.com/repo/$RCE/OES11-SP2-Updates/sle-11-x86_64/",
-                "name" : "OES11-SP2-Updates",
-                "distro_target" : "sle-11-x86_64",
-                "description" : "Novell Open Enterprise Server 11.2",
-                "enabled" : true,
-                "autorefresh" : true,
-                "installer_updates" : false
-            }
-        ]
-    },
-    {
         "id" : -1,
         "name" : "Ubuntu 18.04",
         "identifier" : "Ubuntu-Client",
@@ -917,7 +917,7 @@
     {
         "id" : -3,
         "name" : "RHEL5 Base",
-        "identifier" : "rhel5-base",
+        "identifier" : "rhel-base",
         "former_identifier" : "",
         "version" : "5",
         "release_type" : null,
@@ -954,7 +954,7 @@
     {
         "id" : -4,
         "name" : "RHEL5 Base",
-        "identifier" : "rhel5-base",
+        "identifier" : "rhel-base",
         "former_identifier" : "",
         "version" : "5",
         "release_type" : null,
@@ -991,7 +991,7 @@
     {
         "id" : -5,
         "name" : "RHEL6 Base",
-        "identifier" : "rhel6-base",
+        "identifier" : "rhel-base",
         "former_identifier" : "",
         "version" : "6",
         "release_type" : null,
@@ -1028,7 +1028,7 @@
     {
         "id" : -6,
         "name" : "RHEL6 Base",
-        "identifier" : "rhel6-base",
+        "identifier" : "rhel-base",
         "former_identifier" : "",
         "version" : "6",
         "release_type" : null,
@@ -1065,7 +1065,7 @@
     {
         "id" : -7,
         "name" : "RHEL7 Base",
-        "identifier" : "rhel7-base",
+        "identifier" : "rhel-base",
         "former_identifier" : "",
         "version" : "7",
         "release_type" : null,

--- a/susemanager-sync-data/susemanager-sync-data.changes
+++ b/susemanager-sync-data/susemanager-sync-data.changes
@@ -1,3 +1,4 @@
+- Enable product detection for plain rhel systems (bsc#1136301)
 - add channel family definitions for SLES12 SP3 LTSS (bsc#1139693)
 - add OPENSUSE to allowed channel_families to make
   openSUSE Leap product visible in the product list (bsc#1138364)


### PR DESCRIPTION
## What does this PR change?

In case we detect a rhel/centos system without res product we assign the rhel-base product which gives access to susemanager tools channels without a res subscription. Detection of res subscription was in the end not needed since its implied by (not) having the res product package installed on a system.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #
Tracks # https://github.com/SUSE/spacewalk/pull/7943

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
