### PR TITLE
Manager uyuni base

### DIFF
--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- /etc/rhn also was packaged for spacewalk-backend-tools
 - Add '--latest' support for reposync on DEB based repositories
 - Require uyuni-base-common for /etc/rhn
 - Do not try to download RPMs from the unresolved mirrorlist URL

--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -1023,7 +1023,6 @@ rm -f %{rhnconf}/rhnSecret.py*
 %defattr(-,root,root)
 %doc LICENSE
 %doc README.ULN
-%attr(0750,root,%{apache_group}) %dir %{rhnconf}
 %attr(644,root,%{apache_group}) %{rhnconfigdefaults}/rhn_server_satellite.conf
 %config(noreplace) %{_sysconfdir}/logrotate.d/spacewalk-backend-tools
 %config(noreplace) %{rhnconf}/signing.conf

--- a/client/tools/mgr-osad/mgr-osad.changes
+++ b/client/tools/mgr-osad/mgr-osad.changes
@@ -1,3 +1,5 @@
+- Require uyuni-base-common for /etc/rhn (for osa-dispatcher)
+
 -------------------------------------------------------------------
 Wed Jul 31 17:28:01 CEST 2019 - jgonzalez@suse.com
 

--- a/client/tools/mgr-osad/mgr-osad.spec
+++ b/client/tools/mgr-osad/mgr-osad.spec
@@ -69,6 +69,8 @@ BuildRequires:  perl
 Requires:       %{pythonX}-%{name} = %{version}-%{release}
 Conflicts:      mgr-osa-dispatcher < %{version}-%{release}
 Conflicts:      mgr-osa-dispatcher > %{version}-%{release}
+BuildRequires:  uyuni-base-common
+Requires(pre):  uyuni-base-common
 %if 0%{?suse_version} >= 1210
 BuildRequires:  systemd
 %{?systemd_requires}
@@ -594,7 +596,6 @@ rpm -ql osa-dispatcher | xargs -n 1 /sbin/restorecon -rvi {}
 %ghost %attr(640,%{apache_user},root) %{_var}/log/rhn/osa-dispatcher.log
 %if 0%{?suse_version}
 %{_sbindir}/rcosa-dispatcher
-%attr(750, root, %{apache_group}) %dir %{_sysconfdir}/rhn
 %dir %{rhnroot}
 %attr(755,root,%{apache_group}) %dir %{rhnroot}/config-defaults
 %dir %{_sysconfdir}/rhn/tns_admin

--- a/spacewalk/admin/spacewalk-admin.changes
+++ b/spacewalk/admin/spacewalk-admin.changes
@@ -1,3 +1,5 @@
+- Require uyuni-base-common for /etc/rhn
+
 -------------------------------------------------------------------
 Wed May 15 15:07:09 CEST 2019 - jgonzalez@suse.com
 

--- a/spacewalk/admin/spacewalk-admin.spec
+++ b/spacewalk/admin/spacewalk-admin.spec
@@ -48,6 +48,8 @@ BuildArch:      noarch
 %if 0%{?suse_version}
 BuildRequires:  spacewalk-config
 %endif
+BuildRequires:  uyuni-base-common
+Requires(pre):  uyuni-base-common
 
 %description
 Various utility scripts and data files for Spacewalk installations.
@@ -116,9 +118,6 @@ sed -i 's|#!/usr/bin/python|#!/usr/bin/python3|' $RPM_BUILD_ROOT/usr/bin/mgr-eve
 %{_unitdir}/spacewalk-wait-for-taskomatic.service
 %{_unitdir}/mgr-events-config.service
 %{_unitdir}/mgr-websockify.service
-%endif
-%if 0%{?suse_version}
-%attr(0750,root,www) %dir %{_sysconfdir}/rhn
 %endif
 
 %changelog


### PR DESCRIPTION
## What does this PR change?

Remove remaining occurrences of packaged /etc/rhn directory. New packages are being used successfully, so we can continue cleaning up:

suma-head-srv:~ # rpm -qf /etc/rhn/
uyuni-base-common-1.0.0-400.3.1.develHead.x86_64
spacewalk-admin-4.0.7-400.1.38.develHead.noarch
mgr-osa-dispatcher-4.0.9-400.1.3.develHead.noarch
spacewalk-backend-tools-4.0.19-400.10.1.develHead.noarch
