### PR TITLE
Prevent needlessly firing channel-repodata (bsc1137715)

### DIFF
--- a/backend/server/rhnRepository.py
+++ b/backend/server/rhnRepository.py
@@ -258,7 +258,7 @@ class Repository(rhnRepository.Repository):
         except IOError:
             e = sys.exc_info()[1]
             # For file not found, queue up a regen, and return 404
-            if e.errno == 2 and file_name != "comps.xml" and file_name != "modules.yaml":
+            if e.errno == 2 and file_name not in ["comps.xml", "modules.yaml", "repomd.xml.asc", "repomd.xml.key"]:
                 taskomatic.add_to_repodata_queue(self.channelName,
                                                  "repodata request", file_name, bypass_filters=True)
                 rhnSQL.commit()

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- Prevent unnecessary triggering of channel-repodata tasks when GPG
+  signing is disabled (bsc#1137715)
 - Fix spacewalk-repo-sync for Ubuntu repositories in mirror case (bsc#1136029)
 - Add support for ULN repositories on new Zypper based reposync.
 


### PR DESCRIPTION
## What does this PR change?

It adds `repomd.xml.key` and `repomd.xml.asc` to a whitelist of files which will not trigger a channel-repodata Taskomatic task if they trigger a 404 error (from traditional clients failing to download them.

### Background

Repo files are served either via the Java backend (in the case of Salt minions) or the Python backend (in the case of traditional clients).

It is possible, in some cases, that those backends return a 404 error, when a file is missing. This happens in two cases:

1- if the file is missing because metadata is stale (needs regeneration)
2- if the file is missing because it is optional - it will be missing regardless regeneration


Only in the Python backend, metadata regeneration is triggered in any case a 404 error is produced (except on a whitelist), as a "safety net" in case repository metadata was not completed for unknown reasons.

Problem is exacerbated by the fact `repomd.xml.key`/`repomd.xml.asc` files are not in this whitelist and are also normally missing (unless user has taken extra steps to generate GPG signatures, which is a minority of use cases).

The end result is that many operations on traditional clients, directly on indirectly relying on `zypper ref`, will cause metadata regeneration. This can be long and might produce `zypper ref` errors until it's finished on Salt minions.

This PR addresses this problem at least for `repomd.xml.key`/`repomd.xml.asc` files.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **testsuite**

- [x] **DONE**

## Test coverage
- No tests: **testsuite**

- [x] **DONE**

## Links

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1137715

Tracks https://github.com/SUSE/spacewalk/pull/8064

- [x] **DONE**


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
