### PR TITLE
Content Lifecycle sources will no longer include cloned channels by other projects

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
@@ -299,6 +299,17 @@ public class ContentProjectFactory extends HibernateFactory {
     }
 
     /**
+     * List all SoftwareEnvironmentTarget
+     * @return list with all SoftwareEnvironmentTarget
+     */
+    public static List<SoftwareEnvironmentTarget> listSoftwareEnvironmentTarget() {
+        CriteriaBuilder builder = getSession().getCriteriaBuilder();
+        CriteriaQuery<SoftwareEnvironmentTarget> query = builder.createQuery(SoftwareEnvironmentTarget.class);
+        query.from(SoftwareEnvironmentTarget.class);
+        return getSession().createQuery(query).list();
+    }
+
+    /**
      * Looks up SoftwareEnvironmentTarget with given id
      *
      * @param label the {@link Channel} label

--- a/java/code/src/com/suse/manager/webui/Router.java
+++ b/java/code/src/com/suse/manager/webui/Router.java
@@ -54,6 +54,7 @@ import com.suse.manager.webui.controllers.VirtualHostManagerController;
 import com.suse.manager.webui.controllers.VirtualNetsController;
 import com.suse.manager.webui.controllers.VirtualPoolsController;
 import com.suse.manager.webui.controllers.VisualizationController;
+import com.suse.manager.webui.controllers.channels.ChannelsApiController;
 import com.suse.manager.webui.controllers.contentmanagement.ContentManagementApiController;
 import com.suse.manager.webui.controllers.contentmanagement.ContentManagementViewsController;
 import com.suse.manager.webui.errors.NotFoundException;
@@ -103,6 +104,9 @@ public class Router implements SparkApplication {
         // Content Management Routes
         ContentManagementViewsController.initRoutes(jade);
         ContentManagementApiController.initRoutes();
+
+        // Channels
+        ChannelsApiController.initRoutes();
 
         // Admin Router
         AdminViewsController.initRoutes(jade);

--- a/java/code/src/com/suse/manager/webui/controllers/ActivationKeysController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/ActivationKeysController.java
@@ -14,30 +14,35 @@
  */
 package com.suse.manager.webui.controllers;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
+import static com.suse.manager.webui.controllers.channels.ChannelsUtils.generateChannelJson;
+import static com.suse.manager.webui.controllers.channels.ChannelsUtils.getPossibleBaseChannels;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.json;
+
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.ChannelFactory;
 import com.redhat.rhn.domain.token.ActivationKey;
 import com.redhat.rhn.domain.token.ActivationKeyFactory;
 import com.redhat.rhn.domain.user.User;
-import com.redhat.rhn.manager.channel.ChannelManager;
+
 import com.suse.manager.reactor.utils.LocalDateTimeISOAdapter;
 import com.suse.manager.reactor.utils.OptionalTypeAdapterFactory;
 import com.suse.manager.webui.utils.gson.ChannelsJson;
 import com.suse.manager.webui.utils.gson.ResultJson;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import org.apache.http.HttpStatus;
+import org.apache.log4j.Logger;
+
 import java.time.LocalDateTime;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import org.apache.http.HttpStatus;
-import org.apache.log4j.Logger;
+
 import spark.Request;
 import spark.Response;
-
-import static com.suse.manager.webui.utils.SparkApplicationHelper.json;
 /**
  * Controller class providing backend code for the systems page.
  */
@@ -85,15 +90,6 @@ public class ActivationKeysController {
         });
     }
 
-    /**
-     * Get a list of base {@link Channel} visible to the current user
-     *
-     * @param user the current user
-     * @return the list of base Channel the user can access
-     */
-    public static List<Channel> getPossibleBaseChannels(User user) {
-        return ChannelFactory.listSubscribableBaseChannels(user);
-    }
 
     /**
      * Get available base channels for a user.
@@ -158,19 +154,4 @@ public class ActivationKeysController {
         }
     }
 
-    /**
-     * Generate a {@link ChannelsJson} object with all accessible child channels for the given base channel
-     *
-     * @param base the base channel
-     * @param user the current user
-     * @return the ChannelsJson object containing all base:children channels
-     */
-    public static ChannelsJson generateChannelJson(Channel base, User user) {
-        List<Channel> children = ChannelFactory.getAccessibleChildChannels(base, user);
-        Map<Long, Boolean> recommendedFlags = ChannelManager.computeChannelRecommendedFlags(base, children.stream());
-        ChannelsJson jsonChannel = new ChannelsJson();
-        jsonChannel.setBase(base);
-        jsonChannel.setChildrenWithRecommendedAndArch(children.stream(), recommendedFlags);
-        return jsonChannel;
-    }
 }

--- a/java/code/src/com/suse/manager/webui/controllers/channels/ChannelsApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/channels/ChannelsApiController.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.webui.controllers.channels;
+
+import static com.suse.manager.webui.controllers.channels.ChannelsUtils.generateChannelJson;
+import static com.suse.manager.webui.controllers.channels.ChannelsUtils.getPossibleBaseChannels;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.json;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withUser;
+import static spark.Spark.get;
+
+import com.redhat.rhn.domain.contentmgmt.ContentProjectFactory;
+import com.redhat.rhn.domain.user.User;
+
+import com.suse.manager.webui.utils.gson.ChannelsJson;
+import com.suse.manager.webui.utils.gson.ResultJson;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import spark.Request;
+import spark.Response;
+
+/**
+ * Spark controller for Channels Api.
+ */
+public class ChannelsApiController {
+
+    private ChannelsApiController() {
+    }
+
+    /** Invoked from Router. Init routes for ContentManagement Api.*/
+    public static void initRoutes() {
+        get("/manager/api/channels",
+                withUser(ChannelsApiController::getAllChannels));
+    }
+
+    /**
+     * Get all the existing channels for a user
+     *
+     * @param req the request
+     * @param res the response
+     * @param user the current user
+     * @return the json response
+     */
+    public static String getAllChannels(Request req, Response res, User user) {
+        Boolean filterClm = Boolean.parseBoolean(req.queryParams("filterClm"));
+        Set<Long> filterOutIds = new HashSet<>();
+        if (filterClm) {
+            // filtering Content Lifecycle Management target channels
+            filterOutIds.addAll(ContentProjectFactory.listSoftwareEnvironmentTarget().stream()
+                    .map(tgt -> tgt.getChannel().getId())
+                    .collect(Collectors.toSet()));
+        }
+
+        List<ChannelsJson> jsonChannelsFiltered = getPossibleBaseChannels(user).stream()
+                .map(base -> generateChannelJson(base, user))
+                .filter(c -> !filterOutIds.contains(c.getBase().getId()))
+                .collect(Collectors.toList());
+
+        return json(res, ResultJson.success(jsonChannelsFiltered));
+    }
+
+
+}

--- a/java/code/src/com/suse/manager/webui/controllers/channels/ChannelsUtils.java
+++ b/java/code/src/com/suse/manager/webui/controllers/channels/ChannelsUtils.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.webui.controllers.channels;
+
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.channel.ChannelFactory;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.manager.channel.ChannelManager;
+
+import com.suse.manager.webui.utils.gson.ChannelsJson;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Useful channels methods for web apis
+ */
+public class ChannelsUtils {
+
+    private ChannelsUtils() {
+    }
+
+    /**
+     * Generate a {@link ChannelsJson} object with all accessible child channels for the given base channel
+     *
+     * @param base the base channel
+     * @param user the current user
+     * @return the ChannelsJson object containing all base:children channels
+     */
+    public static ChannelsJson generateChannelJson(Channel base, User user) {
+        List<Channel> children = ChannelFactory.getAccessibleChildChannels(base, user);
+        Map<Long, Boolean> recommendedFlags = ChannelManager.computeChannelRecommendedFlags(base, children.stream());
+        ChannelsJson jsonChannel = new ChannelsJson();
+        jsonChannel.setBase(base);
+        jsonChannel.setChildrenWithRecommendedAndArch(children.stream(), recommendedFlags);
+        return jsonChannel;
+    }
+
+    /**
+     * Get a list of base {@link Channel} visible to the current user
+     *
+     * @param user the current user
+     * @return the list of base Channel the user can access
+     */
+    public static List<Channel> getPossibleBaseChannels(User user) {
+        return ChannelFactory.listSubscribableBaseChannels(user);
+    }
+
+}

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,4 +1,5 @@
 - Cloning Errata from a specific channel should not take packages
+- Hide channels managed by Content Lifecycle projects from available sources (bsc#1137965)
   from other channels (bsc#1142764)
 - add caret sorting for rpm versioning
 - improve performance for retrieving the user permissions on channels (bsc#1140644)

--- a/web/html/src/core/channels/api/use-channels-tree-api.js
+++ b/web/html/src/core/channels/api/use-channels-tree-api.js
@@ -49,7 +49,7 @@ const useChannelsTreeApi = (): UseChannelsType => {
   const [isChannelsTreeLoaded, setIsChannelsTreeLoaded] = useState(false);
 
   const fetchChannelsTree = (): Promise<ChannelsTreeType> => {
-    return  Network.get(`/rhn/manager/api/activation-keys/base-channels/-1/child-channels`)
+    return  Network.get(`/rhn/manager/api/channels?filterClm=true`)
       .promise.then(data => {
         const channelsTree = flattenChannelsTree(data.data);
         setChannelsTree(channelsTree);

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Hide channels managed by Content Lifecycle projects from available sources (bsc#1137965)
 - Add unsupported browser warning when using Internet Explorer
 
 -------------------------------------------------------------------
@@ -6,7 +7,7 @@ Wed Jul 31 17:38:44 CEST 2019 - jgonzalez@suse.com
 - version 4.0.12-1
 - Add new validation to avoid creating content lifecycle projects starting with a number (bsc#1139493)
 - Redirect to first step of channel assignment after change channel submit (bsc#1137244)
-- add error messages, hints for image profile edit page (bsc#1127319) 
+- add error messages, hints for image profile edit page (bsc#1127319)
 - Allow virtualization tab for foreign systems (bsc#1116869)
 - Add checks for empty required entries on formula forms (bsc#1109639)
 - Fix big formula checkbox not supported in Firefox


### PR DESCRIPTION
## What does this PR change?

Content Lifecycle sources will no longer include cloned channels by other projects

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed.

- [ ] **DONE**

## Test coverage
- No tests:

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/8092

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
