### PR TITLE
Testsuite: Double the timeout when building two images simultaneously

### DIFF
--- a/testsuite/features/min_docker_auth_registry.feature
+++ b/testsuite/features/min_docker_auth_registry.feature
@@ -54,3 +54,6 @@ Feature: Build image with authenticated registry
   Scenario: Cleanup: delete portus image
     Given I am authorized as "admin" with password "admin"
     When I delete the image "portus_profile" with version "latest" via XML-RPC calls
+
+  Scenario: Cleanup: kill stale portus image build jobs
+    When I kill remaining Salt jobs on "sle-minion"

--- a/testsuite/features/min_docker_build_image.feature
+++ b/testsuite/features/min_docker_build_image.feature
@@ -59,3 +59,6 @@ Feature: Build container images
     And I delete the image "suse_key" with version "Latest_key-activation1" via XML-RPC calls
     And I delete the image "suse_real_key" with version "GUI_BUILT_IMAGE" via XML-RPC calls
     And I delete the image "suse_real_key" with version "GUI_DOCKERADMIN" via XML-RPC calls
+
+  Scenario: Cleanup: kill stale image build jobs
+    When I kill remaining Salt jobs on "sle-minion"

--- a/testsuite/features/min_docker_build_image.feature
+++ b/testsuite/features/min_docker_build_image.feature
@@ -19,7 +19,7 @@ Feature: Build container images
     Given I am authorized as "admin" with password "admin"
     When I schedule the build of image "suse_key" with version "Latest_key-activation1" via XML-RPC calls
     And I schedule the build of image "suse_simple" with version "Latest_simple" via XML-RPC calls
-    And I wait at most 500 seconds until all "5" container images are built correctly in the GUI
+    And I wait at most 1000 seconds until all "5" container images are built correctly in the GUI
 
   Scenario: Delete image via XML-RPC calls
     Given I am authorized as "admin" with password "admin"
@@ -32,7 +32,7 @@ Feature: Build container images
     Given I am authorized as "admin" with password "admin"
     When I schedule the build of image "suse_simple" with version "Latest_simple" via XML-RPC calls
     And I schedule the build of image "suse_key" with version "Latest_key-activation1" via XML-RPC calls
-    And I wait at most 500 seconds until all "5" container images are built correctly in the GUI
+    And I wait at most 1000 seconds until all "5" container images are built correctly in the GUI
 
   Scenario: Build an image via the GUI
     Given I am authorized as "admin" with password "admin"

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -724,3 +724,11 @@ When(/^I install "([^"]*)" to custom formula metadata directory "([^"]*)"$/) do 
   raise 'File injection failed' unless return_code.zero?
   $server.run("chmod 644 " + dest)
 end
+
+When(/^I kill remaining Salt jobs on "([^"]*)"$/) do |minion|
+  system_name = get_system_name(minion)
+  output = $server.run("salt #{system_name} saltutil.kill_all_jobs")
+  if output.include?(system_name) && output.include?('Signal 9 sent to job')
+    puts output
+  end
+end


### PR DESCRIPTION
In some test cases, two images are being built at the same time. Since those builds are executed sequentially, the timeout for these cases should be twice as much.

If the image builds time out, the respective Salt jobs still keep running, and this blocks the subsequent features in the test suite, causing unrelated failures. This PR adds another cleanup scenario to kill the stale jobs which we don't care about anymore.

Port of https://github.com/SUSE/spacewalk/pull/8042

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
