### PR TITLE
Add virtual storage pool edit action

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -7094,6 +7094,12 @@ Follow this url to see the full list of inactive systems:
           <context context-type="sourcefile">com.redhat.rhn.domain.action.ActionFormatter.getActionType</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="virt.pool_update">
+        <source>Virtual storage pool update</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">com.suse.manager.webui.controllers.VirtualPoolsController</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="channels.subscribers.updated">
         <source>{0} channel subscriber(s) successfully updated.</source>
         <context-group name="ctx">

--- a/java/code/src/com/suse/manager/webui/controllers/VirtualPoolsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/VirtualPoolsController.java
@@ -110,6 +110,8 @@ public class VirtualPoolsController {
                 withUserPreferences(withCsrfToken(withUser(this::show))), jade);
         get("/manager/systems/details/virtualization/storage/:sid/new",
                 withUserPreferences(withCsrfToken(withUser(this::createDialog))), jade);
+        get("/manager/systems/details/virtualization/storage/:sid/edit/:name",
+                withUserPreferences(withCsrfToken(withUser(this::editDialog))), jade);
         get("/manager/api/systems/details/virtualization/pools/:sid/data",
                 withUser(this::data));
         get("/manager/api/systems/details/virtualization/pools/:sid/capabilities",
@@ -153,6 +155,25 @@ public class VirtualPoolsController {
      */
     public ModelAndView createDialog(Request request, Response response, User user) {
         return renderWithActionChains(request, response, user, "create", null);
+    }
+
+
+    /**
+     * Displays the virtual storage pool edit page.
+     *
+     * @param request the request
+     * @param response the response
+     * @param user the user
+     * @return the ModelAndView object to render the page
+     */
+    public ModelAndView editDialog(Request request, Response response, User user) {
+        return renderWithActionChains(request, response, user, "edit",
+            () -> {
+                Map<String, Object> data = new HashMap<>();
+                data.put("poolName", request.params("name"));
+                return data;
+            }
+        );
     }
 
 

--- a/java/code/src/com/suse/manager/webui/controllers/VirtualPoolsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/VirtualPoolsController.java
@@ -22,6 +22,7 @@ import static spark.Spark.get;
 import static spark.Spark.post;
 
 import com.redhat.rhn.common.hibernate.LookupException;
+import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.domain.action.ActionChain;
 import com.redhat.rhn.domain.action.ActionChainFactory;
 import com.redhat.rhn.domain.action.ActionFactory;
@@ -125,6 +126,8 @@ public class VirtualPoolsController {
                 withUser(this::poolDelete));
         post("/manager/api/systems/details/virtualization/pools/:sid/create",
                 withUser(this::poolCreate));
+        post("/manager/api/systems/details/virtualization/pools/:sid/edit",
+                withUser(this::poolEdit));
     }
 
     /**
@@ -367,6 +370,20 @@ public class VirtualPoolsController {
 
             return action;
         }, VirtualPoolCreateActionJson.class);
+    }
+
+
+    /**
+     * Executes the POST query to edit a virtual pool.
+     *
+     * @param request the request
+     * @param response the response
+     * @param user the user
+     * @return JSON list of created action IDs
+     */
+    public String poolEdit(Request request, Response response, User user) {
+        String actionName = LocalizationService.getInstance().getMessage("virt.pool_update");
+        return poolCreateOrUpdate(request, response, user, actionName);
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -1868,6 +1868,7 @@ public class SaltServerActionService {
                         }
                         pillar.put("source", source);
                     }
+                    pillar.put("action_type", action.getUuid() != null ? "defined" : "running");
 
                     return State.apply(
                             Collections.singletonList("virt.pool-create"),

--- a/java/code/src/com/suse/manager/webui/templates/virtualization/pools/edit.jade
+++ b/java/code/src/com/suse/manager/webui/templates/virtualization/pools/edit.jade
@@ -1,0 +1,23 @@
+include ../../system-common.jade
+#virtualpools-edit
+
+script(src='/javascript/momentjs/moment-with-langs.min.js?cb=#{webBuildtimestamp}', type='text/javascript')
+script(src='/javascript/validator/validator.min.js?cb=#{webBuildtimestamp}', type='text/javascript')
+
+script(type='text/javascript').
+    window.csrfToken = "#{csrf_token}";
++userPreferences
+
+script(type='text/javascript').
+    spaImportReactPage('virtualization/pools/edit/pools-edit')
+        .then(function(module) {
+            module.renderer(
+              'virtualpools-edit',
+              {
+                  serverId: "#{server.id}",
+                  actionChains: !{actionChains},
+                  timezone: "#{h.renderTimezone()}",
+                  localTime: "#{h.renderLocalTime()}",
+                  poolName: "#{poolName}",
+              }
+        )});

--- a/susemanager-utils/susemanager-sls/salt/virt/pool-create.sls
+++ b/susemanager-utils/susemanager-sls/salt/virt/pool-create.sls
@@ -1,5 +1,8 @@
-pool_running:
-  virt.pool_running:
+{% set pool_state = salt.virt.pool_info(pillar['pool_name']).get(pillar['pool_name'], {}).get('state') %}
+{% set state = 'running' if pool_state == 'running' else pillar['action_type'] %}
+
+pool_{{ state }}:
+  virt.pool_{{ state }}:
     - name: {{ pillar['pool_name'] }}
     - ptype: {{ pillar['pool_type'] }}
     {% if pillar['target']|default(none) %}

--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -352,6 +352,7 @@ The check box can be identified by name, id or label text.
 
 ```cucumber
   When I wait until table row for "test-vm" contains button "Resume"
+  When I wait until the tree item "test-pool1" contains "test-pool1 is started automatically" button
 ```
 
 

--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -242,6 +242,19 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And file "/var/lib/libvirt/images/test-pool1" should have 755 permissions on "kvm_server"
 
 @virthost_kvm
+  Scenario: Edit a virtual storage pool for KVM
+    Given I am on the "Virtualization" page of this "kvm_server"
+    When I follow "Storage"
+    And I click on "Edit Pool" in tree item "test-pool1"
+    And I wait until I see "General" text
+    And I enter "0711" as "target_mode"
+    And I check "autostart"
+    And I click on "Update"
+    Then I should see a "Virtual Storage Pools and Volumes" text
+    And I wait until the tree item "test-pool1" contains "test-pool1 is started automatically" button
+    And file "/var/lib/libvirt/images/test-pool1" should have 711 permissions on "kvm_server"
+
+@virthost_kvm
   Scenario: Cleanup: Unregister the KVM virtualization host
     Given I am on the Systems overview page of this "kvm_server"
     When I follow "Delete System"

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -479,6 +479,12 @@ When(/^I wait until the tree item "([^"]+)" contains "([^"]+)" text$/) do |item,
   end
 end
 
+When(/^I wait until the tree item "([^"]+)" contains "([^"]+)" button$/) do |item, button|
+  xpath_query = "//span[contains(text(), '#{item}')]/"\
+      "ancestor::div[contains(@class, 'product-details-wrapper')]/descendant::*[@title='#{button}']"
+  raise "xpath: #{xpath_query} not found" unless find(:xpath, xpath_query, wait: DEFAULT_TIMEOUT)
+end
+
 When(/^I open the sub-list of the product "(.*?)"$/) do |product|
   xpath = "//span[contains(text(), '#{product}')]/ancestor::div[contains(@class, 'product-details-wrapper')]/div/i[contains(@class, 'fa-angle-right')]"
   # within(:xpath, xpath) do

--- a/web/html/src/manager/virtualization/index.js
+++ b/web/html/src/manager/virtualization/index.js
@@ -5,5 +5,6 @@ export default {
   'virtualization/guests/console/guests-console': () => import('./guests/console/guests-console.renderer'),
   'virtualization/pools/list/pools-list': () => import('./pools/list/pools-list.renderer'),
   'virtualization/pools/create/pools-create': () => import('./pools/create/pools-create.renderer'),
+  'virtualization/pools/edit/pools-edit': () => import('./pools/edit/pools-edit.renderer'),
 }
 

--- a/web/html/src/manager/virtualization/pools/edit/pools-edit.js
+++ b/web/html/src/manager/virtualization/pools/edit/pools-edit.js
@@ -1,0 +1,69 @@
+// @flow
+import type { ActionChain } from 'components/action-schedule';
+
+import * as React from 'react';
+import { TopPanel } from 'components/panels/TopPanel';
+import { Loading } from 'components/utils/Loading';
+import { VirtualizationPoolsActionApi } from '../virtualization-pools-action-api';
+import { VirtualizationPoolDefinitionApi } from '../virtualization-pool-definition-api';
+import { PoolProperties } from '../pool-properties';
+
+type Props = {
+  serverId: string,
+  poolName: string,
+  localTime: string,
+  timezone: string,
+  actionChains: Array<ActionChain>,
+};
+
+export function PoolsEdit(props: Props) {
+  return (
+    <VirtualizationPoolsActionApi
+      hostid={props.serverId}
+      bounce={`/rhn/manager/systems/details/virtualization/storage/${props.serverId}`}
+    >
+    {
+      ({
+        onAction,
+        messages: actionMessages
+      }) => (
+        <VirtualizationPoolDefinitionApi
+          hostid={props.serverId}
+          poolName={props.poolName}
+        >
+        {
+          ({
+            definition,
+            messages: definitionMessages,
+          }) => {
+            if (definition == null) {
+              return <Loading />;
+            }
+
+            const onSubmit = (model: Object) => onAction('edit', [model.name], model);
+
+            return (
+              <TopPanel
+                title={props.poolName}
+              >
+                <PoolProperties
+                  serverId={props.serverId}
+                  submitText={t('Update')}
+                  submit={onSubmit}
+                  initialModel={definition}
+                  messages={actionMessages.concat(definitionMessages)}
+                  timezone={props.timezone}
+                  localTime={props.localTime}
+                  actionChains={props.actionChains}
+                />
+              </TopPanel>
+            );
+          }
+        }
+        </VirtualizationPoolDefinitionApi>
+      )
+    }
+    </VirtualizationPoolsActionApi>
+  );
+}
+

--- a/web/html/src/manager/virtualization/pools/edit/pools-edit.renderer.js
+++ b/web/html/src/manager/virtualization/pools/edit/pools-edit.renderer.js
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { PoolsEdit } from './pools-edit';
+import SpaRenderer from "core/spa/spa-renderer";
+
+export const renderer = (id, { serverId, actionChains, timezone, localTime, poolName }) => {
+  SpaRenderer.renderNavigationReact(
+    <PoolsEdit
+      serverId={serverId}
+      poolName={poolName}
+      actionChains={actionChains}
+      timezone={timezone}
+      localTime={localTime}
+    />,
+    document.getElementById(id),
+  );
+};
+

--- a/web/html/src/manager/virtualization/pools/list/pools-list.js
+++ b/web/html/src/manager/virtualization/pools/list/pools-list.js
@@ -247,6 +247,12 @@ export function PoolsList(props: Props) {
                           />
                         )
                       }
+                      <LinkButton
+                        title={t('Edit Pool')}
+                        className="btn-default btn-sm"
+                        icon="fa-edit"
+                        href={`/rhn/manager/systems/details/virtualization/storage/${props.serverId}/edit/${pool.name}`}
+                      />
                       <ModalButton
                         className="btn-default btn-sm"
                         title={t("Delete")}


### PR DESCRIPTION
## What does this PR change?

This adds actions to the virtual storage management page.

## GUI diff

Added buttons for the storage pool actions

![system_details_salt_virtual_pools](https://user-images.githubusercontent.com/397931/73186396-ed584c80-411f-11ea-9156-bbaeb5e5589e.png)

- [X] **DONE**

## Documentation
- [uyuni-docs](uyuni-project/uyuni-docs#52) PR or issue was created

- [X] **DONE**

## Test coverage
- Unit tests were added
- Cucumber tests were added

- [X] **DONE**

## Links

SUSE/spacewalk#7037

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
