### PR TITLE
Add bootstrap repo entries for Ubuntu channels for Uyuni

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -794,5 +794,15 @@ DATA = {
         'PDID' : [-1, 1918], 'PKGLIST' : PKGLISTUBUNTU1804,
         'DEST' : '/srv/www/htdocs/pub/repositories/ubuntu/18/4/bootstrap/',
         'TYPE' : 'deb'
+    },
+    'ubuntu-16.04-amd64-uyuni' : {
+        'BASECHANNEL' : 'ubuntu-16.04-pool-amd64-uyuni', 'PKGLIST' : PKGLISTUBUNTU1604,
+        'DEST' : '/srv/www/htdocs/pub/repositories/ubuntu/16/4/bootstrap/',
+        'TYPE' : 'deb'
+    },
+    'ubuntu-18.04-amd64-uyuni' : {
+        'BASECHANNEL' : 'ubuntu-18.04-pool-amd64-uyuni', 'PKGLIST' : PKGLISTUBUNTU1804,
+        'DEST' : '/srv/www/htdocs/pub/repositories/ubuntu/18/4/bootstrap/',
+        'TYPE' : 'deb'
     }
 }

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- Add missing bootstrap repo entries for Ubuntu repositories
+
 -------------------------------------------------------------------
 Wed Jul 31 17:45:28 CEST 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
Add missing bootstrap repo entries for duplicate Ubuntu channels for Uyuni.
See https://github.com/uyuni-project/uyuni/pull/1222

Fixes #1249 