### PR TITLE
Aggregate merged subscriptions in the web UI

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/subscriptionmatching/SubscriptionMatchProcessor.java
+++ b/java/code/src/com/suse/manager/webui/services/subscriptionmatching/SubscriptionMatchProcessor.java
@@ -62,7 +62,7 @@ public class SubscriptionMatchProcessor {
                     latestStart,
                     latestEnd,
                     messages(input.get(), output.get()),
-                    subscriptions(input.get(), output.get()),
+                    subscriptions(output.get()),
                     products,
                     unmatchedProductIds(products),
                     pinnedMatches(input.get(), output.get()),
@@ -143,9 +143,9 @@ public class SubscriptionMatchProcessor {
                 .map(m -> translateMessage(m, input)) .collect(toList());
     }
 
-    private Map<String, Subscription> subscriptions(InputJson input, OutputJson output) {
+    private Map<String, Subscription> subscriptions(OutputJson output) {
         Map<Long, Integer> matchedQuantity = matchedQuantity(output);
-        return input.getSubscriptions().stream()
+        return output.getSubscriptions().stream()
                 .filter(s -> s.getQuantity() != null)
                 .map(js -> new Subscription(js.getId(),
                         js.getPartNumber(),

--- a/java/code/src/com/suse/manager/webui/services/subscriptionmatching/test/SubscriptionMatchProcessorTest.java
+++ b/java/code/src/com/suse/manager/webui/services/subscriptionmatching/test/SubscriptionMatchProcessorTest.java
@@ -64,7 +64,7 @@ public class SubscriptionMatchProcessorTest extends BaseTestCaseWithUser {
         input = new InputJson(new Date(), new LinkedList<>(), new LinkedList<>(),
                 new LinkedList<>(), new LinkedList<>(), new LinkedList<>());
         output = new OutputJson(new Date(), new LinkedList<>(), new LinkedList<>(),
-                new HashMap<>());
+                new HashMap<>(), new LinkedList<>());
     }
 
     public void testMatcherDataNotAvailable() {

--- a/java/code/src/com/suse/manager/webui/services/subscriptionmatching/test/SubscriptionMatchProcessorTest.java
+++ b/java/code/src/com/suse/manager/webui/services/subscriptionmatching/test/SubscriptionMatchProcessorTest.java
@@ -116,8 +116,10 @@ public class SubscriptionMatchProcessorTest extends BaseTestCaseWithUser {
     public void testUnsatisfiedMatchAdjustment() throws Exception {
         input.getSystems().add(new SystemJson(1L, "Sys1", null, true,
                 false, new HashSet<>(), new HashSet<>()));
-        input.getSubscriptions().add(new SubscriptionJson(100L, "123456", "subs name", 1,
-                new Date(), new Date(), "user", new HashSet<>()));
+        SubscriptionJson sub = new SubscriptionJson(100L, "123456", "subs name", 1,
+                new Date(), new Date(), "user", new HashSet<>());
+        input.getSubscriptions().add(sub);
+        output.getSubscriptions().add(sub);
 
         LinkedList<MessageJson> messages = new LinkedList<>();
         Map<String, String> messageData = new HashMap<>();
@@ -134,8 +136,10 @@ public class SubscriptionMatchProcessorTest extends BaseTestCaseWithUser {
     }
 
     public void testSubscriptions() {
-        input.getSubscriptions().add(new SubscriptionJson(1L, "123456", "subs name", 3,
-                new Date(0), new Date(1000), "user", new HashSet<>()));
+        SubscriptionJson sub = new SubscriptionJson(1L, "123456", "subs name", 3,
+                new Date(0), new Date(1000), "user", new HashSet<>());
+        input.getSubscriptions().add(sub);
+        output.getSubscriptions().add(sub);
 
         MatchJson match = new MatchJson(20L, 1L, 100L, 200, true);
         output.getMatches().add(match);
@@ -155,8 +159,10 @@ public class SubscriptionMatchProcessorTest extends BaseTestCaseWithUser {
     }
 
     public void testSubscriptionPolicy() {
-        input.getSubscriptions().add(new SubscriptionJson(1L, "123456", "subs name", 3,
-                new Date(0), new Date(1000), "user", new HashSet<>()));
+        SubscriptionJson sub = new SubscriptionJson(1L, "123456", "subs name", 3,
+                new Date(0), new Date(1000), "user", new HashSet<>());
+        input.getSubscriptions().add(sub);
+        output.getSubscriptions().add(sub);
         setSubscriptionPolicy(1L, "my policy");
 
         Subscription subscription = ((MatcherUiData) processor
@@ -167,8 +173,10 @@ public class SubscriptionMatchProcessorTest extends BaseTestCaseWithUser {
     }
 
     public void testSubscriptionNullPolicy() {
-        input.getSubscriptions().add(new SubscriptionJson(1L, "123456", "subs name", 3,
-                new Date(0), new Date(1000), "user", new HashSet<>()));
+        SubscriptionJson sub = new SubscriptionJson(1L, "123456", "subs name", 3,
+                new Date(0), new Date(1000), "user", new HashSet<>());
+        input.getSubscriptions().add(sub);
+        output.getSubscriptions().add(sub);
         setSubscriptionPolicy(1L, null);
 
         Map<String, Subscription> subscriptions = ((MatcherUiData) processor
@@ -304,6 +312,7 @@ public class SubscriptionMatchProcessorTest extends BaseTestCaseWithUser {
                 1, date("2009-03-01T00:00:00.000Z"), date("2018-02-28T00:00:00.000Z"), "",
                 Collections.singleton(1004L));
         input.setSubscriptions(Arrays.asList(subscription));
+        output.setSubscriptions(Arrays.asList(subscription));
         List<MatchJson> matches = Arrays.asList(new MatchJson(100L, 10L, 1000L, 100, true));
         input.setPinnedMatches(matches);
         output.setMatches(matches);
@@ -333,6 +342,7 @@ public class SubscriptionMatchProcessorTest extends BaseTestCaseWithUser {
                 1, date("2009-03-01T00:00:00.000Z"), date("2018-02-28T00:00:00.000Z"), "",
                 Collections.singleton(1004L));
         input.setSubscriptions(Arrays.asList(subscription));
+        output.setSubscriptions(Arrays.asList(subscription));
         input.setPinnedMatches(Arrays.asList(new MatchJson(100L, 10L, 1L, 100, null)));
 
         // create a corresponding pin
@@ -393,7 +403,7 @@ public class SubscriptionMatchProcessorTest extends BaseTestCaseWithUser {
                 0, date("2009-03-01T00:00:00.000Z"), date("2010-02-28T00:00:00.000Z"), "",
                 Collections.singleton(1004L)));
         input.setSubscriptions(subscriptions);
-
+        output.setSubscriptions(subscriptions);
 
         // SYSTEMS
         List<SystemJson> systems = new LinkedList<>();

--- a/java/code/src/com/suse/matcher/json/OutputJson.java
+++ b/java/code/src/com/suse/matcher/json/OutputJson.java
@@ -37,6 +37,9 @@ public class OutputJson {
     /** The messages. */
     private List<MessageJson> messages = new LinkedList<>();
 
+    /** The subscriptions. */
+    private List<SubscriptionJson> subscriptions;
+
     /**
      * Standard constructor.
      *
@@ -44,13 +47,15 @@ public class OutputJson {
      * @param matchesIn the matches
      * @param messagesIn the messages
      * @param subscriptionPoliciesIn mapping from subscription id to its policy
+     * @param subscriptionsIn the subscriptions
      */
-    public OutputJson(Date timestampIn, List<MatchJson> matchesIn,
-                      List<MessageJson> messagesIn, Map<Long, String> subscriptionPoliciesIn) {
+    public OutputJson(Date timestampIn, List<MatchJson> matchesIn, List<MessageJson> messagesIn,
+            Map<Long, String> subscriptionPoliciesIn, List<SubscriptionJson> subscriptionsIn) {
         timestamp = timestampIn;
         matches = matchesIn;
         messages = messagesIn;
         subscriptionPolicies = subscriptionPoliciesIn;
+        subscriptions = subscriptionsIn;
     }
 
     /**
@@ -121,5 +126,23 @@ public class OutputJson {
      */
     public void setMessages(List<MessageJson> messagesIn) {
         messages = messagesIn;
+    }
+
+    /**
+     * Gets the subscriptions.
+     *
+     * @return subscriptions
+     */
+    public List<SubscriptionJson> getSubscriptions() {
+        return subscriptions;
+    }
+
+    /**
+     * Sets the subscriptions.
+     *
+     * @param subscriptions the subscriptions
+     */
+    public void setSubscriptions(List<SubscriptionJson> subscriptions) {
+        this.subscriptions = subscriptions;
     }
 }

--- a/java/code/src/com/suse/matcher/json/OutputJson.java
+++ b/java/code/src/com/suse/matcher/json/OutputJson.java
@@ -140,9 +140,9 @@ public class OutputJson {
     /**
      * Sets the subscriptions.
      *
-     * @param subscriptions the subscriptions
+     * @param subscriptionsIn the subscriptions
      */
-    public void setSubscriptions(List<SubscriptionJson> subscriptions) {
-        this.subscriptions = subscriptions;
+    public void setSubscriptions(List<SubscriptionJson> subscriptionsIn) {
+        this.subscriptions = subscriptionsIn;
     }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Read the subscriptions from the output instead of input (bsc#1140332)
 - remove undefined variable from redhat_register snippet
 - Add a method in API to check if the provided session key is a valid one.
 - Associate VMs and systems with the same machine ID at bootstrap (bsc#1144176)

--- a/web/html/src/manager/audit/subscription-matching/subscription-matching-messages.js
+++ b/web/html/src/manager/audit/subscription-matching/subscription-matching-messages.js
@@ -39,6 +39,10 @@ const Messages = createReactClass({
           message = t("Two subscriptions with the same part number are in a bundle - merged into a single one");
           additionalInformation = subscriptions[data["new_subscription_id"]].partNumber;
           break;
+        case "merge_subscriptions" :
+          message = t("Two subscriptions with the same part number (and other properties) have been merged together - start/end dates might be indicative");
+          additionalInformation = data["part_number"];
+          break;
         default:
           message = rawMessage["type"];
           // we do not know the shape of the data, it could even be a complex nested object (bsc#1125600)

--- a/web/html/src/manager/audit/subscription-matching/subscription-matching-subscriptions.js
+++ b/web/html/src/manager/audit/subscription-matching/subscription-matching-subscriptions.js
@@ -56,7 +56,7 @@ const Subscriptions = createReactClass({
           <Table
             data={this.buildRows(this.props.subscriptions)}
             identifier={(row) => row.id}
-            cssClassFunction={(row) => moment(row.endDate).isBefore(moment()) ? "text-muted" : null }
+            cssClassFunction={(row) => moment(row.endDate).isBefore(moment()) || moment(row.startDate).isAfter(moment()) ? "text-muted" : null }
             loadState={this.props.loadState}
             saveState={this.props.saveState}
             initialSortColumnKey="partNumber"

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Report merge_subscriptions message in a readable way (bsc#1140332)
 - Use ReactJS Context in Form components
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

When subscriptions get merged in matcher (e.g. OEM subscriptions that have same properties are merged into a single subscription with accumulated quantity), we want reflect this in the SUMA UI as well.

This is indicated via a special message (`merge_subscriptions`) that's generated by matcher when the subscriptions are merged. In SUMA, we process this message and merge the subscriptions in the UI. We also add an entry in the "Messages" tab informing the user about this merge.

**Matcher counterpart** is here: https://github.com/openSUSE/subscription-matcher/pull/12

## GUI diff

Before:
![ss-before1](https://user-images.githubusercontent.com/1412268/60669099-c7aae380-9e6d-11e9-8e26-bd3ed8d1049d.png)


After (note the line with **Aggregated** name):
![ss-after1](https://user-images.githubusercontent.com/1412268/60669112-cd082e00-9e6d-11e9-989a-b64e02e3cade.png)
![ss-after2](https://user-images.githubusercontent.com/1412268/60669113-cda0c480-9e6d-11e9-8eb9-ddd8d24014ae.png)


- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Tracks # https://github.com/SUSE/spacewalk/issues/7978


- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"