### PR TITLE
Do not rely on double slashes with proxy cobbler API endpoint

### DIFF
--- a/proxy/installer/cobbler-proxy.conf
+++ b/proxy/installer/cobbler-proxy.conf
@@ -1,5 +1,5 @@
-ProxyPass /cobbler_api $PROTO://$RHN_PARENT/download//cobbler_api
-ProxyPassReverse /cobbler_api $PROTO://$RHN_PARENT/download//cobbler_api
+ProxyPass /cobbler_api $PROTO://$RHN_PARENT/download/cobbler_api
+ProxyPassReverse /cobbler_api $PROTO://$RHN_PARENT/download/cobbler_api
 RewriteRule ^/cblr/svc/op/ks/(.*)$ /download/$0 [P,L]
 RewriteRule ^/cblr/svc/op/autoinstall/(.*)$ /download/$0 [P,L]
 ProxyPass /cblr $PROTO://$RHN_PARENT/cblr

--- a/proxy/installer/spacewalk-proxy-installer.changes
+++ b/proxy/installer/spacewalk-proxy-installer.changes
@@ -1,3 +1,5 @@
+- Remove double slashes from cobbler api endpoint (bsc#1133800)
+
 -------------------------------------------------------------------
 Wed May 15 15:13:56 CEST 2019 - jgonzalez@suse.com
 

--- a/proxy/installer/spacewalk-proxy-installer.spec
+++ b/proxy/installer/spacewalk-proxy-installer.spec
@@ -22,6 +22,8 @@
 %{!?pylint_check: %global pylint_check 1}
 %endif
 
+%define apacheconfdir %{_sysconfdir}/apache2
+
 %if 0%{?suse_version} > 1320 || 0%{?fedora}
 # SLE15 and Fedora builds on Python 3
 %global build_py3   1
@@ -108,6 +110,9 @@ if [ -f /etc/sysconfig/apache2 ]; then
     sysconf_addword /etc/sysconfig/apache2 APACHE_MODULES proxy_http
 fi
 sed -i -e"s/^range_offset_limit -1 KB/range_offset_limit none/" /etc/squid/squid.conf
+if [ -f %{apacheconfdir}/conf.d/cobbler-proxy.conf ]; then
+    sed -i -e "s;download//cobbler_api;download/cobbler_api;g" %{apacheconfdir}/conf.d/cobbler-proxy.conf
+fi
 %endif
 
 %install

--- a/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-www.conf
+++ b/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-www.conf
@@ -39,7 +39,7 @@ SSLProxyEngine on
 # processes the incoming URL and converts it into something
 # slightly more Struts friendly.
 RewriteRule ^/ks/cfg([-a-zA-Z0-9\._/\%\ ]*)$ /rhn/kickstart/DownloadFile.do?ksurl=$1
-RewriteRule ^/download/(.*)$ /rhn/common/DownloadFile.do?url=$1
+RewriteRule ^/download/(.*)$ /rhn/common/DownloadFile.do?url=/$1
 RewriteRule ^/rpc/api /rhn/rpc/api
 RewriteRule ^/ks/dist(.*)$ /rhn/common/DownloadFile.do?url=/ks/dist$1
 RewriteRule ^(/ty/.*)$ /rhn/common/DownloadFile.do?url=$1

--- a/spacewalk/config/spacewalk-config.changes
+++ b/spacewalk/config/spacewalk-config.changes
@@ -1,3 +1,5 @@
+- Fix URL rewrites for proxy cobbler api endpoint (bsc#1133800)
+
 -------------------------------------------------------------------
 Wed May 15 15:10:31 CEST 2019 - jgonzalez@suse.com
 

--- a/spacewalk/config/spacewalk-config.spec
+++ b/spacewalk/config/spacewalk-config.spec
@@ -104,8 +104,8 @@ ln -sf  %{apacheconfdir}/conf/ssl.crt/server.crt $RPM_BUILD_ROOT/etc/pki/tls/cer
 %files
 %defattr(-,root,root,-)
 %attr(400,root,root) %config(noreplace) %{_sysconfdir}/rhn/spacewalk-repo-sync/uln.conf
-%config(noreplace) %{apacheconfdir}/conf.d/zz-spacewalk-www.conf
-%config(noreplace) %{apacheconfdir}/conf.d/os-images.conf
+%config %{apacheconfdir}/conf.d/zz-spacewalk-www.conf
+%config %{apacheconfdir}/conf.d/os-images.conf
 %config(noreplace) %{_sysconfdir}/webapp-keyring.gpg
 %attr(440,root,root) %config %{_sysconfdir}/sudoers.d/spacewalk
 %dir %{_var}/lib/cobbler/


### PR DESCRIPTION
The proxy endpoint for cobbler api relies on a double slash to be redirected successfully to the local cobbler server:
```
ProxyPass /cobbler_api $PROTO://$RHN_PARENT/download//cobbler_api
```
This approach is not safe, and even against the URI RFC.
Moreover, a recent update for apache changed behavior on treating double slashes and it causes the following bug: https://bugzilla.suse.com/1133800

The second slash gets discarded while rewriting on the server, and the following code fails:

https://github.com/uyuni-project/uyuni/blob/aabe1d351d35360bacd6820032c3b52834ecead7/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java#L158-L163

The PR removes the need to carry the slash from the proxy, and adds it when rewriting the URL on the server side.

Port of https://github.com/SUSE/spacewalk/pull/8009

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
