### PR TITLE
Get FQDN to match SSL data instead of just a hostname (bsc#1141663)

### DIFF
--- a/utils/spacewalk-clone-by-date
+++ b/utils/spacewalk-clone-by-date
@@ -24,7 +24,7 @@ import getpass
 import os
 from optparse import OptionParser
 import simplejson as json
-from socket import gethostname
+import socket
 
 try:
     # python 2
@@ -261,7 +261,7 @@ def parse_args():
                       + "are available for removal).")
     parser.add_option("-s", "--server", dest="server",
                       help="Server URL to use for api connections (defaults to %default)",
-                      default="https://" + gethostname() + "/rpc/api")
+                      default="https://" + socket.getfqdn() + "/rpc/api")
     parser.add_option("-u", "--username", dest="username", help="Username")
     parser.add_option("-v", "--validate", dest='validate', action='store_true',
                       help="Run repoclosure on the set of specified repositories.")

--- a/utils/spacewalk-clone-by-date
+++ b/utils/spacewalk-clone-by-date
@@ -200,6 +200,28 @@ def vararg_callback(option, opt_str, value, parser):
         curr_value.append(value)
 
 
+def get_localhost_fqdn():
+    """
+    Get FQDN of the current machine.
+
+    :return:
+    """
+    fqdn = None
+    try:
+        for family, socktype, proto, canonname, sockaddr in socket.getaddrinfo(
+                socket.gethostname(), 0, 0, 0, 0, socket.AI_CANONNAME):
+            if canonname:
+                fqdn = canonname
+                break
+    except socket.gaierror as exc:
+        pass  # Silence here
+    except Exception as exc:
+        print("Unhandled exception occurred while getting FQDN:", exc)
+
+    return fqdn or socket.getfqdn()  # Fall-back to the /etc/hosts's FQDN
+
+
+
 def parse_args():
     parser = HackedOptionParser()
     parser.add_option("-a", "--parents", dest="parents", action='callback',
@@ -261,7 +283,7 @@ def parse_args():
                       + "are available for removal).")
     parser.add_option("-s", "--server", dest="server",
                       help="Server URL to use for api connections (defaults to %default)",
-                      default="https://" + socket.getfqdn() + "/rpc/api")
+                      default="https://" + get_localhost_fqdn() + "/rpc/api")
     parser.add_option("-u", "--username", dest="username", help="Username")
     parser.add_option("-v", "--validate", dest='validate', action='store_true',
                       help="Run repoclosure on the set of specified repositories.")

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,5 +1,6 @@
 - Use the same client tools for openSUSE Leap 15.0 for all openSUSE Leap
   15.X releases.
+- Fixes SSL hostname matching (bsc#1141663)
 - hostname-rename: change hostname in cobbler db and autoinst data
 - Adds support for Ubuntu and Debian channels to spacewalk-common-channels.
 


### PR DESCRIPTION
## What does this PR change?

Bugfix: SSL hostname doesn't match the default server.

## Links

- [x] **DONE**

## Changelogs


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
