### PR TITLE
Testsuite: abort spacewalk-repo-sync

### DIFF
--- a/testsuite/features/core_srv_sync_channels.feature
+++ b/testsuite/features/core_srv_sync_channels.feature
@@ -63,3 +63,6 @@ Feature: Be able to list available channels and enable them
     When I remove the mgr-sync cache file
     And I execute mgr-sync refresh
     Then I should get "Timeout. No user input for 60 seconds. Exiting..."
+
+  Scenario: Cleanup: abort all reposync activity
+    Then I make sure no spacewalk-repo-sync is in execution

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -110,6 +110,14 @@ When(/^I execute mgr\-sync refresh$/) do
   $command_output = sshcmd('mgr-sync refresh', ignore_err: true)[:stderr]
 end
 
+When(/^I make sure no spacewalk\-repo\-sync is in execution$/) do
+  repeat_until_timeout(message: 'Could not kill all spacewalk-repo-sync instances') do
+    command_output = sshcmd('killall spacewalk-repo-sync', ignore_err: true)
+    break unless command_output[:stderr].empty?
+    sleep 2
+  end
+end
+
 When(/^I execute mgr\-bootstrap "([^"]*)"$/) do |arg1|
   arch = 'x86_64'
   $command_output = sshcmd("mgr-bootstrap --activation-keys=1-SUSE-PKG-#{arch} #{arg1}")[:stdout]


### PR DESCRIPTION
## What does this PR change?

It kills spacewalk-repo-sync processes spawned by core_srv_sync_channels.feature as a cleanup step.

Rationale: subsequent features will not suffer from major contention over I/O, CPU and possibly some database tables thereby (potentially/hopefully) stabilizing the testsuite.

Note that the testsuite's ability to verify correct operation when a major repository synchronization is in progress is lost. Nevertheless, that is believed not to be a frequent use case, as first repository synchronizations typically happen at setup time, and regular reposyncs are much quicker (and happen during the night, or in otherwise non-busy hour as per configuration).

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: testsuite

- [x] **DONE**

## Test coverage
- No tests: testsuite

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/8075

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
