### PR TITLE
Improving navigation steps in the testsuite

### DIFF
--- a/testsuite/features/core_srv_push_package.feature
+++ b/testsuite/features/core_srv_push_package.feature
@@ -15,7 +15,6 @@ Feature: Push a package with unset vendor
 
   Scenario: Push a package with unset vendor
     When I push package "/root/subscription-tools-1.0-0.noarch.rpm" into "test_base_channel" channel
-    And I follow the left menu "Software > Channel List > All"
     Then I should see package "subscription-tools-1.0-0.noarch" in channel "Test Base Channel"
 
   Scenario: Check vendor of package displayed in web UI

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -284,7 +284,7 @@ end
 
 Then(/^I clean the search index on the server$/) do
   output = sshcmd('/usr/sbin/rcrhn-search cleanindex', ignore_err: true)
-  raise if output[:stdout].include?('ERROR')
+  raise 'The output includes an error log' if output[:stdout].include?('ERROR')
 end
 
 When(/^I execute spacewalk\-channel and pass "([^"]*)"$/) do |arg1|
@@ -339,28 +339,28 @@ Then(/^service "([^"]*)" is enabled on "([^"]*)"$/) do |service, host|
   node = get_target(host)
   output, _code = node.run("systemctl is-enabled '#{service}'", false)
   output = output.split(/\n+/)[-1]
-  raise if output != 'enabled'
+  raise "Service #{service} not enabled" if output != 'enabled'
 end
 
 Then(/^service "([^"]*)" is active on "([^"]*)"$/) do |service, host|
   node = get_target(host)
   output, _code = node.run("systemctl is-active '#{service}'", false)
   output = output.split(/\n+/)[-1]
-  raise if output != 'active'
+  raise "Service #{service} not active" if output != 'active'
 end
 
 Then(/^socket "([^"]*)" is enabled on "([^"]*)"$/) do |service, host|
   node = get_target(host)
   output, _code = node.run("systemctl is-enabled '#{service}.socket'", false)
   output = output.split(/\n+/)[-1]
-  raise if output != 'enabled'
+  raise "Service #{service} not enabled" if output != 'enabled'
 end
 
 Then(/^socket "([^"]*)" is active on "([^"]*)"$/) do |service, host|
   node = get_target(host)
   output, _code = node.run("systemctl is-active '#{service}.socket'", false)
   output = output.split(/\n+/)[-1]
-  raise if output != 'active'
+  raise "Service #{service} not active" if output != 'active'
 end
 
 When(/^I run "([^"]*)" on "([^"]*)"$/) do |cmd, host|

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -79,7 +79,7 @@ When(/^I follow the event "([^"]*)" completed during last minute$/) do |event|
   current_minute = now.strftime('%H:%M')
   previous_minute = (now - 60).strftime('%H:%M')
   xpath_query = "//a[contains(text(), '#{event}')]/../..//td[4][contains(text(),'#{current_minute}') or contains(text(),'#{previous_minute}')]/../td[3]/a[1]"
-  raise unless find(:xpath, xpath_query).click
+  raise "xpath: #{xpath_query} not found" unless find_and_wait_click(:xpath, xpath_query).click
 end
 
 # spacewalk errors steps
@@ -105,7 +105,7 @@ end
 
 # action chains
 When(/^I check radio button "(.*?)"$/) do |arg1|
-  raise unless choose(arg1)
+  raise "#{arg1} can't be checked" unless choose(arg1)
 end
 
 When(/^I enter as remote command this script in$/) do |multiline|
@@ -138,14 +138,13 @@ Then(/^I should see the CPU frequency of the client$/) do
   step %(I should see a "#{cpu.to_i / 1000} GHz" text)
 end
 
-Then(/^I should see the power is "([^"]*)"$/) do |arg1|
+Then(/^I should see the power is "([^"]*)"$/) do |status|
   within(:xpath, "//*[@for='powerStatus']/..") do
-    10.times do
-      break if has_content?(arg1)
-      find(:xpath, '//button[@value="Get status"]').click unless has_content?(arg1)
-      sleep 3
+    repeat_until_timeout(timeout: DEFAULT_TIMEOUT, message: "power is not #{status}") do
+      break if has_content?(status)
+      find(:xpath, '//button[@value="Get status"]').click
     end
-    raise unless has_content?(arg1)
+    raise "Power status #{status} not found" unless has_content?(status)
   end
 end
 
@@ -340,7 +339,8 @@ Then(/^"([^"]*)" should exist in the metadata for "([^"]*)"$/) do |file, host|
   node = $client
   arch, _code = node.run('uname -m')
   arch.chomp!
-  raise unless file_exists?(node, "#{client_raw_repodata_dir("test-channel-#{arch}")}/#{file}")
+  dir_file = client_raw_repodata_dir("test-channel-#{arch}")
+  raise "File #{dir_file}/#{file} not exist" unless file_exists?(node, "#{dir_file}/#{file}")
 end
 
 Then(/^I should have '([^']*)' in the patch metadata$/) do |text|
@@ -352,7 +352,7 @@ end
 
 # package steps
 Then(/^I should see package "([^"]*)"$/) do |package|
-  raise unless all(:xpath, "//div[@class=\"table-responsive\"]/table/tbody/tr/td/a[contains(.,'#{package}')]").any?
+  step %(I should see a "#{package}" text)
 end
 
 Given(/^I am on the manage software channels page$/) do
@@ -383,35 +383,36 @@ end
 # setup wizard
 
 When(/^I make the credentials primary$/) do
-  raise unless find('i.fa-star-o').click
+  raise 'xpath: i.fa-star-o not found' unless find('i.fa-star-o').click
 end
 
 When(/^I delete the primary credentials$/) do
-  raise unless find('i.fa-trash-o', match: :first).click
+  raise 'xpath: i.fa-trash-o not found' unless find('i.fa-trash-o', match: :first).click
   step 'I click on "Delete"'
 end
 
 When(/^I view the primary subscription list$/) do
-  raise unless find('i.fa-th-list', match: :first).click
+  raise 'xpath: i.fa-th-list not found' unless find('i.fa-th-list', match: :first).click
 end
 
 When(/^I view the primary subscription list for SCC user$/) do
   within(:xpath, "//h3[contains(text(), 'SCC user')]/../..") do
-    raise unless find('i.fa-th-list', match: :first).click
+    raise 'xpath: i.fa-th-list not found' unless find('i.fa-th-list', match: :first).click
   end
 end
 
 And(/^I select "(.*?)" in the dropdown list of the architecture filter$/) do |architecture|
   # let the the select2js box filter open the hidden options
-  raise unless find(:xpath, "//div[@id='s2id_product-arch-filter']/ul/li/input").click
+  xpath_query = "//div[@id='s2id_product-arch-filter']/ul/li/input"
+  raise "xpath: #{xpath_query} not found" unless find(:xpath, xpath_query).click
   # select the desired option
-  raise unless find(:xpath, "//div[@id='select2-drop']/ul/li/div[contains(text(), '#{architecture}')]").click
+  raise "Architecture #{architecture} not found" unless find(:xpath, "//div[@id='select2-drop']/ul/li/div[contains(text(), '#{architecture}')]").click
 end
 
 When(/^I select "([^\"]*)" as a product$/) do |product|
   # click on the checkbox to select the product
   xpath = "//span[contains(text(), '#{product}')]/ancestor::div[contains(@class, 'product-details-wrapper')]/div/input[@type='checkbox']"
-  raise unless find(:xpath, xpath).set(true)
+  raise "xpath: #{xpath} not found" unless find(:xpath, xpath).set(true)
 end
 
 And(/^I open the sub-list of the product "(.*?)"$/) do |product|
@@ -419,24 +420,24 @@ And(/^I open the sub-list of the product "(.*?)"$/) do |product|
   # within(:xpath, xpath) do
   #   raise unless find('i.fa-angle-down').click
   # end
-  raise unless find(:xpath, xpath).click
+  raise "xpath: #{xpath} not found" unless find(:xpath, xpath).click
 end
 
 When(/^I select the addon "(.*?)"$/) do |addon|
   # click on the checkbox of the sublist to select the addon product
   xpath = "//span[contains(text(), '#{addon}')]/ancestor::div[contains(@class, 'product-details-wrapper')]/div/input[@type='checkbox']"
-  raise unless find(:xpath, xpath).set(true)
+  raise "xpath: #{xpath} not found" unless find(:xpath, xpath).set(true)
 end
 
 And(/^I should see that the "(.*?)" product is "(.*?)"$/) do |product, recommended|
   xpath = "//span[text()[normalize-space(.) = '#{product}'] and ./span/text() = '#{recommended}']"
-  raise unless find(:xpath, xpath)
+  raise "xpath: #{xpath} not found" unless find(:xpath, xpath)
 end
 
 Then(/^I should see the "(.*?)" selected$/) do |product|
   xpath = "//span[contains(text(), '#{product}')]/ancestor::div[contains(@class, 'product-details-wrapper')]"
   product_identifier = find(:xpath, xpath)['data-identifier']
-  raise unless has_checked_field?('checkbox-for-' + product_identifier)
+  raise "#{product_identifier} is not checked" unless has_checked_field?('checkbox-for-' + product_identifier)
 end
 
 And(/^I wait until I see "(.*?)" product has been added$/) do |product|
@@ -453,7 +454,7 @@ And(/^I wait until I see "(.*?)" product has been added$/) do |product|
 end
 
 When(/^I click the Add Product button$/) do
-  raise unless find('button#addProducts').click
+  raise "xpath: button#addProducts not found" unless find('button#addProducts').click
 end
 
 Then(/^the SLE12 products should be added$/) do
@@ -472,7 +473,7 @@ end
 
 When(/^I click the channel list of product "(.*?)"$/) do |product|
   xpath = "//span[contains(text(), '#{product}')]/ancestor::div[contains(@class, 'product-details-wrapper')]/div/a[contains(@class, 'showChannels')]"
-  raise unless find(:xpath, xpath).click
+  raise "xpath: #{xpath} not found" unless find_and_wait_click(:xpath, xpath).click
 end
 
 Then(/^I see verification succeeded/) do
@@ -494,21 +495,21 @@ end
 
 Then(/^I should see a table line with "([^"]*)", "([^"]*)", "([^"]*)"$/) do |arg1, arg2, arg3|
   within(:xpath, "//div[@class=\"table-responsive\"]/table/tbody/tr[.//td[contains(.,'#{arg1}')]]") do
-    raise unless find_link(arg2)
-    raise unless find_link(arg3)
+    raise "Link #{arg2} not found" unless find_link(arg2)
+    raise "Link #{arg3} not found" unless find_link(arg3)
   end
 end
 
 Then(/^I should see a table line with "([^"]*)", "([^"]*)"$/) do |arg1, arg2|
   within(:xpath, "//div[@class=\"table-responsive\"]/table/tbody/tr[.//td[contains(.,'#{arg1}')]]") do
-    raise unless find_link(arg2)
+    raise "Link #{arg2} not found" unless find_link(arg2)
   end
 end
 
 Then(/^a table line should contain system "([^"]*)", "([^"]*)"$/) do |host, text|
   system_name = get_system_name(host)
   within(:xpath, "//div[@class=\"table-responsive\"]/table/tbody/tr[.//td[contains(.,'#{system_name}')]]") do
-    raise unless find_all(:xpath, "//td[contains(., '#{text}')]")
+    raise "Text #{text} not found" unless find_all(:xpath, "//td[contains(., '#{text}')]")
   end
 end
 
@@ -718,8 +719,7 @@ end
 
 Then(/^I should see "([^"]*)" at least (\d+) minutes after I scheduled an action$/) do |text, minutes|
   # TODO is there a better way then page.all ?
-  elements = page.all('div', text: text)
-  raise if elements.nil?
+  raise "Text #{text} not found in the page" unless page.all('div', text: text).any?
   match = elements[0].text.match(/#{text}\s*(\d+\/\d+\/\d+ \d+:\d+:\d+ (AM|PM)+ [^\s]+)/)
   raise "No element found matching text '#{text}'" if match.nil?
   text_time = DateTime.strptime("#{match.captures[0]}", '%m/%d/%C %H:%M:%S %p %Z')
@@ -776,10 +776,10 @@ And(/^I should see the toggler "([^"]*)"$/) do |target_status|
   case target_status
   when 'enabled'
     xpath = "//i[contains(@class, 'fa-toggle-on')]"
-    raise unless find(:xpath, xpath)
+    raise "xpath: #{xpath} not found" unless find(:xpath, xpath)
   when 'disabled'
     xpath = "//i[contains(@class, 'fa-toggle-off')]"
-    raise unless find(:xpath, xpath)
+    raise "xpath: #{xpath} not found" unless find(:xpath, xpath)
   else
     raise 'Invalid target status.'
   end
@@ -789,10 +789,10 @@ And(/^I click on the "([^"]*)" toggler$/) do |target_status|
   case target_status
   when 'enabled'
     xpath = "//i[contains(@class, 'fa-toggle-on')]"
-    raise unless find(:xpath, xpath).click
+    raise "xpath: #{xpath} not found" unless find(:xpath, xpath).click
   when 'disabled'
     xpath = "//i[contains(@class, 'fa-toggle-off')]"
-    raise unless find(:xpath, xpath).click
+    raise "xpath: #{xpath} not found" unless find(:xpath, xpath).click
   else
     raise 'Invalid target status.'
   end
@@ -806,9 +806,9 @@ And(/^I should see the child channel "([^"]*)" "([^"]*)"$/) do |target_channel, 
 
   case target_status
   when 'selected'
-    raise unless has_checked_field?(channel_checkbox_id)
+    raise "#{channel_checkbox_id} is not selected" unless has_checked_field?(channel_checkbox_id)
   when 'unselected'
-    raise if has_checked_field?(channel_checkbox_id)
+    raise "#{channel_checkbox_id} is selected" if has_checked_field?(channel_checkbox_id)
   else
     raise 'Invalid target status.'
   end
@@ -824,9 +824,9 @@ And(/^I should see the child channel "([^"]*)" "([^"]*)" and "([^"]*)"$/) do |ta
 
   case target_status
   when 'selected'
-    raise unless has_checked_field?(channel_checkbox_id, disabled: true)
+    raise "#{channel_checkbox_id} is not selected" unless has_checked_field?(channel_checkbox_id, disabled: true)
   when 'unselected'
-    raise if has_checked_field?(channel_checkbox_id, disabled: true)
+    raise "#{channel_checkbox_id} is selected" if has_checked_field?(channel_checkbox_id, disabled: true)
   else
     raise 'Invalid target status.'
   end
@@ -838,7 +838,7 @@ And(/^I select the child channel "([^"]*)"$/) do |target_channel|
   xpath = "//label[contains(text(), '#{target_channel}')]"
   channel_checkbox_id = find(:xpath, xpath)['for']
 
-  raise if has_checked_field?(channel_checkbox_id)
+  raise "Field #{channel_checkbox_id} is checked" if has_checked_field?(channel_checkbox_id)
   find(:xpath, "//input[@id='#{channel_checkbox_id}']").click
 end
 
@@ -857,9 +857,9 @@ And(/^I should see "([^"]*)" "([^"]*)" for the "([^"]*)" channel$/) do |target_r
 
   case target_status
   when 'selected'
-    raise if find(:xpath, xpath)['checked'].nil?
+    raise "xpath: #{xpath} is not selected" if find(:xpath, xpath)['checked'].nil?
   when 'unselected'
-    raise unless find(:xpath, xpath)['checked'].nil?
+    raise "xpath: #{xpath} is selected" unless find(:xpath, xpath)['checked'].nil?
   end
 end
 
@@ -870,10 +870,10 @@ And(/^the notification badge and the table should count the same amount of messa
 
   if table_notifications_count == '0'
     puts "All notification-messages are read, I expect no notification badge"
-    raise if all(:xpath, badge_xpath).any?
+    raise "xpath: #{badge_xpath} found" if all(:xpath, badge_xpath).any?
   else
     puts "Unread notification-messages count = " + table_notifications_count
-    raise unless find(:xpath, badge_xpath)
+    raise "xpath: #{badge_xpath} not found" unless find(:xpath, badge_xpath)
   end
 end
 
@@ -890,8 +890,8 @@ Then(/^I check the first notification message$/) do
     puts "There are no notification messages, nothing to do then"
   else
     within(:xpath, '//section') do
-      row = first(:xpath, "//div[@class=\"table-responsive\"]/table/tbody/tr[.//td]")
-      row.first(:xpath, './/input[@type="checkbox"]').set(true)
+      row = find(:xpath, "//div[@class=\"table-responsive\"]/table/tbody/tr[.//td]", match: :first)
+      row.find(:xpath, './/input[@type="checkbox"]', match: :first).set(true)
     end
   end
 end
@@ -899,7 +899,7 @@ end
 And(/^I delete it via the "([^"]*)" button$/) do |target_button|
   if count_table_items != '0'
     xpath_for_delete_button = "//button[contains(text(), '#{target_button}')]"
-    raise unless find(:xpath, xpath_for_delete_button).click
+    raise "xpath: #{xpath_for_delete_button} not found" unless find_and_wait_click(:xpath, xpath_for_delete_button).click
 
     step %(I wait until I see "1 message deleted successfully." text)
   end
@@ -908,7 +908,7 @@ end
 And(/^I mark as read it via the "([^"]*)" button$/) do |target_button|
   if count_table_items != '0'
     xpath_for_read_button = "//button[contains(text(), '#{target_button}')]"
-    raise unless find(:xpath, xpath_for_read_button).click
+    raise "xpath: #{xpath_for_read_button} not found" unless find_and_wait_click(:xpath, xpath_for_read_button).click
 
     step %(I wait until I see "1 message read status updated successfully." text)
   end

--- a/testsuite/features/step_definitions/content_lifecycle_steps.rb
+++ b/testsuite/features/step_definitions/content_lifecycle_steps.rb
@@ -1,13 +1,13 @@
 When(/^I click the environment build button$/) do
-  page.find(:xpath, '//*[@id="cm-build-modal-save-button"]').click
+  find(:xpath, '//*[@id="cm-build-modal-save-button"]').click
 end
 
 When(/^I click promote for Development to QA$/) do
-  page.find(:xpath, '//*[@id="dev_name-promote-modal-link"]').click
+  find(:xpath, '//*[@id="dev_name-promote-modal-link"]').click
 end
 
 When(/^I click promote for QA to Production$/) do
-  page.find(:xpath, '//*[@id="qa_name-promote-modal-link"]').click
+  find(:xpath, '//*[@id="qa_name-promote-modal-link"]').click
 end
 
 When(/^I should see a "([^"]*)" text in the environment "([^"]*)"$/) do |text, env|
@@ -24,6 +24,6 @@ end
 
 Then(/^I wait until I see "([^"]*)" text in the environment "([^"]*)"$/) do |text, env|
   within(:xpath, "//h3[text()='#{env}']/../..") do
-    raise unless page.has_text?(text, wait: DEFAULT_TIMEOUT)
+    raise "Text #{text} not found" unless page.has_text?(text, wait: DEFAULT_TIMEOUT)
   end
 end

--- a/testsuite/features/step_definitions/datepicker_steps.rb
+++ b/testsuite/features/step_definitions/datepicker_steps.rb
@@ -85,7 +85,7 @@ end
 
 Given(/^I pick "([^"]*)" as time$/) do |arg1|
   find('.ui-timepicker-input').click
-  timepicker = first('ul.ui-timepicker-list')
+  timepicker = find('ul.ui-timepicker-list', match: :first)
   time = timepicker.find(:xpath, "//*[normalize-space(text())='#{arg1}']")
   time.click
 end

--- a/testsuite/features/step_definitions/docker_steps.rb
+++ b/testsuite/features/step_definitions/docker_steps.rb
@@ -71,8 +71,8 @@ end
 
 When(/^I check the first image$/) do
   within(:xpath, '//section') do
-    row = first(:xpath, "//div[@class='table-responsive']/table/tbody/tr[.//td]")
-    row.first(:xpath, ".//input[@type='checkbox']").set(true)
+    row = find(:xpath, "//div[@class='table-responsive']/table/tbody/tr[.//td]", match: :first)
+    row.find(:xpath, ".//input[@type='checkbox']", match: :first).set(true)
   end
 end
 

--- a/testsuite/features/step_definitions/lock_packages_on_client.rb
+++ b/testsuite/features/step_definitions/lock_packages_on_client.rb
@@ -3,7 +3,7 @@
 
 Then(/^"(.*?)" is locked on this client$/) do |pkg|
   zypp_lock_file = '/etc/zypp/locks'
-  raise unless file_exists?($client, zypp_lock_file)
+  raise "File already exist: #{zypp_lock_file}" unless file_exists?($client, zypp_lock_file)
   command = "zypper locks  --solvables | grep #{pkg}"
   $client.run(command, true, 600, 'root')
 end
@@ -11,13 +11,14 @@ end
 Then(/^package "(.*?)" is reported as locked$/) do |pkg|
   find(:xpath, "(//a[text()='#{pkg}'])[1]")
   locked_pkgs = all(:xpath, "//i[@class='fa fa-lock']/../a")
-  raise if locked_pkgs.empty?
-  raise unless locked_pkgs.find { |a| a.text =~ /^#{pkg}/ }
+  raise 'No packages locked' if locked_pkgs.empty?
+  raise "Package #{pkg} not found as locked" unless locked_pkgs.find { |a| a.text =~ /^#{pkg}/ }
 end
 
 Then(/^"(.*?)" is unlocked on this client$/) do |pkg|
   zypp_lock_file = '/etc/zypp/locks'
-  raise unless file_exists?($client, zypp_lock_file)
+  raise "File #{zypp_lock_file} not found" unless file_exists?($client, zypp_lock_file)
+
   command = "zypper locks  --solvables | grep #{pkg}"
   $client.run(command, false, 600, 'root')
 end
@@ -26,14 +27,14 @@ Then(/^package "(.*?)" is reported as unlocked$/) do |pkg|
   find(:xpath, "(//a[text()='#{pkg}'])[1]")
   locked_pkgs = all(:xpath, "//i[@class='fa fa-lock']/../a")
 
-  raise if locked_pkgs.find { |a| a.text =~ /^#{pkg}/ }
+  raise "Package #{pkg} found as locked" if locked_pkgs.find { |a| a.text =~ /^#{pkg}/ }
 end
 
 Then(/^the package scheduled is "(.*?)"$/) do |pkg|
   match = find(:xpath, "//li[@class='list-group-item']//li")
 
-  raise unless match
-  raise unless match.text =~ /^#{pkg}/
+  raise 'List of packages not found' unless match
+  raise "Package #{pkg} not found" unless match.text =~ /^#{pkg}/
 end
 
 Then(/^the action status is "(.*?)"$/) do |status|
@@ -85,19 +86,16 @@ Then(/^only packages "(.*?)" are reported as pending to be unlocked$/) do |pkgs|
                 "span[@class='label label-info' and contains(text(), 'Unlocking...')]]"
   matches = all(:xpath, xpath_query)
 
-  raise if matches.size != pkgs.size
+  raise "Matches count #{matches.size} is different than packages count #{pkgs.size}" if matches.size != pkgs.size
 end
 
 When(/^I select all the packages$/) do
   within(:xpath, '//section') do
     # use div/div/div for cve audit which has two tables
     top_level_xpath_query = "//div[@class='table-responsive']/table/thead/tr[.//input[@type='checkbox']]"
-    row = first(:xpath, top_level_xpath_query)
-    if row.nil?
-      sleep 1
-      $stderr.puts 'ERROR - try again'
-      row = first(:xpath, top_level_xpath_query)
-    end
-    row.first(:xpath, './/input[@type="checkbox"]').set(true)
+    row = find(:xpath, top_level_xpath_query, match: :first)
+    raise "xpath: #{top_level_xpath_query} not found" if row.nil?
+
+    row.find(:xpath, './/input[@type="checkbox"]', match: :first).set(true)
   end
 end

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -12,53 +12,46 @@ end
 
 Then(/^I should see a "(.*)" text in the content area$/) do |txt|
   within('#spacewalk-content') do
-    raise unless page.has_content?(txt)
+    raise "Text #{txt} not found" unless page.has_content?(txt)
   end
 end
 
 Then(/^I should not see a "(.*)" text in the content area$/) do |txt|
   within('#spacewalk-content') do
-    raise unless page.has_no_content?(txt)
+    raise "Text #{txt} found" unless page.has_no_content?(txt)
   end
 end
 
 When(/^I click on "([^"]+)" in row "([^"]+)"$/) do |link, item|
   within(:xpath, "//tr[td[contains(.,'#{item}')]]") do
-    click_link_or_button(link)
+    click_link_or_button_and_wait(link)
   end
 end
 
 Then(/^the current path is "([^"]*)"$/) do |arg1|
-  raise unless current_path == arg1
+  raise "Path #{current_path} different than #{arg1}" unless current_path == arg1
 end
 
 When(/^I wait until I see "([^"]*)" text$/) do |text|
-  raise unless page.has_text?(text, wait: DEFAULT_TIMEOUT)
+  raise "Text #{text} not found" unless page.has_text?(text, wait: DEFAULT_TIMEOUT)
 end
 
 When(/^I wait until I do not see "([^"]*)" text$/) do |text|
-  raise unless page.has_no_text?(text, wait: DEFAULT_TIMEOUT)
+  raise "Text #{text} found" unless page.has_no_text?(text, wait: DEFAULT_TIMEOUT)
 end
 
 When(/^I wait at most (\d+) seconds until I see "([^"]*)" text$/) do |seconds, text|
-  repeat_until_timeout(timeout: seconds, message: "Couldn't find text '#{text}'") do
-    break if page.has_content?(text)
-    sleep 3
-  end
+  raise "Text #{text} not found" unless page.has_content?(text, wait: seconds)
 end
 
 When(/^I wait until I see "([^"]*)" text or "([^"]*)" text$/) do |text1, text2|
-  repeat_until_timeout(message: "Couldn't find either '#{text1}' or '#{text2}'") do
-    break if page.has_content?(text1) || page.has_content?(text2)
-    sleep 3
-  end
+  raise "Text #{text1} or #{text2} not found" unless page.has_content?(text1, wait: DEFAULT_TIMEOUT) || page.has_content?(text2, wait: DEFAULT_TIMEOUT)
 end
 
 When(/^I wait until I see "([^"]*)" text, refreshing the page$/) do |text|
-  text.gsub! '$PRODUCT', $product
+  text.gsub! '$PRODUCT', $product # TODO: Rid of this substitution, using another step
   repeat_until_timeout(message: "Couldn't find text '#{text}'") do
     break if page.has_content?(text)
-    sleep 1
     page.evaluate_script 'window.location.reload()'
   end
 end
@@ -67,7 +60,6 @@ When(/^I wait at most (\d+) seconds until the event is completed, refreshing the
   repeat_until_timeout(timeout: timeout.to_i, message: 'Event not yet completed') do
     break if page.has_content?("This action's status is: Completed.")
     raise 'Event failed' if page.has_content?("This action's status is: Failed.")
-    sleep 1
     page.evaluate_script 'window.location.reload()'
   end
 end
@@ -80,7 +72,6 @@ end
 When(/^I wait until I do not see "([^"]*)" text, refreshing the page$/) do |text|
   repeat_until_timeout(message: "Text '#{text}' is still visible") do
     break unless page.has_content?(text)
-    sleep 3
     page.evaluate_script 'window.location.reload()'
   end
 end
@@ -93,7 +84,6 @@ end
 Then(/^I wait until I see the (VNC|spice) graphical console$/) do |type|
   repeat_until_timeout(message: "The #{type} graphical console didn't load") do
     break unless page.has_xpath?('.//canvas')
-    sleep 3
   end
 end
 
@@ -151,7 +141,7 @@ end
 # Click on a button
 #
 When(/^I click on "([^"]*)"$/) do |text|
-  click_button(text, wait: CLICK_TIMEOUT, match: :first)
+  click_button_and_wait(text, match: :first)
 end
 
 #
@@ -159,7 +149,7 @@ end
 # the given "id"
 When(/^I click on "([^"]*)" in element "([^"]*)"$/) do |text, element_id|
   within(:xpath, "//div[@id=\"#{element_id}\"]") do
-    click_button(text, wait: CLICK_TIMEOUT, match: :first)
+    click_button_and_wait(text, match: :first)
   end
 end
 
@@ -175,13 +165,14 @@ end
 # Click on a link
 #
 When(/^I follow "([^"]*)"$/) do |text|
-  click_link(text, wait: CLICK_TIMEOUT)
+  click_link_and_wait(text)
 end
+
 #
 # Click on the first link
 #
 When(/^I follow first "([^"]*)"$/) do |text|
-  click_link(text, wait: CLICK_TIMEOUT, match: :first)
+  click_link_and_wait(text, match: :first)
 end
 
 #
@@ -194,7 +185,7 @@ When(/^I follow "([^"]*)" in element "([^"]*)"$/) do |arg1, arg2|
 end
 
 When(/^I want to add a new credential$/) do
-  raise unless find('i.fa-plus-circle').click
+  raise 'xpath: i.fa-plus-circle not found' unless find_and_wait_click('i.fa-plus-circle').click
 end
 
 When(/^I follow "([^"]*)" in the (.+)$/) do |arg1, arg2|
@@ -231,7 +222,7 @@ end
 When(/^I follow "([^"]*)" on "(.*?)" row$/) do |text, host|
   system_name = get_system_name(host)
   xpath_query = "//tr[td[contains(.,'#{system_name}')]]//a[contains(., '#{text}')]"
-  raise unless find(:xpath, xpath_query).click
+  raise "xpath: #{xpath_query} not found" unless find_and_wait_click(:xpath, xpath_query).click
 end
 
 When(/^I enter "(.*?)" in the editor$/) do |arg1|
@@ -269,7 +260,7 @@ When(/^I follow the left menu "([^"]*)"$/) do |menu_path|
     target_link_path += parent_wrapper_path + parent_level_path
   end
   # finally go to the target page
-  find(:xpath, target_link_path).click
+  find_and_wait_click(:xpath, target_link_path).click
 end
 
 #
@@ -278,7 +269,7 @@ end
 
 Given(/^I am not authorized$/) do
   visit Capybara.app_host
-  raise unless find_button('Sign In').visible?
+  raise "Button 'Sign In' not visible" unless find_button('Sign In').visible?
 end
 
 When(/^I go to the home page$/) do
@@ -287,7 +278,7 @@ end
 
 Given(/^I access the host the first time$/) do
   visit Capybara.app_host
-  raise unless page.has_content?('Create ' + product + ' Administrator')
+  raise "Text 'Create #{product} Administrator' not found" unless page.has_content?("Create #{product} Administrator")
 end
 
 # Admin Page steps
@@ -310,8 +301,8 @@ Given(/^I am on the Systems overview page of this "([^"]*)"$/) do |host|
   system_name = get_system_name(host)
   steps %(
     Given I am on the Systems page
+    When I follow "#{system_name}"
   )
-  step %(I follow "#{system_name}")
 end
 
 Given(/^I am on the "([^"]*)" page of this "([^"]*)"$/) do |page, host|
@@ -351,23 +342,20 @@ Given(/^I am on the active Users page$/) do
 end
 
 Then(/^Table row for "([^"]*)" should contain "([^"]*)"$/) do |arg1, arg2|
-  within(:xpath, "//div[@class=\"table-responsive\"]/table/tbody/tr[.//a[contains(.,'#{arg1}')]]") do
-    raise unless has_content?(arg2)
+  xpath_query = "//div[@class=\"table-responsive\"]/table/tbody/tr[.//a[contains(.,'#{arg1}')]]"
+  within(:xpath, xpath_query) do
+    raise "xpath: #{xpath_query} has no content #{arg2}" unless has_content?(arg2)
   end
 end
 
 When(/^I wait until table row for "([^"]*)" contains button "([^"]*)"$/) do |text, button|
-  repeat_until_timeout(message: "Couldn't find #{button} button in row with #{text} text") do
-    break if all(:xpath, "//tr[td[contains(., '#{text}')]]/td/descendant::*[self::a or self::button][@title='#{button}']").any?
-    sleep 1
-  end
+  xpath_query = "//tr[td[contains(., '#{text}')]]/td/descendant::*[self::a or self::button][@title='#{button}']"
+  raise "xpath: #{xpath_query} not found" unless all(:xpath, xpath_query, wait: DEFAULT_TIMEOUT).any?
 end
 
 When(/^I wait until table row contains a "([^"]*)" text$/) do |text|
-  repeat_until_timeout(message: "Couldn't find #{text} in any row") do
-    break if all(:xpath, "//div[@class=\"table-responsive\"]/table/tbody/tr[.//td[contains(.,'#{text}')]]").any?
-    sleep 1
-  end
+  xpath_query = "//div[@class=\"table-responsive\"]/table/tbody/tr[.//td[contains(.,'#{text}')]]"
+  raise "xpath: #{xpath_query} not found" unless all(:xpath, xpath_query, wait: DEFAULT_TIMEOUT).any?
 end
 
 # login, logout steps
@@ -376,11 +364,12 @@ Given(/^I am authorized as "([^"]*)" with password "([^"]*)"$/) do |user, passwd
   visit Capybara.app_host
   next if page.all(:xpath, "//header//span[text()='#{user}']").any?
 
-  page.find(:xpath, "//header//i[@class='fa fa-sign-out']").click if page.all(:xpath, "//header//i[@class='fa fa-sign-out']").any?
+  find_and_wait_click(:xpath, "//header//i[@class='fa fa-sign-out']").click if page.all(:xpath, "//header//i[@class='fa fa-sign-out']").any?
 
   fill_in 'username', with: user
   fill_in 'password', with: passwd
-  click_button 'Sign In'
+  click_button_and_wait('Sign In')
+
   step %(I should be logged in)
 end
 
@@ -389,20 +378,20 @@ Given(/^I am authorized$/) do
 end
 
 When(/^I sign out$/) do
-  page.find(:xpath, "//a[@href='/rhn/Logout.do']").click
+  find_and_wait_click(:xpath, "//a[@href='/rhn/Logout.do']").click
 end
 
 Then(/^I should not be authorized$/) do
-  raise if all(:xpath, "//a[@href='/rhn/Logout.do']").any?
+  raise 'User is authorized' if all(:xpath, "//a[@href='/rhn/Logout.do']").any?
 end
 
 Then(/^I should be logged in$/) do
-  raise unless all(:xpath, "//a[@href='/rhn/Logout.do']").any?
+  raise 'User is not logged in' unless all(:xpath, "//a[@href='/rhn/Logout.do']").any?
 end
 
 Then(/^I am logged in$/) do
-  raise unless page.find(:xpath, "//a[@href='/rhn/Logout.do']").visible?
-  raise unless page.has_content?('You have just created your first ' + product + ' user. To finalize your installation please use the Setup Wizard')
+  raise 'User is not logged in' unless find(:xpath, "//a[@href='/rhn/Logout.do']").visible?
+  raise 'The welcome meesage is not shown' unless page.has_content?("You have just created your first #{product} user. To finalize your installation please use the Setup Wizard")
 end
 
 Given(/^I am on the patches page$/) do
@@ -411,7 +400,8 @@ Given(/^I am on the patches page$/) do
 end
 
 Then(/^I should see an update in the list$/) do
-  raise unless all(:xpath, '//div[@class="table-responsive"]/table/tbody/tr/td/a').any?
+  xpath_query = '//div[@class="table-responsive"]/table/tbody/tr/td/a'
+  raise "xpath: #{xpath_query} not found" unless all(:xpath, xpath_query).any?
 end
 
 When(/^I check test channel$/) do
@@ -455,7 +445,7 @@ end
 
 Then(/^I should see "([^"]*)" systems selected for SSM$/) do |arg|
   within(:xpath, '//span[@id="spacewalk-set-system_list-counter"]') do
-    raise unless has_content?(arg)
+    raise "There are not #{arg} systems selected" unless has_content?(arg)
   end
 end
 
@@ -463,18 +453,12 @@ end
 # Test for a text in the whole page
 #
 Then(/^I should see a "([^"]*)" text$/) do |text|
-  text.gsub! '$PRODUCT', $product
-  unless page.has_content?(text)
-    sleep 2
-    raise unless page.has_content?(text)
-  end
+  text.gsub! '$PRODUCT', $product # TODO: Rid of this substitution, using another step
+  raise "Text #{text} not found" unless page.has_content?(text)
 end
 
 Then(/^I should see a "([^"]*)" text or "([^"]*)" text$/) do |text1, text2|
-  unless page.has_content?(text1) || page.has_content?(text2)
-    sleep 2
-    raise unless page.has_content?(text1) || page.has_content?(text2)
-  end
+  raise "Text #{text1} and #{text2} are not found" unless page.has_content?(text1) || page.has_content?(text2)
 end
 
 #
@@ -482,7 +466,7 @@ end
 #
 Then(/^I should see "([^"]*)" in the textarea$/) do |arg1|
   within('textarea') do
-    raise unless page.has_content?(arg1)
+    raise "Text #{arg1} not found" unless page.has_content?(arg1)
   end
 end
 
@@ -490,10 +474,7 @@ end
 # Test for a text in the whole page using regexp
 #
 Then(/^I should see a text like "([^"]*)"$/) do |title|
-  unless page.has_content?(Regexp.new(title))
-    sleep 2
-    raise unless page.has_content?(Regexp.new(title))
-  end
+  raise "Text #{title} not found" unless page.has_content?(Regexp.new(title))
 end
 
 #
@@ -506,26 +487,19 @@ end
 #
 # Test for a visible link in the whole page
 #
-Then(/^I should see a "([^"]*)" link$/) do |arg1|
-  link = first(:link, arg1)
-  if link.nil?
-    sleep 3
-    $stderr.puts 'ERROR - try again'
-    raise unless first(:link, arg1).visible?
-  else
-    raise unless link.visible?
-  end
+Then(/^I should see a "([^"]*)" link$/) do |text|
+  raise "Link #{text} is not visible" unless all(:link, text, visible: true).any?
 end
 
 #
 # Validate link is gone
 #
 Then(/^I should not see a "([^"]*)" link$/) do |arg1|
-  raise unless page.has_no_link?(arg1)
+  raise "Link #{arg1} is present" unless page.has_no_link?(arg1)
 end
 
 Then(/^I should see a "([^"]*)" button$/) do |arg1|
-  raise unless find_button(arg1).visible?
+  raise "Link #{arg1} is not visible" unless find_button(arg1).visible?
 end
 
 Then(/^I should see a "(.*?)" link in the text$/) do |linktext, text|
@@ -540,31 +514,31 @@ end
 #
 Then(/^I should see a "([^"]*)" link in element "([^"]*)"$/) do |link, element|
   within(:xpath, "//div[@id=\"#{element}\" or @class=\"#{element}\"]") do
-    raise unless find_link(link).visible?
+    raise "Link #{link} not visible" unless find_link(link).visible?
   end
 end
 
 Then(/^I should not see a "([^"]*)" link in element "([^"]*)"$/) do |link, element|
   within(:xpath, "//div[@id=\"#{element}\" or @class=\"#{element}\"]") do
-    raise unless has_no_link?(link)
+    raise "Link #{link} is present" unless has_no_link?(link)
   end
 end
 
 Then(/^I should see a "([^"]*)" text in element "([^"]*)"$/) do |text, element|
   within(:xpath, "//div[@id=\"#{element}\" or @class=\"#{element}\"]") do
-    raise unless has_content?(text)
+    raise "Text #{text} not found in #{element}" unless has_content?(text)
   end
 end
 
 Then(/^I should not see a "([^"]*)" text in element "([^"]*)"$/) do |text, element|
   within(:xpath, "//div[@id=\"#{element}\" or @class=\"#{element}\"]") do
-    raise if has_content?(text)
+    raise "Text #{text} found in #{element}" if has_content?(text)
   end
 end
 
 Then(/^I should see a "([^"]*)" or "([^"]*)" text in element "([^"]*)"$/) do |text1, text2, element|
   within(:xpath, "//div[@id=\"#{element}\" or @class=\"#{element}\"]") do
-    raise unless has_content?(text1) || has_content?(text2)
+    raise "Texts #{text1} and #{text2} not found in #{element}" unless has_content?(text1) || has_content?(text2)
   end
 end
 
@@ -646,40 +620,37 @@ end
 
 Then(/^I should see a "([^"]*)" link in list "([^"]*)"$/) do |arg1, arg2|
   within(:xpath, "//ul[@id=\"#{arg2}\" or @class=\"#{arg2}\"]") do
-    raise unless find_link(arg1).visible?
+    raise "Link #{arg1} not visible" unless find_link(arg1).visible?
   end
 end
 
 Then(/^I should see a "([^"]*)" button in "([^"]*)" form$/) do |arg1, arg2|
   within(:xpath, "//form[@id='#{arg2}' or @name=\"#{arg2}\"]") do
-    raise unless find_button(arg1)
+    raise "Button #{arg1} not found" unless find_button(arg1)
   end
 end
 
 Then(/^I select the "([^"]*)" repo$/) do |repo|
-  within page.first('a', text: repo) do
-    within(:xpath, '../..') do
-      first('input[type=checkbox]').set(true)
-    end
-  end
+  repo = find(:xpath, "//a[contains(.,'#{repo}')]/../..//*[@type='checkbox']", match: :first)
+  repo.set(true) unless repo.nil?
 end
 
 Then(/^I check the row with the "([^"]*)" link$/) do |arg1|
   within(:xpath, "//a[text()='#{arg1}']/../..") do
-    first('input[type=checkbox]').set(true)
+    find('input[type=checkbox]', match: :first).set(true)
   end
 end
 
 Then(/^I check the row with the "([^"]*)" text$/) do |text|
   within(:xpath, "//tr[td[contains(., '#{text}')]]") do
-    first('input[type=checkbox]').set(true)
+    find('input[type=checkbox]', match: :first).set(true)
   end
 end
 
 Then(/^I check the row with the "([^"]*)" hostname$/) do |host|
   system_name = get_system_name(host)
   within(:xpath, "//tr[td[contains(., '#{system_name}')]]") do
-    first('input[type=checkbox]').set(true)
+    find('input[type=checkbox]', match: :first).set(true)
   end
 end
 
@@ -687,28 +658,28 @@ end
 # Test if an option is selected
 #
 Then(/^option "([^"]*)" is selected as "([^"]*)"$/) do |arg1, arg2|
-  raise unless has_select?(arg2, selected: arg1)
+  raise "#{arg1} is not selected as #{arg2}" unless has_select?(arg2, selected: arg1)
 end
 
 #
 # Test if a radio button is checked
 #
 Then(/^radio button "([^"]*)" is checked$/) do |arg1|
-  raise unless has_checked_field?(arg1)
+  raise "#{arg1} is unchecked" unless has_checked_field?(arg1)
 end
 
 #
 # Test if a checkbox is checked
 #
 Then(/^I should see "([^"]*)" as checked$/) do |arg1|
-  raise unless has_checked_field?(arg1)
+  raise "#{arg1} is unchecked" unless has_checked_field?(arg1)
 end
 
 #
 # Test if a checkbox is unchecked
 #
 Then(/^I should see "([^"]*)" as unchecked$/) do |arg1|
-  raise unless has_unchecked_field?(arg1)
+  raise "#{arg1} is checked" unless has_unchecked_field?(arg1)
 end
 
 #
@@ -723,19 +694,19 @@ Then(/^the "([^\"]*)" field should be disabled$/) do |arg1|
 end
 
 Then(/^I should see "([^"]*)" in field "([^"]*)"$/) do |arg1, arg2|
-  raise unless page.has_field?(arg2, with: arg1)
+  raise "Field #{arg2} with #{arg1} value not found" unless page.has_field?(arg2, with: arg1)
 end
 
 Then(/^I should see a "([^"]*)" element in "([^"]*)" form$/) do |arg1, arg2|
   within(:xpath, "//form[@id=\"#{arg2}\"] | //form[@name=\"#{arg2}\"]") do
-    raise unless find_field(arg1, match: :first).visible?
+    raise "Field #{arg1} not found" unless find_field(arg1, match: :first).visible?
   end
 end
 
 Then(/^I should see a "([^"]*)" editor in "([^"]*)" form$/) do |arg1, arg2|
   within(:xpath, "//form[@id=\"#{arg2}\"] | //form[@name=\"#{arg2}\"]") do
-    raise unless page.find("textarea##{arg1}", visible: false)
-    raise unless page.has_css?("##{arg1}-editor")
+    raise "xpath: textarea##{arg1} not found" unless find("textarea##{arg1}", visible: false)
+    raise "css: ##{arg1}-editor not found" unless page.has_css?("##{arg1}-editor")
   end
 end
 
@@ -743,36 +714,31 @@ Then(/^I should see a Sign Out link$/) do
   raise unless all(:xpath, "//a[@href='/rhn/Logout.do']").any?
 end
 
-When(/^I check "([^"]*)" in the list$/) do |arg1|
+When(/^I check "([^"]*)" in the list$/) do |text|
   within(:xpath, '//section') do
     # use div/div/div for cve audit which has two tables
-    row = first(:xpath, "//div[@class=\"table-responsive\"]/table/tbody/tr[.//td[contains(.,'#{arg1}')]]")
-    if row.nil?
-      sleep 10
-      $stderr.puts 'ERROR - try again'
-      row = first(:xpath, "//div[@class=\"table-responsive\"]/table/tbody/tr[.//td[contains(.,'#{arg1}')]]")
-    end
-    row.first(:xpath, './/input[@type="checkbox"]').set(true) unless row.nil?
+    top_level_xpath_query = "//div[@class=\"table-responsive\"]/table/tbody/tr[.//td[contains(.,'#{text}')]]"
+    row = find(:xpath, top_level_xpath_query, match: :first)
+    raise "xpath: #{top_level_xpath_query} not found" if row.nil?
+
+    row.find(:xpath, './/input[@type="checkbox"]', match: :first).set(true)
   end
 end
 
-When(/^I uncheck "([^"]*)" in the list$/) do |arg1|
+When(/^I uncheck "([^"]*)" in the list$/) do |text|
   within(:xpath, '//section') do
     # use div/div/div for cve audit which has two tables
-    top_level_xpath_query = "//div[@class='table-responsive']/table/tbody/tr[.//td[contains(.,'#{arg1}')] and .//input[@type='checkbox' and @checked]]"
-    row = first(:xpath, top_level_xpath_query)
-    if row.nil?
-      sleep 3
-      $stderr.puts 'ERROR - try again'
-      row = first(:xpath, top_level_xpath_query)
-    end
-    row.first(:xpath, './/input[@type="checkbox"]').set(false) unless row.nil?
+    top_level_xpath_query = "//div[@class='table-responsive']/table/tbody/tr[.//td[contains(.,'#{text}')] and .//input[@type='checkbox' and @checked]]"
+    row = find(:xpath, top_level_xpath_query, match: :first)
+    raise "xpath: #{top_level_xpath_query} not found" if row.nil?
+
+    row.find(:xpath, './/input[@type="checkbox"]', match: :first).set(false)
   end
 end
 
 Then(/^I should see (\d+) "([^"]*)" fields in "([^"]*)" form$/) do |count, name, id|
   within(:xpath, "//form[@id=\"#{id}\" or  @name=\"#{id}\"]") do
-    raise unless has_field?(name, count: count.to_i)
+    raise "#{id} form has not #{count} fields with name #{name}" unless has_field?(name, count: count.to_i)
   end
 end
 
@@ -784,12 +750,11 @@ When(/^I click on "([^"]*)" in "([^"]*)" modal$/) do |btn, title|
   # We wait until the element becomes visible, because
   # the fade out animation might still be in progress
   repeat_until_timeout(message: "Couldn't find the #{title} modal") do
-    break if all(:xpath, path, visible: true).any?
-    sleep 1
+    break if all(:xpath, path).any?
   end
 
-  within(:xpath, path, visible: :all) do
-    find(:xpath, ".//button[@title = \"#{btn}\"]", visible: :all).click
+  within(:xpath, path) do
+    find(:xpath, ".//button[@title = \"#{btn}\"]").click
   end
 end
 

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -181,12 +181,12 @@ end
 
 Then(/^I should see "([^"]*)" hostname$/) do |host|
   system_name = get_system_name(host)
-  raise unless page.has_content?(system_name)
+  raise "Hostname #{system_name} is not present" unless page.has_content?(system_name)
 end
 
 Then(/^I should not see "([^"]*)" hostname$/) do |host|
   system_name = get_system_name(host)
-  raise if page.has_content?(system_name)
+  raise "Hostname #{system_name} is present" if page.has_content?(system_name)
 end
 
 When(/^I expand the results for "([^"]*)"$/) do |host|
@@ -205,7 +205,7 @@ end
 Then(/^I should see "([^"]*)" in the command output for "([^"]*)"$/) do |text, host|
   system_name = get_system_name(host)
   within("pre[id='#{system_name}-results']") do
-    raise unless page.has_content?(text)
+    raise "Text '#{text}' not found in the results of #{system_name}" unless page.has_content?(text)
   end
 end
 
@@ -226,7 +226,7 @@ Then(/^I click on the css "(.*)" until page does contain "([^"]*)" text$/) do |c
 end
 
 When(/^I click on the css "(.*)"$/) do |css|
-  find(css).click
+  find_and_wait_click(css).click
 end
 
 When(/^I enter "(.*)" in the css "(.*)"$/) do |input, css|
@@ -252,11 +252,11 @@ When(/^I ([^ ]*) the "([^"]*)" formula$/) do |action, formula|
   xpath_query = "//a[@id = '#{formula}']/i[@class = 'fa fa-lg fa-square-o']" if action == 'check'
   xpath_query = "//a[@id = '#{formula}']/i[@class = 'fa fa-lg fa-check-square-o']" if action == 'uncheck'
   if all(:xpath, xpath_query).any?
-    raise unless find(:xpath, xpath_query).click
+    raise "xpath: #{xpath_query} not found" unless find(:xpath, xpath_query).click
   else
     xpath_query = "//a[@id = '#{formula}']/i[@class = 'fa fa-lg fa-check-square-o']" if action == 'check'
     xpath_query = "//a[@id = '#{formula}']/i[@class = 'fa fa-lg fa-square-o']" if action == 'uncheck'
-    assert all(:xpath, xpath_query).any?, 'Checkbox could not be found'
+    raise "xpath: #{xpath_query} not found" unless all(:xpath, xpath_query).any?
   end
 end
 
@@ -480,7 +480,7 @@ Then(/^the pillar data for "([^"]*)" should (be|contain|not contain) "([^"]*)" o
   if minion == 'sle-minion'
     cmd = 'salt'
     extra_cmd = ''
-  elsif ['ssh-minion', 'ceos-minion', 'ceos-ssh-minion', 'ubuntu-minion', 'ubuntu-ssh-minion'].include?(minion)
+  elsif %w[ssh-minion ceos-minion ceos-ssh-minion ubuntu-minion ubuntu-ssh-minion].include?(minion)
     cmd = 'salt-ssh'
     extra_cmd = '-i --roster-file=/tmp/roster_tests -w -W 2>/dev/null'
     $server.run("printf '#{system_name}:\n  host: #{system_name}\n  user: root\n  passwd: linux\n' > /tmp/roster_tests")
@@ -535,26 +535,26 @@ end
 When(/^I reject "([^"]*)" from the Pending section$/) do |host|
   system_name = get_system_name(host)
   xpath_query = "//tr[td[contains(.,'#{system_name}')]]//button[@title = 'Reject']"
-  raise unless find(:xpath, xpath_query).click
+  raise "xpath: #{xpath_query} not found" unless find(:xpath, xpath_query).click
 end
 
 When(/^I delete "([^"]*)" from the Rejected section$/) do |host|
   system_name = get_system_name(host)
   xpath_query = "//tr[td[contains(.,'#{system_name}')]]//button[@title = 'Delete']"
-  raise unless find(:xpath, xpath_query).click
+  raise "xpath: #{xpath_query} not found" unless find(:xpath, xpath_query).click
 end
 
 When(/^I see "([^"]*)" fingerprint$/) do |host|
   node = get_target(host)
   output, _code = node.run('salt-call --local key.finger')
   fing = output.split("\n")[1].strip!
-  raise unless page.has_content?(fing)
+  raise "Text: #{fing} not found" unless page.has_content?(fing)
 end
 
 When(/^I accept "([^"]*)" key$/) do |host|
   system_name = get_system_name(host)
   xpath_query = "//tr[td[contains(.,'#{system_name}')]]//button[@title = 'Accept']"
-  raise unless find(:xpath, xpath_query).click
+  raise "xpath: #{xpath_query} not found" unless find(:xpath, xpath_query).click
 end
 
 When(/^I go to the minion onboarding page$/) do

--- a/testsuite/features/support/setup_browser.rb
+++ b/testsuite/features/support/setup_browser.rb
@@ -21,7 +21,6 @@ $stdout.sync = true
 STARTTIME = Time.new.to_i
 Capybara.default_max_wait_time = 10
 DEFAULT_TIMEOUT = 250
-CLICK_TIMEOUT = Capybara.default_max_wait_time * 2
 
 def enable_assertions
   # include assertion globally
@@ -52,6 +51,13 @@ After do |scenario|
     # embed the image name in the cucumber HTML report
     embed('screenshots/' + img_name, 'image/png')
     debug_server_on_realtime_failure
+  end
+end
+
+AfterStep do
+  if all('.senna-loading').any?
+    puts "WARN: Step ends with an ajax transition not finished, let's wait a bit!"
+    raise 'Timeout: Waiting AJAX transition' unless has_no_css?('.senna-loading')
   end
 end
 


### PR DESCRIPTION
## What does this PR change?

It improves navigation steps in the test-suite, so we give support for Single Page Application feature (#1001).
- Wrappers for `click_button`, `click_link`, `click_link_or_button` and `find` Capybara methods, in order to check if we still under a SPA transition
- Added a safeguard in AfterStep for SPA transition, but we need to discuss that solution
- ~~Capybara by default will not consider hidden elements now~~ We solved with the wrappers
- Add descriptions to the exceptions we raise related to Capybara conditions, to have a better comprehension of issues
- ~~New steps created to replace $PRODUCT value, only when we need, not on every "I should see a" step"~~ We replace $PRODUCT by "Uyuni" as agreed in https://github.com/SUSE/spacewalk/pull/8992

- [x] No changelog needed