### PR TITLE
Testsuite: Kill reposync task until we don't find any for 120 seconds

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -112,7 +112,7 @@ end
 
 When(/^I make sure no spacewalk\-repo\-sync is executing$/) do
   kill_failure_streak = 0
-  repeat_until_timeout(message: 'Could not kill all spacewalk-repo-sync instances') do
+  while kill_failure_streak <= 120
     command_output = sshcmd('killall spacewalk-repo-sync', ignore_err: true)
     kill_failed = !command_output[:stderr].empty?
 
@@ -122,8 +122,6 @@ When(/^I make sure no spacewalk\-repo\-sync is executing$/) do
     else
       kill_failure_streak = 0
     end
-
-    break if kill_failure_streak == 10
   end
 end
 


### PR DESCRIPTION
## What does this PR change?

At the moment we want to kill all reposync process during the testsuite execution.

With the current code, if we fail 10 times in a row in a window span of 10 seconds when killing a reposync process, we assume there are not any gonna be any other reposync execution.

This assumption seems not to be enough, given that sometimes taskomatic wait more than 10 seconds before picking up the next reposync task.

With this patch, we ensure that for a sapn 2 minutes Taskomatic has not executed a reposync task before assuming there are not reposync tasks anymore.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **testsuite**

- [x] **DONE**

## Test coverage
- No tests: **testsuite**

- [x] **DONE**

## Links

Fixes #
Tracks https://github.com/SUSE/spacewalk/pull/8129

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
