### PR TITLE
Testsuite: move product test to non-idempotent section

### DIFF
--- a/testsuite/run_sets/testsuite.yml
+++ b/testsuite/run_sets/testsuite.yml
@@ -118,7 +118,6 @@
 - features/allcli_software_channels.feature
 - features/allcli_software_channels_dependencies.feature
 - features/srv_change_task_schedule.feature
-- features/srv_sync_products.feature
 - features/srv_notifications.feature
 - features/minkvm_guests.feature
 - features/minxen_guests.feature
@@ -131,6 +130,8 @@
 
 # IMMUTABLE ORDER
 
+# this feature is not idempotent and might slow down other features, so it is better near the end
+- features/srv_sync_products.feature
 # this feature is destructive for other features, so it is better at the end
 - features/srv_smdba.feature
 # this feature is needed for gathering log/debug infos


### PR DESCRIPTION
## What does this PR change?

It moves the product syncing feature near the end of the testsuite because of two reasons:

 - the test is currently in the idempotent section but it is not really idempotent. Nor it can easily be made idempotent, as we do not support removal of SUSE channels
 - there is a chance background reposync slows down concurrent features excessively on our hardware, leading to timeouts

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **testsuite**
- [x] **DONE**

## Test coverage
- No tests: **testsuite**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/8050
- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
