### PR TITLE
Use openSUSE 15.0 client tools for all openSUSE 15.X releases

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -615,25 +615,27 @@ checksum = sha256
 base_channels = opensuse_leap15_1-%(arch)s
 repo_url = http://download.opensuse.org/update/leap/15.1/non-oss/
 
+# This is expected. openSUSE Leap 15.0 client tools are valid for all openSUSE Leap 15.X releases
 [opensuse_leap15_1-uyuni-client]
 name     = Uyuni Client Tools for %(base_channel_name)s
 archs    = x86_64
 base_channels = opensuse_leap15_1-%(arch)s
 checksum = sha256
-gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.1/repodata/repomd.xml.key
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.1/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
 
+# This is expected. openSUSE Leap 15.0 client tools are valid for all openSUSE Leap 15.X releases
 [opensuse_leap15_1-uyuni-client-devel]
 name     = Uyuni Client Tools for %(base_channel_name)s (Development)
 archs    = x86_64
 base_channels = opensuse_leap15_1-%(arch)s
 checksum = sha256
-gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.1/repodata/repomd.xml.key
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.1/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
 
 [sles12-sp3-uyuni-client]
 name     = Uyuni Client Tools for SLES12 SP3

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,5 @@
+- Use the same client tools for openSUSE Leap 15.0 for all openSUSE Leap
+  15.X releases.
 - hostname-rename: change hostname in cobbler db and autoinst data
 - Adds support for Ubuntu and Debian channels to spacewalk-common-channels.
 


### PR DESCRIPTION
## What does this PR change?

Use openSUSE 15.0 client tools for all openSUSE 15.X releases

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: spacewalk-common-channels is not covered.

- [x] **DONE**

## Test coverage
- No tests: spacewalk-common-channels is not covered.

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
