### PR TITLE
common-channels: Fix repo type assignment for type YUM

### DIFF
--- a/utils/spacewalk-common-channels
+++ b/utils/spacewalk-common-channels
@@ -271,6 +271,7 @@ Create everything as well as unlimited activation key for every channel:
 
         if create_channel:
             base_info = channels[base_channel_label]
+            repo_type = base_info.get('repo_type', DEFAULT_REPO_TYPE) or DEFAULT_REPO_TYPE
             if options.verbose:
                 sys.stdout.write("Base channel '%s' - creating...\n"
                                  % base_info['name'])
@@ -278,7 +279,7 @@ Create everything as well as unlimited activation key for every channel:
                 sys.stdout.write(
                     "* label=%s, summary=%s, arch=%s, repo_type=%s, checksum=%s\n" % (
                         base_info['label'], base_info['summary'],
-                        base_info['arch'], base_info.get('repo_type', DEFAULT_REPO_TYPE),
+                        base_info['arch'], repo_type,
                         base_info['checksum']))
 
             if not options.dry_run:
@@ -292,7 +293,7 @@ Create everything as well as unlimited activation key for every channel:
                                                        'id': base_info['gpgkey_id'],
                                                        'fingerprint': base_info['gpgkey_fingerprint']})
                     client.channel.software.createRepo(key,
-                                                       base_info['yum_repo_label'], base_info.get('repo_type', DEFAULT_REPO_TYPE),
+                                                       base_info['yum_repo_label'], repo_type,
                                                        base_info['repo_url'])
                     client.channel.software.associateRepo(key,
                                                           base_info['label'], base_info['yum_repo_label'])
@@ -345,6 +346,7 @@ Create everything as well as unlimited activation key for every channel:
 
         for child_channel_label in sorted(child_channels[base_channel_label]):
             child_info = channels[child_channel_label]
+            repo_type = child_info.get('repo_type', DEFAULT_REPO_TYPE) or DEFAULT_REPO_TYPE
             if options.verbose:
                 sys.stdout.write("* Child channel '%s' - creating...\n"
                                  % child_info['name'])
@@ -352,7 +354,7 @@ Create everything as well as unlimited activation key for every channel:
                 sys.stdout.write(
                     "** label=%s, summary=%s, arch=%s, parent=%s, repo_type=%s, checksum=%s\n"
                     % (child_info['label'], child_info['summary'],
-                       child_info['arch'], base_channel_label, child_info.get('repo_type', DEFAULT_REPO_TYPE),
+                       child_info['arch'], base_channel_label, repo_type,
                        child_info['checksum']))
 
             if not options.dry_run:
@@ -367,7 +369,7 @@ Create everything as well as unlimited activation key for every channel:
                                                        'id': child_info['gpgkey_id'],
                                                        'fingerprint': child_info['gpgkey_fingerprint']})
                     client.channel.software.createRepo(key,
-                                                       child_info['yum_repo_label'], child_info.get('repo_type', DEFAULT_REPO_TYPE),
+                                                       child_info['yum_repo_label'], repo_type,
                                                        child_info['repo_url'])
                     client.channel.software.associateRepo(key,
                                                           child_info['label'], child_info['yum_repo_label'])

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,4 @@
+- common-channels: Fix repo type assignment for type YUM
 - Use the same client tools for openSUSE Leap 15.0 for all openSUSE Leap
   15.X releases.
 - hostname-rename: change hostname in cobbler db and autoinst data


### PR DESCRIPTION
In `spacewalk-common-channels` tool, `repo-type` argument was set empty string for default repo type `yum`. This PR fixes it to be set correctly.

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/1203

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
