### PR TITLE
Revert of the autoupdate for the timepicker component

### DIFF
--- a/web/html/src/components/datetimepicker.js
+++ b/web/html/src/components/datetimepicker.js
@@ -141,31 +141,6 @@ class DateTimePicker extends React.Component {
         };
     }
 
-    componentWillMount() {
-       // Set 1 minute interval for updating time
-       const now = new Date();
-       const nextMinute = new Date(now);
-       nextMinute.setSeconds(0);
-       nextMinute.setMinutes(nextMinute.getMinutes() + 1)
-       this.timeOut = setTimeout(this.changeTime, nextMinute - now);
-       this.timer = setInterval(this.changeTime, 60000);
-    }
-
-    componentWillUnmount() {
-        clearTimeout(this.timeOut);
-        clearInterval(this.timer);
-    }
-
-   changeTime = () => {
-       // Check if date set is in the future if not, update displayed time
-       const setDate = this.props.value;
-       const now = new Date(Date.now());
-       now.setMilliseconds(0);
-
-       if(setDate < now) {
-           this.props.onChange(now);
-       }
-   }
 
     onDateChanged(date) {
         const value = this.props.value;


### PR DESCRIPTION
## What does this PR change?

Revert of the PR: https://github.com/SUSE/spacewalk/pull/5801/files

This is creating a bug because the update is done with the browser timezone and the timepicker might have a date with the timezone of the server.

For instance, if the server has the American timezone (-04:00) and I am accessing the UI in Germany, the auto-update will start auto-updating the time with the browser timezone, which will schedule the action in the future. 

Anyway this behavior it's not needed, even if the time is some minutes in the past, it means "execute it now", which is exactly what we want.  

We might recover this when we add the library "moment-timezone".


## Documentation
- No documentation needed

- [ ] **DONE**

## Test coverage
- No tests

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
