### PR TITLE
Fix import of "rhnAuthPAM" to avoid issues when using "rhnpush"

### DIFF
--- a/backend/server/rhnUser.py
+++ b/backend/server/rhnUser.py
@@ -111,7 +111,7 @@ class User:
                                    self.contact["login"])
             if data['use_pam_authentication'] == 'Y':
                 # use PAM
-                import rhnAuthPAM
+                from . import rhnAuthPAM
                 return rhnAuthPAM.check_password(self.contact["login"],
                                                  password, CFG.pam_auth_service)
         # If the entry in rhnUserInfo is 'N', perform regular authentication
@@ -387,7 +387,7 @@ def __reserve_user_db(user, password):
         # contact exists, check password
         if data['use_pam_authentication'] == 'Y' and CFG.pam_auth_service:
             # We use PAM for authentication
-            import rhnAuthPAM
+            from . import rhnAuthPAM
             if rhnAuthPAM.check_password(user, password, CFG.pam_auth_service) > 0:
                 return 1
             return -1
@@ -478,7 +478,7 @@ def __new_user_db(username, password, email, org_id, org_password):
     # Note that if the user is only reserved we don't do PAM authentication
     if data.get('use_pam_authentication') == 'Y' and CFG.pam_auth_service:
         # Check the password with PAM
-        import rhnAuthPAM
+        from . import rhnAuthPAM
         if rhnAuthPAM.check_password(username, password, CFG.pam_auth_service) <= 0:
             # Bad password
             raise rhnFault(2)

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- Fix import of rhnAuthPAM to avoid issues when using rhnpush.
+
 -------------------------------------------------------------------
 Wed Jul 31 17:30:57 CEST 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue importing the `rhnAuthPAM` module that is producing issues when running `rhnpush` using PAM.

Before this PR, an ISE is produced and the package is not pushed:
```
# rhnpush --ca-chain=/etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT -c CHANNEL package.rpm
SUSE Manager username:
SUSE Manager password: 
Internal Server Error
#
```

After this PR, the package is successfully pushed:
```
# rhnpush --ca-chain=/etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT -c CHANNEL package.rpm
SUSE Manager username:
SUSE Manager password: 
#
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **bugfix**

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/1202

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
