### PR TITLE
Use VERSION_ID instead of VERSION to extract the OS version

### DIFF
--- a/testsuite/features/support/client_stack.rb
+++ b/testsuite/features/support/client_stack.rb
@@ -68,9 +68,9 @@ def check_restart(host, node, time_out)
 end
 
 # Extract the OS version by decoding the value in '/etc/os-release'
-# e.g.: VERSION="12-SP1"
+# e.g.: VERSION_ID="12-SP1"
 def get_os_version(node)
-  os_version_raw, _code = node.run('grep "VERSION=" /etc/os-release')
+  os_version_raw, _code = node.run('grep "VERSION_ID=" /etc/os-release')
   os_version = os_version_raw.strip.split('=')[1]
   return nil if os_version.nil?
   os_version.delete! '"'


### PR DESCRIPTION
## What does this PR change?

Use `VERSION_ID` instead of `VERSION` to extract the OS version

`VERSION`is not present, for example, at openSUSE Tumbleweed, and at other distributions such as Fedora it includes the pretty name (for example: `VERSION="17 (Beefy Miracle)"`)

https://www.freedesktop.org/software/systemd/man/os-release.html (or `man os-release`)

> VERSION_ID=
> 
> A lower-case string (mostly numeric, no spaces or other characters outside of 0–9, a–z, ".", "_" and "-") identifying the operating system version, excluding any OS name information or release code name, and suitable for processing by scripts or usage in generated filenames. This field is optional. Example: "VERSION_ID=17" or "VERSION_ID=11.04".

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Testsuite fix.

- [x] **DONE**

## Test coverage
- No tests: Testsuite fix.

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
