### PR TITLE
Testsuite: Adapt 'Change the schedule of a task'

### DIFF
--- a/testsuite/features/srv_change_task_schedule.feature
+++ b/testsuite/features/srv_change_task_schedule.feature
@@ -3,38 +3,38 @@
 
 Feature: Change the schedule of a task
 
-  Scenario: Change the schedule of task mgr-sync-refresh-default to weekly
+  Scenario: Change the schedule of task sandbox-cleanup-default to weekly
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Admin > Task Schedules"
-    And I follow "mgr-sync-refresh-default"
+    And I follow "sandbox-cleanup-default"
     And I check radio button "weekly"
     And I select "Friday" from "date_day_week"
     And I click on "Update Schedule"
-    Then I should see a "Schedule mgr-sync-refresh-default has been updated." text
+    Then I should see a "Schedule sandbox-cleanup-default has been updated." text
     When I follow the left menu "Admin > Task Schedules"
-    And I follow "mgr-sync-refresh-default"
+    And I follow "sandbox-cleanup-default"
     Then I should see a "Friday" text
     And radio button "weekly" is checked
 
-  Scenario: Change the schedule of task mgr-sync-refresh-default to monthly
+  Scenario: Change the schedule of task sandbox-cleanup-default to monthly
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Admin > Task Schedules"
-    And I follow "mgr-sync-refresh-default"
+    And I follow "sandbox-cleanup-default"
     And I check radio button "monthly"
     And I select "17" from "date_day_month"
     And I click on "Update Schedule"
-    Then I should see a "Schedule mgr-sync-refresh-default has been updated." text
+    Then I should see a "Schedule sandbox-cleanup-default has been updated." text
     When I follow the left menu "Admin > Task Schedules"
-    And I follow "mgr-sync-refresh-default"
+    And I follow "sandbox-cleanup-default"
     Then radio button "monthly" is checked
 
-  Scenario: Change the schedule of task mgr-sync-refresh-default back to daily
+  Scenario: Change the schedule of task sandbox-cleanup-default back to daily
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Admin > Task Schedules"
-    And I follow "mgr-sync-refresh-default"
+    And I follow "sandbox-cleanup-default"
     And I check radio button "daily"
     And I click on "Update Schedule"
-    Then I should see a "Schedule mgr-sync-refresh-default has been updated." text
+    Then I should see a "Schedule sandbox-cleanup-default has been updated." text
     When I follow the left menu "Admin > Task Schedules"
-    And I follow "mgr-sync-refresh-default"
+    And I follow "sandbox-cleanup-default"
     Then radio button "daily" is checked


### PR DESCRIPTION
## What does this PR change?

Adapts 'Change the schedule of a task' feature to change the schedule of another task, given that the one used so far is deleted during the testsuite run, introduced by https://github.com/uyuni-project/uyuni/pull/1100/

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **testsuite**

- [x] **DONE**

## Test coverage
- No tests: **testsuite**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/8106

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
