### PR TITLE
Manager migrate

### DIFF
--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -397,42 +397,6 @@ upgrade_schema() {
     fi
 }
 
-convert_cobbler_files() {
-    OLD_COBBLER_DIR=/var/lib/cobbler/config
-    NEW_COBBLER_DIR=/var/lib/cobbler/collections
-
-    for OLDDIR in $OLD_COBBLER_DIR/*.d
-    do
-        if [ ! -z "$(ls $OLDDIR)" ]; then
-            NEWDIR=$NEW_COBBLER_DIR/`basename $OLDDIR | sed -e "s/\.d$//"`
-            if [ ! -d $NEWDIR ]; then
-                mkdir $NEWDIR
-            fi
-            echo "`date +"%H:%M:%S"`   Converting $OLDDIR --> $NEWDIR"
-            for FILE in $OLDDIR/*
-            do
-                sed -e "s/kickstart/autoinstall/" \
-                    -e "s/ks_meta/autoinstall_meta/" \
-                    -e "s/ksmeta/autoinstall_meta/" \
-                    -e "s/kopts/kernel_options/" \
-                    -e "s;/var/lib/rhn/kickstarts;;g" \
-                    -e "s/kopts_post/kernel_options_post/" \
-                $FILE > $NEWDIR/`basename $FILE`
-            done
-        fi
-    done
-
-    if [ ! -z "$(ls /var/lib/rhn/kickstarts/upload)" ]; then
-        cp -a /var/lib/rhn/kickstarts/upload/* /var/lib/cobbler/templates/upload
-    fi
-    if [ ! -z "$(ls /var/lib/rhn/kickstarts/wizard)" ]; then
-        cp -a /var/lib/rhn/kickstarts/wizard/* /var/lib/cobbler/templates/wizard
-    fi
-    if [ ! -z "$(ls /var/lib/rhn/kickstarts/snippets)" ]; then
-        cp -a /var/lib/rhn/kickstarts/snippets/* /var/lib/cobbler/snippets/spacewalk
-    fi
-}
-
 copy_remote_files() {
     SUMAFILES="/etc/salt
                /root/ssl-build
@@ -485,7 +449,7 @@ copy_remote_files() {
     chown -R wwwrun.www /var/spacewalk
     ln -sf /srv/www/htdocs/pub/RHN-ORG-TRUSTED-SSL-CERT /etc/pki/trust/anchors
     update-ca-certificates
-    convert_cobbler_files
+    /usr/lib/susemanager/bin/migrate-cobbler.sh
 }
 
 create_ssh_key() {

--- a/susemanager/bin/migrate-cobbler.sh
+++ b/susemanager/bin/migrate-cobbler.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+OLD_COBBLER_DIR=/var/lib/cobbler/config
+NEW_COBBLER_DIR=/var/lib/cobbler/collections
+
+for OLDDIR in $OLD_COBBLER_DIR/*.d
+do
+    if [ ! -z "$(ls $OLDDIR)" ]; then
+        NEWDIR=$NEW_COBBLER_DIR/`basename $OLDDIR | sed -e "s/\.d$//"`
+        if [ ! -d $NEWDIR ]; then
+            mkdir $NEWDIR
+        fi
+        echo "`date +"%H:%M:%S"`   Converting $OLDDIR --> $NEWDIR"
+        for FILE in $OLDDIR/*
+        do
+            sed -e "s;/var/lib/rhn/kickstarts;;g" \
+                -e "s/kickstart/autoinstall/" \
+                -e "s/ks_meta/autoinstall_meta/" \
+                -e "s/ksmeta/autoinstall_meta/" \
+                -e "s/kopts/kernel_options/" \
+                -e "s/kopts_post/kernel_options_post/" \
+            $FILE > $NEWDIR/`basename $FILE`
+        done
+    fi
+done
+
+if [ -d /var/lib/rhn/kickstarts/upload ] && [ ! -z "$(ls /var/lib/rhn/kickstarts/upload)" ]; then
+    mkdir -p /var/lib/cobbler/templates/upload
+    cp -a /var/lib/rhn/kickstarts/upload/* /var/lib/cobbler/templates/upload
+fi
+if [ -d /var/lib/rhn/kickstarts/wizard ] && [ ! -z "$(ls /var/lib/rhn/kickstarts/wizard)" ]; then
+    mkdir -p /var/lib/rhn/kickstarts/wizard
+    cp -a /var/lib/rhn/kickstarts/wizard/* /var/lib/cobbler/templates/wizard
+fi
+if [ -d /var/lib/rhn/kickstarts/snippets ] && [ ! -z "$(ls /var/lib/rhn/kickstarts/snippets)" ]; then
+    mkdir -p /var/lib/rhn/kickstarts/snippets
+    cp -a /var/lib/rhn/kickstarts/snippets/* /var/lib/cobbler/snippets/spacewalk
+fi

--- a/susemanager/bin/server-migrator.sh
+++ b/susemanager/bin/server-migrator.sh
@@ -1,5 +1,24 @@
 #!/bin/bash
 
+echo
+echo
+echo "==================================================================="
+echo "This script will migrate the Uyuni server from 4.0.1 to 4.0.2 which"
+echo "also implies replacing the underlying operating system."
+echo
+echo "During migration the services need to be shut down and after"
+echo "successful migration the server needs to be rebooted."
+echo
+echo "Since there is no chance to fix any issues during migration,"
+echo "make sure you have a backup before continuing. If you are"
+echo "running Uyuni server on a virtual machine, it is advisable"
+echo "to create a snapshot before performing the migration!"
+echo "==================================================================="
+echo
+echo
+read -n 1 -s -r -p "Press any key to start the migration or CTRL+C to cancel...";
+echo
+
 spacewalk-service stop
 cp -a /var/lib/cobbler /var/lib/cobbler.old
 cp -a /var/lib/rhn/kickstarts /var/lib/rhn/kickstarts.old
@@ -10,7 +29,7 @@ zypper ar -n "Main Repository" http://download.opensuse.org/distribution/leap/15
 zypper ar -n "Main Update Repository" http://download.opensuse.org/update/leap/15.1/oss repo-update
 zypper ar -n "Non-OSS Repository" http://download.opensuse.org/distribution/leap/15.1/repo/non-oss repo-non-oss
 zypper ar -n "Update Repository (Non-Oss)" http://download.opensuse.org/update/leap/15.1/non-oss/ repo-update-non-oss
-zypper ar -n "Uyuni Server 4.0.2" https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_15.1/repo/Uyuni-Server-4.0-POOL-x86_64-Media1/ uyuni-server-4.0.2
+zypper ar -n "Uyuni Server latest" https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_15.1/repo/Uyuni-Server-4.0-POOL-x86_64-Media1/ uyuni-server-latest
 zypper ref
 rpm -e --nodeps atftp
 rpm -e --nodeps python-Cheetah
@@ -32,3 +51,8 @@ if [ -d /var/lib/rhn/kickstarts.old/wizard ]; then
 fi
 rm -rf /var/lib/cobbler.old /var/lib/rhn/kickstarts.old
 /usr/lib/susemanager/bin/migrate-cobbler.sh
+
+echo
+echo "==================================================================="
+echo "Reboot the machine for the new version now!
+echo "==================================================================="

--- a/susemanager/bin/server-migrator.sh
+++ b/susemanager/bin/server-migrator.sh
@@ -7,7 +7,7 @@ echo "This script will migrate Uyuni server to the latest version which"
 echo "also implies replacing the underlying operating system."
 echo
 echo "During migration the services need to be shut down and after"
-echo "successful migration the server needs to be rebooted."
+echo "successful migration the server needs to be rebooted manually."
 echo
 echo "Since there is no chance to fix any issues during migration,"
 echo "make sure you have a backup before continuing. If you are"

--- a/susemanager/bin/server-migrator.sh
+++ b/susemanager/bin/server-migrator.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+spacewalk-service stop
+cp -a /var/lib/cobbler /var/lib/cobbler.old
+cp -a /var/lib/rhn/kickstarts /var/lib/rhn/kickstarts.old
+rm /var/lib/cobbler/snippets/spacewalk
+mv /etc/zypp/repos.d /etc/zypp/repos.d.old
+mkdir /etc/zypp/repos.d
+zypper ar -n "Main Repository" http://download.opensuse.org/distribution/leap/15.1/repo/oss repo-oss
+zypper ar -n "Main Update Repository" http://download.opensuse.org/update/leap/15.1/oss repo-update
+zypper ar -n "Non-OSS Repository" http://download.opensuse.org/distribution/leap/15.1/repo/non-oss repo-non-oss
+zypper ar -n "Update Repository (Non-Oss)" http://download.opensuse.org/update/leap/15.1/non-oss/ repo-update-non-oss
+zypper ar -n "Uyuni Server 4.0.2" https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_15.1/repo/Uyuni-Server-4.0-POOL-x86_64-Media1/ uyuni-server-4.0.2
+zypper ref
+rpm -e --nodeps atftp
+rpm -e --nodeps python-Cheetah
+rpm -e --nodeps apache2-mod_wsgi
+rpm -e --nodeps python-netaddr
+rpm -e --nodeps pxe-default-image-opensuse42-3
+zypper -n dup
+update-alternatives --set java /usr/lib64/jvm/jre-11-openjdk/bin/java
+update-alternatives --set servlet /usr/share/java/servletapi5-5.0.18.jar
+spacewalk-schema-upgrade -y
+if [ -d /var/lib/cobbler.old/config ]; then
+  cp -a /var/lib/cobbler.old/config /var/lib/cobbler
+fi
+if [ -d /var/lib/rhn/kickstarts.old/upload ]; then
+  cp -a /var/lib/rhn/kickstarts.old/upload /var/lib/rhn/kickstarts
+fi
+if [ -d /var/lib/rhn/kickstarts.old/wizard ]; then
+  cp -a /var/lib/rhn/kickstarts.old/wizard /var/lib/rhn/kickstarts
+fi
+rm -rf /var/lib/cobbler.old /var/lib/rhn/kickstarts.old
+/usr/lib/susemanager/bin/migrate-cobbler.sh

--- a/susemanager/bin/server-migrator.sh
+++ b/susemanager/bin/server-migrator.sh
@@ -3,7 +3,7 @@
 echo
 echo
 echo "==================================================================="
-echo "This script will migrate the Uyuni server from 4.0.1 to 4.0.2 which"
+echo "This script will migrate Uyuni server to the latest version which"
 echo "also implies replacing the underlying operating system."
 echo
 echo "During migration the services need to be shut down and after"

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- add support for in-place migration
 - Make dmidecode part of the bootstrap repositiories (bsc#1137952)
 - respect new location for autoinstall templates during migration
 

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,4 +1,4 @@
-- add support for in-place migration
+- add support for in-place migration (Uyuni only for now)
 - Make dmidecode part of the bootstrap repositiories (bsc#1137952)
 - respect new location for autoinstall templates during migration
 


### PR DESCRIPTION
## What does this PR change?

Support in-place migration. This will certainly need an adaption for the final repos, but it is working quite well already and can be used for testing.

## GUI diff

No difference.

## Documentation

In order to migrate an Uyuni server 4.0.1 (based on leap 42.3) to 4.0.2 (based on leap 15.1), user just needs to run /usr/lib/susemanager/bin/server-migrator.sh

## Test coverage

Once merged, we should perform the following tests:

Run a complete testsuite on Uyuni 4.0.1. Then upgrade Uyuni server to 4.0.2 via this server-migrator.sh script. After that, re-run the idempotent tests to find any issues that can be caused due to differences to a fresh installation.

