### PR TITLE
Prevent CherryPy timeouts (bsc#1118175)

### DIFF
--- a/spacewalk/setup/salt/susemanager.conf
+++ b/spacewalk/setup/salt/susemanager.conf
@@ -4,6 +4,7 @@ rest_cherrypy:
   host: 127.0.0.1
   collect_stats: false
   disable_ssl: true
+  expire_responses: false
   ssl_crt: /etc/pki/tls/certs/spacewalk.crt
   ssl_key: /etc/pki/tls/private/spacewalk.key
 

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,4 @@
+- prevent CherryPy timeouts (bsc#1118175)
 - configure 150 Tomcat workers by default, matching httpds MaxClients
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Prevents the CherryPy library from killing requests if they take too long.

This timeout is not appropriate in the context of Salt:

https://github.com/cherrypy/cherrypy/issues/1501

And actually even in the context of CherryPy itself - a follow-up on that issue removed the timeout check entirely from the library:

https://github.com/cherrypy/cherrypy/issues/1625 https://github.com/cherrypy/cherrypy/pull/1651

At this point in time, it's not documented any more: http://docs.cherrypy.org/en/latest/advanced.html


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **functionality was removed, nothing to test**

- [x] **DONE**


## Links


Tracks https://github.com/SUSE/spacewalk/pull/8059

- [x] **DONE**


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
