### PR TITLE
Do not duplicate "http/s" protocol when using proxy with deb repos (bsc#1138313)

### DIFF
--- a/backend/satellite_tools/repo_plugins/deb_src.py
+++ b/backend/satellite_tools/repo_plugins/deb_src.py
@@ -101,14 +101,15 @@ class DebRepo(object):
             try:
                 proxies=""
                 if self.proxy:
+                    (scheme, netloc, path, query, fragid) = urlparse.urlsplit(self.proxy)
                     proxies = {
-                        'http' : 'http://'+self.proxy,
-                        'https' : 'http://'+self.proxy
+                        'http' : 'http://'+netloc,
+                        'https' : 'http://'+netloc
                     }
                     if self.proxy_username and self.proxy_password:
                         proxies = {
-                            'http' : 'http://'+self.proxy_username+":"+self.proxy_password+"@"+self.proxy,
-                            'https' : 'http://'+self.proxy_username+":"+self.proxy_password+"@"+self.proxy,
+                            'http' : 'http://'+self.proxy_username+":"+self.proxy_password+"@"+netloc,
+                            'https' : 'http://'+self.proxy_username+":"+self.proxy_password+"@"+netloc,
                         }
                 data = requests.get(url, proxies=proxies, cert=(self.sslclientcert, self.sslclientkey),
                                     verify=self.sslcacert)

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- Do not duplicate "http://" protocol when using proxies with "deb"
+  repositories (bsc#1138313)
 - Fix reposync when dealing with RedHat CDN (bsc#1138358)
 - Prevent FileNotFoundError: repomd.xml.key traceback (bsc#1137940)
 - Add journalctl output to spacewalk-debug tarballs


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue on `deb_src` plugin for `spacewalk-repo-sync` when dealing with "DEB" repositories and there is a proxy defined on `/etc/rhn/rhn.conf`.

If a proxy is defined on `/etc/rhn/rhn.conf` like this:
```
server.satellite.http_proxy = myproxy:8080
```

Then `spacewalk-repo-sync` is going to use a proxy url like `http://http://myproxy:8080` which is wrong.

This issue has been reported by @rpasche at https://github.com/uyuni-project/uyuni/issues/1095

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **this should be covered on our cucumber testsuite**

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/1095

Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
