### PR TITLE
Testsuite: avoid failing on error

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -288,11 +288,7 @@ When(/^I refresh the metadata for "([^"]*)"$/) do |host|
     $client.run('rhn_check -vvv', true, 500, 'root')
     client_refresh_metadata
   when 'sle-minion'
-    repeat_until_timeout(message: 'Could not refresh metadata') do
-      _out, code = $minion.run('zypper --non-interactive refresh -s', true, 200, 'root')
-      break if code.zero?
-      sleep 3
-    end
+    $minion.run_until_ok('zypper --non-interactive refresh -s')
   else
     raise 'Invalid target.'
   end


### PR DESCRIPTION
Intent of the original code was the same as run_until_ok, but actually
failed because fatal was set to true.

## What does this PR change?

It fixes up https://github.com/uyuni-project/uyuni/pull/1060, which did not give the expected result. In case `zypper` fails, instead of retrying, an exception is raised because `fatal` is set to `true`:

```
When I refresh the metadata for "sle-minion"
features/step_definitions/common_steps.rb:285

FAIL: zypper --non-interactive refresh -s returned 4. output : All services have been refreshed.
Retrieving repository 'Test Base Channel' metadata [.
Permission to access 'https://suma-head-pxy.mgr.suse.de:443/rhn/manager/download/test_base_channel/repodata/repomd.xml?[TOKEN]' denied.

[...]

./features/support/lavanda.rb:41:in `run'
./features/step_definitions/common_steps.rb:292:in `block (2 levels) in '
./features/support/commonlib.rb:73:in `block in repeat_until_timeout'
/usr/lib64/ruby/2.5.0/timeout.rb:93:in `block in timeout'
[...]
./features/support/commonlib.rb:62:in `repeat_until_timeout'
./features/step_definitions/common_steps.rb:291:in `/^I refresh the metadata for "([^"]*)"$/'
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: testsuite
- [ ] **DONE**

## Test coverage
- No tests: testsuite

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/8046

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
