### PR TITLE
Add version to lucene dep

### DIFF
--- a/search-server/spacewalk-search/spacewalk-search.changes
+++ b/search-server/spacewalk-search/spacewalk-search.changes
@@ -1,3 +1,4 @@
+- require lucene version we use
 - move /usr/share/rhn/config-defaults to uyuni-base-common
 - Add search server JDBC idle time config options to rhn_search.conf
 

--- a/search-server/spacewalk-search/spacewalk-search.spec
+++ b/search-server/spacewalk-search/spacewalk-search.spec
@@ -38,12 +38,12 @@ ExcludeArch:    aarch64
 
 BuildRequires:  apache-mybatis
 BuildRequires:  hadoop
-BuildRequires:  lucene
+BuildRequires:  lucene == 2.4.1
 BuildRequires:  nutch-core
 BuildRequires:  picocontainer
 Requires:       apache-mybatis
 Requires:       hadoop
-Requires:       lucene
+Requires:       lucene == 2.4.1
 Requires:       nutch-core
 Requires:       picocontainer
 BuildRequires:  uyuni-base-common


### PR DESCRIPTION
## What does this PR change?

OpenSUSE ship a much newer version of lucene which is imcompatible with the code we have.
Require the exact version we use and ship with Uyuni.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **just dependeny**

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/1248

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
