### PR TITLE
KVM tests: grep for login\: to detect a VM has started

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -822,7 +822,7 @@ When(/^I wait until virtual machine "([^"]*)" on "([^"]*)" is started$/) do |vm,
   begin
     Timeout.timeout(DEFAULT_TIMEOUT) do
       loop do
-        _output, code = node.run("grep -i 'started openssh' /tmp/#{vm}.console.log", fatal = false)
+        _output, code = node.run("grep -i 'linux\:' /tmp/#{vm}.console.log", fatal = false)
         break if code.zero?
         sleep 1
       end


### PR DESCRIPTION
## What does this PR change?

grepping for 'started openssh' is not reliable enough since some of the
images don't show it. Grep for the 'login:' invite instead.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: testsuite internal change

- [X] **DONE**

## Test coverage
- No tests: testsuite internal change

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
