### PR TITLE
Fix reposync when dealing with RedHat CDN (bsc#1138358)

### DIFF
--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -37,10 +37,10 @@ import types
 import urlgrabber
 
 try:
-    from urllib import urlencode
+    from urllib import urlencode, unquote
     from urlparse import urlsplit, urlparse, urlunparse
 except:
-    from urllib.parse import urlsplit, urlencode, urlparse, urlunparse
+    from urllib.parse import urlsplit, urlencode, urlparse, urlunparse, unquote
 
 import xml.etree.ElementTree as etree
 
@@ -609,7 +609,7 @@ type=rpm-md
             query_params['ssl_clientcert'] = self.sslclientcert
         if self.sslclientkey:
             query_params['ssl_clientkey'] = self.sslclientkey
-        new_query = urlencode(query_params, doseq=True)
+        new_query = unquote(urlencode(query_params, doseq=True))
         if self.authtoken:
             ret_url = "{0}&{1}".format(url, new_query)
         else:

--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -341,8 +341,8 @@ def write_ssl_set_cache(ca_cert, client_cert, client_key):
             cert_file = os.path.join(ssldir, "%s.pem" % name)
             if not os.path.exists(cert_file):
                 create_dir_tree(ssldir)
-                f = open(cert_file, "w")
-                f.write(str(pem))
+                f = open(cert_file, "wb")
+                f.write(pem)
                 f.close()
             filenames[cert] = cert_file
 

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Fix reposync when dealing with RedHat CDN (bsc#1138358)
 - Prevent FileNotFoundError: repomd.xml.key traceback (bsc#1137940)
 - Add journalctl output to spacewalk-debug tarballs
 - Prevent unnecessary triggering of channel-repodata tasks when GPG


### PR DESCRIPTION
## What does this PR change?

This PR fixes "reposync" to be able to deal with RedHat CDN.

There were few issues affecting here:

- The paths used for passing `ssl_capath`, `ssl_clientcert` and `ssl_clientkey` as part of the URL query shouldn't be escaped.
- Certificates files should be written as bytes to avoid `<memory at 0x....>` as the content of the file
- Since Zypper only accepts `ssl_capath` (and not a CA cert file), it's needed to decouple the provided CA file into single certificates files and run `c_rehash` on that directory to allow curl to work properly using a custom CA path.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **no tests for RHEL cdn**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/salt-board/issues/387

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
