### PR TITLE
Manager migrate

### DIFF
--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -397,42 +397,6 @@ upgrade_schema() {
     fi
 }
 
-convert_cobbler_files() {
-    OLD_COBBLER_DIR=/var/lib/cobbler/config
-    NEW_COBBLER_DIR=/var/lib/cobbler/collections
-
-    for OLDDIR in $OLD_COBBLER_DIR/*.d
-    do
-        if [ ! -z "$(ls $OLDDIR)" ]; then
-            NEWDIR=$NEW_COBBLER_DIR/`basename $OLDDIR | sed -e "s/\.d$//"`
-            if [ ! -d $NEWDIR ]; then
-                mkdir $NEWDIR
-            fi
-            echo "`date +"%H:%M:%S"`   Converting $OLDDIR --> $NEWDIR"
-            for FILE in $OLDDIR/*
-            do
-                sed -e "s/kickstart/autoinstall/" \
-                    -e "s/ks_meta/autoinstall_meta/" \
-                    -e "s/ksmeta/autoinstall_meta/" \
-                    -e "s/kopts/kernel_options/" \
-                    -e "s;/var/lib/rhn/kickstarts;;g" \
-                    -e "s/kopts_post/kernel_options_post/" \
-                $FILE > $NEWDIR/`basename $FILE`
-            done
-        fi
-    done
-
-    if [ ! -z "$(ls /var/lib/rhn/kickstarts/upload)" ]; then
-        cp -a /var/lib/rhn/kickstarts/upload/* /var/lib/cobbler/templates/upload
-    fi
-    if [ ! -z "$(ls /var/lib/rhn/kickstarts/wizard)" ]; then
-        cp -a /var/lib/rhn/kickstarts/wizard/* /var/lib/cobbler/templates/wizard
-    fi
-    if [ ! -z "$(ls /var/lib/rhn/kickstarts/snippets)" ]; then
-        cp -a /var/lib/rhn/kickstarts/snippets/* /var/lib/cobbler/snippets/spacewalk
-    fi
-}
-
 copy_remote_files() {
     SUMAFILES="/etc/salt
                /root/ssl-build
@@ -485,7 +449,7 @@ copy_remote_files() {
     chown -R wwwrun.www /var/spacewalk
     ln -sf /srv/www/htdocs/pub/RHN-ORG-TRUSTED-SSL-CERT /etc/pki/trust/anchors
     update-ca-certificates
-    convert_cobbler_files
+    /usr/lib/susemanager/bin/migrate-cobbler.sh
 }
 
 create_ssh_key() {

--- a/susemanager/bin/migrate-cobbler.sh
+++ b/susemanager/bin/migrate-cobbler.sh
@@ -13,11 +13,11 @@ do
         echo "`date +"%H:%M:%S"`   Converting $OLDDIR --> $NEWDIR"
         for FILE in $OLDDIR/*
         do
-            sed -e "s/kickstart/autoinstall/" \
+            sed -e "s;/var/lib/rhn/kickstarts;;g" \
+                -e "s/kickstart/autoinstall/" \
                 -e "s/ks_meta/autoinstall_meta/" \
                 -e "s/ksmeta/autoinstall_meta/" \
                 -e "s/kopts/kernel_options/" \
-                -e "s;/var/lib/rhn/kickstarts;;g" \
                 -e "s/kopts_post/kernel_options_post/" \
             $FILE > $NEWDIR/`basename $FILE`
         done

--- a/susemanager/bin/migrate-cobbler.sh
+++ b/susemanager/bin/migrate-cobbler.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+OLD_COBBLER_DIR=/var/lib/cobbler/config
+NEW_COBBLER_DIR=/var/lib/cobbler/collections
+
+for OLDDIR in $OLD_COBBLER_DIR/*.d
+do
+    if [ ! -z "$(ls $OLDDIR)" ]; then
+        NEWDIR=$NEW_COBBLER_DIR/`basename $OLDDIR | sed -e "s/\.d$//"`
+        if [ ! -d $NEWDIR ]; then
+            mkdir $NEWDIR
+        fi
+        echo "`date +"%H:%M:%S"`   Converting $OLDDIR --> $NEWDIR"
+        for FILE in $OLDDIR/*
+        do
+            sed -e "s/kickstart/autoinstall/" \
+                -e "s/ks_meta/autoinstall_meta/" \
+                -e "s/ksmeta/autoinstall_meta/" \
+                -e "s/kopts/kernel_options/" \
+                -e "s;/var/lib/rhn/kickstarts;;g" \
+                -e "s/kopts_post/kernel_options_post/" \
+            $FILE > $NEWDIR/`basename $FILE`
+        done
+    fi
+done
+
+if [ ! -z "$(ls /var/lib/rhn/kickstarts/upload)" ]; then
+    cp -a /var/lib/rhn/kickstarts/upload/* /var/lib/cobbler/templates/upload
+fi
+if [ ! -z "$(ls /var/lib/rhn/kickstarts/wizard)" ]; then
+    cp -a /var/lib/rhn/kickstarts/wizard/* /var/lib/cobbler/templates/wizard
+fi
+if [ ! -z "$(ls /var/lib/rhn/kickstarts/snippets)" ]; then
+    cp -a /var/lib/rhn/kickstarts/snippets/* /var/lib/cobbler/snippets/spacewalk
+fi

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- put cobbler migration to separate script for inplace migration
 - Make dmidecode part of the bootstrap repositiories (bsc#1137952)
 - respect new location for autoinstall templates during migration
 


### PR DESCRIPTION
## What does this PR change?

inplace migrations also will need to migrate the cobbler database; so move this code into separate script than can be called from either migration script. We do not want to maintain two instances of the same code.

Internal only. Not user visible.

.specfile does not need update; it will already install all files from the bin directory. So this is straight forward.