### PR TITLE
Uyuni new proxy base os

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -954,45 +954,45 @@ name      = OpenStack 3.0 packages for Oracle Linux 6 (%(arch)s)
 base_channels = oraclelinux6-%(arch)s
 repo_url = http://yum.oracle.com/repo/OracleLinux/OL6/openstack30/%(arch)s/
 
-[uyuni-server-40]
+[uyuni-server-40-leap-151]
 name     = Uyuni Server 4.0 for %(base_channel_name)s
 archs    = x86_64
-base_channels = opensuse_leap42_3-%(arch)s
+base_channels = opensuse_leap15_1-%(arch)s
 checksum = sha256
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-4.0-POOL-x86_64-Media1/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-4.0-POOL-x86_64-Media1/
 
-[uyuni-server-devel]
+[uyuni-server-devel-leap-151]
 name     = Uyuni Server for %(base_channel_name)s (Development)
 archs    = x86_64
-base_channels = opensuse_leap42_3-%(arch)s
+base_channels = opensuse_leap15_1-%(arch)s
 checksum = sha256
-gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_42.3/repo/Uyuni-Server-4.0-POOL-x86_64-Media1/repodata/repomd.xml.key
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_15.1/repo/Uyuni-Server-4.0-POOL-x86_64-Media1/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_42.3/repo/Uyuni-Server-4.0-POOL-x86_64-Media1/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_15.1/repo/Uyuni-Server-4.0-POOL-x86_64-Media1/
 
-[uyuni-proxy-40]
+[uyuni-proxy-40-leap-151]
 name     = Uyuni Proxy 4.0 for %(base_channel_name)s
 archs    = x86_64
-base_channels = opensuse_leap42_3-%(arch)s
+base_channels = opensuse_leap15_1-%(arch)s
 checksum = sha256
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Proxy-4.0-POOL-x86_64-Media1/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Proxy-4.0-POOL-x86_64-Media1/
 
-[uyuni-proxy-devel]
+[uyuni-proxy-devel-leap-151]
 name     = Uyuni Proxy for %(base_channel_name)s (Development)
 archs    = x86_64
-base_channels = opensuse_leap42_3-%(arch)s
+base_channels = opensuse_leap15_1-%(arch)s
 checksum = sha256
-gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_42.3/repo/Uyuni-Proxy-4.0-POOL-x86_64-Media1/repodata/repomd.xml.key
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_15.1/repo/Uyuni-Proxy-4.0-POOL-x86_64-Media1/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_42.3/repo/Uyuni-Proxy-4.0-POOL-x86_64-Media1/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_15.1/repo/Uyuni-Proxy-4.0-POOL-x86_64-Media1/
 
 [ubuntu-1604-pool-amd64]
 label    = ubuntu-16.04-pool-amd64

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -473,60 +473,6 @@ repo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/nig
 
 #---
 
-[opensuse_leap42_3]
-checksum = sha256
-archs    = x86_64
-name     = openSUSE Leap 42.3 (%(arch)s)
-gpgkey_url = http://download.opensuse.org/distribution/leap/42.3/repo/oss/suse/repodata/repomd.xml.key
-gpgkey_id = 3DBDC284
-gpgkey_fingerprint = 22C0 7BA5 3417 8CD0 2EFE  22AA B88B 2FD4 3DBD C284
-repo_url = http://download.opensuse.org/distribution/leap/42.3/repo/oss/suse/
-dist_map_release = 42.3
-
-[opensuse_leap42_3-non-oss]
-label    = %(base_channel)s-non-oss
-name     = openSUSE 42.3 non oss (%(arch)s)
-archs    = x86_64
-checksum = sha256
-base_channels = opensuse_leap42_3-%(arch)s
-repo_url = http://download.opensuse.org/distribution/leap/42.3/repo/non-oss/suse/
-
-[opensuse_leap42_3-updates]
-label    = %(base_channel)s-updates
-name     = openSUSE Leap 42.3 Updates (%(arch)s)
-archs    = x86_64
-checksum = sha256
-base_channels = opensuse_leap42_3-%(arch)s
-repo_url = http://download.opensuse.org/update/leap/42.3/oss/
-
-[opensuse_leap42_3-non-oss-updates]
-label    = %(base_channel)s-non-oss-updates
-name     = openSUSE Leap 42.3 non oss Updates (%(arch)s)
-archs    = x86_64
-checksum = sha256
-base_channels = opensuse_leap42_3-%(arch)s
-repo_url = http://download.opensuse.org/update/leap/42.3/non-oss/
-
-[opensuse_leap42_3-uyuni-client]
-name     = Uyuni Client Tools for %(base_channel_name)s
-archs    = x86_64
-base_channels = opensuse_leap42_3-%(arch)s
-checksum = sha256
-gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_42-Uyuni-Client-Tools/openSUSE_Leap_42.3/repodata/repomd.xml.key
-gpgkey_id = %(_uyuni_gpgkey_id)s
-gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_42-Uyuni-Client-Tools/openSUSE_Leap_42.3/
-
-[opensuse_leap42_3-uyuni-client-devel]
-name     = Uyuni Client Tools for %(base_channel_name)s (Development)
-archs    = x86_64
-base_channels = opensuse_leap42_3-%(arch)s
-checksum = sha256
-gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_42-Uyuni-Client-Tools/openSUSE_Leap_42.3/repodata/repomd.xml.key
-gpgkey_id = %(_uyuni_gpgkey_id)s
-gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_42-Uyuni-Client-Tools/openSUSE_Leap_42.3/
-
 [opensuse_leap15_0]
 checksum = sha256
 archs    = x86_64

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,5 @@
+- Set openSUSE Leap 15.1 as new Base OS for Uyuni Server and Proxy
+- Remove EOL openSUSE Leap 42.3 from spacewalk-common-channels
 - Require uyuni-base-common for /etc/rhn
 - add spacewalk-watch-channel-sync.sh to spacewalk-utils
 


### PR DESCRIPTION
## What does this PR change?

New base OS for Uyuni 4.0 (Server and Proxy) is openSUSE Leap 15.1 . This PR change the base
OS in spacewalk-common-channels . To have a unique label we need to put the OS somehow in the label.

In addition this PR remove openSUSE Leap 42.3 which is EOL since some month.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- https://github.com/SUSE/spacewalk/issues/9024

- [x] **DONE**

## Test coverage
- No tests: **just a setup problem**

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/1256
Tracks

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
