### PR TITLE
Testsuite: fix accidentally broken step

### DIFF
--- a/testsuite/features/step_definitions/centos_tradclient.rb
+++ b/testsuite/features/step_definitions/centos_tradclient.rb
@@ -11,10 +11,8 @@ def wait_action_complete(actionid)
   @sid = @cli.call('auth.login', 'admin', 'admin')
   repeat_until_timeout(timeout: 300, message: 'Action was not found among completed actions') do
     list = @cli.call('schedule.list_completed_actions', @sid)
-    list.each do |action|
-      break if action['id'] == actionid
-      sleep 2
-    end
+    break if list.any? { |a| a['id'] == actionid }
+    sleep 2
   end
 end
 


### PR DESCRIPTION
## What does this PR change?

A previous refactoring broke `wait_action_complete`, which currently sleeps for 2 seconds per Action instead of 2 seconds in total. This results in timeouts. This PR addresses the problem.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **testsuite**
- [x] **DONE**

## Test coverage
- No tests: **testsuite**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/8051
- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
