### PR TITLE
Fix mgr daemon timer service

### DIFF
--- a/client/rhel/mgr-daemon/mgr-daemon.changes
+++ b/client/rhel/mgr-daemon/mgr-daemon.changes
@@ -1,3 +1,5 @@
+- fix systemd timer configuration on SLE12 (bsc#1142038)
+
 - rhnsd service was replaced by rhnsd timer (bsc#1138130)
 
 -------------------------------------------------------------------

--- a/client/rhel/mgr-daemon/mgr-daemon.spec
+++ b/client/rhel/mgr-daemon/mgr-daemon.spec
@@ -112,6 +112,11 @@ your machine, and runs any actions.
 %build
 make -f Makefile.rhnsd %{?_smp_mflags} CFLAGS="-pie -fPIE -Wl,-z,relro,-z,now %{optflags}" %{?is_deb:PLATFORM=deb}
 
+%if 0%{?suse_version} && 0%{?suse_version} <= 1315
+# systemd < v229 does not have RandomizedDelaySec keyword
+sed -i 's/RandomizedDelaySec/RandomSec/' rhnsd.timer
+%endif
+
 %install
 make -f Makefile.rhnsd install VERSION=%{version}-%{release} PREFIX=$RPM_BUILD_ROOT MANPATH=%{_mandir} INIT_DIR=$RPM_BUILD_ROOT/%{_initrddir} %{?is_deb:PLATFORM=deb} CONFIG_DIR=$RPM_BUILD_ROOT/%{_sysconfdir}/sysconfig/rhn
 


### PR DESCRIPTION
## What does this PR change?

On SLE12 we have systemd v228 which does not know about the optionRandomizedDelaySec in the timer configuration. This option exists only since v229 (SLE15).
With older systemd version the option was named RandomSec.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/8374
Tracks https://github.com/SUSE/spacewalk/pull/8421

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
