### PR TITLE
Fix Hibernate unit tests SQL error

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
@@ -595,11 +595,11 @@ select sa.server_id
     <sql-query name="Action.lookupPendingMinionActions">
         <![CDATA[select {ra.*}
                      from rhnAction {ra},
-                     (select NULL as uuid from dual) ra_1_,
+                     (select NULL as uuid, NULL as force from dual) ra_1_,
                      (select NULL as uuid from dual) ra_2_,
                      (select NULL as uuid from dual) ra_3_,
                      (select NULL as uuid from dual) ra_4_,
-                     (select NULL as uuid from dual) ra_5_,
+                     (select NULL as uuid, NULL as force from dual) ra_5_,
                      (select NULL as uuid from dual) ra_6_,
                      (select NULL as uuid, NULL as memory from dual) ra_7_,
                      (select NULL as uuid, NULL as vcpu from dual) ra_8_,


### PR DESCRIPTION
## What does this PR change?

Fix the following error:

> Caused by: org.postgresql.util.PSQLException: ERROR: column ra_1_.force does not exist
>  Position: 364

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: unit test fix

- [X] **DONE**

## Test coverage
- No tests: Unit test fix

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
