### PR TITLE
Testsuite: improve spacewalk-repo-sync killing mechanism

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -111,10 +111,19 @@ When(/^I execute mgr\-sync refresh$/) do
 end
 
 When(/^I make sure no spacewalk\-repo\-sync is in execution$/) do
+  kill_failure_streak = 0
   repeat_until_timeout(message: 'Could not kill all spacewalk-repo-sync instances') do
     command_output = sshcmd('killall spacewalk-repo-sync', ignore_err: true)
-    break unless command_output[:stderr].empty?
-    sleep 2
+    kill_failed = !command_output[:stderr].empty?
+
+    if kill_failed
+      kill_failure_streak += 1
+      sleep 1
+    else
+      kill_failure_streak = 0
+    end
+
+    break if kill_failure_streak == 10
   end
 end
 


### PR DESCRIPTION
## What does this PR change?

Fixes implementation of https://github.com/uyuni-project/uyuni/pull/1090, which failed to catch some cases.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **testsuite**

- [x] **DONE**

## Test coverage
- No tests: **testsuite**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/8086

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
