### PR TITLE
Improve package states buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ java/*.txt
 java/*.out
 java/test-results
 java/**/*.iml
+javabuild/checkstyle.cache.src
 thrift/gen-*
 search-server/spacewalk-search/.classpath
 search-server/spacewalk-search/.project
@@ -55,6 +56,7 @@ web/html/bootstrap/
 web/rpm-build
 web/rhn-web-*.tar.gz
 sqlnet.log
+testsuite/.rakeTasks
 backend/reports
 backend/satellite_tools/spacewalk-repo-syncc
 node_modules
@@ -70,3 +72,6 @@ out/
 java/buildconf/checkstyle.cache.src
 reports/
 *.mypy*
+
+# Python
+venv/

--- a/java/code/src/com/suse/manager/webui/templates/minion/packages.jade
+++ b/java/code/src/com/suse/manager/webui/templates/minion/packages.jade
@@ -4,8 +4,14 @@ include ./minion-header.jade
 
 script(type='text/javascript').
     window.csrfToken = "#{csrf_token}";
-    window.serverId = "#{server.id}";
 
 script(type='text/javascript').
     spaImportReactPage('minion/packages/package-states')
-        .then(function(module) { module.renderer('package-states')});
+        .then(function(module) {
+            module.renderer(
+                'package-states',
+                {
+                    serverId: "#{server.id}"
+                }
+            )
+        })

--- a/testsuite/features/secondary/min_salt_software_states.feature
+++ b/testsuite/features/secondary/min_salt_software_states.feature
@@ -45,7 +45,7 @@ Feature: Salt package states
     Then I should see a "milkyway-dummy" text
     And "milkyway-dummy" should be installed on "sle-minion"
     And I change the state of "milkyway-dummy" to "Removed" and ""
-    Then I should see a "1 Changes" text
+    Then I should see a "1 Change" text
     And I click save
     Then I wait until I see "Package states have been saved." text
     And I click apply
@@ -60,7 +60,7 @@ Feature: Salt package states
     Then I should see a "milkyway-dummy" text
     And "milkyway-dummy" should not be installed on "sle-minion"
     And I change the state of "milkyway-dummy" to "Installed" and ""
-    Then I should see a "1 Changes" text
+    Then I should see a "1 Change" text
     And I click save
     Then I wait until I see "Package states have been saved." text
     And I click apply
@@ -75,7 +75,7 @@ Feature: Salt package states
     Then I should see a "virgo-dummy" text
     And "virgo-dummy-1.0" should be installed on "sle-minion"
     And I change the state of "virgo-dummy" to "Installed" and "Any"
-    Then I should see a "1 Changes" text
+    Then I should see a "1 Change" text
     And I click save
     Then I wait until I see "Package states have been saved." text
     And I click apply
@@ -90,7 +90,7 @@ Feature: Salt package states
     Then I should see a "andromeda-dummy" text
     And "andromeda-dummy-1.0" should be installed on "sle-minion"
     And I change the state of "andromeda-dummy" to "Installed" and "Latest"
-    Then I should see a "1 Changes" text
+    Then I should see a "1 Change" text
     And I click save
     Then I wait until I see "Package states have been saved." text
     And I click apply

--- a/testsuite/features/secondary/min_state_config_channel.feature
+++ b/testsuite/features/secondary/min_state_config_channel.feature
@@ -46,7 +46,8 @@ Feature: State Configuration channels
     When I am on the Systems overview page of this "sle-minion"
     And I follow "States" in the content area
     And I follow "Configuration Channels" in the content area
-    And I click on "Search"
+    And I follow "Search" in element "config-channels-tabs"
+    And I click on "Search" in element "search-row"
     Then I should see a "My State Channel" text
     And I should see a "statechannel" text
     And I should see a "statechannel2" text
@@ -74,7 +75,8 @@ Feature: State Configuration channels
     When I am on the Systems overview page of this "sle-minion"
     And I follow "States" in the content area
     And I follow "Configuration Channels" in the content area
-    And I click on "Search"
+    And I follow "Search" in element "config-channels-tabs"
+    And I click on "Search" in element "search-row"
     Then I should see a "My State Channel" text
     And I should see a "statechannel3" text
     And I check "statechannel3-cbox"

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -148,7 +148,7 @@ end
 # Click on a button which appears inside of <div> with
 # the given "id"
 When(/^I click on "([^"]*)" in element "([^"]*)"$/) do |text, element_id|
-  within(:xpath, "//div[@id=\"#{element_id}\"]") do
+  within(:xpath, "//div[@id='#{element_id}']") do
     click_button_and_wait(text, match: :first)
   end
 end
@@ -191,7 +191,7 @@ end
 # Click on a link which appears inside of <div> with
 # the given "id"
 When(/^I follow "([^"]*)" in element "([^"]*)"$/) do |arg1, arg2|
-  within(:xpath, "//div[@id=\"#{arg2}\"]") do
+  within(:xpath, "//div[@id='#{arg2}']") do
     step %(I follow "#{arg1}")
   end
 end

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -608,6 +608,7 @@ When(/^I refresh page until I do not see "(.*?)" hostname as text$/) do |minion|
 end
 
 When(/^I list packages with "(.*?)"$/) do |str|
+  find(:xpath, "//a[@href='#search']").click
   find('input#package-search').set(str)
   find('button#search').click
 end

--- a/web/html/src/components/config-channels.js
+++ b/web/html/src/components/config-channels.js
@@ -276,7 +276,13 @@ class ConfigChannels extends React.Component {
         {elements.length > 0 ? elements :
             <tr>
                 <td colSpan="2">
-                    <div>{t("No states assigned. Use search to find and assign states.")}</div>
+                    <div>
+                      {
+                        this.state.view === "changes"
+                        ? t("No current changes.")
+                        : t("No states assigned. Use search to find and assign states.")
+                      }
+                    </div>
                 </td>
             </tr>
         }
@@ -285,11 +291,9 @@ class ConfigChannels extends React.Component {
   }
 
   setView(view) {
-    return event => {
-      this.setState({
-          view: view
-      });
-    }
+    this.setState({
+      view: view
+    });
   }
 
   showPopUp(channel) {
@@ -364,21 +368,54 @@ class ConfigChannels extends React.Component {
       <Messages items={this.state.messages}/>
       : null;
 
+    const headerTabs = () => {
+      const length = this.state.changed.size;
+      let changesText = t('Changes');
+      if (length === 1) {
+        changesText = t('1 Change');
+      } else if (length > 1) {
+        changesText = length + ' ' + t('Changes');
+      }
+
+      return (
+        <div className="spacewalk-content-nav">
+          <ul className="nav nav-tabs">
+            <li className={this.state.view === 'search' || this.state.view === '' ? 'active' : ''}>
+              <a href='#search' onClick={() => this.setView('search')}>{t('Search')}</a>
+            </li>
+            <li className={this.state.view === 'changes' ? 'active' : ''}>
+              <a href='#changes' onClick={() => this.setView('changes')}>{changesText}</a>
+            </li>
+            <li className={this.state.view === 'system' ? 'active' : ''}>
+              <a href='#system' onClick={() => this.setView('system')}>{t('System')}</a>
+            </li>
+          </ul>
+        </div>)
+    };
+
+
     return (
       <span>
         {messages}
         <InnerPanel title={t("Configuration Channels")} icon="spacewalk-icon-salt-add" buttons={buttons}>
-          { !this.state.rank &&
-            <PanelRow className="input-group">
-              <TextField id="search-field" value={this.state.filter} placeholder={t("Search in configuration channels")} onChange={this.onSearchChange} onPressEnter={this.search}/>
-              <span className="input-group-btn">
-                <AsyncButton id="search-states" text={t("Search")} action={this.search} />
-                <button id="system-btn" className={this.state.view == "system" ? "btn btn-info" : "btn btn-default"} onClick={this.setView("system")}>{t("System")}</button>
-                <button id="changes-btn" className={this.state.view == "changes" ? "btn btn-info" : "btn btn-default"} disabled={this.state.changed.size == 0} onClick={this.setView("changes")}>
-                  {this.state.changed.size > 0 ? this.state.changed.size : t("No")} {t("Changes")}
-                </button>
-              </span>
-            </PanelRow>
+
+          { !this.state.rank && headerTabs()}
+
+          {
+            !this.state.rank && this.state.view === "search" &&
+            <div className={"row"}>
+              <div className={"col-md-5"}>
+                <div style={{paddingBottom: 0.7 + 'em'}}>
+                  <div className="input-group">
+                    <TextField id="search-field" value={this.state.filter} placeholder={t("Search in configuration channels")}
+                               onChange={this.onSearchChange} onPressEnter={this.search} />
+                    <span className="input-group-btn">
+                      <AsyncButton id="search-states" text={t("Search")} action={this.search} />
+                     </span>
+                  </div>
+                </div>
+              </div>
+            </div>
           }
 
           { this.state.rank ?

--- a/web/html/src/components/config-channels.js
+++ b/web/html/src/components/config-channels.js
@@ -378,7 +378,7 @@ class ConfigChannels extends React.Component {
       }
 
       return (
-        <div className="spacewalk-content-nav">
+        <div className="spacewalk-content-nav" id="config-channels-tabs">
           <ul className="nav nav-tabs">
             <li className={this.state.view === 'search' || this.state.view === '' ? 'active' : ''}>
               <a href='#search' onClick={() => this.setView('search')}>{t('Search')}</a>
@@ -403,7 +403,7 @@ class ConfigChannels extends React.Component {
 
           {
             !this.state.rank && this.state.view === "search" &&
-            <div className={"row"}>
+            <div className={"row"} id={"search-row"}>
               <div className={"col-md-5"}>
                 <div style={{paddingBottom: 0.7 + 'em'}}>
                   <div className="input-group">

--- a/web/html/src/components/fields.js
+++ b/web/html/src/components/fields.js
@@ -20,7 +20,7 @@ class TextField extends React.Component {
         const defaultClassName = this.props.className ? this.props.className : 'form-control';
 
         return (<input id={this.props.id} className={defaultClassName}
-                    value={this.props.defaultValue}
+                    value={this.props.value}
                     placeholder={this.props.placeholder}
                     type="text"
                     onChange={(e) => this.props.onChange(e)}

--- a/web/html/src/manager/minion/index.js
+++ b/web/html/src/manager/minion/index.js
@@ -2,5 +2,5 @@ export default {
   'minion/config-channels/minion-config-channels': () => import('./config-channels/minion-config-channels'),
   'minion/formula/minion-formula': () => import('./formula/minion-formula.renderer'),
   'minion/formula/minion-formula-selection': () => import('./formula/minion-formula-selection.renderer'),
-  'minion/packages/package-states': () => import('./packages/package-states')
+  'minion/packages/package-states': () => import('./packages/package-states.renderer')
 }

--- a/web/html/src/manager/minion/packages/package-states.js
+++ b/web/html/src/manager/minion/packages/package-states.js
@@ -1,13 +1,13 @@
 // @flow
 import React, {useEffect, useState, useRef} from "react";
 import {useImmer} from 'use-immer';
-import Buttons from "components/buttons";
+import * as Buttons from "components/buttons";
 import {InnerPanel} from 'components/panels/InnerPanel';
 import Fields from "components/fields";
 import {Messages} from "components/messages";
 import withPageWrapper from "components/general/with-page-wrapper";
 import {hot} from 'react-hot-loader';
-import {showErrorToastr} from "../../../components/toastr/toastr";
+import {showErrorToastr} from "components/toastr/toastr";
 import usePackageStatesApi from "./use-package-states.api";
 import type {
   ChangesMapObject,

--- a/web/html/src/manager/minion/packages/package-states.js
+++ b/web/html/src/manager/minion/packages/package-states.js
@@ -3,7 +3,6 @@ import React, {useEffect, useState, useRef} from "react";
 import {useImmer} from 'use-immer';
 import Buttons from "components/buttons";
 import {InnerPanel} from 'components/panels/InnerPanel';
-import {Select} from 'components/input/Select';
 import Fields from "components/fields";
 import {Messages} from "components/messages";
 import withPageWrapper from "components/general/with-page-wrapper";
@@ -21,7 +20,7 @@ import * as packageHelpers from "./package-utils";
 const AsyncButton = Buttons.AsyncButton;
 const TextField = Fields.TextField;
 
-type PropsType = {serverId: string};
+type PropsType = { serverId: string };
 type ViewType = "search" | "system" | "changes";
 
 const PackageStates = ({serverId}: PropsType) => {
@@ -47,7 +46,7 @@ const PackageStates = ({serverId}: PropsType) => {
   }, [changed, packageStates, searchResults, view]);
 
   useEffect(() => {
-    if(view === "search") {
+    if (view === "search") {
       triggerSearch();
     }
   }, [view])
@@ -109,11 +108,9 @@ const PackageStates = ({serverId}: PropsType) => {
     }
   };
 
-  // Use this one only for Select's:
-  // https://github.com/Semantic-Org/Semantic-UI-React/issues/638#issuecomment-252035750
   const handleStateChangeEvent = (original) => {
-    return (event, data): void => {
-      const newPackageStateId: OptionalValue = packageHelpers.selectValue2PackageState(parseInt(data));
+    return (event): void => {
+      const newPackageStateId: OptionalValue = packageHelpers.selectValue2PackageState(parseInt(event.target.value));
       const newPackageConstraintId: OptionalValue =
         (newPackageStateId === packageHelpers.INSTALLED ? packageHelpers.LATEST : original.versionConstraintId);
       addChanged(
@@ -124,11 +121,9 @@ const PackageStates = ({serverId}: PropsType) => {
     }
   };
 
-  // Use this one only for Select's:
-  // https://github.com/Semantic-Org/Semantic-UI-React/issues/638#issuecomment-252035750
   const handleConstraintChangeEvent = (original) => {
-    return (event, data): void => {
-      const newPackageConstraintId: OptionalValue = packageHelpers.selectValue2VersionConstraints(parseInt(data));
+    return (event): void => {
+      const newPackageConstraintId: OptionalValue = packageHelpers.selectValue2VersionConstraints(parseInt(event.target.value));
       const key = packageHelpers.packageStateKey(original);
       const currentState: PackagesObject = changed[key];
       const currentPackageStateId: OptionalValue =
@@ -205,9 +200,9 @@ const PackageStates = ({serverId}: PropsType) => {
   const buttons = [
     <AsyncButton id="save" action={save} text={t("Save")} disabled={!isApplyButtonDisabled}
                  key={"save"}/>,
-    <span {...(isApplyButtonDisabled) ? {title: t("Please save all your changes before applying!")}: {}}>
+    <span {...(isApplyButtonDisabled) ? {title: t("Please save all your changes before applying!")} : {}}>
       <AsyncButton id="apply" action={applyPackageState} text={t("Apply changes")}
-                 disabled={isApplyButtonDisabled} key={"apply"}
+                   disabled={isApplyButtonDisabled} key={"apply"}
       />
     </span>
   ];
@@ -222,7 +217,7 @@ const PackageStates = ({serverId}: PropsType) => {
     }
 
     return (
-      <div className="spacewalk-content-nav">
+      <div className="spacewalk-content-nav" id="package-states-tabs">
         <ul className="nav nav-tabs">
           <li className={view === 'search' || view === '' ? 'active' : ''}>
             <a href='#search' onClick={() => changeTabUrl('search')}>{t('Search')}</a>
@@ -239,15 +234,15 @@ const PackageStates = ({serverId}: PropsType) => {
 
   const renderSearchBar = () => {
     return (
-      <div className={"row"}>
+      <div className={"row"} id={"search-row"}>
         <div className={"col-md-5"}>
           <div style={{paddingBottom: 0.7 + 'em'}}>
             <div className="input-group">
               <TextField id="package-search" value={filter} placeholder={t("Search package")}
                          onChange={onSearchChange} onPressEnter={triggerSearch} className="form-control"/>
               <span className="input-group-btn">
-          <AsyncButton id="search" text={t("Search")} action={search} ref={searchRef} key={"searchButton"}/>
-        </span>
+                <AsyncButton id="search" text={t("Search")} action={search} ref={searchRef} key={"searchButton"}/>
+              </span>
             </div>
           </div>
         </div>
@@ -293,13 +288,13 @@ const PackageStates = ({serverId}: PropsType) => {
 
     if (currentState.packageStateId === packageHelpers.INSTALLED) {
       versionConstraintSelect =
-        <Select id={currentState.name + "-version-constraint"}
+        <select id={currentState.name + "-version-constraint"}
                 className="form-control"
                 value={packageHelpers.versionConstraints2selectValue(currentState.versionConstraintId)}
                 onChange={handleConstraintChangeEvent(row.original)}>
           <option value="0">{t("Latest")}</option>
           <option value="1">{t("Any")}</option>
-        </Select>;
+        </select>;
     }
 
     const key = packageHelpers.packageStateKey(currentState);
@@ -311,7 +306,7 @@ const PackageStates = ({serverId}: PropsType) => {
     return (
       <div className="row">
         <div className={"col-md-3"}>
-          <Select key={currentState.name}
+          <select key={currentState.name}
                   id={currentState.name + "-pkg-state"}
                   className="form-control"
                   value={packageHelpers.packageState2selectValue(currentState.packageStateId)}
@@ -319,7 +314,7 @@ const PackageStates = ({serverId}: PropsType) => {
             <option value="-1">{t("Unmanaged")}</option>
             <option value="0">{t("Installed")}</option>
             <option value="1">{t("Removed")}</option>
-          </Select>
+          </select>
         </div>
         <div className={"col-md-3"}>
           {versionConstraintSelect}

--- a/web/html/src/manager/minion/packages/package-states.js
+++ b/web/html/src/manager/minion/packages/package-states.js
@@ -21,26 +21,22 @@ import * as packageHelpers from "./package-utils";
 const AsyncButton = Buttons.AsyncButton;
 const TextField = Fields.TextField;
 
-const action = {
-  SAVE: "Save",
-  APPLY: "Apply",
-  GETSERVERPACKAGES: "GetServerPackages",
-  SEARCH: "Search"
-};
+type PropsType = {serverId: string};
+type ViewType = "search" | "system" | "changes";
 
-const PackageStates = ({serverId}) => {
+const PackageStates = ({serverId}: PropsType) => {
   const [filter, setFilter] = useState<string>("");
-  const [view, setView] = useState<string>("system");
+  const [view, setView] = useState<ViewType>("system");
   const [tableRows, setTableRows] = useState<Array<PackagesObject>>([]);
   const [changed, setChanged] = useImmer<ChangesMapObject>({});
   const searchRef = useRef<AsyncButton>();
 
   const {
-    messages, fetchPackageStatesApi, packageStates, searchResults
+    messages, onActionPackageStatesApi, packageStates, searchResults
   } = usePackageStatesApi();
 
   useEffect(() => {
-    fetchPackageStatesApi(action.GETSERVERPACKAGES, serverId)
+    onActionPackageStatesApi({type: "GetServerPackages", serverId})
       .catch((error => {
         showErrorToastr(error, {autoHide: false});
       }));
@@ -49,6 +45,12 @@ const PackageStates = ({serverId}) => {
   useEffect(() => {
     generateTableData();
   }, [changed, packageStates, searchResults, view]);
+
+  useEffect(() => {
+    if(view === "search") {
+      triggerSearch();
+    }
+  }, [view])
 
   function addChanged(original: Package, newPackageStateId: OptionalValue, newVersionConstraintId: OptionalValue): void {
     const key = packageHelpers.packageStateKey(original);
@@ -78,7 +80,7 @@ const PackageStates = ({serverId}) => {
   }
 
   const applyPackageState = () => {
-    fetchPackageStatesApi(action.APPLY, serverId)
+    onActionPackageStatesApi({type: "Apply", serverId})
       .then(data => {
         console.log("apply action queued:" + data);
       }).catch(error => {
@@ -87,15 +89,7 @@ const PackageStates = ({serverId}) => {
   };
 
   const save = (): Promise<any> => {
-    const toSave = [];
-    for (const state in changed) {
-      if (changed.hasOwnProperty(state) && typeof changed[state].value === 'object') {
-        toSave.push(changed[state].value)
-      } else {
-        console.log("Cannot save empty object.")
-      }
-    }
-    return fetchPackageStatesApi(action.SAVE, serverId, "", toSave, changed)
+    return onActionPackageStatesApi({type: "Save", serverId, changed})
       .then(() => {
         setView("system");
         setChanged(() => {
@@ -156,7 +150,7 @@ const PackageStates = ({serverId}) => {
   };
 
   const search = (): Promise<any> => {
-    return fetchPackageStatesApi(action.SEARCH, serverId, filter)
+    return onActionPackageStatesApi({type: "Search", serverId, filter})
       .then(() => {
         setView("search");
       })
@@ -211,7 +205,7 @@ const PackageStates = ({serverId}) => {
   const buttons = [
     <AsyncButton id="save" action={save} text={t("Save")} disabled={!isApplyButtonDisabled}
                  key={"save"}/>,
-    <span {...(isApplyButtonDisabled) ? {title: t("Please always save your changes before applying!")}: {}}>
+    <span {...(isApplyButtonDisabled) ? {title: t("Please save all your changes before applying!")}: {}}>
       <AsyncButton id="apply" action={applyPackageState} text={t("Apply changes")}
                  disabled={isApplyButtonDisabled} key={"apply"}
       />
@@ -281,7 +275,11 @@ const PackageStates = ({serverId}) => {
       {elements.length > 0 ? elements :
         <tr>
           <td colSpan="2">
-            <div>{t("No package states.")}</div>
+            {
+              view === "changes"
+                ? t("No current changes.")
+                : t("No package states.")
+            }
           </td>
         </tr>
       }
@@ -355,4 +353,4 @@ const PackageStates = ({serverId}) => {
   );
 };
 
-export default hot(module)(withPageWrapper(PackageStates));
+export default hot(module)(withPageWrapper<PropsType>(PackageStates));

--- a/web/html/src/manager/minion/packages/package-states.renderer.js
+++ b/web/html/src/manager/minion/packages/package-states.renderer.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import PackageStates from './package-states';
+import SpaRenderer from "core/spa/spa-renderer";
+
+export const renderer = (id, {serverId}) => {
+  SpaRenderer.renderNavigationReact(
+    <PackageStates
+      serverId={serverId}
+    />,
+    document.getElementById(id)
+  );
+};

--- a/web/html/src/manager/minion/packages/package-utils.js
+++ b/web/html/src/manager/minion/packages/package-utils.js
@@ -1,0 +1,59 @@
+//@flow
+import type {Package, OptionalValue} from "./package.type";
+
+export const UNMANAGED = {};
+export const INSTALLED: OptionalValue = {value: 0};
+export const REMOVED: OptionalValue = {value: 1};
+export const PURGED: OptionalValue = {value: 2};
+
+export const LATEST: OptionalValue = {value: 0};
+export const ANY: OptionalValue = {value: 1};
+
+export function selectValue2PackageState(value: number): OptionalValue {
+  switch (value) {
+    case -1:
+      return UNMANAGED;
+    case 0:
+      return INSTALLED;
+    case 1:
+      return REMOVED;
+    case 2:
+      return PURGED;
+    default:
+      return UNMANAGED;
+  }
+}
+
+export function packageState2selectValue(ps: OptionalValue): number {
+  return ps.value !== undefined ? ps.value : -1;
+}
+
+export function versionConstraints2selectValue(vc: OptionalValue): number {
+  return vc.value === undefined ? 1 : vc.value;
+}
+
+export function normalizePackageState(ps: OptionalValue): OptionalValue {
+  return selectValue2PackageState(packageState2selectValue(ps));
+}
+
+export function normalizePackageVersionConstraint(vc: OptionalValue): OptionalValue {
+  return selectValue2VersionConstraints(versionConstraints2selectValue(vc))
+}
+
+export function selectValue2VersionConstraints(value: number): OptionalValue {
+  switch (value) {
+    case 0:
+      return LATEST;
+    case 1:
+      return ANY;
+    default:
+      return LATEST;
+  }
+}
+
+export function packageStateKey(packageState: Package): string {
+  const version: string = (typeof packageState.version === "string") ? packageState.version : "null";
+  const epoch: string = (typeof packageState.epoch === "string") ? packageState.epoch : "null";
+  const release: string = (typeof packageState.release === "string" && packageState.release) ? packageState.release : "null";
+  return packageState.name + version + release + epoch + packageState.arch;
+}

--- a/web/html/src/manager/minion/packages/package.type.js
+++ b/web/html/src/manager/minion/packages/package.type.js
@@ -1,0 +1,24 @@
+// @flow
+
+export type OptionalValue = {
+  value?: number,
+}
+
+export type Package = {
+  arch: string,
+  name: string,
+  packageStateId: OptionalValue,
+  versionConstraintId: OptionalValue,
+  epoch?: string,
+  release?: string,
+  version?: string,
+}
+
+export type PackagesObject = {
+  original: Package,
+  value?: Package,
+}
+
+export type ChangesMapObject = {
+  [key: string]: PackagesObject
+}

--- a/web/html/src/manager/minion/packages/use-package-states.api.js
+++ b/web/html/src/manager/minion/packages/use-package-states.api.js
@@ -1,0 +1,129 @@
+//@flow
+import Network from "utils/network";
+import React, {useState} from "react";
+import {Utils as MessagesUtils} from "components/messages";
+import type {
+  ChangesMapObject,
+  Package,
+} from "./package.type";
+import * as packageHelpers from "./package-utils";
+
+const action = {
+  SAVE: "Save",
+  APPLY: "Apply",
+  GETSERVERPACKAGES: "GetServerPackages",
+  SEARCH: "Search"
+};
+
+const usePackageStatesApi = () => {
+  const [messages, setMessages] = useState("");
+  const [packageStates, setPackageStates] = useState<Array<Package>>([]);
+  const [searchResults, setSearchResults] = useState<Array<Package>>([]);
+
+  function fetchPackageStatesApi(apiAction: string,
+                                 serverId: string,
+                                 filter: string = "",
+                                 toSave: Array<Package> = [],
+                                 changed: ChangesMapObject = {}): Promise<any> {
+    if (apiAction === action.SAVE) {
+      console.log("Save posted");
+      return Network.post(
+        "/rhn/manager/api/states/packages/save",
+        JSON.stringify({
+          sid: serverId,
+          packageStates: toSave
+        }),
+        "application/json"
+      ).promise
+        .then((data: Array<Package>) => {
+            console.log("Save success: (data in next line)");
+            console.log(data);
+            updateAfterSave(data, changed);
+            setMessages(MessagesUtils.info(t('Package states have been saved.')));
+          }
+        )
+    } else if (apiAction === action.APPLY) {
+      console.log("Apply posted");
+      return Network.post(
+        "/rhn/manager/api/states/apply",
+        JSON.stringify({
+          id: serverId,
+          type: "SERVER",
+          states: ["packages"]
+        }),
+        "application/json"
+      ).promise
+        .then((data) => {
+          console.log("Apply success");
+          setMessages(MessagesUtils.info(<span>{t("Applying the packages states has been ")}
+            <a href={"/rhn/systems/details/history/Event.do?sid=" + serverId + "&aid=" + data}>{t("scheduled")}</a>
+              </span>));
+        });
+    } else if (apiAction === action.GETSERVERPACKAGES) {
+      console.log("Getserverpackages executed");
+      return Network.get(
+        "/rhn/manager/api/states/packages?sid=" + serverId
+      ).promise
+        .then((data: Array<Package>) => {
+          console.log("Successfully got server packages.");
+          updateAfterServerGetPackages(data);
+        });
+    } else if (apiAction === action.SEARCH) {
+      console.log("Search executed");
+      return Network.get(
+        "/rhn/manager/api/states/packages/match?sid=" + serverId + "&target=" + filter
+      ).promise
+        .then((data: Array<Package>) => {
+          console.log("Search Results:");
+          console.log(data);
+          updateAfterSearch(data);
+          return null;
+        })
+    }
+    return Promise.reject();
+  }
+
+  function updateAfterSearch(serverSearchResults: Array<Package>): void {
+    const newSearchResults = serverSearchResults.map((state) => {
+      state.packageStateId = packageHelpers.normalizePackageState(state.packageStateId);
+      state.versionConstraintId = packageHelpers.normalizePackageVersionConstraint(state.versionConstraintId);
+      return state;
+    });
+    setSearchResults(newSearchResults);
+  }
+
+  function updateAfterServerGetPackages(serverPackages: Array<Package>): void {
+    const newPackageStates = serverPackages.map(state => {
+      state.packageStateId = packageHelpers.normalizePackageState(state.packageStateId);
+      state.versionConstraintId = packageHelpers.normalizePackageVersionConstraint(state.versionConstraintId);
+      return state;
+    });
+    setPackageStates(newPackageStates);
+  }
+
+  function updateAfterSave(newServerPackages: Array<Package>, changed: ChangesMapObject): void {
+    const newPackageStates: any = newServerPackages.map((state: Package) => {
+      state.packageStateId = packageHelpers.normalizePackageState(state.packageStateId);
+      return state;
+    });
+    const newSearchResults =
+      searchResults.map<Package>((state: Package) => {
+        const key = packageHelpers.packageStateKey(state);
+        const tempchanged = changed[key];
+        if (tempchanged !== undefined && typeof tempchanged.value === 'object') {
+          return tempchanged.value;
+        } else {
+          return state;
+        }
+      });
+    setPackageStates(newPackageStates);
+    setSearchResults(newSearchResults);
+  }
+
+  return {
+    messages: messages, packageStates, searchResults, fetchPackageStatesApi
+  }
+
+};
+
+export default usePackageStatesApi;

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,4 +1,5 @@
 - Fix sorting issues on content filter list page (bsc#1145591)
+- Improve the UI of the salt packages state and configuration channels page to use tabs instead
 - Remove/change text on edit filters for clp (bsc#1145608)
 - Redirect to project when canceling creating a filter (bsc#1145750)
 - Better visualization of the filters attached to a CLM Project. Allow/deny are now split


### PR DESCRIPTION
## What does this PR change?

The searchbar in System --> States --> Packages was remodeled.

## GUI diff

Before: 

![41647517-e94014b0-7476-11e8-9744-18839affd93a](https://user-images.githubusercontent.com/7080830/41833401-740d0788-7850-11e8-9c72-450c106a1fcf.png)

After:

![Tab-Layout](https://user-images.githubusercontent.com/15035141/63334540-ed1b8000-c33b-11e9-852b-da7cd99cc0ad.png)

- [X] **DONE**

## Documentation
- No documentation needed: No docs for the exact GUI usage are existing, so none were created.

- [X] **DONE**

## Test coverage
- No tests: Only minor GUI fixes

- [X] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/5002

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint" (Test skipped, there are no changes to test)		 
- [ ] Re-run test "spacecmd_unittests"
