### PR TITLE
XML-RPC API call for server monitoring

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/admin/monitoring/AdminMonitoringHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/admin/monitoring/AdminMonitoringHandler.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.frontend.xmlrpc.admin.monitoring;
+
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.xmlrpc.BaseHandler;
+import com.redhat.rhn.frontend.xmlrpc.satellite.MonitoringException;
+import com.suse.manager.webui.services.impl.MonitoringService;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * AdminMonitoringHandler
+ * @xmlrpc.namespace admin.monitoring
+ * @xmlrpc.doc Provides methods to manage the monitoring of the Uyuni server.
+ */
+public class AdminMonitoringHandler extends BaseHandler {
+
+    /**
+     * Enable monitoring.
+     * @param loggedInUser the current user
+     * @return a map with the status of each exporter
+     *
+     * @xmlrpc.doc Enable monitoring.
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.returntype
+     *  #array()
+     *      #struct("Exporters")
+     *          #prop("boolean", "node")
+     *          #prop("boolean", "tomcat")
+     *          #prop("boolean", "taskomatic")
+     *          #prop("boolean", "postgres")
+     *      #struct_end()
+     *  #array_end()
+     */
+    public Map<String, Boolean> enable(User loggedInUser) {
+        ensureSatAdmin(loggedInUser);
+        Optional<Map<String, Boolean>> exporters = MonitoringService.enableMonitoring();
+        return exporters.orElseThrow(() -> new MonitoringException("Error enabling server monitoring"));
+    }
+
+    /**
+     * Disable monitoring.
+     * @param loggedInUser the current user
+     * @return a map with the status of each exporter
+     *
+     * @xmlrpc.doc Disable monitoring.
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.returntype
+     *  #array()
+     *      #struct("Exporters")
+     *          #prop("boolean", "node")
+     *          #prop("boolean", "tomcat")
+     *          #prop("boolean", "taskomatic")
+     *          #prop("boolean", "postgres")
+     *      #struct_end()
+     *  #array_end()
+     */
+    public Map<String, Boolean> disable(User loggedInUser) {
+        ensureSatAdmin(loggedInUser);
+        Optional<Map<String, Boolean>> exporters = MonitoringService.disableMonitoring();
+        return exporters.orElseThrow(() -> new MonitoringException("Error disabling server monitoring"));
+    }
+
+    /**
+     * Get the status of each Prometheus exporter.
+     * @param loggedInUser the current user
+     * @return a map with the status of each exporter
+     *
+     * @xmlrpc.doc Get the status of each Prometheus exporter.
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.returntype
+     *  #array()
+     *      #struct("Exporters")
+     *          #prop("boolean", "node")
+     *          #prop("boolean", "tomcat")
+     *          #prop("boolean", "taskomatic")
+     *          #prop("boolean", "postgres")
+     *      #struct_end()
+     *  #array_end()
+     */
+    public Map<String, Boolean> getStatus(User loggedInUser) {
+        ensureSatAdmin(loggedInUser);
+        Optional<Map<String, Boolean>> exporters = MonitoringService.getStatus();
+        return exporters.orElseThrow(() -> new MonitoringException("Error getting server monitoring status"));
+    }
+
+}

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/admin/monitoring/test/AdminMonitoringHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/admin/monitoring/test/AdminMonitoringHandlerTest.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.frontend.xmlrpc.admin.monitoring.test;
+
+import com.redhat.rhn.frontend.xmlrpc.PermissionCheckFailureException;
+import com.redhat.rhn.frontend.xmlrpc.admin.monitoring.AdminMonitoringHandler;
+import com.redhat.rhn.frontend.xmlrpc.test.BaseHandlerTestCase;
+import com.suse.manager.webui.services.impl.MonitoringService;
+
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+public class AdminMonitoringHandlerTest extends BaseHandlerTestCase {
+
+    public void testGetStatus() {
+        BiFunction<String, Optional<String>, Optional<InputStream>> execCtl =
+                (String cmd, Optional<String> pillar) -> {
+                    return Optional.of(this.getClass()
+                            .getResourceAsStream("/com/suse/manager/webui/services/impl/test/monitoring/status.json"));
+                };
+
+        MonitoringService.setExecCtlFunction(execCtl);
+
+        AdminMonitoringHandler handler = new AdminMonitoringHandler();
+
+        Map<String, Boolean> res = handler.getStatus(satAdmin);
+        assertTrue(res.get("node"));
+        assertTrue(res.get("postgres"));
+        assertTrue(res.get("tomcat"));
+        assertTrue(res.get("taskomatic"));
+    }
+
+    public void testEnable() {
+        BiFunction<String, Optional<String>, Optional<InputStream>> execCtl =
+                (String cmd, Optional<String> pillar) -> {
+                    return Optional.of(this.getClass()
+                            .getResourceAsStream("/com/suse/manager/webui/services/impl/test/monitoring/enable.json"));
+                };
+
+        MonitoringService.setExecCtlFunction(execCtl);
+
+        AdminMonitoringHandler handler = new AdminMonitoringHandler();
+
+        Map<String, Boolean> res = handler.enable(satAdmin);
+        assertTrue(res.get("node"));
+        assertTrue(res.get("postgres"));
+        assertTrue(res.get("tomcat"));
+        assertTrue(res.get("taskomatic"));
+    }
+
+    public void testDisable() {
+        BiFunction<String, Optional<String>, Optional<InputStream>> execCtl =
+                (String cmd, Optional<String> pillar) -> {
+                    return Optional.of(this.getClass()
+                            .getResourceAsStream("/com/suse/manager/webui/services/impl/test/monitoring/disable.json"));
+                };
+
+        MonitoringService.setExecCtlFunction(execCtl);
+
+        AdminMonitoringHandler handler = new AdminMonitoringHandler();
+
+        Map<String, Boolean> res = handler.enable(satAdmin);
+        assertFalse(res.get("node"));
+        assertFalse(res.get("postgres"));
+        assertFalse(res.get("tomcat"));
+        assertFalse(res.get("taskomatic"));
+    }
+
+    public void testRoleCheck() {
+        AdminMonitoringHandler handler = new AdminMonitoringHandler();
+
+        try {
+            Map<String, Boolean> res = handler.enable(regular);
+            fail("PermissionCheckFailureException should be thrown");
+        } catch (PermissionCheckFailureException e) {
+        }
+
+        try {
+            Map<String, Boolean> res = handler.enable(admin);
+            fail("PermissionCheckFailureException should be thrown");
+        } catch (PermissionCheckFailureException e) {
+        }
+    }
+}

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/handler-manifest.xml
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/handler-manifest.xml
@@ -1,6 +1,7 @@
 <factory>
   <template name="actionchain" classname="com.redhat.rhn.frontend.xmlrpc.chain.ActionChainHandler" />
   <template name="activationkey" classname="com.redhat.rhn.frontend.xmlrpc.activationkey.ActivationKeyHandler"/>
+  <template name="admin.monitoring" classname="com.redhat.rhn.frontend.xmlrpc.admin.monitoring.AdminMonitoringHandler"/>
   <template name="api" classname="com.redhat.rhn.frontend.xmlrpc.api.ApiHandler" />
   <template name="audit" classname="com.redhat.rhn.frontend.xmlrpc.audit.CVEAuditHandler" />
   <template name="auth" classname="com.redhat.rhn.frontend.xmlrpc.auth.AuthHandler" />

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/proxy/ProxyHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/proxy/ProxyHandler.java
@@ -18,6 +18,8 @@ import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.ChannelFamily;
 import com.redhat.rhn.domain.channel.ChannelFamilyFactory;
 import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerFactory;
+import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.xmlrpc.BaseHandler;
 import com.redhat.rhn.frontend.xmlrpc.InvalidProxyVersionException;
 import com.redhat.rhn.frontend.xmlrpc.MethodInvalidParamException;
@@ -26,6 +28,7 @@ import com.redhat.rhn.frontend.xmlrpc.ProxyAlreadyRegisteredException;
 import com.redhat.rhn.frontend.xmlrpc.ProxyMissingEntitlementException;
 import com.redhat.rhn.frontend.xmlrpc.ProxyNotActivatedException;
 import com.redhat.rhn.frontend.xmlrpc.ProxySystemIsSatelliteException;
+import com.redhat.rhn.frontend.xmlrpc.system.XmlRpcSystemHelper;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.system.SystemManager;
 
@@ -176,5 +179,27 @@ public class ProxyHandler extends BaseHandler {
             }
         }
         return returnList;
+    }
+
+    /**
+     * List the proxies within the user's organization.
+     * @param loggedInUser The current user
+     * @return  list of Maps containing "id", "name", and "last_checkin"
+     *
+     * @xmlrpc.doc List the proxies within the user's organization.
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.returntype
+     * #array()
+     *   $SystemOverviewSerializer
+     * #array_end()
+     */
+    public Object[] listProxies(User loggedInUser) {
+        List<Server> proxies = ServerFactory.lookupProxiesByOrg(loggedInUser);
+        List toReturn = new ArrayList();
+        XmlRpcSystemHelper helper = XmlRpcSystemHelper.getInstance();
+        for (Server server : proxies) {
+            toReturn.add(helper.format(server));
+        }
+        return toReturn.toArray();
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/satellite/MonitoringException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/satellite/MonitoringException.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.frontend.xmlrpc.satellite;
+
+import com.redhat.rhn.FaultException;
+
+/**
+ * Server monitoring exception.
+ */
+public class MonitoringException extends FaultException {
+
+    /**
+     * Constructor
+     * @param message the message
+     */
+    public MonitoringException(String message) {
+        super(2880, "serverMonitoringError", message);
+    }
+}

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/satellite/SatelliteHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/satellite/SatelliteHandler.java
@@ -14,23 +14,20 @@
  */
 package com.redhat.rhn.frontend.xmlrpc.satellite;
 
-import com.redhat.rhn.domain.server.Server;
-import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.xmlrpc.BaseHandler;
-import com.redhat.rhn.frontend.xmlrpc.system.XmlRpcSystemHelper;
+import com.redhat.rhn.frontend.xmlrpc.proxy.ProxyHandler;
 
 import org.apache.log4j.Logger;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * SatelliteHandler
  *
  * @xmlrpc.namespace satellite
  * @xmlrpc.doc Provides methods to obtain details on the Satellite.
+ * @deprecated deprecated in favour of proxy and admin.monitoring namespaces.
  */
+@Deprecated
 public class SatelliteHandler extends BaseHandler {
     private static Logger log = Logger.getLogger(SatelliteHandler.class);
 
@@ -39,6 +36,7 @@ public class SatelliteHandler extends BaseHandler {
      * @param loggedInUser The current user
      * @return  list of Maps containing "id", "name", and "last_checkin"
      *
+     * @deprecated moved to proxy.listProxies
      * @xmlrpc.doc List the proxies within the user's organization.
      * @xmlrpc.param #param("string", "sessionKey")
      * @xmlrpc.returntype
@@ -46,14 +44,10 @@ public class SatelliteHandler extends BaseHandler {
      *   $SystemOverviewSerializer
      * #array_end()
      */
+    @Deprecated
     public Object[] listProxies(User loggedInUser) {
-        List<Server> proxies = ServerFactory.lookupProxiesByOrg(loggedInUser);
-        List toReturn = new ArrayList();
-        XmlRpcSystemHelper helper = XmlRpcSystemHelper.getInstance();
-        for (Server server : proxies) {
-            toReturn.add(helper.format(server));
-        }
-        return toReturn.toArray();
+        ProxyHandler proxyHandler = new ProxyHandler();
+        return proxyHandler.listProxies(loggedInUser);
     }
 
     /**
@@ -62,24 +56,30 @@ public class SatelliteHandler extends BaseHandler {
      * @param loggedInUser The current user
      * @return True if monitoring is enabled
      *
+     * @deprecated deprecated unused method. See new namespace admin.monitoring.
      * @xmlrpc.doc Indicates if monitoring is enabled on the satellite
      * @xmlrpc.param #param("string", "sessionKey")
      * @xmlrpc.returntype #param("boolean", "True if monitoring is enabled")
      */
+    @Deprecated
     public boolean isMonitoringEnabled(User loggedInUser) {
         return false;
     }
 
     /**
+     * Use system.getEntitlements() and check the monitoring entitlement.
+     *
      * Indicates if monitoring is enabled on the satellite
      * available since API version 10.14
      * @param clientcert client certificate of the system.
      * @return True if monitoring is enabled
      *
+     * @deprecated deprecated unused method. See new namespace admin.monitoring.
      * @xmlrpc.doc Indicates if monitoring is enabled on the satellite
      * @xmlrpc.param #param_desc("string", "systemid", "systemid file")
      * @xmlrpc.returntype #param("boolean", "True if monitoring is enabled")
      */
+    @Deprecated
     public boolean isMonitoringEnabledBySystemId(String clientcert) {
         return false;
     }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add XML-RPC API calls to manage server monitoring
 - Allow adding monitoring entitlement to openSUSE Leap 15.x
 - Add support for Salt Formulas to be used with standalone Salt
 - Fix channel sync status logic in products page (bsc#1131721)


### PR DESCRIPTION
## What does this PR change?

Add API calls to enable/disable/get status of server monitoring.

## GUI diff

No difference.

## Documentation
- No documentation needed: API docs generate automatically

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes #https://github.com/SUSE/spacewalk/issues/8013

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
