### PR TITLE
Fix etc rhn in proxy common

### DIFF
--- a/proxy/proxy/spacewalk-proxy.changes
+++ b/proxy/proxy/spacewalk-proxy.changes
@@ -1,3 +1,4 @@
+- use /etc/rhn from uyuni-base-common
 - move /usr/share/rhn/config-defaults to uyuni-base-common
 
 -------------------------------------------------------------------

--- a/proxy/proxy/spacewalk-proxy.spec
+++ b/proxy/proxy/spacewalk-proxy.spec
@@ -40,8 +40,6 @@ BuildRequires:  %{pythonX}
 BuildArch:      noarch
 Requires:       %{pythonX}-spacewalk-usix
 Requires:       httpd
-Requires(pre):  uyuni-base-common
-BuildRequires:  uyuni-base-common
 %if 0%{?pylint_check}
 BuildRequires:  spacewalk-python2-pylint
 %endif
@@ -165,6 +163,8 @@ between an Spacewalk Proxy Server and parent Spacewalk server.
 %package common
 Summary:        Modules shared by Spacewalk Proxy components
 Group:          Applications/Internet
+Requires(pre):  uyuni-base-common
+BuildRequires:  uyuni-base-common
 %if 0%{?suse_version}
 BuildRequires:  apache2
 %else
@@ -477,7 +477,6 @@ fi
 %attr(750,%{apache_user},%{apache_group}) %dir %{_var}/spool/rhn-proxy/list
 %attr(770,root,%{apache_group}) %dir %{_var}/log/rhn
 # config files
-%attr(755,root,%{apache_group}) %dir %{rhnconf}
 %attr(640,root,%{apache_group}) %config(noreplace) %{rhnconf}/rhn.conf
 %attr(644,root,%{apache_group}) %{_prefix}/share/rhn/config-defaults/rhn_proxy.conf
 %attr(644,root,%{apache_group}) %config %{httpdconf}/spacewalk-proxy.conf


### PR DESCRIPTION
## What does this PR change?

Fix file conflict caused by spacewalk-proxy-common and /etc/rhn directory.
Use now the version from uyuni-base-common.
Also move the dependencies to this subpackage.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **fix building**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
