### PR TITLE
Provisioning for salt minions

### DIFF
--- a/java/buildconf/checkstyle.xml
+++ b/java/buildconf/checkstyle.xml
@@ -230,6 +230,7 @@ MINUS_ASSIGN, MOD, MOD_ASSIGN, NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION, RCURLY, S
         <!-- the ${basedir} property to allow Checkstyle to be run  -->
         <!-- from any directory within a project.                   -->
         <property name="headerFile" value="${checkstyle.header.file}"/>
+        <property name="multiLines" value="2"/>
     </module>
 
     <module name="FileTabCharacter"/>

--- a/java/code/src/com/redhat/rhn/domain/action/kickstart/KickstartActionDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/kickstart/KickstartActionDetails.hbm.xml
@@ -16,6 +16,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         <property name="kickstartHost" type="string" column="kickstart_host"/>
         <property name="staticDevice" type="string" column="static_device"/>
         <property name="cobblerSystemName" type="string" column="cobbler_system_name"/>
+        <property name="upgrade" column="upgrade" type="yes_no" not-null="true"/>
 
                 <many-to-one name="parentAction" column="action_id"
                         class="com.redhat.rhn.domain.action.Action" outer-join="true"

--- a/java/code/src/com/redhat/rhn/domain/action/kickstart/KickstartActionDetails.java
+++ b/java/code/src/com/redhat/rhn/domain/action/kickstart/KickstartActionDetails.java
@@ -23,6 +23,7 @@ public class KickstartActionDetails extends BaseKickstartActionDetails {
 
 
     private String staticDevice;
+    private boolean upgrade = false;
 
 
     /**
@@ -39,4 +40,17 @@ public class KickstartActionDetails extends BaseKickstartActionDetails {
         this.staticDevice = s;
     }
 
+    /**
+     * @return Returns the upgrade.
+     */
+    public boolean getUpgrade() {
+        return upgrade;
+    }
+
+    /**
+     * @param upgradeIn The upgrade to set.
+     */
+    public void setUpgrade(boolean upgradeIn) {
+        this.upgrade = upgradeIn;
+    }
 }

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartFactory.java
@@ -967,6 +967,7 @@ public class KickstartFactory extends HibernateFactory {
      * @param tree to delete
      */
     public static void removeKickstartableTree(KickstartableTree tree) {
+        tree.removeSaltFS();
         singleton.removeObject(tree);
     }
 

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartSession.java
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartSession.java
@@ -460,6 +460,16 @@ public class KickstartSession {
     }
 
     /**
+     * Mark this KickstartSession as complete.
+     * @param messageIn to fill into into the History field
+     */
+    public void markComplete(String messageIn) {
+        this.setState(KickstartFactory.SESSION_STATE_COMPLETE);
+        this.setAction(null);
+        this.addHistory(this.getState(), messageIn);
+    }
+
+    /**
      * Add a History entry
      * @param stateIn to set
      * @param messageIn to set on the history item

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartableTree.java
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartableTree.java
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2009--2015 Red Hat, Inc.
+ * Copyright (c) 2010--2019 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -11,9 +12,6 @@
  * Red Hat trademarks are not licensed under GPLv2. No permission is
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
- */
-/*
- * Copyright (c) 2010 SUSE LLC
  */
 package com.redhat.rhn.domain.kickstart;
 

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartableTree.java
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartableTree.java
@@ -27,14 +27,23 @@ import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.kickstart.cobbler.CobblerCommand;
 import com.redhat.rhn.manager.kickstart.cobbler.CobblerXMLRPCHelper;
 
+import com.suse.manager.webui.services.SaltConstants;
+
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.log4j.Logger;
 import org.cobbler.CobblerConnection;
 import org.cobbler.Distro;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -43,6 +52,7 @@ import java.util.List;
  */
 public class KickstartableTree extends BaseDomainHelper {
 
+    private static Logger log = Logger.getLogger(KickstartableTree.class);
     private static final String INVALID_INITRD = "kickstart.tree.invalidinitrd";
     private static final String INVALID_KERNEL = "kickstart.tree.invalidkernel";
     private String basePath;
@@ -549,4 +559,55 @@ public class KickstartableTree extends BaseDomainHelper {
         }
     }
 
+    /**
+     * Create or Update the Salt Filesystem with kernel and initrd
+     */
+    public void createOrUpdateSaltFS() {
+        String root = SaltConstants.SUMA_STATE_FILES_ROOT_PATH;
+        Path fullDir = Paths.get(root, "bootloader", org.getId().toString(), this.label);
+        try {
+            Files.createDirectories(fullDir);
+        }
+        catch (IOException e) {
+            log.error("Unable to create directory " + fullDir, e);
+            return;
+        }
+        try {
+            List<Path> targets = new LinkedList<>();
+            if (isPathsValid()) {
+                targets.add(Paths.get(getInitrdPath()));
+                targets.add(Paths.get(getKernelPath()));
+            }
+            if (doesParaVirt()) {
+                targets.add(Paths.get(getKernelXenPath()));
+            }
+            if (pathExists(getInitrdXenPath())) {
+                targets.add(Paths.get(getInitrdXenPath()));
+            }
+
+            for (Path target : targets) {
+                Path source = fullDir.resolve(target.getFileName());
+                if (!pathExists(source.toString())) {
+                    Files.createSymbolicLink(source, target);
+                }
+            }
+        }
+        catch (IOException e) {
+            log.error("Unable to create link", e);
+        }
+    }
+
+    /**
+     * Remove the Salt Filesystem
+     */
+    public void removeSaltFS() {
+        String root = SaltConstants.SUMA_STATE_FILES_ROOT_PATH;
+        Path fullDir = Paths.get(root, "bootloader", org.getId().toString(), this.label);
+        try {
+            FileUtils.deleteDirectory(fullDir.toFile());
+        }
+        catch (Exception e) {
+            log.error("Unable to delete directory " + fullDir, e);
+        }
+    }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/saltkey/SaltKeyHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/saltkey/SaltKeyHandler.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.frontend.xmlrpc.saltkey;
+
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.xmlrpc.BaseHandler;
+
+import com.suse.manager.utils.SaltKeyUtils;
+
+/**
+ * SaltKeyHandler
+ * @xmlrpc.namespace saltkey
+ * @xmlrpc.doc Provides methods to manage salt keys
+ */
+public class SaltKeyHandler extends BaseHandler {
+
+    /**
+     * API endpoint to delete minion keys
+     * @param loggedInUser the user
+     * @param minionId the key identifier (minionId)
+     * @return 1 on success otherwise 0
+     *
+     * @xmlrpc.doc Delete a minion key
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param("string", "minionId")
+     * @xmlrpc.returntype #return_int_success()
+     */
+    public int delete(User loggedInUser, String minionId) {
+        ensureOrgAdmin(loggedInUser);
+        if (SaltKeyUtils.deleteSaltKey(loggedInUser, minionId)) {
+            return 1;
+        }
+        return 0;
+    }
+}

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 SUSE LLC
+ * Copyright (c) 2015--2019 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
@@ -139,10 +139,8 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                 will(returnValue(Optional.of(MINION_ID)));
                 allowing(saltServiceMock).getMachineId(MINION_ID);
                 will(returnValue(Optional.of(MACHINE_ID)));
-                if (key != null) {
-                    allowing(saltServiceMock).getGrains(MINION_ID);
-                    will(returnValue(getGrains(MINION_ID, null, key)));
-                }
+                allowing(saltServiceMock).getGrains(MINION_ID);
+                will(returnValue(getGrains(MINION_ID, null, key)));
                 allowing(saltServiceMock).syncGrains(with(any(MinionList.class)));
                 allowing(saltServiceMock).syncModules(with(any(MinionList.class)));
             } };
@@ -1273,30 +1271,6 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         } finally {
             MinionPendingRegistrationService.removeMinion(MINION_ID);
         }
-    }
-
-    /**
-     * Tests that grains aren't queried for an existing non-retail minion.
-     *
-     * @throws Exception if anything goes wrong
-     */
-    public void testNoGrainsQueryForNonRetailMinion() throws Exception {
-        MinionServer server = MinionServerFactoryTest.createTestMinionServer(user);
-        server.setMinionId(MINION_ID);
-        server.setMachineId(MACHINE_ID);
-        executeTest((saltServiceMock, key) ->
-                        new Expectations(){ {
-                            allowing(saltServiceMock).getMasterHostname(MINION_ID);
-                            will(returnValue(Optional.of(MINION_ID)));
-                            allowing(saltServiceMock).getMachineId(MINION_ID);
-                            will(returnValue(Optional.of(MACHINE_ID)));
-                            never(saltServiceMock).getGrains(MINION_ID); // we test that grains aren't queried here!
-                            allowing(saltServiceMock).syncModules(with(any(MinionList.class)));
-                        } },
-                null,
-                (minion, machineId, key) -> { },
-                null,
-                DEFAULT_CONTACT_METHOD);
     }
 
     /**

--- a/java/code/src/com/suse/manager/utils/SaltKeyUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltKeyUtils.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.utils;
+
+import com.redhat.rhn.domain.server.MinionServerFactory;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.xmlrpc.PermissionCheckFailureException;
+
+import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.salt.netapi.calls.wheel.Key;
+
+import java.util.stream.Stream;
+
+/**
+ * SaltKeyUtils
+ */
+public class SaltKeyUtils {
+
+    private static final SaltService SALT_SERVICE = SaltService.INSTANCE;
+
+    private SaltKeyUtils() { }
+
+    /**
+     * Delete a salt key
+     * @param user the user
+     * @param minionId the key identifier (minion id)
+     * @return true on success otherwise false
+     * @throws PermissionCheckFailureException requires org admin privileges
+     */
+    public static boolean deleteSaltKey(User user, String minionId)
+            throws PermissionCheckFailureException {
+
+        //Note: since salt only allows globs we have to do our own strict matching
+        Key.Names keys = SALT_SERVICE.getKeys();
+        boolean exists = Stream.concat(
+                Stream.concat(
+                        keys.getDeniedMinions().stream(),
+                        keys.getMinions().stream()),
+                Stream.concat(
+                        keys.getUnacceptedMinions().stream(),
+                        keys.getRejectedMinions().stream())
+        ).anyMatch(minionId::equals);
+
+        if (exists) {
+            return MinionServerFactory.findByMinionId(minionId).map(minionServer -> {
+                if (minionServer.getOrg().equals(user.getOrg())) {
+                    SALT_SERVICE.deleteKey(minionId);
+                    return true;
+                }
+                else {
+                    return false;
+                }
+            }).orElseGet(() -> {
+                SALT_SERVICE.deleteKey(minionId);
+                return true;
+            });
+        }
+        else {
+            return false;
+        }
+    }
+}

--- a/java/code/webapp/WEB-INF/pages/common/fragments/kickstart/schedule/ks-wizard.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/kickstart/schedule/ks-wizard.jspf
@@ -41,7 +41,7 @@
                 <%@ include file="/WEB-INF/pages/common/fragments/kickstart/schedule/proxy-options.jspf" %>
 
         <c:if test="${requestScope.hasProfiles == 'true'}">
-          <rhn:require acl="system_has_management_entitlement()">
+          <rhn:require acl="system_has_management_entitlement() or system_has_salt_entitlement()">
                 <%@ include file="/WEB-INF/pages/common/fragments/kickstart/schedule/schedule-options.jspf" %>
           </rhn:require>
           <table width="100%">
@@ -52,7 +52,7 @@
                         value="<bean:message key='kickstart.schedule.button0.jsp'/>"
                         onclick="setStep('fourth');this.form.submit();" />
                           </c:if>
-                <rhn:require acl="system_has_management_entitlement()">
+                <rhn:require acl="system_has_management_entitlement() or system_has_salt_entitlement()">
                 <input type="button" class="btn btn-default" value="<bean:message key='kickstart.schedule.button1.jsp'/>" onclick="setStep('second');this.form.submit();" />
                 <input type="button" class="btn btn-default" value="<bean:message key='kickstart.schedule.button2.jsp'/>" onclick="setStep('third');this.form.submit();" />
                 </rhn:require>

--- a/java/conf/cobbler/snippets/minion_script
+++ b/java/conf/cobbler/snippets/minion_script
@@ -1,0 +1,57 @@
+# begin SUSE Manager registration
+<script>
+    <filename>uyuni-minion.sh</filename>
+    <source>
+        <![CDATA[
+cat <<EOF >"/etc/salt/minion.d/susemanager.conf"
+master: $redhat_management_server
+
+EOF
+#if $varExists('registration_key') or $varExists('redhat_management_key')
+cat <<EOF >>"/etc/salt/minion.d/susemanager.conf"
+grains:
+    susemanager:
+EOF
+#end if
+#if $varExists('redhat_management_key')
+cat <<EOF >>"/etc/salt/minion.d/susemanager.conf"
+        management_key: "$redhat_management_key"
+EOF
+#end if
+#if $varExists('registration_key')
+cat <<EOF >>"/etc/salt/minion.d/susemanager.conf"
+        activation_key: "$registration_key"
+EOF
+#end if
+
+#if not $varExists('dont_register')
+# if you don't want to register, set the 'dont_register' variable
+
+systemctl restart salt-minion
+systemctl enable salt-minion
+#end if
+
+#if not $varExists('dont_disable_automatic_onlineupdate')
+YAOU_SYSCFGFILE="/etc/sysconfig/automatic_online_update"
+if [ -f "$YAOU_SYSCFGFILE" ]; then
+  echo "* Disable YAST automatic online update."
+  sed -i 's/^ *AOU_ENABLE_CRONJOB.*/AOU_ENABLE_CRONJOB="false"/' "$YAOU_SYSCFGFILE"
+  for D in /etc/cron.*; do
+    test -L $D/opensuse.org-online_update && rm $D/opensuse.org-online_update
+  done
+fi
+#end if
+
+#if not $varExists('dont_disable_local_repos')
+echo "* Disable all repos not provided by SUSE Manager Server."
+zypper ms -d --all
+zypper ms -e --medium-type plugin
+zypper mr -d --all
+zypper mr -e --medium-type plugin
+#end if
+
+        ]]>
+    </source>
+</script>
+# end SUSE Manager registration
+

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- implement provisioning for salt clients
 - New Single Page Application engine for the UI
 - Check that a channel doesn't have clones before deleting it (bsc#1138454)
 - Fix: initialize the hibernate transaction when merging errata via XMLRPC API (bsc#1145584)

--- a/schema/spacewalk/common/data/rhnServerGroupTypeFeature.sql
+++ b/schema/spacewalk/common/data/rhnServerGroupTypeFeature.sql
@@ -259,6 +259,11 @@ values (lookup_sg_type('salt_entitled'), lookup_feature_type('ftr_system_custom_
 
 insert into rhnServerGroupTypeFeature (server_group_type_id, feature_id,
                                        created, modified)
+values (lookup_sg_type('salt_entitled'), lookup_feature_type('ftr_kickstart'),
+        current_timestamp,current_timestamp);
+
+insert into rhnServerGroupTypeFeature (server_group_type_id, feature_id,
+                                       created, modified)
 values (lookup_sg_type('salt_entitled'), lookup_feature_type('ftr_power_management'),
         current_timestamp,current_timestamp);
 

--- a/schema/spacewalk/common/tables/rhnActionKickstart.sql
+++ b/schema/spacewalk/common/tables/rhnActionKickstart.sql
@@ -25,6 +25,9 @@ CREATE TABLE rhnActionKickstart
     kickstart_host      VARCHAR2(256),
     static_device       VARCHAR2(32),
     cobbler_system_name VARCHAR2(256),
+    upgrade             CHAR(1) DEFAULT ('N') NOT NULL
+                            CONSTRAINT rhn_actionks_up_ck
+                                CHECK (upgrade in ('Y', 'N')),
     created             timestamp with local time zone
                             DEFAULT (current_timestamp) NOT NULL,
     modified            timestamp with local time zone

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- enable provisioning for salt clients
 - Bump version to 4.1.0
 - Allow package changelog entries with more than 3000 characters (bsc#1144889)
 - add caret sorting for rpm versioning

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.14-to-susemanager-schema-4.0.15/010_kickstart_for_salt.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.14-to-susemanager-schema-4.0.15/010_kickstart_for_salt.sql
@@ -1,0 +1,7 @@
+insert into rhnServerGroupTypeFeature (server_group_type_id, feature_id,
+                                       created, modified)
+select lookup_sg_type('salt_entitled'), lookup_feature_type('ftr_kickstart'),
+        current_timestamp,current_timestamp from dual
+where not exists ( select 1 from rhnServerGroupTypeFeature
+    where server_group_type_id = lookup_sg_type('salt_entitled')
+      and feature_id = lookup_feature_type('ftr_kickstart') );

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.14-to-susemanager-schema-4.0.15/011-add-upgrade-ks-action-details.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.14-to-susemanager-schema-4.0.15/011-add-upgrade-ks-action-details.sql
@@ -1,0 +1,5 @@
+alter table rhnActionKickstart drop CONSTRAINT if exists rhn_actionks_up_ck;
+alter table rhnActionKickstart add column if not exists
+            upgrade CHAR(1) DEFAULT ('N') NOT NULL
+                    CONSTRAINT rhn_actionks_up_ck
+                    CHECK (upgrade in ('Y', 'N'));

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.0-to-susemanager-schema-4.1.1/010_kickstart_for_salt.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.0-to-susemanager-schema-4.1.1/010_kickstart_for_salt.sql
@@ -1,0 +1,7 @@
+insert into rhnServerGroupTypeFeature (server_group_type_id, feature_id,
+                                       created, modified)
+select lookup_sg_type('salt_entitled'), lookup_feature_type('ftr_kickstart'),
+        current_timestamp,current_timestamp from dual
+where not exists ( select 1 from rhnServerGroupTypeFeature
+    where server_group_type_id = lookup_sg_type('salt_entitled')
+      and feature_id = lookup_feature_type('ftr_kickstart') );

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.0-to-susemanager-schema-4.1.1/011-add-upgrade-ks-action-details.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.0-to-susemanager-schema-4.1.1/011-add-upgrade-ks-action-details.sql
@@ -1,0 +1,5 @@
+alter table rhnActionKickstart drop CONSTRAINT if exists rhn_actionks_up_ck;
+alter table rhnActionKickstart add column if not exists
+            upgrade CHAR(1) DEFAULT ('N') NOT NULL
+                    CONSTRAINT rhn_actionks_up_ck
+                    CHECK (upgrade in ('Y', 'N'));

--- a/susemanager-utils/susemanager-sls/salt/bootloader/42_uyuni_reinstall.templ
+++ b/susemanager-utils/susemanager-sls/salt/bootloader/42_uyuni_reinstall.templ
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+echo "menuentry \"{{ pillar.get('uyuni-reinstall-name') }}\" {"
+if [ -d /sys/firmware/efi ] && [ "x${GRUB_USE_LINUXEFI}" = "xtrue" ]; then
+    echo "    linuxefi /boot/uyuni-reinstall-kernel {{ pillar.get('uyuni-reinstall-kopts') }}"
+    echo "    initrdefi /boot/uyuni-reinstall-initrd"
+else
+    echo "    linux /boot/uyuni-reinstall-kernel {{ pillar.get('uyuni-reinstall-kopts') }}"
+    echo "    initrd /boot/uyuni-reinstall-initrd"
+fi
+echo "}"
+

--- a/susemanager-utils/susemanager-sls/salt/bootloader/autoinstall.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootloader/autoinstall.sls
@@ -1,0 +1,42 @@
+{% if pillar['uyuni-reinstall-kernel'] and pillar['uyuni-reinstall-initrd'] %}
+mgr_copy_kernel:
+  file.managed:
+    - name: /boot/uyuni-reinstall-kernel
+    - source: salt://bootloader/{{ pillar.get('uyuni-reinstall-kernel') }}
+
+mgr_copy_initrd:
+  file.managed:
+    - name: /boot/uyuni-reinstall-initrd
+    - source: salt://bootloader/{{ pillar.get('uyuni-reinstall-initrd') }}
+
+mgr_create_grub2_entry:
+  file.managed:
+    - name: /etc/grub.d/42_uyuni_reinstall
+    - source: salt://bootloader/42_uyuni_reinstall.templ
+    - template: jinja
+    - mode: 0755
+
+mgr_set_default_boot:
+  file.replace:
+    - name: /etc/default/grub
+    - pattern: GRUB_DEFAULT=.*
+    - repl: GRUB_DEFAULT={{ pillar.get('uyuni-reinstall-name') }}
+    - require:
+      - file: mgr_create_grub2_entry
+
+mgr_generate_grubconf:
+  cmd.run:
+    - name: grub2-mkconfig -o /boot/grub2/grub.cfg
+    - onchanges:
+      - file: mgr_copy_kernel
+      - file: mgr_copy_initrd
+      - file: mgr_create_grub2_entry
+      - file: mgr_set_default_boot
+
+mgr_autoinstall_start:
+  cmd.run:
+    - name: shutdown -r +1
+    - onchanges:
+      - cmd: mgr_generate_grubconf
+
+{% endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- implement provisioning for salt clients
 - dmidecode does not exist on ppc64le and s390x (bsc#1145119)
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Support re-installation using autoyast of kickstart profile for salt minions.

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- https://github.com/SUSE/spacewalk/issues/9216

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/7465
Tracks ...

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
