### PR TITLE
Let 10 minutes for package list refresh to happen

### DIFF
--- a/testsuite/features/step_definitions/centos_tradclient.rb
+++ b/testsuite/features/step_definitions/centos_tradclient.rb
@@ -5,11 +5,11 @@ require 'xmlrpc/client'
 require 'time'
 require 'date'
 
-def wait_action_complete(actionid)
+def wait_action_complete(actionid, timeout: DEFAULT_TIMEOUT)
   host = $server.full_hostname
   @cli = XMLRPC::Client.new2('http://' + host + '/rpc/api')
   @sid = @cli.call('auth.login', 'admin', 'admin')
-  repeat_until_timeout(timeout: 300, message: 'Action was not found among completed actions') do
+  repeat_until_timeout(timeout: timeout, message: 'Action was not found among completed actions') do
     list = @cli.call('schedule.list_completed_actions', @sid)
     list.each do |action|
       break if action['id'] == actionid
@@ -32,7 +32,7 @@ When(/^I refresh the packages on "([^"]*)" through XML-RPC$/) do |host|
 
   id_refresh = @cli.call('system.schedule_package_refresh', @sid, node_id, date_schedule_now)
   node.run('rhn_check -vvv')
-  wait_action_complete(id_refresh)
+  wait_action_complete(id_refresh, timeout: 600)
 end
 
 When(/^I run a script on "([^"]*)" through XML-RPC$/) do |host|


### PR DESCRIPTION
## What does this PR change?

It leaves more time for the refresh package list to finish on traditional CentOS minion.

## Links

Fixes the test suite

Ports
* 4.0 SUSE/spacewalk#8028
* 3.2 SUSE/spacewalk#8029
* 3.1 SUSE/spacewalk#8030

## Changelogs

- [x] No changelog needed
