### PR TITLE
Fix init ssl on proxy activate

### DIFF
--- a/client/rhel/rhnlib/rhn/SSL.py
+++ b/client/rhel/rhnlib/rhn/SSL.py
@@ -113,7 +113,7 @@ class SSLSocket:
         # Set server name if defined. This allows connections to
         # SNI-enabled servers
         if server_name is not None:
-            self._connection.set_tlsext_host_name(server_name)
+            self._connection.set_tlsext_host_name(bstr(server_name))
         # Place the connection in client mode
         self._connection.set_connect_state()
 

--- a/client/rhel/rhnlib/rhnlib.changes
+++ b/client/rhel/rhnlib/rhnlib.changes
@@ -1,3 +1,4 @@
+- fix initialize ssl connection (bsc#1144155)
 - Add SNI support for clients
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

fix ssl init on proxy activation. Function expects a byte string with python 3

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- found by Cucumber tests

- [x] **DONE**

## Links

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1144155
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
