### PR TITLE
Fix encoding issues with DB bytes values (bsc#1144300)

### DIFF
--- a/backend/satellite_tools/satCerts.py
+++ b/backend/satellite_tools/satCerts.py
@@ -104,7 +104,7 @@ def _checkCertMatch_rhnCryptoKey(cert, description, org_id, deleteRowYN=0,
     row = lookup_cert(description, org_id)
     rhn_cryptokey_id = -1
     if row:
-        if cert == rhnSQL.read_lob(row['key']).decode():
+        if cert == rhnSQL._fix_encoding(rhnSQL.read_lob(row['key'])):
             # match found, nothing to do
             if verbosity:
                 print("Nothing to do: certificate to be pushed matches certificate in database.")

--- a/backend/server/action/scap.py
+++ b/backend/server/action/scap.py
@@ -36,7 +36,7 @@ def xccdf_eval(server_id, action_id, dry_run=0):
         'path': d['path'],
         'id': action_id,
         'file_size': _scap_file_limit(server_id),
-        'params': rhnSQL.read_lob(d['parameters']).decode() or ''
+        'params': rhnSQL._fix_encoding(rhnSQL.read_lob(d['parameters']) or '')
     },)
 
 

--- a/backend/server/action/script.py
+++ b/backend/server/action/script.py
@@ -43,7 +43,7 @@ def run(server_id, action_id, dry_run=0):
         data['username'] = info['username']
         data['groupname'] = info['groupname']
         data['timeout'] = info['timeout'] or ''
-        data['script'] = rhnSQL.read_lob(info['script']).decode() or ''
+        data['script'] = rhnSQL._fix_encoding(rhnSQL.read_lob(info['script']) or '')
         # used to make the resulting times make some sense in the db
         data['now'] = info['now']
 

--- a/backend/server/configFilesHandler.py
+++ b/backend/server/configFilesHandler.py
@@ -348,7 +348,7 @@ class ConfigFilesHandler(rhnHandler):
         row = h.fetchone_dict()
 
         if row:
-            db_contents = rhnSQL.read_lob(row['contents']).decode() or ''
+            db_contents = rhnSQL._fix_encoding(rhnSQL.read_lob(row['contents']) or '')
             if file_contents == db_contents:
                 # Same content
                 file['config_content_id'] = row['id']
@@ -517,7 +517,7 @@ class ConfigFilesHandler(rhnHandler):
 def format_file_results(row, server=None):
     encoding = ''
     contents = None
-    contents = rhnSQL.read_lob(row['file_contents']).decode() or ''
+    contents = rhnSQL._fix_encoding(rhnSQL.read_lob(row['file_contents']) or '')
     checksum = row['checksum'] or ''
 
     if server and (row['is_binary'] == 'N') and contents:

--- a/backend/server/handlers/config_mgmt/rhn_config_management.py
+++ b/backend/server/handlers/config_mgmt/rhn_config_management.py
@@ -496,7 +496,7 @@ class ConfigManagement(configFilesHandler.ConfigFilesHandler):
         # Empty files or directories may have NULL instead of lobs
         fc_lob = f.get('file_contents')
         if fc_lob:
-            f['file_content'] = rhnSQL.read_lob(fc_lob).decode().splitlines()
+            f['file_content'] = rhnSQL._fix_encoding(rhnSQL.read_lob(fc_lob)).splitlines()
         else:
             f['file_content'] = ''
         return f

--- a/backend/server/rhnSQL/__init__.py
+++ b/backend/server/rhnSQL/__init__.py
@@ -333,6 +333,17 @@ def Date(*args, **kwargs):
     db = __test_DB()
     return db.Date(*args, **kwargs)
 
+
+def _fix_encoding(text):
+    if isinstance(text, str):
+        return text
+    elif isinstance(text, bytes):
+        try:
+            return text.decode("utf8")
+        except:
+            return text.decode("iso8859-1")
+
+
 def read_lob(lob):
     if not lob:
         return None

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Fix encoding issues with DB bytes values (bsc#1144300)
 - Avoid traceback on mgr-inter-sync when there are problems
   with cache of packages (bsc#1143016)
 - do not overwrite comps and module data with older versions


### PR DESCRIPTION
## What does this PR change?

This PR fixes two issues that are produced when handling `bytea` (lob) values from the database.

- The `rhnSQL.read_lob` can return `None` in some cases [1], which has no `.decode()` method available.
- Bytes coming from the DB might not be encoded as `UTF8` so we should handle them as `is8859-1` to avoid getting `UnicodeDecodeError` exception.

So, this PR introduces `rhnSQL._fix_encoding()` method to wrap the `decode` logic based and use it when dealing with bytes from the DB.

[1] - https://github.com/uyuni-project/uyuni/blob/master/backend/server/rhnSQL/__init__.py#L338


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **bugfix**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/8987

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
