### PR TITLE
Tools channels are not supported in uyuni so removed it from cucumber test

### DIFF
--- a/testsuite/features/srv_content_lifecycle.feature
+++ b/testsuite/features/srv_content_lifecycle.feature
@@ -37,10 +37,8 @@ Feature: Content lifecycle
     And I select "SLES12-SP4-Pool for x86_64" from "selectedBaseChannel"
     And I click on "Save"
     Then I wait until I see "SLES12-SP4-Pool for x86_64" text
-    And I should see a "SLE-Manager-Tools12-Updates for x86_64 SP4" text
     And I should see a "SLES12-SP4-Updates for x86_64" text
-    And I should see a "SLE-Manager-Tools12-Pool for x86_64 SP4" text
-    And I should see a "Build (4)" text
+    And I should see a "Build (2)" text
     And I should see a "Version 1: (draft - not built) - Check the changes below" text
 
   Scenario: Add environments to the project
@@ -73,7 +71,7 @@ Feature: Content lifecycle
     When I follow the left menu "Content Lifecycle > Projects"
     And I follow "clp_name"
     Then I should see a "not built" text in the environment "qa_name"
-    When I click on "Build (4)"
+    When I click on "Build (2)"
     And I should see a "Version 1 history" text
     When I enter "test version message 1" as "message"
     And I click the environment build button


### PR DESCRIPTION
## What does this PR change?

Tools channels are not supported in Uyuni, this PR remove the reference of that channel from the test.

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: **A test has been fixed**

- [ ] **DONE**

## Test coverage
- Cucumber tests were updated

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
