### PR TITLE
Fix testsuite for CLM (uyuni vs suma)

### DIFF
--- a/testsuite/features/srv_content_lifecycle.feature
+++ b/testsuite/features/srv_content_lifecycle.feature
@@ -37,9 +37,25 @@ Feature: Content lifecycle
     And I select "SLES12-SP4-Pool for x86_64" from "selectedBaseChannel"
     And I click on "Save"
     Then I wait until I see "SLES12-SP4-Pool for x86_64" text
+    And I should see a "Version 1: (draft - not built) - Check the changes below" text
+
+  @uyuni
+  Scenario: Verify added sources for Uyuni
+    Given I am authorized as "admin" with password "admin"
+    When I follow the left menu "Content Lifecycle > Projects"
+    And I follow "clp_name"
     And I should see a "SLES12-SP4-Updates for x86_64" text
     And I should see a "Build (2)" text
-    And I should see a "Version 1: (draft - not built) - Check the changes below" text
+
+  @susemanager
+  Scenario: Verify added sources for Suse Manager
+    Given I am authorized as "admin" with password "admin"
+    When I follow the left menu "Content Lifecycle > Projects"
+    And I follow "clp_name"
+    And I should see a "SLE-Manager-Tools12-Updates for x86_64 SP4" text
+    And I should see a "SLES12-SP4-Updates for x86_64" text
+    And I should see a "SLE-Manager-Tools12-Pool for x86_64 SP4" text
+    And I should see a "Build (4)" text
 
   Scenario: Add environments to the project
     Given I am authorized as "admin" with password "admin"
@@ -71,7 +87,7 @@ Feature: Content lifecycle
     When I follow the left menu "Content Lifecycle > Projects"
     And I follow "clp_name"
     Then I should see a "not built" text in the environment "qa_name"
-    When I click on "Build (2)"
+    When I click on "Build"
     And I should see a "Version 1 history" text
     When I enter "test version message 1" as "message"
     And I click the environment build button

--- a/testsuite/features/support/setup_browser.rb
+++ b/testsuite/features/support/setup_browser.rb
@@ -101,6 +101,11 @@ Before('@susemanager') do |scenario|
   scenario.skip_invoke! unless $product == 'SUSE Manager'
 end
 
+# do some tests only if the server is using Uyuni
+Before('@uyuni') do |scenario|
+  scenario.skip_invoke! unless $product == 'Uyuni'
+end
+
 # do test only if HTTP proxy for SUSE Manager is defined
 Before('@server_http_proxy') do |scenario|
   scenario.skip_invoke! unless $server_http_proxy


### PR DESCRIPTION
## What does this PR change?

This is related to https://github.com/uyuni-project/uyuni/pull/1138

Since the channels available in Uyuni vs Suma are different, we need a smarter logic to handle the CLM testsuite.

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed

- [ ] **DONE**

## Test coverage
- No tests

- [ ] **DONE**


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test" 
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
