### PR TITLE
Do not try to download RPMs from the unresolved mirrorlist URL

### DIFF
--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -543,7 +543,8 @@ class ContentSource:
         zypp_repo_url = self._prep_zypp_repo_url(self.url)
 
         mirrorlist = self._get_mirror_list(repo, zypp_repo_url)
-        repo.baseurl = repo.baseurl + mirrorlist
+        if mirrorlist:
+            repo.baseurl = mirrorlist
         repo.urls = repo.baseurl
 
         # Manually call Zypper

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Do not try to download RPMs from the unresolved mirrorlist URL
 - Fix encoding issues with DB bytes values (bsc#1144300)
 - Avoid traceback on mgr-inter-sync when there are problems
   with cache of packages (bsc#1143016)


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue when running `spacewalk-repo-sync` using a RPM repository which uses a "mirrorlist" URL (like centos7). On those cases, even if the list of mirrors is resolved, the first try of downloading each RPM is made against the unresolved mirrorlist URL, so an "ERROR" is shown on the reposync log file.

Since "reposync" does multiple tries, the next one is made against the right resolved mirror URL and the RPM is actually successfully downloaded. This also explains why the error is only shown in the log files but not in the CLI, since after the second try, the RPM is actually downloaded.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **bugfix**

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/1243

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
