### PR TITLE
Fallbacks when searching for errata on cloning via API (bsc#1137308)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/test/ErrataHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/test/ErrataHandlerTest.java
@@ -658,6 +658,14 @@ public class ErrataHandlerTest extends BaseHandlerTestCase {
     }
 
     public void testCloneErrata() throws Exception {
+        cloneErrataTest(false);
+    }
+
+    public void testCloneVendorErrata() throws Exception {
+        cloneErrataTest(true);
+    }
+
+    private void cloneErrataTest(boolean vendor) throws Exception {
         Channel channel = ChannelFactoryTest.createTestChannel(admin);
         channel.setOrg(admin.getOrg());
 
@@ -671,8 +679,11 @@ public class ErrataHandlerTest extends BaseHandlerTestCase {
 
         channel.addPackage(chanPack);
 
-        Errata toClone = ErrataFactoryTest.createTestPublishedErrata(
-                admin.getOrg().getId());
+        Long orgId = admin.getOrg().getId();;
+        if (vendor) {
+            orgId = null;
+        }
+        Errata toClone = ErrataFactoryTest.createTestPublishedErrata(orgId);
         toClone.addPackage(errataPack);
 
         ArrayList errata = new ArrayList();

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fallback to logged-in-user org and then vendor errata when looking up erratum on cloning (bsc#1137308)
 - Improve performance of 'Systems requiring reboot' page (fate#327780)
 - Allow virtualization tab for foreign systems (bsc#1116869)
 - Keep querystring on ListTag parent_url for actions that have the cid param (bsc#1134677)


### PR DESCRIPTION
## What does this PR change?

 When cloning errata into cloned channel by advisory names (e.g. the
 errata.clone endpoint), the code looks up the errata to-be-cloned by
 given advisory names and organization of the original of the given
 channel.
 
 Before this commit, the 'clone' endpoint failed in following situations:
 
 1. Cloning a vendor (i.e. `org_id == null`, advisory name does not contain
 'CL-' prefix) erratum to a custom cloned channel: spacewalk tried to
 look up the errata based on advisory name (with no 'CL-' prefix!) and
 original channel org (`org_id != null` in this scenario). This search
 failed because the vendor errata have `org_id == null`.
 
 2. Cloning a cloned errata (`org_id != null`, prefix 'CL-') to a channel
 that is a clone of a vendor channel: spacewalk tried to look up the
 errata based on advisory name (with 'CL-' prefix this time!) and
 original channel org (`org_id == null` in this scenario - the original is
 a vendor channel). This search failed because the vendor errata don't
 have the 'CL-' prefix.
 
 
 
 ## GUI diff
 
 No difference.
 
 - [x] **DONE**
 
 ## Documentation
 bugfix
 - [x] **DONE**
 
 ## Test coverage
 - jUnit
 
 - [x] **DONE**
 
 ## Links
 
 Tracks https://bugzilla.suse.com/show_bug.cgi?id=1137308

https://github.com/SUSE/spacewalk/issues/8033
 
 - [x] **DONE**
 
 ## Changelogs
 
 If you don't need a changelog check, please mark this checkbox:
 
 - [ ] No changelog needed
 
 If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
 
 
 ## Re-run a test
 
 If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:
 
 - [ ] Re-run test "changelog_test"
 - [ ] Re-run test "backend_unittests_pgsql"
 - [ ] Re-run test "java_lint_checkstyle"		 
 - [ ] Re-run test "java_pgsql_tests"		 
 - [ ] Re-run test "ruby_rubocop"
 - [ ] Re-run test "schema_migration_test_oracle"
 - [ ] Re-run test "schema_migration_test_pgsql"		 
 - [ ] Re-run test "susemanager_unittests"
 - [ ] Re-run test "javascript_lint"