### PR TITLE
Check for result of image rsync transfer to catch failures early

### DIFF
--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Check for result of image rsync transfer to catch failures early (bsc#1104949)
 - Force VM off before deleting it (bsc#1138127)
 - Allow forcing off or resetting VMs
 - Fix the indentation so that custom formulas can be read correctly (bsc#1136937)


### PR DESCRIPTION
## What does this PR change?

`rsync.rsync` state does not throw exception on file transfer, only return retcode different to 0. However calling java code seems not to check for return codes, only exceptions. So throw an exception in case of failed rsync tranfer.
On the other hand `file.move` does throws an exception on failure, so no change needed here.

## Documentation
- No documentation needed: bugfix

- [X] **DONE**

## Test coverage
- No tests: Success case covered by existing tests. No tests for failures

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/7806

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
