### PR TITLE
1139493 - Use channel name regex instead for the project label validation

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/channel/CreateChannelCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/CreateChannelCommand.java
@@ -44,9 +44,9 @@ public class CreateChannelCommand {
     public static final int CHANNEL_NAME_MAX_LENGTH = 256;
     public static final int CHANNEL_LABEL_MIN_LENGTH = 6;
 
-    protected static final String CHANNEL_NAME_REGEX =
+    public static final String CHANNEL_NAME_REGEX =
         "^[a-zA-Z][\\w\\d\\s\\-\\.\\'\\(\\)\\/\\_]*$";
-    protected static final String CHANNEL_LABEL_REGEX =
+    public static final String CHANNEL_LABEL_REGEX =
         "^[a-z\\d][a-z\\d\\-\\.\\_]*$";
 
     protected static final String GPG_KEY_REGEX = "^[0-9A-F]{8}$";

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/EnvironmentHandler.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/EnvironmentHandler.java
@@ -65,8 +65,8 @@ public class EnvironmentHandler {
         if (!ValidationUtils.isLabelValid(envRequest.getLabel())) {
             requestErrors.put(
                     "label",
-                    "Label must contain only lowercase letters, hyphens ('-'), periods ('.'), " +
-                            "underscores ('_'), and numerals."
+                    "Label must begin with a letter and must contain only lowercase letters, hyphens ('-')," +
+                            " periods ('.'), underscores ('_'), and numerals."
             );
         }
 

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ProjectHandler.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ProjectHandler.java
@@ -86,8 +86,8 @@ public class ProjectHandler {
         if (!ValidationUtils.isLabelValid(projPropsRequest.getLabel())) {
             requestErrors.put(
                     "label",
-                    "Label must contain only lowercase letters, hyphens ('-'), periods ('.'), " +
-                            "underscores ('_'), and numerals."
+                    "Label must begin with a letter and must contain only lowercase letters, hyphens ('-')," +
+                            " periods ('.'), underscores ('_'), and numerals."
             );
         }
 

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ValidationUtils.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ValidationUtils.java
@@ -14,14 +14,14 @@
  */
 package com.suse.manager.webui.controllers.contentmanagement.handlers;
 
+import com.redhat.rhn.manager.channel.CreateChannelCommand;
+
 import java.util.regex.Pattern;
 
 /**
  * Utility class for validations
  */
 public class ValidationUtils {
-    private static final String PROJECT_LABEL_REGEX =
-            "^[a-z\\d][a-z\\d\\-\\.\\_]*$";
 
     private ValidationUtils() { }
 
@@ -31,7 +31,8 @@ public class ValidationUtils {
      * @return true if label is valid
      */
     public static Boolean isLabelValid(String label) {
-        return Pattern.compile(PROJECT_LABEL_REGEX).matcher(label).find();
+        return Pattern.compile(CreateChannelCommand.CHANNEL_LABEL_REGEX).matcher(label).find() &&
+                Pattern.compile(CreateChannelCommand.CHANNEL_NAME_REGEX).matcher(label).find();
     }
 
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,4 +1,5 @@
 - Fallback to logged-in-user org and then vendor errata when looking up erratum on cloning (bsc#1137308)
+- Add new validation to avoid creating content lifecycle projects starting with a number (bsc#1139493)
 - Improve performance of 'Systems requiring reboot' page (fate#327780)
 - Allow virtualization tab for foreign systems (bsc#1116869)
 - Keep querystring on ListTag parent_url for actions that have the cid param (bsc#1134677)

--- a/web/html/src/components/toastr/toastr.css
+++ b/web/html/src/components/toastr/toastr.css
@@ -36,6 +36,7 @@
     background-color: #f2dede !important;
     border-color: #ebccd1 !important;
     background-image: none !important;
+    opacity: 1 !important;
 }
 
 :global(.toast-error .toast-message:after) {


### PR DESCRIPTION
## What does this PR change?

Use channel name regex instead for the project label validation

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed

- [ ] **DONE**

## Test coverage
- No tests

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/8195
- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
