### PR TITLE
Alter schema upgrade script to avoid failiures when migrating from 3.2

### DIFF
--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.2-to-susemanager-schema-4.0.3/200-suseUserRoleView.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.2-to-susemanager-schema-4.0.3/200-suseUserRoleView.sql.oracle
@@ -1,0 +1,1 @@
+-- intentionally blank, corresponds to 200-suseUserRoleView.sql.postgresql

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.2-to-susemanager-schema-4.0.3/200-suseUserRoleView.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.2-to-susemanager-schema-4.0.3/200-suseUserRoleView.sql.postgresql
@@ -1,3 +1,4 @@
+-- oracle equivalent source sha1 445702c0958eb00a67d966f0d5403174c4e8f450
 --
 -- Copyright (c) 2018 SUSE LLC
 --
@@ -8,6 +9,8 @@
 -- along with this software; if not, see
 -- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 --
+
+DROP VIEW IF EXISTS suseChannelUserRoleView;
 
 CREATE OR REPLACE VIEW
 suseChannelUserRoleView


### PR DESCRIPTION
## What does this PR change?

Alter schema upgrade script to avoid failures when migrating from 3.2.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: just a schema upgrade script fix

- [x] **DONE**

## Test coverage
- No tests: just a schema upgrade script fix

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/8887

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
