### PR TITLE
Fix tests for server monitoring

### DIFF
--- a/testsuite/features/srv_monitoring.feature
+++ b/testsuite/features/srv_monitoring.feature
@@ -13,9 +13,9 @@ Feature: Monitor SUSE Manager server
     And I wait until I do not see "Disabling services..." text
     Then I should see a "Monitoring disabled successfully." text
     And I should see a list item with text "System" and bullet with "danger" icon
+    And I should see a list item with text "PostgreSQL database" and bullet with "danger" icon
     And I should see a list item with text "Taskomatic (Java JMX)" and bullet with "danger" icon
     And I should see a list item with text "Tomcat (Java JMX)" and bullet with "danger" icon
-    And I should see a list item with text "PostgreSQL database" and bullet with "danger" icon
     And I should see a "Enable services" button
 
   Scenario: Check that monitoring is disabled using the UI
@@ -23,9 +23,9 @@ Feature: Monitor SUSE Manager server
     When I follow the left menu "Admin > Manager Configuration > Monitoring"
     And I wait until I do not see "Checking services..." text
     Then I should see a list item with text "System" and bullet with "danger" icon
+    And I should see a list item with text "PostgreSQL database" and bullet with "danger" icon
     And I should see a list item with text "Taskomatic (Java JMX)" and bullet with "danger" icon
     And I should see a list item with text "Tomcat (Java JMX)" and bullet with "danger" icon
-    And I should see a list item with text "PostgreSQL database" and bullet with "danger" icon
     And I should see a "Enable services" button
 
   Scenario: Enable monitoring from the UI
@@ -36,7 +36,7 @@ Feature: Monitor SUSE Manager server
     And I wait until I do not see "Enabling services..." text
     Then I should see a "Monitoring enabled successfully." text
     And I should see a list item with text "System" and bullet with "success" icon
+    And I should see a list item with text "PostgreSQL database" and bullet with "success" icon
     And I should see a list item with text "Taskomatic (Java JMX)" and bullet with "success" icon
     And I should see a list item with text "Tomcat (Java JMX)" and bullet with "success" icon
-    And I should see a list item with text "PostgreSQL database" and bullet with "success" icon
     And I should see a "Disable services" button

--- a/testsuite/features/srv_monitoring.feature
+++ b/testsuite/features/srv_monitoring.feature
@@ -4,6 +4,20 @@
 
 Feature: Monitor SUSE Manager server
 
+  # This assumes that monitoring is enabled via sumaform
+  Scenario: Disable monitoring from the UI
+    Given I am authorized as "admin" with password "admin"
+    When I follow the left menu "Admin > Manager Configuration > Monitoring"
+    And I wait until I do not see "Checking services..." text
+    And I click on "Disable services"
+    And I wait until I do not see "Disabling services..." text
+    Then I should see a "Monitoring disabled successfully." text
+    And I should see a list item with text "System" and bullet with "danger" icon
+    And I should see a list item with text "Taskomatic (Java JMX)" and bullet with "danger" icon
+    And I should see a list item with text "Tomcat (Java JMX)" and bullet with "danger" icon
+    And I should see a list item with text "PostgreSQL database" and bullet with "danger" icon
+    And I should see a "Enable services" button
+
   Scenario: Check that monitoring is disabled using the UI
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Admin > Manager Configuration > Monitoring"
@@ -26,16 +40,3 @@ Feature: Monitor SUSE Manager server
     And I should see a list item with text "Tomcat (Java JMX)" and bullet with "success" icon
     And I should see a list item with text "PostgreSQL database" and bullet with "success" icon
     And I should see a "Disable services" button
-
-  Scenario: Disable monitoring from the UI
-    Given I am authorized as "admin" with password "admin"
-    When I follow the left menu "Admin > Manager Configuration > Monitoring"
-    And I wait until I do not see "Checking services..." text
-    And I click on "Disable services"
-    And I wait until I do not see "Disabling services..." text
-    Then I should see a "Monitoring disabled successfully." text
-    And I should see a list item with text "System" and bullet with "danger" icon
-    And I should see a list item with text "Taskomatic (Java JMX)" and bullet with "danger" icon
-    And I should see a list item with text "Tomcat (Java JMX)" and bullet with "danger" icon
-    And I should see a list item with text "PostgreSQL database" and bullet with "danger" icon
-    And I should see a "Enable services" button


### PR DESCRIPTION
## What does this PR change?

This patch should fix the tests for server monitoring by changing the order. We usually run the testsuite using the `monitored=true` [option from sumaform](https://github.com/uyuni-project/sumaform/blob/master/README_ADVANCED.md#prometheusgrafana-monitoring). This will make sure that monitoring of the server is enabled by default, so it is no surprise that the test will fail in the previous order. Important note: this patch assumes that monitoring is always enabled by default, so tests will fail in case it is not!

## GUI diff

No difference.

## Documentation

- No documentation needed, only tests are changed.

## Test coverage

- No new tests, only existing tests changed.

## Links

Downstream issue: https://github.com/SUSE/spacewalk/issues/8944

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
