### PR TITLE
remove duplicate info message when change system properties (bsc#1111371)

### DIFF
--- a/branding/java/code/src/com/redhat/rhn/branding/strings/StringResource_en_US.xml
+++ b/branding/java/code/src/com/redhat/rhn/branding/strings/StringResource_en_US.xml
@@ -1814,7 +1814,7 @@ available for this kickstart profile to function properly.
         <source>System &lt;strong&gt;{0}&lt;/strong&gt; has a pending autoinstallation scheduled.</source>
       </trans-unit>
       <trans-unit id="sdc.details.edit.propertieschangedupdate">
-        <source>System properties changed for &lt;strong&gt;{0}&lt;/strong&gt;. &lt;br/&gt; &lt;strong&gt;{0}&lt;/strong&gt; will be &lt;strong&gt;fully updated&lt;/strong&gt; in accordance with Auto Patch Update preference.</source>
+        <source>&lt;strong&gt;{0}&lt;/strong&gt; will be &lt;strong&gt;fully updated&lt;/strong&gt; in accordance with Auto Patch Update preference.</source>
       </trans-unit>
       <trans-unit id="api.errata.invaliderrata">
         <source>Invalid patch: {0}</source>

--- a/branding/spacewalk-branding.changes
+++ b/branding/spacewalk-branding.changes
@@ -1,3 +1,4 @@
+- Remove duplicate information message when changing system properties (bsc#1111371)
 - Fix big formula checkbox not supported in Firefox
 - Update help URLs in the UI
 

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -6244,7 +6244,7 @@ Follow this url to see the full list of inactive systems:
         </context-group>
       </trans-unit>
       <trans-unit id="sdc.details.edit.propertieschangedupdate">
-        <source>System properties changed for &lt;strong&gt;{0}&lt;/strong&gt;. &lt;br/&gt; &lt;strong&gt;{0}&lt;/strong&gt; will be &lt;strong&gt;fully updated&lt;/strong&gt; in accordance with Auto Errata Update preference.</source>
+        <source>&lt;strong&gt;{0}&lt;/strong&gt; will be &lt;strong&gt;fully updated&lt;/strong&gt; in accordance with Auto Errata Update preference.</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/details/Edit.do</context>
           <context context-type="paramnotes">{0} - name of a system ex: highwind</context>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Remove duplicate information message when changing system properties (bsc#1111371)
 - Align selection column in software channel managers (bsc#1122559)
 - API Documentation: mention the shebang in the system.scheduleScriptRun doc strings (bsc#1138655)
 - Enable product detection for plain rhel systems (bsc#1136301)


### PR DESCRIPTION
## What does this PR change?
When you modify flag Auto Patch Update: Automatic application of relevant patches and save the changes, some information will be displayed in duplicate. 
This PR removes duplicate information from the info message when auto patch update is selected.

## GUI diff

Remove duplicated information from info message.

Before:
![1111371-before](https://user-images.githubusercontent.com/2996004/61868515-6fe22400-aed1-11e9-9357-ff05bed4f1df.png)

After:
![1111371-after](https://user-images.githubusercontent.com/2996004/61868528-7a9cb900-aed1-11e9-8481-ec69e52953da.png)


- [x] **DONE**

## Documentation
- No documentation needed: improve information message

- [X] **DONE**

## Test coverage
- No tests: just an adjustment in information message

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/6075
Tracks 
Manager-4.0 https://github.com/SUSE/spacewalk/pull/8855


- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
