### PR TITLE
Do not add "susemanager" as prerequire for "spacewalk-java"

### DIFF
--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -192,7 +192,6 @@ BuildRequires:  tomcat6-lib
 %endif # 0{?suse_version}
 %endif # 0{?fedora} || 0{?rhel} >= 7
 Requires(pre):  salt
-Requires(pre):  susemanager
 %if 0%{?fedora} || 0%{?rhel} >=7
 Requires:       apache-commons-cli
 Requires:       apache-commons-codec


### PR DESCRIPTION
## What does this PR change?

This PR removes the `susemanager` package as prerequires for `spacewalk-java` introduced by https://github.com/uyuni-project/uyuni/pull/1187 since it produces dependency problems at building the package.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **change on spec file**

- [x] **DONE**

## Test coverage
- No tests: **change on spec file**

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
