### PR TITLE
common-channels: Duplicate Ubuntu channels for Uyuni

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -1041,13 +1041,60 @@ checksum = sha256
 base_channels = ubuntu-16.04-pool-amd64
 repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial/universe/binary-amd64/
 
+[ubuntu-1604-pool-amd64-uyuni]
+label    = ubuntu-16.04-pool-amd64-uyuni
+checksum = sha256
+archs    = amd64-deb
+repo_type = deb
+name     = Ubuntu 16.04 LTS AMD64 Base for Uyuni
+gpgkey_url =
+gpgkey_id =
+gpgkey_fingerprint =
+repo_url = http://localhost/pub/repositories/empty-deb/?uniquekey=1604-uyuni
+
+[ubuntu-1604-amd64-main-uyuni]
+label    = ubuntu-1604-amd64-main-uyuni
+checksum = sha256
+archs    = amd64-deb
+repo_type = deb
+name     = Ubuntu 16.04 LTS AMD64 Main for Uyuni
+base_channels = ubuntu-16.04-pool-amd64-uyuni
+repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial/main/binary-amd64/
+
+[ubuntu-1604-amd64-updates-uyuni]
+label    = ubuntu-1604-amd64-main-updates-uyuni
+name     = Ubuntu 16.04 LTS AMD64 Main Updates for Uyuni
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = ubuntu-16.04-pool-amd64-uyuni
+repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial-updates/main/binary-amd64/
+
+[ubuntu-1604-amd64-security-uyuni]
+label    = ubuntu-1604-amd64-main-security-uyuni
+name     = Ubuntu 16.04 LTS AMD64 Security for Uyuni
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = ubuntu-16.04-pool-amd64-uyuni
+repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial-security/main/binary-amd64/
+
+[ubuntu-1604-amd64-universe-uyuni]
+label    = ubuntu-1604-amd64-main-universe-uyuni
+name     = Ubuntu 16.04 LTS AMD64 Universe for Uyuni
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = ubuntu-16.04-pool-amd64-uyuni
+repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial/universe/binary-amd64/
+
 [ubuntu-1604-amd64-uyuni-client]
 label    = ubuntu-1604-amd64-uyuni-client
 name     = Uyuni Client Tools for Ubuntu 16.04 AMD64
 archs    = amd64-deb
 repo_type = deb
 checksum = sha256
-base_channels = ubuntu-16.04-pool-amd64
+base_channels = ubuntu-16.04-pool-amd64-uyuni
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/Ubuntu1604-Uyuni-Client-Tools/xUbuntu_16.04/
 
 [ubuntu-1604-amd64-uyuni-client-devel]
@@ -1056,7 +1103,7 @@ name     = Uyuni Client Tools for Ubuntu 16.04 AMD64 (Developement)
 archs    = amd64-deb
 repo_type = deb
 checksum = sha256
-base_channels = ubuntu-16.04-pool-amd64
+base_channels = ubuntu-16.04-pool-amd64-uyuni
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/Ubuntu1604-Uyuni-Client-Tools/xUbuntu_16.04/
 
 [ubuntu-1804-pool-amd64]
@@ -1106,13 +1153,60 @@ checksum = sha256
 base_channels = ubuntu-18.04-pool-amd64
 repo_url = http://archive.ubuntu.com/ubuntu/dists/bionic/universe/binary-amd64/
 
+[ubuntu-1804-pool-amd64-uyuni]
+label    = ubuntu-18.04-pool-amd64-uyuni
+checksum = sha256
+archs    = amd64-deb
+repo_type = deb
+name     = Ubuntu 18.04 LTS AMD64 Base for Uyuni
+gpgkey_url =
+gpgkey_id =
+gpgkey_fingerprint =
+repo_url = http://localhost/pub/repositories/empty-deb/?uniquekey=1804-uyuni
+
+[ubuntu-1804-amd64-main-uyuni]
+label    = ubuntu-1804-amd64-main-uyuni
+checksum = sha256
+archs    = amd64-deb
+repo_type = deb
+name     = Ubuntu 18.04 LTS AMD64 Main for Uyuni
+base_channels = ubuntu-18.04-pool-amd64-uyuni
+repo_url = http://archive.ubuntu.com/ubuntu/dists/bionic/main/binary-amd64/
+
+[ubuntu-1804-amd64-main-updates-uyuni]
+label    = ubuntu-1804-amd64-main-updates-uyuni
+name     = Ubuntu 18.04 LTS AMD64 Main Updates for Uyuni
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = ubuntu-18.04-pool-amd64-uyuni
+repo_url = http://archive.ubuntu.com/ubuntu/dists/bionic-updates/main/binary-amd64/
+
+[ubuntu-1804-amd64-main-security-uyuni]
+label    = ubuntu-1804-amd64-main-security-uyuni
+name     = Ubuntu 18.04 LTS AMD64 Main Security for Uyuni
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = ubuntu-18.04-pool-amd64-uyuni
+repo_url = http://archive.ubuntu.com/ubuntu/dists/bionic-security/main/binary-amd64/
+
+[ubuntu-1804-amd64-universe-uyuni]
+label    = ubuntu-1804-amd64-main-universe-uyuni
+name     = Ubuntu 18.04 LTS AMD64 Universe for Uyuni
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = ubuntu-18.04-pool-amd64-uyuni
+repo_url = http://archive.ubuntu.com/ubuntu/dists/bionic/universe/binary-amd64/
+
 [ubuntu-1804-amd64-uyuni-client]
 label    = ubuntu-1804-amd64-uyuni-client
 name     = Uyuni Client Tools for Ubuntu 18.04 AMD64
 archs    = amd64-deb
 repo_type = deb
 checksum = sha256
-base_channels = ubuntu-18.04-pool-amd64
+base_channels = ubuntu-18.04-pool-amd64-uyuni
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/Ubuntu1804-Uyuni-Client-Tools/xUbuntu_18.04/
 
 [ubuntu-1804-amd64-uyuni-client-devel]
@@ -1121,7 +1215,7 @@ name     = Uyuni Client Tools for Ubuntu 18.04 AMD64 (Development)
 archs    = amd64-deb
 repo_type = deb
 checksum = sha256
-base_channels = ubuntu-18.04-pool-amd64
+base_channels = ubuntu-18.04-pool-amd64-uyuni
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/Ubuntu1804-Uyuni-Client-Tools/xUbuntu_18.04/
 
 [debian-9-pool-amd64]

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,5 @@
+- common-channels: Duplicate Ubuntu channels for Uyuni
+
 -------------------------------------------------------------------
 Wed Jul 31 17:37:23 CEST 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
Duplicates Ubuntu channels for Uyuni to be created with a custom base channel, instead of attaching to the one from SCC.

Fixes https://github.com/uyuni-project/uyuni/issues/1217