### PR TITLE
Unaligned columns in software channel managers(BSC#1122559)

### DIFF
--- a/java/code/webapp/WEB-INF/pages/common/fragments/manage/managers.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/manage/managers.jspf
@@ -31,13 +31,13 @@
             </rl:selectablecolumn>
         </c:if>
         <c:if test="${not is_custom}">
-            <rl:column>
+            <rl:column headertext="">
                 <input type="checkbox" disabled="1"/>
             </rl:column>
         </c:if>
     </c:if>
     <c:if test='${current.disabled}'>
-        <rl:column>
+        <rl:column headertext="">
             <input type="checkbox" disabled="1" checked="1"/>
         </rl:column>
     </c:if>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Align selection column in software channel managers (bsc#1122559)
 - API Documentation: mention the shebang in the system.scheduleScriptRun doc strings (bsc#1138655)
 - Enable product detection for plain rhel systems (bsc#1136301)
 - For orphan contentsources, look also in susesccrepositoryauth to make sure they are not being referenced (bsc#1138275)


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rjmateus@gmail.com>

## What does this PR change?
Problem: Select in left menu "Software" => "Channels" => "All". Click on a channel, then select "Managers" tab. If the software channel is from a different organization then the logged-in user, the number of column headers are different from the number of column in the row. The result is un-aligned table content.
The column taglib only adds the header for the specific column if we set one of the following properties: "headertext" or "headerkey". In this case, we just want to add the 'th' for this column without any value, just to align the table content.

## GUI diff

Just re-align table in a corner case.
Before: ![1122559-before](https://user-images.githubusercontent.com/2996004/61779297-56b97480-adf8-11e9-957c-406c4651071e.png)

After: ![1122559-after](https://user-images.githubusercontent.com/2996004/61779331-646efa00-adf8-11e9-81f0-bab0937053f6.png)


- [x] **DONE**

## Documentation

- No documentation needed: Just improving the current behavior no changes for the user.
- [x] **DONE**

## Test coverage
- No tests: just an adjustment in the GUI (still need to run the all test in my machine)

- [ ] **DONE**


## Links

Fixes https://github.com/SUSE/spacewalk/issues/6873

Relevant branches (GitHub automatic links expected below):
 - Manager-4.0: https://github.com/SUSE/spacewalk/pull/8835

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed (re-run changelog_test is needed) 

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
