### PR TITLE
WIP: add Multi-Arch header for Debian packages

### DIFF
--- a/backend/server/importlib/backendOracle.py
+++ b/backend/server/importlib/backendOracle.py
@@ -202,6 +202,7 @@ class OracleBackend(Backend):
                   'header_start': DBint(),
                   'header_end': DBint(),
                   'last_modified': DBdateTime(),
+                  'multi_arch': DBstring(16),
               },
               pk=['org_id', 'name_id', 'evr_id', 'package_arch_id',
                   'checksum_id'],

--- a/backend/server/importlib/debPackage.py
+++ b/backend/server/importlib/debPackage.py
@@ -32,6 +32,9 @@ class debBinaryPackage(headerSource.rpmBinaryPackage):
         headerSource.rpmBinaryPackage.__init__(self)
 
         self.tagMap = headerSource.rpmBinaryPackage.tagMap.copy()
+        self.tagMap.update({
+            'multi_arch': 'Multi-Arch'
+        })
 
         # Remove already-mapped tags
         self._already_mapped = [

--- a/backend/server/importlib/debPackage.py
+++ b/backend/server/importlib/debPackage.py
@@ -33,7 +33,7 @@ class debBinaryPackage(headerSource.rpmBinaryPackage):
 
         self.tagMap = headerSource.rpmBinaryPackage.tagMap.copy()
         self.tagMap.update({
-            'multi_arch': 'Multi-Arch'
+            'multi_arch': 'Multi-Arch',
         })
 
         # Remove already-mapped tags

--- a/backend/server/importlib/importLib.py
+++ b/backend/server/importlib/importLib.py
@@ -506,6 +506,7 @@ class Package(IncompletePackage):
         'path': StringType,
         'md5sum': StringType,       # xml dumps < 3.5
         'sigmd5': StringType,
+        'multi_arch': StringType,
         # These attributes are lists of objects
         'files'             : [File],
         'requires'          : [Dependency],

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Task_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Task_queries.xml
@@ -454,7 +454,7 @@ where snc.errata_id = :errata_id
          pevr.version as version, pevr.release as release,
          p.summary, p.description, pa.label as arch_label,
          p.build_time, p.path, p.package_size, p.payload_size, p.installed_size,
-         p.copyright, p.vendor, p.build_host, p.header_start, p.header_end,
+         p.copyright, p.vendor, p.build_host, p.header_start, p.header_end, p.multi_arch,
          srpm.name as source_rpm, pg.name as package_group_name,
          cs.checksum, cs.checksum_type as checksum_type,
          prd.primary_xml as primary_xml, prd.filelist as filelist_xml, prd.other as other_xml

--- a/java/code/src/com/redhat/rhn/frontend/dto/PackageDto.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/PackageDto.java
@@ -590,7 +590,7 @@ public class PackageDto extends BaseDto {
      * @param multiArchIn The Multi-Arch header for Debian
      */
     public void setMultiArch(String multiArchIn) {
-        multiArch = multiArchIn;
+        this.multiArch = multiArchIn;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/dto/PackageDto.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/PackageDto.java
@@ -61,6 +61,7 @@ public class PackageDto extends BaseDto {
     private Blob otherXml;
     private Blob filelistXml;
     private String cookie;
+    private String multiArch;
 
 
     // Pre-existing queries returning this as a string.
@@ -583,5 +584,19 @@ public class PackageDto extends BaseDto {
      */
     public String getFile() {
         return PackageHelper.getPackageFileFromPath(getPath());
+    }
+
+    /**
+     * @param multiArchIn The Multi-Arch header for Debian
+     */
+    public void setMultiArch(String multiArchIn) {
+        multiArch = multiArchIn;
+    }
+
+    /**
+     * @return Returns the Multi-Arch header
+     */
+    public String getMultiArch() {
+        return multiArch;
     }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
@@ -106,9 +106,10 @@ public class DebPackageWriter {
                 out.newLine();
             }
 
-            String multiarch = pkgDto.getMultiArch();
-            if (multiarch != null) {
-                out.write("Multi-Arch: " + multiarch);
+            String multiArch = pkgDto.getMultiArch();
+            if (multiArch != null && !multiArch.equalsIgnoreCase("")) {
+                out.write("Multi-Arch: ");
+                out.write(multiArch);
                 out.newLine();
             }
 

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
@@ -106,6 +106,12 @@ public class DebPackageWriter {
                 out.newLine();
             }
 
+            String multiarch = pkgDto.getMultiArch();
+            if (multiarch != null) {
+                out.write("Multi-Arch: " + multiarch);
+                out.newLine();
+            }
+
             // dependencies
             addPackageDepData(
                     out,

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Write Multi-Arch header for Debian packages if present
 - Allow adding monitoring entitlement to openSUSE Leap 15.x
 - Add support for Salt Formulas to be used with standalone Salt
 - Fix channel sync status logic in products page (bsc#1131721)


### PR DESCRIPTION
## What does this PR change?

**This is WIP It's a first attempt to add the ```Multi-Arch``` header to Debian packages**

## GUI diff

No difference.

Before:

After:

- [X] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #1030 (it might fix it)
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
