### PR TITLE
Add new packages names to instructions for adding remote commands support for traditional clients

### DIFF
--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -873,10 +873,13 @@ if [ $ALLOW_REMOTE_COMMANDS -eq 1 ] ; then
     echo "  NOTE: use an activation key to subscribe to the tools"
     if [ "$INSTALLER" == zypper ] ; then
         echo "        channel and zypper update rhncfg-actions"
+        echo "        or zypper update mgr-cfg-actions starting with 4.0"
     elif [ "$INSTALLER" == yum ] ; then
         echo "        channel and yum upgrade rhncfg-actions"
+        echo "        or yum upgrade mgr-cfg-actions starting with 4.0"
     else
         echo "        channel and up2date rhncfg-actions"
+        echo "        or up2date mgr-cfg-actions starting with 4.0"
     fi
     if [ -x "/usr/bin/rhn-actions-control" ] ; then
         rhn-actions-control --enable-run
@@ -884,11 +887,14 @@ if [ $ALLOW_REMOTE_COMMANDS -eq 1 ] ; then
         echo "Error setting permissions for remote commands."
         echo "    Please ensure that the activation key subscribes the"
         if [ "$INSTALLER" == zypper ] ; then
-            echo "    system to the tools channel and zypper updates rhncfg-actions."
+            echo "    system to the tools channel and zypper update rhncfg-actions"
+            echo "    or zypper update mgr-cfg-actions starting with 4.0."
         elif [ "$INSTALLER" == yum ] ; then
-            echo "    system to the tools channel and yum updates rhncfg-actions."
+            echo "    system to the tools channel and yum updates rhncfg-actions"
+            echo "    or yum update mgr-cfg-actions starting with 4.0."
         else
-            echo "    system to the tools channel and up2dates rhncfg-actions."
+            echo "    system to the tools channel and up2dates rhncfg-actions"
+            echo "    or up2date mgr-cfg-actions starting with 4.0."
         fi
         exit
     fi

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,6 @@
+- Add new packages names to instructions for adding remote commands
+  support for traditional clients (bsc#1137255)
+
 -------------------------------------------------------------------
 Tue May 21 10:56:53 CEST 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Add new packages names to instructions for adding remote commands support for traditional clients

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Doc about this was already updated

- [x] **DONE**

## Test coverage
- No tests: Only text changes

- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/8019

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
