### PR TITLE
Fix for CVE-2019-10136

### DIFF
--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,7 @@
+- Fix for CVE-2019-10136. An attacker with a valid, but expired,
+  authenticated set of headers could move some digits around,
+  artificially extending the session validity without modifying
+  the checksum. (bsc#1136480)
 - Do not duplicate "http://" protocol when using proxies with "deb"
   repositories (bsc#1138313)
 - Fix reposync when dealing with RedHat CDN (bsc#1138358)


### PR DESCRIPTION
## What does this PR change?

Separating fields for signature hash calculation and switching to hmac.

With the previous implementaion it was possible to construct the same hash by moving chars between fields. The current implementation is using fixed size fields and hmac to prevent this.

## GUI diff

No difference.

## Documentation
- No documentation needed: This is a bugfi.

## Test coverage
- No tests: 



## Links

https://www.suse.com/security/cve/CVE-2019-10136/


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
