### PR TITLE
Add missing changelog for dmicode changes

### DIFF
--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,5 +1,5 @@
 - Make sure dmidecode is installed during bootstrap to ensure that hardware
-  refresh works for all operating systems
+  refresh works for all operating systems (bsc#1137952)
 - Prevent stuck Actions when onboarding KVM host minions (bsc#1137888)
 - Fix formula name encoding on Python 3 (bsc#1137533)
 - More thorougly disable the Salt mine in util.mgr_mine_config_clean_up (bsc#1135075)

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,4 +1,4 @@
-- Make dmidecode part of the bootstrap repositiories
+- Make dmidecode part of the bootstrap repositiories (bsc#1137952)
 - respect new location for autoinstall templates during migration
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Add missing changelog for dmicode changes (complements https://github.com/uyuni-project/uyuni/pull/1102)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Adding missing changelog.

- [x] **DONE**

## Test coverage
- No tests: Adding missing changelog.

- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/8116

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
