### PR TITLE
Require "cobbler" for "spacewalk-java" and "spacewalk-config"

### DIFF
--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Prerequire cobbler package
 - Prerequire salt package to avoid not existing user issues
 - Remove duplicate information message when changing system properties (bsc#1111371)
 - Align selection column in software channel managers (bsc#1122559)

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,4 +1,4 @@
-- Prerequire cobbler package
+- Require cobbler package
 - Prerequire salt package to avoid not existing user issues
 - Remove duplicate information message when changing system properties (bsc#1111371)
 - Align selection column in software channel managers (bsc#1122559)

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,4 +1,4 @@
-- Prerequire cobbler package (bsc#1140967)
+- Prerequire cobbler package
 - Prerequire salt package to avoid not existing user issues
 - Remove duplicate information message when changing system properties (bsc#1111371)
 - Align selection column in software channel managers (bsc#1122559)

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,4 +1,4 @@
-- Prerequire cobbler package
+- Prerequire cobbler package (bsc#1140967)
 - Prerequire salt package to avoid not existing user issues
 - Remove duplicate information message when changing system properties (bsc#1111371)
 - Align selection column in software channel managers (bsc#1122559)

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -189,7 +189,7 @@ BuildRequires:  tomcat6-lib
 %endif # 0{?suse_version}
 %endif # 0{?fedora} || 0{?rhel} >= 7
 Requires(pre):  salt
-Requires(pre):  cobbler
+Requires:       cobbler
 BuildRequires:  cobbler
 %if 0%{?fedora} || 0%{?rhel} >=7
 Requires:       apache-commons-cli

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -18,9 +18,6 @@
 
 
 %define cobblerdir      %{_localstatedir}/lib/cobbler
-%define cobprofdir      %{cobblerdir}/templates
-%define cobprofdirup    %{cobprofdir}/upload
-%define cobprofdirwiz   %{cobprofdir}/wizard
 %define cobdirsnippets  %{cobblerdir}/snippets
 %define realcobsnippetsdir  %{cobdirsnippets}/spacewalk
 %define run_checkstyle  1

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -192,6 +192,8 @@ BuildRequires:  tomcat6-lib
 %endif # 0{?suse_version}
 %endif # 0{?fedora} || 0{?rhel} >= 7
 Requires(pre):  salt
+Requires(pre):  cobbler
+BuildRequires:  cobbler
 %if 0%{?fedora} || 0%{?rhel} >=7
 Requires:       apache-commons-cli
 Requires:       apache-commons-codec
@@ -657,10 +659,6 @@ install -d -m 755 $RPM_BUILD_ROOT%{_prefix}/share/rhn/config-defaults
 install -d -m 755 $RPM_BUILD_ROOT%{_prefix}/share/rhn/search
 install -d -m 755 $RPM_BUILD_ROOT%{_prefix}/share/rhn/search/lib
 install -d -m 755 $RPM_BUILD_ROOT%{_prefix}/share/spacewalk/taskomatic
-install -d -m 755 $RPM_BUILD_ROOT%{cobprofdir}
-install -d -m 755 $RPM_BUILD_ROOT%{cobprofdirup}
-install -d -m 755 $RPM_BUILD_ROOT%{cobprofdirwiz}
-install -d -m 755 $RPM_BUILD_ROOT%{cobdirsnippets}
 %if 0%{?suse_version}
 install -d -m 755 $RPM_BUILD_ROOT/%{_localstatedir}/lib/spacewalk/scc
 install -d -m 755 $RPM_BUILD_ROOT/%{_localstatedir}/lib/spacewalk/subscription-matcher
@@ -966,10 +964,6 @@ fi
 %{jardir}/taglibs-standard.jar
 %endif
 
-%dir %{cobprofdir}
-%dir %{cobprofdirup}
-%dir %{cobprofdirwiz}
-%dir %{cobdirsnippets}
 %dir %{realcobsnippetsdir}
 %config %{realcobsnippetsdir}/default_motd
 %config %{realcobsnippetsdir}/keep_system_id

--- a/spacewalk/config/spacewalk-config.changes
+++ b/spacewalk/config/spacewalk-config.changes
@@ -1,3 +1,4 @@
+- Prerequire Cobbler package
 - mark zz-spacewalk-www.conf and os-images.conf as plain %config
   instead of %config(noreplace):
   Those files were never meant to be edited by the user. The package

--- a/spacewalk/config/spacewalk-config.changes
+++ b/spacewalk/config/spacewalk-config.changes
@@ -1,4 +1,4 @@
-- Prerequire Cobbler package
+- Require Cobbler package
 - mark zz-spacewalk-www.conf and os-images.conf as plain %config
   instead of %config(noreplace):
   Those files were never meant to be edited by the user. The package

--- a/spacewalk/config/spacewalk-config.spec
+++ b/spacewalk/config/spacewalk-config.spec
@@ -54,6 +54,8 @@ Requires(preun): initscripts
 # We need package httpd to be able to assign group apache in files section
 Requires(pre): %{apachepkg}
 Requires:       openssl
+BuildRequires:  cobbler
+Requires(pre):  cobbler
 
 %global prepdir %{_var}/lib/rhn/rhn-satellite-prep
 
@@ -108,9 +110,7 @@ ln -sf  %{apacheconfdir}/conf/ssl.crt/server.crt $RPM_BUILD_ROOT/etc/pki/tls/cer
 %config %{apacheconfdir}/conf.d/os-images.conf
 %config(noreplace) %{_sysconfdir}/webapp-keyring.gpg
 %attr(440,root,root) %config %{_sysconfdir}/sudoers.d/spacewalk
-%dir %{_var}/lib/cobbler/
 %dir %{_var}/lib/cobbler/kickstarts/
-%dir %{_var}/lib/cobbler/snippets/
 %attr(0755,root,%{apache_group}) %dir %{rhnconfigdefaults}
 %config(noreplace) %{_var}/lib/cobbler/kickstarts/spacewalk-sample.ks
 %config(noreplace) %{_var}/lib/cobbler/snippets/spacewalk_file_preservation

--- a/spacewalk/config/spacewalk-config.spec
+++ b/spacewalk/config/spacewalk-config.spec
@@ -55,7 +55,7 @@ Requires(preun): initscripts
 Requires(pre): %{apachepkg}
 Requires:       openssl
 BuildRequires:  cobbler
-Requires(pre):  cobbler
+Requires:       cobbler
 
 %global prepdir %{_var}/lib/rhn/rhn-satellite-prep
 


### PR DESCRIPTION
## What does this PR change?

This PR adds `cobbler` as `BuildRequires` and `Requires` for `spacewalk-java` and `spacewalk-config` and avoid owning cobbler specific directories by those to spacewalk packages.

## GUI diff

No difference.
- [x] **DONE**

## Documentation
- No documentation needed: **changes on specfile**
- [x] **DONE**

## Test coverage
- No tests: **changes on specfile**
- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/8869

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
