### PR TITLE
Switch to new module path for which_bin

### DIFF
--- a/susemanager-utils/susemanager-sls/src/grains/cpuinfo.py
+++ b/susemanager-utils/susemanager-sls/src/grains/cpuinfo.py
@@ -17,7 +17,7 @@ def _lscpu(feedback):
 
     :return:
     '''
-    lscpu = salt.utils.which_bin(['lscpu'])
+    lscpu = salt.utils.path.which_bin(['lscpu'])
     if lscpu is not None:
         try:
             log.debug("Trying lscpu to get CPU socket count")
@@ -69,7 +69,7 @@ def _dmidecode(feedback):
 
     :return:
     '''
-    dmidecode = salt.utils.which_bin(['dmidecode'])
+    dmidecode = salt.utils.path.which_bin(['dmidecode'])
     if dmidecode is not None:
         try:
             log.debug("Trying dmidecode to get CPU socket count")

--- a/susemanager-utils/susemanager-sls/src/modules/udevdb.py
+++ b/susemanager-utils/susemanager-sls/src/modules/udevdb.py
@@ -21,7 +21,7 @@ def __virtual__():
     '''
     Only work when udevadm is installed.
     '''
-    return salt.utils.which_bin(['udevadm']) is not None
+    return salt.utils.path.which_bin(['udevadm']) is not None
 
 
 def exportdb():

--- a/susemanager-utils/susemanager-sls/src/tests/test_grains_cpuinfo.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_grains_cpuinfo.py
@@ -36,7 +36,7 @@ def test_cpusockets_dmidecode():
 
     sample = mockery.get_test_data('dmidecode.sample')
     cpuinfo.log = MagicMock()
-    with patch('salt.utils.which_bin', MagicMock(return_value="/bogus/path")):
+    with patch('salt.utils.path.which_bin', MagicMock(return_value="/bogus/path")):
         with patch.dict(cpuinfo.__salt__, {'cmd.run_all': MagicMock(return_value={'retcode': 0, 'stdout': sample})}):
             out = cpuinfo._dmidecode([])
             assert type(out) == dict
@@ -73,7 +73,7 @@ def test_cpusockets_lscpu():
     '''
     for fn_smpl in ['lscpu.ppc64le.sample', 'lscpu.s390.sample', 'lscpu.sample']:
         cpuinfo.log = MagicMock()
-        with patch('salt.utils.which_bin', MagicMock(return_value="/bogus/path")):
+        with patch('salt.utils.path.which_bin', MagicMock(return_value="/bogus/path")):
             with patch.dict(cpuinfo.__salt__,
                             {'cmd.run_all': MagicMock(return_value={'retcode': 0,
                                                                     'stdout': mockery.get_test_data(fn_smpl)})}):

--- a/susemanager-utils/susemanager-sls/src/tests/test_module_sumautil.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_module_sumautil.py
@@ -17,7 +17,7 @@ def test_livepatching_kernelliveversion():
     '''
 
     sumautil.log = MagicMock()
-    with patch('salt.utils.which_bin', MagicMock(return_value="/bogus/path")):
+    with patch('salt.utils.path.which_bin', MagicMock(return_value="/bogus/path")):
         mock = MagicMock(side_effect=[{ 'retcode': 0, 'stdout': 'ready' },
                                       { 'retcode': 0, 'stdout': mockery.get_test_data('livepatching-1.sample')}
                                      ]);
@@ -36,6 +36,6 @@ def test_livepatching_kernelliveversion():
             assert 'mgr_kernel_live_version' in out
             assert out['mgr_kernel_live_version'] == 'kgraft_patch_2_2_1'
 
-    with patch('salt.utils.which_bin', MagicMock(return_value=None)):
+    with patch('salt.utils.path.which_bin', MagicMock(return_value=None)):
         out = sumautil.get_kernel_live_version()
         assert out is None

--- a/susemanager-utils/susemanager-sls/src/tests/test_module_udevdb.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_module_udevdb.py
@@ -15,10 +15,10 @@ def test_virtual():
 
     :return:
     '''
-    with patch('salt.utils.which_bin', MagicMock(return_value=None)):
+    with patch('salt.utils.path.which_bin', MagicMock(return_value=None)):
         assert udevdb.__virtual__() is False
 
-    with patch('salt.utils.which_bin', MagicMock(return_value="/bogus/path")):
+    with patch('salt.utils.path.which_bin', MagicMock(return_value="/bogus/path")):
         assert udevdb.__virtual__() is True
 
 


### PR DESCRIPTION
## What does this PR change?

The old module is marked as deprecated and that's why we are switching to the new import path now.


## GUI diff

No difference.


## Documentation
- No documentation needed: This is just internal stuff.

## Test coverage
- Also changed usage in tests.

- [x] **DONE**

## Links

https://github.com/SUSE/salt-board/issues/339

Relevant branches (GitHub automatic links expected below):
 - Manager-3.1
 - Manager-3.2
 - Uyuni

- [ ] **DONE**

## Changelogs

I don't know. De we need an entry?

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
