### PR TITLE
For orphan vendor contentsources, look also in susesccrepositoryauth table as well.

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/channel/ContentSource.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/ContentSource.hbm.xml
@@ -108,6 +108,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
               from rhncontentsource cs
              where cs.org_id is null
                and not exists (select 1 from rhnchannelcontentsource ccs where ccs.source_id = cs.id)
+               and not exists (select 1 from susesccrepositoryauth sccra where sccra.source_id = cs.id)
         ]]>
         <return alias="cs" class="com.redhat.rhn.domain.channel.ContentSource" />
     </sql-query>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- For orphan contentsources, look also in susesccrepositoryauth to make sure they are not being referenced (bsc#1138275)
 - Fallback to logged-in-user org and then vendor errata when looking up erratum on cloning (bsc#1137308)
 - Add new validation to avoid creating content lifecycle projects starting with a number (bsc#1139493)
 - Improve performance of 'Systems requiring reboot' page (fate#327780)


### PR DESCRIPTION
## What does this PR change?
For orphan vendor contentsources, look also in susesccrepositoryauth table to make sure they are not being referenced there. 


## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: **Bug fix**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [x] **DONE**

## Test coverage
- No tests: **Existing tests should cover this*
- [x] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/8121
Tracks # 
4.0 **https://github.com/SUSE/spacewalk/pull/8274**
3.2 **https://github.com/SUSE/spacewalk/pull/8273**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
