### PR TITLE
Add "susemanager" package as prerequire for "spacewalk-java"

### DIFF
--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add susemanager as prerequired for spacewalk-java
 - Cloning Errata from a specific channel should not take packages
 - Hide channels managed by Content Lifecycle projects from available sources (bsc#1137965)
   from other channels (bsc#1142764)

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -192,6 +192,8 @@ BuildRequires:  tomcat6-lib
 %endif # 0{?suse_version}
 %endif # 0{?fedora} || 0{?rhel} >= 7
 Requires(pre):  salt
+#!BuildIgnore:  udev-mini libudev-mini1
+Requires(pre):  susemanager
 %if 0%{?fedora} || 0%{?rhel} >=7
 Requires:       apache-commons-cli
 Requires:       apache-commons-codec


### PR DESCRIPTION
## What does this PR change?

This PR pre-requieres `susemanager` package for `spacewalk-java`.

With this change, we fix an issue that is produced when `spacewalk-java` package is installed before `susemanager` due non-existing `susemanager` group.

The `susemanager` group is created during `susemanager` package "pre" installation step.

**NOTE:**
The `#!BuildIgnore udev-mini libudev-mini1` is needed for avoiding conflicts with multiple libudev versions.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **changes on specfile**
- [x] **DONE**

## Test coverage
- No tests: **changes on specfile**

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
