### PR TITLE
Add --allow-downgrades to apt-get to fix failing test

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -572,7 +572,7 @@ When(/^I install package "([^"]*)" on this "([^"]*)"$/) do |package, host|
   elsif file_exists?(node, '/usr/bin/yum')
     cmd = "yum -y install #{package}"
   elsif file_exists?(node, '/usr/bin/apt-get')
-    cmd = "apt-get --assume-yes install #{package}"
+    cmd = "apt-get --assume-yes install #{package} --allow-downgrades"
   else
     raise 'Not found: zypper, yum or apt-get'
   end


### PR DESCRIPTION
## What does this PR change?

Fixes the apt-get install options to allow downgrades. This allows us to install from virgo-dummy-2.0 to virgo-dummy-1.0 without having a failing test "Scenario: Pre-requisite: install virgo-dummy-1.0 packages"

## Links

Fixes https://github.com/SUSE/spacewalk/issues/7996

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
