### PR TITLE
Testsuite: work around Ruby issue 15886

### DIFF
--- a/testsuite/features/step_definitions/centos_tradclient.rb
+++ b/testsuite/features/step_definitions/centos_tradclient.rb
@@ -9,18 +9,13 @@ def wait_action_complete(actionid)
   host = $server.full_hostname
   @cli = XMLRPC::Client.new2('http://' + host + '/rpc/api')
   @sid = @cli.call('auth.login', 'admin', 'admin')
-  complete_timeout = 300
-  Timeout.timeout(complete_timeout) do
-    loop do
-      list = @cli.call('schedule.list_completed_actions', @sid)
-      list.each do |action|
-        return true if action['id'] == actionid
-        sleep(2)
-      end
+  repeat_until_timeout(timeout: 300, message: 'Action was not found among completed actions') do
+    list = @cli.call('schedule.list_completed_actions', @sid)
+    list.each do |action|
+      break if action['id'] == actionid
+      sleep 2
     end
   end
-rescue Timeout::Error
-  raise 'Action did not complete. It was not found in completed actions'
 end
 
 When(/^I authenticate to XML-RPC$/) do

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -64,19 +64,13 @@ When(/^I wait at most (\d+) seconds until event "([^"]*)" is completed$/) do |fi
 end
 
 When(/^I wait until I see the event "([^"]*)" completed during last minute, refreshing the page$/) do |event|
-  begin
-    Timeout.timeout(DEFAULT_TIMEOUT) do
-      loop do
-        now = Time.now
-        current_minute = now.strftime('%H:%M')
-        previous_minute = (now - 60).strftime('%H:%M')
-        break if page.has_xpath?("//a[contains(text(),'#{event}')]/../..//td[4][contains(text(),'#{current_minute}') or contains(text(),'#{previous_minute}')]/../td[3]/a[1]")
-        sleep 1
-        page.evaluate_script 'window.location.reload()'
-      end
-    end
-  rescue Timeout::Error
-    raise "Couldn't find the event #{event} in webpage"
+  repeat_until_timeout(message: "Couldn't find the event #{event}") do
+    now = Time.now
+    current_minute = now.strftime('%H:%M')
+    previous_minute = (now - 60).strftime('%H:%M')
+    break if page.has_xpath?("//a[contains(text(),'#{event}')]/../..//td[4][contains(text(),'#{current_minute}') or contains(text(),'#{previous_minute}')]/../td[3]/a[1]")
+    sleep 1
+    page.evaluate_script 'window.location.reload()'
   end
 end
 
@@ -857,16 +851,10 @@ And(/^the notification badge and the table should count the same amount of messa
 end
 
 And(/^I wait until radio button "([^"]*)" is checked, refreshing the page$/) do |arg1|
-  begin
-    Timeout.timeout(DEFAULT_TIMEOUT) do
-      loop do
-        break if has_checked_field?(arg1)
-        sleep 1
-        page.evaluate_script 'window.location.reload()'
-      end
-    end
-  rescue Timeout::Error
-    raise "Couldn't find checked radio button #{arg1} in webpage"
+  repeat_until_timeout(message: "Couldn't find checked radio button #{arg1}") do
+    break if has_checked_field?(arg1)
+    sleep 1
+    page.evaluate_script 'window.location.reload()'
   end
 end
 
@@ -943,23 +931,17 @@ When(/^I wait until all events in history are completed$/) do
     And I follow "History" in the content area
     Then I should see a "System History" text
   )
-  begin
-    events_icons = "//div[@class='table-responsive']/table/tbody/tr/td[2]/i"
-    Timeout.timeout(DEFAULT_TIMEOUT) do
-      loop do
-        pickedup = false
-        events = all(:xpath, events_icons)
-        events.each do |ev|
-          if ev[:class].include?('fa-exchange')
-            pickedup = true
-            break
-          end
-        end
-        break if not pickedup
-        sleep 1
+  events_icons = "//div[@class='table-responsive']/table/tbody/tr/td[2]/i"
+  repeat_until_timeout(message: 'Not all events in history were completed') do
+    pickedup = false
+    events = all(:xpath, events_icons)
+    events.each do |ev|
+      if ev[:class].include?('fa-exchange')
+        pickedup = true
+        break
       end
     end
-  rescue Timeout::Error
-    raise "Timed out waiting for the system events to complete."
+    break unless pickedup
+    sleep 1
   end
 end

--- a/testsuite/features/step_definitions/docker_steps.rb
+++ b/testsuite/features/step_definitions/docker_steps.rb
@@ -45,32 +45,25 @@ When(/^I wait at most (\d+) seconds until container "([^"]*)" is built successfu
     end
   end
   raise 'unable to find the image id' if image_id.zero?
-  begin
-    Timeout.timeout(timeout.to_i) do
-      loop do
-        idetails = cont_op.get_image_details(image_id)
-        break if idetails['buildStatus'] == 'completed' && idetails['inspectStatus'] == 'completed'
-        raise 'image build failed.' if idetails['buildStatus'] == 'failed'
-        raise 'image inspect failed.' if idetails['inspectStatus'] == 'failed'
-        sleep 5
-      end
-    end
-  rescue Timeout::Error
-    raise 'image build failed. Timeout'
+
+  repeat_until_timeout(timeout: timeout.to_i, message: 'image build did not complete') do
+    idetails = cont_op.get_image_details(image_id)
+    break if idetails['buildStatus'] == 'completed' && idetails['inspectStatus'] == 'completed'
+    raise 'image build failed.' if idetails['buildStatus'] == 'failed'
+    raise 'image inspect failed.' if idetails['inspectStatus'] == 'failed'
+    sleep 5
   end
 end
 
 When(/^I wait at most (\d+) seconds until all "([^"]*)" container images are built correctly in the GUI$/) do |timeout, count|
   def ck_container_imgs(timeout, count)
-    Timeout.timeout(timeout.to_i) do
+    repeat_until_timeout(timeout: timeout, message: 'at least one image was not built correctly') do
       step %(I navigate to images webpage)
       step %(I wait until I do not see "There are no entries to show." text)
       raise 'error detected while building images' if has_xpath?("//*[contains(@title, 'Failed')]")
       break if has_xpath?("//*[contains(@title, 'Built')]", count: count)
       sleep 5
     end
-  rescue Timeout::Error
-    raise 'at least one image was not built correctly'
   end
   # don't run this for sles11 (docker feature is not there)
   ck_container_imgs(timeout, count) unless sle11family($minion)

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -41,58 +41,34 @@ When(/^I wait until I do not see "([^"]*)" text$/) do |text|
 end
 
 When(/^I wait at most (\d+) seconds until I see "([^"]*)" text$/) do |seconds, text|
-  begin
-    Timeout.timeout(seconds.to_i) do
-      loop do
-        break if page.has_content?(text)
-        sleep 3
-      end
-    end
-  rescue Timeout::Error
-    raise "Couldn't find the #{text} in webpage"
+  repeat_until_timeout(timeout: seconds, message: "Couldn't find text '#{text}'") do
+    break if page.has_content?(text)
+    sleep 3
   end
 end
 
 When(/^I wait until I see "([^"]*)" text or "([^"]*)" text$/) do |text1, text2|
-  begin
-    Timeout.timeout(DEFAULT_TIMEOUT) do
-      loop do
-        break if page.has_content?(text1) || page.has_content?(text2)
-        sleep 3
-      end
-    end
-  rescue Timeout::Error
-    raise "Couldn't find the #{text1} and #{text2} in webpage"
+  repeat_until_timeout(message: "Couldn't find either '#{text1}' or '#{text2}'") do
+    break if page.has_content?(text1) || page.has_content?(text2)
+    sleep 3
   end
 end
 
 When(/^I wait until I see "([^"]*)" text, refreshing the page$/) do |text|
   text.gsub! '$PRODUCT', $product
-  begin
-    Timeout.timeout(DEFAULT_TIMEOUT) do
-      loop do
-        break if page.has_content?(text)
-        sleep 1
-        page.evaluate_script 'window.location.reload()'
-      end
-    end
-  rescue Timeout::Error
-    raise "Couldn't find the #{text} in webpage"
+  repeat_until_timeout(message: "Couldn't find text '#{text}'") do
+    break if page.has_content?(text)
+    sleep 1
+    page.evaluate_script 'window.location.reload()'
   end
 end
 
 When(/^I wait at most (\d+) seconds until the event is completed, refreshing the page$/) do |timeout|
-  begin
-    Timeout.timeout(timeout.to_i) do
-      loop do
-        break if page.has_content?("This action's status is: Completed.")
-        raise 'Event failed' if page.has_content?("This action's status is: Failed.")
-        sleep 1
-        page.evaluate_script 'window.location.reload()'
-      end
-    end
-  rescue Timeout::Error
-    raise "Event not completed in #{timeout} seconds"
+  repeat_until_timeout(timeout: timeout.to_i, message: 'Event not yet completed') do
+    break if page.has_content?("This action's status is: Completed.")
+    raise 'Event failed' if page.has_content?("This action's status is: Failed.")
+    sleep 1
+    page.evaluate_script 'window.location.reload()'
   end
 end
 
@@ -102,16 +78,10 @@ When(/^I wait until I see the name of "([^"]*)", refreshing the page$/) do |host
 end
 
 When(/^I wait until I do not see "([^"]*)" text, refreshing the page$/) do |text|
-  begin
-    Timeout.timeout(DEFAULT_TIMEOUT) do
-      loop do
-        break unless page.has_content?(text)
-        sleep 3
-        page.evaluate_script 'window.location.reload()'
-      end
-    end
-  rescue Timeout::Error
-    raise "The #{text} was always there in webpage"
+  repeat_until_timeout(message: "Text '#{text}' is still visible") do
+    break unless page.has_content?(text)
+    sleep 3
+    page.evaluate_script 'window.location.reload()'
   end
 end
 
@@ -121,15 +91,9 @@ When(/^I wait until I do not see the name of "([^"]*)", refreshing the page$/) d
 end
 
 Then(/^I wait until I see the (VNC|spice) graphical console$/) do |type|
-  begin
-    Timeout.timeout(DEFAULT_TIMEOUT) do
-      loop do
-        break unless page.has_xpath?('.//canvas')
-        sleep 3
-      end
-    end
-  rescue Timeout::Error
-    raise "The #{type} graphical console didn't load"
+  repeat_until_timeout(message: "The #{type} graphical console didn't load") do
+    break unless page.has_xpath?('.//canvas')
+    sleep 3
   end
 end
 
@@ -388,28 +352,16 @@ Then(/^Table row for "([^"]*)" should contain "([^"]*)"$/) do |arg1, arg2|
 end
 
 When(/^I wait until table row for "([^"]*)" contains button "([^"]*)"$/) do |text, button|
-  begin
-    Timeout.timeout(DEFAULT_TIMEOUT) do
-      loop do
-        break if all(:xpath, "//tr[td[contains(., '#{text}')]]/td/descendant::*[self::a or self::button][@title='#{button}']").any?
-        sleep 1
-      end
-    end
-  rescue Timeout::Error
-    raise "Couldn't find #{button} button in row with #{text} text"
+  repeat_until_timeout(message: "Couldn't find #{button} button in row with #{text} text") do
+    break if all(:xpath, "//tr[td[contains(., '#{text}')]]/td/descendant::*[self::a or self::button][@title='#{button}']").any?
+    sleep 1
   end
 end
 
 When(/^I wait until table row contains a "([^"]*)" text$/) do |text|
-  begin
-    Timeout.timeout(DEFAULT_TIMEOUT) do
-      loop do
-        break if has_xpath?("//div[@class=\"table-responsive\"]/table/tbody/tr[.//td[contains(.,'#{text}')]]")
-        sleep 1
-      end
-    end
-  rescue Timeout::Error
-    raise "Couldn't find #{text} in any row"
+  repeat_until_timeout(message: "Couldn't find #{text} in any row") do
+    break if has_xpath?("//div[@class=\"table-responsive\"]/table/tbody/tr[.//td[contains(.,'#{text}')]]")
+    sleep 1
   end
 end
 
@@ -628,32 +580,25 @@ end
 When(/^I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows$/) do
   # this step is used for long operations like refreshing caches, repositories, etc.
   # therefore we use a non-standard timeout
-  refresh_timeout = 800
-  begin
-    Timeout.timeout(refresh_timeout) do
-      loop do
-        visit current_url
-        # get all texts in the table column under the "Status" header
-        under_status = "//tr/td[count(//th[contains(*/text(), 'Status')]/preceding-sibling::*) + 1]"
-        statuses = page.all(:xpath, under_status).map(&:text)
+  repeat_until_timeout(timeout: 800, message: 'Task does not look FINISHED yet') do
+    visit current_url
+    # get all texts in the table column under the "Status" header
+    under_status = "//tr/td[count(//th[contains(*/text(), 'Status')]/preceding-sibling::*) + 1]"
+    statuses = page.all(:xpath, under_status).map(&:text)
 
-        # disregard any number of initial SKIPPED rows
-        # this is expected when Taskomatic triggers the same task concurrently
-        first_non_skipped = statuses.drop_while do |status|
-          status == 'SKIPPED'
-        end.first
+    # disregard any number of initial SKIPPED rows
+    # this is expected when Taskomatic triggers the same task concurrently
+    first_non_skipped = statuses.drop_while do |status|
+      status == 'SKIPPED'
+    end.first
 
-        # halt in case we are done, or if an error is detected
-        break if first_non_skipped == 'FINISHED'
-        raise('Taskomatic task was INTERRUPTED') if first_non_skipped == 'INTERRUPTED'
+    # halt in case we are done, or if an error is detected
+    break if first_non_skipped == 'FINISHED'
+    raise('Taskomatic task was INTERRUPTED') if first_non_skipped == 'INTERRUPTED'
 
-        # otherwise either no row is shown yet, or the task is still RUNNING
-        # continue waiting
-        sleep 1
-      end
-    end
-  rescue Timeout::Error
-    raise "Task does not look FINISHED after #{refresh_timeout} seconds"
+    # otherwise either no row is shown yet, or the task is still RUNNING
+    # continue waiting
+    sleep 1
   end
 end
 
@@ -828,15 +773,9 @@ When(/^I click on "([^"]*)" in "([^"]*)" modal$/) do |btn, title|
 
   # We wait until the element becomes visible, because
   # the fade out animation might still be in progress
-  begin
-    Timeout.timeout(DEFAULT_TIMEOUT) do
-      loop do
-        break if page.has_xpath?(path, visible: true)
-        sleep 1
-      end
-    end
-  rescue Timeout::Error
-    raise "Couldn't find the #{title} modal"
+  repeat_until_timeout(message: "Couldn't find the #{title} modal") do
+    break if page.has_xpath?(path, visible: true)
+    sleep 1
   end
 
   within(:xpath, path, visible: :all) do

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -7,25 +7,18 @@ require 'tempfile'
 
 Given(/^the Salt master can reach "(.*?)"$/) do |minion|
   system_name = get_system_name(minion)
-  begin
-    start = Time.now
-    # 300 is the default 1st keepalive interval for the minion
-    # where it realizes the connection is stuck
-    keepalive_timeout = 300
-    Timeout.timeout(keepalive_timeout) do
-      # only try 3 times
-      3.times do
-        out, _code = $server.run("salt #{system_name} test.ping")
-        if out.include?(system_name) && out.include?('True')
-          finished = Time.now
-          puts "Took #{finished.to_i - start.to_i} seconds to contact the minion"
-          break
-        end
-        sleep(1)
-      end
+  start = Time.now
+  # 300 is the default 1st keepalive interval for the minion
+  # where it realizes the connection is stuck
+  repeat_until_timeout(timeout: 300, retries: 3, message: "Master can not communicate with #{minion}", report_result: true) do
+    out, _code = $server.run("salt #{system_name} test.ping")
+    if out.include?(system_name) && out.include?('True')
+      finished = Time.now
+      puts "Took #{finished.to_i - start.to_i} seconds to contact the minion"
+      break
     end
-  rescue Timeout::Error
-    raise "Master can not communicate with #{minion}: #{@output[:stdout]}"
+    sleep 1
+    out
   end
 end
 
@@ -61,34 +54,22 @@ end
 
 When(/^I wait at most (\d+) seconds until Salt master sees "([^"]*)" as "([^"]*)"$/) do |key_timeout, minion, key_type|
   cmd = "salt-key --list #{key_type}"
-  begin
-    Timeout.timeout(key_timeout.to_i) do
-      loop do
-        system_name = get_system_name(minion)
-        unless system_name.empty?
-          output, return_code = $server.run(cmd, false)
-          break if return_code.zero? && output.include?(system_name)
-        end
-        sleep 1
-      end
+  repeat_until_timeout(timeout: key_timeout.to_i, message: "Minion '#{minion}' is not listed among #{key_type} keys on Salt master") do
+    system_name = get_system_name(minion)
+    unless system_name.empty?
+      output, return_code = $server.run(cmd, false)
+      break if return_code.zero? && output.include?(system_name)
     end
-  rescue Timeout::Error
-    raise "Minion \"#{minion}\" is not listed among #{key_type} keys on Salt master after #{key_timeout} seconds"
+    sleep 1
   end
 end
 
 When(/^I wait until no Salt job is running on "([^"]*)"$/) do |minion|
   target = get_target(minion)
-  begin
-    Timeout.timeout(DEFAULT_TIMEOUT) do
-      loop do
-        output, _code = target.run('salt-call -lquiet saltutil.running')
-        break if output == "local:\n"
-        sleep 3
-      end
-    end
-  rescue Timeout::Error
-    raise "A Salt job is still running on #{minion} after timeout"
+  repeat_until_timeout(message: "A Salt job is still running on #{minion}") do
+    output, _code = target.run('salt-call -lquiet saltutil.running')
+    break if output == "local:\n"
+    sleep 3
   end
 end
 
@@ -188,19 +169,13 @@ When(/^I click on preview$/) do
 end
 
 When(/^I click on run$/) do
-  begin
-    Timeout.timeout(DEFAULT_TIMEOUT) do
-      loop do
-        begin
-          find('button#run').click
-          break
-        rescue Capybara::ElementNotFound
-          sleep(5)
-        end
-      end
+  repeat_until_timeout(message: "Run button not found") do
+    begin
+      find('button#run').click
+      break
+    rescue Capybara::ElementNotFound
+      sleep(5)
     end
-  rescue Timeout::Error
-    raise 'Run button not found'
   end
 end
 
@@ -235,41 +210,19 @@ Then(/^I should see "([^"]*)" in the command output for "([^"]*)"$/) do |text, h
 end
 
 Then(/^I click on the css "(.*)" until page does not contain "([^"]*)" text$/) do |css, text|
-  not_found = false
-  begin
-    Timeout.timeout(DEFAULT_TIMEOUT) do
-      loop do
-        unless page.has_content?(text)
-          not_found = true
-          break
-        end
-        find(css).click
-        sleep 3
-      end
-    end
-  rescue Timeout::Error
-    raise "'#{text}' still found after several tries"
+  repeat_until_timeout(message: "'#{text}' still found") do
+    break unless page.has_content?(text)
+    find(css).click
+    sleep 3
   end
-  raise unless not_found
 end
 
 Then(/^I click on the css "(.*)" until page does contain "([^"]*)" text$/) do |css, text|
-  found = false
-  begin
-    Timeout.timeout(DEFAULT_TIMEOUT) do
-      loop do
-        if page.has_content?(text)
-          found = true
-          break
-        end
-        find(css).click
-        sleep 3
-      end
-    end
-  rescue Timeout::Error
-    raise "'#{text}' cannot be found after several tries"
+  repeat_until_timeout(message: "'#{text}' was not found") do
+    break if page.has_content?(text)
+    find(css).click
+    sleep 3
   end
-  raise unless found
 end
 
 When(/^I click on the css "(.*)"$/) do |css|
@@ -649,21 +602,15 @@ end
 
 Then(/^I wait for "([^"]*)" to be uninstalled on "([^"]*)"$/) do |package, host|
   node = get_target(host)
-  uninstalled = false
-  output = ''
-  begin
-    Timeout.timeout(DEFAULT_TIMEOUT) do
-      loop do
-        output, code = node.run("rpm -q #{package}", false)
-        if code.nonzero?
-          uninstalled = true
-          break
-        end
-        sleep 1
-      end
+  repeat_until_timeout(message: "Package removal failed", report_result: true) do
+    output, code = node.run("rpm -q #{package}", false)
+    if code.nonzero?
+      uninstalled = true
+      break
     end
+    sleep 1
+    "code #{code}, #{output}"
   end
-  raise "Package removal failed (Code #{$CHILD_STATUS}): #{$ERROR_INFO}: #{output}" unless uninstalled
 end
 
 Then(/^I wait for "([^"]*)" to be installed on this "([^"]*)"$/) do |package, host|

--- a/testsuite/features/step_definitions/xmlrpc_common.rb
+++ b/testsuite/features/step_definitions/xmlrpc_common.rb
@@ -456,15 +456,9 @@ Then(/^there should be no more my action chain$/) do
 end
 
 When(/^I wait until there are no more action chains$/) do
-  begin
-    Timeout.timeout(DEFAULT_TIMEOUT) do
-      loop do
-        break if rpc.list_chains.empty?
-        sleep(2)
-      end
-    end
-  rescue Timeout::Error
-    raise unless rpc.list_chains.empty?
+  repeat_until_timeout(message: 'Action Chains still present') do
+    break if rpc.list_chains.empty?
+    sleep 2
   end
 end
 
@@ -497,15 +491,9 @@ Then(/^there should be no more any scheduled actions$/) do
 end
 
 Then(/^I wait until there are no more scheduled actions$/) do
-  begin
-    Timeout.timeout(DEFAULT_TIMEOUT) do
-      loop do
-        break if scdrpc.list_in_progress_actions.empty?
-        sleep(2)
-      end
-    end
-  rescue Timeout::Error
-    raise unless scdrpc.list_in_progress_actions.empty?
+  repeat_until_timeout(message: 'Scheduled actions still present') do
+    break if scdrpc.list_in_progress_actions.empty?
+    sleep 2
   end
 end
 

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -50,3 +50,40 @@ def inject_salt_pillar_file(source, file)
   $server.run("chgrp salt #{dest}")
   return_code
 end
+
+# Repeatedly executes a block raising an exception in case it is not finished within timeout seconds
+# or retries attempts, whichever comes first.
+# Exception will optionally contain the specified message and the result from the last block execution, if any, in case
+# report_result is set to true
+#
+# Implementation works around https://bugs.ruby-lang.org/issues/15886
+def repeat_until_timeout(timeout: DEFAULT_TIMEOUT, retries: nil, message: nil, report_result: false)
+  last_result = nil
+  Timeout.timeout(timeout) do
+    # HACK: Timeout.timeout might not raise Timeout::Error depending on the yielded code block
+    # Pitfalls with this method have been long known according to the following articles:
+    # https://rnubel.svbtle.com/ruby-timeouts
+    # https://vaneyckt.io/posts/the_disaster_that_is_rubys_timeout_method
+    # At the time of writing some of the problems described have been addressed.
+    # However, at least https://bugs.ruby-lang.org/issues/15886 remains reproducible and code below
+    # works around it by adding an additional check between loops
+    start = Time.new
+    attempts = 0
+    while (Time.new - start <= timeout) && (retries.nil? || attempts < retries)
+      last_result = yield
+      attempts += 1
+    end
+
+    detail = format_detail(message, last_result, report_result)
+    raise "Giving up after #{attempts} attempts#{detail}" if attempts == retries
+    raise "Timeout after #{timeout} seconds (repeat_until_timeout)#{detail}"
+  end
+rescue Timeout::Error
+  raise "Timeout after #{timeout} seconds (Timeout.timeout)#{format_detail(message, last_result, report_result)}"
+end
+
+def format_detail(message, last_result, report_result)
+  formatted_message = "#{': ' unless message.nil?}#{message}"
+  formatted_result = "#{', last result was: ' unless last_result.nil?}#{last_result}" if report_result
+  "#{formatted_message}#{formatted_result}"
+end

--- a/testsuite/features/support/lavanda.rb
+++ b/testsuite/features/support/lavanda.rb
@@ -45,27 +45,21 @@ module LavandaBasic
 
   def run_until_ok(cmd)
     result = nil
-    Timeout.timeout(DEFAULT_TIMEOUT) do
-      loop do
-        result, code = run(cmd, false)
-        break if code.zero?
-        sleep 2
-      end
+    repeat_until_timeout(report_result: true) do
+      result, code = run(cmd, false)
+      break if code.zero?
+      sleep 2
+      result
     end
-  rescue Timeout::Error
-    raise "timeout finished! something went wrong! \n #{result}"
   end
 
   def run_until_fail(cmd)
     result = nil
-    Timeout.timeout(DEFAULT_TIMEOUT) do
-      loop do
-        result, code = run(cmd, false)
-        break if code.nonzero?
-        sleep 2
-      end
+    repeat_until_timeout(report_result: true) do
+      result, code = run(cmd, false)
+      break if code.nonzero?
+      sleep 2
+      result
     end
-  rescue Timeout::Error
-    raise "timeout finished! something went wrong! \n #{result}"
   end
 end


### PR DESCRIPTION
## What does this PR change?

MRI Ruby method `Timeout.timeout` might not raise `Timeout::Error` depending on the yielded code block.

Pitfalls with this method have been long known according to the following articles:

https://rnubel.svbtle.com/ruby-timeouts
https://vaneyckt.io/posts/the_disaster_that_is_rubys_timeout_method

At the time of writing some of the problems described have been addressed.

However, at least https://bugs.ruby-lang.org/issues/15886 remains reproducible and code below works around it by adding an additional check between loops.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **testsuite**

- [x] **DONE**

## Test coverage
- No tests: **testsuite**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/7986

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

