### PR TITLE
TESTSUITE: Add a loop check when refreshing the repo metadata on a SLES minion

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -281,14 +281,18 @@ When(/I view system with id "([^"]*)"/) do |arg1|
   visit Capybara.app_host + '/rhn/systems/details/Overview.do?sid=' + arg1
 end
 
-# weak deaps steps
+# weak dependencies steps
 When(/^I refresh the metadata for "([^"]*)"$/) do |host|
   case host
   when 'sle-client'
     $client.run('rhn_check -vvv', true, 500, 'root')
     client_refresh_metadata
   when 'sle-minion'
-    $minion.run('zypper --non-interactive ref -s', true, 500, 'root')
+    repeat_until_timeout(message: 'Could not refresh metadata') do
+      _out, code = $minion.run('zypper --non-interactive refresh -s', true, 200, 'root')
+      break if code.zero?
+      sleep 3
+    end
   else
     raise 'Invalid target.'
   end


### PR DESCRIPTION
## What does this PR change?
Add a loop check when refreshing the repo metadata on a SLES minion.

This is necessary given that in Scenario "Chanel subscription via SSM", right after we subscribe a minion to new channels, we try to refresh the repo metadata on the minion, but the access token for those channels is not enabled yet and zypper fails, due to a race condition on enabling the access token.
After a short amount of time (1-2 seconds) the access token is enabled.

This race condition only appears in the testsuite and does not affect the customers.

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: testsuite fix
- [ ] **DONE**

## Test coverage
- No tests:testsuite fix

- [ ] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/8017

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
