### PR TITLE
Content Lifecycle Management: Implement 'filter errata by synopsis'

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ErrataFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ErrataFilter.java
@@ -62,6 +62,8 @@ public class ErrataFilter extends ContentFilter<Errata> {
                 switch (matcher) {
                     case EQUALS:
                         return getField(erratum, field, String.class).equals(value);
+                    case CONTAINS:
+                        return getField(erratum, field, String.class).contains(value);
                     default:
                         throw new UnsupportedOperationException("Matcher " + matcher + " not supported");
                 }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ErrataFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ErrataFilter.java
@@ -58,6 +58,13 @@ public class ErrataFilter extends ContentFilter<Errata> {
                     default:
                         throw new UnsupportedOperationException("Matcher " + matcher + " not supported");
                 }
+            case "synopsis":
+                switch (matcher) {
+                    case EQUALS:
+                        return getField(erratum, field, String.class).equals(value);
+                    default:
+                        throw new UnsupportedOperationException("Matcher " + matcher + " not supported");
+                }
             default:
                 throw new UnsupportedOperationException("Field " + field + " not supported");
         }
@@ -69,6 +76,8 @@ public class ErrataFilter extends ContentFilter<Errata> {
                 return type.cast(erratum.getAdvisoryName());
             case "issue_date":
                 return type.cast(erratum.getIssueDate().toInstant().atZone(ZoneId.systemDefault()));
+            case "synopsis":
+                return type.cast(erratum.getSynopsis());
             default:
                 throw new UnsupportedOperationException("Field " + field + " not supported");
         }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
@@ -55,6 +55,7 @@ public class FilterCriteria {
         validCombinations.add(Triple.of(PACKAGE, EQUALS, "nevr"));
         validCombinations.add(Triple.of(PACKAGE, EQUALS, "nevra"));
         validCombinations.add(Triple.of(ERRATUM, EQUALS, "advisory_name"));
+        validCombinations.add(Triple.of(ERRATUM, EQUALS, "synopsis"));
         validCombinations.add(Triple.of(ERRATUM, GREATER, "issue_date"));
         validCombinations.add(Triple.of(ERRATUM, GREATEREQ, "issue_date"));
     }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
@@ -56,6 +56,7 @@ public class FilterCriteria {
         validCombinations.add(Triple.of(PACKAGE, EQUALS, "nevra"));
         validCombinations.add(Triple.of(ERRATUM, EQUALS, "advisory_name"));
         validCombinations.add(Triple.of(ERRATUM, EQUALS, "synopsis"));
+        validCombinations.add(Triple.of(ERRATUM, CONTAINS, "synopsis"));
         validCombinations.add(Triple.of(ERRATUM, GREATER, "issue_date"));
         validCombinations.add(Triple.of(ERRATUM, GREATEREQ, "issue_date"));
     }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentFilterTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentFilterTest.java
@@ -157,4 +157,23 @@ public class ContentFilterTest extends JMockBaseTestCaseWithUser {
         assertTrue(erratum3.getIssueDate().toInstant().atZone(ZoneId.systemDefault()).toString()
                 + " should be equal " +  criteriaDate.toString(), filter.test(erratum3));
     }
+
+    /**
+     * Test basic Errata filtering based on equal match on synopsis
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testErrataByEqualSynopsisFilter() throws Exception {
+        String cveName1 = TestUtils.randomString().substring(0, 13);
+        Errata erratum1 = ErrataTestUtils.createTestErrata(user, Collections.singleton(ErrataTestUtils.createTestCve(cveName1)));
+        erratum1.setSynopsis("recommended update: " + cveName1);
+        String cveName2 = TestUtils.randomString().substring(0, 13);
+        Errata erratum2 = ErrataTestUtils.createTestErrata(user, Collections.singleton(ErrataTestUtils.createTestCve(cveName2)));
+        erratum2.setSynopsis("recommended update: " + cveName2);
+
+        FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.EQUALS, "synopsis", erratum1.getSynopsis());
+        ContentFilter filter = ContentManager.createFilter("synopsis-filter", DENY, ERRATUM, criteria, user);
+        assertTrue(filter.test(erratum1));
+        assertFalse(filter.test(erratum2));
+    }
 }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentFilterTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentFilterTest.java
@@ -176,4 +176,33 @@ public class ContentFilterTest extends JMockBaseTestCaseWithUser {
         assertTrue(filter.test(erratum1));
         assertFalse(filter.test(erratum2));
     }
+
+    /**
+     * Test basic Errata filtering based on partial match on synopsis
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testErrataByContainsSynopsisFilter() throws Exception {
+        String cveName1 = TestUtils.randomString().substring(0, 13);
+        Errata erratum1 = ErrataTestUtils.createTestErrata(user, Collections.singleton(ErrataTestUtils.createTestCve(cveName1)));
+        erratum1.setSynopsis("recommended update: " + cveName1);
+        String cveName2 = TestUtils.randomString().substring(0, 13);
+        Errata erratum2 = ErrataTestUtils.createTestErrata(user, Collections.singleton(ErrataTestUtils.createTestCve(cveName2)));
+        erratum2.setSynopsis("recommended update: " + cveName2);
+
+        FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.CONTAINS, "synopsis", erratum1.getSynopsis());
+        ContentFilter filter = ContentManager.createFilter("synopsis-filter", DENY, ERRATUM, criteria, user);
+        assertTrue(filter.test(erratum1));
+        assertFalse(filter.test(erratum2));
+
+        FilterCriteria criteria2 = new FilterCriteria(FilterCriteria.Matcher.CONTAINS, "synopsis", "recommended update:");
+        ContentFilter filter2 = ContentManager.createFilter("synopsis-filter2", DENY, ERRATUM, criteria2, user);
+        assertTrue(filter2.test(erratum1));
+        assertTrue(filter2.test(erratum2));
+
+        FilterCriteria criteria3 = new FilterCriteria(FilterCriteria.Matcher.CONTAINS, "synopsis", "imsurethisdoesntexist");
+        ContentFilter filter3 = ContentManager.createFilter("synopsis-filter3", DENY, ERRATUM, criteria3, user);
+        assertFalse(filter3.test(erratum1));
+        assertFalse(filter3.test(erratum2));
+    }
 }

--- a/java/code/src/com/redhat/rhn/frontend/events/AlignSoftwareTargetAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/AlignSoftwareTargetAction.java
@@ -79,7 +79,7 @@ public class AlignSoftwareTargetAction implements MessageAction {
     public Consumer<Exception> getExceptionHandler() {
         return (e) -> {
             if (e instanceof AlignSoftwareTargetException) {
-                LOG.error("Error aligning target " + ((AlignSoftwareTargetException) e).getTarget(), e);
+                LOG.error("Error aligning target " + ((AlignSoftwareTargetException) e).getTarget().getId(), e);
                 AlignSoftwareTargetException exc = ((AlignSoftwareTargetException) e);
                 exc.getTarget().setStatus(Status.FAILED);
                 ContentProjectFactory.save(exc.getTarget());

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Implement filtering errata by synopsis in Content Lifecycle Management
 - Normalize date formats for actions, notifications and clm (bsc#1142774)
 - Implement ALLOW filters in Content Lifecycle Management
 - move /usr/share/rhn/config-defaults to uyuni-base-common

--- a/web/html/src/manager/content-management/list-filters/filter-form.js
+++ b/web/html/src/manager/content-management/list-filters/filter-form.js
@@ -152,6 +152,20 @@ const FilterForm = (props: Props) => {
           </div>
         }
 
+        {
+          (filtersEnum.enum.ERRATUM_BYSYNOPSIS.key === props.filter.type
+              || filtersEnum.enum.ERRATUM_BYSYNOPSIS_CONTAINS.key === props.filter.type) &&
+          <div className="row">
+            <Text
+              name="synopsis"
+              label={t("Synopsis")}
+              labelClass="col-md-3"
+              divClass="col-md-6"
+              required
+            />
+          </div>
+        }
+
         <Radio
           inline
           name="rule"

--- a/web/html/src/manager/content-management/list-filters/filter.utils.js
+++ b/web/html/src/manager/content-management/list-filters/filter.utils.js
@@ -31,6 +31,9 @@ export function mapFilterFormToRequest(filterForm: FilterFormType, projectLabel:
     requestForm.criteriaValue = filterForm.issueDate
       ? moment(Functions.Utils.dateWithoutTimezone(filterForm.issueDate, localTime)).format("YYYY-MM-DDTHH:mm:ss.SSSZ")
       :  "";
+  } else if (filterForm.type === filtersEnum.enum.ERRATUM_BYSYNOPSIS.key || filterForm.type === filtersEnum.enum.ERRATUM_BYSYNOPSIS_CONTAINS.key) {
+    requestForm.criteriaKey = "synopsis";
+    requestForm.criteriaValue = filterForm.synopsis;
   } else {
     requestForm.criteriaKey = "name";
     requestForm.criteriaValue = filterForm.criteria;
@@ -87,6 +90,13 @@ export function mapResponseToFilterForm(filtersResponse: Array<FilterServerType>
     } else if (filterResponse.criteriaKey === "advisory_name") {
       filterForm.type = filtersEnum.enum.ERRATUM.key;
       filterForm["advisoryName"] = filterResponse.criteriaValue;
+    } else if (filterResponse.criteriaKey === "synopsis") {
+      if (filterResponse.matcher === "equals") {
+          filterForm.type = filtersEnum.enum.ERRATUM_BYSYNOPSIS.key;
+      } else if (filterResponse.matcher === "contains") {
+          filterForm.type = filtersEnum.enum.ERRATUM_BYSYNOPSIS_CONTAINS.key;
+      }
+      filterForm["synopsis"] = filterResponse.criteriaValue;
     } else if (filterResponse.criteriaKey === "issue_date") {
       filterForm.type = filtersEnum.enum.ERRATUM_BYDATE.key;
       filterForm["issueDate"] = Functions.Utils.dateWithTimezone(filterResponse.criteriaValue);

--- a/web/html/src/manager/content-management/shared/business/filters.enum.js
+++ b/web/html/src/manager/content-management/shared/business/filters.enum.js
@@ -32,6 +32,18 @@ export const filtersOptionsEnum : FiltersOptionEnumType = new Proxy({
       entityType: 'erratum',
       matcher: 'greatereq',
       text: 'Patch (issued after)',
+    },
+    ERRATUM_BYSYNOPSIS: {
+      key: 'erratum_bysynopsis',
+      entityType: 'erratum',
+      matcher: 'equals',
+      text: 'Patch (equals Synopsis)',
+    },
+    ERRATUM_BYSYNOPSIS_CONTAINS: {
+      key: 'erratum_bysynopsis_contains',
+      entityType: 'erratum',
+      matcher: 'contains',
+      text: 'Patch (contains Synopsis)',
     }
   },
   objectDefaultValueHandler(defaultState)

--- a/web/html/src/manager/content-management/shared/type/filter.type.js
+++ b/web/html/src/manager/content-management/shared/type/filter.type.js
@@ -23,6 +23,7 @@ export type FilterFormType = {
   release?: string,
   architecture?: string,
   advisoryName?: string,
+  synopsis?: string,
   criteria?: string,
   issueDate?: Date
 }

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Implement filtering errata by synopsis in Content Lifecycle Management
 - Normalize date formats for actions, notifications and clm (bsc#1142774)
 - Implement ALLOW filters in Content Lifecycle Management
 - move /usr/share/rhn/config-defaults to uyuni-base-common


### PR DESCRIPTION
## What does this PR change?

$subj.
The matcher for the errata synopsis is `EQUALS` - that means filtering happens
on exact synopsis match.


## GUI diff

(just added one option to the selectbox in the filter dialog)


## Documentation
- https://github.com/SUSE/spacewalk/issues/8981
- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/8529

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"