### PR TITLE
Testsuite: Taskomatic table test fix

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -583,14 +583,19 @@ When(/^I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINI
   repeat_until_timeout(timeout: 800, message: 'Task does not look FINISHED yet') do
     visit current_url
     # get all texts in the table column under the "Status" header
-    under_status = "//tr/td[count(//th[contains(*/text(), 'Status')]/preceding-sibling::*) + 1]"
-    statuses = page.all(:xpath, under_status).map(&:text)
+    status_tds = "//tr/td[count(//th[contains(*/text(), 'Status')]/preceding-sibling::*) + 1]"
+    statuses = page.all(:xpath, status_tds).map(&:text)
 
-    # disregard any number of initial SKIPPED rows
-    # this is expected when Taskomatic triggers the same task concurrently
-    first_non_skipped = statuses.drop_while do |status|
-      status == 'SKIPPED'
-    end.first
+    # get all texts in the table column under the "Start time" header
+    start_time_tds = "//tr/td[count(//th[contains(*/text(), 'Start Time')]/preceding-sibling::*) + 1]"
+    start_times = page.all(:xpath, start_time_tds).map(&:text)
+
+    # disregard any number of initial unimportant rows, that is:
+    #  - INTERRUPTED rows with no start time (expected when Taskomatic had been restarted)
+    #  - SKIPPED rows (expected when Taskomatic triggers the same task concurrently)
+    first_non_skipped = statuses.zip(start_times).drop_while do |status, start_time|
+      (status == 'INTERRUPTED' && start_time.empty?) || status == 'SKIPPED'
+    end.first.first
 
     # halt in case we are done, or if an error is detected
     break if first_non_skipped == 'FINISHED'


### PR DESCRIPTION
## What does this PR change?

If Taskomatic is restarted (via systemd) it can leave behind some interrupted runs without start time.

Sumaform does that, so interrupted runs before anything else do typically happen. What only happened in https://ci.suse.de/view/Manager/view/Manager-Head/job/manager-Head-cucumber/2420/testReport/ is that errata-cache was the particular job that was interrupted, and this broke ~17 tests.

The problem is, interrupted runs without start time may be displayed at the top in the run table of their bunch:

![noerror](https://user-images.githubusercontent.com/250541/59388645-9c503f80-8d6c-11e9-93db-78f6310a099a.png)

This presently confuses the testsuite which considers the latest run to be in error, while it is not - the INTERRUPTED row is just a sign of a past restart.  

This code change  makes the code robust with respect to this particular condition.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **testsuite**

- [x] **DONE**

## Test coverage
- No tests: **testsuite**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/8098

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
