### PR TITLE
Ensure "bytes" type when using "hashlib.update" (bsc#1138822)

### DIFF
--- a/backend/server/rhnServer/server_lib.py
+++ b/backend/server/rhnServer/server_lib.py
@@ -28,6 +28,7 @@ from spacewalk.common.rhnException import rhnException
 from spacewalk.common.rhnConfig import CFG
 
 from spacewalk.server import rhnSQL
+from rhn.i18n import bstr
 
 # Do not import server.apacheAuth in this module, or the secret generation
 # script will traceback - since it would try to import rhnSecret which doesn't
@@ -345,13 +346,13 @@ def generate_random_string(length=20):
     random_bytes = 16
     length = int(length)
     s = hashlib.new('sha1')
-    s.update("%.8f" % time.time())
-    s.update(str(os.getpid()))
+    s.update(bstr("%.8f" % time.time()))
+    s.update(bstr(str(os.getpid())))
     devrandom = open('/dev/urandom')
     result = []
     cur_length = 0
     while 1:
-        s.update(devrandom.read(random_bytes))
+        s.update(bstr(devrandom.read(random_bytes)))
         buf = s.hexdigest()
         result.append(buf)
         cur_length = cur_length + len(buf)

--- a/backend/server/rhnServer/server_lib.py
+++ b/backend/server/rhnServer/server_lib.py
@@ -348,7 +348,7 @@ def generate_random_string(length=20):
     s = hashlib.new('sha1')
     s.update(bstr("%.8f" % time.time()))
     s.update(bstr(str(os.getpid())))
-    devrandom = open('/dev/urandom')
+    devrandom = open('/dev/urandom', mode='rb')
     result = []
     cur_length = 0
     while 1:

--- a/backend/server/test/attic/rhnActivationKey.py
+++ b/backend/server/test/attic/rhnActivationKey.py
@@ -21,6 +21,7 @@ import time
 from spacewalk.common import usix
 
 from spacewalk.server import rhnSQL
+from rhn.i18n import bstr
 
 
 class InvalidTokenError(Exception):
@@ -191,12 +192,12 @@ class ActivationKey:
 
     def generate_token(self):
         s = hashlib.new('sha1')
-        s.update(str(os.getpid()))
+        s.update(bstr(str(os.getpid())))
         for field in ['org_id', 'user_id', 'server_id']:
             if self._row_reg_token.has_key(field):
                 val = self._row_reg_token[field]
-            s.update(str(val))
-        s.update("%.8f" % time.time())
+            s.update(bstr(str(val)))
+        s.update(bstr("%.8f" % time.time()))
         self._token = s.hexdigest()
         return self._token
 

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- Ensure bytes type when using hashlib to avoid traceback
+  on XMLRPC call to "registration.register_osad" (bsc#1138822)
 - Fix for CVE-2019-10136. An attacker with a valid, but expired,
   authenticated set of headers could move some digits around,
   artificially extending the session validity without modifying

--- a/client/debian/apt-spacewalk/spacewalk
+++ b/client/debian/apt-spacewalk/spacewalk
@@ -32,6 +32,7 @@ from up2date_client import config
 from up2date_client import rhnChannel
 from up2date_client import up2dateAuth
 from up2date_client import up2dateErrors
+from rhn.i18n import bstr
 
 
 
@@ -247,8 +248,8 @@ class spacewalk_method(pkg_acquire_method):
             data = res.read(4096)
             if not len(data):
                 break
-            hash_sha256.update(data)
-            hash_md5.update(data)
+            hash_sha256.update(bstr(data))
+            hash_md5.update(bstr(data))
             f.write(data)
         res.close()
         f.close()

--- a/client/tools/mgr-cfg/config_common/utils.py
+++ b/client/tools/mgr-cfg/config_common/utils.py
@@ -178,7 +178,7 @@ def getContentChecksum(checksum_type, contents):
         engine = hashlib.new(checksum_type, usedforsecurity=False)
     else:
         engine = hashlib.new(checksum_type)
-    engine.update(contents)
+    engine.update(bstr(contents))
     return engine.hexdigest()
 
 def sha256_file(filename):

--- a/client/tools/mgr-cfg/mgr-cfg.changes
+++ b/client/tools/mgr-cfg/mgr-cfg.changes
@@ -1,3 +1,5 @@
+- Ensure bytes type when using hashlib to avoid traceback (bsc#1138822)
+
 -------------------------------------------------------------------
 Wed May 15 20:06:15 CEST 2019 - jgonzalez@suse.com
 

--- a/client/tools/mgr-osad/mgr-osad.changes
+++ b/client/tools/mgr-osad/mgr-osad.changes
@@ -1,3 +1,4 @@
+- Ensure bytes type when using hashlib to avoid traceback (bsc#1138822)
 - Fix obsolete for old osad packages, to allow installing mgr-osad
   even by using osad at yum/zyppper install (bsc#1139453)
 

--- a/client/tools/mgr-osad/src/jabber_lib.py
+++ b/client/tools/mgr-osad/src/jabber_lib.py
@@ -1381,7 +1381,7 @@ def generate_random_string(length=20):
     result = []
     cur_length = 0
     while 1:
-        s.update(devrandom.read(random_bytes))
+        s.update(bstr(devrandom.read(random_bytes)))
         buf = s.hexdigest()
         result.append(buf)
         cur_length = cur_length + len(buf)


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue when dealing with `hashlib` library after migration to Python3.

The `hashlib.update` method only accepts `bytes` and not `str` anymore, so this PR fixes this issue by wrapping the input parameter with `rhn.i18n.bstr` [1] which ensure the input is always `bytes`.

[1] - https://github.com/uyuni-project/uyuni/blob/master/client/rhel/rhnlib/rhn/i18n.py#L38

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **python3 migration**

- [x] **DONE**

## Test coverage
- No tests: **python3 migration**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/salt-board/issues/389

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
