### PR TITLE
Fix minor issues in step definition

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -939,7 +939,7 @@ When(/^I wait until all events in history are completed$/) do
   end
 end
 
-And(/I should see a list item with text "([^"]*)" and bullet with "([^"]*)" icon/) do |text, class_name|
+Then(/^I should see a list item with text "([^"]*)" and bullet with "([^"]*)" icon$/) do |text, class_name|
   item_xpath = "//ul/li[text()='#{text}']/i[contains(@class, 'text-#{class_name}')]"
   find(:xpath, item_xpath)
 end


### PR DESCRIPTION
## What does this PR change?

This patch is forward-porting some minor changes to a step definition used with monitoring tests.

## GUI diff

No difference.

## Documentation

No documentation needed.

## Test coverage

No tests needed.

## Links

Port of changes made in downstream PR: https://github.com/SUSE/spacewalk/issues/8357

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
