### PR TITLE
Master - big formula checkbox fix

### DIFF
--- a/branding/css/susemanager-theme.less
+++ b/branding/css/susemanager-theme.less
@@ -1055,11 +1055,6 @@ i.spacewalk-help-link {
   color: #777;
 }
 
-input.big-checkbox {
-  height: 25px;
-  width: 25px;
-}
-
 .input-group.small-color-picker {
   width: 130px;
 }

--- a/branding/spacewalk-branding.changes
+++ b/branding/spacewalk-branding.changes
@@ -1,3 +1,4 @@
+- Fix big formula checkbox not supported in Firefox
 - Update help URLs in the UI
 
 -------------------------------------------------------------------

--- a/web/html/src/components/formulas/FormulaComponentGenerator.js
+++ b/web/html/src/components/formulas/FormulaComponentGenerator.js
@@ -84,7 +84,9 @@ function generateFormulaComponentForId(element, value, formulaForm, id, wrapper)
     else if (element.$type === "boolean")
         return wrapper(
                 element.$name,
-                <input type="checkbox" className="big-checkbox" onChange={formulaForm.handleChange} name={element.$name} id={id} title={element.$help} disabled={isDisabled} checked={value} />
+                <div className="checkbox">
+                    <input type="checkbox" onChange={formulaForm.handleChange} name={element.$name} id={id} title={element.$help} disabled={isDisabled} checked={value} />
+                </div>
         );
     else {
         console.error("Unknown $type: " + element.$type);

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fix big formula checkbox not supported in Firefox
 - Allow forcing off or resetting VMs
 - Adjust title icons
 - Fix VM creation dialog with non-default pools and networks (bsc#1138268)


### PR DESCRIPTION
## What does this PR change?

Do not use big `checkbox` style: it's not well supported by common browsers (i.e. Firefox)

**Note**: the result with this change is not *perfectly* aligned, but it is a common pattern through the entire product as we are *hacking* a bit the bootstrap structure. Let's fix this current issue, then we will align the entire product with *one-line-fix* later, hopefully.

## GUI diff

Before:
![Screenshot from 2019-05-31 14-43-45](https://user-images.githubusercontent.com/7080830/58706490-862ca180-83b2-11e9-8bb4-3c26070da225.png)

After:
![Screenshot from 2019-05-31 14-43-12](https://user-images.githubusercontent.com/7080830/58706496-89c02880-83b2-11e9-893f-0e6c5ae1c229.png)


- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/7688
Tracks https://github.com/SUSE/spacewalk/pull/7984

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
