### PR TITLE
Testsuite: More robust staging tests

### DIFF
--- a/testsuite/features/min_salt_install_with_staging.feature
+++ b/testsuite/features/min_salt_install_with_staging.feature
@@ -55,13 +55,7 @@ Feature: Install a package on the minion with staging enabled
 
   Scenario: Install patch in the future and check for staging
     Given I am on the Systems overview page of this "sle-minion"
-    And I remove package "virgo-dummy" from this "sle-minion"
-    And I enable repository "Devel_Galaxy_BuildRepo" on this "sle-minion"
-    And I install package "virgo-dummy-1.0" on this "sle-minion"
-    And I wait for "30" seconds
     And I follow "Software" in the content area
-    And I click on "Update Package List"
-    And I wait for "30" seconds
     And I follow "Patches" in the content area
     When I check "virgo-dummy-3456" in the list
     And I click on "Apply Patches"

--- a/testsuite/features/min_salt_install_with_staging.feature
+++ b/testsuite/features/min_salt_install_with_staging.feature
@@ -52,7 +52,6 @@ Feature: Install a package on the minion with staging enabled
     Then I should see a "1 package install has been scheduled for" text
     And I wait until the package "orion-dummy-1.1-1.1" has been cached on this "sle-minion"
     And I wait for "orion-dummy-1.1-1.1" to be installed on this "sle-minion"
-    Then I remove package "orion-dummy-1.1-1.1" from this "sle-minion"
 
   Scenario: Install patch in the future and check for staging
     Given I am on the Systems overview page of this "sle-minion"
@@ -77,6 +76,9 @@ Feature: Install a package on the minion with staging enabled
     Given I am on the Systems overview page of this "sle-minion"
     When I follow "Software" in the content area
     And I follow "List / Remove"
+    And I enter "orion-dummy" in the css "input[placeholder='Filter by Package Name: ']"
+    And I click on the css "button.spacewalk-button-filter"
+    And I check "orion-dummy" in the list
     And I enter "virgo-dummy" in the css "input[placeholder='Filter by Package Name: ']"
     And I click on the css "button.spacewalk-button-filter"
     And I check "virgo-dummy" in the list

--- a/testsuite/features/min_salt_install_with_staging.feature
+++ b/testsuite/features/min_salt_install_with_staging.feature
@@ -12,11 +12,12 @@
 
 Feature: Install a package on the minion with staging enabled
 
-  Scenario: Pre-requisite: install virgo-dummy-1.0 package
+  Scenario: Pre-requisite: install virgo-dummy-1.0 package, make sure orion-dummy is not present
     When I enable repository "Devel_Galaxy_BuildRepo" on this "sle-minion"
+    And I run "zypper --non-interactive remove -y orion-dummy" on "sle-minion" without error control
     And I install package "virgo-dummy-1.0" on this "sle-minion"
 
-  Scenario: Pre-requisite: refresh package list and check newly installed packages on SLE minion client
+  Scenario: Pre-requisite: refresh package list
     When I refresh packages list via spacecmd on "sle-minion"
     And I wait until refresh package list on "sle-minion" is finished
     Then spacecmd should show packages "virgo-dummy-1.0" installed on "sle-minion"


### PR DESCRIPTION
## What does this PR change?
It removes a couple of race conditions in Cucumber tests for the minion staging (predownloading) feature.

Previous code relied on two 30-second pauses which are not guaranteed to be sufficient - new code removes them by using pre-requirements and cleanups differently. New code is also faster by about one minute.

This is expected to take care of intermittent Install a package on the minion with staging enabled. Install patch in the future and check for staging (min_salt_install_with_staging.feature) failures.

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: teststuite

- [ ] **DONE**

## Test coverage
- No tests: testsuite

- [ ] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/8073

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
