### PR TITLE
Add missing changelog entries

### DIFF
--- a/susemanager-frontend/susemanager-nodejs-sdk-devel/susemanager-nodejs-sdk-devel.changes
+++ b/susemanager-frontend/susemanager-nodejs-sdk-devel/susemanager-nodejs-sdk-devel.changes
@@ -1,3 +1,5 @@
+- upgrade eslint and react-select minors
+
 -------------------------------------------------------------------
 Wed May 15 15:30:31 CEST 2019 - jgonzalez@suse.com
 

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Add new validation to avoid creating content lifecycle projects starting with a number (bsc#1139493)
 - Redirect to first step of channel assignment after change channel submit (bsc#1137244)
 - add error messages, hints for image profile edit page (bsc#1127319) 
 - Allow virtualization tab for foreign systems (bsc#1116869)


### PR DESCRIPTION
## What does this PR change?

Add missing changelogs.

The entry for spacewalk-web was only added to spacewalk-java.

The entry for susemanager-nodejs-sdk-devel is required as it's the only change to this package.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Add missing changelogs

- [x] **DONE**

## Test coverage
- No tests: Add missing changelogs

- [x] **DONE**

## Links

None.

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
