### PR TITLE
API Documentation: mention the shebang in the system.scheduleScriptRun doc strings

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -4253,7 +4253,8 @@ public class SystemHandler extends BaseHandler {
      * @xmlrpc.param #param_desc("string", "groupname", "Group to run script as.")
      * @xmlrpc.param #param_desc("int", "timeout", "Seconds to allow the script to run
      *before timing out.")
-     * @xmlrpc.param #param_desc("string", "script", "Contents of the script to run.")
+     * @xmlrpc.param #param_desc("string", "script", "Contents of the script to run.
+     * Must start with a shebang (e.g. #!/bin/bash)")
      * @xmlrpc.param #param_desc("dateTime.iso8601", "earliestOccurrence",
      * "Earliest the script can run.")
      * @xmlrpc.returntype int - ID of the script run action created. Can be used to fetch
@@ -4317,7 +4318,8 @@ public class SystemHandler extends BaseHandler {
      * @xmlrpc.param #param_desc("string", "groupname", "Group to run script as.")
      * @xmlrpc.param #param_desc("int", "timeout", "Seconds to allow the script to run
      *before timing out.")
-     * @xmlrpc.param #param_desc("string", "script", "Contents of the script to run.")
+     * @xmlrpc.param #param_desc("string", "script", "Contents of the script to run.
+     * Must start with a shebang (e.g. #!/bin/bash)")
      * @xmlrpc.param #param_desc("dateTime.iso8601", "earliestOccurrence",
      * "Earliest the script can run.")
      * @xmlrpc.returntype int - ID of the script run action created. Can be used to fetch
@@ -4350,7 +4352,8 @@ public class SystemHandler extends BaseHandler {
      * @xmlrpc.param #param_desc("string", "groupname", "Group to run script as.")
      * @xmlrpc.param #param_desc("int", "timeout", "Seconds to allow the script to run
      *before timing out.")
-     * @xmlrpc.param #param_desc("string", "script", "Contents of the script to run.")
+     * @xmlrpc.param #param_desc("string", "script", "Contents of the script to run.
+     * Must start with a shebang (e.g. #!/bin/bash)")
      * @xmlrpc.param #param_desc("dateTime.iso8601", "earliestOccurrence",
      * "Earliest the script can run.")
      * @xmlrpc.returntype int - ID of the script run action created. Can be used to fetch
@@ -4389,7 +4392,8 @@ public class SystemHandler extends BaseHandler {
      * @xmlrpc.param #param_desc("string", "groupname", "Group to run script as.")
      * @xmlrpc.param #param_desc("int", "timeout", "Seconds to allow the script to run
      *before timing out.")
-     * @xmlrpc.param #param_desc("string", "script", "Contents of the script to run.")
+     * @xmlrpc.param #param_desc("string", "script", "Contents of the script to run.
+     * Must start with a shebang (e.g. #!/bin/bash)")
      * @xmlrpc.param #param_desc("dateTime.iso8601", "earliestOccurrence",
      * "Earliest the script can run.")
      * @xmlrpc.returntype int - ID of the script run action created. Can be used to fetch

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- API Documentation: mention the shebang in the system.scheduleScriptRun doc strings (bsc#1138655)
 - Enable product detection for plain rhel systems (bsc#1136301)
 - For orphan contentsources, look also in susesccrepositoryauth to make sure they are not being referenced (bsc#1138275)
 - Fallback to logged-in-user org and then vendor errata when looking up erratum on cloning (bsc#1137308)


### PR DESCRIPTION
....not mentioning it leads to confusion about the script parameter contents.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: this is a documentation
- [x] **DONE**

## Test coverage
- no tests for docs

- [x] **DONE**

## Links


Tracks https://github.com/SUSE/spacewalk/issues/8282 

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests" 		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"