### PR TITLE
Master - bsc1138268 - Create VM with no default pool/net fix

### DIFF
--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -693,6 +693,15 @@ Then "test-vm" virtual machine on "virt-server" should have no cdrom
 When I delete all "test-vm.*" volumes from "default" pool on "kvm-server" without error control
 ```
 
+* Add or remove virtual network or storage pools
+
+```cucumber
+When I create test-net1 virtual network on "kvm-server"
+When I create test-pool1 virtual storage pool on "kvm-server"
+When I delete test-net1 virtual network on "kvm-server"
+When I delete test-pool1 virtual storage pool on "kvm-server"
+```
+
 <a name="c" />
 
 ### Writing new steps

--- a/testsuite/features/minkvm_guests.feature
+++ b/testsuite/features/minkvm_guests.feature
@@ -34,8 +34,11 @@ Feature: Be able to manage KVM virtual machines via the GUI
 @virthost_kvm
   Scenario: Prepare a KVM test virtual machine and list it
     Given I am on the "Virtualization" page of this "kvm-server"
-    When I create default virtual network on "kvm-server"
+    When I delete default virtual network on "kvm-server"
     And I create test-net0 virtual network on "kvm-server"
+    And I create test-net1 virtual network on "kvm-server"
+    And I delete default virtual storage pool on "kvm-server"
+    And I create test-pool0 virtual storage pool on "kvm-server"
     And I create "test-vm" virtual machine on "kvm-server"
     And I wait until I see "test-vm" text
 
@@ -84,19 +87,19 @@ Feature: Be able to manage KVM virtual machines via the GUI
     Then I should see "512" in field "memory"
     And I should see "1" in field "vcpu"
     And option "VNC" is selected as "graphicsType"
-    And option "default" is selected as "network0_source"
+    And option "test-net0" is selected as "network0_source"
     And option "ide" is selected as "disk0_bus"
     When I enter "1024" as "memory"
     And I enter "2" as "vcpu"
     And I select "Spice" from "graphicsType"
-    And I select "test-net0" from "network0_source"
+    And I select "test-net1" from "network0_source"
     And I enter "02:34:56:78:9a:bc" as "network0_mac"
     And I select "scsi" from "disk0_bus"
     And I click on "Update"
     Then I should see a "Hosted Virtual Systems" text
     And "test-vm" virtual machine on "kvm-server" should have 1024MB memory and 2 vcpus
     And "test-vm" virtual machine on "kvm-server" should have spice graphics device
-    And "test-vm" virtual machine on "kvm-server" should have 1 NIC using "test-net0" network
+    And "test-vm" virtual machine on "kvm-server" should have 1 NIC using "test-net1" network
     And "test-vm" virtual machine on "kvm-server" should have a NIC with 02:34:56:78:9a:bc MAC address
     And "test-vm" virtual machine on "kvm-server" should have a "test-vm_disk.qcow2" scsi disk
 
@@ -106,10 +109,10 @@ Feature: Be able to manage KVM virtual machines via the GUI
     When I click on "Edit" in row "test-vm"
     And I wait until I do not see "Loading..." text
     And I click on "add_nic"
-    And I select "test-net0" from "network1_source"
+    And I select "test-net1" from "network1_source"
     And I click on "Update"
     Then I should see a "Hosted Virtual Systems" text
-    And "test-vm" virtual machine on "kvm-server" should have 2 NIC using "test-net0" network
+    And "test-vm" virtual machine on "kvm-server" should have 2 NIC using "test-net1" network
 
 @virthost_kvm
   Scenario: Delete a network interface from a KVM virtual machine
@@ -119,7 +122,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I click on "remove_nic1"
     And I click on "Update"
     Then I should see a "Hosted Virtual Systems" text
-    And "test-vm" virtual machine on "kvm-server" should have 1 NIC using "test-net0" network
+    And "test-vm" virtual machine on "kvm-server" should have 1 NIC using "test-net1" network
 
 @virthost_kvm
   Scenario: Add a disk and a cdrom to a KVM virtual machine
@@ -159,13 +162,14 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I wait until I see "General" text
     And I enter "test-vm2" as "name"
     And I enter "/var/testsuite-data/disk-image-template.qcow2" as "disk0_source_template"
+    And I select "test-net0" from "network0_source"
     And I select "Spice" from "graphicsType"
     And I click on "Create"
     Then I should see a "Hosted Virtual Systems" text
     When I wait until I see "test-vm2" text
     And I wait until table row for "test-vm2" contains button "Stop"
     And "test-vm2" virtual machine on "kvm-server" should have 1024MB memory and 1 vcpus
-    And "test-vm2" virtual machine on "kvm-server" should have 1 NIC using "default" network
+    And "test-vm2" virtual machine on "kvm-server" should have 1 NIC using "test-net0" network
     And "test-vm2" virtual machine on "kvm-server" should have a "test-vm2_system.qcow2" virtio disk
 
 @virthost_kvm
@@ -195,8 +199,9 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I run "virsh undefine --remove-all-storage test-vm" on "kvm-server" without error control
     And I run "virsh destroy test-vm2" on "kvm-server" without error control
     And I run "virsh undefine --remove-all-storage test-vm2" on "kvm-server" without error control
-    And I run "virsh net-destroy test-net0" on "kvm-server" without error control
-    And I run "virsh net-undefine test-net0" on "kvm-server" without error control
-    And I delete all "test-vm.*" volumes from "default" pool on "kvm-server" without error control
+    And I delete test-net0 virtual network on "kvm-server" without error control
+    And I delete test-net1 virtual network on "kvm-server" without error control
+    And I delete test-pool0 virtual storage pool on "kvm-server" without error control
+    And I delete all "test-vm.*" volumes from "test-pool0" pool on "kvm-server" without error control
     # Remove the virtpoller cache to avoid problems
     And I run "rm /var/cache/virt_state.cache" on "kvm-server" without error control

--- a/testsuite/features/minxen_guests.feature
+++ b/testsuite/features/minxen_guests.feature
@@ -33,8 +33,11 @@ Feature: Be able to manage XEN virtual machines via the GUI
 @virthost_xen
   Scenario: Prepare a Xen test virtual machine and list it
     Given I am on the "Virtualization" page of this "xen-server"
-    When I create default virtual network on "xen-server"
+    When I delete default virtual network on "xen-server"
     And I create test-net0 virtual network on "xen-server"
+    And I create test-net1 virtual network on "xen-server"
+    And I delete default virtual storage pool on "xen-server"
+    And I create test-pool0 virtual storage pool on "xen-server"
     And I create "test-vm" virtual machine on "xen-server"
     And I wait until I see "test-vm" text
 
@@ -83,16 +86,17 @@ Feature: Be able to manage XEN virtual machines via the GUI
     Then I should see "512" in field "memory"
     And I should see "1" in field "vcpu"
     And option "VNC" is selected as "graphicsType"
+    And option "test-net0" is selected as "network0_source"
     When I enter "1024" as "memory"
     And I enter "2" as "vcpu"
     And I select "Spice" from "graphicsType"
-    And I select "test-net0" from "network0_source"
+    And I select "test-net1" from "network0_source"
     And I enter "02:34:56:78:9a:bc" as "network0_mac"
     And I click on "Update"
     Then I should see a "Hosted Virtual Systems" text
     And "test-vm" virtual machine on "xen-server" should have 1024MB memory and 2 vcpus
     And "test-vm" virtual machine on "xen-server" should have spice graphics device
-    And "test-vm" virtual machine on "xen-server" should have 1 NIC using "test-net0" network
+    And "test-vm" virtual machine on "xen-server" should have 1 NIC using "test-net1" network
     And "test-vm" virtual machine on "xen-server" should have a NIC with 02:34:56:78:9a:bc MAC address
     And "test-vm" virtual machine on "xen-server" should have a "test-vm_disk.qcow2" ide disk
 
@@ -102,10 +106,10 @@ Feature: Be able to manage XEN virtual machines via the GUI
     When I click on "Edit" in row "test-vm"
     And I wait until I do not see "Loading..." text
     And I click on "add_nic"
-    And I select "test-net0" from "network1_source"
+    And I select "test-net1" from "network1_source"
     And I click on "Update"
     Then I should see a "Hosted Virtual Systems" text
-    And "test-vm" virtual machine on "xen-server" should have 2 NIC using "test-net0" network
+    And "test-vm" virtual machine on "xen-server" should have 2 NIC using "test-net1" network
 
 @virthost_xen
   Scenario: Delete a network interface from a Xen virtual machine
@@ -115,7 +119,7 @@ Feature: Be able to manage XEN virtual machines via the GUI
     And I click on "remove_nic1"
     And I click on "Update"
     Then I should see a "Hosted Virtual Systems" text
-    And "test-vm" virtual machine on "xen-server" should have 1 NIC using "test-net0" network
+    And "test-vm" virtual machine on "xen-server" should have 1 NIC using "test-net1" network
 
 @virthost_xen
   Scenario: Add a disk and a cdrom to a Xen virtual machine
@@ -156,13 +160,14 @@ Feature: Be able to manage XEN virtual machines via the GUI
     And I wait until I see "General" text
     And I enter "test-vm2" as "name"
     And I enter "/var/testsuite-data/disk-image-template-xenpv.qcow2" as "disk0_source_template"
+    And I select "test-net0" from "network0_source"
     And I select "Spice" from "graphicsType"
     And I click on "Create"
     Then I should see a "Hosted Virtual Systems" text
     When I wait until I see "test-vm2" text
     And I wait until table row for "test-vm2" contains button "Stop"
     And "test-vm2" virtual machine on "xen-server" should have 1024MB memory and 1 vcpus
-    And "test-vm2" virtual machine on "xen-server" should have 1 NIC using "default" network
+    And "test-vm2" virtual machine on "xen-server" should have 1 NIC using "test-net0" network
     And "test-vm2" virtual machine on "xen-server" should have a "test-vm2_system.qcow2" xen disk
 
 @virthost_xen
@@ -180,12 +185,13 @@ Feature: Be able to manage XEN virtual machines via the GUI
     And I enter "test-vm3" as "name"
     And I select "Fully Virtualized" from "osType"
     And I enter "/var/testsuite-data/disk-image-template.qcow2" as "disk0_source_template"
+    And I select "test-net0" from "network0_source"
     And I click on "Create"
     Then I should see a "Hosted Virtual Systems" text
     When I wait until I see "test-vm3" text
     And I wait until table row for "test-vm3" contains button "Stop"
     And "test-vm3" virtual machine on "xen-server" should have 1024MB memory and 1 vcpus
-    And "test-vm3" virtual machine on "xen-server" should have 1 NIC using "default" network
+    And "test-vm3" virtual machine on "xen-server" should have 1 NIC using "test-net0" network
     And "test-vm3" virtual machine on "xen-server" should have a "test-vm3_system.qcow2" xen disk
 
 @virthost_xen
@@ -210,8 +216,9 @@ Feature: Be able to manage XEN virtual machines via the GUI
     And I run "virsh undefine --remove-all-storage test-vm2" on "xen-server" without error control
     And I run "virsh destroy test-vm3" on "xen-server" without error control
     And I run "virsh undefine --remove-all-storage test-vm3" on "xen-server" without error control
-    And I run "virsh net-destroy test-net0" on "xen-server" without error control
-    And I run "virsh net-undefine test-net0" on "xen-server" without error control
-    And I delete all "test-vm.*" volumes from "default" pool on "kvm-server" without error control
+    And I delete test-net0 virtual network on "xen-server" without error control
+    And I delete test-net1 virtual network on "xen-server" without error control
+    And I delete test-pool0 virtual storage pool on "xen-server" without error control
+    And I delete all "test-vm.*" volumes from "default" pool on "xen-server" without error control
     # Remove the virtpoller cache to avoid problems
     And I run "rm /var/cache/virt_state.cache" on "xen-server" without error control

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -742,7 +742,7 @@ When(/^I create "([^"]*)" virtual machine on "([^"]*)"$/) do |vm_name, host|
   # Actually define the VM, but don't start it
   raise 'not found: virt-install' unless file_exists?(node, '/usr/bin/virt-install')
   node.run("virt-install --name #{vm_name} --memory 512 --vcpus 1 --disk path=#{disk_path} "\
-           " --network network=default --graphics vnc "\
+           " --network network=test-net0 --graphics vnc "\
            "--serial pty,log.file=/tmp/#{vm_name}.console.log,log.append=off "\
            "--import --hvm --noautoconsole --noreboot")
 end
@@ -751,8 +751,8 @@ When(/^I create ([^ ]*) virtual network on "([^"]*)"$/) do |net_name, host|
   node = get_target(host)
 
   networks = {
-    "default" => { "bridge" => "virbr0", "subnet" => 122 },
-    "test-net0" => { "bridge" => "virbr1", "subnet" => 124 }
+    "test-net0" => { "bridge" => "virbr0", "subnet" => 124 },
+    "test-net1" => { "bridge" => "virbr1", "subnet" => 126 }
   }
 
   net = networks[net_name]

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -775,6 +775,56 @@ When(/^I create ([^ ]*) virtual network on "([^"]*)"$/) do |net_name, host|
   node.run("virsh net-start #{net_name}", false)
 end
 
+When(/^I delete ([^ ]*) virtual network on "([^"]*)"((?: without error control)?)$/) do |net_name, host, error_control|
+  node = get_target(host)
+  _output, code = node.run("virsh net-dumpxml #{net_name}", false)
+  if code.zero?
+    steps %(
+      When I run "virsh net-destroy #{net_name}" on "#{host}"#{error_control}
+      And I run "virsh net-undefine #{net_name}" on "#{host}"#{error_control}
+    )
+  end
+end
+
+When(/^I create ([^ ]*) virtual storage pool on "([^"]*)"$/) do |pool_name, host|
+  node = get_target(host)
+
+  pool_def = %(<pool type='dir'>
+      <name>#{pool_name}</name>
+      <capacity unit='bytes'>0</capacity>
+      <allocation unit='bytes'>0</allocation>
+      <available unit='bytes'>0</available>
+      <source>
+      </source>
+      <target>
+        <path>/var/lib/libvirt/images/#{pool_name}</path>
+      </target>
+    </pool>
+  )
+
+  # Some pools like the default one may already be defined.
+  _output, code = node.run("virsh pool-dumpxml #{pool_name}", false)
+  node.run("echo -e \"#{pool_def}\" >/tmp/#{pool_name}.xml && virsh pool-define /tmp/#{pool_name}.xml") unless code.zero?
+  node.run("mkdir -p /var/lib/libvirt/images/#{pool_name}")
+
+  # Ensure the pool is started
+  node.run("virsh pool-start #{pool_name}", false)
+end
+
+When(/^I delete ([^ ]*) virtual storage pool on "([^"]*)"((?: without error control)?)$/) do |pool_name, host, error_control|
+  node = get_target(host)
+  _output, code = node.run("virsh pool-dumpxml #{pool_name}", false)
+  if code.zero?
+    steps %(
+      When I run "virsh pool-destroy #{pool_name}" on "#{host}"#{error_control}
+      And I run "virsh pool-undefine #{pool_name}" on "#{host}"#{error_control}
+    )
+  end
+
+  # only delete the folders we created
+  step %(I run "rm -rf /var/lib/libvirt/images/#{pool_name}" on "#{host}"#{error_control}) if pool_name.start_with? "test-"
+end
+
 Then(/^I should see "([^"]*)" virtual machine (shut off|running|paused) on "([^"]*)"$/) do |vm, state, host|
   node = get_target(host)
   repeat_until_timeout(message: "#{vm} virtual machine on #{host} never reached state #{state}") do

--- a/web/html/src/manager/virtualization/guests/guest-properties.js
+++ b/web/html/src/manager/virtualization/guests/guest-properties.js
@@ -84,7 +84,7 @@ class GuestProperties extends React.Component<Props> {
                         const { initialModel } = this.props;
 
                         if (initialModel != null && networks != null && pools != null
-                            && osTypes.length > 0 && domainsCaps.length > 0 && allMessages.length === 0) {
+                            && osTypes.length > 0 && domainsCaps.length > 0) {
                           return (
                             <GuestPropertiesForm
                               submitText={this.props.submitText}

--- a/web/html/src/manager/virtualization/guests/properties/guest-disks-panel.js
+++ b/web/html/src/manager/virtualization/guests/properties/guest-disks-panel.js
@@ -24,7 +24,7 @@ function getFileSourceFields(model: Object, index: number, pools: Array<Object>,
         divClass="col-md-6"
         disabled={!onlyHandledDisks}
         required
-        defaultValue={pools.find(pool => pool.name === 'default') ? 'default' : pools[0]}
+        defaultValue={pools.find(pool => pool.name === 'default') ? 'default' : pools[0].name}
       >
         {
           pools.map(k => <option key={k.name} value={k.name}>{k.name}</option>)

--- a/web/html/src/manager/virtualization/guests/properties/guest-nics-panel.js
+++ b/web/html/src/manager/virtualization/guests/properties/guest-nics-panel.js
@@ -60,7 +60,7 @@ function guestNicFields(model: Object, index: number, networks: Array<Object>,
             key={`network${index}_source`}
             disabled={!onlyHandledNics}
             required
-            defaultValue={networks.find(net => net.name === 'default') ? 'default' : networks[0]}
+            defaultValue={networks.find(net => net.name === 'default') ? 'default' : networks[0].name}
           >
             {
               networks.map(k => <option key={k.name} value={k.name}>{k.name}</option>)

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fix VM creation dialog with non-default pools and networks (bsc#1138268)
 - Update help URLs in the UI (bsc#1136764)
 - Force python-numpy and python-PyJWT dependencies (bsc#1137357)
 - Add state EDITED to filters in the Content Lifecycle


### PR DESCRIPTION
## What does this PR change?

Fix VM creation or editing dialog when there is no `default` virtual storage pool or network.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: implementation detail

- [X] **DONE**

## Test coverage
- Cucumber tests were adapted

- [X] **DONE**

## Links

Fixes [bsc#1138268](https://bugzilla.suse.com/show_bug.cgi?id=1138268)

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
