### PR TITLE
Add '--latest' support for "reposync" on DEB based repositories

### DIFF
--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Add '--latest' support for reposync on DEB based repositories
 - Require uyuni-base-common for /etc/rhn
 - Do not try to download RPMs from the unresolved mirrorlist URL
 - Fix encoding issues with DB bytes values (bsc#1144300)


### PR DESCRIPTION
## What does this PR change?

This PR add `--latest` filtering support for "reposync" when dealing with DEB based repositories.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **alredy documented on reposync options**

- [x] **DONE**

## Test coverage
- No tests: **no tests for deb_src**

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/1246

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
