### PR TITLE
Add mising changelog entry for spacewalk-config

### DIFF
--- a/spacewalk/config/spacewalk-config.changes
+++ b/spacewalk/config/spacewalk-config.changes
@@ -1,3 +1,9 @@
+- mark zz-spacewalk-www.conf and os-images.conf as plain %config
+  instead of %config(noreplace):
+  Those files were never meant to be edited by the user. The package
+  will preserve your edits as .rpmsave files.
+  If you need edits, you will have to merge them after every upgrade
+  from the rpmsave files from now on.
 - Fix URL rewrites for proxy cobbler api endpoint (bsc#1133800)
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Add mising changelog entry for spacewalk-config

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Changelog fix

- [x] **DONE**

## Test coverage
- No documentation needed: Changelog fix

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
