### PR TITLE
Fix cloning errata take pkgs from other channels

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/channel/manage/ConfirmErrataAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/channel/manage/ConfirmErrataAction.java
@@ -90,7 +90,7 @@ public class ConfirmErrataAction extends RhnListAction {
         Long sourceCid = null;
         Channel srcChan = null;
         String selChannel = request.getParameter(SELECTED_CHANNEL);
-        if ((selChannel != null) && (selChannel.equals(""))) {
+        if ((selChannel != null) && (!selChannel.equals(""))) {
             sourceCid = Long.parseLong(selChannel);
             srcChan = ChannelFactory.lookupByIdAndUser(sourceCid, user);
         }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Cloning Errata from a specific channel should not take packages
+  from other channels (bsc#1142764)
 - add caret sorting for rpm versioning
 - improve performance for retrieving the user permissions on channels (bsc#1140644)
 


### PR DESCRIPTION
## What does this PR change?

Cloning Errata from a specified channel should only take packages from that channel and not all listed in the errata when they come from a different channel.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/8865
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
