### PR TITLE
CLM deny patch contains package

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
@@ -32,6 +32,13 @@ import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.CONTAINS;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.EQUALS;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.GREATER;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.GREATEREQ;
+import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.CONTAINS_PKG_NAME;
+import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.CONTAINS_PKG_LT_EVR;
+import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.CONTAINS_PKG_LE_EVR;
+import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.CONTAINS_PKG_EQ_EVR;
+import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.CONTAINS_PKG_GE_EVR;
+import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.CONTAINS_PKG_GT_EVR;
+
 
 /**
  * The criteria used for matching objects (Package, Errata) in {@link ContentFilter}
@@ -60,6 +67,12 @@ public class FilterCriteria {
         validCombinations.add(Triple.of(ERRATUM, CONTAINS, "synopsis"));
         validCombinations.add(Triple.of(ERRATUM, GREATER, "issue_date"));
         validCombinations.add(Triple.of(ERRATUM, GREATEREQ, "issue_date"));
+        validCombinations.add(Triple.of(ERRATUM, CONTAINS_PKG_NAME, "package_name"));
+        validCombinations.add(Triple.of(ERRATUM, CONTAINS_PKG_LT_EVR, "package_nevr"));
+        validCombinations.add(Triple.of(ERRATUM, CONTAINS_PKG_LE_EVR, "package_nevr"));
+        validCombinations.add(Triple.of(ERRATUM, CONTAINS_PKG_EQ_EVR, "package_nevr"));
+        validCombinations.add(Triple.of(ERRATUM, CONTAINS_PKG_GE_EVR, "package_nevr"));
+        validCombinations.add(Triple.of(ERRATUM, CONTAINS_PKG_GT_EVR, "package_nevr"));
     }
 
     /**
@@ -67,6 +80,12 @@ public class FilterCriteria {
      */
     public enum Matcher {
         CONTAINS("contains"),
+        CONTAINS_PKG_NAME("contains_pkg_name"),
+        CONTAINS_PKG_LT_EVR("contains_pkg_lt_evr"), // <
+        CONTAINS_PKG_LE_EVR("contains_pkg_le_evr"), // <=
+        CONTAINS_PKG_EQ_EVR("contains_pkg_eq_evr"), // ==
+        CONTAINS_PKG_GE_EVR("contains_pkg_ge_evr"), // >=
+        CONTAINS_PKG_GT_EVR("contains_pkg_gt_evr"), // >
         EQUALS("equals"),
         GREATER("greater"),
         GREATEREQ("greatereq");

--- a/java/code/src/com/suse/manager/utils/PackageUtils.java
+++ b/java/code/src/com/suse/manager/utils/PackageUtils.java
@@ -74,6 +74,49 @@ public class PackageUtils {
         return new PackageEvr(epoch, version, release);
     }
 
+    /**
+     * Parses a RPM package version string to create a {@link PackageEvr} object.
+     *
+     * RPM package version policy format: [epoch:]version[-release]
+     *
+     * @param version the package version string
+     * @return the package EVR
+     */
+    public static PackageEvr parseRpmEvr(String version) {
+        String release = "";
+        String epoch = null;
+
+        int epochIndex = version.indexOf(':');
+        if (epochIndex > 0) {
+            // Strip away optional 'epoch'
+            epoch = version.substring(0, epochIndex);
+            version = version.substring(epochIndex + 1);
+        }
+
+        int releaseIndex = version.lastIndexOf('-');
+        if (releaseIndex > 0) {
+            // Strip away optional 'release'
+            release = version.substring(releaseIndex + 1);
+            version = version.substring(0, releaseIndex);
+        }
+
+        return new PackageEvr(epoch, version, release);
+    }
+
+    /**
+     * Detect package type and call the correct parser for the version string.
+     *
+     * @param pkg the package
+     * @param version the version string
+     * @return parsed PackageEvr object
+     */
+    public static PackageEvr parsePackageEvr(Package pkg, String version) {
+        if (PackageUtils.isTypeDeb(pkg)) {
+            return PackageUtils.parseDebianEvr(version);
+        }
+        return PackageUtils.parseRpmEvr(version);
+    }
+
     private static String getArchTypeLabel(Package pkg) {
         return pkg.getPackageArch().getArchType().getLabel();
     }

--- a/java/code/src/com/suse/manager/utils/test/PackageUtilsTest.java
+++ b/java/code/src/com/suse/manager/utils/test/PackageUtilsTest.java
@@ -20,6 +20,7 @@ import com.redhat.rhn.domain.rhnpackage.PackageFactory;
 import com.redhat.rhn.domain.rhnpackage.test.PackageTest;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.suse.manager.utils.PackageUtils;
+import com.suse.manager.webui.controllers.DownloadController.PkgInfo;
 
 public class PackageUtilsTest extends BaseTestCaseWithUser {
 
@@ -84,5 +85,29 @@ public class PackageUtilsTest extends BaseTestCaseWithUser {
         assertNull(evr.getEpoch());
         assertEquals("2-3-4", evr.getVersion());
         assertEquals("5", evr.getRelease());
+    }
+
+    public void testParseRpmEvr() {
+        PackageEvr evr;
+
+        evr = PackageUtils.parseRpmEvr("1:1.2.3-4.5");
+        assertEquals("1", evr.getEpoch());
+        assertEquals("1.2.3", evr.getVersion());
+        assertEquals("4.5", evr.getRelease());
+
+        evr = PackageUtils.parseRpmEvr("1.2.3-4.5");
+        assertNull(evr.getEpoch());
+        assertEquals("1.2.3", evr.getVersion());
+        assertEquals("4.5", evr.getRelease());
+
+        evr = PackageUtils.parseRpmEvr("1:1.2.3-4.5");
+        assertEquals("1", evr.getEpoch());
+        assertEquals("1.2.3", evr.getVersion());
+        assertEquals("4.5", evr.getRelease());
+
+        evr = PackageUtils.parseRpmEvr("1.2.3");
+        assertNull(evr.getEpoch());
+        assertEquals("1.2.3", evr.getVersion());
+        assertEquals("", evr.getRelease());
     }
 }

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/mappers/ResponseMappers.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/mappers/ResponseMappers.java
@@ -199,7 +199,7 @@ public class ResponseMappers {
                         OffsetDateTime offsetDateTime = OffsetDateTime.parse(
                                 filter.getCriteria().getValue(), timeFormatter
                         );
-                        var criteriaValueDate = Date.from(Instant.from(offsetDateTime));
+                        Date criteriaValueDate = Date.from(Instant.from(offsetDateTime));
 
                         contentFilterResponse.setCriteriaValue(ViewHelper.getInstance().renderDate(criteriaValueDate));
                     }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- implement "patch contains package" Filter for Content Lifecycle Management
 - implement Filter Patch "by type" Content Lifecycle Management
 - Implement filtering errata by synopsis in Content Lifecycle Management
 - Normalize date formats for actions, notifications and clm (bsc#1142774)

--- a/web/html/src/manager/content-management/list-filters/filter-form.js
+++ b/web/html/src/manager/content-management/list-filters/filter-form.js
@@ -183,6 +183,19 @@ const FilterForm = (props: Props) => {
           </div>
         }
 
+        {
+          filtersEnum.enum.ERRATUM_PKG_NAME.key === props.filter.type &&
+          <div className="row">
+            <Text
+              name="criteria"
+              label={t("Package name")}
+              labelClass="col-md-3"
+              divClass="col-md-6"
+              required
+            />
+          </div>
+        }
+
         <Radio
           inline
           name="rule"
@@ -194,6 +207,7 @@ const FilterForm = (props: Props) => {
           label={t("Rule")}
           labelClass="col-md-3"
           divClass="col-md-6" />
+
 
       </React.Fragment>
     </Form>

--- a/web/html/src/manager/content-management/list-filters/filter-form.js
+++ b/web/html/src/manager/content-management/list-filters/filter-form.js
@@ -124,6 +124,42 @@ const FilterForm = (props: Props) => {
         }
 
         {
+          (filtersEnum.enum.ERRATUM_PKG_LT_EVR.key === props.filter.type ||
+          filtersEnum.enum.ERRATUM_PKG_LE_EVR.key === props.filter.type ||
+          filtersEnum.enum.ERRATUM_PKG_EQ_EVR.key === props.filter.type ||
+          filtersEnum.enum.ERRATUM_PKG_GE_EVR.key === props.filter.type ||
+          filtersEnum.enum.ERRATUM_PKG_GT_EVR.key === props.filter.type ) &&
+          <>
+            <Text
+              name="packageName"
+              label={t("Package Name")}
+              labelClass="col-md-3"
+              divClass="col-md-6"
+              required
+            />
+            <Text
+              name="epoch"
+              label={t("Epoch")}
+              labelClass="col-md-3"
+              divClass="col-md-6" />
+            <Text
+              name="version"
+              label={t("Version")}
+              labelClass="col-md-3"
+              divClass="col-md-6"
+              required
+            />
+            <Text
+              name="release"
+              label={t("Release")}
+              labelClass="col-md-3"
+              divClass="col-md-6"
+              required
+            />
+          </>
+        }
+
+        {
           filtersEnum.enum.ERRATUM.key === props.filter.type &&
           <div className="row">
             <Text

--- a/web/html/src/manager/content-management/list-filters/filter.utils.js
+++ b/web/html/src/manager/content-management/list-filters/filter.utils.js
@@ -26,6 +26,15 @@ export function mapFilterFormToRequest(filterForm: FilterFormType, projectLabel:
   } else if (filterForm.type === filtersEnum.enum.ERRATUM_PKG_NAME.key) {
     requestForm.criteriaKey = "package_name";
     requestForm.criteriaValue = filterForm.criteria;
+  } else if (filterForm.type === filtersEnum.enum.ERRATUM_PKG_LT_EVR.key ||
+             filterForm.type === filtersEnum.enum.ERRATUM_PKG_LE_EVR.key ||
+             filterForm.type === filtersEnum.enum.ERRATUM_PKG_EQ_EVR.key ||
+             filterForm.type === filtersEnum.enum.ERRATUM_PKG_GE_EVR.key ||
+             filterForm.type === filtersEnum.enum.ERRATUM_PKG_GT_EVR.key) {
+    const epochName = !_isEmpty(filterForm.epoch) ? `${filterForm.epoch}:` : '';
+    requestForm.criteriaKey = "package_nevr"
+    requestForm.criteriaValue =
+      `${filterForm.packageName || ""} ${epochName}${filterForm.version|| ""}-${filterForm.release|| ""}`;
   } else if (filterForm.type === filtersEnum.enum.ERRATUM.key) {
     requestForm.criteriaKey = "advisory_name";
     requestForm.criteriaValue = filterForm.advisoryName;
@@ -58,6 +67,7 @@ export function mapResponseToFilterForm(filtersResponse: Array<FilterServerType>
 
     if(filterResponse.criteriaKey === "nevr") {
       filterForm.type = filtersEnum.enum.PACKAGE_NEVRA.key;
+
       if(!_isEmpty(filterResponse.criteriaValue)) {
         const [
           ,
@@ -92,6 +102,34 @@ export function mapResponseToFilterForm(filtersResponse: Array<FilterServerType>
         filterForm.version = version;
         filterForm.release = release;
         filterForm.architecture = architecture;
+      }
+    } else if(filterResponse.criteriaKey === "package_nevr") {
+      if (filterForm.matcher === "contains_pkg_lt_evr") {
+        filterForm.type = filtersEnum.enum.ERRATUM_PKG_LT_EVR.key;
+      } else if (filterForm.matcher === "contains_pkg_le_evr") {
+        filterForm.type = filtersEnum.enum.ERRATUM_PKG_LE_EVR.key;
+      } else if (filterForm.matcher === "contains_pkg_eq_evr") {
+        filterForm.type = filtersEnum.enum.ERRATUM_PKG_EQ_EVR.key;
+      } else if (filterForm.matcher === "contains_pkg_ge_evr") {
+        filterForm.type = filtersEnum.enum.ERRATUM_PKG_GE_EVR.key;
+      } else if (filterForm.matcher === "contains_pkg_gt_evr") {
+        filterForm.type = filtersEnum.enum.ERRATUM_PKG_GT_EVR.key;
+      }
+
+      if(!_isEmpty(filterResponse.criteriaValue)) {
+        const [
+          ,
+          packageName,
+          ,
+          epoch,
+          version,
+          release
+        ] = filterResponse.criteriaValue.match(/(.*) ((.*):)?(.*)-(.*)/);
+
+        filterForm.packageName = packageName;
+        filterForm.epoch = epoch;
+        filterForm.version = version;
+        filterForm.release = release;
       }
     } else if (filterResponse.criteriaKey === "advisory_name") {
       filterForm.type = filtersEnum.enum.ERRATUM.key;

--- a/web/html/src/manager/content-management/list-filters/filter.utils.js
+++ b/web/html/src/manager/content-management/list-filters/filter.utils.js
@@ -23,6 +23,9 @@ export function mapFilterFormToRequest(filterForm: FilterFormType, projectLabel:
       requestForm.criteriaValue =
         `${filterForm.packageName || ""}-${epochName}${filterForm.version || ""}-${filterForm.release || ""}.${filterForm.architecture}`;
     }
+  } else if (filterForm.type === filtersEnum.enum.ERRATUM_PKG_NAME.key) {
+    requestForm.criteriaKey = "package_name";
+    requestForm.criteriaValue = filterForm.criteria;
   } else if (filterForm.type === filtersEnum.enum.ERRATUM.key) {
     requestForm.criteriaKey = "advisory_name";
     requestForm.criteriaValue = filterForm.advisoryName;
@@ -106,6 +109,9 @@ export function mapResponseToFilterForm(filtersResponse: Array<FilterServerType>
     } else if (filterResponse.criteriaKey === "issue_date") {
       filterForm.type = filtersEnum.enum.ERRATUM_BYDATE.key;
       filterForm["issueDate"] = Functions.Utils.dateWithTimezone(filterResponse.criteriaValue);
+    } else if (filterResponse.criteriaKey === "package_name") {
+      filterForm.type = filtersEnum.enum.ERRATUM_PKG_NAME.key
+      filterForm.criteria = filterResponse.criteriaValue;
     } else if (filterResponse.criteriaKey === "name") {
       filterForm.type = filtersEnum.enum.PACKAGE.key;
       filterForm.criteria = filterResponse.criteriaValue;

--- a/web/html/src/manager/content-management/shared/business/filters.enum.js
+++ b/web/html/src/manager/content-management/shared/business/filters.enum.js
@@ -50,6 +50,12 @@ export const filtersOptionsEnum : FiltersOptionEnumType = new Proxy({
       entityType: 'erratum',
       matcher: 'contains',
       text: 'Patch (contains Synopsis)',
+    },
+    ERRATUM_PKG_NAME: {
+      key: 'erratum_pkg_name',
+      entityType: 'erratum',
+      matcher: 'contains_pkg_name',
+      text: 'Patch contains package name',
     }
   },
   objectDefaultValueHandler(defaultState)
@@ -67,7 +73,8 @@ function getFilterDescription (filter: Object): string {
   const matcherDescription = {
     equals: " matching ",
     contains: " containing ",
-    greatereq: " greater or equal "
+    greatereq: " greater or equal ",
+    contains_pkg_name: " contains package name "
   }
 
   return `${filter.name}: deny ${filter.entityType} ${matcherDescription[filter.matcher] || ""} ${filter.criteriaValue} (${filter.criteriaKey})`;

--- a/web/html/src/manager/content-management/shared/business/filters.enum.js
+++ b/web/html/src/manager/content-management/shared/business/filters.enum.js
@@ -56,6 +56,36 @@ export const filtersOptionsEnum : FiltersOptionEnumType = new Proxy({
       entityType: 'erratum',
       matcher: 'contains_pkg_name',
       text: 'Patch contains package name',
+    },
+    ERRATUM_PKG_LT_EVR: {
+      key: 'erratum_pkg_lt_evr',
+      entityType: 'erratum',
+      matcher: 'contains_pkg_lt_evr',
+      text: 'Patch contains package with version lower than',
+    },
+    ERRATUM_PKG_LE_EVR: {
+      key: 'erratum_pkg_le_evr',
+      entityType: 'erratum',
+      matcher: 'contains_pkg_le_evr',
+      text: 'Patch contains package with version lower or equal than',
+    },
+    ERRATUM_PKG_EQ_EVR: {
+      key: 'erratum_pkg_eq_evr',
+      entityType: 'erratum',
+      matcher: 'contains_pkg_eq_evr',
+      text: 'Patch contains package with version equal',
+    },
+    ERRATUM_PKG_GE_EVR: {
+      key: 'erratum_pkg_ge_evr',
+      entityType: 'erratum',
+      matcher: 'contains_pkg_ge_evr',
+      text: 'Patch contains package with version greater or equal than',
+    },
+    ERRATUM_PKG_GT_EVR: {
+      key: 'erratum_pkg_gt_evr',
+      entityType: 'erratum',
+      matcher: 'contains_pkg_gt_evr',
+      text: 'Patch contains package with version greater than',
     }
   },
   objectDefaultValueHandler(defaultState)
@@ -74,7 +104,12 @@ function getFilterDescription (filter: Object): string {
     equals: " matching ",
     contains: " containing ",
     greatereq: " greater or equal ",
-    contains_pkg_name: " contains package name "
+    contains_pkg_name: " contains package name ",
+    contains_pkg_lt_evr: " contains package with version lower than ",
+    contains_pkg_le_evr: " contains package with version lower or equal than ",
+    contains_pkg_eq_evr: " contains package with version equal than ",
+    contains_pkg_ge_evr: " contains package with version greater or equal than ",
+    contains_pkg_gt_evr: " contains package with version greater than "
   }
 
   return `${filter.name}: deny ${filter.entityType} ${matcherDescription[filter.matcher] || ""} ${filter.criteriaValue} (${filter.criteriaKey})`;

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- implement "patch contains package" Filter for Content Lifecycle Management
 - implement Filter Patch "by type" Content Lifecycle Management
 - Implement filtering errata by synopsis in Content Lifecycle Management
 - Normalize date formats for actions, notifications and clm (bsc#1142774)


### PR DESCRIPTION
## What does this PR change?

CML Filter "Patch contains package". Can be used for the Live Patching Use Case.

Filter all patches which contain a package with given name.
More specific filters for match the version number are available:

- Filter all patches which contain a package with given nevr <  EVR
- Filter all patches which contain a package with given nevr <= EVR
- Filter all patches which contain a package with given nevr == EVR
- Filter all patches which contain a package with given nevr >= EVR
- Filter all patches which contain a package with given nevr >  EVR

## GUI diff

No difference.

![Screenshot_20190809_170950](https://user-images.githubusercontent.com/1038917/62789097-8939c180-bac8-11e9-97c8-738dfe30185c.png)


![Screenshot_20190809_171153](https://user-images.githubusercontent.com/1038917/62789308-ee8db280-bac8-11e9-94f6-7c4d5aa8cefa.png)


- [ ] **DONE**

## Documentation
- https://github.com/SUSE/spacewalk/issues/8962

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/8542
Tracks 

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"  		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
