### PR TITLE
Remove all use of com.google.common types

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/test/VirtualGuestsControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/VirtualGuestsControllerTest.java
@@ -32,10 +32,10 @@ import com.redhat.rhn.manager.system.VirtualizationActionCommand;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.testing.ServerTestUtils;
 
-import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
+import com.google.gson.reflect.TypeToken;
 import com.suse.manager.reactor.messaging.test.SaltTestUtils;
 import com.suse.manager.virtualization.DomainCapabilitiesJson;
 import com.suse.manager.virtualization.GuestDefinition;

--- a/java/code/src/com/suse/manager/webui/controllers/test/VirtualNetsControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/VirtualNetsControllerTest.java
@@ -24,10 +24,10 @@ import com.redhat.rhn.manager.system.VirtualizationActionCommand;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.testing.ServerTestUtils;
 
-import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
+import com.google.gson.reflect.TypeToken;
 import com.suse.manager.reactor.messaging.test.SaltTestUtils;
 import com.suse.manager.virtualization.VirtManager;
 import com.suse.manager.webui.controllers.VirtualNetsController;

--- a/java/code/src/com/suse/manager/webui/controllers/test/VirtualPoolsControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/VirtualPoolsControllerTest.java
@@ -24,10 +24,10 @@ import com.redhat.rhn.manager.system.VirtualizationActionCommand;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.testing.ServerTestUtils;
 
-import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
+import com.google.gson.reflect.TypeToken;
 import com.suse.manager.reactor.messaging.test.SaltTestUtils;
 import com.suse.manager.virtualization.VirtManager;
 import com.suse.manager.webui.controllers.VirtualPoolsController;

--- a/java/code/src/com/suse/manager/webui/services/test/SaltActionChainGeneratorServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltActionChainGeneratorServiceTest.java
@@ -15,7 +15,11 @@
 
 package com.suse.manager.webui.services.test;
 
-import com.google.common.collect.ImmutableMap;
+import static com.suse.manager.webui.services.SaltActionChainGeneratorService.ACTIONCHAIN_SLS_FOLDER;
+import static com.suse.manager.webui.services.SaltActionChainGeneratorService.ACTION_STATE_ID_PREFIX;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+
 import com.redhat.rhn.domain.action.ActionChain;
 import com.redhat.rhn.domain.action.ActionChainFactory;
 import com.redhat.rhn.domain.server.MinionServer;
@@ -24,10 +28,12 @@ import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.TestUtils;
+
 import com.suse.manager.webui.services.SaltActionChainGeneratorService;
 import com.suse.manager.webui.utils.SaltModuleRun;
 import com.suse.manager.webui.utils.SaltState;
 import com.suse.manager.webui.utils.SaltSystemReboot;
+
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;
@@ -35,13 +41,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
-
-import static com.suse.manager.webui.services.SaltActionChainGeneratorService.ACTIONCHAIN_SLS_FOLDER;
-import static com.suse.manager.webui.services.SaltActionChainGeneratorService.ACTION_STATE_ID_PREFIX;
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonMap;
+import java.util.TreeMap;
 
 public class SaltActionChainGeneratorServiceTest extends BaseTestCaseWithUser {
 
@@ -62,10 +65,11 @@ public class SaltActionChainGeneratorServiceTest extends BaseTestCaseWithUser {
                 1,
                 singletonMap("mods", "remotecommands"),
                 singletonMap("pillar",
-                        ImmutableMap.<String, String>builder()
-                                .put("mgr_remote_cmd_script", "salt://scripts/script_1.sh")
-                                .put("mgr_remote_cmd_runas", "foobar")
-                                .build()
+                        // Use a TreeMap to keep the keys order or they may break the assert
+                        new TreeMap<String, String>() {{
+                                put("mgr_remote_cmd_script", "salt://scripts/script_1.sh");
+                                put("mgr_remote_cmd_runas", "foobar");
+                        }}
                 )
         ));
         states.add(new SaltModuleRun(
@@ -95,8 +99,8 @@ public class SaltActionChainGeneratorServiceTest extends BaseTestCaseWithUser {
                         "    -   mods: remotecommands\n" +
                         "    -   kwargs:\n" +
                         "            pillar:\n" +
-                        "                mgr_remote_cmd_script: salt://scripts/script_1.sh\n" +
                         "                mgr_remote_cmd_runas: foobar\n" +
+                        "                mgr_remote_cmd_script: salt://scripts/script_1.sh\n" +
                         "mgr_actionchain_131_action_2_chunk_1:\n" +
                         "    module.run:\n" +
                         "    -   name: state.apply\n" +
@@ -128,10 +132,11 @@ public class SaltActionChainGeneratorServiceTest extends BaseTestCaseWithUser {
                 1,
                 singletonMap("mods", "remotecommands"),
                 singletonMap("pillar",
-                        ImmutableMap.<String, String>builder()
-                                .put("mgr_remote_cmd_script", "salt://scripts/script_1.sh")
-                                .put("mgr_remote_cmd_runas", "foobar")
-                                .build()
+                        // Use a TreeMap to keep the keys order or they may break the assert
+                        new TreeMap<String, String>() {{
+                                put("mgr_remote_cmd_script", "salt://scripts/script_1.sh");
+                                put("mgr_remote_cmd_runas", "foobar");
+                        }}
                 )
         ));
         states.add(new SaltSystemReboot(
@@ -166,8 +171,8 @@ public class SaltActionChainGeneratorServiceTest extends BaseTestCaseWithUser {
                         "    -   mods: remotecommands\n" +
                         "    -   kwargs:\n" +
                         "            pillar:\n" +
-                        "                mgr_remote_cmd_script: salt://scripts/script_1.sh\n" +
                         "                mgr_remote_cmd_runas: foobar\n" +
+                        "                mgr_remote_cmd_script: salt://scripts/script_1.sh\n" +
                         "mgr_actionchain_131_action_2_chunk_1:\n" +
                         "    module.run:\n" +
                         "    -   name: system.reboot\n" +
@@ -292,10 +297,10 @@ public class SaltActionChainGeneratorServiceTest extends BaseTestCaseWithUser {
                 1,
                 singletonMap("mods", "remotecommands"),
                 singletonMap("pillar",
-                        ImmutableMap.<String, String>builder()
-                                .put("mgr_remote_cmd_script", "salt://scripts/script_1.sh")
-                                .put("mgr_remote_cmd_runas", "foobar")
-                                .build()
+                        new HashMap<String, String>() {{
+                                put("mgr_remote_cmd_script", "salt://scripts/script_1.sh");
+                                put("mgr_remote_cmd_runas", "foobar");
+                        }}
                 )
         ));
         states.add(new SaltSystemReboot(
@@ -309,13 +314,13 @@ public class SaltActionChainGeneratorServiceTest extends BaseTestCaseWithUser {
                 0,
                 emptyMap(),
                 singletonMap("pillar",
-                        ImmutableMap.<String, String>builder()
-                                .put("actionchain_id:", "35")
-                                .put("chunk", "2")
-                                .put("next_action_id", "397")
-                                .put("ssh_extra_filerefs", "salt://scripts/script_1.sh,salt://scripts/script_3.sh,salt://channels," +
-                                        service.getActionChainSLSFileName(actionChain.getId(), minionSummary1, 2))
-                                .build()
+                        new HashMap<String, String>() {{
+                                put("actionchain_id:", "35");
+                                put("chunk", "2");
+                                put("next_action_id", "397");
+                                put("ssh_extra_filerefs", "salt://scripts/script_1.sh,salt://scripts/script_3.sh,salt://channels," +
+                                        service.getActionChainSLSFileName(actionChain.getId(), minionSummary1, 2));
+                        }}
                 )
         ));
         states.add(new SaltModuleRun(
@@ -324,10 +329,10 @@ public class SaltActionChainGeneratorServiceTest extends BaseTestCaseWithUser {
                 3,
                 singletonMap("mods", "remotecommands"),
                 singletonMap("pillar",
-                        ImmutableMap.<String, String>builder()
-                                .put("mgr_remote_cmd_script", "salt://scripts/script_3.sh")
-                                .put("mgr_remote_cmd_runas", "foobar")
-                                .build()
+                        new HashMap<String, String>() {{
+                                put("mgr_remote_cmd_script", "salt://scripts/script_3.sh");
+                                put("mgr_remote_cmd_runas", "foobar");
+                        }}
                 )
         ));
 
@@ -455,10 +460,10 @@ public class SaltActionChainGeneratorServiceTest extends BaseTestCaseWithUser {
                 1,
                 singletonMap("mods", "remotecommands"),
                 singletonMap("pillar",
-                        ImmutableMap.<String, String>builder()
-                                .put("mgr_remote_cmd_script", "salt://scripts/script_1.sh")
-                                .put("mgr_remote_cmd_runas", "foobar")
-                                .build()
+                        new HashMap<String, String>() {{
+                                put("mgr_remote_cmd_script", "salt://scripts/script_1.sh");
+                                put("mgr_remote_cmd_runas", "foobar");
+                        }}
                 )
         ));
         states.add(new SaltModuleRun(ACTION_STATE_ID_PREFIX + actionChain.getId() + "_action_" + 2,
@@ -474,12 +479,12 @@ public class SaltActionChainGeneratorServiceTest extends BaseTestCaseWithUser {
                 0,
                 emptyMap(),
                 singletonMap("pillar",
-                        ImmutableMap.<String, String>builder()
-                                .put("actionchain_id:", "35")
-                                .put("chunk", "2")
-                                .put("next_action_id", "397")
-                                .put("ssh_extra_filerefs", "salt://scripts/script_2.sh,salt://channels," + sls2Name)
-                                .build()
+                        new HashMap<String, String>() {{
+                                put("actionchain_id:", "35");
+                                put("chunk", "2");
+                                put("next_action_id", "397");
+                                put("ssh_extra_filerefs", "salt://scripts/script_2.sh,salt://channels," + sls2Name);
+                        }}
                 )
         ));
 


### PR DESCRIPTION
## What does this PR change?

`com.google.common` types have been mistakenly used in some test classes.
Since those were in our classpath due to checkstyle-all, we need to get
rid of them.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: tests internal changes

- [X] **DONE**

## Test coverage
- No tests: Getting rid of accidental dependency in tests

- [X] **DONE**

## Links

Fixes SUSE/spacewalk#7307

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
