### PR TITLE
spacewalk-setups: bring default maxThreads back to 150

### DIFF
--- a/spacewalk/setup/share/server.xml.xsl
+++ b/spacewalk/setup/share/server.xml.xsl
@@ -14,7 +14,7 @@
     <xsl:copy-of select="@*" />
     <xsl:attribute name="URIEncoding">UTF-8</xsl:attribute>
     <xsl:attribute name="address">127.0.0.1</xsl:attribute>
-    <xsl:attribute name="maxThreads">650</xsl:attribute>
+    <xsl:attribute name="maxThreads">150</xsl:attribute>
     <xsl:attribute name="connectionTimeout">20000</xsl:attribute>
   </xsl:element>
   <xsl:if test="not(../Connector[@port='8009' and @address='::1'])">
@@ -23,7 +23,7 @@
     <xsl:copy-of select="@*" />
     <xsl:attribute name="URIEncoding">UTF-8</xsl:attribute>
     <xsl:attribute name="address">::1</xsl:attribute>
-    <xsl:attribute name="maxThreads">650</xsl:attribute>
+    <xsl:attribute name="maxThreads">150</xsl:attribute>
     <xsl:attribute name="connectionTimeout">20000</xsl:attribute>
   </xsl:element>
   </xsl:if>
@@ -34,7 +34,7 @@
     <xsl:copy-of select="@*" />
     <xsl:attribute name="URIEncoding">UTF-8</xsl:attribute>
     <xsl:attribute name="address">::1</xsl:attribute>
-    <xsl:attribute name="maxThreads">650</xsl:attribute>
+    <xsl:attribute name="maxThreads">150</xsl:attribute>
     <xsl:attribute name="connectionTimeout">20000</xsl:attribute>
   </xsl:element>
 </xsl:template>

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,5 @@
+- configure 150 Tomcat workers by default, matching httpds MaxClients
+
 -------------------------------------------------------------------
 Wed Jul 31 17:36:47 CEST 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Changes `spacewalk-setup` to configure Tomcat's default parameters to match Apache's.

Tomcat should have no more workers than Apache has (`MaxClients`, recently renamed to `MaxRequestWorkers`). We had 650 and 150, this PR brings the value to 150.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **refactoring**

- [x] **DONE**

## Test coverage
- No tests: **covered via PTS**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/8059

- [x] **DONE**


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
