### PR TITLE
Fix a copy and paste error in get_os_version

### DIFF
--- a/testsuite/features/support/client_stack.rb
+++ b/testsuite/features/support/client_stack.rb
@@ -70,7 +70,7 @@ end
 # Extract the OS version and OS family
 # We get these data decoding the values in '/etc/os-release'
 def get_os_version(node)
-  os_family_raw, _code = $proxy.run('grep "^ID=" /etc/os-release')
+  os_family_raw, _code = node.run('grep "^ID=" /etc/os-release')
   os_family = os_family_raw.strip.split('=')[1]
   return nil, nil if os_family.nil?
   os_family.delete! '"'


### PR DESCRIPTION
## What does this PR change?

This PR fixes another error introduced in latest changes to `get_os_version`.

Tracks 3.2 SUSE/spacewalk#8199
  4.0 SUSE/spacewalk#
