### PR TITLE
Use obs-to-maven for ivy dependencies.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.git.*.rpm
 *.Ds_Store
 java/build
+java/buildconf/ivy/repository/
 java/lib
 java/*.log
 java/*.log.*

--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -22,7 +22,7 @@
         <dependency org="suse" name="commons-jexl" rev="2.1.1" />
         <dependency org="suse" name="commons-lang3" rev="3.4" />
         <dependency org="suse" name="commons-logging" rev="1.2" />
-        <dependency org="suse" name="commons-validator" rev="1.1.4" />
+        <dependency org="suse" name="commons-validator" rev="1.3.1" />
         <dependency org="suse" name="concurrent" rev="1.3.4" />
         <dependency org="suse" name="concurrentlinkedhashmap-lru" rev="1.3.1" />
         <dependency org="suse" name="dom4j" rev="1.6.1" />
@@ -47,16 +47,16 @@
         <dependency org="suse" name="jboss-logging" rev="3.3.0" />
         <dependency org="suse" name="jcommon" rev="1.0.16" />
         <dependency org="suse" name="jdom" rev="1.1" />
-        <dependency org="suse" name="joda-time" rev="2.9.4" />
+        <dependency org="suse" name="joda-time" rev="2.10.1" />
         <dependency org="suse" name="jose4j" rev="0.5.1" />
         <dependency org="suse" name="log4j" rev="1.2.17" />
-        <dependency org="suse" name="jsch" rev="0.1.54" />
-        <dependency org="suse" name="netty-buffer" rev="4.1.8" />
-        <dependency org="suse" name="netty-codec" rev="4.1.8" />
-        <dependency org="suse" name="netty-common" rev="4.1.8" />
-        <dependency org="suse" name="netty-handler" rev="4.1.8" />
-        <dependency org="suse" name="netty-resolver" rev="4.1.8" />
-        <dependency org="suse" name="netty-transport" rev="4.1.8" />
+        <dependency org="suse" name="jsch" rev="0.1.55" />
+        <dependency org="suse" name="netty-buffer" rev="4.1.8.Final" />
+        <dependency org="suse" name="netty-codec" rev="4.1.8.Final" />
+        <dependency org="suse" name="netty-common" rev="4.1.8.Final" />
+        <dependency org="suse" name="netty-handler" rev="4.1.8.Final" />
+        <dependency org="suse" name="netty-resolver" rev="4.1.8.Final" />
+        <dependency org="suse" name="netty-transport" rev="4.1.8.Final" />
         <dependency org="suse" name="oro" rev="2.0.8" />
         <dependency org="suse" name="pgjdbc-ng" rev="0.7.1" />
         <dependency org="suse" name="postgresql-jdbc" rev="9.4" />
@@ -77,14 +77,14 @@
         <dependency org="suse" name="spark-core" rev="2.7.2" />
         <dependency org="suse" name="spark-template-jade" rev="2.3" />
         <dependency org="suse" name="statistics" rev="1.0.2" />
-        <dependency org="suse" name="stax-api" rev="1.0-2" />
+        <dependency org="suse" name="stax-api" rev="1.0.1" />
         <dependency org="suse" name="stax2-api" rev="3.1.4" />
         <dependency org="suse" name="stringtree-json" rev="2.0.9" />
         <dependency org="suse" name="struts" rev="1.2.9" />
         <dependency org="suse" name="taglibs-standard-impl" rev="1.2.5" />
         <dependency org="suse" name="taglibs-standard-jstlel" rev="1.2.5" />
         <dependency org="suse" name="taglibs-standard-spec" rev="1.2.5" />
-        <dependency org="suse" name="woodstox-core-asl" rev="4.4.1" />
+        <dependency org="suse" name="woodstox-core-asl" rev="4.4.2" />
         <dependency org="suse" name="xalan-j2" rev="2.7.2" />
         <dependency org="suse" name="xalan-j2-serializer" rev="2.7.2" />
         <dependency org="suse" name="xerces-j2" rev="2.11.0" />
@@ -99,22 +99,23 @@
         <dependency org="suse" name="tomcat-servlet-4.0-api" rev="9.0.14" />
 
         <!-- Compilation and testing -->
-        <dependency org="suse" name="checkstyle-all" rev="6.11.2" />
+        <dependency org="com.puppycrawl.tools" name="checkstyle" rev="6.11.2">
+          <exclude org="com.sun"/>
+        </dependency>
         <dependency org="suse" name="hamcrest-core" rev="1.3" />
         <dependency org="suse" name="hamcrest-library" rev="1.3" />
-        <dependency org="suse" name="jacocoant" rev="0.7.7" />
-        <dependency org="suse" name="jaxb-api" rev="2.3.0" />
-        <dependency org="suse" name="jaxb-core" rev="2.3.0" />
-        <dependency org="suse" name="jaxb-impl" rev="2.3.0" />
-        <dependency org="suse" name="junit" rev="3.8.2" />
-        <dependency org="suse" name="jmock" rev="2.6.0" />
-        <dependency org="suse" name="jmock-junit3" rev="2.6.0" />
-        <dependency org="suse" name="jmock-legacy" rev="2.6.0" />
-        <dependency org="suse" name="mockobjects" rev="0.09" />
-        <dependency org="suse" name="mockobjects-core" rev="0.09" />
-        <dependency org="suse" name="mockobjects-jdk1.4-j2ee1.3" rev="0.09" />
-        <dependency org="suse" name="objenesis" rev="1.0" />
-        <dependency org="suse" name="strutstest" rev="2.1.3" />
-        <dependency org="suse" name="websocket-api" rev="1.1" />
+        <dependency org="javax.xml.bind" name="jaxb-api" rev="2.3.0" transitive="false"/>
+        <dependency org="com.sun.xml.bind" name="jaxb-core" rev="2.3.0" transitive="false"/>
+        <dependency org="com.sun.xml.bind" name="jaxb-impl" rev="2.3.0" transitive="false"/>
+        <dependency org="junit" name="junit" rev="3.8.2" transitive="false"/>
+        <dependency org="org.jmock" name="jmock" rev="2.6.0" transitive="false"/>
+        <dependency org="org.jmock" name="jmock-junit3" rev="2.6.0" transitive="false"/>
+        <dependency org="org.jmock" name="jmock-legacy" rev="2.6.0" transitive="false"/>
+        <dependency org="mockobjects" name="mockobjects-core" rev="0.09" transitive="false"/>
+        <dependency org="mockobjects" name="mockobjects-jdk1.4-j2ee1.3" rev="0.09" transitive="false"/>
+        <dependency org="org.objenesis" name="objenesis" rev="1.0" transitive="false"/>
+        <dependency org="javax.websocket" name="javax.websocket-api" rev="1.1" transitive="false"/>
+        <dependency org="strutstestcase" name="strutstestcase" rev="2.1.3-1.2-2.4" transitive="false"/>
+        <dependency org="org.jacoco" name="org.jacoco.ant" rev="0.7.7.201606060606" transitive="false"/>
     </dependencies>
 </ivy-module>

--- a/java/buildconf/ivy/ivyconf.xml
+++ b/java/buildconf/ivy/ivyconf.xml
@@ -1,8 +1,12 @@
 <ivysettings>
-  <settings defaultResolver="default" />
+  <settings defaultResolver="central" />
   <resolvers>
-    <url name="default">
-      <artifact pattern="http://ramrod.mgr.suse.de/ivy/master/[artifact]-[revision].[ext]" />
-    </url>
+    <filesystem name="suse" m2compatible="true" local="true">
+      <artifact pattern="${ivy.conf.dir}/repository/[organization]/[artifact]/[revision]/[artifact]-[revision].[ext]" />
+    </filesystem>
+    <ibiblio name="central" m2compatible="true"/>
   </resolvers>
+  <modules>
+    <module organisation="suse" name="*" resolver="suse"/>
+  </modules>
 </ivysettings>

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -1,0 +1,316 @@
+repositories:
+  Leap:
+    project: openSUSE:Leap:15.1
+    repository: standard
+  Uyuni_Other:
+    project: systemsmanagement:Uyuni:Master:Other
+    repository: openSUSE_Leap_15.1
+  Uyuni:
+    project: systemsmanagement:Uyuni:Master
+    repository: openSUSE_Leap_15.1
+artifacts:
+  - artifact: asm
+    package: asm3
+    jar: asm3-all
+    repository: Leap
+  - artifact: antlr
+    repository: Leap
+  - artifact: bcel
+    repository: Leap
+  - artifact: byte-buddy
+    repository: Uyuni_Other
+  - artifact: c3p0
+    repository: Uyuni_Other
+  - artifact: cglib
+    repository: Leap
+  - artifact: classmate
+    repository: Uyuni_Other
+  - artifact: classpathx-mail-1.3.1-monolithic
+    package: classpathx-mail
+    jar: classpathx-mail-1.3.1-monolithic
+    repository: Leap
+  - artifact: commons-beanutils
+    package: apache-commons-beanutils
+    repository: Leap
+  - artifact: commons-cli
+    package: apache-commons-cli
+    repository: Leap
+  - artifact: commons-codec
+    package: apache-commons-codec
+    repository: Leap
+  - artifact: commons-collections
+    package: apache-commons-collections
+    repository: Leap
+  - artifact: commons-digester
+    package: jakarta-commons-digester
+    jar: jakarta-commons-digester-[0-9.]+\.jar
+    repository: Leap
+  - artifact: commons-discovery
+    package: jakarta-commons-discovery
+    repository: Leap
+  - artifact: commons-el
+    package: jakarta-commons-el
+    repository: Uyuni_Other
+  - artifact: commons-fileupload
+    package: jakarta-commons-fileupload
+    repository: Leap
+  - artifact: commons-io
+    package: apache-commons-io
+    repository: Leap
+  - artifact: commons-jexl
+    package: apache-commons-jexl
+    repository: Uyuni_Other
+  - artifact: commons-lang3
+    package: apache-commons-lang3
+    repository: Leap
+  - artifact: commons-logging
+    package: apache-commons-logging
+    jar: apache-commons-logging\.jar
+    repository: Leap
+  - artifact: commons-validator
+    package: apache-commons-validator
+    repository: Leap
+  - artifact: concurrent
+    repository: Uyuni_Other
+  - artifact: concurrentlinkedhashmap-lru
+    repository: Uyuni_Other
+  - artifact: dom4j
+    jar: dom4j-[0-9.]+
+    repository: Leap
+  - artifact: dwr
+    repository: Uyuni_Other
+  - artifact: ehcache-core
+    package: ehcache
+    repository: Uyuni_Other
+  - artifact: geronimo-jta-1.1-api
+    package: geronimo-specs
+    rpm: geronimo-jta-1_1
+    repository: Leap
+  - artifact: google-gson
+    repository: Uyuni_Other
+  - artifact: hibernate-c3p0
+    package: hibernate5
+    jar: hibernate-c3p0
+    repository: Uyuni_Other
+  - artifact: hibernate-commons-annotations
+    repository: Uyuni_Other
+  - artifact: hibernate-core
+    package: hibernate5
+    jar: hibernate-core
+    repository: Uyuni_Other
+  - artifact: hibernate-ehcache
+    package: hibernate5
+    jar: hibernate-ehcache
+    repository: Uyuni_Other
+  - artifact: httpasyncclient
+    package: httpcomponents-asyncclient
+    jar: httpasyncclient-[0-9.]+
+    repository: Uyuni_Other
+  - artifact: httpclient
+    package: httpcomponents-client
+    jar: httpclient-[0-9.]+
+    repository: Uyuni_Other
+  - artifact: httpcore
+    package: httpcomponents-core
+    jar: httpcore-[0-9.]+
+    repository: Uyuni_Other
+  - artifact: httpcore-nio
+    package: httpcomponents-core
+    jar: httpcore-nio
+    repository: Uyuni_Other
+  - artifact: jade4j
+    repository: Uyuni_Other
+  - artifact: jaf
+    package: gnu-jaf
+    repository: Leap
+  - artifact: jakarta-persistence-api
+    package: jpa-api
+    repository: Uyuni_Other
+  - artifact: java-saml
+    jar: java-saml-[0-9.]+
+    repository: Uyuni_Other
+  - artifact: java-saml-core
+    package: java-saml
+    jar: java-saml-core
+    repository: Uyuni_Other
+  - artifact: javassist
+    repository: Uyuni_Other
+  - artifact: jboss-logging
+    repository: Uyuni_Other
+  - artifact: jcommon
+    repository: Uyuni_Other
+  - artifact: jdom
+    rpm: jdom
+    repository: Leap
+  - artifact: joda-time
+    repository: Uyuni_Other
+  - artifact: jose4j
+    repository: Uyuni_Other
+  - artifact: log4j
+    repository: Leap
+  - artifact: jsch
+    repository: Uyuni_Other
+  - artifact: netty-buffer
+    package: netty
+    jar: netty-buffer
+    repository: Uyuni_Other
+  - artifact: netty-codec
+    package: netty
+    jar: netty-codec
+    repository: Uyuni_Other
+  - artifact: netty-common
+    package: netty
+    jar: netty-common
+    repository: Uyuni_Other
+  - artifact: netty-handler
+    package: netty
+    jar: netty-handler
+    repository: Uyuni_Other
+  - artifact: netty-resolver
+    package: netty
+    jar: netty-resolver
+    repository: Uyuni_Other
+  - artifact: netty-transport
+    package: netty
+    jar: netty-transport
+    repository: Uyuni_Other
+  - artifact: oro
+    repository: Leap
+  - artifact: pgjdbc-ng
+    repository: Uyuni_Other
+  - artifact: postgresql-jdbc
+    repository: Uyuni_Other
+  - artifact: quartz
+    repository: Uyuni
+  - artifact: redstone-xmlrpc
+    jar: redstone-xmlrpc-[0-9.]+
+    repository: Uyuni_Other
+  - artifact: redstone-xmlrpc-client
+    package: redstone-xmlrpc
+    jar: redstone-xmlrpc-client
+    repository: Uyuni_Other
+  - artifact: salt-netapi-client
+    repository: Uyuni
+  - artifact: simpleclient
+    package: prometheus-client-java
+    jar: simpleclient-[0-9.]+
+    repository: Uyuni_Other
+  - artifact: simpleclient_common
+    package: prometheus-client-java
+    jar: simpleclient_common
+    repository: Uyuni_Other
+  - artifact: simpleclient_httpserver
+    package: prometheus-client-java
+    jar: simpleclient_httpserver
+    repository: Uyuni_Other
+  - artifact: simpleclient_servlet
+    package: prometheus-client-java
+    jar: simpleclient_servlet
+    repository: Uyuni_Other
+  - artifact: simple-core
+    # How comes that package is not noarch?
+    arch: x86_64
+    jar: simple-core
+    repository: Uyuni_Other
+  - artifact: simple-xml
+    repository: Uyuni_Other
+  - artifact: sitemesh
+    repository: Uyuni_Other
+  - artifact: slf4j-api
+    package: slf4j
+    jar: api
+    repository: Leap
+  - artifact: slf4j-log4j12
+    package: slf4j
+    jar: log4j12
+    repository: Leap
+  - artifact: snakeyaml
+    repository: Uyuni_Other
+  - artifact: spark-core
+    repository: Uyuni_Other
+  - artifact: spark-template-jade
+    repository: Uyuni_Other
+  - artifact: statistics
+    repository: Uyuni_Other
+  - artifact: stax-api
+    package: woodstox
+    jar: stax-api
+    repository: Uyuni_Other
+  - artifact: stax2-api
+    package: woodstox
+    jar: stax2-api
+    repository: Uyuni_Other
+  - artifact: stringtree-json
+    repository: Uyuni_Other
+  - artifact: struts
+    rpm: struts-[0-9.]+
+    repository: Uyuni_Other
+  - artifact: taglibs-standard-impl
+    package: tomcat-taglibs-standard-1_2_5
+    jar: taglibs-standard-impl
+    repository: Uyuni_Other
+  - artifact: taglibs-standard-jstlel
+    package: tomcat-taglibs-standard-1_2_5
+    jar: taglibs-standard-jstlel
+    repository: Uyuni_Other
+  - artifact: taglibs-standard-spec
+    package: tomcat-taglibs-standard-1_2_5
+    jar: taglibs-standard-spec
+    repository: Uyuni_Other
+  - artifact: woodstox-core-asl
+    package: woodstox
+    jar: woodstox-core-asl
+    repository: Uyuni_Other
+  - artifact: xalan-j2
+    rpm: xalan-j2-[0-9.]+
+    jar: xalan-j2-[0-9.]+
+    repository: Leap
+  - artifact: xalan-j2-serializer
+    package: xalan-j2
+    rpm: xalan-j2-[0-9.]+
+    jar: xalan-j2-serializer
+    repository: Leap
+  - artifact: xerces-j2
+    rpm: xerces-j2-[0-9.]+
+    jar: xerces-j2-[0-9.]+
+    repository: Leap
+  - artifact: xmlsec
+    repository: Uyuni_Other
+
+  - artifact: jasper
+    package: tomcat
+    rpm: tomcat-lib
+    jar: jasper\.jar
+    repository: Leap
+  - artifact: jasper-el
+    package: tomcat
+    rpm: tomcat-lib
+    jar: jasper-el
+    repository: Leap
+  - artifact: tomcat-el-3.0-api
+    package: tomcat
+    rpm: tomcat-el-3_0-api
+    jar: tomcat-el-3.0-api
+    repository: Leap
+  - artifact: tomcat-jsp-2.3-api
+    package: tomcat
+    rpm: tomcat-jsp-2_3-api
+    repository: Leap
+  - artifact: tomcat-juli
+    package: tomcat
+    rpm: tomcat-lib
+    jar: tomcat-juli
+    repository: Leap
+  - artifact: tomcat-servlet-4.0-api
+    package: tomcat
+    rpm: tomcat-servlet-4_0-api
+    repository: Leap
+
+  - artifact: hamcrest-core
+    package: hamcrest
+    jar: hamcrest/core
+    repository: Leap
+  - artifact: hamcrest-library
+    package: hamcrest
+    jar: hamcrest/library
+    repository: Leap

--- a/java/manager-build.xml
+++ b/java/manager-build.xml
@@ -61,8 +61,14 @@
     <delete dir="${test.results.dir}" />
   </target>
 
-  <target name="ivy" description="Retrieves dependencies through ivy">
-    <ivy-retrieve sync="true" />
+  <target name="obs-to-maven" description="Updates local maven repository with OBS jars">
+    <exec failonerror="true" executable="obs-to-maven">
+      <arg line="${basedir}/buildconf/ivy/obs-maven-config.yaml ${basedir}/buildconf/ivy/repository" />
+    </exec>
+  </target>
+
+  <target name="ivy" depends="obs-to-maven" description="Retrieves dependencies through ivy">
+    <ivy-retrieve sync="true" type="jar,bundle"/>
   </target>
 
   <target name="refresh-branding-jar" depends="clean" description="Compiles and builds the SUSE branding jar">
@@ -324,7 +330,7 @@
 
   <target name="checkstyle" depends="compile" description="Runs the checkstyle tool on sources">
     <taskdef resource="com/puppycrawl/tools/checkstyle/ant/checkstyle-ant-task.properties" classpathref="libjars" />
-    <checkstyle config="buildconf/checkstyle.xml">
+    <checkstyle config="${basedir}/buildconf/checkstyle.xml">
       <classpath>
         <path location="${build.dir}/classes" />
         <path refid="libjars" />

--- a/java/scripts/docker-checkstyle.sh
+++ b/java/scripts/docker-checkstyle.sh
@@ -2,7 +2,7 @@
 
 # Resolve libs and run tests
 cd /manager/java
-ant resolve-ivy
+ant -f manager-build.xml ivy
 
 ant -f manager-build.xml checkstyle
 

--- a/java/scripts/docker-testing-pgsql.sh
+++ b/java/scripts/docker-testing-pgsql.sh
@@ -22,7 +22,7 @@ cp /root/rhn.conf /etc/rhn/rhn.conf
 
 # Resolve libs and run tests
 cd /manager/java
-ant resolve-ivy
+ant -f manager-build.xml ivy
 
 cp buildconf/test/rhn.conf.postgresql-example buildconf/test/rhn.conf
 ant -f manager-build.xml refresh-branding-jar $TARGET

--- a/susemanager-utils/testing/automation/java-checkstyle.sh
+++ b/susemanager-utils/testing/automation/java-checkstyle.sh
@@ -4,5 +4,44 @@ HERE=`dirname $0`
 . $HERE/VERSION
 GITROOT=`readlink -f $HERE/../../../`
 
+CREDENTIALS="${HOME}/.oscrc"
+
+help() {
+  echo ""
+  echo "Script to run a docker container to verify java code style"
+  echo ""
+  echo "Syntax: "
+  echo ""
+  echo "${SCRIPT} -c /path/to/oscrc"
+  echo ""
+  echo "Where: "
+  echo "  -c  Path to the OSC credentials. Default: ${CREDENTIALS}"
+  echo ""
+}
+
+while getopts "c:h" opts; do
+  case "${opts}" in
+    c) CREDENTIALS=${OPTARG};;
+    h) help
+       exit 0;;
+    *) echo "Invalid syntax. Use ${SCRIPT} -h"
+       exit 1;;
+  esac
+done
+shift $((OPTIND-1))
+
+if [ "${CREDENTIALS}" == "" ]; then
+  echo "ERROR: Mandatory paramenter -c is missing!"
+  exit 1
+fi
+
+if [ ! -f ${CREDENTIALS} ]; then
+  echo "ERROR: File ${CREDENTIALS} does not exist!"
+  exit 1
+fi
+
 docker pull $REGISTRY/$PGSQL_CONTAINER
-docker run --privileged --rm=true -v "$GITROOT:/manager" $REGISTRY/$PGSQL_CONTAINER /manager/java/scripts/docker-checkstyle.sh
+docker run --privileged --rm=true -v "$GITROOT:/manager" \
+    --mount type=bind,source=${CREDENTIALS},target=/root/.oscrc \
+    $REGISTRY/$PGSQL_CONTAINER \
+    /manager/java/scripts/docker-checkstyle.sh

--- a/susemanager-utils/testing/automation/java-unittests-pgsql.sh
+++ b/susemanager-utils/testing/automation/java-unittests-pgsql.sh
@@ -1,13 +1,51 @@
 #! /bin/sh
 
 TARGET="test-pr"
-if [ -n "$1" ]; then
-    TARGET=$1
-fi
 
 HERE=`dirname $0`
 . $HERE/VERSION
 GITROOT=`readlink -f $HERE/../../../`
 
+CREDENTIALS="${HOME}/.oscrc"
+
+help() {
+  echo ""
+  echo "Script to run a docker container to run the pgsql Java unit tests"
+  echo ""
+  echo "Syntax: "
+  echo ""
+  echo "${SCRIPT} -c /path/to/oscrc [-t ant-target]"
+  echo ""
+  echo "Where: "
+  echo "  -c  Path to the OSC credentials. Default: ${CREDENTIALS}"
+  echo "  -t  Ant target to run. Default: ${TARGET}"
+  echo ""
+}
+
+while getopts "c:t:h" opts; do
+  case "${opts}" in
+    c) CREDENTIALS=${OPTARG};;
+    t) TARGET=${OPTARG};;
+    h) help
+       exit 0;;
+    *) echo "Invalid syntax. Use ${SCRIPT} -h"
+       exit 1;;
+  esac
+done
+shift $((OPTIND-1))
+
+if [ "${CREDENTIALS}" == "" ]; then
+  echo "ERROR: Mandatory paramenter -c is missing!"
+  exit 1
+fi
+
+if [ ! -f ${CREDENTIALS} ]; then
+  echo "ERROR: File ${CREDENTIALS} does not exist!"
+  exit 1
+fi
+
 docker pull $REGISTRY/$PGSQL_CONTAINER
-docker run --privileged --rm=true -v "$GITROOT:/manager" $REGISTRY/$PGSQL_CONTAINER /manager/java/scripts/docker-testing-pgsql.sh $TARGET
+docker run --privileged --rm=true -v "$GITROOT:/manager" \
+    --mount type=bind,source=${CREDENTIALS},target=/root/.oscrc \
+    $REGISTRY/$PGSQL_CONTAINER \
+    /manager/java/scripts/docker-testing-pgsql.sh ${TARGET}

--- a/susemanager-utils/testing/docker/master/uyuni-master-base/add_packages.sh
+++ b/susemanager-utils/testing/docker/master/uyuni-master-base/add_packages.sh
@@ -46,6 +46,7 @@ zypper --non-interactive in  \
 # Packages required to run the Java unit tests
 zypper --non-interactive in ant \
              ant-junit \
+             obs-to-maven \
              apache-ivy \
              java-11-openjdk-devel \
              pam \

--- a/susemanager-utils/testing/docker/master/uyuni-master-root/add_repositories.sh
+++ b/susemanager-utils/testing/docker/master/uyuni-master-root/add_repositories.sh
@@ -6,4 +6,5 @@ zypper rr 'NON OSS Update'
 
 zypper ar -f http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/openSUSE_Leap_15.1/ "Uyuni:Master:15.1"
 zypper ar -f http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/Other/openSUSE_Leap_15.1/ "Uyuni:Master:Other:15.1"
+zypper ar -f https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Utils/openSUSE_Leap_15.1/ "Uyuni:Master:Utils:15.1"
 #zypper ar -f http://download.suse.de/ibs/Devel:/Galaxy:/pylint/SLE_12_SP3/ "pylint"

--- a/susemanager-utils/testing/docker/master/uyuni-push-to-obs/add_yarn.sh
+++ b/susemanager-utils/testing/docker/master/uyuni-push-to-obs/add_yarn.sh
@@ -1,7 +1,9 @@
 #!/bin/bash -e
 
-# nobody user is required for npm
-useradd --no-create-home --shell /dev/null nobody
+# nobody user is required for npm but we may already have it
+if test ! $(getent passwd nobody); then
+    useradd --no-create-home --shell /dev/null nobody
+fi
 
 # Yarn is required for susemanager-nodejs-sdk-devel
 npm install -g yarn@v1.9.4


### PR DESCRIPTION
## What does this PR change?

Uses https://github.com/cbosdo/obs-to-maven to fetch the ivy dependencies. This all requires the developer to run the `obs_to_maven` script manually.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: build chain change

- [X] **DONE**

## Test coverage
- No tests: build chain change

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
