### PR TITLE
Fix obsolete for old osad packages (bsc#1139453)

### DIFF
--- a/client/tools/mgr-osad/mgr-osad.changes
+++ b/client/tools/mgr-osad/mgr-osad.changes
@@ -1,3 +1,6 @@
+- Fix obsolete for old osad packages, to allow installing mgr-osad
+  even by using osad at yum/zyppper install (bsc#1139453)
+
 -------------------------------------------------------------------
 Wed May 15 20:07:58 CEST 2019 - jgonzalez@suse.com
 

--- a/client/tools/mgr-osad/mgr-osad.spec
+++ b/client/tools/mgr-osad/mgr-osad.spec
@@ -52,7 +52,7 @@ License:        GPL-2.0-only
 Group:          System Environment/Daemons
 Version:        4.0.8
 Provides:       %{oldname} = %{oldversion}
-Obsoletes:      %{oldname} = %{oldversion}
+Obsoletes:      %{oldname} < %{oldversion}
 Release:        1%{?dist}
 Url:            https://github.com/uyuni-project/uyuni
 Source0:        https://github.com/spacewalkproject/spacewalk/archive/%{name}-%{version}.tar.gz


### PR DESCRIPTION
## What does this PR change?

 Fix obsolete for old osad packages, to allow installing mgr-osad even by using osad at yum/zyppper install (bsc#1139453)

To test, I had to hack a CentOS instance from sumaform, to disable 4.0 devel client tools, and client tools from SCC, as this trick doesn't work.

Then I used https://w3.suse.de/~jgonzalez/test/test/ which is basically client tools from SCC + mgr-osad packages with my patch, and that works fine:

```
[root@suma-32-min-centos7 yum.repos.d]# yum info mgr-osad
Failed to set locale, defaulting to C
Loaded plugins: fastestmirror, susemanagerplugin, yumnotify
Loading mirror speeds from cached hostfile
 * base: centos.mirror.constant.com
 * centosplus: mirror.fileplanet.com
 * extras: mirror.metrocast.net
 * updates: mirrors.greenmountainaccess.net
Test                                                                                                                                                                                                                                                    | 1.5 kB  00:00:00     
Test/primary                                                                                                                                                                                                                                            |  83 kB  00:00:00     
Test                                                                                                                                                                                                                                                                   655/655
Available Packages
Name        : mgr-osad
Arch        : noarch
Version     : 4.0.8
Release     : 400.2.2.develHead
Size        : 14 k
Repo        : Test
Summary     : Open Source Architecture Daemon
URL         : https://github.com/uyuni-project/uyuni
License     : GPL-2.0-only
Description : OSAD agent receives commands over jabber protocol from Spacewalk Server and
            : commands are instantly executed.
            : 
            : This package effectively replaces the behavior of rhnsd/rhn_check that
            : only poll the Spacewalk Server from time to time.

[root@suma-32-min-centos7 yum.repos.d]# yum install osad    
Failed to set locale, defaulting to C
Loaded plugins: fastestmirror, susemanagerplugin, yumnotify
Loading mirror speeds from cached hostfile
 * base: centos.mirror.constant.com
 * centosplus: mirror.fileplanet.com
 * extras: mirror.metrocast.net
 * updates: mirrors.greenmountainaccess.net
Package osad is obsoleted by mgr-osad, trying to install mgr-osad-4.0.8-400.2.2.develHead.noarch instead
Resolving Dependencies
--> Running transaction check
---> Package mgr-osad.noarch 0:4.0.8-400.2.2.develHead will be installed
--> Processing Dependency: python2-mgr-osad = 4.0.8-400.2.2.develHead for package: mgr-osad-4.0.8-400.2.2.develHead.noarch
--> Running transaction check
---> Package python2-mgr-osad.noarch 0:4.0.8-400.2.2.develHead will be installed
--> Processing Dependency: python2-mgr-osa-common = 4.0.8 for package: python2-mgr-osad-4.0.8-400.2.2.develHead.noarch
--> Processing Dependency: rhnlib >= 2.8.3 for package: python2-mgr-osad-4.0.8-400.2.2.develHead.noarch
--> Processing Dependency: python2-rhn-client-tools >= 2.8.4 for package: python2-mgr-osad-4.0.8-400.2.2.develHead.noarch
--> Processing Dependency: python-jabberpy for package: python2-mgr-osad-4.0.8-400.2.2.develHead.noarch
--> Processing Dependency: spacewalk-usix for package: python2-mgr-osad-4.0.8-400.2.2.develHead.noarch
--> Running transaction check
---> Package python-jabberpy.x86_64 0:0.5-0.2.1 will be installed
---> Package python2-mgr-osa-common.noarch 0:4.0.8-400.2.2.develHead will be installed
---> Package python2-rhnlib.noarch 0:4.0.8-31.1 will be installed
--> Processing Dependency: pyOpenSSL for package: python2-rhnlib-4.0.8-31.1.noarch
---> Package python2-spacewalk-client-tools.noarch 0:4.0.9-65.1 will be installed
--> Processing Dependency: spacewalk-client-tools = 4.0.9-65.1 for package: python2-spacewalk-client-tools-4.0.9-65.1.noarch
--> Processing Dependency: python-ethtool >= 0.4 for package: python2-spacewalk-client-tools-4.0.9-65.1.noarch
--> Processing Dependency: python-gudev for package: python2-spacewalk-client-tools-4.0.9-65.1.noarch
--> Processing Dependency: python-hwdata for package: python2-spacewalk-client-tools-4.0.9-65.1.noarch
--> Processing Dependency: suseRegisterInfo for package: python2-spacewalk-client-tools-4.0.9-65.1.noarch
--> Processing Dependency: python-dmidecode for package: python2-spacewalk-client-tools-4.0.9-65.1.noarch
---> Package spacewalk-usix.noarch 0:4.0.9-8.1 will be installed
--> Running transaction check
---> Package pyOpenSSL.x86_64 0:0.13.1-4.el7 will be installed
---> Package python-dmidecode.x86_64 0:3.12.2-3.el7 will be installed
--> Processing Dependency: libxml2-python for package: python-dmidecode-3.12.2-3.el7.x86_64
--> Processing Dependency: libxml2mod.so()(64bit) for package: python-dmidecode-3.12.2-3.el7.x86_64
---> Package python-ethtool.x86_64 0:0.8-7.el7 will be installed
--> Processing Dependency: libnl.so.1()(64bit) for package: python-ethtool-0.8-7.el7.x86_64
---> Package python-gudev.x86_64 0:147.2-7.el7 will be installed
--> Processing Dependency: libgudev1 >= 147 for package: python-gudev-147.2-7.el7.x86_64
--> Processing Dependency: pygobject2 for package: python-gudev-147.2-7.el7.x86_64
--> Processing Dependency: libgudev-1.0.so.0()(64bit) for package: python-gudev-147.2-7.el7.x86_64
---> Package python2-hwdata.noarch 0:2.3.5-12.1 will be installed
---> Package spacewalk-client-tools.noarch 0:4.0.9-65.1 will be installed
---> Package suseRegisterInfo.noarch 0:4.0.4-24.1 will be installed
--> Processing Dependency: python2-suseRegisterInfo = 4.0.4-24.1 for package: suseRegisterInfo-4.0.4-24.1.noarch
--> Running transaction check
---> Package libgudev1.x86_64 0:219-62.el7_6.6 will be installed
--> Processing Dependency: systemd-libs = 219-62.el7_6.6 for package: libgudev1-219-62.el7_6.6.x86_64
---> Package libnl.x86_64 0:1.1.4-3.el7 will be installed
---> Package libxml2-python.x86_64 0:2.9.1-6.el7_2.3 will be installed
---> Package pygobject2.x86_64 0:2.28.6-11.el7 will be installed
---> Package python2-suseRegisterInfo.noarch 0:4.0.4-24.1 will be installed
--> Running transaction check
---> Package systemd-libs.x86_64 0:219-57.el7 will be updated
--> Processing Dependency: systemd-libs = 219-57.el7 for package: systemd-219-57.el7.x86_64
---> Package systemd-libs.x86_64 0:219-62.el7_6.6 will be an update
--> Running transaction check
---> Package systemd.x86_64 0:219-57.el7 will be updated
--> Processing Dependency: systemd = 219-57.el7 for package: systemd-sysv-219-57.el7.x86_64
---> Package systemd.x86_64 0:219-62.el7_6.6 will be an update
--> Processing Dependency: libcryptsetup.so.12(CRYPTSETUP_2.0)(64bit) for package: systemd-219-62.el7_6.6.x86_64
--> Processing Dependency: libcryptsetup.so.12()(64bit) for package: systemd-219-62.el7_6.6.x86_64
--> Running transaction check
---> Package cryptsetup-libs.x86_64 0:1.7.4-4.el7 will be updated
---> Package cryptsetup-libs.x86_64 0:2.0.3-3.el7 will be an update
--> Processing Dependency: libjson-c.so.2()(64bit) for package: cryptsetup-libs-2.0.3-3.el7.x86_64
---> Package systemd-sysv.x86_64 0:219-57.el7 will be updated
---> Package systemd-sysv.x86_64 0:219-62.el7_6.6 will be an update
--> Running transaction check
---> Package json-c.x86_64 0:0.11-4.el7_0 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

===============================================================================================================================================================================================================================================================================
 Package                                                                        Arch                                                   Version                                                                   Repository                                               Size
===============================================================================================================================================================================================================================================================================
Installing:
 mgr-osad                                                                       noarch                                                 4.0.8-400.2.2.develHead                                                   Test                                                     14 k
Installing for dependencies:
 json-c                                                                         x86_64                                                 0.11-4.el7_0                                                              base                                                     31 k
 libgudev1                                                                      x86_64                                                 219-62.el7_6.6                                                            updates                                                  96 k
 libnl                                                                          x86_64                                                 1.1.4-3.el7                                                               base                                                    128 k
 libxml2-python                                                                 x86_64                                                 2.9.1-6.el7_2.3                                                           base                                                    247 k
 pyOpenSSL                                                                      x86_64                                                 0.13.1-4.el7                                                              base                                                    135 k
 pygobject2                                                                     x86_64                                                 2.28.6-11.el7                                                             base                                                    226 k
 python-dmidecode                                                               x86_64                                                 3.12.2-3.el7                                                              base                                                     83 k
 python-ethtool                                                                 x86_64                                                 0.8-7.el7                                                                 base                                                     33 k
 python-gudev                                                                   x86_64                                                 147.2-7.el7                                                               base                                                     18 k
 python-jabberpy                                                                x86_64                                                 0.5-0.2.1                                                                 Test                                                     48 k
 python2-hwdata                                                                 noarch                                                 2.3.5-12.1                                                                Test                                                     33 k
 python2-mgr-osa-common                                                         noarch                                                 4.0.8-400.2.2.develHead                                                   Test                                                     33 k
 python2-mgr-osad                                                               noarch                                                 4.0.8-400.2.2.develHead                                                   Test                                                     22 k
 python2-rhnlib                                                                 noarch                                                 4.0.8-31.1                                                                Test                                                     65 k
 python2-spacewalk-client-tools                                                 noarch                                                 4.0.9-65.1                                                                Test                                                    101 k
 python2-suseRegisterInfo                                                       noarch                                                 4.0.4-24.1                                                                Test                                                     10 k
 spacewalk-client-tools                                                         noarch                                                 4.0.9-65.1                                                                Test                                                    375 k
 spacewalk-usix                                                                 noarch                                                 4.0.9-8.1                                                                 Test                                                    7.2 k
 suseRegisterInfo                                                               noarch                                                 4.0.4-24.1                                                                Test                                                    6.5 k
Updating for dependencies:
 cryptsetup-libs                                                                x86_64                                                 2.0.3-3.el7                                                               base                                                    338 k
 systemd                                                                        x86_64                                                 219-62.el7_6.6                                                            updates                                                 5.1 M
 systemd-libs                                                                   x86_64                                                 219-62.el7_6.6                                                            updates                                                 407 k
 systemd-sysv                                                                   x86_64                                                 219-62.el7_6.6                                                            updates                                                  84 k

Transaction Summary
===============================================================================================================================================================================================================================================================================
Install  1 Package  (+19 Dependent packages)
Upgrade             (  4 Dependent packages)

Total download size: 7.5 M
Is this ok [y/d/N]:
```
## GUI diff

No difference.

## Documentation
- No documentation needed: Doc is already updated to mention `mgr-osad`, this is for convenience.

- [x] **DONE**

## Test coverage
- No tests: Already covered, the cucumber testsuite discovered this issue.

- [x] **DONE**

## Links

Fixes: https://github.com/SUSE/spacewalk/issues/8220
Tracks: https://github.com/SUSE/spacewalk/pull/8226

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
