### PR TITLE
Simplify get_os_version usage

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -582,7 +582,7 @@ end
 
 And(/^I create the "([^"]*)" bootstrap repository for "([^"]*)" on the server$/) do |arch, host|
   node = get_target(host)
-  os_version = get_os_version(node, false)
+  os_version, _os_family = get_os_version(node)
   cmd = 'false'
   if (os_version.include? '12') || (os_version.include? '15')
     cmd = "mgr-create-bootstrap-repo -c SLE-#{os_version}-#{arch}"

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -569,10 +569,15 @@ end
 
 When(/^I enable repositories before installing Docker$/) do
   # Distribution Pool and Update
-  os_version = get_os_version($minion, false)
-  arch, _code = $minion.run('uname -m')
-  puts $minion.run("zypper mr --enable SLE-#{os_version}-#{arch.strip}-Pool")
-  puts $minion.run("zypper mr --enable SLE-#{os_version}-#{arch.strip}-Update")
+  os_version, os_family = get_os_version($minion)
+  if /opensuse/ =~ os_family
+    puts $proxy.run("zypper mr --enable openSUSE-Leap-#{os_version}-Pool")
+    puts $proxy.run("zypper mr --enable openSUSE-Leap-#{os_version}-Update")
+  else
+    arch, _code = $minion.run('uname -m')
+    puts $minion.run("zypper mr --enable SLE-#{os_version}-#{arch.strip}-Pool")
+    puts $minion.run("zypper mr --enable SLE-#{os_version}-#{arch.strip}-Update")
+  end
 
   # Tools
   out, _code = $minion.run('zypper lr | grep SLE-Manager-Tools | cut -d"|" -f2')
@@ -593,10 +598,15 @@ end
 
 When(/^I disable repositories after installing Docker$/) do
   # Distribution Pool and Update
-  os_version = get_os_version($minion, false)
-  arch, _code = $minion.run('uname -m')
-  puts $minion.run("zypper mr --disable SLE-#{os_version}-#{arch.strip}-Update")
-  puts $minion.run("zypper mr --disable SLE-#{os_version}-#{arch.strip}-Pool")
+  os_version, os_family = get_os_version($minion)
+  if /opensuse/ =~ os_family
+    puts $proxy.run("zypper mr --disable openSUSE-Leap-#{os_version}-Pool")
+    puts $proxy.run("zypper mr --disable openSUSE-Leap-#{os_version}-Update")
+  else
+    arch, _code = $minion.run('uname -m')
+    puts $minion.run("zypper mr --disable SLE-#{os_version}-#{arch.strip}-Update")
+    puts $minion.run("zypper mr --disable SLE-#{os_version}-#{arch.strip}-Pool")
+  end
 
   # Tools
   out, _code = $minion.run('zypper lr | grep SLE-Manager-Tools | cut -d"|" -f2')
@@ -617,12 +627,10 @@ end
 
 When(/^I enable repositories before installing branch server$/) do
   # Distribution Pool and Update
-  os_version = get_os_version($proxy, false)
-  os_family, _code = $proxy.run('grep "ID" /etc/os-release')
+  os_version, os_family = get_os_version($proxy)
   if /opensuse/ =~ os_family
-    leap_version = get_os_version($proxy)
-    puts $proxy.run("zypper mr --enable openSUSE-Leap-#{leap_version}-Pool")
-    puts $proxy.run("zypper mr --enable openSUSE-Leap-#{leap_version}-Update")
+    puts $proxy.run("zypper mr --enable openSUSE-Leap-#{os_version}-Pool")
+    puts $proxy.run("zypper mr --enable openSUSE-Leap-#{os_version}-Update")
   else
     arch, _code = $proxy.run('uname -m')
     # take all repos that matche the following pattern "SLE.*#{os_version}-#{arch.strip}.*"
@@ -633,12 +641,10 @@ end
 
 When(/^I disable repositories after installing branch server$/) do
   # Distribution Pool and Update
-  os_version = get_os_version($proxy, false)
-  os_family, _code = $proxy.run('grep "ID" /etc/os-release')
+  os_version, os_family = get_os_version($proxy)
   if /opensuse/ =~ os_family
-    leap_version = get_os_version($proxy)
-    puts $proxy.run("zypper mr --disable openSUSE-Leap-#{leap_version}-Pool")
-    puts $proxy.run("zypper mr --disable openSUSE-Leap-#{leap_version}-Update")
+    puts $proxy.run("zypper mr --disable openSUSE-Leap-#{os_version}-Pool")
+    puts $proxy.run("zypper mr --disable openSUSE-Leap-#{os_version}-Update")
   else
     arch, _code = $proxy.run('uname -m')
     # take all repos that matche the following pattern "SLE.*#{os_version}-#{arch.strip}.*"

--- a/testsuite/features/support/client_stack.rb
+++ b/testsuite/features/support/client_stack.rb
@@ -67,17 +67,21 @@ def check_restart(host, node, time_out)
   end
 end
 
-# Extract the OS version by decoding the value in '/etc/os-release'
-# Use VERSION id = false, VERSION_ID otherwise
-def get_os_version(node, id = true)
-  field = id ? 'VERSION_ID' : 'VERSION'
-  os_version_raw, _code = node.run('grep "' + field + '=" /etc/os-release')
+# Extract the OS version and OS family
+# We get these data decoding the values in '/etc/os-release'
+def get_os_version(node)
+  os_family_raw, _code = $proxy.run('grep "^ID=" /etc/os-release')
+  os_family = os_family_raw.strip.split('=')[1]
+  return nil, nil if os_family.nil?
+  os_family.delete! '"'
+
+  os_version_raw, _code = node.run('grep "^VERSION_ID=" /etc/os-release')
   os_version = os_version_raw.strip.split('=')[1]
-  return nil if os_version.nil?
+  return nil, nil if os_version.nil?
   os_version.delete! '"'
-  # OS release for SLES 11 is not consistent with SLES 12
-  # so we need to replace the dot with '-SP'
-  _out, code = node.run('pidof systemd', false)
-  os_version.gsub!(/\./, '-SP') unless code.zero?
-  os_version
+
+  # on SLES, we need to replace the dot with '-SP'
+  os_version.gsub!(/\./, '-SP') if os_family =~ /^sles/
+
+  [os_version, os_family]
 end

--- a/testsuite/features/support/minion_checks.rb
+++ b/testsuite/features/support/minion_checks.rb
@@ -1,7 +1,7 @@
 # check if the minion is a SLE-15
 def minion_is_sle15
   node = get_target('sle-minion')
-  os_version = get_os_version(node, false)
-  return false if os_version.nil?
-  os_version.include? '15'
+  os_version, os_family = get_os_version(node)
+  return false if os_version.nil? || os_family.nil?
+  (os_version =~ /^15/) && (os_family =~ /^sles/)
 end


### PR DESCRIPTION
## What does this PR change?

This refactoring makes function `get_os_version` openSUSE-aware while making the API simpler.

It also fixes the docker steps in case we use openSUSE.

*Note*: this PR will conflict with the following PRs:
* #1123
* SUSE/spacewalk#8170
* SUSE/spacewalk#8171

(Adapt Docker and OS image idempotency steps to SLE 15)

but that's okay, I can fix them afterwards.


## Changelogs

- [ ] No changelog needed
