### PR TITLE
Improve menu scrollbar style for firefox

### DIFF
--- a/branding/css/susemanager-theme.less
+++ b/branding/css/susemanager-theme.less
@@ -142,13 +142,15 @@ section {
     position: fixed;
     #nav nav ul.level1 {
       overflow-y: auto !important;
+      scrollbar-color: rgba(173,216,230,0.5) transparent;
+      scrollbar-width: thin;
       &::-webkit-scrollbar {
         width: 7px;
       }
       &::-webkit-scrollbar-thumb {
         border-radius: 10px;
-        -webkit-box-shadow: inset 0 0 6px rgba(0,178,226,0.5);
-        background: rgba(0,178,226,0.5);
+        -webkit-box-shadow: inset 0 0 6px rgba(173,216,230,0.5);
+        background: rgba(173,216,230,0.5);
       }
     }
   }

--- a/branding/spacewalk-branding.changes
+++ b/branding/spacewalk-branding.changes
@@ -1,3 +1,4 @@
+- Improve menu scrollbar style for firefox
 - Migrate login to Spark
 - Add UI message when salt-formulas system folders are unreachable (bsc#1142309)
 - add missing strings for tasks


### PR DESCRIPTION
## What does this PR change?

- Improve menu scrollbar style for firefox


## GUI diff

Chrome;

![Screenshot from 2019-07-30 01-35-46](https://user-images.githubusercontent.com/1140720/62091826-c2716680-b26a-11e9-8f73-83a6a1f0669f.png)
 
Firefox

![Screenshot from 2019-07-30 01-36-06](https://user-images.githubusercontent.com/1140720/62091831-c69d8400-b26a-11e9-93a7-77a29ca27084.png)

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test" 
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
