### PR TITLE
Content Lifecycle Management testsuite fixes/improvements

### DIFF
--- a/testsuite/features/srv_content_lifecycle.feature
+++ b/testsuite/features/srv_content_lifecycle.feature
@@ -132,3 +132,11 @@ Feature: Content lifecycle
     And I click on "Promote environment" in "Promote version 2 into prod_name" modal
     Then I should see a "Version 2 successfully promoted into prod_name" text
     And I should see a "Version 2: test version message 2" text in the environment "prod_name"
+
+  Scenario: Clean up the Content Lifecycle Management feature
+    Given I am authorized as "admin" with password "admin"
+    When I follow the left menu "Content Lifecycle > Projects"
+    And I follow "clp_name"
+    When I click on "Delete"
+    Then I click on "Delete" in element "delete-project-modal"
+    And I should see a "Project clp_label deleted successfully" text

--- a/testsuite/features/srv_content_lifecycle.feature
+++ b/testsuite/features/srv_content_lifecycle.feature
@@ -15,7 +15,7 @@ Feature: Content lifecycle
     And I enter "clp_name" as "name"
     And I enter "clp_desc" as "description"
     And I click on "Create"
-    Then I should see a "Project clp_label created successfully" text
+    Then I wait until I see "Project clp_label created successfully" text
     And I should see a "Content Lifecycle Project - clp_name" text
 
   Scenario: Verify the content lifecycle project page
@@ -37,7 +37,7 @@ Feature: Content lifecycle
     And I follow "Attach/Detach Sources"
     And I select "SLES12-SP4-Pool for x86_64" from "selectedBaseChannel"
     And I click on "Save"
-    Then I should see a "Sources edited successfully" text
+    Then I wait until I see "Sources edited successfully" text
     And I should see a "SLES12-SP4-Pool for x86_64" text
     And I should see a "SLE-Manager-Tools12-Updates for x86_64 SP4" text
     And I should see a "SLES12-SP4-Updates for x86_64" text
@@ -54,14 +54,14 @@ Feature: Content lifecycle
     And I enter "dev_name" as "name"
     And I enter "dev_desc" as "description"
     And I click on "Save"
-    Then I should see a "Environment created successfully" text
+    Then I wait until I see "Environment created successfully" text
     And I should see a "dev_name" text
     And I should see a "dev_desc" text
     When I follow "Add Environment"
     And I enter "prod_name" as "name"
     And I enter "prod_desc" as "description"
     And I click on "Save"
-    Then I should see a "Environment created successfully" text
+    Then I wait until I see "Environment created successfully" text
     And I should see a "prod_name" text
     And I should see a "prod_desc" text
     When I follow "Add Environment"
@@ -69,7 +69,7 @@ Feature: Content lifecycle
     And I enter "qa_desc" as "description"
     And I select "prod_name" from "predecessorLabel"
     And I click on "Save"
-    Then I should see a "Environment created successfully" text
+    Then I wait until I see "Environment created successfully" text
     And I should see a "qa_name" text
     And I should see a "qa_desc" text
 
@@ -79,9 +79,7 @@ Feature: Content lifecycle
     And I follow "clp_name"
     Then I should see a "not built" text in the environment "qa_name"
     When I click on "Build (4)"
-    Then I should see a "Version 1: test version message 1" text in the environment "dev_name"
     And I should see a "Version 1 history" text
-    #And I should see a "Sources edited successfully" text
     When I enter "test version message 1" as "message"
     And I click the environment build button
     Then I should see a "Version 1 successfully built into dev_name" text
@@ -98,11 +96,11 @@ Feature: Content lifecycle
     And I should see a "not built" text in the environment "qa_name"
     When I click promote for Development to QA
     And I click on "Promote environment" in "Promote version 1 into qa_name" modal
-    Then I should see a "Version 1 successfully promoted into qa_name" text
+    Then I wait until I see "Version 1 successfully promoted into qa_name" text
     And I should see a "Version 1: test version message 1" text in the environment "qa_name"
     When I click promote for QA to Production
     And I click on "Promote environment" in "Promote version 1 into prod_name" modal
-    Then I should see a "Version 1 successfully promoted into prod_name" text
+    Then I wait until I see "Version 1 successfully promoted into prod_name" text
     And I should see a "Version 1: test version message 1" text in the environment "prod_name"
 
   Scenario: Add new sources and promote again
@@ -113,24 +111,24 @@ Feature: Content lifecycle
     When I follow "Attach/Detach Sources"
     And I add the "Test Base Channel" channel to sources
     And I click on "Save"
-    Then I should see a "Sources edited successfully" text
+    Then I wait until I see "Sources edited successfully" text
     And I should see a "Test Base Channel" text
     And I should see a "Build (1)" text
     And I should see a "Version 2: (draft - not built) - Check the changes below" text
     When I click on "Build (1)"
-    Then I should see a "Version 2 history" text
+    Then I wait until I see "Version 2 history" text
     When I enter "test version message 2" as "message"
     And I enter "test version message 2" as "message"
     And I click the environment build button
-    Then I should see a "Version 2 successfully built into dev_name" text
+    Then I wait until I see "Version 2 successfully built into dev_name" text
     And I should see a "Version 2: test version message 2" text
     When I click promote for Development to QA
     And I click on "Promote environment" in "Promote version 2 into qa_name" modal
-    Then I should see a "Version 2 successfully promoted into qa_name" text
+    Then I wait until I see "Version 2 successfully promoted into qa_name" text
     And I should see a "Version 2: test version message 2" text in the environment "qa_name"
     When I click promote for QA to Production
     And I click on "Promote environment" in "Promote version 2 into prod_name" modal
-    Then I should see a "Version 2 successfully promoted into prod_name" text
+    Then I wait until I see "Version 2 successfully promoted into prod_name" text
     And I should see a "Version 2: test version message 2" text in the environment "prod_name"
 
   Scenario: Clean up the Content Lifecycle Management feature
@@ -139,4 +137,4 @@ Feature: Content lifecycle
     And I follow "clp_name"
     When I click on "Delete"
     Then I click on "Delete" in element "delete-project-modal"
-    And I should see a "Project clp_label deleted successfully" text
+    And I wait until I see "Project clp_label deleted successfully" text

--- a/testsuite/features/srv_content_lifecycle.feature
+++ b/testsuite/features/srv_content_lifecycle.feature
@@ -15,8 +15,7 @@ Feature: Content lifecycle
     And I enter "clp_name" as "name"
     And I enter "clp_desc" as "description"
     And I click on "Create"
-    Then I wait until I see "Project clp_label created successfully" text
-    And I should see a "Content Lifecycle Project - clp_name" text
+    Then I wait until I see "Content Lifecycle Project - clp_name" text
 
   Scenario: Verify the content lifecycle project page
     Given I am authorized as "admin" with password "admin"
@@ -37,8 +36,7 @@ Feature: Content lifecycle
     And I follow "Attach/Detach Sources"
     And I select "SLES12-SP4-Pool for x86_64" from "selectedBaseChannel"
     And I click on "Save"
-    Then I wait until I see "Sources edited successfully" text
-    And I should see a "SLES12-SP4-Pool for x86_64" text
+    Then I wait until I see "SLES12-SP4-Pool for x86_64" text
     And I should see a "SLE-Manager-Tools12-Updates for x86_64 SP4" text
     And I should see a "SLES12-SP4-Updates for x86_64" text
     And I should see a "SLE-Manager-Tools12-Pool for x86_64 SP4" text
@@ -54,23 +52,20 @@ Feature: Content lifecycle
     And I enter "dev_name" as "name"
     And I enter "dev_desc" as "description"
     And I click on "Save"
-    Then I wait until I see "Environment created successfully" text
-    And I should see a "dev_name" text
+    Then I wait until I see "dev_name" text
     And I should see a "dev_desc" text
     When I follow "Add Environment"
     And I enter "prod_name" as "name"
     And I enter "prod_desc" as "description"
     And I click on "Save"
-    Then I wait until I see "Environment created successfully" text
-    And I should see a "prod_name" text
+    Then I wait until I see "prod_name" text
     And I should see a "prod_desc" text
     When I follow "Add Environment"
     And I enter "qa_name" as "name"
     And I enter "qa_desc" as "description"
     And I select "prod_name" from "predecessorLabel"
     And I click on "Save"
-    Then I wait until I see "Environment created successfully" text
-    And I should see a "qa_name" text
+    Then I wait until I see "qa_name" text
     And I should see a "qa_desc" text
 
   Scenario: Build the sources in the project
@@ -82,7 +77,7 @@ Feature: Content lifecycle
     And I should see a "Version 1 history" text
     When I enter "test version message 1" as "message"
     And I click the environment build button
-    Then I should see a "Version 1 successfully built into dev_name" text
+    Then I wait until I see "Version 1 successfully built into dev_name" text
     And I should see a "Version 1: test version message 1" text
 
   Scenario: Promote promote the sources in the project
@@ -96,12 +91,10 @@ Feature: Content lifecycle
     And I should see a "not built" text in the environment "qa_name"
     When I click promote for Development to QA
     And I click on "Promote environment" in "Promote version 1 into qa_name" modal
-    Then I wait until I see "Version 1 successfully promoted into qa_name" text
-    And I should see a "Version 1: test version message 1" text in the environment "qa_name"
+    Then I wait until I see "Version 1: test version message 1" text in the environment "qa_name"
     When I click promote for QA to Production
     And I click on "Promote environment" in "Promote version 1 into prod_name" modal
-    Then I wait until I see "Version 1 successfully promoted into prod_name" text
-    And I should see a "Version 1: test version message 1" text in the environment "prod_name"
+    Then I wait until I see "Version 1: test version message 1" text in the environment "prod_name"
 
   Scenario: Add new sources and promote again
     Given I am authorized as "admin" with password "admin"
@@ -111,25 +104,20 @@ Feature: Content lifecycle
     When I follow "Attach/Detach Sources"
     And I add the "Test Base Channel" channel to sources
     And I click on "Save"
-    Then I wait until I see "Sources edited successfully" text
-    And I should see a "Test Base Channel" text
+    Then I wait until I see "Test Base Channel" text
     And I should see a "Build (1)" text
     And I should see a "Version 2: (draft - not built) - Check the changes below" text
     When I click on "Build (1)"
     Then I wait until I see "Version 2 history" text
     When I enter "test version message 2" as "message"
-    And I enter "test version message 2" as "message"
     And I click the environment build button
-    Then I wait until I see "Version 2 successfully built into dev_name" text
-    And I should see a "Version 2: test version message 2" text
+    Then I wait until I see "Version 2: test version message 2" text
     When I click promote for Development to QA
     And I click on "Promote environment" in "Promote version 2 into qa_name" modal
-    Then I wait until I see "Version 2 successfully promoted into qa_name" text
-    And I should see a "Version 2: test version message 2" text in the environment "qa_name"
+    Then I wait until I see "Version 2: test version message 2" text in the environment "qa_name"
     When I click promote for QA to Production
     And I click on "Promote environment" in "Promote version 2 into prod_name" modal
-    Then I wait until I see "Version 2 successfully promoted into prod_name" text
-    And I should see a "Version 2: test version message 2" text in the environment "prod_name"
+    Then I wait until I see "Version 2: test version message 2" text in the environment "prod_name"
 
   Scenario: Clean up the Content Lifecycle Management feature
     Given I am authorized as "admin" with password "admin"
@@ -137,4 +125,5 @@ Feature: Content lifecycle
     And I follow "clp_name"
     When I click on "Delete"
     Then I click on "Delete" in element "delete-project-modal"
-    And I wait until I see "Project clp_label deleted successfully" text
+    Then I wait until I see "Content Lifecycle Projects" text
+    And I should see a "There are no entries to show." text

--- a/testsuite/features/step_definitions/content_lifecycle_steps.rb
+++ b/testsuite/features/step_definitions/content_lifecycle_steps.rb
@@ -21,3 +21,9 @@ When(/^I add the "([^"]*)" channel to sources$/) do |channel|
     find(:xpath, './/input[@type="checkbox"]').set(true)
   end
 end
+
+Then(/^I wait until I see "([^"]*)" text in the environment "([^"]*)"$/) do |text, env|
+  within(:xpath, "//h3[text()='#{env}']/../..") do
+    raise unless page.has_text?(text, wait: DEFAULT_TIMEOUT)
+  end
+end

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -159,6 +159,14 @@ When(/^I click on "([^"]*)"$/) do |arg1|
   end
 end
 #
+# Click on a button which appears inside of <div> with
+# the given "id"
+When(/^I click on "([^"]*)" in element "([^"]*)"$/) do |arg1, arg2|
+  within(:xpath, "//div[@id=\"#{arg2}\"]") do
+    click_button arg1, match: :first
+  end
+end
+#
 # Click on a button and confirm in alert box
 When(/^I click on "([^"]*)" and confirm$/) do |arg1|
   accept_alert do


### PR DESCRIPTION
## What does this PR change?

Make the Content Lifecycle Management testsuite feature more  reliable waiting for popup messages to appear, and making the test 100% idempotent.

Port of https://github.com/SUSE/spacewalk/pull/8079 and https://github.com/SUSE/spacewalk/pull/8087 and https://github.com/SUSE/spacewalk/pull/8095

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
