### PR TITLE
Fix css for more space between close button and text.

### DIFF
--- a/web/html/src/components/toastr/toastr.css
+++ b/web/html/src/components/toastr/toastr.css
@@ -4,7 +4,7 @@
 }
 
 :global(.toast) {
-    padding: 15px !important;
+    padding: 15px 30px !important;
     text-align: center !important;
     width: 32% !important;
     font-size: 15px;


### PR DESCRIPTION
## What does this PR change?

The space between the close button of alerts and the text.

## GUI diff

^^

Before:

![Screenshot-2019-6-4 SUSE Manager - Content Lifecycle - Projects - before](https://user-images.githubusercontent.com/15035141/58882669-0fa6e100-86dd-11e9-8d1c-92b2f83685af.png)

After:

![Screenshot-2019-6-4 SUSE Manager - Content Lifecycle - Projects - after](https://user-images.githubusercontent.com/15035141/58882674-15042b80-86dd-11e9-854f-db3582757de1.png)

- [x] **DONE**

## Documentation
- No documentation needed: It adds just more margin for left and right... Hope this doesn't need to be documented.
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [x] **DONE**

## Test coverage
- No tests: No tests needed, just some css change.
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #
Tracks https://github.com/SUSE/spacewalk/issues/7527

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"  
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
