### PR TITLE
Adapt spacewalk-client-tools and mgr-daemon to rhnsd.timer

### DIFF
--- a/client/rhel/mgr-daemon/mgr-daemon.changes
+++ b/client/rhel/mgr-daemon/mgr-daemon.changes
@@ -1,3 +1,5 @@
+- rhnsd service was replaced by rhnsd timer (bsc#1138130)
+
 -------------------------------------------------------------------
 Wed May 15 20:07:33 CEST 2019 - jgonzalez@suse.com
 

--- a/client/rhel/mgr-daemon/mgr-daemon.spec
+++ b/client/rhel/mgr-daemon/mgr-daemon.spec
@@ -176,6 +176,7 @@ rm -rf $RPM_BUILD_ROOT/%{_datadir}/locale
 %if 0%{?suse_version} >= 1210
 %service_add_post rhnsd.timer
 %service_add_post spacewalk-update-status.service
+%{_bindir}/systemctl start rhnsd.timer || :
 %else
 %{fillup_and_insserv rhnsd}
 %endif

--- a/client/rhel/spacewalk-client-tools/50-spacewalk-client.preset
+++ b/client/rhel/spacewalk-client-tools/50-spacewalk-client.preset
@@ -1,3 +1,3 @@
-enable rhnsd.service
+enable rhnsd.timer
 enable osad.service
 enable rhn-virtualization-host.service

--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes
@@ -1,3 +1,7 @@
+- The rhnsd service was replaced by rhnsd timer, so
+  registration script and systemd presets are now adapted
+  to this (bsc#1138130)
+
 -------------------------------------------------------------------
 Wed May 15 15:09:40 CEST 2019 - jgonzalez@suse.com
 

--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.spec
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.spec
@@ -561,7 +561,7 @@ ln -s spacewalk-channel $RPM_BUILD_ROOT%{_sbindir}/rhn-channel
 mkdir -p $RPM_BUILD_ROOT/var/lib/up2date
 mkdir -pm700 $RPM_BUILD_ROOT%{_localstatedir}/spool/up2date
 touch $RPM_BUILD_ROOT%{_localstatedir}/spool/up2date/loginAuth.pkl
-%if 0%{?fedora} || 0%{?mageia} || 0%{?debian} >= 8 || 0%{?ubuntu} >= 1504
+%if 0%{?fedora} || 0%{?mageia} || 0%{?debian} >= 8 || 0%{?ubuntu} >= 1504 || 0%{?sle_version} >= 120000 || 0%{?rhel} >= 7
 mkdir -p $RPM_BUILD_ROOT/%{_presetdir}
 install 50-spacewalk-client.preset $RPM_BUILD_ROOT/%{_presetdir}
 %endif
@@ -745,7 +745,7 @@ make -f Makefile.rhn-client-tools test
 #public keys and certificates
 %{_datadir}/rhn/RHNS-CA-CERT
 
-%if 0%{?fedora} || 0%{?mageia} || 0%{?debian} >= 8 || 0%{?ubuntu} >= 1504
+%if 0%{?fedora} || 0%{?mageia} || 0%{?debian} >= 8 || 0%{?ubuntu} >= 1504 || 0%{?sle_version} >= 120000 || 0%{?rhel} >= 7
 %{_presetdir}/50-spacewalk-client.preset
 %endif
 

--- a/client/rhel/spacewalk-client-tools/src/up2date_client/rhnreg.py
+++ b/client/rhel/spacewalk-client-tools/src/up2date_client/rhnreg.py
@@ -70,8 +70,8 @@ def startRhnsd():
         if os.access("/usr/lib/systemd/system/rhnsd.service", os.R_OK):
             # systemd
             if os.access("/usr/bin/systemctl", os.R_OK|os.X_OK):
-                os.system("/usr/bin/systemctl enable rhnsd > /dev/null");
-                os.system("/usr/bin/systemctl start rhnsd > /dev/null");
+                os.system("/usr/bin/systemctl enable rhnsd.timer > /dev/null");
+                os.system("/usr/bin/systemctl start rhnsd.timer > /dev/null");
             else:
                 print(_("Warning: unable to enable rhnsd with systemd"))
         else:


### PR DESCRIPTION
### What does this PR change?

Adapt spacewalk-client-tools to rhnsd.timer

Otherwise the timer never starts, and the clients never check in.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- https://github.com/SUSE/spacewalk/issues/8149

- [x] **DONE**

## Test coverage
- No tests: Obviously not covered by the tests, but we should think about something fore the future :-D

- [x] **DONE**

## Links

## Links

Fixes https://github.com/SUSE/spacewalk/issues/8127
Tracks https://github.com/SUSE/spacewalk/pull/8128

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
