### PR TITLE
Force vm off

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
@@ -250,6 +250,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
           <join table="rhnActionVirtShutdown">
             <key column="action_id"/>
             <property name="uuid"/>
+            <property name="force" type="yes_no"/>
           </join>
         </subclass>
 
@@ -282,6 +283,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
           <join table="rhnActionVirtReboot">
             <key column="action_id"/>
             <property name="uuid"/>
+            <property name="force" type="yes_no"/>
           </join>
         </subclass>
 
@@ -482,11 +484,11 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         <![CDATA[
 select {ra.*}
     from rhnAction {ra},
-    (select NULL as uuid from dual) ra_1_,
+    (select NULL as uuid, NULL as force from dual) ra_1_,
     (select NULL as uuid from dual) ra_2_,
     (select NULL as uuid from dual) ra_3_,
     (select NULL as uuid from dual) ra_4_,
-    (select NULL as uuid from dual) ra_5_,
+    (select NULL as uuid, NULL as force from dual) ra_5_,
     (select NULL as uuid from dual) ra_6_,
     (select NULL as uuid, NULL as memory from dual) ra_7_,
     (select NULL as uuid, NULL as vcpu from dual) ra_8_,

--- a/java/code/src/com/redhat/rhn/domain/action/virtualization/BaseVirtualizationAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/virtualization/BaseVirtualizationAction.java
@@ -24,6 +24,8 @@ import java.util.Map;
  */
 public abstract class BaseVirtualizationAction extends Action {
 
+    public static final String FORCE_STRING = "force";
+
     private String uuid;
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationRebootAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationRebootAction.java
@@ -14,10 +14,37 @@
  */
 package com.redhat.rhn.domain.action.virtualization;
 
+import java.util.Map;
+
 /**
  * VirtualizationRebootAction - Class representing TYPE_VIRTUALIZATION_REBOOT
  * @version $Rev$
  */
 public class VirtualizationRebootAction extends BaseVirtualizationAction {
 
+    private boolean force = false;
+
+    /**
+     * @return Returns whether to force off rather than cleanly shutting down.
+     */
+    public boolean isForce() {
+        return force;
+    }
+
+    /**
+     * @param forceIn whether to force off rather than cleanly shutting down.
+     */
+    public void setForce(boolean forceIn) {
+        force = forceIn;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void extractParameters(Map context) {
+        if (context.containsKey(BaseVirtualizationAction.FORCE_STRING)) {
+            setForce(Boolean.valueOf((String)context.get(
+                    BaseVirtualizationAction.FORCE_STRING)));
+        }
+    }
 }

--- a/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationShutdownAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationShutdownAction.java
@@ -14,10 +14,37 @@
  */
 package com.redhat.rhn.domain.action.virtualization;
 
+import java.util.Map;
+
 /**
  * VirtualizationShutdownAction - Class representing TYPE_VIRTUALIZATION_SHUTDOWN
  * @version $Rev$
  */
 public class VirtualizationShutdownAction extends BaseVirtualizationAction {
 
+    private boolean force = false;
+
+    /**
+     * @return Returns whether to force off rather than cleanly shutting down.
+     */
+    public boolean isForce() {
+        return force;
+    }
+
+    /**
+     * @param forceIn whether to force off rather than cleanly shutting down.
+     */
+    public void setForce(boolean forceIn) {
+        force = forceIn;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void extractParameters(Map context) {
+        if (context.containsKey(BaseVirtualizationAction.FORCE_STRING)) {
+            setForce(Boolean.valueOf((String)context.get(
+                    BaseVirtualizationAction.FORCE_STRING)));
+        }
+    }
 }

--- a/java/code/src/com/redhat/rhn/domain/action/virtualization/test/VirtualizationActionsTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/virtualization/test/VirtualizationActionsTest.java
@@ -85,6 +85,34 @@ public class VirtualizationActionsTest extends BaseTestCaseWithUser {
         }
     }
 
+    public void testDomainForceoff() throws Exception {
+        Action a = ActionFactoryTest.createAction(user, ActionFactory.TYPE_VIRTUALIZATION_SHUTDOWN);
+        VirtualizationShutdownAction va = (VirtualizationShutdownAction)a;
+        va.setForce(true);
+        flushAndEvict(va);
+
+        Action a1 = ActionFactory.lookupById(a.getId());
+        assertNotNull(a1);
+
+        assertTrue(a1 instanceof VirtualizationShutdownAction);
+        VirtualizationShutdownAction rebootAction = (VirtualizationShutdownAction)a1;
+        assertTrue(rebootAction.isForce());
+    }
+
+    public void testDomainReset() throws Exception {
+        Action a = ActionFactoryTest.createAction(user, ActionFactory.TYPE_VIRTUALIZATION_REBOOT);
+        VirtualizationRebootAction va = (VirtualizationRebootAction)a;
+        va.setForce(true);
+        flushAndEvict(va);
+
+        Action a1 = ActionFactory.lookupById(a.getId());
+        assertNotNull(a1);
+
+        assertTrue(a1 instanceof VirtualizationRebootAction);
+        VirtualizationRebootAction rebootAction = (VirtualizationRebootAction)a1;
+        assertTrue(rebootAction.isForce());
+    }
+
     public void testSetMemory() throws Exception {
         Action a = ActionFactoryTest.createAction(user, ActionFactory.TYPE_VIRTUALIZATION_SET_MEMORY);
         flushAndEvict(a);

--- a/java/code/src/com/suse/manager/webui/controllers/VirtualGuestsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/VirtualGuestsController.java
@@ -28,6 +28,7 @@ import com.redhat.rhn.domain.action.ActionChain;
 import com.redhat.rhn.domain.action.ActionChainFactory;
 import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.ActionType;
+import com.redhat.rhn.domain.action.virtualization.BaseVirtualizationAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationCreateAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationCreateActionDiskDetails;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationCreateActionInterfaceDetails;
@@ -328,7 +329,11 @@ public class VirtualGuestsController {
                                                               ((VirtualGuestSetterActionJson)data).getValue());
                         }
                         else {
-                            result = triggerGuestAction(host, guest, type, user, new HashMap<>());
+                            Map<String, String> context = new HashMap<>();
+                            if (data.getForce() != null) {
+                                context.put(BaseVirtualizationAction.FORCE_STRING, Boolean.toString(data.getForce()));
+                            }
+                            result = triggerGuestAction(host, guest, type, user, context);
                         }
                     }
                     String status = result != null ? result : "Failed";

--- a/java/code/src/com/suse/manager/webui/utils/gson/VirtualGuestsBaseActionJson.java
+++ b/java/code/src/com/suse/manager/webui/utils/gson/VirtualGuestsBaseActionJson.java
@@ -23,6 +23,7 @@ import java.util.List;
 public class VirtualGuestsBaseActionJson {
 
     private List<String> uuids;
+    private Boolean force;
 
     /**
      * @return the list of UUIDs of virtual guests to act on
@@ -36,5 +37,19 @@ public class VirtualGuestsBaseActionJson {
      */
     public void setUuids(List<String> uuidsIn) {
         this.uuids = uuidsIn;
+    }
+
+    /**
+     * @return Returns whether to force the action.
+     */
+    public Boolean getForce() {
+        return force;
+    }
+
+    /**
+     * @param forceIn whether to force the action.
+     */
+    public void setForce(Boolean forceIn) {
+        force = forceIn;
     }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Allow forcing off or resetting VMs
 - Explicitly mention in API docs that to preserve LF/CR, user needs to encode the data(bsc#1135442)
 - Switch menu links and adjust title icons
 - Add XML-RPC API calls to manage server monitoring

--- a/schema/spacewalk/common/tables/rhnActionVirtReboot.sql
+++ b/schema/spacewalk/common/tables/rhnActionVirtReboot.sql
@@ -21,6 +21,10 @@ CREATE TABLE rhnActionVirtReboot
                        REFERENCES rhnAction (id)
                        ON DELETE CASCADE,
     uuid       VARCHAR2(128) NOT NULL,
+    force      CHAR(1)
+                   DEFAULT ('N') NOT NULL
+                   CONSTRAINT rhn_avreboot_force_ck
+                       CHECK (force in ('Y','N')),
     created    timestamp with local time zone
                    DEFAULT (current_timestamp) NOT NULL,
     modified   timestamp with local time zone

--- a/schema/spacewalk/common/tables/rhnActionVirtShutdown.sql
+++ b/schema/spacewalk/common/tables/rhnActionVirtShutdown.sql
@@ -21,6 +21,10 @@ CREATE TABLE rhnActionVirtShutdown
                        REFERENCES rhnAction (id)
                        ON DELETE CASCADE,
     uuid       VARCHAR2(128) NOT NULL,
+    force      CHAR(1)
+                   DEFAULT ('N') NOT NULL
+                   CONSTRAINT rhn_avshutdown_force_ck
+                       CHECK (force in ('Y','N')),
     created    timestamp with local time zone
                    DEFAULT (current_timestamp) NOT NULL,
     modified   timestamp with local time zone

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Allow forcing off or resetting VMs
 - fix schema migration for suseSCCRepositoryAuth (bsc#1136558)
 - Add built time column to suseContentEnvironmentTarget
 

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.12-to-susemanager-schema-4.0.13/001-rhnVirtActions-force.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.12-to-susemanager-schema-4.0.13/001-rhnVirtActions-force.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 001-rhnVirtActions-force.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.12-to-susemanager-schema-4.0.13/001-rhnVirtActions-force.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.12-to-susemanager-schema-4.0.13/001-rhnVirtActions-force.sql.postgresql
@@ -1,0 +1,34 @@
+-- oracle equivalent source sha1 8f5bb67bb415c3f971d4119b13a1b09623f4ee85
+--
+--
+-- Copyright (c) 2019 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is                                                                                                                                               
+-- granted to use or replicate Red Hat trademarks that are incorporated                                                                                                                                            
+-- in this software or its documentation.                                                                                                                                                                          
+--
+
+ALTER TABLE rhnActionVirtShutdown
+    DROP CONSTRAINT IF EXISTS rhn_avshutdown_force_ck;
+
+ALTER TABLE rhnActionVirtShutdown
+    ADD COLUMN IF NOT EXISTS force CHAR(1)
+       DEFAULT ('N') NOT NULL
+       CONSTRAINT rhn_avshutdown_force_ck
+           CHECK (force in ('Y','N'));
+
+ALTER TABLE rhnActionVirtReboot
+    DROP CONSTRAINT IF EXISTS rhn_avreboot_force_ck;
+
+ALTER TABLE rhnActionVirtReboot
+    ADD COLUMN IF NOT EXISTS force CHAR(1)
+       DEFAULT ('N') NOT NULL
+       CONSTRAINT rhn_avreboot_force_ck
+           CHECK (force in ('Y','N'));

--- a/susemanager-utils/susemanager-sls/salt/virt/reset.sls
+++ b/susemanager-utils/susemanager-sls/salt/virt/reset.sls
@@ -1,0 +1,9 @@
+powered_off:
+  virt.powered_off:
+    - name: {{ pillar['domain_name'] }}
+
+restarted:
+  virt.running:
+    - name: {{ pillar['domain_name'] }}
+    - require:
+      - virt: powered_off

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Allow forcing off or resetting VMs
 - Fix the indentation so that custom formulas can be read correctly (bsc#1136937)
 - Make sure dmidecode is installed during bootstrap to ensure that hardware
   refresh works for all operating systems (bsc#1137952)

--- a/web/html/src/components/dialog/DangerDialog.js
+++ b/web/html/src/components/dialog/DangerDialog.js
@@ -43,6 +43,7 @@ function DangerDialog(props) {
           content={props.content}
           title={props.title}
           buttons={buttons}
+          onClosePopUp={props.onClosePopUp}
           />
     );
 }

--- a/web/html/src/manager/virtualization/guests/list/ActionConfirm.js
+++ b/web/html/src/manager/virtualization/guests/list/ActionConfirm.js
@@ -1,0 +1,89 @@
+// @flow
+
+const React = require('react');
+const { DangerDialog } = require('components/dialog/DangerDialog');
+
+type Props =  {
+  id: string,
+  type: string,
+  name: string,
+  icon: string,
+  selected: Object[],
+  fn: Function,
+  canForce: boolean,
+  forceName?: string,
+  onClose?: Function,
+};
+
+type State = {
+  force: boolean,
+};
+
+class ActionConfirm extends React.Component<Props, State> {
+
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      force: false,
+    };
+  }
+
+  closePopUp = () => {
+    this.setState({force: false});
+    if (this.props.onClose) {
+      this.props.onClose();
+    }
+  }
+
+  render() {
+    return (
+      <DangerDialog
+        id={this.props.id}
+        title={t(`${this.props.name} ${this.props.selected.length === 1 ? 'Guest' : 'Selected Guest(s)'}`)}
+        content={(
+          <>
+            { this.props.canForce &&
+              <p>
+                <input
+                  type="checkbox"
+                  id="force"
+                  defaultChecked={false}
+                  checked={this.state.force}
+                  onChange={event => this.setState({force: event.target.checked})}
+                />
+                <label htmlFor="force">{this.props.forceName}</label>
+              </p>
+            }
+            { this.props.selected.length === 1 &&
+              <span>
+                {t('Are you sure you want to {0} guest ',
+                 this.state.force && this.props.forceName
+                  ? this.props.forceName.toLowerCase() : this.props.name.toLowerCase())}
+                <strong>{this.props.selected[0].name}</strong>
+                ?
+              </span>
+            }
+            { this.props.selected.length > 1 &&
+              <span>
+                {t('Are you sure you want to {0} the selected guests? ({1} guests selected)',
+                  this.state.force && this.props.forceName
+                    ? this.props.forceName.toLowerCase() : this.props.name.toLowerCase(),
+                  this.props.selected.length)}
+                ?
+              </span>
+            }
+          </>
+        )}
+        onConfirm={() => this.props.fn(this.props.type, this.props.selected.map(item => item.uuid),
+                                       this.props.canForce ? {force: this.state.force} : {})}
+        onClosePopUp={() => this.closePopUp()}
+        submitText={this.state.force && this.props.forceName ? this.props.forceName : this.props.name}
+        submitIcon={this.props.icon}
+      />
+    );
+  }
+}
+
+module.exports = {
+  ActionConfirm,
+}

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Allow forcing off or resetting VMs
 - Adjust title icons
 - Fix VM creation dialog with non-default pools and networks (bsc#1138268)
 - Update help URLs in the UI (bsc#1136764)


### PR DESCRIPTION
## What does this PR change?

Add a checkbox in the VM shutdown and reboot modal dialogs to allow forcing the VM off or resetting it.

## GUI diff

Add a checkbox in the VM shutdown and reboot modal dialogs to allow forcing the VM off or resetting it.

Before:

No checkbox, no force off / reset possible

After:

Force off / reset possible by checking the box before hitting the button in the modal

- [X] **DONE**

## Documentation
- No documentation needed: tiny enough change in a modal dialog and the text of the modal explains it all.

- [X] **DONE**

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint" (Test skipped, there are no changes to test)		 
