### PR TITLE
BSC#1109639 - Check mandatory field $key for formulas

### DIFF
--- a/web/html/src/components/FormulaForm.js
+++ b/web/html/src/components/FormulaForm.js
@@ -23,7 +23,7 @@ class FormulaForm extends React.Component {
     constructor(props) {
         super(props);
 
-        ["saveFormula", "handleChange", "clearValues"].forEach(method => this[method] = this[method].bind(this));
+        ["saveFormula", "handleChange", "clearValues", "getMessageText"].forEach(method => this[method] = this[method].bind(this));
 
         const previewMessage = <p>On this page you can configure <a href="https://docs.saltstack.com/en/latest/topics/development/conventions/formulas.html" target="_blank" rel="noopener noreferrer">Salt Formulas</a> to automatically install and configure software.</p>;
 
@@ -123,7 +123,11 @@ class FormulaForm extends React.Component {
             this.props.saveUrl,
             JSON.stringify(formData),
             "application/json"
-          ).promise.then(function (data) { if (data instanceof Array) this.setState({ messages: data, errors: [] }); }.bind(this),
+          ).promise.then(function (data) {
+            if (data instanceof Array) {
+              this.setState({ messages: data.map(msg => this.getMessageText(msg)), errors: [] });
+            }
+          }.bind(this),
             function (error) {
                 try {
                     this.setState({
@@ -236,6 +240,10 @@ class FormulaForm extends React.Component {
         for (let key in layout)
             form.push(generateFormulaComponent(layout[key], values[key], this));
         return form;
+    }
+
+    getMessageText(msg) {
+      return this.props.messageTexts[msg] ? t(this.props.messageTexts[msg]) : msg;
     }
 
     render() {

--- a/web/html/src/components/FormulaForm.js
+++ b/web/html/src/components/FormulaForm.js
@@ -23,7 +23,7 @@ class FormulaForm extends React.Component {
     constructor(props) {
         super(props);
 
-        ["saveFormula", "handleChange", "clearValues", "getMessageText"].forEach(method => this[method] = this[method].bind(this));
+        ["saveFormula", "handleChange", "clearValues"].forEach(method => this[method] = this[method].bind(this));
 
         const previewMessage = <p>On this page you can configure <a href="https://docs.saltstack.com/en/latest/topics/development/conventions/formulas.html" target="_blank" rel="noopener noreferrer">Salt Formulas</a> to automatically install and configure software.</p>;
 
@@ -78,6 +78,24 @@ class FormulaForm extends React.Component {
         });
     }
 
+    getEmptyValues$key() {
+      let requiredErrors = [];
+
+      function checkDeepInt(values) {
+        if (values instanceof Object) {
+          if ("$key" in values && !values['$key']) {
+            requiredErrors.push(values['$key_name']);
+          }
+
+          Object.values(values).forEach((value) => checkDeepInt(value));
+        }
+      }
+
+      checkDeepInt(this.state.formulaValues)
+
+      return requiredErrors;
+    }
+
     saveFormula(event) {
         event.preventDefault();
         this.setState({ formulaChanged: false });
@@ -86,7 +104,6 @@ class FormulaForm extends React.Component {
         if (formType === 'SYSTEM') {
             formType = 'SERVER';
         }
-
         let formData = {
             type: formType,
             id: this.props.systemId,
@@ -94,11 +111,19 @@ class FormulaForm extends React.Component {
             content: this.getValuesClean(preprocessCleanValues(this.state.formulaValues, this.state.formulaLayout))
         };
 
-        Network.post(
+        const emptyRequiredFields = [...new Set(this.getEmptyValues$key())];
+
+        if(emptyRequiredFields.length > 0) {
+            this.setState({
+                    messages: [],
+                    errors: [ t("Please input required fields: {0}", emptyRequiredFields.join(', ')) ]
+            });
+        } else {
+          Network.post(
             this.props.saveUrl,
             JSON.stringify(formData),
             "application/json"
-        ).promise.then(function (data) { if (data instanceof Array) this.setState({ messages: data.map(msg => this.getMessageText(msg)) }); }.bind(this),
+          ).promise.then(function (data) { if (data instanceof Array) this.setState({ messages: data, errors: [] }); }.bind(this),
             function (error) {
                 try {
                     this.setState({
@@ -110,6 +135,7 @@ class FormulaForm extends React.Component {
                     });
                 }
             }.bind(this));
+        }
         window.scrollTo(0, 0);
     }
 
@@ -212,15 +238,11 @@ class FormulaForm extends React.Component {
         return form;
     }
 
-    getMessageText(msg) {
-      return this.props.messageTexts[msg] ? t(this.props.messageTexts[msg]) : msg;
-    }
-
     render() {
         let messageItems = this.state.messages.map((msg) => {
             return { severity: "info", text: msg };
         });
-        messageItems.concat(this.state.errors.map((msg) => {
+        messageItems = messageItems.concat(this.state.errors.map((msg) => {
             return { severity: "error", text: msg };
         }));
         const messages = <Messages items={messageItems} />;
@@ -566,6 +588,9 @@ function generateValues(layout, group_data, system_data) {
             }
 
             result[key] = value
+            if(key === '$key') {
+              result['$key_name'] = element.$name;
+            }
         }
         return result;
     }

--- a/web/html/src/components/formulas/EditGroup.js
+++ b/web/html/src/components/formulas/EditGroup.js
@@ -216,8 +216,10 @@ class EditDictionaryGroup extends React.Component {
     wrapKeyGroup(element_name, innerHTML) {
         return (
             <div className="form-group" key={element_name}>
-                <label className="col-lg-3 control-label" style={{"color": "green"}}>
-                    {element_name + ":"}
+                <label className="col-lg-3 control-label">
+                    {element_name}
+                    <span className="required-form-field"> *</span>
+                    :
                 </label>
                 <div className="col-lg-6" >
                     {innerHTML}

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Add checks for empty required entries on formula forms (bsc#1109639)
 - Fix big formula checkbox not supported in Firefox
 - Allow forcing off or resetting VMs
 - Adjust title icons


### PR DESCRIPTION
## What does this PR change?
This adds checks for required fields in in salt formula pages. This blocks submitting the form if not all the required fields are filled out. This is just a front end check, there are issues preventing back end checks, detailed in issue #7058 

#5957 
https://bugzilla.suse.com/show_bug.cgi?id=1109639

based on https://github.com/SUSE/spacewalk/pull/7061

## GUI diff.

Before:

After:
![Screenshot from 2019-06-17 14-46-26](https://user-images.githubusercontent.com/1140720/59609159-cc059b80-910e-11e9-8e2a-2c41afe60ea1.png)


- [ ] **DONE**


## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #https://github.com/SUSE/spacewalk/issues/5957

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
