### PR TITLE
Power off VM before deleting it

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/virt/deleted.sls
+++ b/susemanager-utils/susemanager-sls/salt/virt/deleted.sls
@@ -1,4 +1,10 @@
+vm_stopped:
+  virt.powered_off:
+    - name: {{ pillar['domain_name'] }}
+
 mgr_virt_destroy:
   module.run:
     - name: virt.purge
     - vm_: {{ pillar['domain_name'] }}
+    - requires:
+      - virt: vm_stopped

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Force VM off before deleting it (bsc#1138127)
 - Allow forcing off or resetting VMs
 - Fix the indentation so that custom formulas can be read correctly (bsc#1136937)
 - Make sure dmidecode is installed during bootstrap to ensure that hardware

--- a/testsuite/features/minkvm_guests.feature
+++ b/testsuite/features/minkvm_guests.feature
@@ -180,6 +180,13 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I close the window
 
 @virthost_kvm
+  Scenario: delete a running KVM virtual machine
+    Given I am on the "Virtualization" page of this "kvm-server"
+    When I click on "Delete" in row "test-vm2"
+    And I click on "Delete" in "Delete Guest" modal
+    Then I should not see a "test-vm2" virtual machine on "kvm-server"
+
+@virthost_kvm
   Scenario: Cleanup: Unregister the KVM virtualization host
     Given I am on the Systems overview page of this "kvm-server"
     When I follow "Delete System"

--- a/testsuite/features/minxen_guests.feature
+++ b/testsuite/features/minxen_guests.feature
@@ -195,6 +195,13 @@ Feature: Be able to manage XEN virtual machines via the GUI
     And "test-vm3" virtual machine on "xen-server" should have a "test-vm3_system.qcow2" xen disk
 
 @virthost_xen
+  Scenario: delete a running Xen virtual machine
+    Given I am on the "Virtualization" page of this "xen-server"
+    When I click on "Delete" in row "test-vm3"
+    And I click on "Delete" in "Delete Guest" modal
+    Then I should not see a "test-vm3" virtual machine on "xen-server"
+
+@virthost_xen
   Scenario: Cleanup: Unregister the Xen virtualization host
     Given I am on the Systems overview page of this "xen-server"
     When I follow "Delete System"


### PR DESCRIPTION
## What does this PR change?

Libvirt can't delete a running virtual machine. Ensure the VM is powered
off before attempting to delete it.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: no mention on any restriction on the Delete action in the doc

- [X] **DONE**

## Test coverage
- Cucumber tests were added

- [X] **DONE**

## Links

Fixes [bsc#1138127](https://bugzilla.suse.com/show_bug.cgi?id=1138127)

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
