### PR TITLE
Leap 15 1 change

### DIFF
--- a/susemanager-utils/testing/docker/master/Makefile
+++ b/susemanager-utils/testing/docker/master/Makefile
@@ -1,8 +1,9 @@
 VERSION = 4.0.0
 REGISTRY = registry.mgr.suse.de
 SHELL := /bin/bash
-# --no-cache=true
 BUILDOPTS=
+#--no-cache=true
+PUSH_IT=false
 
 all: uyuni-master-root uyuni-master-base uyuni-master-cobbler uyuni-master-gatherer uyuni-master-spacewalkkoan uyuni-master-pgsql uyuni-master-pgsql-4eclipse uyuni-master-nodejs uyuni-push-to-obs
 
@@ -15,8 +16,8 @@ uyuni-master-root::
 	docker tag $@ $@:$(VERSION); \
 	docker tag $@ $(REGISTRY)/$@:latest; \
 	docker tag $@:$(VERSION) $(REGISTRY)/$@:$(VERSION); \
-	docker push $(REGISTRY)/$@:latest ; \
-	docker push $(REGISTRY)/$@:$(VERSION); \
+	$(PUSH_IT) && docker push $(REGISTRY)/$@:latest ; \
+	$(PUSH_IT) && docker push $(REGISTRY)/$@:$(VERSION); \
 	popd
 
 uyuni-master-base::
@@ -28,8 +29,8 @@ uyuni-master-base::
 	docker tag $@ $@:$(VERSION); \
 	docker tag $@ $(REGISTRY)/$@:latest; \
 	docker tag $@:$(VERSION) $(REGISTRY)/$@:$(VERSION); \
-	docker push $(REGISTRY)/$@:latest ; \
-	docker push $(REGISTRY)/$@:$(VERSION); \
+	$(PUSH_IT) && docker push $(REGISTRY)/$@:latest ; \
+	$(PUSH_IT) && docker push $(REGISTRY)/$@:$(VERSION); \
 	popd
 
 uyuni-master-cobbler::
@@ -41,8 +42,8 @@ uyuni-master-cobbler::
 	docker tag $@ $@:$(VERSION); \
 	docker tag $@ $(REGISTRY)/$@:latest; \
 	docker tag $@:$(VERSION) $(REGISTRY)/$@:$(VERSION); \
-	docker push $(REGISTRY)/$@:latest ; \
-	docker push $(REGISTRY)/$@:$(VERSION); \
+	$(PUSH_IT) && docker push $(REGISTRY)/$@:latest ; \
+	$(PUSH_IT) && docker push $(REGISTRY)/$@:$(VERSION); \
 	popd
 
 uyuni-master-gatherer::
@@ -54,8 +55,8 @@ uyuni-master-gatherer::
 	docker tag $@ $@:$(VERSION); \
 	docker tag $@ $(REGISTRY)/$@:latest; \
 	docker tag $@:$(VERSION) $(REGISTRY)/$@:$(VERSION); \
-	docker push $(REGISTRY)/$@:latest ; \
-	docker push $(REGISTRY)/$@:$(VERSION); \
+	$(PUSH_IT) && docker push $(REGISTRY)/$@:latest ; \
+	$(PUSH_IT) && docker push $(REGISTRY)/$@:$(VERSION); \
 	popd
 
 uyuni-master-spacewalkkoan::
@@ -67,8 +68,8 @@ uyuni-master-spacewalkkoan::
 	docker tag $@ $@:$(VERSION); \
 	docker tag $@ $(REGISTRY)/$@:latest; \
 	docker tag $@:$(VERSION) $(REGISTRY)/$@:$(VERSION); \
-	docker push $(REGISTRY)/$@:latest ; \
-	docker push $(REGISTRY)/$@:$(VERSION); \
+	$(PUSH_IT) && docker push $(REGISTRY)/$@:latest ; \
+	$(PUSH_IT) && docker push $(REGISTRY)/$@:$(VERSION); \
 	popd
 
 uyuni-master-pgsql::
@@ -80,8 +81,8 @@ uyuni-master-pgsql::
 	docker tag $@ $@:$(VERSION); \
 	docker tag $@ $(REGISTRY)/$@:latest; \
 	docker tag $@:$(VERSION) $(REGISTRY)/$@:$(VERSION); \
-	docker push $(REGISTRY)/$@:latest ; \
-	docker push $(REGISTRY)/$@:$(VERSION); \
+	$(PUSH_IT) && docker push $(REGISTRY)/$@:latest ; \
+	$(PUSH_IT) && docker push $(REGISTRY)/$@:$(VERSION); \
 	popd
 
 uyuni-master-pgsql-4eclipse::
@@ -93,8 +94,8 @@ uyuni-master-pgsql-4eclipse::
 	docker tag $@ $@:$(VERSION); \
 	docker tag $@ $(REGISTRY)/$@:latest; \
 	docker tag $@:$(VERSION) $(REGISTRY)/$@:$(VERSION); \
-	docker push $(REGISTRY)/$@:latest ; \
-	docker push $(REGISTRY)/$@:$(VERSION); \
+	$(PUSH_IT) && docker push $(REGISTRY)/$@:latest ; \
+	$(PUSH_IT) && docker push $(REGISTRY)/$@:$(VERSION); \
 	popd
 
 uyuni-master-nodejs::
@@ -106,8 +107,8 @@ uyuni-master-nodejs::
 	docker tag $@ $@:$(VERSION); \
 	docker tag $@ $(REGISTRY)/$@:latest; \
 	docker tag $@:$(VERSION) $(REGISTRY)/$@:$(VERSION); \
-	docker push $(REGISTRY)/$@:latest ; \
-	docker push $(REGISTRY)/$@:$(VERSION); \
+	$(PUSH_IT) && docker push $(REGISTRY)/$@:latest ; \
+	$(PUSH_IT) && docker push $(REGISTRY)/$@:$(VERSION); \
 	popd
 
 uyuni-push-to-obs::
@@ -119,6 +120,6 @@ uyuni-push-to-obs::
 	docker tag $@ $@:$(VERSION); \
 	docker tag $@ $(REGISTRY)/$@:latest; \
 	docker tag $@:$(VERSION) $(REGISTRY)/$@:$(VERSION); \
-	docker push $(REGISTRY)/$@:latest ; \
-	docker push $(REGISTRY)/$@:$(VERSION); \
+	$(PUSH_IT) && docker push $(REGISTRY)/$@:latest ; \
+	$(PUSH_IT) && docker push $(REGISTRY)/$@:$(VERSION); \
 	popd

--- a/susemanager-utils/testing/docker/master/uyuni-master-root/Dockerfile
+++ b/susemanager-utils/testing/docker/master/uyuni-master-root/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION                4.0.0
 
-FROM opensuse/leap:15.0
+FROM opensuse/leap:15.1
 MAINTAINER Michael Calmer "Michael.Calmer@suse.com"
 
 # Add the repositories

--- a/susemanager-utils/testing/docker/master/uyuni-master-root/add_packages.sh
+++ b/susemanager-utils/testing/docker/master/uyuni-master-root/add_packages.sh
@@ -4,19 +4,16 @@ set -e
 # Packages required to run the pylint
 zypper in -y  make \
               python3 \
-	      python3-PyYAML \
+              python3-PyYAML \
               python3-base \
               python3-configobj \
               python3-devel \
               python3-mock \
-	      python3-nose \
+              python3-nose \
               python3-pylint \
-              python3-pytest
-
-# python3-urlgabber is not part of neither SLE or openSUSE 15.X
-curl https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/openSUSE_Leap_15.0/noarch/python3-urlgrabber.rpm -o /tmp/python3-urlgrabber.rpm && \
-rpm -i /tmp/python3-urlgrabber.rpm && \
-rm -rf python3-urlgrabber.rpm
+              python3-pytest \
+              python3-urlgrabber \
+              curl
 
 zypper -n in vim less
 

--- a/susemanager-utils/testing/docker/master/uyuni-master-root/add_repositories.sh
+++ b/susemanager-utils/testing/docker/master/uyuni-master-root/add_repositories.sh
@@ -4,6 +4,6 @@ set -e
 zypper rr 'NON OSS'
 zypper rr 'NON OSS Update'
 
-zypper ar -f http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/openSUSE_Leap_15.0/ "Uyuni:Master:15.0"
-zypper ar -f http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/Other/openSUSE_Leap_15.0/ "Uyuni:Master:Other:15.0"
+zypper ar -f http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/openSUSE_Leap_15.1/ "Uyuni:Master:15.1"
+zypper ar -f http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/Other/openSUSE_Leap_15.1/ "Uyuni:Master:Other:15.1"
 #zypper ar -f http://download.suse.de/ibs/Devel:/Galaxy:/pylint/SLE_12_SP3/ "pylint"

--- a/susemanager-utils/testing/docker/master/uyuni-push-to-obs/Dockerfile
+++ b/susemanager-utils/testing/docker/master/uyuni-push-to-obs/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION                4.0.0
 
-FROM opensuse/leap:15.0
+FROM opensuse/leap:15.1
 MAINTAINER Julio Gonzalez "jgonzalez@suse.com"
 
 # Add the repositories

--- a/susemanager-utils/testing/docker/master/uyuni-push-to-obs/add_repositories.sh
+++ b/susemanager-utils/testing/docker/master/uyuni-push-to-obs/add_repositories.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
 
-zypper ar -f https://download.opensuse.org/repositories/home:/mcalmer:/tito/openSUSE_Leap_15.0/home:mcalmer:tito.repo
-zypper ar -f http://download.suse.de/ibs/SUSE:/CA/openSUSE_Leap_15.0/SUSE:CA.repo
+zypper ar -f https://download.opensuse.org/repositories/home:/mcalmer:/tito/openSUSE_Leap_15.1/home:mcalmer:tito.repo
+zypper ar -f http://download.suse.de/ibs/SUSE:/CA/openSUSE_Leap_15.1/SUSE:CA.repo


### PR DESCRIPTION
## What does this PR change?

Uyuni now uses openSUSE Leap 15.1 .
Change docker images to use it as well.

Additionally adapt the makefile to push only on request.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **no code change**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
