### PR TITLE
add missing task strings 

### DIFF
--- a/branding/java/code/src/com/redhat/rhn/branding/strings/StringResource_en_US.xml
+++ b/branding/java/code/src/com/redhat/rhn/branding/strings/StringResource_en_US.xml
@@ -2028,8 +2028,17 @@ tree will not be usable for autoinstalling.
       <trans-unit id="task.status.mgr-sync-refresh">
         <source>Refresh mgr-sync data</source>
       </trans-unit>
+      <trans-unit id="task.status.minion-action-chain-cleanup">
+        <source>Cleanup action-chains on minions</source>
+      </trans-unit>
       <trans-unit id="task.status.minion-action-executor">
         <source>Execute actions on minions</source>
+      </trans-unit>
+      <trans-unit id="task.status.notifications-cleanup">
+        <source>Cleanup notifications</source>
+      </trans-unit>
+      <trans-unit id="task.status.minion-checkin">
+        <source>Execute check-in for minions</source>
       </trans-unit>
       <trans-unit id="task.status.token-cleanup">
         <source>Cleanup channel tokens</source>

--- a/branding/spacewalk-branding.changes
+++ b/branding/spacewalk-branding.changes
@@ -1,3 +1,5 @@
+- add missing strings for tasks 
+
 -------------------------------------------------------------------
 Wed Jul 31 17:31:26 CEST 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?
this is already merged in 4.0  
**add description**

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
