### PR TITLE
Update hostname rename

### DIFF
--- a/utils/spacewalk-hostname-rename
+++ b/utils/spacewalk-hostname-rename
@@ -418,8 +418,11 @@ do
     [ -n "${ssl_var}" ] && CML_NEW_SSL_CERT_REQUEST=1
 done
 
+OLD_HOSTNAME=$(grep ^redhat_management_server /etc/cobbler/settings | awk '{print $2}')
+
 echo "=============================================" | tee -a $LOG
 echo "hostname: $HOSTNAME" | tee -a $LOG
+echo "old hostname: $OLD_HOSTNAME"  | tee -a $LOG
 echo "ip: $IP" | tee -a $LOG
 echo "=============================================" | tee -a $LOG
 
@@ -506,6 +509,16 @@ print_status 0  # just simulate end
 echo -n "Changing cobbler settings ... " | tee -a $LOG
 /usr/bin/spacewalk-setup-cobbler >> $LOG 2>&1
 print_status $?
+
+echo -n "Changing kernel_options ... " | tee -a $LOG
+spacewalk-sql --select-mode - >>$LOG <<EOS
+UPDATE rhnKickstartableTree
+SET kernel_options = REPLACE(kernel_options, '$OLD_HOSTNAME', '$HOSTNAME'),
+    kernel_options_post = REPLACE(kernel_options_post, '$OLD_HOSTNAME', '$HOSTNAME');
+COMMIT;
+$DBSHELL_QUIT
+EOS
+print_status 0  # just simulate end
 
 echo -n "Changing jabberd settings ... " | tee -a $LOG
 # delete old dispatcher(s)

--- a/utils/spacewalk-hostname-rename
+++ b/utils/spacewalk-hostname-rename
@@ -518,6 +518,11 @@ SET kernel_options = REPLACE(kernel_options, '$OLD_HOSTNAME', '$HOSTNAME'),
 COMMIT;
 $DBSHELL_QUIT
 EOS
+for FILE in /var/lib/cobbler/collections/profiles/*
+do
+    backup_file $FILE
+    sed -i "s/$OLD_HOSTNAME/$HOSTNAME/g" $FILE
+done
 print_status 0  # just simulate end
 
 echo -n "Changing jabberd settings ... " | tee -a $LOG

--- a/utils/spacewalk-hostname-rename
+++ b/utils/spacewalk-hostname-rename
@@ -520,6 +520,9 @@ do
     backup_file ${ETC_JABBERD_DIR}/${jabber_config_file}
 done
 
+# clean jabberd database
+rm -f /var/lib/jabberd/db/*
+
 if [ -e $SPW_SETUP_JABBERD ]
 then
     $SPW_SETUP_JABBERD --macros "hostname:$HOSTNAME"
@@ -530,8 +533,6 @@ else
         --conf=$SAT_LOCAL_RULES_CONF \
        >> /dev/null 2>&1
 fi
-# clean jabberd database
-rm -f /var/lib/jabberd/db/*
 print_status $?
 
 echo -n "Starting spacewalk services ... " | tee -a $LOG

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,4 @@
+- hostname-rename: change hostname in cobbler db and autoinst data
 - Adds support for Ubuntu and Debian channels to spacewalk-common-channels.
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Tested hostname rename script and found two small issues

1. we need to clean the jabberd DB before we call spacewalk-setup-jabberd as it generates a new DB structure.
2. we should update kernel_options in DB for kickstartable trees to update the "install=..." option.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- manual

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
