### PR TITLE
Force PyJWT and numpy dependencies

### DIFF
--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Force python-numpy and python-PyJWT dependencies (bsc#1137357)
 - Add state EDITED to filters in the Content Lifecycle
 - Add built time date to the Content Lifecycle Environments
 

--- a/web/spacewalk-web.spec
+++ b/web/spacewalk-web.spec
@@ -94,8 +94,12 @@ Provides:       spacewalk(spacewalk-base) = %{version}-%{release}
 Requires:       susemanager-frontend-libs
 %if 0%{?suse_version} >= 1500
 Requires:       python3-websockify
+Requires:       python3-PyJWT
+Requires:       python3-numpy
 %else
 Requires:       python-websockify
+Requires:       python-PyJWT
+Requires:       python-numpy
 %endif
 %endif
 Requires:       httpd


### PR DESCRIPTION
## What does this PR change?

Those packages are Recommends of python-websockify, but we need them.
Now they will be installed  even though recommends are disabled.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: packaging fix

- [X] **DONE**

## Test coverage
- No tests: packaging fix

- [X] **DONE**

## Links

Fixes [bsc#1137357](https://bugzilla.suse.com/show_bug.cgi?id=1137357) and SUSE/spacewalk#8036

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
