### PR TITLE
Add opensuse product class

### DIFF
--- a/susemanager-sync-data/channel_families.json
+++ b/susemanager-sync-data/channel_families.json
@@ -48,6 +48,10 @@
         "name": "openSUSE"
     }, 
     {
+        "label": "OPENSUSE",
+        "name": "openSUSE Products"
+    },
+    {
         "label": "SLES12-GA-LTSS-X86", 
         "name": "SUSE Linux Enterprise Server 12 LTSS (x86)"
     }, 

--- a/susemanager-sync-data/susemanager-sync-data.changes
+++ b/susemanager-sync-data/susemanager-sync-data.changes
@@ -1,3 +1,6 @@
+- add OPENSUSE to allowed channel_families to make
+  openSUSE Leap product visible in the product list (bsc#1138364)
+
 -------------------------------------------------------------------
 Wed May 15 15:36:15 CEST 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

openSUSE Leap 15.1 is now available via SCC but even with an updated product_tree the product does not appear in the product list.
The reason is, that the  new product_class "OPENSUSE" is not in the list of allowed channel_family.

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- manual 

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/8133

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
