### PR TITLE
Enable spacewalk update service after update

### DIFF
--- a/client/rhel/mgr-daemon/mgr-daemon.changes
+++ b/client/rhel/mgr-daemon/mgr-daemon.changes
@@ -1,3 +1,6 @@
+- enable spacewalk-update-service on package installation
+  (bsc#1143789)
+
 -------------------------------------------------------------------
 Wed Jul 31 17:26:37 CEST 2019 - jgonzalez@suse.com
 

--- a/client/rhel/mgr-daemon/mgr-daemon.spec
+++ b/client/rhel/mgr-daemon/mgr-daemon.spec
@@ -200,10 +200,6 @@ if [ -f %{_unitdir}/rhnsd.service ]; then
         rm -f /etc/rc?.d/[SK]??rhnsd
     fi
 fi
-if [ -f %{_unitdir}/spacewalk-update-status.service ]; then
-    # take care that this is always enabled if it exists
-    /usr/bin/systemctl --quiet enable spacewalk-update-status.service 2>&1 ||:
-fi
 %endif
 %endif
 %if %{_vendor} == "debbuild"
@@ -281,6 +277,13 @@ if [ -f %{_unitdir}/rhnsd.service ]; then
     systemctl daemon-reload >/dev/null 2>&1 || :
 fi
 %endif
+
+%posttrans
+if [ -f %{_unitdir}/spacewalk-update-status.service ]; then
+    # take care that this is always enabled if it exists
+    /usr/bin/systemctl --quiet enable spacewalk-update-status.service 2>&1 ||:
+fi
+
 
 %if 0%{?fedora} || 0%{?suse_version} >= 1210 || 0%{?mageia} || 0%{?ubuntu} >= 1504 || 0%{?debian} >= 8 || 0%{?rhel} >= 7
 %files

--- a/client/rhel/spacewalk-client-tools/50-spacewalk-client.preset
+++ b/client/rhel/spacewalk-client-tools/50-spacewalk-client.preset
@@ -1,3 +1,4 @@
 enable rhnsd.timer
+enable spacewalk-update-status.service
 enable osad.service
 enable rhn-virtualization-host.service

--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes
@@ -1,3 +1,5 @@
+- enable spacewalk-update-service on package installation
+  (bsc#1143789)
 - Invalidate cache 5 minutes before actual expiration(bsc#1143562)
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

We renamed rhnsd into mgr-daemon. Installing this on a system is the same as deleting rhnsd and install mgr-daemon as RPM cannot detect that this is a normal package update.

The order of the scriptlets is, that first the `%post` of the new rpm gets executed and after this the `%postun` of the removed package. As both packages provide the same service name it gets disabled in the `%postun` of the already installed RPM.

The only way to workaround it is to enable the service in `%posttrans`.

For new installations this PR add it to the presets to get it automatically enabled on package installation. Also when we remove the hard coded enable at a later point in time.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/8949
Tracks https://github.com/SUSE/spacewalk/pull/8980

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
