### PR TITLE
Fixes CVE-2019-10137 that allows path traversal

### DIFF
--- a/proxy/proxy/rhnProxyAuth.py
+++ b/proxy/proxy/rhnProxyAuth.py
@@ -466,7 +466,15 @@ class AuthLocalBackend:
         return rhnCache.delete(rkey)
 
     def _compute_key(self, key):
-        return os.path.join(self._cache_prefix, str(key))
+        # stripping forward slashes from the key.
+        key = bytes([char for char in os.fsencode(key) if char != ord('/')]).decode()
+
+        key_path = os.path.join(self._cache_prefix, str(key))
+        if not os.path.normpath(key_path).startswith(self._cache_prefix):
+            raise ValueError("Path traversal detected for X-RHN-Server-ID. " +
+                             "User is trying to set a path as server-id.")
+        else:
+            return key_path
 
     def __len__(self):
         pass

--- a/proxy/proxy/spacewalk-proxy.changes
+++ b/proxy/proxy/spacewalk-proxy.changes
@@ -3,7 +3,7 @@
   unauthenticated, attacker could use this flaw to test the
   existence of arbitrary files, or if they have access to the
   proxy's filesystem, execute arbitrary code in the context of the
-  proxy. (bsc#1136480)
+  proxy. (bsc#1136476)
 
 -------------------------------------------------------------------
 Wed May 15 15:12:44 CEST 2019 - jgonzalez@suse.com

--- a/proxy/proxy/spacewalk-proxy.changes
+++ b/proxy/proxy/spacewalk-proxy.changes
@@ -1,3 +1,10 @@
+- Fix for CVE-2019-10137. A path traversal flaw was found in the
+  way the proxy processes cached client tokens. A remote,
+  unauthenticated, attacker could use this flaw to test the
+  existence of arbitrary files, or if they have access to the
+  proxy's filesystem, execute arbitrary code in the context of the
+  proxy. (bsc#1136480)
+
 -------------------------------------------------------------------
 Wed May 15 15:12:44 CEST 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Since a user could set the server id to a path, a path traversal could be done. This would allow an attacker to check if files are present in the filesystem.
A check was addded that raises an exception when someone tries to break out of the cache directory and we are also stripping forward slashes from the key.

## GUI diff

No difference.

## Documentation
- No documentation needed: This is a bugfix.

## Test coverage
- No tests: 

## Links

https://www.suse.com/security/cve/CVE-2019-10137/

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
