### PR TITLE
Prevent traceback on "mgr-inter-sync"

### DIFF
--- a/backend/satellite_tools/satsync.py
+++ b/backend/satellite_tools/satsync.py
@@ -1110,7 +1110,7 @@ class Syncer:
 
             for pid in pids:
                 # XXX Catch errors
-                if (not package_collection.has_package(pid)
+                if (not package_collection.has_package(pid) or not package_collection.get_package(pid)
                         or package_collection.get_package(pid)['last_modified']
                         != short_package_collection.get_package(pid)['last_modified']):
                     # not in the cache

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- Avoid traceback on mgr-inter-sync when there are problems
+  with cache of packages (bsc#1143016)
 - do not overwrite comps and module data with older versions
 - fix issue with "dists" keyword in url hostname
 - import packages from all collections of a patch not just first one


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue that is producing a traceback when certain errors are produced during a `mgr-inter-sync` execution:

- Do not crash when there are issues with cache of packages

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **bugfix**

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
