### PR TITLE
Dmidecode in bootstrap repo fix

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -138,7 +138,7 @@ mgr_update_basic_pkgs:
       - openssl
 {%- if grains['os_family'] == 'Suse' and grains['osrelease'] in ['11.3', '11.4'] %}
       - pmtools
-{%- else %}
+{%- elif grains['cpuarch'] in ['aarch64', 'x86_64'] %}
       - dmidecode
 {%- endif %}
 {%- if grains['os_family'] == 'Suse' %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- dmidecode does not exist on ppc64le and s390x (bsc#1145119)
+
 -------------------------------------------------------------------
 Wed Jul 31 17:42:04 CEST 2019 - jgonzalez@suse.com
 

--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -351,11 +351,18 @@ PKGLIST15 = [
     "salt",
     "python3-salt",
     "salt-minion",
-    "dmidecode",
 ]
 
-PKGLIST15_NO_Z = [
+PKGLIST15_X86_ARM = [
+    "dmidecode",
     "libunwind",
+]
+
+PKGLIST15_PPC = [
+    "libunwind",
+]
+
+PKGLIST15_Z = [
 ]
 
 PKGLISTUBUNTU1604 = [
@@ -722,35 +729,35 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/3/bootstrap/'
     },
     'SLE-15-aarch64' : {
-        'PDID' : [1589, 1709], 'PKGLIST' : PKGLIST15 + PKGLIST15_NO_Z,
+        'PDID' : [1589, 1709], 'PKGLIST' : PKGLIST15 + PKGLIST15_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/0/bootstrap/'
     },
     'SLE-15-ppc64le' : {
-        'PDID' : [1588, 1710], 'PKGLIST' : PKGLIST15 + PKGLIST15_NO_Z,
+        'PDID' : [1588, 1710], 'PKGLIST' : PKGLIST15 + PKGLIST15_PPC,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/0/bootstrap/'
     },
     'SLE-15-s390x' : {
-        'PDID' : [1587, 1711], 'PKGLIST' : PKGLIST15,
+        'PDID' : [1587, 1711], 'PKGLIST' : PKGLIST15 + PKGLIST15_Z,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/0/bootstrap/'
     },
     'SLE-15-x86_64' : {
-        'PDID' : [1576, 1712], 'PKGLIST' : PKGLIST15 + PKGLIST15_NO_Z,
+        'PDID' : [1576, 1712], 'PKGLIST' : PKGLIST15 + PKGLIST15_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/0/bootstrap/'
     },
     'SLE-15-SP1-aarch64' : {
-        'PDID' : [1769, 1709], 'PKGLIST' : PKGLIST15 + PKGLIST15_NO_Z,
+        'PDID' : [1769, 1709], 'PKGLIST' : PKGLIST15 + PKGLIST15_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/1/bootstrap/'
     },
     'SLE-15-SP1-ppc64le' : {
-        'PDID' : [1770, 1710], 'PKGLIST' : PKGLIST15 + PKGLIST15_NO_Z,
+        'PDID' : [1770, 1710], 'PKGLIST' : PKGLIST15 + PKGLIST15_PPC,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/1/bootstrap/'
     },
     'SLE-15-SP1-s390x' : {
-        'PDID' : [1771, 1711], 'PKGLIST' : PKGLIST15,
+        'PDID' : [1771, 1711], 'PKGLIST' : PKGLIST15 + PKGLIST15_Z,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/1/bootstrap/'
     },
     'SLE-15-SP1-x86_64' : {
-        'PDID' : [1772, 1712], 'PKGLIST' : PKGLIST15 + PKGLIST15_NO_Z,
+        'PDID' : [1772, 1712], 'PKGLIST' : PKGLIST15 + PKGLIST15_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/1/bootstrap/'
     },
     'openSUSE-Leap-42.3-x86_64' : {
@@ -758,11 +765,11 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/opensuse/42/3/bootstrap/'
     },
     'openSUSE-Leap-15-x86_64' : {
-        'BASECHANNEL' : 'opensuse_leap15_0-x86_64', 'PKGLIST' : PKGLIST15 + PKGLIST15_NO_Z,
+        'BASECHANNEL' : 'opensuse_leap15_0-x86_64', 'PKGLIST' : PKGLIST15 + PKGLIST15_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/opensuse/15/0/bootstrap/'
     },
     'openSUSE-Leap-15.1-x86_64' : {
-        'BASECHANNEL' : 'opensuse_leap15_1-x86_64', 'PKGLIST' : PKGLIST15 + PKGLIST15_NO_Z,
+        'BASECHANNEL' : 'opensuse_leap15_1-x86_64', 'PKGLIST' : PKGLIST15 + PKGLIST15_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/opensuse/15/1/bootstrap/'
     },
     'centos-6-x86_64' : {

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- dmidecode does not exist on s390x (bsc#1145119)
 - move /usr/share/rhn/config-defaults to uyuni-base-common
 - Add missing bootstrap repo entries for Ubuntu repositories
 


### PR DESCRIPTION
## What does this PR change?

'dmidecode' does not exist for s390x. Create arch specific arrays for easier maintaining
the differences.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/9023
Tracks https://github.com/SUSE/spacewalk/pull/9022 https://github.com/SUSE/spacewalk/pull/9021

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
