### PR TITLE
Add journalctl output to spacewalk-debug tarballs

### DIFF
--- a/backend/satellite_tools/spacewalk-debug
+++ b/backend/satellite_tools/spacewalk-debug
@@ -117,6 +117,9 @@ mkdir -p $DIR/database/trc
 mkdir -p $DIR/cobbler-lib
 mkdir -p $DIR/tasko
 mkdir -p $DIR/salt-states
+if [ -f /usr/bin/journalctl ]; then
+  mkdir -p $DIR/systemd
+fi
 
 echo "    * copying configuration information"
 if [ -d /etc/httpd ]; then
@@ -169,6 +172,10 @@ if [ -d $MATCHER_DATA_DIR ]; then
 fi
 
 echo "    * copying logs"
+if [ -f /usr/bin/journalctl ]; then
+  /usr/bin/journalctl -m > $DIR/systemd/journalctl.log
+fi
+
 if [ -d /var/log/httpd ]; then
     cp -fapRd /var/log/httpd $DIR/httpd-logs
 elif [ -d /var/log/apache2 ]; then

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Add journalctl output to spacewalk-debug tarballs
 - Prevent unnecessary triggering of channel-repodata tasks when GPG
   signing is disabled (bsc#1137715)
 - Fix spacewalk-repo-sync for Ubuntu repositories in mirror case (bsc#1136029)


### PR DESCRIPTION
## What does this PR change?

Add journalctl output to spacewalk-debug tarballs. Useful, for example, to check kernel logs.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: spacewalk-debug is used only at CI.

- [x] **DONE**

## Test coverage
- No tests: spacewalk-debug not covered.

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/8071

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
