### PR TITLE
Add a missing --yes for apt-get in boostrap script

### DIFF
--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -639,7 +639,7 @@ if [ "$INSTALLER" == apt ]; then
         done
     fi
     # try update main packages for registration from any repo which is available
-    apt-get install --only-upgrade salt-common salt-minion ||:
+    apt-get --yes install --only-upgrade salt-common salt-minion ||:
 
     # remove bootstrap repo
     rm -f $CLIENT_REPO_FILE

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,4 @@
+- Run bootstrap.sh completely unattended on Ubuntu (bsc#1137881)
 - Add new packages names to instructions for adding remote commands
   support for traditional clients (bsc#1137255)
 


### PR DESCRIPTION
## What does this PR change?

With this the boostrap script now runs unattended on Ubuntu minions.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: bootstrap script fix

- [X] **DONE**

## Test coverage
- No tests: bootstrap script fix

- [X] **DONE**

## Links

Fixes [bsc#1137881](https://bugzilla.suse.com/show_bug.cgi?id=1137881)

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
