### PR TITLE
Manager cobbler migrate

### DIFF
--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -415,11 +415,16 @@ convert_cobbler_files() {
                     -e "s/ks_meta/autoinstall_meta/" \
                     -e "s/ksmeta/autoinstall_meta/" \
                     -e "s/kopts/kernel_options/" \
+                    -e "s;/var/lib/rhn/kickstarts;;g" \
                     -e "s/kopts_post/kernel_options_post/" \
                 $FILE > $NEWDIR/`basename $FILE`
             done
         fi
     done
+
+    if [ ! -z "$(ls /var/lib/rhn/kickstarts/upload)" ]; then
+        cp -a /var/lib/rhn/kickstarts/upload/* /var/lib/cobbler/templates/upload
+    fi
 }
 
 copy_remote_files() {

--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -425,6 +425,12 @@ convert_cobbler_files() {
     if [ ! -z "$(ls /var/lib/rhn/kickstarts/upload)" ]; then
         cp -a /var/lib/rhn/kickstarts/upload/* /var/lib/cobbler/templates/upload
     fi
+    if [ ! -z "$(ls /var/lib/rhn/kickstarts/wizard)" ]; then
+        cp -a /var/lib/rhn/kickstarts/wizard/* /var/lib/cobbler/templates/wizard
+    fi
+    if [ ! -z "$(ls /var/lib/rhn/kickstarts/snippets)" ]; then
+        cp -a /var/lib/rhn/kickstarts/snippets/* /var/lib/cobbler/snippets/spacewalk
+    fi
 }
 
 copy_remote_files() {

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- respect new location for autoinstall templates during migration
+
 -------------------------------------------------------------------
 Wed May 15 15:28:52 CEST 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

In SUSE Manager 4.0, the location for autoinstallation templates has changed from /var/lib/rhn/kickstarts/upload to /var/lib/cobbler/templates/upload . So the references in the profiles need to be adapted during migration and the profiles need to be copied to the new location. Otherwise migrated autoinstallations will fail like this:

File not found: /var/lib/cobbler/templates/var/lib/rhn/kickstarts/upload/proxy4--1.cfg

Newly created autoinstallations are not affected, only ones migrated from a previous 3.2 server.

These changes are only in the migration part of the mgr-setup script so it is safe to apply to all 4.0 trees.