### PR TITLE
testsuite: fix VM start detection

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -829,9 +829,10 @@ Then(/^"([^"]*)" virtual machine on "([^"]*)" should have a "([^"]*)" ([^ ]*) di
   repeat_until_timeout(message: "#{vm} virtual machine on #{host} never got a #{path} #{bus} disk") do
     output, _code = node.run("virsh dumpxml #{vm}")
     tree = Nokogiri::XML(output)
-    disks = tree.xpath("//disk")
-    disk = disks[disks.find_index { |x| x.xpath('source/@file')[0].to_s.include? path }]
-    break if disk.xpath('target/@bus')[0].to_s == bus
+    disks = tree.xpath("//disk").select do |x|
+      (x.xpath('source/@file')[0].to_s.include? path) && (x.xpath('target/@bus')[0].to_s == bus)
+    end
+    break if !disks.empty?
     sleep 3
   end
 end

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -770,7 +770,7 @@ end
 When(/^I wait until virtual machine "([^"]*)" on "([^"]*)" is started$/) do |vm, host|
   node = get_target(host)
   repeat_until_timeout(message: "#{vm} virtual machine on #{host} OS failed did not come up yet") do
-    _output, code = node.run("grep -i 'linux\:' /tmp/#{vm}.console.log", fatal = false)
+    _output, code = node.run("grep -i 'login\:' /tmp/#{vm}.console.log", fatal = false)
     break if code.zero?
     sleep 1
   end


### PR DESCRIPTION
## What does this PR change?

Fixes KVM test suite

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: Fixes KVM test suite

- [X] **DONE**

## Test coverage
- No tests: Fixes KVM test suite

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
