### PR TITLE
CLM: By Date Filter

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ErrataFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ErrataFilter.java
@@ -17,6 +17,9 @@ package com.redhat.rhn.domain.contentmgmt;
 
 import com.redhat.rhn.domain.errata.Errata;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
@@ -38,6 +41,13 @@ public class ErrataFilter extends ContentFilter<Errata> {
         switch (matcher) {
             case EQUALS:
                 return getField(erratum, field, String.class).equals(value);
+            case GREATER:
+                ZonedDateTime valDate = ZonedDateTime.parse(value, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+                return getField(erratum, field, ZonedDateTime.class).isAfter(valDate);
+            case GREATEREQ:
+                ZonedDateTime valDate2 = ZonedDateTime.parse(value, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+                ZonedDateTime erratumDate = getField(erratum, field, ZonedDateTime.class);
+                return erratumDate.isEqual(valDate2) || erratumDate.isAfter(valDate2);
             default:
                 throw new UnsupportedOperationException("Matcher " + matcher + " not supported");
         }
@@ -47,6 +57,8 @@ public class ErrataFilter extends ContentFilter<Errata> {
         switch (field) {
             case "advisory_name":
                 return type.cast(erratum.getAdvisoryName());
+            case "issue_date":
+                return type.cast(erratum.getIssueDate().toInstant().atZone(ZoneId.systemDefault()));
             default:
                 throw new UnsupportedOperationException("Field " + field + " not supported");
         }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ErrataFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ErrataFilter.java
@@ -38,18 +38,27 @@ public class ErrataFilter extends ContentFilter<Errata> {
         String field = getCriteria().getField();
         String value = getCriteria().getValue();
 
-        switch (matcher) {
-            case EQUALS:
-                return getField(erratum, field, String.class).equals(value);
-            case GREATER:
+        switch (field) {
+            case "issue_date":
                 ZonedDateTime valDate = ZonedDateTime.parse(value, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
-                return getField(erratum, field, ZonedDateTime.class).isAfter(valDate);
-            case GREATEREQ:
-                ZonedDateTime valDate2 = ZonedDateTime.parse(value, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
-                ZonedDateTime erratumDate = getField(erratum, field, ZonedDateTime.class);
-                return erratumDate.isEqual(valDate2) || erratumDate.isAfter(valDate2);
+                ZonedDateTime issueDate = getField(erratum, field, ZonedDateTime.class);
+                switch (matcher) {
+                    case GREATEREQ:
+                        return !issueDate.isBefore(valDate);
+                    case GREATER:
+                        return issueDate.isAfter(valDate);
+                    default:
+                        throw new UnsupportedOperationException("Matcher " + matcher + " not supported");
+                }
+            case "advisory_name":
+                switch (matcher) {
+                    case EQUALS:
+                        return getField(erratum, field, String.class).equals(value);
+                    default:
+                        throw new UnsupportedOperationException("Matcher " + matcher + " not supported");
+                }
             default:
-                throw new UnsupportedOperationException("Matcher " + matcher + " not supported");
+                throw new UnsupportedOperationException("Field " + field + " not supported");
         }
     }
 

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
@@ -30,6 +30,8 @@ import static com.redhat.rhn.domain.contentmgmt.ContentFilter.EntityType.ERRATUM
 import static com.redhat.rhn.domain.contentmgmt.ContentFilter.EntityType.PACKAGE;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.CONTAINS;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.EQUALS;
+import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.GREATER;
+import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.GREATEREQ;
 
 /**
  * The criteria used for matching objects (Package, Errata) in {@link ContentFilter}
@@ -53,6 +55,8 @@ public class FilterCriteria {
         validCombinations.add(Triple.of(PACKAGE, EQUALS, "nevr"));
         validCombinations.add(Triple.of(PACKAGE, EQUALS, "nevra"));
         validCombinations.add(Triple.of(ERRATUM, EQUALS, "advisory_name"));
+        validCombinations.add(Triple.of(ERRATUM, GREATER, "issue_date"));
+        validCombinations.add(Triple.of(ERRATUM, GREATEREQ, "issue_date"));
     }
 
     /**
@@ -60,7 +64,9 @@ public class FilterCriteria {
      */
     public enum Matcher {
         CONTAINS("contains"),
-        EQUALS("equals");
+        EQUALS("equals"),
+        GREATER("greater"),
+        GREATEREQ("greater-equal");
 
         private String label;
 

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
@@ -66,7 +66,7 @@ public class FilterCriteria {
         CONTAINS("contains"),
         EQUALS("equals"),
         GREATER("greater"),
-        GREATEREQ("greater-equal");
+        GREATEREQ("greatereq");
 
         private String label;
 

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/test/FilterCriteriaTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/test/FilterCriteriaTest.java
@@ -19,8 +19,11 @@ import com.redhat.rhn.domain.contentmgmt.FilterCriteria;
 import junit.framework.TestCase;
 
 import static com.redhat.rhn.domain.contentmgmt.ContentFilter.EntityType.PACKAGE;
+import static com.redhat.rhn.domain.contentmgmt.ContentFilter.EntityType.ERRATUM;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.CONTAINS;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.EQUALS;
+import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.GREATER;
+import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.GREATEREQ;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.validate;
 
 /**
@@ -32,6 +35,8 @@ public class FilterCriteriaTest extends TestCase {
         validate(PACKAGE, CONTAINS, "name");
         validate(PACKAGE, EQUALS, "nevr");
         validate(PACKAGE, EQUALS, "nevra");
+        validate(ERRATUM, GREATER, "issue_date");
+        validate(ERRATUM, GREATEREQ, "issue_date");
     }
 
     public void testIllegalValidation() {

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/test/DebReleaseWriterTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/test/DebReleaseWriterTest.java
@@ -59,6 +59,7 @@ public class DebReleaseWriterTest extends BaseTestCaseWithUser {
 
         DebReleaseWriter writer = new DebReleaseWriter(channel, prefix);
         writer.generateRelease();
+        String releaseDatetime = DebReleaseWriter.RFC822_DATE_FORMAT.format(ZonedDateTime.now());
 
         String releaseContent = FileUtils.readStringFromFile(prefix + "Release");
 
@@ -66,7 +67,7 @@ public class DebReleaseWriterTest extends BaseTestCaseWithUser {
                 "Label: " + channel.getLabel() + "\n" +
                 "Suite: " + channel.getLabel() + "\n" +
                 "Architectures: ia64\n" +
-                "Date: " + DebReleaseWriter.RFC822_DATE_FORMAT.format(ZonedDateTime.now()) + "\n" +
+                "Date: " + releaseDatetime + "\n" +
                 "Description: TestChannel description\n" +
                 "MD5Sum:\n" +
                 " d41d8cd98f00b204e9800998ecf8427e 0 main/binary-ia64/Packages\n" +

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/mappers/ResponseMappers.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/mappers/ResponseMappers.java
@@ -32,10 +32,16 @@ import com.suse.manager.webui.controllers.contentmanagement.response.ProjectProp
 import com.suse.manager.webui.controllers.contentmanagement.response.ProjectResponse;
 import com.suse.manager.webui.controllers.contentmanagement.response.ProjectResumeResponse;
 import com.suse.manager.webui.controllers.contentmanagement.response.ProjectSoftwareSourceResponse;
+import com.suse.manager.webui.utils.ViewHelper;
 
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
 
 /**
  * Utility class to map db entities into view response beans
@@ -187,7 +193,19 @@ public class ResponseMappers {
                     contentFilterResponse.setEntityType(filter.getEntityType().getLabel());
                     contentFilterResponse.setMatcher(filter.getCriteria().getMatcher().getLabel());
                     contentFilterResponse.setCriteriaKey(filter.getCriteria().getField());
-                    contentFilterResponse.setCriteriaValue(filter.getCriteria().getValue());
+                    // If we have a date as a criteria value we need to format it with the current user timezone
+                    if (filter.getCriteria().getField().equals("issue_date")) {
+                        DateTimeFormatter timeFormatter = DateTimeFormatter.ISO_DATE_TIME;
+                        OffsetDateTime offsetDateTime = OffsetDateTime.parse(
+                                filter.getCriteria().getValue(), timeFormatter
+                        );
+                        var criteriaValueDate = Date.from(Instant.from(offsetDateTime));
+
+                        contentFilterResponse.setCriteriaValue(ViewHelper.getInstance().renderDate(criteriaValueDate));
+                    }
+                    else {
+                        contentFilterResponse.setCriteriaValue(filter.getCriteria().getValue());
+                    }
                     contentFilterResponse.setDeny(filter.getRule() == ContentFilter.Rule.DENY);
                     contentFilterResponse.setProjects(
                             projects.stream()

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/templates/list-filters.jade
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/templates/list-filters.jade
@@ -1,6 +1,7 @@
 include /templates/common.jade
 
 +userRoles
++userLocalization
 
 #content-management-list-filters
 

--- a/java/code/src/com/suse/manager/webui/templates/common.jade
+++ b/java/code/src/com/suse/manager/webui/templates/common.jade
@@ -12,3 +12,10 @@ mixin userPreferences
 mixin userRoles
     script(type='text/javascript').
         const global_userRoles = !{roles};
+
+mixin userLocalization
+    script(type='text/javascript').
+        window.global_user_localization = {
+            timezone: "#{h.renderTimezone()}",
+            localTime: "#{h.renderLocalTime()}",
+        };

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- implement "by date" Filter for Content Lifecycle Management
 - Require uyuni-base-common for /etc/rhn
 - Support partly patched CVEs in CVE audit (bsc#1137229)
 - UI render without error if salt-formulas system folders are unreachable (bsc#1142309)

--- a/web/html/src/components/input/Form.js
+++ b/web/html/src/components/input/Form.js
@@ -132,7 +132,12 @@ class Form extends React.Component<Props, State> {
         model[component.props.name] = component.props.value;
         return { model };
       },
-      () => this.validate(component, component.props));
+      () => {
+        this.validate(component, component.props);
+        if (this.props.onChange) {
+          this.props.onChange(this.state.model, this.state.isValid);
+        };
+      });
     }
   }
 

--- a/web/html/src/components/input/InputBase.js
+++ b/web/html/src/components/input/InputBase.js
@@ -65,7 +65,11 @@ class InputBase extends React.Component<Props, State> {
 
   // eslint-disable-next-line
   UNSAFE_componentWillReceiveProps(nextProps) {
-    if (!(nextProps.value === this.props.value && nextProps.disabled === this.props.disabled
+    const valueNotChanged =
+      (nextProps.value instanceof Date && this.props.value instanceof Date
+        && nextProps.value.getTime() === this.props.value.getTime())
+      || nextProps.value === this.props.value;
+    if (!(valueNotChanged && nextProps.disabled === this.props.disabled
               && nextProps.required === this.props.required)) {
       if (this.props.validate) this.props.validate(this, nextProps);
       this.setState({

--- a/web/html/src/core/user-localization/use-user-localization.js
+++ b/web/html/src/core/user-localization/use-user-localization.js
@@ -1,5 +1,6 @@
 // @flow
-// Note: To use this component make sure it's used in a placed wrapped by the roles-context-provider
+// Note: To use this component make sure it's used in a page wrapped by the UserLocalizationProvider
+// (user-localization-context.js)
 import {useContext} from 'react';
 import {UserLocalizationContext} from "core/user-localization/user-localization-context";
 

--- a/web/html/src/core/user-localization/use-user-localization.js
+++ b/web/html/src/core/user-localization/use-user-localization.js
@@ -1,0 +1,8 @@
+// @flow
+// Note: To use this component make sure it's used in a placed wrapped by the roles-context-provider
+import {useContext} from 'react';
+import {UserLocalizationContext} from "core/user-localization/user-localization-context";
+
+const useUserLocalization = () => useContext(UserLocalizationContext);
+
+export default useUserLocalization;

--- a/web/html/src/core/user-localization/user-localization-context.js
+++ b/web/html/src/core/user-localization/user-localization-context.js
@@ -1,0 +1,20 @@
+// @flow
+// Note: to use this component you have to make sure the current user roles are injected with withRolesTemplate
+// and jade mixin userRoles
+import React from 'react';
+import type {Node} from 'react';
+
+export type userLocalizationType = {
+  timezone: string,
+  localTime: string,
+};
+declare var global_user_localization: userLocalizationType;
+
+const UserLocalizationContext = React.createContext<userLocalizationType>({});
+
+const UserLocalizationProvider = ({children}: {children: Node}) =>
+  <UserLocalizationContext.Provider value={typeof global_user_localization !== 'undefined' ? global_user_localization : {}}>
+    {children}
+  </UserLocalizationContext.Provider>
+
+export { UserLocalizationProvider, UserLocalizationContext};

--- a/web/html/src/core/user-localization/user-localization-context.js
+++ b/web/html/src/core/user-localization/user-localization-context.js
@@ -1,6 +1,6 @@
 // @flow
-// Note: to use this component you have to make sure the current user roles are injected with withRolesTemplate
-// and jade mixin userRoles
+// Note: to use this component you have to make sure the current user localization are injected with
+// the jade mixin userLocalization
 import React from 'react';
 import type {Node} from 'react';
 

--- a/web/html/src/flow-typed/globals.js
+++ b/web/html/src/flow-typed/globals.js
@@ -1,2 +1,4 @@
+
 declare function t(msg: string, ...args?: Array<any>): string;
 declare function $(...args?: any): any;
+declare var moment: Class<moment$Moment>;

--- a/web/html/src/flow-typed/npm/moment_v2.x.x.js
+++ b/web/html/src/flow-typed/npm/moment_v2.x.x.js
@@ -1,0 +1,378 @@
+// flow-typed signature: bdbe0aef9ec361f34b006c04979aac41
+// flow-typed version: c6154227d1/moment_v2.x.x/flow_>=v0.25.x <=v0.103.x
+
+type moment$MomentOptions = {
+  y?: number | string,
+  year?: number | string,
+  years?: number | string,
+  M?: number | string,
+  month?: number | string,
+  months?: number | string,
+  d?: number | string,
+  day?: number | string,
+  days?: number | string,
+  date?: number | string,
+  h?: number | string,
+  hour?: number | string,
+  hours?: number | string,
+  m?: number | string,
+  minute?: number | string,
+  minutes?: number | string,
+  s?: number | string,
+  second?: number | string,
+  seconds?: number | string,
+  ms?: number | string,
+  millisecond?: number | string,
+  milliseconds?: number | string
+};
+
+type moment$MomentObject = {
+  years: number,
+  months: number,
+  date: number,
+  hours: number,
+  minutes: number,
+  seconds: number,
+  milliseconds: number
+};
+
+type moment$MomentCreationData = {
+  input: string,
+  format: string,
+  locale: Object,
+  isUTC: boolean,
+  strict: boolean
+};
+
+type moment$CalendarFormat = string | ((moment: moment$Moment) => string);
+
+type moment$CalendarFormats = {
+  sameDay?: moment$CalendarFormat,
+  nextDay?: moment$CalendarFormat,
+  nextWeek?: moment$CalendarFormat,
+  lastDay?: moment$CalendarFormat,
+  lastWeek?: moment$CalendarFormat,
+  sameElse?: moment$CalendarFormat
+};
+
+type moment$Inclusivity = "()" | "[)" | "()" | "(]" | "[]";
+
+declare class moment$LocaleData {
+  months(moment: moment$Moment): string;
+  monthsShort(moment: moment$Moment): string;
+  monthsParse(month: string): number;
+  weekdays(moment: moment$Moment): string;
+  weekdaysShort(moment: moment$Moment): string;
+  weekdaysMin(moment: moment$Moment): string;
+  weekdaysParse(weekDay: string): number;
+  longDateFormat(dateFormat: string): string;
+  isPM(date: string): boolean;
+  meridiem(hours: number, minutes: number, isLower: boolean): string;
+  calendar(
+    key:
+      | "sameDay"
+      | "nextDay"
+      | "lastDay"
+      | "nextWeek"
+      | "prevWeek"
+      | "sameElse",
+    moment: moment$Moment
+  ): string;
+  relativeTime(
+    number: number,
+    withoutSuffix: boolean,
+    key: "s" | "m" | "mm" | "h" | "hh" | "d" | "dd" | "M" | "MM" | "y" | "yy",
+    isFuture: boolean
+  ): string;
+  pastFuture(diff: any, relTime: string): string;
+  ordinal(number: number): string;
+  preparse(str: string): any;
+  postformat(str: string): any;
+  week(moment: moment$Moment): string;
+  invalidDate(): string;
+  firstDayOfWeek(): number;
+  firstDayOfYear(): number;
+}
+declare class moment$MomentDuration {
+  humanize(suffix?: boolean): string;
+  milliseconds(): number;
+  asMilliseconds(): number;
+  seconds(): number;
+  asSeconds(): number;
+  minutes(): number;
+  asMinutes(): number;
+  hours(): number;
+  asHours(): number;
+  days(): number;
+  asDays(): number;
+  months(): number;
+  asWeeks(): number;
+  weeks(): number;
+  asMonths(): number;
+  years(): number;
+  asYears(): number;
+  add(value: number | moment$MomentDuration | Object, unit?: string): this;
+  subtract(value: number | moment$MomentDuration | Object, unit?: string): this;
+  as(unit: string): number;
+  get(unit: string): number;
+  toJSON(): string;
+  toISOString(): string;
+  isValid(): boolean;
+}
+declare class moment$Moment {
+  static ISO_8601: string;
+  static (string?: ?string): moment$Moment;
+  static (
+    initDate:
+      | moment$MomentOptions
+      | number
+      | Date
+      | Array<number>
+      | moment$Moment
+      | string
+      | null
+      | void
+      | []
+      | {}
+  ): moment$Moment;
+  static (array: []): moment$Moment;
+  static (object: {}): moment$Moment;
+  static (string: ?string, format: string | Array<string>): moment$Moment;
+  static (
+    string: ?string,
+    format: string | Array<string>,
+    strict: boolean
+  ): moment$Moment;
+  static (
+    string: ?string,
+    format: string | Array<string>,
+    locale: string
+  ): moment$Moment;
+  static (
+    string: ?string,
+    format: string | Array<string>,
+    locale: string,
+    strict: boolean
+  ): moment$Moment;
+  static unix(seconds: number): moment$Moment;
+  static utc(): moment$Moment;
+  static utc(
+    initDate:
+      | moment$MomentOptions
+      | number
+      | Date
+      | Array<number>
+      | moment$Moment
+      | string
+      | null
+      | void
+  ): moment$Moment;
+  static utc(string: string, format: string | Array<string>): moment$Moment;
+  static utc(
+    string: string,
+    format: string | Array<string>,
+    strict: boolean
+  ): moment$Moment;
+  static utc(
+    string: string,
+    format: string | Array<string>,
+    locale: string
+  ): moment$Moment;
+  static utc(
+    string: string,
+    format: string | Array<string>,
+    locale: string,
+    strict: boolean
+  ): moment$Moment;
+  static parseZone(): moment$Moment;
+  static parseZone(rawDate: string | null | void): moment$Moment;
+  static parseZone(
+    rawDate: string,
+    format: string | Array<string>
+  ): moment$Moment;
+  static parseZone(
+    rawDate: string,
+    format: string | Array<string>,
+    strict: boolean
+  ): moment$Moment;
+  static parseZone(
+    rawDate: string,
+    format: string | Array<string>,
+    locale: string
+  ): moment$Moment;
+  static parseZone(
+    rawDate: string,
+    format: string | Array<string>,
+    locale: string,
+    strict: boolean
+  ): moment$Moment;
+  isValid(): boolean;
+  invalidAt(): 0 | 1 | 2 | 3 | 4 | 5 | 6;
+  creationData(): moment$MomentCreationData;
+  millisecond(number: number): this;
+  milliseconds(number: number): this;
+  millisecond(): number;
+  milliseconds(): number;
+  second(number: number): this;
+  seconds(number: number): this;
+  second(): number;
+  seconds(): number;
+  minute(number: number): this;
+  minutes(number: number): this;
+  minute(): number;
+  minutes(): number;
+  hour(number: number): this;
+  hours(number: number): this;
+  hour(): number;
+  hours(): number;
+  date(number: number): this;
+  dates(number: number): this;
+  date(): number;
+  dates(): number;
+  day(day: number | string): this;
+  days(day: number | string): this;
+  day(): number;
+  days(): number;
+  weekday(number: number): this;
+  weekday(): number;
+  isoWeekday(day: number | string): this;
+  isoWeekday(): number;
+  dayOfYear(day: number): this;
+  dayOfYear(): number;
+  week(number: number): this;
+  weeks(number: number): this;
+  week(): number;
+  weeks(): number;
+  isoWeek(number: number): this;
+  isoWeeks(number: number): this;
+  isoWeek(): number;
+  isoWeeks(): number;
+  month(number: number): this;
+  months(number: number): this;
+  month(): number;
+  months(): number;
+  quarter(number: number): this;
+  quarter(): number;
+  year(number: number): this;
+  years(number: number): this;
+  year(): number;
+  years(): number;
+  weekYear(number: number): this;
+  weekYear(): number;
+  isoWeekYear(number: number): this;
+  isoWeekYear(): number;
+  weeksInYear(): number;
+  isoWeeksInYear(): number;
+  get(string: string): number;
+  set(unit: string, value: number): this;
+  set(options: { [unit: string]: number }): this;
+  static max(...dates: Array<moment$Moment>): moment$Moment;
+  static max(dates: Array<moment$Moment>): moment$Moment;
+  static min(...dates: Array<moment$Moment>): moment$Moment;
+  static min(dates: Array<moment$Moment>): moment$Moment;
+  add(
+    value: number | moment$MomentDuration | moment$Moment | Object,
+    unit?: string
+  ): this;
+  subtract(
+    value: number | moment$MomentDuration | moment$Moment | string | Object,
+    unit?: string
+  ): this;
+  startOf(unit: string): this;
+  endOf(unit: string): this;
+  local(): this;
+  utc(): this;
+  utcOffset(
+    offset: number | string,
+    keepLocalTime?: boolean,
+    keepMinutes?: boolean
+  ): this;
+  utcOffset(): number;
+  format(format?: string): string;
+  fromNow(removeSuffix?: boolean): string;
+  from(
+    value: moment$Moment | string | number | Date | Array<number>,
+    removePrefix?: boolean
+  ): string;
+  toNow(removePrefix?: boolean): string;
+  to(
+    value: moment$Moment | string | number | Date | Array<number>,
+    removePrefix?: boolean
+  ): string;
+  calendar(refTime?: any, formats?: moment$CalendarFormats): string;
+  diff(
+    date: moment$Moment | string | number | Date | Array<number>,
+    format?: string,
+    floating?: boolean
+  ): number;
+  valueOf(): number;
+  unix(): number;
+  daysInMonth(): number;
+  toDate(): Date;
+  toArray(): Array<number>;
+  toJSON(): string;
+  toISOString(keepOffset?: boolean): string;
+  toObject(): moment$MomentObject;
+  isBefore(
+    date?: moment$Moment | string | number | Date | Array<number>,
+    units?: ?string
+  ): boolean;
+  isSame(
+    date?: moment$Moment | string | number | Date | Array<number>,
+    units?: ?string
+  ): boolean;
+  isAfter(
+    date?: moment$Moment | string | number | Date | Array<number>,
+    units?: ?string
+  ): boolean;
+  isSameOrBefore(
+    date?: moment$Moment | string | number | Date | Array<number>,
+    units?: ?string
+  ): boolean;
+  isSameOrAfter(
+    date?: moment$Moment | string | number | Date | Array<number>,
+    units?: ?string
+  ): boolean;
+  isBetween(
+    from: moment$Moment | string | number | Date | Array<number>,
+    to: moment$Moment | string | number | Date | Array<number>,
+    units?: string,
+    inclusivity?: moment$Inclusivity
+  ): boolean;
+  isDST(): boolean;
+  isDSTShifted(): boolean;
+  isLeapYear(): boolean;
+  clone(): moment$Moment;
+  static isMoment(obj: any): boolean;
+  static isDate(obj: any): boolean;
+  static updateLocale(locale: string, localeData?: ?Object): void;
+  static defineLocale(locale: string, localeData?: ?Object): void;
+  static locale(locale?: string, localeData?: Object): string;
+  static locale(locales: Array<string>): string;
+  locale(locale: string, customization?: Object | null): moment$Moment;
+  locale(): string;
+  static months(): Array<string>;
+  static monthsShort(): Array<string>;
+  static now(): number;
+  static weekdays(): Array<string>;
+  static weekdaysShort(): Array<string>;
+  static weekdaysMin(): Array<string>;
+  static months(): string;
+  static monthsShort(): string;
+  static weekdays(): string;
+  static weekdaysShort(): string;
+  static weekdaysMin(): string;
+  static localeData(key?: string): moment$LocaleData;
+  localeData(): moment$LocaleData;
+  static duration(
+    value: number | Object | string,
+    unit?: string
+  ): moment$MomentDuration;
+  static isDuration(obj: any): boolean;
+  static normalizeUnits(unit: string): string;
+  static invalid(object: any): moment$Moment;
+}
+
+declare module "moment" {
+  declare module.exports: Class<moment$Moment>;
+}

--- a/web/html/src/manager/content-management/list-filters/filter-edit.js
+++ b/web/html/src/manager/content-management/list-filters/filter-edit.js
@@ -10,6 +10,7 @@ import FilterForm from "./filter-form";
 import {showDialog} from "components/dialog/util";
 import {mapFilterFormToRequest} from "./filter.utils";
 import _isEmpty from "lodash/isEmpty";
+import useUserLocalization from "core/user-localization/use-user-localization";
 
 const FilterEditModalContent = ({open, isLoading, filter, onChange, onClientValidate, editing}) => {
   if (!open) {
@@ -52,6 +53,7 @@ const FilterEdit = (props: FilterEditProps) => {
   const [open, setOpen] = useState(false);
   const [item, setFormData] = useState(props.initialFilterForm);
   const [formValidInClient, setFormValidInClient] = useState(true);
+  const {localTime} = useUserLocalization();
 
   const modalNameId = `${props.id}-modal`;
 
@@ -107,7 +109,7 @@ const FilterEdit = (props: FilterEditProps) => {
                         text={t('Delete')}
                         disabled={isLoading}
                         handler={() => {
-                          onAction(mapFilterFormToRequest(item, props.projectLabel), "delete", item.id)
+                          onAction(mapFilterFormToRequest(item, props.projectLabel, localTime), "delete", item.id)
                             .then((updatedListOfFilters) => {
                               closeDialog(modalNameId);
                               showSuccessToastr(t("Filter deleted successfully"));
@@ -141,7 +143,7 @@ const FilterEdit = (props: FilterEditProps) => {
                             showErrorToastr(t("Check the required fields below"), {autoHide : false});
                           } else {
                             if (props.editing) {
-                              onAction(mapFilterFormToRequest(item, props.projectLabel), "update", item.id)
+                              onAction(mapFilterFormToRequest(item, props.projectLabel, localTime), "update", item.id)
                                 .then((updatedListOfFilters) => {
                                   if(!_isEmpty(props.projectLabel)){
                                     closeDialog(modalNameId);
@@ -156,7 +158,7 @@ const FilterEdit = (props: FilterEditProps) => {
                                   showErrorToastr(error, {autoHide: false});
                                 })
                             } else {
-                              onAction(mapFilterFormToRequest(item, props.projectLabel), "create")
+                              onAction(mapFilterFormToRequest(item, props.projectLabel, localTime), "create")
                                 .then((updatedListOfFilters) => {
                                   if(!_isEmpty(props.projectLabel)){
                                     closeDialog(modalNameId);

--- a/web/html/src/manager/content-management/list-filters/filter-form.js
+++ b/web/html/src/manager/content-management/list-filters/filter-form.js
@@ -1,12 +1,15 @@
 //@flow
 import React from 'react';
 import {Text} from "components/input/Text";
+import {DateTime} from "components/input/DateTime";
 import {Select} from "components/input/Select";
 import {Form} from "components/input/Form";
 import {Check} from "components/input/Check";
 import type {FilterFormType} from "../shared/type/filter.type";
 import filtersEnum from "../shared/business/filters.enum";
 import type {FilterOptionType} from "../shared/business/filters.enum";
+import useUserLocalization from "core/user-localization/use-user-localization";
+import Functions from "utils/functions";
 
 type Props = {
   filter: FilterFormType,
@@ -16,6 +19,8 @@ type Props = {
 }
 
 const FilterForm = (props: Props) => {
+
+  const {timezone, localTime} = useUserLocalization();
 
   return (
     <Form
@@ -128,6 +133,22 @@ const FilterForm = (props: Props) => {
               divClass="col-md-6"
               required
             />
+          </div>
+        }
+
+        {
+          filtersEnum.enum.ERRATUM_BYDATE.key === props.filter.type &&
+          <div className="row">
+            <DateTime
+              name="issueDate"
+              label={t("Issued After")}
+              labelClass="col-md-3"
+              divClass="col-md-6"
+              required
+              timezone={timezone}
+              defaultValue={Functions.Utils.dateWithTimezone(localTime)}
+            />
+
           </div>
         }
 

--- a/web/html/src/manager/content-management/list-filters/filter.utils.js
+++ b/web/html/src/manager/content-management/list-filters/filter.utils.js
@@ -5,7 +5,7 @@ import filtersEnum from "../shared/business/filters.enum";
 import type {FilterFormType, FilterServerType} from "../shared/type/filter.type";
 import Functions from "utils/functions";
 
-export function mapFilterFormToRequest(filterForm: FilterFormType, projectLabel: string): FilterServerType {
+export function mapFilterFormToRequest(filterForm: FilterFormType, projectLabel: string, localTime: string): FilterServerType {
   const requestForm = {};
   requestForm.projectLabel = projectLabel;
   requestForm.name = filterForm.name;
@@ -28,7 +28,9 @@ export function mapFilterFormToRequest(filterForm: FilterFormType, projectLabel:
     requestForm.criteriaValue = filterForm.advisoryName;
   } else if (filterForm.type === filtersEnum.enum.ERRATUM_BYDATE.key) {
     requestForm.criteriaKey = "issue_date";
-    requestForm.criteriaValue = filterForm.issueDate ? moment(filterForm.issueDate).format("YYYY-MM-DDTHH:mm:ssZ"):  "";
+    requestForm.criteriaValue = filterForm.issueDate
+      ? moment(Functions.Utils.dateWithoutTimezone(filterForm.issueDate, localTime)).format("YYYY-MM-DDTHH:mm:ss.SSSZ")
+      :  "";
   } else {
     requestForm.criteriaKey = "name";
     requestForm.criteriaValue = filterForm.criteria;

--- a/web/html/src/manager/content-management/list-filters/filter.utils.js
+++ b/web/html/src/manager/content-management/list-filters/filter.utils.js
@@ -1,7 +1,9 @@
 //@flow
+/* global moment */
 import _isEmpty from "lodash/isEmpty";
 import filtersEnum from "../shared/business/filters.enum";
 import type {FilterFormType, FilterServerType} from "../shared/type/filter.type";
+import Functions from "utils/functions";
 
 export function mapFilterFormToRequest(filterForm: FilterFormType, projectLabel: string): FilterServerType {
   const requestForm = {};
@@ -24,6 +26,9 @@ export function mapFilterFormToRequest(filterForm: FilterFormType, projectLabel:
   } else if (filterForm.type === filtersEnum.enum.ERRATUM.key) {
     requestForm.criteriaKey = "advisory_name";
     requestForm.criteriaValue = filterForm.advisoryName;
+  } else if (filterForm.type === filtersEnum.enum.ERRATUM_BYDATE.key) {
+    requestForm.criteriaKey = "issue_date";
+    requestForm.criteriaValue = filterForm.issueDate ? moment(filterForm.issueDate).format("YYYY-MM-DDTHH:mm:ssZ"):  "";
   } else {
     requestForm.criteriaKey = "name";
     requestForm.criteriaValue = filterForm.criteria;
@@ -80,6 +85,9 @@ export function mapResponseToFilterForm(filtersResponse: Array<FilterServerType>
     } else if (filterResponse.criteriaKey === "advisory_name") {
       filterForm.type = filtersEnum.enum.ERRATUM.key;
       filterForm["advisoryName"] = filterResponse.criteriaValue;
+    } else if (filterResponse.criteriaKey === "issue_date") {
+      filterForm.type = filtersEnum.enum.ERRATUM_BYDATE.key;
+      filterForm["issueDate"] = Functions.Utils.dateWithTimezone(filterResponse.criteriaValue);
     } else if (filterResponse.criteriaKey === "name") {
       filterForm.type = filtersEnum.enum.PACKAGE.key;
       filterForm.criteria = filterResponse.criteriaValue;

--- a/web/html/src/manager/content-management/list-filters/list-filters.renderer.js
+++ b/web/html/src/manager/content-management/list-filters/list-filters.renderer.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import ListFilters from './list-filters';
 import "./list-filters.css";
 import {RolesProvider} from "core/auth/roles-context";
+import {UserLocalizationProvider} from "core/user-localization/user-localization-context";
 
 window.pageRenderers = window.pageRenderers || {};
 window.pageRenderers.contentManagement = window.pageRenderers.contentManagement || {};
@@ -18,12 +19,14 @@ window.pageRenderers.contentManagement.listFilters.renderer = (id, {filters, pro
 
   ReactDOM.render(
     <RolesProvider>
-      <ListFilters
-        filters={filtersJson}
-        openFilterId={openFilterId}
-        projectLabel={projectLabel}
-        flashMessage={flashMessage}
-      />
+      <UserLocalizationProvider>
+        <ListFilters
+          filters={filtersJson}
+          openFilterId={openFilterId}
+          projectLabel={projectLabel}
+          flashMessage={flashMessage}
+        />
+      </UserLocalizationProvider>
     </RolesProvider>,
     document.getElementById(id),
   );

--- a/web/html/src/manager/content-management/shared/business/filters.enum.js
+++ b/web/html/src/manager/content-management/shared/business/filters.enum.js
@@ -26,6 +26,12 @@ export const filtersOptionsEnum : FiltersOptionEnumType = new Proxy({
       entityType: 'erratum',
       matcher: 'equals',
       text: 'Patch (matches Advisory Name)',
+    },
+    ERRATUM_BYDATE: {
+      key: 'erratum_bydate',
+      entityType: 'erratum',
+      matcher: 'greater',
+      text: 'Patch (issued after)',
     }
   },
   objectDefaultValueHandler(defaultState)
@@ -42,7 +48,8 @@ function findByKey(key: string): FilterOptionType {
 function getFilterDescription (filter: Object): string {
   const matcherDescription = {
     equals: " matching ",
-    contains: " containing "
+    contains: " containing ",
+    greater: " greater "
   }
 
   return `${filter.name}: deny ${filter.entityType} ${matcherDescription[filter.matcher] || ""} ${filter.criteriaValue} (${filter.criteriaKey})`;

--- a/web/html/src/manager/content-management/shared/business/filters.enum.js
+++ b/web/html/src/manager/content-management/shared/business/filters.enum.js
@@ -30,7 +30,7 @@ export const filtersOptionsEnum : FiltersOptionEnumType = new Proxy({
     ERRATUM_BYDATE: {
       key: 'erratum_bydate',
       entityType: 'erratum',
-      matcher: 'greater',
+      matcher: 'greatereq',
       text: 'Patch (issued after)',
     }
   },
@@ -49,7 +49,7 @@ function getFilterDescription (filter: Object): string {
   const matcherDescription = {
     equals: " matching ",
     contains: " containing ",
-    greater: " greater "
+    greatereq: " greater or equal "
   }
 
   return `${filter.name}: deny ${filter.entityType} ${matcherDescription[filter.matcher] || ""} ${filter.criteriaValue} (${filter.criteriaKey})`;

--- a/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-view.js
+++ b/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-view.js
@@ -1,5 +1,5 @@
 //@flow
-// globals moment
+/* global moment */
 import React from 'react';
 import _isEmpty from "lodash/isEmpty"
 
@@ -7,8 +7,6 @@ import type {ProjectEnvironmentType} from '../../../type/project.type.js';
 import type {ProjectHistoryEntry} from "../../../type/project.type";
 import {getVersionMessageByNumber} from "../properties/properties.utils";
 import {objectDefaultValueHandler} from "core/utils/objects";
-
-declare var moment: any;
 
 type Props = {
   environment: ProjectEnvironmentType,

--- a/web/html/src/manager/content-management/shared/type/filter.type.js
+++ b/web/html/src/manager/content-management/shared/type/filter.type.js
@@ -24,4 +24,5 @@ export type FilterFormType = {
   architecture?: string,
   advisoryName?: string,
   criteria?: string,
+  issueDate?: Date
 }

--- a/web/html/src/utils/functions.js
+++ b/web/html/src/utils/functions.js
@@ -40,6 +40,19 @@ function dateWithTimezone(dateString: string): Date {
     return final;
 }
 
+// it does the opposite of dateWithTimezone: transforms its result on the original date
+function dateWithoutTimezone(dateStringToTransform: string, originalDateString: string): Date {
+  const offsetNum = originalDateString[originalDateString.length - 1].toUpperCase() === "Z"
+    ? 0
+    : parseInt(originalDateString.substring(originalDateString.length - 6).replace(':', ''), 10);
+  const serverOffset = Math.trunc(offsetNum / 100) * 60 + offsetNum % 100;
+  const dateToTransform = new Date(dateStringToTransform);
+  const clientOffset = -dateToTransform.getTimezoneOffset();
+
+  const final = new Date(dateToTransform.getTime() - (serverOffset - clientOffset) * 60000);
+  return final;
+}
+
 function LocalDateTime(date: Date): string {
     const padTo = (v) => {
         v = v.toString();
@@ -160,6 +173,7 @@ module.exports = {
         sortById: sortById,
         sortByText: sortByText,
         dateWithTimezone: dateWithTimezone,
+        dateWithoutTimezone: dateWithoutTimezone,
         sortByNumber: sortByNumber,
         sortByDate: sortByDate,
         urlBounce: urlBounce,

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- implement "by date" Filter for Content Lifecycle Management
 - Hide channels managed by Content Lifecycle projects from available sources (bsc#1137965)
 - Add unsupported browser warning when using Internet Explorer
 


### PR DESCRIPTION
## What does this PR change?

Add Erratum Filter "by date" for `greater` and `greater-equal` an issue date.
The UI uses internally only `greater-equal` as we think if a customer want to exclude all patches greater then 1st of X he also mean a patch which was issued exactly at midnight and not starting one millisecond after this time.

## GUI diff

![Screenshot_20190807_141756](https://user-images.githubusercontent.com/1038917/62622250-2a384900-b91e-11e9-97d3-984600621bc0.png)

![Screenshot_20190807_141927](https://user-images.githubusercontent.com/1038917/62622317-5fdd3200-b91e-11e9-8b02-d15c3083b17f.png)

- [x] **DONE**

## Documentation

- https://github.com/SUSE/spacewalk/issues/8962

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/8525
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"  		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
