### PR TITLE
Add real URLs for Ubuntu repositories, add Security, Universe and Client Tools for Ubuntu, security  for Debian 9, and repositories for Debian 10

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -1012,16 +1012,52 @@ archs    = amd64-deb
 repo_type = deb
 name     = Ubuntu 16.04 LTS AMD64 Main
 base_channels = ubuntu-16.04-pool-amd64
-repo_url = http://mirror.example.com/ubuntu/dists/xenial/main/binary-amd64/
+repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial/main/binary-amd64/
 
 [ubuntu-1604-amd64-updates]
 label    = ubuntu-1604-amd64-main-updates
-name     = Ubuntu 16.04 LTS AMD64 Updates
+name     = Ubuntu 16.04 LTS AMD64 Main Updates
 archs    = amd64-deb
 repo_type = deb
 checksum = sha256
 base_channels = ubuntu-16.04-pool-amd64
-repo_url = http://mirror.example.com/ubuntu/dists/xenial-updates/main/binary-amd64/
+repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial-updates/main/binary-amd64/
+
+[ubuntu-1604-amd64-security]
+label    = ubuntu-1604-amd64-main-security
+name     = Ubuntu 16.04 LTS AMD64 Security
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = ubuntu-16.04-pool-amd64
+repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial-security/main/binary-amd64/
+
+[ubuntu-1604-amd64-universe]
+label    = ubuntu-1604-amd64-main-universe
+name     = Ubuntu 16.04 LTS AMD64 Universe
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = ubuntu-16.04-pool-amd64
+repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial/universe/binary-amd64/
+
+[ubuntu-1604-amd64-uyuni-client]
+label    = ubuntu-1604-amd64-uyuni-client
+name     = Uyuni Client Tools for Ubuntu 16.04 AMD64
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = ubuntu-16.04-pool-amd64
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/Ubuntu1604-Uyuni-Client-Tools/xUbuntu_16.04/
+
+[ubuntu-1604-amd64-uyuni-client-devel]
+label    = ubuntu-1604-amd64-uyuni-client-devel
+name     = Uyuni Client Tools for Ubuntu 16.04 AMD64 (Developement)
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = ubuntu-16.04-pool-amd64
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/Ubuntu1604-Uyuni-Client-Tools/xUbuntu_16.04/
 
 [ubuntu-1804-pool-amd64]
 label    = ubuntu-18.04-pool-amd64
@@ -1041,7 +1077,7 @@ archs    = amd64-deb
 repo_type = deb
 name     = Ubuntu 18.04 LTS AMD64 Main
 base_channels = ubuntu-18.04-pool-amd64
-repo_url = http://mirror.example.com/ubuntu/dists/bionic/main/binary-amd64/
+repo_url = http://archive.ubuntu.com/ubuntu/dists/bionic/main/binary-amd64/
 
 [ubuntu-1804-amd64-main-updates]
 label    = ubuntu-1804-amd64-main-updates
@@ -1050,7 +1086,43 @@ archs    = amd64-deb
 repo_type = deb
 checksum = sha256
 base_channels = ubuntu-18.04-pool-amd64
-repo_url = http://mirror.example.com/ubuntu/dists/bionic-updates/main/binary-amd64/
+repo_url = http://archive.ubuntu.com/ubuntu/dists/bionic-updates/main/binary-amd64/
+
+[ubuntu-1804-amd64-main-security]
+label    = ubuntu-1804-amd64-main-security
+name     = Ubuntu 18.04 LTS AMD64 Main Security
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = ubuntu-18.04-pool-amd64
+repo_url = http://archive.ubuntu.com/ubuntu/dists/bionic-security/main/binary-amd64/
+
+[ubuntu-1804-amd64-universe]
+label    = ubuntu-1804-amd64-main-universe
+name     = Ubuntu 18.04 LTS AMD64 Universe
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = ubuntu-18.04-pool-amd64
+repo_url = http://archive.ubuntu.com/ubuntu/dists/bionic/universe/binary-amd64/
+
+[ubuntu-1804-amd64-uyuni-client]
+label    = ubuntu-1804-amd64-uyuni-client
+name     = Uyuni Client Tools for Ubuntu 18.04 AMD64
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = ubuntu-18.04-pool-amd64
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/Ubuntu1804-Uyuni-Client-Tools/xUbuntu_18.04/
+
+[ubuntu-1804-amd64-uyuni-client-devel]
+label    = ubuntu-1804-amd64-uyuni-client-devel
+name     = Uyuni Client Tools for Ubuntu 18.04 AMD64 (Development)
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = ubuntu-18.04-pool-amd64
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/Ubuntu1804-Uyuni-Client-Tools/xUbuntu_18.04/
 
 [debian-9-pool-amd64]
 label    = debian-9-pool-amd64
@@ -1061,7 +1133,7 @@ name     = Debian 9 (stretch) pool for amd64
 gpgkey_url =
 gpgkey_id =
 gpgkey_fingerprint =
-repo_url = http://ftp.debian.org/debian/dists/stretch/main/binary-amd64/
+repo_url = http://deb.debian.org/debian/dists/stretch/main/binary-amd64/
 
 [debian-9-amd64-main-updates]
 label    = debian-9-amd64-main-updates
@@ -1070,4 +1142,43 @@ archs    = amd64-deb
 repo_type = deb
 checksum = sha256
 base_channels = debian-9-pool-amd64
-repo_url = http://ftp.debian.org/debian/dists/stretch-updates/main/binary-amd64/
+repo_url = http://deb.debian.org/debian/dists/stretch-updates/main/binary-amd64/
+
+[debian-9-amd64-main-security]
+label    = debian-9-amd64-main-security
+name     = Debian 9 (stretch) AMD64 Main Security
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = debian-9-pool-amd64
+repo_url = http://security-cdn.debian.org/debian-security/dists/stretch/updates/main/binary-amd64/
+
+[debian-10-pool-amd64]
+label    = debian-10-pool-amd64
+checksum = sha256
+archs    = amd64-deb
+repo_type = deb
+name     = Debian 10 (buster) pool for amd64
+gpgkey_url =
+gpgkey_id =
+gpgkey_fingerprint =
+repo_url = http://deb.debian.org/debian/dists/buster/main/binary-amd64/
+
+[debian-10-amd64-main-updates]
+label    = debian-10-amd64-main-updates
+name     = Debian 10 (buster) AMD64 Main Updates
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = debian-10-pool-amd64
+repo_url = http://deb.debian.org/debian/dists/buster-updates/main/binary-amd64/
+
+[debian-10-amd64-main-security]
+label    = debian-10-amd64-main-security
+name     = Debian 10 (buster) AMD64 Main Security
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = debian-10-pool-amd64
+repo_url = http://security-cdn.debian.org/debian-security/dists/buster/updates/main/binary-amd64/
+


### PR DESCRIPTION
## What does this PR change?

- Real URLs for Ubuntu repositories
- Add Security, Universe and Client Tools repositories for Ubuntu
- Add Security for Debian 9, 
- Add Repositories for Debian 10

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Issue: https://github.com/SUSE/doc-susemanager/issues/592

- [x] **DONE**

## Test coverage
- No tests: Not covered by automated tests

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/8856

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
