### PR TITLE
Support partly patched CVEs in CVE audit (bsc#1137229)

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/cve_audit_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/cve_audit_queries.xml
@@ -61,6 +61,9 @@
         rhnErrata.advisory as errata_advisory,
         rhnErrataPackage.package_id,
         rhnPackageName.name as package_name,
+        rhnPackageEVR.epoch as package_epoch,
+        rhnPackageEVR.version as package_version,
+        rhnPackageEVR.release as package_release,
         (SELECT DISTINCT 1
             FROM rhnServerPackage sp, rhnPackageEVR sevr, rhnPackageUpgradeArchCompat puac
             WHERE rhnServerPackage.server_id = sp.server_id
@@ -123,6 +126,9 @@
         CAST(NULL AS CHAR) AS errata_advisory,
         CAST(NULL AS INTEGER) AS package_id,
         CAST(NULL AS CHAR) AS package_name,
+        CAST(NULL AS CHAR) AS package_epoch,
+        CAST(NULL AS CHAR) AS package_version,
+        CAST(NULL AS CHAR) AS package_release,
         CAST(NULL AS INTEGER) AS package_installed,
         CAST(NULL AS INTEGER) AS channel_id,
         CAST(NULL AS CHAR) AS channel_name,
@@ -158,6 +164,9 @@
         rhnErrata.advisory as errata_advisory,
         rhnErrataPackage.package_id,
         rhnPackageName.name as package_name,
+        rhnPackageEVR.epoch as package_epoch,
+        rhnPackageEVR.version as package_version,
+        rhnPackageEVR.release as package_release,
         (SELECT DISTINCT 1
             FROM suseImageInfoPackage iip, rhnPackageEVR sevr, rhnPackageUpgradeArchCompat puac
             WHERE suseImageInfoPackage.image_info_id = iip.image_info_id
@@ -220,6 +229,9 @@
         CAST(NULL AS CHAR) AS errata_advisory,
         CAST(NULL AS INTEGER) AS package_id,
         CAST(NULL AS CHAR) AS package_name,
+        CAST(NULL AS CHAR) AS package_epoch,
+        CAST(NULL AS CHAR) AS package_version,
+        CAST(NULL AS CHAR) AS package_release,
         CAST(NULL AS INTEGER) AS package_installed,
         CAST(NULL AS INTEGER) AS channel_id,
         CAST(NULL AS CHAR) AS channel_name,

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageEvr.java
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageEvr.java
@@ -119,7 +119,7 @@ public class PackageEvr implements Comparable {
      * {@inheritDoc}
      */
     public boolean equals(Object obj) {
-        if (obj == null || !(obj instanceof PackageEvr)) {
+        if (!(obj instanceof PackageEvr)) {
             return false;
         }
 
@@ -142,6 +142,7 @@ public class PackageEvr implements Comparable {
     /**
      * {@inheritDoc}
      */
+    @Override
     public int compareTo(Object o) {
         // This method mirrors the perl function RHN::Manifest::vercmp
         // There is another perl function, RHN::DB::Package::vercmp which

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Support partly patched CVEs in CVE audit (bsc#1137229)
 - UI render without error if salt-formulas system folders are unreachable (bsc#1142309)
 - Add susemanager as prerequired for spacewalk-java
 - Cloning Errata from a specific channel should not take packages


### PR DESCRIPTION
In some rare cases, a CVE is covered by multiple patches. When a system is assigned snapshot clone channels, they might be partly patched. However, we consider a CVE is patched as soon as we find one installed patch.

To cover this case, we need to check if a newer patch is available in the same channel, or the original channel if this is a clone.

https://bugzilla.suse.com/1137229

Port of https://github.com/SUSE/spacewalk/pull/8190
