### PR TITLE
Null pointer in websocket authentication (bsc#1138454)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/notification/UserNotificationFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/UserNotificationFactory.java
@@ -206,13 +206,23 @@ public class UserNotificationFactory extends HibernateFactory {
      * @return the unread messages size count
      */
     public static long unreadUserNotificationsSize(User userIn) {
+        return unreadUserNotificationsSize(userIn.getId());
+    }
+
+    /**
+     * Get the count of unread messages
+     *
+     * @param userIdIn the user id
+     * @return the unread messages size count
+     */
+    public static long unreadUserNotificationsSize(long userIdIn) {
         CriteriaBuilder builder = getSession().getCriteriaBuilder();
         CriteriaQuery<Long> criteria = builder.createQuery(Long.class);
         Root<UserNotification> root = criteria.from(UserNotification.class);
         CriteriaQuery<Long> count = criteria.select(builder.count(root));
 
         criteria.where(
-                builder.equal(root.get("userId"), userIn.getId()),
+                builder.equal(root.get("userId"), userIdIn),
                 builder.isFalse(root.get("read")));
 
         return getSession().createQuery(count).getSingleResult();

--- a/java/code/src/com/redhat/rhn/frontend/servlets/LocalizedEnvironmentFilter.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/LocalizedEnvironmentFilter.java
@@ -78,7 +78,6 @@ public class LocalizedEnvironmentFilter implements Filter {
     }
 
     private void initializeContext(HttpServletRequest request) {
-        request.getSession().setAttribute("__original_request__", request);
         Context current = Context.getCurrentContext();
         RequestContext requestCtx = new RequestContext(request);
         User user = requestCtx.getCurrentUser();

--- a/java/code/src/com/redhat/rhn/frontend/servlets/PxtSessionDelegateImpl.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/PxtSessionDelegateImpl.java
@@ -204,7 +204,7 @@ public class PxtSessionDelegateImpl implements PxtSessionDelegate {
         pxtSession.setExpires(TimeUtils.currentTimeSeconds() +
                 SessionManager.lifetimeValue());
         savePxtSession(pxtSession);
-
+        request.getSession().setAttribute("webUserID", pxtSession.getWebUserId());
         response.addCookie(pxtCookie);
     }
 
@@ -229,6 +229,7 @@ public class PxtSessionDelegateImpl implements PxtSessionDelegate {
 
         // Invalidate csrf_token
         request.getSession().setAttribute("csrf_token", null);
+        request.getSession().setAttribute("webUserID", null);
 
         refreshPxtSession(request, response, 0);
     }

--- a/java/code/src/com/redhat/rhn/frontend/servlets/test/PxtSessionDelegateImplTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/test/PxtSessionDelegateImplTest.java
@@ -288,6 +288,7 @@ public class PxtSessionDelegateImplTest extends MockObjectTestCase {
 
         context().checking(new Expectations() { {
             oneOf(mockPxtSession).setWebUserId(null);
+            oneOf(mockPxtSession).getWebUserId();
             allowing(mockResponse).addCookie(with(any(Cookie.class)));
         } });
 
@@ -299,6 +300,7 @@ public class PxtSessionDelegateImplTest extends MockObjectTestCase {
 
         context().checking(new Expectations() { {
             allowing(mockPxtSession).setWebUserId(null);
+            oneOf(mockPxtSession).getWebUserId();
             allowing(mockResponse).addCookie(with(any(Cookie.class)));
         } });
 
@@ -330,6 +332,7 @@ public class PxtSessionDelegateImplTest extends MockObjectTestCase {
 
         context().checking(new Expectations() { {
             allowing(mockPxtSession).setWebUserId(null);
+            oneOf(mockPxtSession).getWebUserId();
             oneOf(mockResponse).addCookie(with(zeroMaxAgeCookieMatcher()));
         } });
 

--- a/java/code/src/com/suse/manager/webui/websocket/Notification.java
+++ b/java/code/src/com/suse/manager/webui/websocket/Notification.java
@@ -197,7 +197,7 @@ public class Notification {
      * @param userId authenticated user ID
      * @param session the session to add
      */
-    private static void handshakeSession(Long userId, Session session) {
+    private static void handshakeSession(long userId, Session session) {
         synchronized (LOCK) {
             wsSessions.put(session, userId);
         }

--- a/java/code/src/com/suse/manager/webui/websocket/Notification.java
+++ b/java/code/src/com/suse/manager/webui/websocket/Notification.java
@@ -17,7 +17,6 @@ package com.suse.manager.webui.websocket;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.notification.UserNotificationFactory;
 
-import com.redhat.rhn.domain.user.User;
 import org.apache.log4j.Logger;
 
 import javax.websocket.OnOpen;
@@ -33,6 +32,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -49,7 +49,7 @@ public class Notification {
     private static final Logger LOG = Logger.getLogger(Notification.class);
 
     private static final Object LOCK = new Object();
-    private static Map<Session, User> wsSessions = new HashMap<>();
+    private static Map<Session, Long> wsSessions = new HashMap<>();
     private static Set<Session> brokenSessions = new HashSet<>();
 
     /**
@@ -59,23 +59,23 @@ public class Notification {
      */
     @OnOpen
     public void onOpen(Session session, EndpointConfig config) {
-        User user = (User)session.getUserProperties().get("currentUser");
         if (session != null) {
-            if (user != null) {
-                LOG.debug(String.format("Hooked a new websocket session [id:%s]", session.getId()));
-                handshakeSession(user, session);
+            Optional.ofNullable(session.getUserProperties().get("webUserID"))
+                    .map(webUserID -> (Long) webUserID)
+                    .ifPresentOrElse(userId -> {
+                         LOG.debug(String.format("Hooked a new websocket session [id:%s]", session.getId()));
+                        handshakeSession(userId, session);
 
-                // update the notification counter to the unread messages
-                try {
-                    sendMessage(session, String.valueOf(UserNotificationFactory.unreadUserNotificationsSize(user)));
-                }
-                finally {
-                    HibernateFactory.closeSession();
-                }
-            }
-            else {
-                LOG.debug("no authenticated user.");
-            }
+                        // update the notification counter to the unread messages
+                        try {
+                            sendMessage(session,
+                                    String.valueOf(UserNotificationFactory.unreadUserNotificationsSize(userId)));
+                        }
+                        finally {
+                            HibernateFactory.closeSession();
+                        }
+                    },
+                    ()-> LOG.debug("no authenticated user."));
         }
         else {
             LOG.debug("No web sessionId available. Closing the web socket.");
@@ -194,11 +194,12 @@ public class Notification {
 
     /**
      * Add a new WebSocket Session to the collection
+     * @param userId authenticated user ID
      * @param session the session to add
      */
-    private static void handshakeSession(User user, Session session) {
+    private static void handshakeSession(Long userId, Session session) {
         synchronized (LOCK) {
-            wsSessions.put(session, user);
+            wsSessions.put(session, userId);
         }
     }
 

--- a/java/code/src/com/suse/manager/webui/websocket/Notification.java
+++ b/java/code/src/com/suse/manager/webui/websocket/Notification.java
@@ -63,7 +63,7 @@ public class Notification {
             Optional.ofNullable(session.getUserProperties().get("webUserID"))
                     .map(webUserID -> (Long) webUserID)
                     .ifPresentOrElse(userId -> {
-                         LOG.debug(String.format("Hooked a new websocket session [id:%s]", session.getId()));
+                        LOG.debug(String.format("Hooked a new websocket session [id:%s]", session.getId()));
                         handshakeSession(userId, session);
 
                         // update the notification counter to the unread messages

--- a/java/code/src/com/suse/manager/webui/websocket/WebsocketSessionConfigurator.java
+++ b/java/code/src/com/suse/manager/webui/websocket/WebsocketSessionConfigurator.java
@@ -15,10 +15,6 @@
 
 package com.suse.manager.webui.websocket;
 
-import com.redhat.rhn.domain.user.User;
-import com.redhat.rhn.frontend.struts.RequestContext;
-
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 import javax.websocket.HandshakeResponse;
 import javax.websocket.server.HandshakeRequest;
@@ -35,12 +31,6 @@ public class WebsocketSessionConfigurator extends ServerEndpointConfig.Configura
             HandshakeRequest request,
             HandshakeResponse response) {
         HttpSession httpSession = (HttpSession)request.getHttpSession();
-        HttpServletRequest sr = (HttpServletRequest) httpSession.getAttribute("__original_request__");
-        User user = new RequestContext(sr).getCurrentUser();
-        // force roles to be loaded so now since it will fail from the websocket thread
-        if (user != null) {
-            user.getRoles();
-            config.getUserProperties().put("currentUser", user);
-        }
+        config.getUserProperties().put("webUserID", httpSession.getAttribute("webUserID"));
     }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,5 +1,6 @@
 - implement "patch contains package" Filter for Content Lifecycle Management
 - implement Filter Patch "by type" Content Lifecycle Management
+- Improve websocket authentication to prevent errors in logs (bsc#1138454)
 - Implement filtering errata by synopsis in Content Lifecycle Management
 - Normalize date formats for actions, notifications and clm (bsc#1142774)
 - Implement ALLOW filters in Content Lifecycle Management


### PR DESCRIPTION
## What does this PR change?

Related PR: https://github.com/uyuni-project/uyuni/pull/1205/files
In some scenarios, we get a null pointer exception in the WebsocketSessionConfigurator. The root problem is because we are saving the request in the session, and it saves it not considering the request URL in use.
This can lead to a problem that the request in session when we process the WebsocketSessionConfigurator is not the original request for the web socket itself, but another one (for front-end log for example). Since when we try to use the request it's already consumed, we cannot access some of the data, and the result is the null pointer.
 
I see 3 options to solve this: 

1. Null check where the exception occurs. We need to check also the return of getRequestURI, since that is what is causing the exception.

2. Only save the request to the session when it's a request for websocket. It solves this problem, but the root cause (save request in a shared session) will still be here. In the future, we can have a similar problem, if we start to use more websockets, it can collide again. See changes in LocalizedEnvironmentFilter.java

3. Change WebsocketSessionConfigurator to be self-contained and use only the information we have at the moment. Get the authentication token, validate it, and get the session from the database. Drawback: always we connect a websocket we access the database to get the user session. See changes in WebsocketSessionConfigurator.

4. Add authenticated user to server java session and stop putting the request in the java session. The user id is always the same during the user session.

I implemented the option 4.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: no need. No visible change for user.

- [x] **DONE**

## Test coverage
- No tests: corrected falling tests

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/8156
Tracks:
manager 4.0: https://github.com/SUSE/spacewalk/pull/9077
manager 3.2: https://github.com/SUSE/spacewalk/pull/9088

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
