### PR TITLE
Testsuite: disable periodic mgr-sync

### DIFF
--- a/testsuite/features/core_srv_sync_channels.feature
+++ b/testsuite/features/core_srv_sync_channels.feature
@@ -65,4 +65,10 @@ Feature: Be able to list available channels and enable them
     Then I should get "Timeout. No user input for 60 seconds. Exiting..."
 
   Scenario: Cleanup: abort all reposync activity
+    Given I am authorized as "admin" with password "admin"
+    When I follow the left menu "Admin > Task Schedules"
+    And I follow "mgr-sync-refresh-default"
+    And I choose "disabled"
+    And I click on "Update Schedule"
+    And I click on "Delete Schedule"
     Then I make sure no spacewalk-repo-sync is in execution


### PR DESCRIPTION
## What does this PR change?

Avoids `mgr-sync` to be run at testsuite time.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **testsuite**

- [x] **DONE**

## Test coverage
- No tests: **testsuite**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/8099

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
