### PR TITLE
Uyuni fix mgr virt deps

### DIFF
--- a/client/tools/mgr-virtualization/mgr-virtualization.changes
+++ b/client/tools/mgr-virtualization/mgr-virtualization.changes
@@ -1,3 +1,5 @@
+- fix package dependencies to prevent file conflict (bsc#1143856)
+
 -------------------------------------------------------------------
 Wed Jul 31 17:29:14 CEST 2019 - jgonzalez@suse.com
 

--- a/client/tools/mgr-virtualization/mgr-virtualization.spec
+++ b/client/tools/mgr-virtualization/mgr-virtualization.spec
@@ -75,8 +75,8 @@ Group:          System Environment/Base
 %{?python_provide:%python_provide python2-%{name}-common}
 Provides:       python-%{name}-common = %{oldversion}
 Obsoletes:      python-%{name}-common < %{oldversion}
-Provides:       python-%{oldname}-common = %{oldversion}
-Obsoletes:      python-%{oldname}-common < %{oldversion}
+Provides:       python2-%{oldname}-common = %{oldversion}
+Obsoletes:      python2-%{oldname}-common < %{oldversion}
 Provides:       %{name}-common = %{oldversion}
 Obsoletes:      %{name}-common < %{oldversion}
 Provides:       %{oldname}-common = %{oldversion}


### PR DESCRIPTION
## What does this PR change?

When updating python2-mgr-virtualization-common package we got file conflicts.
The happen because we used not the filename of the old package after the rename.
This is fixed with this PR.

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: **internal**

- [ ] **DONE**

## Test coverage
- No tests: **manual**

- [ ] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/8948

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
