### PR TITLE
Explicity require systemd for spacewalk-client-tools when appropriate

### DIFF
--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes
@@ -1,3 +1,5 @@
+- Make a explicit requirement to systemd for spacewalk-client-tools
+  when rhnsd timer is installed
 - The rhnsd service was replaced by rhnsd timer, so
   registration script and systemd presets are now adapted
   to this (bsc#1138130)

--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.spec
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.spec
@@ -148,6 +148,12 @@ BuildRequires:  yum
 %endif
 %endif
 
+# For the systemd presets
+%if 0%{?fedora} || 0%{?mageia} || 0%{?debian} >= 8 || 0%{?ubuntu} >= 1504 || 0%{?sle_version} >= 120000 || 0%{?rhel} >= 7
+BuildRequires: systemd
+Requires:      systemd
+%endif
+
 %description
 Spacewalk Client Tools provides programs and libraries to allow your
 system to receive software updates from Spacewalk.


### PR DESCRIPTION
## What does this PR change?

This doesn't fix a bug at the clients, but otherwise building for SLE12 at OBS building fails with:
```
[   68s] spacewalk-client-tools-4.0.8-3.1.noarch.rpm: directories not owned by a package:
[   68s]  - /usr/lib/systemd/system-preset
```
(while it doesn't fail at IBS, I guess because of differences at the images).

Not working (until this is merged): https://build.opensuse.org/build/systemsmanagement:Uyuni:Master:SLE12-Uyuni-Client-Tools/SLE_12/aarch64/spacewalk-client-tools/_log
Working, with this patch: https://build.opensuse.org/build/home:juliogonzalezgil:branches:systemsmanagement:Uyuni:Master:SLE12-Uyuni-Client-Tools/SLE_12/aarch64/spacewalk-client-tools/_log

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Fixing builds.

- [x] **DONE**

## Test coverage
- No tests: Was covered by OBS tests already.

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
