### PR TITLE
Fix build for openSUSE Leap 15.1

### DIFF
--- a/tftpsync/susemanager-tftpsync/susemanager-tftpsync.changes
+++ b/tftpsync/susemanager-tftpsync/susemanager-tftpsync.changes
@@ -1,3 +1,5 @@
+- Fix build for openSUSE Leap 15.1
+
 -------------------------------------------------------------------
 Wed May 15 15:36:43 CEST 2019 - jgonzalez@suse.com
 

--- a/tftpsync/susemanager-tftpsync/susemanager-tftpsync.spec
+++ b/tftpsync/susemanager-tftpsync/susemanager-tftpsync.spec
@@ -33,6 +33,7 @@ Source0:        %{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 
 Requires(pre):  cobbler
+BuildRequires:  cobbler
 %if 0%{?build_py3}
 Requires:       python3
 Requires:       python3-six


### PR DESCRIPTION
## What does this PR change?

Fix build for openSUSE Leap 15.1. We install the contents of the package to `/usr/lib/python3.6/site-packages/cobbler`, but the package does not own it.

This path is owned by cobbler package, so we need to require it for building.

Otherwise we get the following error:

```
[   46s] ... running 50-check-filelist
[   46s] ... checking filelist
[   46s] susemanager-tftpsync-4.0.5-400.1.1.uyunimaster.x86_64.rpm: directories not owned by a package:
[   46s]  - /usr/lib/python3.6/site-packages/cobbler
[   46s]  - /usr/lib/python3.6/site-packages/cobbler/__pycache__
[   46s]  - /usr/lib/python3.6/site-packages/cobbler/modules
[   46s]  - /usr/lib/python3.6/site-packages/cobbler/modules/__pycache__
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Fix for building the package

- [x] **DONE**

## Test coverage
- No tests: Fix for building the package, already covered by the checks for Leap 15.1 at OBS.

- [x] **DONE**

## Links

None.

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
