### PR TITLE
Install dmidecode during bootstrap to make sure hardware refresh always works

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -136,11 +136,16 @@ mgr_update_basic_pkgs:
   pkg.latest:
     - pkgs:
       - openssl
+{%- if grains['os_family'] == 'Suse' and grains['osrelease'] in ['11.3', '11.4'] %}
+      - pmtools
+{%- else %}
+      - dmidecode
+{%- endif %}
 {%- if grains['os_family'] == 'Suse' %}
       - zypper
 {%- elif grains['os_family'] == 'RedHat' %}
       - yum
-{% endif %}
+{%- endif %}
 
 # Manage minion key files in case they are provided in the pillar
 {% if pillar['minion_pub'] is defined and pillar['minion_pem'] is defined %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- Make sure dmidecode is installed during bootstrap to ensure that hardware
+  refresh works for all operating systems
 - Prevent stuck Actions when onboarding KVM host minions (bsc#1137888)
 - Fix formula name encoding on Python 3 (bsc#1137533)
 - More thorougly disable the Salt mine in util.mgr_mine_config_clean_up (bsc#1135075)

--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -43,6 +43,7 @@ PKGLIST11 = [
     "libzypp",
     "newt",
     "openssl",
+    "pmtools",
     "python",
     "python-dmidecode",
     "python-ethtool",
@@ -92,6 +93,7 @@ ENHANCE11 = [
 
 PKGLIST12 = [
     "dbus-1-python",
+    "dmidecode",
     "hwdata",
     "libcurl4",
     "libgudev-1_0-0",
@@ -237,6 +239,7 @@ RES6 = [
     "suseRegisterInfo",
     "python2-suseRegisterInfo",
     "python2-hwdata",
+    "dmidecode",
 ]
 
 RES7 = [
@@ -282,6 +285,7 @@ RES7 = [
     "suseRegisterInfo",
     "python2-suseRegisterInfo",
     "python2-hwdata",
+    "dmidecode",
 ]
 
 PKGLIST15 = [
@@ -347,6 +351,7 @@ PKGLIST15 = [
     "salt",
     "python3-salt",
     "salt-minion",
+    "dmidecode",
 ]
 
 PKGLIST15_NO_Z = [
@@ -381,6 +386,7 @@ PKGLISTUBUNTU1604 = [
     "python-pycurl",
     "salt-common",
     "salt-minion",
+    "dmidecode",
 ]
 
 PKGLISTUBUNTU1804 = [
@@ -431,6 +437,7 @@ PKGLISTUBUNTU1804 = [
     "python2.7-minimal",
     "salt-common",
     "salt-minion",
+    "dmidecode",
 ]
 
 DATA = {

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- Make dmidecode part of the bootstrap repositiories
 - respect new location for autoinstall templates during migration
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Right now dmidecode gets installed only by pure chance, as SLE requires it for `SUSEConnect` (so it's part of the image), CentOS/RHEL requires it for `virt-what`, Ubuntu requires it for `ubuntu-standard`.

But openSUSE Leap does not install it by default, so after talking to @meaksh, it seems the best solution is adding it to the bootstrap SLS and to the bootstrap repository.

We detected this problem at the Uyuni Proxy, when it's provisioned as salt minion.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: List of packages for bootstrap repositories are not part of the doc.

- [x] **DONE**

## Test coverage
- No tests: Already covered, detected by the testsuite.

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
