### PR TITLE
Set timeout in Portus image build test case

### DIFF
--- a/testsuite/features/min_docker_auth_registry.feature
+++ b/testsuite/features/min_docker_auth_registry.feature
@@ -33,7 +33,7 @@ Feature: Build image with authenticated registry
 
   Scenario: Verify the status of images in the authenticated image store
     Given I am authorized as "admin" with password "admin"
-    Then container "portus_profile" built successfully
+    When I wait at most 500 seconds until container "portus_profile" is built successfully
 
   Scenario: Cleanup: remove Docker profile for the authenticated image store
     Given I am authorized as "docker" with password "docker"

--- a/testsuite/features/min_docker_build_image.feature
+++ b/testsuite/features/min_docker_build_image.feature
@@ -19,7 +19,7 @@ Feature: Build container images
     Given I am authorized as "admin" with password "admin"
     When I schedule the build of image "suse_key" with version "Latest_key-activation1" via XML-RPC calls
     And I schedule the build of image "suse_simple" with version "Latest_simple" via XML-RPC calls
-    Then all "5" container images are built correctly in the GUI
+    And I wait at most 500 seconds until all "5" container images are built correctly in the GUI
 
   Scenario: Delete image via XML-RPC calls
     Given I am authorized as "admin" with password "admin"
@@ -32,7 +32,7 @@ Feature: Build container images
     Given I am authorized as "admin" with password "admin"
     When I schedule the build of image "suse_simple" with version "Latest_simple" via XML-RPC calls
     And I schedule the build of image "suse_key" with version "Latest_key-activation1" via XML-RPC calls
-    Then all "5" container images are built correctly in the GUI
+    And I wait at most 500 seconds until all "5" container images are built correctly in the GUI
 
   Scenario: Build an image via the GUI
     Given I am authorized as "admin" with password "admin"

--- a/testsuite/features/step_definitions/docker_steps.rb
+++ b/testsuite/features/step_definitions/docker_steps.rb
@@ -34,7 +34,7 @@ When(/^I navigate to images build webpage$/) do
   visit("https://#{$server.full_hostname}/rhn/manager/cm/build")
 end
 
-Then(/^container "([^"]*)" built successfully$/) do |name|
+When(/^I wait at most (\d+) seconds until container "([^"]*)" is built successfully$/) do |timeout, name|
   cont_op.login('admin', 'admin')
   images_list = cont_op.list_images
   image_id = 0
@@ -46,7 +46,7 @@ Then(/^container "([^"]*)" built successfully$/) do |name|
   end
   raise 'unable to find the image id' if image_id.zero?
   begin
-    Timeout.timeout(DEFAULT_TIMEOUT) do
+    Timeout.timeout(timeout.to_i) do
       loop do
         idetails = cont_op.get_image_details(image_id)
         break if idetails['buildStatus'] == 'completed' && idetails['inspectStatus'] == 'completed'
@@ -60,10 +60,9 @@ Then(/^container "([^"]*)" built successfully$/) do |name|
   end
 end
 
-Then(/^all "([^"]*)" container images are built correctly in the GUI$/) do |count|
-  def ck_container_imgs(count)
-    build_timeout = 320
-    Timeout.timeout(build_timeout) do
+When(/^I wait at most (\d+) seconds until all "([^"]*)" container images are built correctly in the GUI$/) do |timeout, count|
+  def ck_container_imgs(timeout, count)
+    Timeout.timeout(timeout.to_i) do
       step %(I navigate to images webpage)
       step %(I wait until I do not see "There are no entries to show." text)
       raise 'error detected while building images' if has_xpath?("//*[contains(@title, 'Failed')]")
@@ -74,7 +73,7 @@ Then(/^all "([^"]*)" container images are built correctly in the GUI$/) do |coun
     raise 'at least one image was not built correctly'
   end
   # don't run this for sles11 (docker feature is not there)
-  ck_container_imgs(count) unless sle11family($minion)
+  ck_container_imgs(timeout, count) unless sle11family($minion)
 end
 
 When(/^I check the first image$/) do


### PR DESCRIPTION
Set a timeout of 500 seconds to Portus image building case, and unify the timeouts in other image building cases.

Port of https://github.com/SUSE/spacewalk/pull/7983

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
