### PR TITLE
Do not run PXE retail tests for Uyuni

### DIFF
--- a/testsuite/run_sets/uyuni.yml
+++ b/testsuite/run_sets/uyuni.yml
@@ -1,0 +1,142 @@
+# This file describes the order of features in a normal testsuite run for Uyuni
+#
+# If you create new features, please see conventions about naming of the
+# feature files in testsuite/docs/Guidelines.md in "Rules for features" chapter,
+# as well as guidelines about idempotency in "Idempotency" chapter.
+
+## Core features BEGIN ###
+
+# IMMUTABLE ORDER
+
+- features/core_first_settings.feature
+# initialize SUSE Manager server
+- features/core_srv_channels_add.feature
+- features/core_srv_push_package.feature
+- features/core_srv_create_repository.feature
+- features/core_srv_users.feature
+- features/core_srv_create_activationkey.feature
+- features/core_srv_osimage_profiles.feature
+- features/core_srv_docker_profiles.feature
+# initialize SUSE Manager proxy
+  # one of: core_proxy_register_as_trad_with_script.feature
+  #         core_proxy_register_as_minion_with_script.feature
+  #         core_proxy_register_as_minion_with_gui.feature
+- features/core_proxy_register_as_minion_with_gui.feature
+- features/core_proxy_branch_network.feature
+# initialize clients
+- features/core_trad_register_client.feature
+- features/core_min_bootstrap.feature
+- features/core_min_salt_ssh.feature
+- features/core_centos_salt_ssh.feature
+- features/core_ubuntu_salt_ssh.feature
+# these features sync real channels (last core features)
+- features/core_srv_sync_channels.feature
+- features/core_srv_setup_wizard.feature
+
+## Core features END ###
+
+
+## Secondary features BEGIN ##
+
+# IDEMPOTENT
+
+- features/srv_menu.feature
+- features/allcli_reboot.feature
+- features/trad_config_channel.feature
+- features/trad_lock_packages.feature
+- features/min_centos_salt.feature
+- features/trad_centos_client.feature
+- features/minssh_centos_salt_install_package_and_patch.feature
+- features/min_ubuntu_salt.feature
+- features/min_ubuntu_salt_install_package.feature
+- features/min_bootstrap_xmlrpc.feature
+- features/minssh_bootstrap_xmlrpc.feature
+- features/min_bootstrap_script.feature
+- features/min_activationkey.feature
+- features/trad_migrate_to_minion.feature
+- features/trad_migrate_to_sshminion.feature
+- features/trad_need_reboot.feature
+- features/trad_ssh_push.feature
+- features/srv_change_password.feature
+- features/srv_check_sync_source_packages.feature
+- features/min_salt_software_states.feature
+- features/min_docker_xmlrpc.feature
+- features/min_docker_build_image.feature
+- features/trad_metadata_check.feature
+- features/srv_clone_channel_npn.feature
+- features/trad_cve_id_new_syntax.feature
+- features/trad_weak_deps.feature
+- features/srv_nagios.feature
+- features/srv_cve_audit.feature
+- features/min_salt_install_with_staging.feature
+- features/srv_xmlrpc_activationkey.feature
+- features/allcli_overview_systems_details.feature
+- features/srv_distro_cobbler.feature
+- features/srv_mainpage.feature
+- features/srv_xmlrpc_user.feature
+- features/srv_salt_download_endpoint.feature
+- features/srv_virtual_host_manager.feature
+- features/trad_baremetal_discovery.feature
+- features/trad_action_chain.feature
+- features/min_action_chain.feature
+- features/minssh_action_chain.feature
+- features/min_salt_formulas.feature
+- features/min_salt_formulas_advanced.feature
+- features/min_docker_auth_registry.feature
+- features/srv_docker_advanced_content_management.feature
+- features/srv_docker_cve_audit.feature
+# OS image build tests are required for proxy_retail_pxeboot feature
+# Disabled until the pxe-formula and branch-formula are compatible with openSUSE Leap 15.1
+#- features/min_osimage_build_image.feature
+- features/min_salt_install_package.feature
+- features/srv_power_management.feature
+- features/srv_datepicker.feature
+- features/trad_openscap_audit.feature
+- features/allcli_system_group.feature
+- features/srv_group_union_intersection.feature
+# Disabled until the pxe-formula and branch-formula are compatible with openSUSE Leap 15.1
+#- features/proxy_retail_pxeboot.feature
+- features/min_salt_openscap_audit.feature
+- features/srv_custom_system_info.feature
+- features/srv_security.feature
+- features/trad_inst_package_and_patch.feature
+- features/trad_check_patches_install.feature
+- features/trad_mgr_bootstrap.feature
+- features/trad_sp_migration.feature
+- features/srv_salt.feature
+- features/min_salt_user_states.feature
+- features/srv_check_channels_page.feature
+- features/min_salt_minion_details.feature
+- features/trad_check_registration.feature
+- features/min_salt_minions_page.feature
+- features/srv_xmlrpc_channel.feature
+- features/allcli_config_channel.feature
+- features/min_config_state_channel.feature
+- features/min_state_config_channel.feature
+- features/min_salt_pkgset_beacon.feature
+- features/srv_patches_page.feature
+- features/srv_spacewalk_channel.feature
+- features/srv_content_lifecycle.feature
+- features/allcli_software_channels.feature
+- features/allcli_software_channels_dependencies.feature
+- features/srv_change_task_schedule.feature
+- features/srv_notifications.feature
+- features/minkvm_guests.feature
+- features/minxen_guests.feature
+- features/min_empty_system_profiles.feature
+- features/min_custom_pkg_download_endpoint.feature
+## Secondary features END ##
+
+
+## Post run features BEGIN ##
+
+# IMMUTABLE ORDER
+
+# this feature is not idempotent and might slow down other features, so it is better near the end
+- features/srv_sync_products.feature
+# this feature is destructive for other features, so it is better at the end
+- features/srv_smdba.feature
+# this feature is needed for gathering log/debug infos
+- features/srv_susemanager_debug.feature
+
+## Post run features END ##


### PR DESCRIPTION
## What does this PR change?

Do not run PXE retail tests for Uyuni as pxe-formula and branch-formula are not ready for openSUSE Leap 15.1 yet.

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: CI change.

- [ ] **DONE**

## Test coverage
- No tests: We are changing tests.

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
