### PR TITLE
Added help links to Content Management pages.

### DIFF
--- a/web/html/src/manager/content-management/list-filters/list-filters.js
+++ b/web/html/src/manager/content-management/list-filters/list-filters.js
@@ -59,7 +59,7 @@ const ListFilters = (props: Props) => {
   );
 
   return (
-    <TopPanel title={t('Content Lifecycle Filters')} icon="fa-filter" button={panelButtons}>
+    <TopPanel title={t('Content Lifecycle Filters')} icon="fa-filter" button={panelButtons} helpUrl="/docs/reference/clm/clm-filters.html">
       <Table
         data={displayedFilters}
         identifier={row => row.name}

--- a/web/html/src/manager/content-management/list-projects/list-projects.js
+++ b/web/html/src/manager/content-management/list-projects/list-projects.js
@@ -67,7 +67,7 @@ const ListProjects = (props: Props) => {
   );
 
   return (
-      <TopPanel title={t('Content Lifecycle Projects')} icon="spacewalk-icon-lifecycle" button={panelButtons}>
+      <TopPanel title={t('Content Lifecycle Projects')} icon="spacewalk-icon-lifecycle" button={panelButtons} helpUrl="/docs/reference/clm/clm-menu.html">
         <Table
           data={normalizedProjects}
           identifier={row => row.label}

--- a/web/html/src/manager/content-management/project/project.js
+++ b/web/html/src/manager/content-management/project/project.js
@@ -69,6 +69,7 @@ const Project = (props: Props) => {
   return (
     <TopPanel
       title={t('Content Lifecycle Project - {0}', project.properties.name)}
+      helpUrl="/docs/reference/clm/clm-projects.html"
       // icon="fa-plus"
       button= {
         hasEditingPermissions &&


### PR DESCRIPTION
## What does this PR change?

Added helplinks to the content management pages.

## GUI diff

Help bubbles near the titles of the pages

Before: Missing

After: Present in the GUI

## Documentation
- No documentation needed: Added the documentation for the pages
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

## Test coverage
- No tests: Just help links?

## Links

Tracks https://github.com/SUSE/spacewalk/issues/7527#issuecomment-491766961

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"   
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
