### PR TITLE
Fix data fsck

### DIFF
--- a/backend/satellite_tools/spacewalk-data-fsck
+++ b/backend/satellite_tools/spacewalk-data-fsck
@@ -45,8 +45,9 @@ def is_sha256_capable():
     cmp = -1
     try:
         h = next(mi)
-        cmp = rpm.labelCompare([h['name'], h['version'], h['release']],
-                               [h['name'], '0.8.1', '1'])
+        cmp = rpm.labelCompare([h['name'].decode("utf-8"),
+                                h['version'].decode("utf-8"),
+                                h['release'].decode("utf-8")], [h['name'].decode("utf-8"), '0.8.1', '1'])
     except StopIteration:
         pass
     return (cmp > 0)

--- a/backend/satellite_tools/spacewalk-data-fsck
+++ b/backend/satellite_tools/spacewalk-data-fsck
@@ -1,5 +1,5 @@
-#!/usr/bin/python
-# -*- coding: UTF-8 -*-
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
 
 import sys
 import os

--- a/backend/satellite_tools/spacewalk-data-fsck
+++ b/backend/satellite_tools/spacewalk-data-fsck
@@ -281,21 +281,24 @@ def delete_package_entry(row):
     return 0
 
 def check_disk_checksum(abs_path, checksum_type, db_checksum):
+    file_checksum = None
+    ret = 0
     try:
-        fp = file(abs_path, 'rb')
+        fp = open(abs_path, 'rb')
         h = checksum.getHashlibInstance(checksum_type, False)
         h.update(fp.read())
         file_checksum = h.hexdigest()
         fp.close()
-    except:
-        file_checksum = None
-    ret = 0
-    if file_checksum != db_checksum:
-        log(0, "File checksum mismatch: %s (%s: %s vs. %s)" %
-            (abs_path, checksum_type, db_checksum, file_checksum))
+    except Exception as exc:
+        log(0, "Unable to calculate checksum: {}".format(str(exc)))
+        ret = 1
+
+    if file_checksum is not None and file_checksum != db_checksum:
+        log(0, "File checksum mismatch: %s (%s: %s vs. %s)" % (abs_path, checksum_type, db_checksum, file_checksum))
         if options.remove_mismatch:
             remove_mismatch(abs_path, options)
         ret = 1
+
     return ret
 
 

--- a/backend/satellite_tools/spacewalk-data-fsck
+++ b/backend/satellite_tools/spacewalk-data-fsck
@@ -45,9 +45,8 @@ def is_sha256_capable():
     cmp = -1
     try:
         h = next(mi)
-        cmp = rpm.labelCompare([h['name'].decode("utf-8"),
-                                h['version'].decode("utf-8"),
-                                h['release'].decode("utf-8")], [h['name'].decode("utf-8"), '0.8.1', '1'])
+        cmp = rpm.labelCompare([h['name'].decode("utf-8"), h['version'].decode("utf-8"), h['release'].decode("utf-8")],
+                               [h['name'].decode("utf-8"), '0.8.1', '1'])
     except StopIteration:
         pass
     return (cmp > 0)

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Fix broken spacewalk-data-fsck utility
 - /etc/rhn also was packaged for spacewalk-backend-tools
 - Add '--latest' support for reposync on DEB based repositories
 - Require uyuni-base-common for /etc/rhn


### PR DESCRIPTION
## What does this PR change?

This is a bugfix PR.

## GUI diff

Before:
```
# spacewalk-data-fsck 
Traceback (most recent call last):
  File "/usr/bin/spacewalk-data-fsck", line 420, in <module>
    exit_value += check_db_vs_disk(options)
  File "/usr/bin/spacewalk-data-fsck", line 91, in check_db_vs_disk
    query = package_query(options)
  File "/usr/bin/spacewalk-data-fsck", line 73, in package_query
    if is_sha256_capable():
  File "/usr/bin/spacewalk-data-fsck", line 49, in is_sha256_capable
    [h['name'], '0.8.1', '1'])
TypeError: argument 1, item 0 must be str or None, not bytes
```

After:

```
Checking if packages from database are present on filesystem
14810 files scanned
Checking if packages from filesystem are present in database
14818 files scanned
```

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [x] **DONE**

## Test coverage

Should pass existing

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
