### PR TITLE
Add package prerequires to avoid issues when users still don't exist

### DIFF
--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Prerequire salt package to avoid not existing user issues
 - Remove duplicate information message when changing system properties (bsc#1111371)
 - Align selection column in software channel managers (bsc#1122559)
 - API Documentation: mention the shebang in the system.scheduleScriptRun doc strings (bsc#1138655)

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -191,6 +191,8 @@ BuildRequires:  tomcat6
 BuildRequires:  tomcat6-lib
 %endif # 0{?suse_version}
 %endif # 0{?fedora} || 0{?rhel} >= 7
+Requires(pre):  salt
+Requires(pre):  susemanager
 %if 0%{?fedora} || 0%{?rhel} >=7
 Requires:       apache-commons-cli
 Requires:       apache-commons-codec


### PR DESCRIPTION
## What does this PR change?

This PR prevents the `spacewalk-java` package to be installed before `salt` and `susemanager` packages are already installed. This way, the users & groups created by those packages will be available when `spacewalk-java` is being installed.

This would prevent issues we already faced at Uyuni stable installation with latest changes on Leap 42.3 which produces issues when installing the `uyuni-pattern` due the users / groups are not existing at the time `spacewalk-java` is being installed.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **change on specfile**

- [x] **DONE**

## Test coverage
- No tests: **change on specfile**

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
