### PR TITLE
Adapt "require" to latest version of gem

### DIFF
--- a/testsuite/features/support/setup_browser.rb
+++ b/testsuite/features/support/setup_browser.rb
@@ -8,7 +8,7 @@ require 'base64'
 require 'capybara'
 require 'capybara/cucumber'
 require 'simplecov'
-require 'minitest/unit'
+require 'minitest/autorun'
 require 'securerandom'
 require 'selenium-webdriver'
 


### PR DESCRIPTION
## What does this PR change?

This PR removes a harmless warning at the beginning of the test suite:
```
Warning: you should require 'minitest/autorun' instead.
Warning: or add 'gem "minitest"' before 'require "minitest/autorun"'
From:
  /root/spacewalk/testsuite/features/support/setup_browser.rb:11:in `require'
```

## Links

* Manager 3.2 SUSE/spacewalk#8166
* Manager 4.0 SUSE/spacewalk#8167

## Changelogs

If you don't need a changelog check, please mark this checkbox:

 - [x] No changelog needed

- [ ] Re-run test "changelog_test" 