### PR TITLE
Avoid restarting salt-minion during onboarding

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/virt/engine-events.sls
+++ b/susemanager-utils/susemanager-sls/salt/virt/engine-events.sls
@@ -11,10 +11,3 @@
   file.absent
 
 {% endif %}
-
-salt-minion:
-  service.running:
-    - enable: True
-    - watch:
-      - file: /etc/salt/minion.d/libvirt-events.conf
-

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Prevent stuck Actions when onboarding KVM host minions (bsc#1137888)
 - Fix formula name encoding on Python 3 (bsc#1137533)
 - More thorougly disable the Salt mine in util.mgr_mine_config_clean_up (bsc#1135075)
 

--- a/testsuite/features/minkvm_guests.feature
+++ b/testsuite/features/minkvm_guests.feature
@@ -17,6 +17,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host! " text
     And I wait until onboarding is completed for "kvm-server"
+    And I restart salt-minion on "kvm-server"
     # Shorten the virtpoller interval to avoid loosing time
     And I reduce virtpoller run interval on "kvm-server"
 


### PR DESCRIPTION
## What does this PR change?

It removes automatic restarting of the salt-minion service for KVM minions, particularly when onboarding.

Restarting the service caused some commands being lost and onboarding to get stuck indefinitely.

Restarting of salt-minion will now have to be performed manually by users in order to activate the libvirt-events engine.

In the testsuite, the restarting will be implemented via an extra step.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Documentation team needs to explain this behavior in manuals.

- [x] **DONE**

## Test coverage
- Cucumber tests were updated

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/8084
Tracks https://github.com/SUSE/spacewalk/pull/8082

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
