### PR TITLE
SPA: fix wrong usage of blank attributes -> _blank

### DIFF
--- a/java/code/src/com/suse/manager/webui/menu/MenuTree.java
+++ b/java/code/src/com/suse/manager/webui/menu/MenuTree.java
@@ -364,16 +364,16 @@ public class MenuTree {
                 );
 
             // Help
-            nodes.add(new MenuItem("Help").withIcon("fa-book").withTarget("blank")
+            nodes.add(new MenuItem("Help").withIcon("fa-book").withTarget("_blank")
                 .addChild(new MenuItem("Documentation_version", Config.get().getString("web.version"))
-                    .withPrimaryUrl("/docs/index.html").withTarget("blank"))
-                .addChild(new MenuItem("Release Notes").withTarget("blank")
+                    .withPrimaryUrl("/docs/index.html").withTarget("_blank"))
+                .addChild(new MenuItem("Release Notes").withTarget("_blank")
                         .addChild(new MenuItem("product_server")
                             .withPrimaryUrl("/docs/release-notes/release-notes-server.html")
-                            .withTarget("blank"))
+                            .withTarget("_blank"))
                         .addChild(new MenuItem("product_proxy")
                                 .withPrimaryUrl("/docs/release-notes/release-notes-proxy.html")
-                                .withTarget("blank"))
+                                .withTarget("_blank"))
                         )
                 .addChild(new MenuItem("API")
                     .addChild(new MenuItem("Overview").withPrimaryUrl("/rhn/apidoc/index.jsp")
@@ -388,10 +388,10 @@ public class MenuTree {
             nodes.add(new MenuItem("External Links").withIcon("fa-link")
                 .addChild(new MenuItem("header.jsp.knowledgebase")
                     .withPrimaryUrl("https://www.suse.com/support/kb/product.php?id=SUSE_Manager")
-                    .withTarget("blank"))
+                    .withTarget("_blank"))
                 .addChild(new MenuItem("header.jsp.documentation")
                     .withPrimaryUrl("https://www.suse.com/documentation/suse_manager/")
-                    .withTarget("blank"))
+                    .withTarget("_blank"))
                 );
         }
         else {
@@ -405,15 +405,15 @@ public class MenuTree {
                 .addChild(new MenuItem("Overview").withPrimaryUrl("/rhn/help/about.do"))
                 .addChild(new MenuItem("Sign In").withPrimaryUrl("/rhn/Login.do"))
                 .addChild(new MenuItem("Documentation_version", Config.get().getString("web.version"))
-                    .withPrimaryUrl("/docs/index.html").withTarget("blank"))
+                    .withPrimaryUrl("/docs/index.html").withTarget("_blank"))
                 .addChild(new MenuItem("Lookup Login/Password").withPrimaryUrl("/rhn/help/ForgotCredentials.do"))
-                .addChild(new MenuItem("Release Notes").withTarget("blank")
+                .addChild(new MenuItem("Release Notes").withTarget("_blank")
                         .addChild(new MenuItem("product_server")
                             .withPrimaryUrl("/docs/release-notes/release-notes-server.html")
-                            .withTarget("blank"))
+                            .withTarget("_blank"))
                         .addChild(new MenuItem("product_proxy")
                                 .withPrimaryUrl("/docs/release-notes/release-notes-proxy.html")
-                                .withTarget("blank"))
+                                .withTarget("_blank"))
                         )
                 .addChild(new MenuItem("API")
                     .addChild(new MenuItem("Overview").withPrimaryUrl("/rhn/apidoc/index.jsp")
@@ -428,10 +428,10 @@ public class MenuTree {
             nodes.add(new MenuItem("External Links").withIcon("fa-link")
                 .addChild(new MenuItem("header.jsp.knowledgebase")
                     .withPrimaryUrl("https://www.suse.com/support/kb/product.php?id=SUSE_Manager")
-                    .withTarget("blank"))
+                    .withTarget("_blank"))
                 .addChild(new MenuItem("header.jsp.documentation")
                     .withPrimaryUrl("https://www.suse.com/documentation/suse_manager/")
-                    .withTarget("blank"))
+                    .withTarget("_blank"))
                 );
         }
 


### PR DESCRIPTION
## What does this PR change?

SPA: fix wrong usage of blank attributes -> _blank

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed

- [ ] **DONE**

## Test coverage
- No tests

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
