### PR TITLE
Add ubuntu channels to spacewalk-common-channels

### DIFF
--- a/utils/spacewalk-common-channels
+++ b/utils/spacewalk-common-channels
@@ -34,6 +34,8 @@ DEFAULT_SERVER = "localhost"
 
 DEFAULT_CONFIG = '/etc/rhn/spacewalk-common-channels.ini'
 
+DEFAULT_REPO_TYPE = 'yum'
+
 CHANNEL_ARCH = {
     'i386':         'channel-ia32',
     'ia64':         'channel-ia64',
@@ -47,6 +49,16 @@ CHANNEL_ARCH = {
     'x86_64':       'channel-x86_64',
     'ppc':          'channel-ppc',
     'ppc64':        'channel-ppc64',
+    'amd64-deb':    'channel-amd64-deb',
+    'ia32-deb':     'channel-ia32-deb',
+    'ia64-deb':     'channel-ia64-deb',
+    'sparc-deb':    'channel-sparc-deb',
+    'alpha-deb':    'channel-alpha-deb',
+    's390-deb':     'channel-s390-deb',
+    'powerpc-deb':  'channel-powerpc-deb',
+    'arm-deb':      'channel-arm-deb',
+    'mips-deb':     'channel-mips-deb'
+
 }
 
 SPLIT_PATTERN = '[ ,]+'
@@ -83,8 +95,8 @@ def connect(user, password, server):
 def add_channels(channels, section, arch, client):
     base_channels = ['']
     optional = ['activationkey', 'base_channel_activationkey', 'gpgkey_url',
-                'gpgkey_id', 'gpgkey_fingerprint', 'yumrepo_url',
-                'yum_repo_label', 'dist_map_release']
+                'gpgkey_id', 'gpgkey_fingerprint', 'repo_url',
+                'yum_repo_label', 'dist_map_release', 'repo_type']
     mandatory = ['label', 'name', 'summary', 'checksum', 'arch', 'section']
 
     config.set(section, 'arch', arch)
@@ -264,9 +276,10 @@ Create everything as well as unlimited activation key for every channel:
                                  % base_info['name'])
             if options.verbose and options.verbose > 1:
                 sys.stdout.write(
-                    "* label=%s, summary=%s, arch=%s, checksum=%s\n" % (
+                    "* label=%s, summary=%s, arch=%s, repo_type=%s, checksum=%s\n" % (
                         base_info['label'], base_info['summary'],
-                        base_info['arch'], base_info['checksum']))
+                        base_info['arch'], base_info.get('repo_type', DEFAULT_REPO_TYPE),
+                        base_info['checksum']))
 
             if not options.dry_run:
                 try:
@@ -279,19 +292,18 @@ Create everything as well as unlimited activation key for every channel:
                                                        'id': base_info['gpgkey_id'],
                                                        'fingerprint': base_info['gpgkey_fingerprint']})
                     client.channel.software.createRepo(key,
-                                                       base_info['yum_repo_label'], 'yum',
-                                                       base_info['yumrepo_url'])
+                                                       base_info['yum_repo_label'], base_info.get('repo_type', DEFAULT_REPO_TYPE),
+                                                       base_info['repo_url'])
                     client.channel.software.associateRepo(key,
                                                           base_info['label'], base_info['yum_repo_label'])
                 except xmlrpclib.Fault as e:
-                    if e.faultCode != 1200:  # ignore if channel exists
-                        sys.stderr.write("ERROR: %s: %s\n" % (
+                    if e.faultCode == 1200:  # ignore if channel exists
+                        sys.stderr.write("WARNING: %s: %s\n" % (
                             base_info['label'], e.faultString))
-                    if e.faultCode == 1200:
+                    else:
                         sys.stderr.write("ERROR: %s: %s\n" % (
                             base_info['label'], e.faultString))
                         sys.exit(2)
-                    continue
 
             if options.key_limit is not None:
                 if options.verbose:
@@ -338,9 +350,9 @@ Create everything as well as unlimited activation key for every channel:
                                  % child_info['name'])
             if options.verbose and options.verbose > 1:
                 sys.stdout.write(
-                    "** label=%s, summary=%s, arch=%s, parent=%s, checksum=%s\n"
+                    "** label=%s, summary=%s, arch=%s, parent=%s, repo_type=%s, checksum=%s\n"
                     % (child_info['label'], child_info['summary'],
-                       child_info['arch'], base_channel_label,
+                       child_info['arch'], base_channel_label, child_info.get('repo_type', DEFAULT_REPO_TYPE),
                        child_info['checksum']))
 
             if not options.dry_run:
@@ -355,15 +367,15 @@ Create everything as well as unlimited activation key for every channel:
                                                        'id': child_info['gpgkey_id'],
                                                        'fingerprint': child_info['gpgkey_fingerprint']})
                     client.channel.software.createRepo(key,
-                                                       child_info['yum_repo_label'], 'yum',
-                                                       child_info['yumrepo_url'])
+                                                       child_info['yum_repo_label'], child_info.get('repo_type', DEFAULT_REPO_TYPE),
+                                                       child_info['repo_url'])
                     client.channel.software.associateRepo(key,
                                                           child_info['label'], child_info['yum_repo_label'])
                 except xmlrpclib.Fault as e:
-                    if e.faultCode != 1200:  # ignore if channel exists
-                        sys.stderr.write("ERROR: %s: %s\n" % (
+                    if e.faultCode == 1200:  # ignore if channel exists
+                        sys.stderr.write("WARNING: %s: %s\n" % (
                             child_info['label'], e.faultString))
-                    if e.faultCode == 1200:
+                    else:
                         sys.stderr.write("ERROR: %s: %s\n" % (
                             child_info['label'], e.faultString))
                         sys.exit(2)

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -54,7 +54,7 @@ name     = Fedora 27 (%(arch)s)
 gpgkey_url = https://getfedora.org/static/F5282EE4.txt
 gpgkey_id = F5282EE4
 gpgkey_fingerprint = 860E 19B0 AFA8 00A1 7518  81A6 F55E 7430 F528 2EE4
-yumrepo_url = https://mirrors.fedoraproject.org/metalink?repo=fedora-27&arch=%(arch)s
+repo_url = https://mirrors.fedoraproject.org/metalink?repo=fedora-27&arch=%(arch)s
 dist_map_release = 27
 
 [fedora27-updates]
@@ -63,7 +63,7 @@ name     = Fedora 27 Updates (%(arch)s)
 archs    = %(_x86_archs)s
 checksum = sha256
 base_channels = fedora27-%(arch)s
-yumrepo_url = https://mirrors.fedoraproject.org/metalink?repo=updates-released-f27&arch=%(arch)s
+repo_url = https://mirrors.fedoraproject.org/metalink?repo=updates-released-f27&arch=%(arch)s
 
 [fedora27-debug]
 label    = %(base_channel)s-debug
@@ -71,7 +71,7 @@ name    = Fedora 27 Debug (%(arch)s)
 archs    = %(_x86_archs)s
 checksum = sha256
 base_channels = fedora27-%(arch)s
-yumrepo_url = https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-27&arch=%(arch)s
+repo_url = https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-27&arch=%(arch)s
 
 [fedora28]
 archs    = %(_x86_archs)s
@@ -80,7 +80,7 @@ name     = Fedora 28 (%(arch)s)
 gpgkey_url = https://getfedora.org/static/9DB62FB1.txt
 gpgkey_id = 9DB62FB1
 gpgkey_fingerprint = 128C F232 A937 1991 C8A6  5695 E08E 7E62 9DB6 2FB1
-yumrepo_url = https://mirrors.fedoraproject.org/metalink?repo=fedora-28&arch=%(arch)s
+repo_url = https://mirrors.fedoraproject.org/metalink?repo=fedora-28&arch=%(arch)s
 dist_map_release = 28
 
 [fedora28-updates]
@@ -89,7 +89,7 @@ name     = Fedora 28 Updates (%(arch)s)
 archs    = %(_x86_archs)s
 checksum = sha256
 base_channels = fedora28-%(arch)s
-yumrepo_url = https://mirrors.fedoraproject.org/metalink?repo=updates-released-f28&arch=%(arch)s
+repo_url = https://mirrors.fedoraproject.org/metalink?repo=updates-released-f28&arch=%(arch)s
 
 [fedora28-debug]
 label    = %(base_channel)s-debug
@@ -97,7 +97,7 @@ name    = Fedora 28 Debug (%(arch)s)
 archs    = %(_x86_archs)s
 checksum = sha256
 base_channels = fedora28-%(arch)s
-yumrepo_url = https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-28&arch=%(arch)s
+repo_url = https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-28&arch=%(arch)s
 
 [fedora28-updates-debug]
 label    = %(base_channel)s-updates-debug
@@ -105,7 +105,7 @@ name    = Fedora 28 Updates Debug (%(arch)s)
 archs    = %(_x86_archs)s
 checksum = sha256
 base_channels = fedora28-%(arch)s
-yumrepo_url = https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f28&arch=%(arch)s
+repo_url = https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f28&arch=%(arch)s
 
 [fedora29]
 archs    = %(_x86_archs)s
@@ -114,7 +114,7 @@ name     = Fedora 29 (%(arch)s)
 gpgkey_url = https://getfedora.org/static/429476B4.txt
 gpgkey_id = 429476B4
 gpgkey_fingerprint = 5A03 B4DD 8254 ECA0 2FDA  1637 A20A A56B 4294 76B4
-yumrepo_url = https://mirrors.fedoraproject.org/metalink?repo=fedora-29&arch=%(arch)s
+repo_url = https://mirrors.fedoraproject.org/metalink?repo=fedora-29&arch=%(arch)s
 dist_map_release = 29
 
 [fedora29-modular]
@@ -123,7 +123,7 @@ name     = Fedora 29 Modular (%(arch)s)
 archs    = %(_x86_archs)s
 checksum = sha256
 base_channels = fedora29-%(arch)s
-yumrepo_url = https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-29&arch=%(arch)s
+repo_url = https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-29&arch=%(arch)s
 
 [fedora29-updates]
 label    = %(base_channel)s-updates
@@ -131,7 +131,7 @@ name     = Fedora 29 Updates (%(arch)s)
 archs    = %(_x86_archs)s
 checksum = sha256
 base_channels = fedora29-%(arch)s
-yumrepo_url = https://mirrors.fedoraproject.org/metalink?repo=updates-released-f29&arch=%(arch)s
+repo_url = https://mirrors.fedoraproject.org/metalink?repo=updates-released-f29&arch=%(arch)s
 
 [fedora29-updates-modular]
 label    = %(base_channel)s-updates-modular
@@ -139,7 +139,7 @@ name     = Fedora 29 Updates Modular (%(arch)s)
 archs    = %(_x86_archs)s
 checksum = sha256
 base_channels = fedora29-%(arch)s
-yumrepo_url = https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f29&arch=%(arch)s
+repo_url = https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f29&arch=%(arch)s
 
 [fedora29-debug]
 label    = %(base_channel)s-debug
@@ -147,7 +147,7 @@ name    = Fedora 29 Debug (%(arch)s)
 archs    = %(_x86_archs)s
 checksum = sha256
 base_channels = fedora29-%(arch)s
-yumrepo_url = https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-29&arch=%(arch)s
+repo_url = https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-29&arch=%(arch)s
 
 [fedora29-updates-debug]
 label    = %(base_channel)s-updates-debug
@@ -155,7 +155,7 @@ name    = Fedora 29 Updates Debug (%(arch)s)
 archs    = %(_x86_archs)s
 checksum = sha256
 base_channels = fedora29-%(arch)s
-yumrepo_url = https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f29&arch=%(arch)s
+repo_url = https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f29&arch=%(arch)s
 
 [centos7]
 archs    = x86_64
@@ -163,7 +163,7 @@ name     = CentOS 7 (%(arch)s)
 gpgkey_url = http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-7
 gpgkey_id = F4A80EB5
 gpgkey_fingerprint = 6341 AB27 53D7 8A78 A7C2  7BB1 24C6 A8A7 F4A8 0EB5
-yumrepo_url = http://mirrorlist.centos.org/?release=7&arch=%(arch)s&repo=os
+repo_url = http://mirrorlist.centos.org/?release=7&arch=%(arch)s&repo=os
 dist_map_release = 7
 
 [centos7-atomic]
@@ -171,91 +171,91 @@ label    = %(base_channel)s-atomic
 archs    = x86_64
 name     = CentOS 7 Atomic (%(arch)s)
 base_channels = centos7-%(arch)s
-yumrepo_url = http://mirror.centos.org/centos-7/7/atomic/%(arch)s
+repo_url = http://mirror.centos.org/centos-7/7/atomic/%(arch)s
 
 [centos7-centosplus]
 label    = %(base_channel)s-centosplus
 archs    = x86_64
 name     = CentOS 7 Plus (%(arch)s)
 base_channels = centos7-%(arch)s
-yumrepo_url = http://mirrorlist.centos.org/?release=7&arch=%(arch)s&repo=centosplus
+repo_url = http://mirrorlist.centos.org/?release=7&arch=%(arch)s&repo=centosplus
 
 [centos7-cloud]
 label    = %(base_channel)s-cloud
 archs    = x86_64
 name     = CentOS 7 Cloud (%(arch)s)
 base_channels = centos7-%(arch)s
-yumrepo_url = http://mirror.centos.org/centos-7/7/cloud/%(arch)s
+repo_url = http://mirror.centos.org/centos-7/7/cloud/%(arch)s
 
 [centos7-cr]
 label    = %(base_channel)s-cr
 archs    = x86_64
 name     = CentOS 7 CR (%(arch)s)
 base_channels = centos7-%(arch)s
-yumrepo_url = http://mirrorlist.centos.org/?release=7&arch=%(arch)s&repo=cr
+repo_url = http://mirrorlist.centos.org/?release=7&arch=%(arch)s&repo=cr
 
 [centos7-extras]
 label    = %(base_channel)s-extras
 archs    = x86_64
 name     = CentOS 7 Extras (%(arch)s)
 base_channels = centos7-%(arch)s
-yumrepo_url = http://mirrorlist.centos.org/?release=7&arch=%(arch)s&repo=extras
+repo_url = http://mirrorlist.centos.org/?release=7&arch=%(arch)s&repo=extras
 
 [centos7-fasttrack]
 label    = %(base_channel)s-fasttrack
 archs    = x86_64
 name     = CentOS 7 FastTrack (%(arch)s)
 base_channels = centos7-%(arch)s
-yumrepo_url = http://mirrorlist.centos.org/?release=7&arch=%(arch)s&repo=fasttrack
+repo_url = http://mirrorlist.centos.org/?release=7&arch=%(arch)s&repo=fasttrack
 
 [centos7-opstools]
 label    = %(base_channel)s-opstools
 archs    = x86_64
 name     = CentOS 7 OpsTools (%(arch)s)
 base_channels = centos7-%(arch)s
-yumrepo_url = http://mirror.centos.org/centos-7/7/opstools/%(arch)s
+repo_url = http://mirror.centos.org/centos-7/7/opstools/%(arch)s
 
 [centos7-paas]
 label    = %(base_channel)s-paas
 archs    = x86_64
 name     = CentOS 7 PaaS (%(arch)s)
 base_channels = centos7-%(arch)s
-yumrepo_url = http://mirror.centos.org/centos-7/7/paas/%(arch)s
+repo_url = http://mirror.centos.org/centos-7/7/paas/%(arch)s
 
 [centos7-rt]
 label    = %(base_channel)s-rt
 archs    = x86_64
 name     = CentOS 7 RT (%(arch)s)
 base_channels = centos7-%(arch)s
-yumrepo_url = http://mirror.centos.org/centos-7/7/rt/%(arch)s
+repo_url = http://mirror.centos.org/centos-7/7/rt/%(arch)s
 
 [centos7-scio]
 label    = %(base_channel)s-scio
 archs    = x86_64
 name     = CentOS 7 Scio (%(arch)s)
 base_channels = centos7-%(arch)s
-yumrepo_url = http://mirror.centos.org/centos-7/7/scio/%(arch)s
+repo_url = http://mirror.centos.org/centos-7/7/scio/%(arch)s
 
 [centos7-storage]
 label    = %(base_channel)s-storage
 archs    = x86_64
 name     = CentOS 7 Storage (%(arch)s)
 base_channels = centos7-%(arch)s
-yumrepo_url = http://mirror.centos.org/centos-7/7/storage/%(arch)s
+repo_url = http://mirror.centos.org/centos-7/7/storage/%(arch)s
 
 [centos7-updates]
 label    = %(base_channel)s-updates
 archs    = x86_64
 name     = CentOS 7 Updates (%(arch)s)
 base_channels = centos7-%(arch)s
-yumrepo_url = http://mirrorlist.centos.org/?release=7&arch=%(arch)s&repo=updates
+repo_url = http://mirrorlist.centos.org/?release=7&arch=%(arch)s&repo=updates
 
 [centos7-virt]
 label    = %(base_channel)s-virt
 archs    = x86_64
 name     = CentOS 7 Virt (%(arch)s)
 base_channels = centos7-%(arch)s
-yumrepo_url = http://mirror.centos.org/centos-7/7/virt/%(arch)s
+repo_url = http://mirror.centos.org/centos-7/7/virt/%(arch)s
 
 [centos7-uyuni-client]
 name     = Uyuni Client Tools for %(base_channel_name)s
@@ -264,7 +264,7 @@ base_channels = centos7-%(arch)s
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-yumrepo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7/
 
 [centos7-uyuni-client-devel]
 name     = Uyuni Client Tools for %(base_channel_name)s (Development)
@@ -273,7 +273,7 @@ base_channels = centos7-%(arch)s
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS7-Uyuni-Client-Tools/CentOS_7/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-yumrepo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS7-Uyuni-Client-Tools/CentOS_7/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS7-Uyuni-Client-Tools/CentOS_7/
 
 [epel7]
 label    = epel7-%(base_channel)s
@@ -283,7 +283,7 @@ base_channels = centos7-%(arch)s scientific7-%(arch)s
 gpgkey_url = http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
 gpgkey_id = 352C64E5
 gpgkey_fingerprint = 91E9 7D7C 4A5E 96F1 7F3E  888F 6A2F AEA2 352C 64E5
-yumrepo_url = http://mirrors.fedoraproject.org/mirrorlist?repo=epel-7&arch=%(arch)s
+repo_url = http://mirrors.fedoraproject.org/mirrorlist?repo=epel-7&arch=%(arch)s
 
 [scientific6]
 archs    = %(_x86_archs)s
@@ -291,7 +291,7 @@ name     = Scientific Linux 6 (%(arch)s)
 gpgkey_url = http://ftp.scientificlinux.org/linux/scientific/6/i386/os/RPM-GPG-KEY-sl6
 gpgkey_id = 9B1FD350
 gpgkey_fingerprint = E2E5 CBB5 6E19 960F F509  6994 915D 75E0 9B1F D350
-yumrepo_url = http://ftp.scientificlinux.org/linux/scientific/6/%(arch)s/os/
+repo_url = http://ftp.scientificlinux.org/linux/scientific/6/%(arch)s/os/
 dist_map_release = 6.2
 
 [scientific6-updates-fast]
@@ -299,14 +299,14 @@ label    = %(base_channel)s-updates-fast
 archs    = %(_x86_archs)s
 name     = Scientific Linux 6 Updates FastBug (%(arch)s)
 base_channels = scientific6-%(arch)s
-yumrepo_url = http://ftp.scientificlinux.org/linux/scientific/6/%(arch)s/updates/fastbugs/
+repo_url = http://ftp.scientificlinux.org/linux/scientific/6/%(arch)s/updates/fastbugs/
 
 [scientific6-updates-security]
 label    = %(base_channel)s-updates-security
 archs    = %(_x86_archs)s
 name     = Scientific Linux 6 Updates Security (%(arch)s)
 base_channels = scientific6-%(arch)s
-yumrepo_url = http://ftp.scientificlinux.org/linux/scientific/6/%(arch)s/updates/security/
+repo_url = http://ftp.scientificlinux.org/linux/scientific/6/%(arch)s/updates/security/
 
 [centos6]
 archs    = %(_x86_archs)s
@@ -314,7 +314,7 @@ name     = CentOS 6 (%(arch)s)
 gpgkey_url = http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-6
 gpgkey_id = C105B9DE
 gpgkey_fingerprint = C1DA C52D 1664 E8A4 386D  BA43 0946 FCA2 C105 B9DE
-yumrepo_url = http://mirrorlist.centos.org/?release=6&arch=%(arch)s&repo=os
+repo_url = http://mirrorlist.centos.org/?release=6&arch=%(arch)s&repo=os
 dist_map_release = 6
 
 [centos6-centosplus]
@@ -322,35 +322,35 @@ label    = %(base_channel)s-centosplus
 archs    = %(_x86_archs)s
 name     = CentOS 6 Plus (%(arch)s)
 base_channels = centos6-%(arch)s
-yumrepo_url = http://mirrorlist.centos.org/?release=6&arch=%(arch)s&repo=centosplus
+repo_url = http://mirrorlist.centos.org/?release=6&arch=%(arch)s&repo=centosplus
 
 [centos6-contrib]
 label    = %(base_channel)s-contrib
 archs    = %(_x86_archs)s
 name     = CentOS 6 Contrib (%(arch)s)
 base_channels = centos6-%(arch)s
-yumrepo_url = http://mirrorlist.centos.org/?release=6&arch=%(arch)s&repo=contrib
+repo_url = http://mirrorlist.centos.org/?release=6&arch=%(arch)s&repo=contrib
 
 [centos6-extras]
 label    = %(base_channel)s-extras
 archs    = %(_x86_archs)s
 name     = CentOS 6 Extras (%(arch)s)
 base_channels = centos6-%(arch)s
-yumrepo_url = http://mirrorlist.centos.org/?release=6&arch=%(arch)s&repo=extras
+repo_url = http://mirrorlist.centos.org/?release=6&arch=%(arch)s&repo=extras
 
 [centos6-fasttrack]
 label    = %(base_channel)s-fasttrack
 archs    = %(_x86_archs)s
 name     = CentOS 6 FastTrack (%(arch)s)
 base_channels = centos6-%(arch)s
-yumrepo_url = http://mirrorlist.centos.org/?release=6&arch=%(arch)s&repo=fasttrack
+repo_url = http://mirrorlist.centos.org/?release=6&arch=%(arch)s&repo=fasttrack
 
 [centos6-updates]
 label    = %(base_channel)s-updates
 archs    = %(_x86_archs)s
 name     = CentOS 6 Updates (%(arch)s)
 base_channels = centos6-%(arch)s
-yumrepo_url = http://mirrorlist.centos.org/?release=6&arch=%(arch)s&repo=updates
+repo_url = http://mirrorlist.centos.org/?release=6&arch=%(arch)s&repo=updates
 
 [centos6-uyuni-client]
 name     = Uyuni Client Tools for %(base_channel_name)s
@@ -359,7 +359,7 @@ base_channels = centos6-%(arch)s
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS6-Uyuni-Client-Tools/CentOS_6/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-yumrepo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS6-Uyuni-Client-Tools/CentOS_6/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS6-Uyuni-Client-Tools/CentOS_6/
 
 [centos6-uyuni-client-devel]
 name     = Uyuni Client Tools for %(base_channel_name)s (Development)
@@ -368,7 +368,7 @@ base_channels = centos6-%(arch)s
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS6-Uyuni-Client-Tools/CentOS_6/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-yumrepo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS6-Uyuni-Client-Tools/CentOS_6/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS6-Uyuni-Client-Tools/CentOS_6/
 
 [epel6]
 label    = epel6-%(base_channel)s
@@ -378,7 +378,7 @@ base_channels = centos6-%(arch)s scientific6-%(arch)s
 gpgkey_url = http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6
 gpgkey_id = 0608B895
 gpgkey_fingerprint = 8C3B E96A F230 9184 DA5C  0DAE 3B49 DF2A 0608 B895
-yumrepo_url = http://mirrors.fedoraproject.org/mirrorlist?repo=epel-6&arch=%(arch)s
+repo_url = http://mirrors.fedoraproject.org/mirrorlist?repo=epel-6&arch=%(arch)s
 
 [spacewalk28-client-scientific6]
 name     = Spacewalk Client 2.8 for %(base_channel_name)s
@@ -387,7 +387,7 @@ base_channels = scientific6-%(arch)s
 gpgkey_url = %(_spacewalk_28client_gpgkey_url)s
 gpgkey_id = %(_spacewalk_28client_gpgkey_id)s
 gpgkey_fingerprint = %(_spacewalk_28client_gpgkey_fingerprint)s
-yumrepo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/spacewalk-2.8-client/epel-6-%(arch)s/
+repo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/spacewalk-2.8-client/epel-6-%(arch)s/
 
 [spacewalk28-client-fedora26]
 name     = Spacewalk Client 2.8 for %(base_channel_name)s
@@ -396,7 +396,7 @@ base_channels = fedora26-%(arch)s
 gpgkey_url = %(_spacewalk_28client_gpgkey_url)s
 gpgkey_id = %(_spacewalk_28client_gpgkey_id)s
 gpgkey_fingerprint = %(_spacewalk_28client_gpgkey_fingerprint)s
-yumrepo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/spacewalk-2.8-client/fedora-26-%(arch)s/
+repo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/spacewalk-2.8-client/fedora-26-%(arch)s/
 
 [spacewalk28-client-fedora27]
 name     = Spacewalk Client 2.8 for %(base_channel_name)s
@@ -405,7 +405,7 @@ base_channels = fedora27-%(arch)s
 gpgkey_url = %(_spacewalk_28client_gpgkey_url)s
 gpgkey_id = %(_spacewalk_28client_gpgkey_id)s
 gpgkey_fingerprint = %(_spacewalk_28client_gpgkey_fingerprint)s
-yumrepo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/spacewalk-2.8-client/fedora-27-%(arch)s/
+repo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/spacewalk-2.8-client/fedora-27-%(arch)s/
 
 [spacewalk28-client-fedora28]
 name     = Spacewalk Client 2.8 for %(base_channel_name)s
@@ -414,7 +414,7 @@ base_channels = fedora28-%(arch)s
 gpgkey_url = %(_spacewalk_28client_gpgkey_url)s
 gpgkey_id = %(_spacewalk_28client_gpgkey_id)s
 gpgkey_fingerprint = %(_spacewalk_28client_gpgkey_fingerprint)s
-yumrepo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/spacewalk-2.8-client/fedora-28-%(arch)s/
+repo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/spacewalk-2.8-client/fedora-28-%(arch)s/
 
 [spacewalk28-client-oraclelinux6]
 name     = Spacewalk Client 2.8 for %(base_channel_name)s
@@ -423,7 +423,7 @@ base_channels = oraclelinux6-%(arch)s
 gpgkey_url = %(_spacewalk_28client_gpgkey_url)s
 gpgkey_id = %(_spacewalk_28client_gpgkey_id)s
 gpgkey_fingerprint = %(_spacewalk_28client_gpgkey_fingerprint)s
-yumrepo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/spacewalk-2.8-client/epel-6-%(arch)s/
+repo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/spacewalk-2.8-client/epel-6-%(arch)s/
 
 [spacewalk28-client-oraclelinux7]
 name     = Spacewalk Client 2.8 for %(base_channel_name)s
@@ -432,7 +432,7 @@ base_channels = oraclelinux7-%(arch)s
 gpgkey_url = %(_spacewalk_28client_gpgkey_url)s
 gpgkey_id = %(_spacewalk_28client_gpgkey_id)s
 gpgkey_fingerprint = %(_spacewalk_28client_gpgkey_fingerprint)s
-yumrepo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/spacewalk-2.8-client/epel-7-%(arch)s/
+repo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/spacewalk-2.8-client/epel-7-%(arch)s/
 
 
 [spacewalk-nightly-client-fedora27]
@@ -442,7 +442,7 @@ base_channels = fedora27-%(arch)s
 gpgkey_url = %(_spacewalk_nightlyclient_gpgkey_url)s
 gpgkey_id = %(_spacewalk_nightlyclient_gpgkey_id)s
 gpgkey_fingerprint = %(_spacewalk_nightlyclient_gpgkey_fingerprint)s
-yumrepo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/nightly-client/fedora-27-%(arch)s/
+repo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/nightly-client/fedora-27-%(arch)s/
 
 [spacewalk-nightly-client-scientific6]
 name     = Spacewalk Client nightly for %(base_channel_name)s
@@ -451,7 +451,7 @@ base_channels = scientific6-%(arch)s
 gpgkey_url = %(_spacewalk_nightlyclient_gpgkey_url)s
 gpgkey_id = %(_spacewalk_nightlyclient_gpgkey_id)s
 gpgkey_fingerprint = %(_spacewalk_nightlyclient_gpgkey_fingerprint)s
-yumrepo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/nightly-client/epel-6-%(arch)s/
+repo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/nightly-client/epel-6-%(arch)s/
 
 [spacewalk-nightly-client-oraclelinux6]
 name     = Spacewalk Client nightly for %(base_channel_name)s
@@ -460,7 +460,7 @@ base_channels = oraclelinux6-%(arch)s
 gpgkey_url = %(_spacewalk_nightlyclient_gpgkey_url)s
 gpgkey_id = %(_spacewalk_nightlyclient_gpgkey_id)s
 gpgkey_fingerprint = %(_spacewalk_nightlyclient_gpgkey_fingerprint)s
-yumrepo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/nightly-client/epel-6-%(arch)s/
+repo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/nightly-client/epel-6-%(arch)s/
 
 [spacewalk-nightly-client-oraclelinux7]
 name     = Spacewalk Client nightly for %(base_channel_name)s
@@ -469,7 +469,7 @@ base_channels = oraclelinux7-%(arch)s
 gpgkey_url = %(_spacewalk_nightlyclient_gpgkey_url)s
 gpgkey_id = %(_spacewalk_nightlyclient_gpgkey_id)s
 gpgkey_fingerprint = %(_spacewalk_nightlyclient_gpgkey_fingerprint)s
-yumrepo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/nightly-client/epel-7-%(arch)s/
+repo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/nightly-client/epel-7-%(arch)s/
 
 #---
 
@@ -480,7 +480,7 @@ name     = openSUSE Leap 42.3 (%(arch)s)
 gpgkey_url = http://download.opensuse.org/distribution/leap/42.3/repo/oss/suse/repodata/repomd.xml.key
 gpgkey_id = 3DBDC284
 gpgkey_fingerprint = 22C0 7BA5 3417 8CD0 2EFE  22AA B88B 2FD4 3DBD C284
-yumrepo_url = http://download.opensuse.org/distribution/leap/42.3/repo/oss/suse/
+repo_url = http://download.opensuse.org/distribution/leap/42.3/repo/oss/suse/
 dist_map_release = 42.3
 
 [opensuse_leap42_3-non-oss]
@@ -489,7 +489,7 @@ name     = openSUSE 42.3 non oss (%(arch)s)
 archs    = x86_64
 checksum = sha256
 base_channels = opensuse_leap42_3-%(arch)s
-yumrepo_url = http://download.opensuse.org/distribution/leap/42.3/repo/non-oss/suse/
+repo_url = http://download.opensuse.org/distribution/leap/42.3/repo/non-oss/suse/
 
 [opensuse_leap42_3-updates]
 label    = %(base_channel)s-updates
@@ -497,7 +497,7 @@ name     = openSUSE Leap 42.3 Updates (%(arch)s)
 archs    = x86_64
 checksum = sha256
 base_channels = opensuse_leap42_3-%(arch)s
-yumrepo_url = http://download.opensuse.org/update/leap/42.3/oss/
+repo_url = http://download.opensuse.org/update/leap/42.3/oss/
 
 [opensuse_leap42_3-non-oss-updates]
 label    = %(base_channel)s-non-oss-updates
@@ -505,7 +505,7 @@ name     = openSUSE Leap 42.3 non oss Updates (%(arch)s)
 archs    = x86_64
 checksum = sha256
 base_channels = opensuse_leap42_3-%(arch)s
-yumrepo_url = http://download.opensuse.org/update/leap/42.3/non-oss/
+repo_url = http://download.opensuse.org/update/leap/42.3/non-oss/
 
 [opensuse_leap42_3-uyuni-client]
 name     = Uyuni Client Tools for %(base_channel_name)s
@@ -515,7 +515,7 @@ checksum = sha256
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_42-Uyuni-Client-Tools/openSUSE_Leap_42.3/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-yumrepo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_42-Uyuni-Client-Tools/openSUSE_Leap_42.3/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_42-Uyuni-Client-Tools/openSUSE_Leap_42.3/
 
 [opensuse_leap42_3-uyuni-client-devel]
 name     = Uyuni Client Tools for %(base_channel_name)s (Development)
@@ -525,7 +525,7 @@ checksum = sha256
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_42-Uyuni-Client-Tools/openSUSE_Leap_42.3/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-yumrepo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_42-Uyuni-Client-Tools/openSUSE_Leap_42.3/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_42-Uyuni-Client-Tools/openSUSE_Leap_42.3/
 
 [opensuse_leap15_0]
 checksum = sha256
@@ -534,7 +534,7 @@ name     = openSUSE Leap 15.0 (%(arch)s)
 gpgkey_url = http://download.opensuse.org/distribution/leap/15.0/repo/oss/repodata/repomd.xml.key
 gpgkey_id = 3DBDC284
 gpgkey_fingerprint = 22C0 7BA5 3417 8CD0 2EFE  22AA B88B 2FD4 3DBD C284
-yumrepo_url = http://download.opensuse.org/distribution/leap/15.0/repo/oss/
+repo_url = http://download.opensuse.org/distribution/leap/15.0/repo/oss/
 dist_map_release = 15.0
 
 [opensuse_leap15_0-non-oss]
@@ -543,7 +543,7 @@ name     = openSUSE 15.0 non oss (%(arch)s)
 archs    = x86_64
 checksum = sha256
 base_channels = opensuse_leap15_0-%(arch)s
-yumrepo_url = http://download.opensuse.org/distribution/leap/15.0/repo/non-oss/
+repo_url = http://download.opensuse.org/distribution/leap/15.0/repo/non-oss/
 
 [opensuse_leap15_0-updates]
 label    = %(base_channel)s-updates
@@ -551,7 +551,7 @@ name     = openSUSE Leap 15.0 Updates (%(arch)s)
 archs    = x86_64
 checksum = sha256
 base_channels = opensuse_leap15_0-%(arch)s
-yumrepo_url = http://download.opensuse.org/update/leap/15.0/oss/
+repo_url = http://download.opensuse.org/update/leap/15.0/oss/
 
 [opensuse_leap15_0-non-oss-updates]
 label    = %(base_channel)s-non-oss-updates
@@ -559,7 +559,7 @@ name     = openSUSE Leap 15.0 non oss Updates (%(arch)s)
 archs    = x86_64
 checksum = sha256
 base_channels = opensuse_leap15_0-%(arch)s
-yumrepo_url = http://download.opensuse.org/update/leap/15.0/non-oss/
+repo_url = http://download.opensuse.org/update/leap/15.0/non-oss/
 
 [opensuse_leap15_0-uyuni-client]
 name     = Uyuni Client Tools for %(base_channel_name)s
@@ -569,7 +569,7 @@ checksum = sha256
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-yumrepo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
 
 [opensuse_leap15_0-uyuni-client-devel]
 name     = Uyuni Client Tools for %(base_channel_name)s (Development)
@@ -579,7 +579,7 @@ checksum = sha256
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-yumrepo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
 
 [opensuse_leap15_1]
 checksum = sha256
@@ -588,7 +588,7 @@ name     = openSUSE Leap 15.1 (%(arch)s)
 gpgkey_url = http://download.opensuse.org/distribution/leap/15.1/repo/oss/repodata/repomd.xml.key
 gpgkey_id = 3DBDC284
 gpgkey_fingerprint = 22C0 7BA5 3417 8CD0 2EFE  22AA B88B 2FD4 3DBD C284
-yumrepo_url = http://download.opensuse.org/distribution/leap/15.1/repo/oss/
+repo_url = http://download.opensuse.org/distribution/leap/15.1/repo/oss/
 dist_map_release = 15.0
 
 [opensuse_leap15_1-non-oss]
@@ -597,7 +597,7 @@ name     = openSUSE 15.1 non oss (%(arch)s)
 archs    = x86_64
 checksum = sha256
 base_channels = opensuse_leap15_1-%(arch)s
-yumrepo_url = http://download.opensuse.org/distribution/leap/15.1/repo/non-oss/
+repo_url = http://download.opensuse.org/distribution/leap/15.1/repo/non-oss/
 
 [opensuse_leap15_1-updates]
 label    = %(base_channel)s-updates
@@ -605,7 +605,7 @@ name     = openSUSE Leap 15.1 Updates (%(arch)s)
 archs    = x86_64
 checksum = sha256
 base_channels = opensuse_leap15_1-%(arch)s
-yumrepo_url = http://download.opensuse.org/update/leap/15.1/oss/
+repo_url = http://download.opensuse.org/update/leap/15.1/oss/
 
 [opensuse_leap15_1-non-oss-updates]
 label    = %(base_channel)s-non-oss-updates
@@ -613,7 +613,7 @@ name     = openSUSE Leap 15.1 non oss Updates (%(arch)s)
 archs    = x86_64
 checksum = sha256
 base_channels = opensuse_leap15_1-%(arch)s
-yumrepo_url = http://download.opensuse.org/update/leap/15.1/non-oss/
+repo_url = http://download.opensuse.org/update/leap/15.1/non-oss/
 
 [opensuse_leap15_1-uyuni-client]
 name     = Uyuni Client Tools for %(base_channel_name)s
@@ -623,7 +623,7 @@ checksum = sha256
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.1/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-yumrepo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.1/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.1/
 
 [opensuse_leap15_1-uyuni-client-devel]
 name     = Uyuni Client Tools for %(base_channel_name)s (Development)
@@ -633,7 +633,7 @@ checksum = sha256
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.1/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-yumrepo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.1/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.1/
 
 [sles12-sp3-uyuni-client]
 name     = Uyuni Client Tools for SLES12 SP3
@@ -643,7 +643,7 @@ checksum = sha256
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/SLE12-Uyuni-Client-Tools/SLE_12/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-yumrepo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/SLE12-Uyuni-Client-Tools/SLE_12/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/SLE12-Uyuni-Client-Tools/SLE_12/
 
 [sles12-sp3-uyuni-client-devel]
 name     = Uyuni Client Tools for SLES12 SP3 (Development)
@@ -653,7 +653,7 @@ checksum = sha256
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE12-Uyuni-Client-Tools/SLE_12/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-yumrepo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE12-Uyuni-Client-Tools/SLE_12/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE12-Uyuni-Client-Tools/SLE_12/
 
 [sles12-sp4-uyuni-client]
 name     = Uyuni Client Tools for SLES12 SP4
@@ -663,7 +663,7 @@ checksum = sha256
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/SLE12-Uyuni-Client-Tools/SLE_12/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-yumrepo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/SLE12-Uyuni-Client-Tools/SLE_12/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/SLE12-Uyuni-Client-Tools/SLE_12/
 
 [sles12-sp4-uyuni-client-devel]
 name     = Uyuni Client Tools for SLES12 SP4 (Development)
@@ -673,7 +673,7 @@ checksum = sha256
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE12-Uyuni-Client-Tools/SLE_12/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-yumrepo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE12-Uyuni-Client-Tools/SLE_12/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE12-Uyuni-Client-Tools/SLE_12/
 
 [sles15-uyuni-client]
 name     = Uyuni Client Tools for SLES15
@@ -683,7 +683,7 @@ checksum = sha256
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-yumrepo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/
 
 [sles15-uyuni-client-devel]
 name     = Uyuni Client Tools for SLES15 (Development)
@@ -693,7 +693,7 @@ checksum = sha256
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-yumrepo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/
 
 [sles15-sp1-uyuni-client]
 name     = Uyuni Client Tools for SLES15 SP1
@@ -703,7 +703,7 @@ checksum = sha256
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-yumrepo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/
 
 [sles15-sp1-devel-uyuni-client]
 name     = Uyuni Client Tools for SLES15 SP1 (Development)
@@ -713,7 +713,7 @@ checksum = sha256
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-yumrepo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/
 
 [oraclelinux7]
 archs    = x86_64
@@ -722,7 +722,7 @@ checksum = sha256
 gpgkey_url = http://yum.oracle.com/RPM-GPG-KEY-oracle-ol7
 gpgkey_id  = EC551F03
 gpgkey_fingerprint = 4214 4123 FECF C55B 9086  313D 72F9 7B74 EC55 1F03
-yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL7/latest/%(arch)s/
+repo_url = http://yum.oracle.com/repo/OracleLinux/OL7/latest/%(arch)s/
 dist_map_release = 7
 
 [oraclelinux7-optional]
@@ -730,119 +730,119 @@ label    = %(base_channel)s-optional
 archs    = x86_64
 name     = Optional Packages for Oracle Linux 7 (%(arch)s)
 base_channels = oraclelinux7-%(arch)s
-yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL7/optional/latest/%(arch)s/
+repo_url = http://yum.oracle.com/repo/OracleLinux/OL7/optional/latest/%(arch)s/
 
 [oraclelinux7-addons]
 label    = %(base_channel)s-addons
 archs    = x86_64
 name     = Addons for Oracle Linux 7 (%(arch)s)
 base_channels = oraclelinux7-%(arch)s
-yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL7/addons/%(arch)s/
+repo_url = http://yum.oracle.com/repo/OracleLinux/OL7/addons/%(arch)s/
 
 [oraclelinux7-uek-r4]
 label    = %(base_channel)s-uek-r4
 archs    = x86_64
 name     = Latest Unbreakable Enterprise Kernel Release 4 for Oracle Linux 7 (%(arch)s)
 base_channels = oraclelinux7-%(arch)s
-yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL7/UEKR4/%(arch)s/
+repo_url = http://yum.oracle.com/repo/OracleLinux/OL7/UEKR4/%(arch)s/
 
 [oraclelinux7-uek-r3]
 label    = %(base_channel)s-uek-r3
 archs    = x86_64
 name     = Latest Unbreakable Enterprise Kernel Release 3 for Oracle Linux 7 (%(arch)s)
 base_channels = oraclelinux7-%(arch)s
-yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL7/UEKR3/%(arch)s/
+repo_url = http://yum.oracle.com/repo/OracleLinux/OL7/UEKR3/%(arch)s/
 
 [oraclelinux7-mysql55]
 label    = %(base_channel)s-mysql55
 archs    = x86_64
 name     = MySQL 5.5 for Oracle Linux 7 (%(arch)s)
 base_channels = oraclelinux7-%(arch)s
-yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL7/MySQL55/%(arch)s/
+repo_url = http://yum.oracle.com/repo/OracleLinux/OL7/MySQL55/%(arch)s/
 
 [oraclelinux7-mysql56]
 label    = %(base_channel)s-mysql56
 archs    = x86_64
 name     = MySQL 5.6 for Oracle Linux 7 (%(arch)s)
 base_channels = oraclelinux7-%(arch)s
-yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL7/MySQL56/%(arch)s/
+repo_url = http://yum.oracle.com/repo/OracleLinux/OL7/MySQL56/%(arch)s/
 
 [oraclelinux7-mysql57]
 label    = %(base_channel)s-mysql57
 archs    = x86_64
 name     = MySQL 5.7 for Oracle Linux 7 (%(arch)s)
 base_channels = oraclelinux7-%(arch)s
-yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL7/MySQL57_community/%(arch)s/
+repo_url = http://yum.oracle.com/repo/OracleLinux/OL7/MySQL57_community/%(arch)s/
 
 [oraclelinux7-spacewalk22-client]
 label    = %(base_channel)s-spacewalk22-client
 archs    = x86_64
 name     = Spacewalk 2.2 Client for Oracle Linux 7 (%(arch)s)
 base_channels = oraclelinux7-%(arch)s
-yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL7/spacewalk22/client/%(arch)s/
+repo_url = http://yum.oracle.com/repo/OracleLinux/OL7/spacewalk22/client/%(arch)s/
 
 [oraclelinux7-spacewalk22-server]
 label    = %(base_channel)s-spacewalk22-server
 archs    = x86_64
 name     = Spacewalk 2.2 Server for Oracle Linux 7 (%(arch)s)
 base_channels = oraclelinux7-%(arch)s
-yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL7/spacewalk22/server/%(arch)s/
+repo_url = http://yum.oracle.com/repo/OracleLinux/OL7/spacewalk22/server/%(arch)s/
 
 [oraclelinux7-spacewalk24-client]
 label    = %(base_channel)s-spacewalk24-client
 archs    = x86_64
 name     = Spacewalk 2.4 Client for Oracle Linux 7 (%(arch)s)
 base_channels = oraclelinux7-%(arch)s
-yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL7/spacewalk24/client/%(arch)s/
+repo_url = http://yum.oracle.com/repo/OracleLinux/OL7/spacewalk24/client/%(arch)s/
 
 [oraclelinux7-spacewalk24-server]
 label    = %(base_channel)s-spacewalk24-server
 archs    = x86_64
 name     = Spacewalk 2.4 Server for Oracle Linux 7 (%(arch)s)
 base_channels = oraclelinux7-%(arch)s
-yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL7/spacewalk24/server/%(arch)s/
+repo_url = http://yum.oracle.com/repo/OracleLinux/OL7/spacewalk24/server/%(arch)s/
 
 [oraclelinux7-openstack20]
 label     = %(base_channel)s-openstack20
 archs     = x86_64
 name      = OpenStack 2.0 packages for Oracle Linux 7 (%(arch)s)
 base_channels = oraclelinux7-%(arch)s
-yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL7/openstack20/%(arch)s/
+repo_url = http://yum.oracle.com/repo/OracleLinux/OL7/openstack20/%(arch)s/
 
 [oraclelinux7-openstack21]
 label     = %(base_channel)s-openstack21
 archs     = x86_64
 name      = OpenStack 2.1 packages for Oracle Linux 7 (%(arch)s)
 base_channels = oraclelinux7-%(arch)s
-yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL7/openstack21/%(arch)s/
+repo_url = http://yum.oracle.com/repo/OracleLinux/OL7/openstack21/%(arch)s/
 
 [oraclelinux7-openstack30]
 label     = %(base_channel)s-openstack30
 archs     = x86_64
 name      = OpenStack 3.0 packages for Oracle Linux 7 (%(arch)s)
 base_channels = oraclelinux7-%(arch)s
-yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL7/openstack30/%(arch)s/
+repo_url = http://yum.oracle.com/repo/OracleLinux/OL7/openstack30/%(arch)s/
 
 [oraclelinux7-openstack30-extras]
 label     = %(base_channel)s-openstack30-extras
 archs     = x86_64
 name      = OpenStack 3.0 Extra packages for Oracle Linux 7 (%(arch)s)
 base_channels = oraclelinux7-%(arch)s
-yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL7/openstack_extras/%(arch)s/
+repo_url = http://yum.oracle.com/repo/OracleLinux/OL7/openstack_extras/%(arch)s/
 
 [oraclelinux7-scl]
 label     = %(base_channel)s-scl
 archs    = x86_64
 name      = Software Collection Library packages for Oracle Linux 7 (%(arch)s)
 base_channels = oraclelinux7-%(arch)s
-yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL7/SoftwareCollections/%(arch)s/
+repo_url = http://yum.oracle.com/repo/OracleLinux/OL7/SoftwareCollections/%(arch)s/
 
 [oraclelinux7-ceph]
 label     = %(base_channel)s-ceph
 archs    = x86_64
 name      = Ceph Storage for Oracle Linux Release 2.0 for Oracle Linux 7 (%(arch)s)
 base_channels = oraclelinux7-%(arch)s
-yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL7/ceph/%(arch)s/
+repo_url = http://yum.oracle.com/repo/OracleLinux/OL7/ceph/%(arch)s/
 
 [oraclelinux6]
 archs    = %(_x86_archs)s
@@ -851,7 +851,7 @@ checksum = sha256
 gpgkey_url = http://yum.oracle.com/RPM-GPG-KEY-oracle-ol6
 gpgkey_id = EC551F03
 gpgkey_fingerprint = 4214 4123 FECF C55B 9086  313D 72F9 7B74 EC55 1F03
-yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL6/latest/%(arch)s/
+repo_url = http://yum.oracle.com/repo/OracleLinux/OL6/latest/%(arch)s/
 dist_map_release = 6
 
 [oraclelinux6-addons]
@@ -859,98 +859,98 @@ label    = %(base_channel)s-addons
 archs    = %(_x86_archs)s
 name     = Addons for Oracle Linux 6 (%(arch)s)
 base_channels = oraclelinux6-%(arch)s
-yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL6/addons/%(arch)s/
+repo_url = http://yum.oracle.com/repo/OracleLinux/OL6/addons/%(arch)s/
 
 [oraclelinux6-uek-r2]
 label    = %(base_channel)s-uek-r2
 archs    = %(_x86_archs)s
 name     = Latest Unbreakable Enterprise Kernel Release 2 for Oracle Linux 6 (%(arch)s)
 base_channels = oraclelinux6-%(arch)s
-yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL6/UEK/latest/%(arch)s/
+repo_url = http://yum.oracle.com/repo/OracleLinux/OL6/UEK/latest/%(arch)s/
 
 [oraclelinux6-uek-r3]
 label    = %(base_channel)s-uek-r3
 archs    = x86_64
 name     = Latest Unbreakable Enterprise Kernel Release 3 for Oracle Linux 6 (%(arch)s)
 base_channels = oraclelinux6-%(arch)s
-yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL6/UEKR3/latest/%(arch)s/
+repo_url = http://yum.oracle.com/repo/OracleLinux/OL6/UEKR3/latest/%(arch)s/
 
 [oraclelinux6-uek-r4]
 label    = %(base_channel)s-uek-r4
 archs    = x86_64
 name     = Latest Unbreakable Enterprise Kernel Release 4 for Oracle Linux 6 (%(arch)s)
 base_channels = oraclelinux6-%(arch)s
-yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL6/UEKR4/latest/%(arch)s/
+repo_url = http://yum.oracle.com/repo/OracleLinux/OL6/UEKR4/latest/%(arch)s/
 
 [oraclelinux6-mysql55]
 label    = %(base_channel)s-mysql55
 archs    = %(_x86_archs)s
 name     = MySQL 5.5 for Oracle Linux 6 (%(arch)s)
 base_channels = oraclelinux6-%(arch)s
-yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL6/MySQL/%(arch)s/
+repo_url = http://yum.oracle.com/repo/OracleLinux/OL6/MySQL/%(arch)s/
 
 [oraclelinux6-mysql56]
 label    = %(base_channel)s-mysql56
 archs    = %(_x86_archs)s
 name     = MySQL 5.6 for Oracle Linux 6 (%(arch)s)
 base_channels = oraclelinux6-%(arch)s
-yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL6/MySQL56/%(arch)s/
+repo_url = http://yum.oracle.com/repo/OracleLinux/OL6/MySQL56/%(arch)s/
 
 [oraclelinux6-mysql57]
 label    = %(base_channel)s-mysql57
 archs    = %(_x86_archs)s
 name     = MySQL 5.7 for Oracle Linux 6 (%(arch)s)
 base_channels = oraclelinux7-%(arch)s
-yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL6/MySQL57_community/%(arch)s/
+repo_url = http://yum.oracle.com/repo/OracleLinux/OL6/MySQL57_community/%(arch)s/
 
 [oraclelinux6-playground]
 label    = %(base_channel)s-playground
 archs    = x86_64
 name     = Playground (Mainline) Kernels for Oracle Linux 6 (%(arch)s)
 base_channels = oraclelinux6-%(arch)s
-yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL6/playground/latest/%(arch)s/
+repo_url = http://yum.oracle.com/repo/OracleLinux/OL6/playground/latest/%(arch)s/
 
 [oraclelinux6-spacewalk22-server]
 label    = %(base_channel)s-spacewalk22-server
 archs    = x86_64
 name     = Spacewalk 2.2 Server for Oracle Linux 6 (%(arch)s)
 base_channels = oraclelinux6-%(arch)s
-yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL6/spacewalk22/server/%(arch)s/
+repo_url = http://yum.oracle.com/repo/OracleLinux/OL6/spacewalk22/server/%(arch)s/
 
 [oraclelinux6-spacewalk22-client]
 label    = %(base_channel)s-spacewalk22-client
 archs    = %(_x86_archs)s
 name     = Spacewalk 2.2 Client for Oracle Linux 6 (%(arch)s)
 base_channels = oraclelinux6-%(arch)s
-yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL6/spacewalk22/client/%(arch)s/
+repo_url = http://yum.oracle.com/repo/OracleLinux/OL6/spacewalk22/client/%(arch)s/
 
 [oraclelinux6-spacewalk24-server]
 label    = %(base_channel)s-spacewalk24-server
 archs    = x86_64
 name     = Spacewalk 2.4 Server for Oracle Linux 6 (%(arch)s)
 base_channels = oraclelinux6-%(arch)s
-yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL6/spacewalk24/server/%(arch)s/
+repo_url = http://yum.oracle.com/repo/OracleLinux/OL6/spacewalk24/server/%(arch)s/
 
 [oraclelinux6-spacewalk24-client]
 label    = %(base_channel)s-spacewalk24-client
 archs    = %(_x86_archs)s
 name     = Spacewalk 2.4 Client for Oracle Linux 6 (%(arch)s)
 base_channels = oraclelinux6-%(arch)s
-yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL6/spacewalk24/client/%(arch)s/
+repo_url = http://yum.oracle.com/repo/OracleLinux/OL6/spacewalk24/client/%(arch)s/
 
 [oraclelinux6-scl]
 label     = %(base_channel)s-scl
 archs    = x86_64
 name      = Software Collection Library packages for Oracle Linux 6 (%(arch)s)
 base_channels = oraclelinux6-%(arch)s
-yumrepo_url = http://public-yum.oracle.com/repo/OracleLinux/OL6/SoftwareCollections/%(arch)s/
+repo_url = http://public-yum.oracle.com/repo/OracleLinux/OL6/SoftwareCollections/%(arch)s/
 
 [oraclelinux6-openstack30]
 label     = %(base_channel)s-openstack30
 archs     = x86_64
 name      = OpenStack 3.0 packages for Oracle Linux 6 (%(arch)s)
 base_channels = oraclelinux6-%(arch)s
-yumrepo_url = http://yum.oracle.com/repo/OracleLinux/OL6/openstack30/%(arch)s/
+repo_url = http://yum.oracle.com/repo/OracleLinux/OL6/openstack30/%(arch)s/
 
 [uyuni-server-40]
 name     = Uyuni Server 4.0 for %(base_channel_name)s
@@ -960,7 +960,7 @@ checksum = sha256
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-4.0-POOL-x86_64-Media1/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-yumrepo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-4.0-POOL-x86_64-Media1/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-4.0-POOL-x86_64-Media1/
 
 [uyuni-server-devel]
 name     = Uyuni Server for %(base_channel_name)s (Development)
@@ -970,7 +970,7 @@ checksum = sha256
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_42.3/repo/Uyuni-Server-4.0-POOL-x86_64-Media1/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-yumrepo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_42.3/repo/Uyuni-Server-4.0-POOL-x86_64-Media1/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_42.3/repo/Uyuni-Server-4.0-POOL-x86_64-Media1/
 
 [uyuni-proxy-40]
 name     = Uyuni Proxy 4.0 for %(base_channel_name)s
@@ -980,7 +980,7 @@ checksum = sha256
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Proxy-4.0-POOL-x86_64-Media1/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-yumrepo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Proxy-4.0-POOL-x86_64-Media1/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Proxy-4.0-POOL-x86_64-Media1/
 
 [uyuni-proxy-devel]
 name     = Uyuni Proxy for %(base_channel_name)s (Development)
@@ -990,4 +990,82 @@ checksum = sha256
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_42.3/repo/Uyuni-Proxy-4.0-POOL-x86_64-Media1/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-yumrepo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_42.3/repo/Uyuni-Proxy-4.0-POOL-x86_64-Media1/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_42.3/repo/Uyuni-Proxy-4.0-POOL-x86_64-Media1/
+
+[ubuntu-1604-pool-amd64]
+label    = ubuntu-16.04-pool-amd64
+checksum = sha256
+archs    = amd64-deb
+repo_type = deb
+name     = ubuntu-16.04-pool for amd64
+gpgkey_url =
+gpgkey_id =
+gpgkey_fingerprint =
+repo_url = http://localhost/pub/repositories/empty-deb/?uniquekey=1604
+
+[ubuntu-1604-amd64-main]
+label    = ubuntu-1604-amd64-main
+checksum = sha256
+archs    = amd64-deb
+repo_type = deb
+name     = Ubuntu 16.04 LTS AMD64 Main
+base_channels = ubuntu-16.04-pool-amd64
+repo_url = http://mirror.example.com/ubuntu/dists/xenial/main/binary-amd64/
+
+[ubuntu-1604-amd64-updates]
+label    = ubuntu-1604-amd64-main-updates
+name     = Ubuntu 16.04 LTS AMD64 Updates
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = ubuntu-16.04-pool-amd64
+repo_url = http://mirror.example.com/ubuntu/dists/xenial-updates/main/binary-amd64/
+
+[ubuntu-1804-pool-amd64]
+label    = ubuntu-18.04-pool-amd64
+checksum = sha256
+archs    = amd64-deb
+repo_type = deb
+name     = ubuntu-18.04-pool for amd64
+gpgkey_url =
+gpgkey_id =
+gpgkey_fingerprint =
+repo_url = http://localhost/pub/repositories/empty-deb/?uniquekey=1804
+
+[ubuntu-1804-amd64-main]
+label    = ubuntu-1804-amd64-main
+checksum = sha256
+archs    = amd64-deb
+repo_type = deb
+name     = Ubuntu 18.04 LTS AMD64 Main
+base_channels = ubuntu-18.04-pool-amd64
+repo_url = http://mirror.example.com/ubuntu/dists/bionic/main/binary-amd64/
+
+[ubuntu-1804-amd64-main-updates]
+label    = ubuntu-1804-amd64-main-updates
+name     = Ubuntu 18.04 LTS AMD64 Main Updates
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = ubuntu-18.04-pool-amd64
+repo_url = http://mirror.example.com/ubuntu/dists/bionic-updates/main/binary-amd64/
+
+[debian-9-pool-amd64]
+label    = debian-9-pool-amd64
+checksum = sha256
+archs    = amd64-deb
+repo_type = deb
+name     = Debian 9 (stretch) pool for amd64
+gpgkey_url =
+gpgkey_id =
+gpgkey_fingerprint =
+repo_url = http://ftp.debian.org/debian/dists/stretch/main/binary-amd64/
+
+[debian-9-amd64-main-updates]
+label    = debian-9-amd64-main-updates
+name     = Debian 9 (stretch) AMD64 Main Updates
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = debian-9-pool-amd64
+repo_url = http://ftp.debian.org/debian/dists/stretch-updates/main/binary-amd64/

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,5 @@
+- Adds support for Ubuntu and Debian channels to spacewalk-common-channels.
+
 -------------------------------------------------------------------
 Wed May 15 15:20:26 CEST 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Adds templates for Ubuntu and Debian channels to `spacewalk-common-channels`.

## GUI diff

No difference.

## Documentation
- https://github.com/SUSE/doc-susemanager/pull/513

- [ ] **DONE**

## Test coverage
- No tests: not needed

## Links

Fixes https://github.com/SUSE/spacewalk/issues/7013

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
