### PR TITLE
Remove zero in brackets if there is nothing to be built & adjusted te…

### DIFF
--- a/testsuite/features/srv_content_lifecycle.feature
+++ b/testsuite/features/srv_content_lifecycle.feature
@@ -109,7 +109,7 @@ Feature: Content lifecycle
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Content Lifecycle > Projects"
     And I follow "clp_name"
-    Then I should see a "Build (0)" text
+    Then I should see a "Build" text
     When I follow "Attach/Detach Sources"
     And I add the "Test Base Channel" channel to sources
     And I click on "Save"

--- a/web/html/src/manager/content-management/shared/components/panels/build/build.js
+++ b/web/html/src/manager/content-management/shared/components/panels/build/build.js
@@ -39,11 +39,6 @@ const Build = ({projectId, onBuild, currentHistoryEntry = {}, changesToBuild, di
     setBuildVersionForm({version: currentVersion ? currentVersion + 1 : 1, message: ""});
   }, [open]);
 
-  let textBuild = "Build";
-  if (changesToBuild.length > 0) {
-    textBuild = "Build (" + changesToBuild.length + ")";
-  }
-
   return (
     <div
       {...(disabled ? {title: "Add an environment to build"} : {})}
@@ -54,7 +49,7 @@ const Build = ({projectId, onBuild, currentHistoryEntry = {}, changesToBuild, di
         <ModalButton
           id={`build-contentmngt-modal-link`}
           className="btn-success"
-          text={textBuild}
+          text={changesToBuild.length > 0 ? `Build (${changesToBuild.length})` : `Build`}
           disabled={disabled}
           target={modalNameId}
           onClick={() => {

--- a/web/html/src/manager/content-management/shared/components/panels/build/build.js
+++ b/web/html/src/manager/content-management/shared/components/panels/build/build.js
@@ -39,6 +39,11 @@ const Build = ({projectId, onBuild, currentHistoryEntry = {}, changesToBuild, di
     setBuildVersionForm({version: currentVersion ? currentVersion + 1 : 1, message: ""});
   }, [open]);
 
+  let textBuild = "Build";
+  if (changesToBuild.length > 0) {
+    textBuild = "Build (" + changesToBuild.length + ")";
+  }
+
   return (
     <div
       {...(disabled ? {title: "Add an environment to build"} : {})}
@@ -49,7 +54,7 @@ const Build = ({projectId, onBuild, currentHistoryEntry = {}, changesToBuild, di
         <ModalButton
           id={`build-contentmngt-modal-link`}
           className="btn-success"
-          text={`Build (${changesToBuild.length})`}
+          text={textBuild}
           disabled={disabled}
           target={modalNameId}
           onClick={() => {


### PR DESCRIPTION
## What does this PR change?

This changes the behavior of the build button. If you have no environment to build, then we omit the `(0)` and just display `Build` instead of `Build (0)`

## GUI diff

Ommited `(0)` if there is nothing to build.

Before:
![Screenshot-2019-6-5 SUSE Manager - Content Lifecycle - Projects - alt](https://user-images.githubusercontent.com/15035141/58940640-4c74e580-877a-11e9-9b8f-3a05494e7cd8.png)

After:

![Screenshot-2019-6-5 SUSE Manager - Content Lifecycle - Projects - neu](https://user-images.githubusercontent.com/15035141/58940649-51399980-877a-11e9-9ce5-5ac8a6d53e89.png)

- [x] **DONE**

## Documentation
- No documentation needed: Just a small change, nothing to document.
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [x] **DONE**

## Test coverage
- No tests: Tests already existed. They were adjusted to the new code behavior.
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #
Tracks https://github.com/SUSE/spacewalk/issues/7527

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"  
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
