### PR TITLE
Use VERSION to detect OS for SLE, VERSION_ID otherwise

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -567,7 +567,7 @@ end
 
 And(/^I create the "([^"]*)" bootstrap repository for "([^"]*)" on the server$/) do |arch, host|
   node = get_target(host)
-  os_version = get_os_version(node)
+  os_version = get_os_version(node, false)
   cmd = 'false'
   if (os_version.include? '12') || (os_version.include? '15')
     cmd = "mgr-create-bootstrap-repo -c SLE-#{os_version}-#{arch}"

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -573,7 +573,7 @@ end
 
 When(/^I enable repositories before installing Docker$/) do
   # Distribution Pool and Update
-  os_version = get_os_version($minion)
+  os_version = get_os_version($minion, false)
   arch, _code = $minion.run('uname -m')
   puts $minion.run("zypper mr --enable SLE-#{os_version}-#{arch.strip}-Pool")
   puts $minion.run("zypper mr --enable SLE-#{os_version}-#{arch.strip}-Update")
@@ -597,7 +597,7 @@ end
 
 When(/^I disable repositories after installing Docker$/) do
   # Distribution Pool and Update
-  os_version = get_os_version($minion)
+  os_version = get_os_version($minion, false)
   arch, _code = $minion.run('uname -m')
   puts $minion.run("zypper mr --disable SLE-#{os_version}-#{arch.strip}-Update")
   puts $minion.run("zypper mr --disable SLE-#{os_version}-#{arch.strip}-Pool")
@@ -621,11 +621,12 @@ end
 
 When(/^I enable repositories before installing branch server$/) do
   # Distribution Pool and Update
-  os_version = get_os_version($proxy)
+  os_version = get_os_version($proxy, false)
   os_family, _code = $proxy.run('grep "ID" /etc/os-release')
   if /opensuse/ =~ os_family
-    puts $proxy.run("zypper mr --enable openSUSE-Leap-#{os_version}-Pool")
-    puts $proxy.run("zypper mr --enable openSUSE-Leap-#{os_version}-Update")
+    leap_version = get_os_version($proxy)
+    puts $proxy.run("zypper mr --enable openSUSE-Leap-#{leap_version}-Pool")
+    puts $proxy.run("zypper mr --enable openSUSE-Leap-#{leap_version}-Update")
   else
     arch, _code = $proxy.run('uname -m')
     # take all repos that matche the following pattern "SLE.*#{os_version}-#{arch.strip}.*"
@@ -636,11 +637,12 @@ end
 
 When(/^I disable repositories after installing branch server$/) do
   # Distribution Pool and Update
-  os_version = get_os_version($proxy)
+  os_version = get_os_version($proxy, false)
   os_family, _code = $proxy.run('grep "ID" /etc/os-release')
   if /opensuse/ =~ os_family
-    puts $proxy.run("zypper mr --disable openSUSE-Leap-#{os_version}-Pool")
-    puts $proxy.run("zypper mr --disable openSUSE-Leap-#{os_version}-Update")
+    leap_version = get_os_version($proxy)
+    puts $proxy.run("zypper mr --disable openSUSE-Leap-#{leap_version}-Pool")
+    puts $proxy.run("zypper mr --disable openSUSE-Leap-#{leap_version}-Update")
   else
     arch, _code = $proxy.run('uname -m')
     # take all repos that matche the following pattern "SLE.*#{os_version}-#{arch.strip}.*"

--- a/testsuite/features/support/client_stack.rb
+++ b/testsuite/features/support/client_stack.rb
@@ -68,9 +68,10 @@ def check_restart(host, node, time_out)
 end
 
 # Extract the OS version by decoding the value in '/etc/os-release'
-# e.g.: VERSION_ID="12-SP1"
-def get_os_version(node)
-  os_version_raw, _code = node.run('grep "VERSION_ID=" /etc/os-release')
+# Use VERSION id = false, VERSION_ID otherwise
+def get_os_version(node, id = true)
+  field = id ? 'VERSION_ID' : 'VERSION'
+  os_version_raw, _code = node.run('grep "' + field + '=" /etc/os-release')
   os_version = os_version_raw.strip.split('=')[1]
   return nil if os_version.nil?
   os_version.delete! '"'

--- a/testsuite/features/support/minion_checks.rb
+++ b/testsuite/features/support/minion_checks.rb
@@ -1,7 +1,7 @@
 # check if the minion is a SLE-15
 def minion_is_sle15
   node = get_target('sle-minion')
-  os_version = get_os_version(node)
+  os_version = get_os_version(node, false)
   return false if os_version.nil?
   os_version.include? '15'
 end


### PR DESCRIPTION
## What does this PR change?

**add description**Use VERSION to detect OS for SLE, VERSION_ID otherwise.

Ideally we should ALWAYS use VERSION_ID for everything, but sadly the repositories for SLE don't use it.

This will fix the problems we detected this weekend when adding the SLE repositories, after #1071 got merged.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Testsuite change

- [x] **DONE**

## Test coverage
- No tests: Testsuite change

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
