### PR TITLE
More reliable tests for "Use Salt presence mechanism on an unreachable minion" and CLM build

### DIFF
--- a/testsuite/features/min_salt_software_states.feature
+++ b/testsuite/features/min_salt_software_states.feature
@@ -117,9 +117,8 @@ Feature: Salt package states
     Then I follow "States" in the content area
     And I run "pkill salt-minion" on "sle-minion"
     And I follow "Highstate" in the content area
-    And I wait for "6" seconds
+    And I wait until I see "No reply from minion" text
     And I run "rcsalt-minion restart" on "sle-minion"
-    And I should see a "No reply from minion" text in element "highstate"
 
   Scenario: Cleanup: remove old packages from SLES minion
     Given I am authorized as "admin" with password "admin"

--- a/testsuite/features/srv_content_lifecycle.feature
+++ b/testsuite/features/srv_content_lifecycle.feature
@@ -93,7 +93,7 @@ Feature: Content lifecycle
     And I click the environment build button
     Then I wait until I see "Version 1 successfully built into dev_name" text
     And I should see a "Version 1: test version message 1" text
-    And I wait until I see "Built" text
+    And I wait at most 600 seconds until I see "Built" text
 
   Scenario: Promote promote the sources in the project
     Given I am authorized as "admin" with password "admin"


### PR DESCRIPTION
## What does this PR change?

I bit more reliable tests for "Use Salt presence mechanism on an unreachable minion" and CLM build. 

## GUI diff

No difference.


- [ ] **DONE**

## Documentation
- No documentation needed

- [ ] **DONE**

## Test coverage
- No tests

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test" 
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
