### PR TITLE
Check for added product in the list instead of the popup text message

### DIFF
--- a/testsuite/features/core_srv_products_page.feature
+++ b/testsuite/features/core_srv_products_page.feature
@@ -44,7 +44,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I select the addon "Legacy Module 12 x86_64"
     Then I should see the "Legacy Module 12 x86_64" selected
     When I click the Add Product button
-    And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
+    And I wait until I see "SUSE Linux Enterprise Server 12 SP2 x86_64" product has been added
     Then the SLE12 products should be added
 
   Scenario: Add a product with recommended enabled
@@ -60,5 +60,5 @@ Feature: Synchronize products in the products page of the Setup Wizard
     Then I should see the "SUSE Linux Enterprise Server 15 x86_64" selected
     Then I should see the "Basesystem Module 15 x86_64" selected
     And I click the Add Product button
-    And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
+    And I wait until I see "SUSE Linux Enterprise Server 15 x86_64" product has been added
     Then the SLE15 products should be added

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -439,6 +439,15 @@ Then(/^I should see the "(.*?)" selected$/) do |product|
   raise unless has_checked_field?('checkbox-for-' + product_identifier)
 end
 
+And(/^I wait until I see "(.*?)" product has been added$/) do |product|
+  repeat_until_timeout(message: "Couldn't find the installed product #{product} in the list") do
+    xpath = "//span[contains(text(), '#{product}')]/ancestor::div[contains(@class, 'product-details-wrapper')]"
+    product_wrapper = find(:xpath, xpath)
+    break if product_wrapper[:class].include?('product-installed')
+    sleep 1
+  end
+end
+
 When(/^I click the Add Product button$/) do
   raise unless find('button#addProducts').click
 end


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/8114

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"    
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
