### PR TITLE
Revert require cobbler and fix cobbler dir permissions

### DIFF
--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,4 +1,4 @@
-- Require cobbler package
+- Prerequire cobbler package
 - Prerequire salt package to avoid not existing user issues
 - Remove duplicate information message when changing system properties (bsc#1111371)
 - Align selection column in software channel managers (bsc#1122559)

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,4 +1,3 @@
-- Prerequire cobbler package
 - Prerequire salt package to avoid not existing user issues
 - Remove duplicate information message when changing system properties (bsc#1111371)
 - Align selection column in software channel managers (bsc#1122559)

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,4 +1,4 @@
-- Prerequire cobbler package (bsc#1140967)
+- Prerequire cobbler package
 - Prerequire salt package to avoid not existing user issues
 - Remove duplicate information message when changing system properties (bsc#1111371)
 - Align selection column in software channel managers (bsc#1122559)

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,4 +1,4 @@
-- Prerequire cobbler package
+- Prerequire cobbler package (bsc#1140967)
 - Prerequire salt package to avoid not existing user issues
 - Remove duplicate information message when changing system properties (bsc#1111371)
 - Align selection column in software channel managers (bsc#1122559)

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- fix permissions of cobbler owned directories
 - Prerequire salt package to avoid not existing user issues
 - Remove duplicate information message when changing system properties (bsc#1111371)
 - Align selection column in software channel managers (bsc#1122559)

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -189,7 +189,7 @@ BuildRequires:  tomcat6-lib
 %endif # 0{?suse_version}
 %endif # 0{?fedora} || 0{?rhel} >= 7
 Requires(pre):  salt
-Requires:       cobbler
+Requires(pre):  cobbler
 BuildRequires:  cobbler
 %if 0%{?fedora} || 0%{?rhel} >=7
 Requires:       apache-commons-cli

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -966,10 +966,12 @@ fi
 %{jardir}/taglibs-standard.jar
 %endif
 
-%dir %{cobprofdir}
+# owned by cobbler needs cobbler permissions
+%attr(755,root,root) %dir %{cobprofdir}
+%attr(755,root,root) %dir %{cobdirsnippets}
+# owned by uyuni
 %dir %{cobprofdirup}
 %dir %{cobprofdirwiz}
-%dir %{cobdirsnippets}
 %dir %{realcobsnippetsdir}
 %config %{realcobsnippetsdir}/default_motd
 %config %{realcobsnippetsdir}/keep_system_id

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -22,7 +22,7 @@
 %define cobprofdirup    %{cobprofdir}/upload
 %define cobprofdirwiz   %{cobprofdir}/wizard
 %define cobdirsnippets  %{cobblerdir}/snippets
-%define realcobsnippetsdir  %{cobdirsnippets}/spacewalk
+%define spacewalksnippetsdir  %{cobdirsnippets}/spacewalk
 %define run_checkstyle  1
 
 %if 0%{?fedora} || 0%{?rhel} >= 7
@@ -724,16 +724,16 @@ cp -a build/classes/com/redhat/rhn/common/conf/test/conf $RPM_BUILD_ROOT%{_datad
 install -m 644 conf/log4j.properties.taskomatic $RPM_BUILD_ROOT%{_datadir}/rhn/classes/log4j.properties
 install -m 644 code/src/ehcache.xml $RPM_BUILD_ROOT%{_datadir}/rhn/classes/ehcache.xml
 
-install -d -m 755 $RPM_BUILD_ROOT%{realcobsnippetsdir}
-install -m 644 conf/cobbler/snippets/default_motd  $RPM_BUILD_ROOT%{realcobsnippetsdir}/default_motd
-install -m 644 conf/cobbler/snippets/keep_system_id  $RPM_BUILD_ROOT%{realcobsnippetsdir}/keep_system_id
-install -m 644 conf/cobbler/snippets/post_reactivation_key  $RPM_BUILD_ROOT%{realcobsnippetsdir}/post_reactivation_key
-install -m 644 conf/cobbler/snippets/post_delete_system  $RPM_BUILD_ROOT%{realcobsnippetsdir}/post_delete_system
-install -m 644 conf/cobbler/snippets/redhat_register  $RPM_BUILD_ROOT%{realcobsnippetsdir}/redhat_register
-install -m 644 conf/cobbler/snippets/sles_register    $RPM_BUILD_ROOT%{realcobsnippetsdir}/sles_register
-install -m 644 conf/cobbler/snippets/sles_register_script $RPM_BUILD_ROOT%{realcobsnippetsdir}/sles_register_script
-install -m 644 conf/cobbler/snippets/sles_no_signature_checks $RPM_BUILD_ROOT%{realcobsnippetsdir}/sles_no_signature_checks
-install -m 644 conf/cobbler/snippets/wait_for_networkmanager_script $RPM_BUILD_ROOT%{realcobsnippetsdir}/wait_for_networkmanager_script
+install -d -m 755 $RPM_BUILD_ROOT%{spacewalksnippetsdir}
+install -m 644 conf/cobbler/snippets/default_motd  $RPM_BUILD_ROOT%{spacewalksnippetsdir}/default_motd
+install -m 644 conf/cobbler/snippets/keep_system_id  $RPM_BUILD_ROOT%{spacewalksnippetsdir}/keep_system_id
+install -m 644 conf/cobbler/snippets/post_reactivation_key  $RPM_BUILD_ROOT%{spacewalksnippetsdir}/post_reactivation_key
+install -m 644 conf/cobbler/snippets/post_delete_system  $RPM_BUILD_ROOT%{spacewalksnippetsdir}/post_delete_system
+install -m 644 conf/cobbler/snippets/redhat_register  $RPM_BUILD_ROOT%{spacewalksnippetsdir}/redhat_register
+install -m 644 conf/cobbler/snippets/sles_register    $RPM_BUILD_ROOT%{spacewalksnippetsdir}/sles_register
+install -m 644 conf/cobbler/snippets/sles_register_script $RPM_BUILD_ROOT%{spacewalksnippetsdir}/sles_register_script
+install -m 644 conf/cobbler/snippets/sles_no_signature_checks $RPM_BUILD_ROOT%{spacewalksnippetsdir}/sles_no_signature_checks
+install -m 644 conf/cobbler/snippets/wait_for_networkmanager_script $RPM_BUILD_ROOT%{spacewalksnippetsdir}/wait_for_networkmanager_script
 
 ln -s -f %{_javadir}/dwr.jar $RPM_BUILD_ROOT%{jardir}/dwr.jar
 %if 0%{?suse_version}
@@ -972,16 +972,16 @@ fi
 # owned by uyuni
 %dir %{cobprofdirup}
 %dir %{cobprofdirwiz}
-%dir %{realcobsnippetsdir}
-%config %{realcobsnippetsdir}/default_motd
-%config %{realcobsnippetsdir}/keep_system_id
-%config %{realcobsnippetsdir}/post_reactivation_key
-%config %{realcobsnippetsdir}/post_delete_system
-%config %{realcobsnippetsdir}/redhat_register
-%config %{realcobsnippetsdir}/sles_register
-%config %{realcobsnippetsdir}/sles_register_script
-%config %{realcobsnippetsdir}/sles_no_signature_checks
-%config %{realcobsnippetsdir}/wait_for_networkmanager_script
+%dir %{spacewalksnippetsdir}
+%config %{spacewalksnippetsdir}/default_motd
+%config %{spacewalksnippetsdir}/keep_system_id
+%config %{spacewalksnippetsdir}/post_reactivation_key
+%config %{spacewalksnippetsdir}/post_delete_system
+%config %{spacewalksnippetsdir}/redhat_register
+%config %{spacewalksnippetsdir}/sles_register
+%config %{spacewalksnippetsdir}/sles_register_script
+%config %{spacewalksnippetsdir}/sles_no_signature_checks
+%config %{spacewalksnippetsdir}/wait_for_networkmanager_script
 %if 0%{?fedora} || 0%{?rhel} >= 7
 %config(noreplace) %{appdir}/rhn/META-INF/context.xml
 %else

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -18,6 +18,9 @@
 
 
 %define cobblerdir      %{_localstatedir}/lib/cobbler
+%define cobprofdir      %{cobblerdir}/templates
+%define cobprofdirup    %{cobprofdir}/upload
+%define cobprofdirwiz   %{cobprofdir}/wizard
 %define cobdirsnippets  %{cobblerdir}/snippets
 %define realcobsnippetsdir  %{cobdirsnippets}/spacewalk
 %define run_checkstyle  1

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -192,8 +192,6 @@ BuildRequires:  tomcat6-lib
 %endif # 0{?suse_version}
 %endif # 0{?fedora} || 0{?rhel} >= 7
 Requires(pre):  salt
-Requires(pre):  cobbler
-BuildRequires:  cobbler
 %if 0%{?fedora} || 0%{?rhel} >=7
 Requires:       apache-commons-cli
 Requires:       apache-commons-codec
@@ -659,6 +657,10 @@ install -d -m 755 $RPM_BUILD_ROOT%{_prefix}/share/rhn/config-defaults
 install -d -m 755 $RPM_BUILD_ROOT%{_prefix}/share/rhn/search
 install -d -m 755 $RPM_BUILD_ROOT%{_prefix}/share/rhn/search/lib
 install -d -m 755 $RPM_BUILD_ROOT%{_prefix}/share/spacewalk/taskomatic
+install -d -m 755 $RPM_BUILD_ROOT%{cobprofdir}
+install -d -m 755 $RPM_BUILD_ROOT%{cobprofdirup}
+install -d -m 755 $RPM_BUILD_ROOT%{cobprofdirwiz}
+install -d -m 755 $RPM_BUILD_ROOT%{cobdirsnippets}
 %if 0%{?suse_version}
 install -d -m 755 $RPM_BUILD_ROOT/%{_localstatedir}/lib/spacewalk/scc
 install -d -m 755 $RPM_BUILD_ROOT/%{_localstatedir}/lib/spacewalk/subscription-matcher
@@ -964,6 +966,10 @@ fi
 %{jardir}/taglibs-standard.jar
 %endif
 
+%dir %{cobprofdir}
+%dir %{cobprofdirup}
+%dir %{cobprofdirwiz}
+%dir %{cobdirsnippets}
 %dir %{realcobsnippetsdir}
 %config %{realcobsnippetsdir}/default_motd
 %config %{realcobsnippetsdir}/keep_system_id

--- a/spacewalk/config/spacewalk-config.changes
+++ b/spacewalk/config/spacewalk-config.changes
@@ -1,4 +1,3 @@
-- Prerequire Cobbler package
 - mark zz-spacewalk-www.conf and os-images.conf as plain %config
   instead of %config(noreplace):
   Those files were never meant to be edited by the user. The package

--- a/spacewalk/config/spacewalk-config.changes
+++ b/spacewalk/config/spacewalk-config.changes
@@ -1,4 +1,4 @@
-- Require Cobbler package
+- Prerequire Cobbler package
 - mark zz-spacewalk-www.conf and os-images.conf as plain %config
   instead of %config(noreplace):
   Those files were never meant to be edited by the user. The package

--- a/spacewalk/config/spacewalk-config.spec
+++ b/spacewalk/config/spacewalk-config.spec
@@ -54,8 +54,6 @@ Requires(preun): initscripts
 # We need package httpd to be able to assign group apache in files section
 Requires(pre): %{apachepkg}
 Requires:       openssl
-BuildRequires:  cobbler
-Requires(pre):  cobbler
 
 %global prepdir %{_var}/lib/rhn/rhn-satellite-prep
 
@@ -110,7 +108,9 @@ ln -sf  %{apacheconfdir}/conf/ssl.crt/server.crt $RPM_BUILD_ROOT/etc/pki/tls/cer
 %config %{apacheconfdir}/conf.d/os-images.conf
 %config(noreplace) %{_sysconfdir}/webapp-keyring.gpg
 %attr(440,root,root) %config %{_sysconfdir}/sudoers.d/spacewalk
+%dir %{_var}/lib/cobbler/
 %dir %{_var}/lib/cobbler/kickstarts/
+%dir %{_var}/lib/cobbler/snippets/
 %attr(0755,root,%{apache_group}) %dir %{rhnconfigdefaults}
 %config(noreplace) %{_var}/lib/cobbler/kickstarts/spacewalk-sample.ks
 %config(noreplace) %{_var}/lib/cobbler/snippets/spacewalk_file_preservation

--- a/spacewalk/config/spacewalk-config.spec
+++ b/spacewalk/config/spacewalk-config.spec
@@ -55,7 +55,7 @@ Requires(preun): initscripts
 Requires(pre): %{apachepkg}
 Requires:       openssl
 BuildRequires:  cobbler
-Requires:       cobbler
+Requires(pre):  cobbler
 
 %global prepdir %{_var}/lib/rhn/rhn-satellite-prep
 


### PR DESCRIPTION
## What does this PR change?

Revert #1192 and just fix directory permissions of cobbler owned directories.
spacewalk-config require no change as the cobbler directories already have the correct permissions.

This reduce the dependency hell and fix crashes in the cucumber testsuite when creating and managing kickstart profiles.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- fix Cucumber tests

- [x] **DONE**

## Links

Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
