### PR TITLE
Omit SUSE Manager product name in test feature

### DIFF
--- a/testsuite/features/srv_monitoring.feature
+++ b/testsuite/features/srv_monitoring.feature
@@ -1,8 +1,7 @@
 # Copyright (c) 2019 SUSE LLC
 # Licensed under the terms of the MIT license.
-#
 
-Feature: Monitor SUSE Manager server
+Feature: Enable and disable monitoring of the server
 
   # This assumes that monitoring is enabled via sumaform
   Scenario: Disable monitoring from the UI


### PR DESCRIPTION
## What does this PR change?

This patch removes the SUSE Manager product name from the monitoring test feature file to make the description applicable for both Uyuni and SUSE Manager.

## GUI diff

No difference.

## Documentation

No documentation needed, only test description changed.

## Test coverage

No tests needed, test description is updated.

## Links

Downstream issue: https://github.com/SUSE/spacewalk/issues/8944

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
