### PR TITLE
Remove whitespace from tested strings

### DIFF
--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -233,9 +233,9 @@ For a test with a regular expression, there is ```I should see a text like "..."
 * Same, but wait until text appears
 
 ```cucumber
-  Then I wait until I see "Successfully bootstrapped host! " text
-  Then I wait until I do not see "Loading..." text
-  Then I wait at most 360 seconds until I see "Product Description" text
+  When I wait until I see "Successfully bootstrapped host!" text
+  When I wait until I do not see "Loading..." text
+  When I wait at most 360 seconds until I see "Product Description" text
 ```
 
 * Same, but re-issue HTTP requests to refresh the page

--- a/testsuite/features/allcli_config_channel.feature
+++ b/testsuite/features/allcli_config_channel.feature
@@ -88,7 +88,7 @@ Feature: Management of configuration of all types of clients in a single channel
     And I should see "sle-client" as link
     And I should see "sle-minion" as link
     When I click on "Deploy Files to Selected Systems"
-    Then I should see a " revision-deploys are being scheduled," text
+    Then I should see a "revision-deploys are being scheduled," text
     And I should see a "0 revision-deploys overridden." text
 
   Scenario: Check that file has been created on traditional client

--- a/testsuite/features/core_centos_salt_ssh.feature
+++ b/testsuite/features/core_centos_salt_ssh.feature
@@ -16,7 +16,7 @@ Feature: Bootstrap a SSH-managed CentOS minion and do some basic operations on i
     And I enter "linux" as "password"
     And I select the hostname of the proxy from "proxies"
     And I click on "Bootstrap"
-    Then I wait until I see "Successfully bootstrapped host! " text
+    And I wait until I see "Successfully bootstrapped host!" text
     And I navigate to "rhn/systems/Overview.do" page
     And I wait until I see the name of "ceos-ssh-minion", refreshing the page
     And I wait until onboarding is completed for "ceos-ssh-minion"

--- a/testsuite/features/core_min_bootstrap.feature
+++ b/testsuite/features/core_min_bootstrap.feature
@@ -54,7 +54,7 @@ Feature: Be able to bootstrap a Salt minion via the GUI
      And I enter "linux" as "password"
      And I select the hostname of the proxy from "proxies"
      And I click on "Bootstrap"
-     And I wait until I see "Successfully bootstrapped host! " text
+     And I wait until I see "Successfully bootstrapped host!" text
 
   Scenario: Check the new bootstrapped minion in System Overview page
      Given I am authorized

--- a/testsuite/features/core_min_salt_ssh.feature
+++ b/testsuite/features/core_min_salt_ssh.feature
@@ -13,7 +13,7 @@ Feature: Be able to bootstrap a Salt host managed via salt-ssh
     And I enter "linux" as "password"
     And I select the hostname of the proxy from "proxies"
     And I click on "Bootstrap"
-    Then I wait until I see "Successfully bootstrapped host! " text
+    And I wait until I see "Successfully bootstrapped host!" text
     And I navigate to "rhn/systems/Overview.do" page
     And I wait until I see the name of "ssh-minion", refreshing the page
     And I wait until onboarding is completed for "ssh-minion"

--- a/testsuite/features/core_proxy_register_as_minion_with_gui.feature
+++ b/testsuite/features/core_proxy_register_as_minion_with_gui.feature
@@ -21,7 +21,7 @@ Feature: Setup SUSE Manager proxy
     And I enter "root" as "user"
     And I enter "linux" as "password"
     And I click on "Bootstrap"
-    And I wait until I see "Successfully bootstrapped host! " text
+    And I wait until I see "Successfully bootstrapped host!" text
     When I navigate to "rhn/systems/Overview.do" page
     And I wait until I see the name of "proxy", refreshing the page
 

--- a/testsuite/features/core_ubuntu_salt_ssh.feature
+++ b/testsuite/features/core_ubuntu_salt_ssh.feature
@@ -16,7 +16,7 @@ Feature: Bootstrap a SSH-managed Ubuntu minion and do some basic operations on i
     And I enter "linux" as "password"
     #    And I select the hostname of the proxy from "proxies"
     And I click on "Bootstrap"
-    Then I wait until I see "Successfully bootstrapped host! " text
+    And I wait until I see "Successfully bootstrapped host!" text
     And I navigate to "rhn/systems/Overview.do" page
     And I wait until I see the name of "ubuntu-minion", refreshing the page
     And I wait until onboarding is completed for "ubuntu-minion"

--- a/testsuite/features/min_activationkey.feature
+++ b/testsuite/features/min_activationkey.feature
@@ -60,7 +60,7 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
     And I select "1-MINION-TEST" from "activationKeys"
     And I select the hostname of the proxy from "proxies"
     And I click on "Bootstrap"
-    Then I wait until I see "Successfully bootstrapped host! " text
+    And I wait until I see "Successfully bootstrapped host!" text
     When I navigate to "rhn/systems/Overview.do" page
     And I wait until I see the name of "sle-minion", refreshing the page
     And I wait until onboarding is completed for "sle-minion"

--- a/testsuite/features/min_centos_salt.feature
+++ b/testsuite/features/min_centos_salt.feature
@@ -29,7 +29,7 @@ Feature: Be able to bootstrap a CentOS minion and do some basic operations on it
     And I select "1-SUSE-PKG-x86_64" from "activationKeys"
     And I select the hostname of the proxy from "proxies"
     And I click on "Bootstrap"
-    And I wait until I see "Successfully bootstrapped host! " text
+    And I wait until I see "Successfully bootstrapped host!" text
     And I navigate to "rhn/systems/Overview.do" page
     And I wait until I see the name of "ceos-minion", refreshing the page
     And I wait until onboarding is completed for "ceos-minion"
@@ -129,7 +129,7 @@ Feature: Be able to bootstrap a CentOS minion and do some basic operations on it
     And I enter "linux" as "password"
     And I select the hostname of the proxy from "proxies"
     And I click on "Bootstrap"
-    Then I wait until I see "Successfully bootstrapped host! " text
+    And I wait until I see "Successfully bootstrapped host!" text
     And I navigate to "rhn/systems/Overview.do" page
     And I wait until I see the name of "ceos-ssh-minion", refreshing the page
     And I wait until onboarding is completed for "ceos-ssh-minion"

--- a/testsuite/features/min_salt_minions_page.feature
+++ b/testsuite/features/min_salt_minions_page.feature
@@ -79,7 +79,7 @@ Feature: Management of minion keys
     And I enter "linux" as "password"
     And I select the hostname of the proxy from "proxies"
     And I click on "Bootstrap"
-    And I wait until I see "Successfully bootstrapped host! " text
+    And I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "sle-minion"
 
   Scenario: Cleanup: restore channels on the minion

--- a/testsuite/features/min_ubuntu_salt.feature
+++ b/testsuite/features/min_ubuntu_salt.feature
@@ -139,7 +139,7 @@ Feature: Be able to bootstrap an Ubuntu minion and do some basic operations on i
     And I enter "linux" as "password"
     And I select the hostname of the proxy from "proxies"
     And I click on "Bootstrap"
-    Then I wait until I see "Successfully bootstrapped host! " text
+    And I wait until I see "Successfully bootstrapped host!" text
     And I navigate to "rhn/systems/Overview.do" page
     And I wait until I see the name of "ubuntu-ssh-minion", refreshing the page
     And I wait until onboarding is completed for "ubuntu-ssh-minion"

--- a/testsuite/features/minkvm_guests.feature
+++ b/testsuite/features/minkvm_guests.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 SUSE LLC
+# Copyright (c) 2018-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Be able to manage KVM virtual machines via the GUI
@@ -15,10 +15,10 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I select "1-SUSE-PKG-x86_64" from "activationKeys"
     And I select the hostname of the proxy from "proxies"
     And I click on "Bootstrap"
-    And I wait until I see "Successfully bootstrapped host! " text
+    And I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "kvm-server"
     And I restart salt-minion on "kvm-server"
-    # Shorten the virtpoller interval to avoid loosing time
+    # Shorten the virtpoller interval to avoid losing time
     And I reduce virtpoller run interval on "kvm-server"
 
 @virthost_kvm

--- a/testsuite/features/minxen_guests.feature
+++ b/testsuite/features/minxen_guests.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 SUSE LLC
+# Copyright (c) 2018-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Be able to manage XEN virtual machines via the GUI
@@ -15,9 +15,9 @@ Feature: Be able to manage XEN virtual machines via the GUI
     And I select "1-SUSE-PKG-x86_64" from "activationKeys"
     And I select the hostname of the proxy from "proxies"
     And I click on "Bootstrap"
-    And I wait until I see "Successfully bootstrapped host! " text
+    And I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "xen-server"
-    # Shorten the virtpoller interval to avoid loosing time
+    # Shorten the virtpoller interval to avoid losing time
     And I reduce virtpoller run interval on "xen-server"
 
 @virthost_xen

--- a/testsuite/features/srv_menu.feature
+++ b/testsuite/features/srv_menu.feature
@@ -16,9 +16,9 @@ Feature: Web UI - Main landing page menu, texts and links
 
   Scenario: Idempotency of complete menu path and direct link
     When I follow the left menu "Software > Manage"
-    Then I should see a " Software Channel Management" text in the content area
+    Then I should see a "Software Channel Management" text in the content area
     When I follow the left menu "Software > Manage > Channels"
-    Then I should see a " Software Channel Management" text in the content area
+    Then I should see a "Software Channel Management" text in the content area
 
   Scenario: Completeness of the side navigation bar and the content frame
     When I follow the left menu "Systems > Overview"

--- a/testsuite/features/trad_centos_client.feature
+++ b/testsuite/features/trad_centos_client.feature
@@ -112,7 +112,7 @@ Feature: Be able to register a CentOS 7 traditional client and do some basic ope
     And I enter "linux" as "password"
     And I select the hostname of the proxy from "proxies"
     And I click on "Bootstrap"
-    Then I wait until I see "Successfully bootstrapped host! " text
+    And I wait until I see "Successfully bootstrapped host!" text
     And I navigate to "rhn/systems/Overview.do" page
     And I wait until I see the name of "ceos-ssh-minion", refreshing the page
     And I wait until onboarding is completed for "ceos-ssh-minion"

--- a/testsuite/features/trad_check_registration.feature
+++ b/testsuite/features/trad_check_registration.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2018 SUSE LLC
+# Copyright (c) 2015-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Client display after registration
@@ -110,7 +110,7 @@ Feature: Client display after registration
     And I should see a "Events" link in the content area
     And I should see a "Pending" link in the content area
     And I should see a "History" link in the content area
-    And I should see a " Pending Events" text
+    And I should see a "Pending Events" text
 
   Scenario: Show Details => Properties page
     Given I am on the Systems overview page of this "sle-client"

--- a/testsuite/features/trad_migrate_to_minion.feature
+++ b/testsuite/features/trad_migrate_to_minion.feature
@@ -16,7 +16,7 @@ Feature: Migrate a traditional client into a Salt minion
     And I select "1-SUSE-PKG-x86_64" from "activationKeys"
     And I select the hostname of the proxy from "proxies"
     And I click on "Bootstrap"
-    Then I wait until I see "Successfully bootstrapped host! " text
+    And I wait until I see "Successfully bootstrapped host!" text
 
   Scenario: Check that the migrated system is now a minion
     Given I am on the Systems overview page of this "sle-migrated-minion"

--- a/testsuite/features/trad_migrate_to_sshminion.feature
+++ b/testsuite/features/trad_migrate_to_sshminion.feature
@@ -37,7 +37,7 @@ Feature: Migrate a traditional client into a Salt SSH minion
     And I select the hostname of the proxy from "proxies"
     And I check "manageWithSSH"
     And I click on "Bootstrap"
-    Then I wait until I see "Successfully bootstrapped host! " text
+    And I wait until I see "Successfully bootstrapped host!" text
 
   Scenario: Check that the migrated system is now a ssh-minion
     Given I am on the Systems overview page of this "sle-migrated-minion"


### PR DESCRIPTION
## What does this PR change?

This PR removes initial and ending spaces from tested strings in prevision of move to capybara 3.0.

See https://github.com/teamcapybara/capybara/blob/master/UPGRADING.md#node.

## Links

Manager 3.2: SUSE/spacewalk#8332
Manager 4.0: SUSE/spacewalk#8334

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
