### PR TITLE
Redirect after software channel change

### DIFF
--- a/web/html/src/manager/systems/subscribe-channels/subscribe-channels.js
+++ b/web/html/src/manager/systems/subscribe-channels/subscribe-channels.js
@@ -324,6 +324,7 @@ class SystemChannels extends React.Component<SystemChannelsProps, SystemChannels
                 messages: msg,
                 scheduled: true
               });
+              window.location = `/rhn/systems/details/SystemChannels.do?sid=${this.props.serverId}`;
             } else {
               this.setState({
                 messages: MessagesUtils.error(data.messages)

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Redirect user back to system after software channel change (bsc#1137244)
 - add error messages, hints for image profile edit page (bsc#1127319) 
 - Allow virtualization tab for foreign systems (bsc#1116869)
 - Add checks for empty required entries on formula forms (bsc#1109639)


### PR DESCRIPTION
## What does this PR change?

**add description**

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Just what was intended in the first place.
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [x] **DONE**

## Test coverage
- No tests: Just a redirect in the case of success.
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #
Tracks https://github.com/SUSE/spacewalk/issues/8025

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
