### PR TITLE
Testsuite: Wait for project to get build first successfully before promoting

### DIFF
--- a/testsuite/features/srv_content_lifecycle.feature
+++ b/testsuite/features/srv_content_lifecycle.feature
@@ -77,6 +77,7 @@ Feature: Content lifecycle
     And I click the environment build button
     Then I wait until I see "Version 1 successfully built into dev_name" text
     And I should see a "Version 1: test version message 1" text
+    And I wait until I see "Built" text
 
   Scenario: Promote promote the sources in the project
     Given I am authorized as "admin" with password "admin"
@@ -123,5 +124,4 @@ Feature: Content lifecycle
     And I follow "clp_name"
     When I click on "Delete"
     Then I click on "Delete" in element "delete-project-modal"
-    Then I wait until I see "Content Lifecycle Projects" text
     And I should see a "There are no entries to show." text


### PR DESCRIPTION
## What does this PR change?
Wait for the project to build successfully before promoting to make workflow consistent and avoid the unwanted result.


## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test" 
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
