### PR TITLE
Fix mgr-virtualization remaining ugettext call

### DIFF
--- a/client/tools/mgr-virtualization/mgr-virtualization.changes
+++ b/client/tools/mgr-virtualization/mgr-virtualization.changes
@@ -1,3 +1,5 @@
+- Fix missing python 3 ugettext (bsc#1138494)
+
 -------------------------------------------------------------------
 Wed May 15 20:08:58 CEST 2019 - jgonzalez@suse.com
 

--- a/client/tools/mgr-virtualization/virtualization/support.py
+++ b/client/tools/mgr-virtualization/virtualization/support.py
@@ -30,6 +30,9 @@ from spacewalk.common.usix import UnicodeType
 
 
 t = gettext.translation('rhn-virtualization', fallback=True)
+# Python 3 translations don't have a ugettext method
+if not hasattr(t, 'ugettext'):
+    t.ugettext = t.gettext
 _ = t.ugettext
 
 try:


### PR DESCRIPTION
## What does this PR change?

poller.py was fixed for python3's lack of ugettext(), but not support.py. (bsc#1138494)

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: fixing a script

- [X] **DONE**

## Test coverage
- No tests: fix for traditional client virtualization tools

- [X] **DONE**

## Links

Fixes [bsc#1138494](https://bugzilla.suse.com/show_bug.cgi?id=1138494)

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
