### PR TITLE
Prevent FileNotFoundError: repomd.xml.key traceback (bsc#1137940)

### DIFF
--- a/backend/server/rhnRepository.py
+++ b/backend/server/rhnRepository.py
@@ -258,10 +258,11 @@ class Repository(rhnRepository.Repository):
         except IOError:
             e = sys.exc_info()[1]
             # For file not found, queue up a regen, and return 404
-            if e.errno == 2 and file_name not in ["comps.xml", "modules.yaml", "repomd.xml.asc", "repomd.xml.key"]:
-                taskomatic.add_to_repodata_queue(self.channelName,
-                                                 "repodata request", file_name, bypass_filters=True)
-                rhnSQL.commit()
+            if e.errno == 2 and file_name not in ["comps.xml", "modules.yaml"]:
+                if file_name not in ["repomd.xml.key", "repomd.xml.asc"]:
+                    taskomatic.add_to_repodata_queue(self.channelName, "repodata request",
+                                                     file_name, bypass_filters=True)
+                    rhnSQL.commit()
                 # This returns 404 to the client
                 raise_with_tb(rhnFault(6), sys.exc_info()[2])
             raise

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Prevent FileNotFoundError: repomd.xml.key traceback (bsc#1137940)
 - Add journalctl output to spacewalk-debug tarballs
 - Prevent unnecessary triggering of channel-repodata tasks when GPG
   signing is disabled (bsc#1137715)


### PR DESCRIPTION
## What does this PR change?

It prevents a traceback on the Python backend introduced by pull #1082:

```
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/<CENSORED!>/server/apacheRequest.py", line 137, in call_function
    response = func(*params)
  File "/usr/lib/python3.6/site-packages/<CENSORED!>/server/rhnRepository.py", line 283, in repodata
    return self._repodata_taskomatic(file_name)
  File "/usr/lib/python3.6/site-packages/<CENSORED!>/server/rhnRepository.py", line 257, in _repodata_taskomatic
    return self._getFile(CFG.REPOMD_CACHE_MOUNT_POINT + "/" + file_path)
  File "/usr/lib/python3.6/site-packages/<CENSORED!>/server/rhnRepository.py", line 325, in _getFile
    return rhnRepository.Repository._getFile(self, path)
  File "/usr/lib/python3.6/site-packages/<CENSORED!>/common/rhnRepository.py", line 210, in _getFile
    return rpclib.transports.File(open(filePath, "rb"), length, name=filePath)
FileNotFoundError: [Errno 2] No such file or directory: '/var/cache/rhn/repodata/test-channel-x86_64/repomd.xml.key'
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **emergency mode fix, tested manually**

- [x] **DONE**

## Links

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1137940
Tracks https://github.com/SUSE/spacewalk/pull/8090

- [x] **DONE**

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "susemanager_unittests"
