### PR TITLE
Don't skip deb pkg tags on pkg import (bsc#1130040)

### DIFF
--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Don't skip Deb package tags on package import (bsc#1130040)
 - spacewalk-remove-channel check that channel doesn't have cloned channels before deleting it (bsc#1138454)
 - Fix broken spacewalk-data-fsck utility
 - /etc/rhn also was packaged for spacewalk-backend-tools


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/8177

When importing Deb pkgs the `Pre-Depends` are skipped. This causes problems later when a package having `Pre-Depends` requirements is upgraded.  This can happen because the `Packages.gz` generated by SUMA is missing this information and `apt-get` relies on this file to calculate the dependencies of a package to install/upgrade.

## GUI diff

No difference.

## Documentation
- No documentation needed: bugfix

## Test coverage
- No tests

- [ ] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/8177

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
