### PR TITLE
Small menu and icon fixes

### DIFF
--- a/java/code/src/com/suse/manager/webui/menu/MenuTree.java
+++ b/java/code/src/com/suse/manager/webui/menu/MenuTree.java
@@ -188,12 +188,12 @@ public class MenuTree {
 
             // Patches
             nodes.add(new MenuItem("Patches").withIcon("spacewalk-icon-patches")
-                .addChild(new MenuItem("Patch List").withPrimaryUrl("/rhn/errata/RelevantErrata.do").withDir("/rhn/errata")
+                .addChild(new MenuItem("Patch List").withDir("/rhn/errata")
+                    .addChild(new MenuItem("All").withPrimaryUrl("/rhn/errata/AllErrata.do").withAltUrl("/rhn/errata/AllBugErrata.do")
+                        .withAltUrl("/rhn/errata/AllEnhancementErrata.do").withAltUrl("/rhn/errata/AllSecurityErrata.do"))
                     .addChild(new MenuItem("Relevant").withPrimaryUrl("/rhn/errata/RelevantErrata.do")
                         .withAltUrl("/rhn/errata/RelevantBugErrata.do").withAltUrl("/rhn/errata/RelevantEnhancementErrata.do")
-                        .withAltUrl("/rhn/errata/RelevantSecurityErrata.do"))
-                    .addChild(new MenuItem("All").withPrimaryUrl("/rhn/errata/AllErrata.do").withAltUrl("/rhn/errata/AllBugErrata.do")
-                        .withAltUrl("/rhn/errata/AllEnhancementErrata.do").withAltUrl("/rhn/errata/AllSecurityErrata.do")))
+                        .withAltUrl("/rhn/errata/RelevantSecurityErrata.do")))
                 .addChild(new MenuItem("Advanced Search").withPrimaryUrl("/rhn/errata/Search.do"))
                 .addChild(
                     new MenuItem("Manage Errata").withVisibility(checkAcl(user, "user_role(channel_admin)")).withDir("/rhn/errata/manage")

--- a/java/code/webapp/WEB-INF/pages/errata/erratasearch.jsp
+++ b/java/code/webapp/WEB-INF/pages/errata/erratasearch.jsp
@@ -25,7 +25,7 @@
     </head>
 
 <body>
-<rhn:toolbar base="h1" icon="header-search"
+<rhn:toolbar base="h1" icon="header-errata"
                helpUrl="/docs/reference/patches/patches-advanced-search.html">
     <bean:message key="erratasearch.jsp.toolbar"/>
   </rhn:toolbar>

--- a/java/code/webapp/WEB-INF/pages/systems/systemsearch.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/systemsearch.jsp
@@ -6,7 +6,7 @@
 
 <html:html >
     <body>
-        <rhn:toolbar base="h1" icon="header-search"
+        <rhn:toolbar base="h1" icon="header-system"
                      helpUrl="/docs/reference/systems/advanced-search.html"
                      imgAlt="search.alt.img">
             <bean:message key="systemsearch.jsp.toolbar"/>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Switch menu links and adjust title icons
 - Add XML-RPC API calls to manage server monitoring
 - Allow adding monitoring entitlement to openSUSE Leap 15.x
 - Add support for Salt Formulas to be used with standalone Salt

--- a/testsuite/features/srv_menu.feature
+++ b/testsuite/features/srv_menu.feature
@@ -8,7 +8,8 @@ Feature: Web UI - Main landing page menu, texts and links
 
   Scenario: The menu direct link accesses the first submenu level only
     When I follow the left menu "Patches > Patch List"
-    Then I should see a "Patches Relevant to Your Systems" text in the content area
+    Then I should see a "All Types" text in the content area
+    Then I should not see a "Patches Relevant to Your Systems" text in the content area
     When I follow the left menu "Configuration > Files"
     Then I should see a "Centrally-Managed Configuration Files" text in the content area
     And I should not see a "Locally Managed Configuration Files" text in the content area

--- a/web/html/src/manager/images/image-build.js
+++ b/web/html/src/manager/images/image-build.js
@@ -250,7 +250,7 @@ class BuildImage extends React.Component {
 
   render() {
     return (
-      <TopPanel title={t("Build Image")} icon="fa fa-cogs" helpUrl="/docs/reference/images/images-build.html">
+      <TopPanel title={t("Build Image")} icon="fa spacewalk-icon-manage-configuration-files" helpUrl="/docs/reference/images/images-build.html">
         <Messages items={this.state.messages}/>
         <Form model={this.state.model} className="image-build-form"
           onChange={this.onFormChange} onSubmit={this.onBuild}

--- a/web/html/src/manager/images/image-profiles.js
+++ b/web/html/src/manager/images/image-profiles.js
@@ -112,7 +112,7 @@ class ImageProfiles extends React.Component {
 
     return (
       <span>
-        <TopPanel title="Image Profiles" icon="fa-list" helpUrl="/docs/reference/images/images-profiles.html" button={ panelButtons }>
+        <TopPanel title="Image Profiles" icon="spacewalk-icon-manage-configuration-files" helpUrl="/docs/reference/images/images-profiles.html" button={ panelButtons }>
           {this.state.messages}
           <Table
             data={this.state.imageprofiles}

--- a/web/html/src/manager/images/image-view.js
+++ b/web/html/src/manager/images/image-view.js
@@ -329,7 +329,7 @@ class ImageView extends React.Component {
     return (
       <span>
         <TopPanel title={this.state.selected ? this.state.selected.name : t("Images")} helpUrl="/docs/reference/images/images-image-list.html"
-               icon={this.state.selected ? "fa-hdd-o" : "fa-list"} button={ panelButtons }>
+               icon={this.state.selected ? "fa-hdd-o" : "spacewalk-icon-manage-configuration-files"} button={ panelButtons }>
           { this.state.messages.length > 0 && <Messages items={this.state.messages}/> }
           { this.state.selected ?
             <ImageViewDetails data={selected} onTabChange={() => this.updateView(getHashId(), getHashTab())}

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Adjust title icons
 - Fix VM creation dialog with non-default pools and networks (bsc#1138268)
 - Update help URLs in the UI (bsc#1136764)
 - Force python-numpy and python-PyJWT dependencies (bsc#1137357)


### PR DESCRIPTION
## What does this PR change?

1. `Patches` submenu: swap `Relevant Patches` and `All`
2. `Advanced search` in `System` and `Patches` should have the same topic related icon
3. `Images` pages icons differs from the section icon


## GUI diff

Before - menu swap
![Screenshot from 2019-05-31 12-21-03](https://user-images.githubusercontent.com/7080830/58699814-b5391800-839e-11e9-87ae-f7454352ee56.png)
After - menu swap
![Screenshot from 2019-05-31 12-21-15](https://user-images.githubusercontent.com/7080830/58699813-b4a08180-839e-11e9-82b2-fa963e947c40.png)

---

Before - images icon
![Screenshot from 2019-05-31 12-21-44](https://user-images.githubusercontent.com/7080830/58699812-b4a08180-839e-11e9-8d3f-ebf33300f640.png)
After - images icon
![Screenshot from 2019-05-31 12-21-57](https://user-images.githubusercontent.com/7080830/58699811-b4a08180-839e-11e9-92c9-3c79a11278da.png)

- [x] **DONE**

## Documentation
- No documentation needed: I don't think these changes really need new screenshots, but maybe @Loquacity  you want to be aware of. The only one that is relevant is the menu switch order, just in case.

- [x] **DONE**

## Test coverage
- Cucumber tests were adapted

- [x] **DONE**

## Links

Fixes #
Tracks # https://github.com/SUSE/spacewalk/pull/7981

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests" 		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
