### PR TITLE
Disallow deleting channels that have clones

### DIFF
--- a/backend/satellite_tools/contentRemove.py
+++ b/backend/satellite_tools/contentRemove.py
@@ -224,6 +224,24 @@ def __listChannels():
     return labels, parents
 
 
+def __clonnedChannels(channelLabel):
+    sql = """
+        select c2.label
+        from rhnChannel c1 inner join rhnChannelCloned clone on c1.id=clone.original_id
+        inner join rhnChannel c2 on c2.id=clone.id
+        where c1.label = :label
+    """
+    h = rhnSQL.prepare(sql)
+    h.execute(label=channelLabel)
+    labels = []
+    while 1:
+        row = h.fetchone_dict()
+        if not row:
+            break
+        labels.append(row['label'])
+
+    return labels
+
 def delete_outside_channels(org):
     rpms_ids = list_packages_without_channels(org, sources=0)
     rpms_paths = _get_package_paths(rpms_ids, sources=0)

--- a/backend/satellite_tools/spacewalk-remove-channel
+++ b/backend/satellite_tools/spacewalk-remove-channel
@@ -38,7 +38,8 @@ from spacewalk.common.rhnConfig import initCFG
 from spacewalk.server import rhnSQL
 
 from spacewalk.satellite_tools.contentRemove import __listChannels, __serverCheck, \
-    __kickstartCheck, delete_channels, UserError, __getMinionsByChannel, __applyChannelState
+    __kickstartCheck, delete_channels, UserError, __getMinionsByChannel, __applyChannelState, \
+    __clonnedChannels
 
 options_table = [
     Option("-v", "--verbose",       action="count",
@@ -155,7 +156,21 @@ def main():
                 for child in children:
                     print("\t\t\t" + child)
 
-    if child_test_fail:
+    clone_test_fail = False
+    for channel in list(channels.keys()):
+        clones_not_deleted=[]
+        for clone in __clonnedChannels(channel):
+            # the clones channels will also be deleted?
+            if clone not in channels:
+                clone_test_fail = True
+                clones_not_deleted.append(clone)
+        if clones_not_deleted:
+            print("Error: cannot remove channel %s: clone channel(s) exist: " % (
+                channel))
+            for clone_channel_error in clones_not_deleted:
+                print("\t\t\t" + clone_channel_error)
+
+    if child_test_fail or clone_test_fail:
         sys.exit(-1)
     if options.unsubscribe:
         if not options.username:

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- spacewalk-remove-channel check that channel doesn't have cloned channels before deleting it (bsc#1138454)
 - Fix broken spacewalk-data-fsck utility
 - /etc/rhn also was packaged for spacewalk-backend-tools
 - Add '--latest' support for reposync on DEB based repositories

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -7944,6 +7944,9 @@ Follow this url to see the full list of inactive systems:
       <trans-unit id="api.channel.delete.haschild">
         <source>This channel has child channels associated with it.  You must delete those channels first before deleting the parent.</source>
       </trans-unit>
+      <trans-unit id="api.channel.delete.hasclones">
+        <source>Unable to delete channel. The channel you have tried to delete has been cloned. You must delete the clones before you can delete this channel. Cloned channels include ({0}{1}).</source>
+      </trans-unit>
       <trans-unit id="api.kickstart.tree.notfound">
         <source>The kickstart tree could not be found.  You may not have access to requested tree.</source>
       </trans-unit>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Check that a channel doesn't have clones before deleting it (bsc#1138454)
 - Fix: initialize the hibernate transaction when merging errata via XMLRPC API (bsc#1145584)
 - Fix documentation of contentmanagement handler (bsc#1145753)
 - Add new API endpoint to list available Filter Criteria

--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- Check that a channel doesn't have clones before deleting it (bsc#1138454)
 - Add unit test for schedule, errata, user, utils, misc, configchannel
   and kickstart modules
 - Multiple minor bugfixes alongside the unit tests

--- a/testsuite/features/srv_delete_channel.feature
+++ b/testsuite/features/srv_delete_channel.feature
@@ -1,0 +1,83 @@
+# COPYRIGHT (c) 2019 SUSE LLC
+# Licensed under the terms of the MIT License.
+
+Feature: Delete channels with child or clone is not allowed
+  we cannot delete a channel if it has a child
+  or have a clone from it
+
+  Scenario: Clone the first channel
+    Given I am on the manage software channels page
+    When I follow "Clone Channel"
+    And I select "Test-Channel-x86_64" as the origin channel
+    And I click on "Clone Channel"
+    Then I should see a "Create Software Channel" text
+    And I should see a "Current state of the channel" text
+    When I click on "Clone Channel"
+    Then I should see a "Clone of Test-Channel-x86_64" text
+
+  Scenario: Clone the second channel using first channel as base
+    Given I am on the manage software channels page
+    When I follow "Clone Channel"
+    And I select "Clone of Test-Channel-x86_64" as the origin channel
+    And I click on "Clone Channel"
+    Then I should see a "Create Software Channel" text
+    And I should see a "Current state of the channel" text
+    When I click on "Clone Channel"
+    Then I should see a "Clone of Clone of Test-Channel-x86_64" text
+
+  Scenario: Try to delete channel with clone
+    Given I am on the manage software channels page
+    When I follow "Clone of Test-Channel-x86_64"
+    And I follow "Delete software channel"
+    And I check "unsubscribeSystems"
+    And I click on "Delete Channel"
+    Then I should see a "Clone of Test-Channel-x86_64" text
+    And I should see a "Unable to delete channel" text
+
+  Scenario: Delete channel without clones neither children
+    Given I am on the manage software channels page
+    When I follow "Clone of Clone of Test-Channel-x86_64"
+    And I follow "Delete software channel"
+    And I check "unsubscribeSystems"
+    And I click on "Delete Channel"
+    Then I should see a "Clone of Clone of Test-Channel-x86_64" text
+    And I should see a "has been deleted" text
+
+  Scenario: Clone a child channel to the Clone of  x86_64 test channel
+    Given I am on the manage software channels page
+    When I follow "Clone Channel"
+    And I select "Test-Channel-x86_64 Child Channel" as the origin channel
+    And I click on "Clone Channel"
+    Then I should see a "Create Software Channel" text
+    And I should see a "Current state of the channel" text
+    When I select "Clone of Test-Channel-x86_64" from "Parent Channel"
+    And I click on "Clone Channel"
+    Then I should see a "Clone of Test-Channel-x86_64 Child Channel" text
+
+  Scenario: Try delete channel with child
+    Given I am on the manage software channels page
+    When I follow "Clone of Test-Channel-x86_64"
+    And I follow "Delete software channel"
+    And I check "unsubscribeSystems"
+    And I click on "Delete Channel"
+    Then I should see a "Clone of Test-Channel-x86_64" text
+    And I should see a "channel has child channels associated" text
+    And I should see a "must delete those channels first before deleting the parent." text
+
+  Scenario: Cleanup: remove cloned child channel
+    Given I am on the manage software channels page
+    When I follow "Clone of Test-Channel-x86_64 Child Channel"
+    And I follow "Delete software channel"
+    And I check "unsubscribeSystems"
+    And I click on "Delete Channel"
+    Then I should see a "Clone of Test-Channel-x86_64 Child Channel" text
+    And I should see a "has been deleted." text
+
+  Scenario: Cleanup: remove cloned parent channel
+    Given I am on the manage software channels page
+    When I follow "Clone of Test-Channel-x86_64"
+    And I follow "Delete software channel"
+    And I check "unsubscribeSystems"
+    And I click on "Delete Channel"
+    Then I should see a "Clone of Test-Channel-x86_64" text
+    And I should see a "has been deleted." text

--- a/testsuite/features/srv_spacewalk_remove_channel_tool.feature
+++ b/testsuite/features/srv_spacewalk_remove_channel_tool.feature
@@ -1,0 +1,46 @@
+# COPYRIGHT (c) 2019 SUSE LLC
+# Licensed under the terms of the MIT License.
+
+Feature: Deleting channels with children or clones is not allowed
+  We cannot delete a channel if it has a clone
+
+  Scenario: Clone the first channel
+    Given I am on the manage software channels page
+    When I follow "Clone Channel"
+    And I select "Test-Channel-x86_64" as the origin channel
+    And I click on "Clone Channel"
+    Then I should see a "Create Software Channel" text
+    And I should see a "Current state of the channel" text
+    When I click on "Clone Channel"
+    Then I should see a "Clone of Test-Channel-x86_64" text
+
+  Scenario: Clone a second channel using first channel as base
+    Given I am on the manage software channels page
+    When I follow "Clone Channel"
+    And I select "Clone of Test-Channel-x86_64" as the origin channel
+    And I click on "Clone Channel"
+    Then I should see a "Create Software Channel" text
+    And I should see a "Current state of the channel" text
+    When I click on "Clone Channel"
+    Then I should see a "Clone of Clone of Test-Channel-x86_64" text
+
+  Scenario: Verify if both clone channels exists
+    When I list channels with spacewalk-remove-channel
+    Then I should get "clone-test-channel-x86_64"
+    And I should get "clone-clone-test-channel-x86_64"
+
+  Scenario: Delete channel with one clone
+    When I delete these channels with spacewalk-remove-channel:
+      |clone-test-channel-x86_64|
+    Then I should get "Error: cannot remove channel"
+    And  I should get "clone channel(s) exist"
+    And  I should get "clone-test-channel-x86_64"
+    And  I should get "clone-clone-test-channel-x86_64"
+
+  Scenario: Delete base channel and clone
+    When I delete these channels with spacewalk-remove-channel:
+      |clone-test-channel-x86_64|
+      |clone-clone-test-channel-x86_64|
+    And I list channels with spacewalk-remove-channel
+    Then I shouldn't get "clone-test-channel-x86_64"
+    And I shouldn't get "clone-clone-test-channel-x86_64"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -5,6 +5,17 @@ require 'xmlrpc/client'
 require 'timeout'
 require 'nokogiri'
 
+When(/^I delete these channels with spacewalk\-remove\-channel:$/) do |table|
+  channels_cmd = "spacewalk-remove-channel "
+  table.raw.each { |x| channels_cmd = channels_cmd + " -c " + x[0] }
+  $command_output, return_code = $server.run(channels_cmd, false)
+end
+
+When(/^I list channels with spacewalk\-remove\-channel$/) do
+  $command_output, return_code = $server.run("spacewalk-remove-channel -l")
+  raise "Unable to run spacewalk-remove-channel -l command on server" unless return_code.zero?
+end
+
 Then(/^"([^"]*)" should be installed on "([^"]*)"$/) do |package, host|
   node = get_target(host)
   node.run("rpm -q #{package}")
@@ -300,25 +311,11 @@ When(/^spacewalk\-channel fails with "([^"]*)"$/) do |arg1|
 end
 
 Then(/^I should get "([^"]*)"$/) do |arg1|
-  found = false
-  $command_output.each_line do |line|
-    if line.include?(arg1)
-      found = true
-      break
-    end
-  end
-  raise "'#{arg1}' not found in output '#{$command_output}'" unless found
+  raise "'#{arg1}' not found in output '#{$command_output}'" unless $command_output.include? arg1
 end
 
 Then(/^I shouldn't get "([^"]*)"$/) do |arg1|
-  found = false
-  $command_output.each_line do |line|
-    if line.include?(arg1)
-      found = true
-      break
-    end
-  end
-  raise "'#{arg1}' found in output '#{$command_output}'" if found
+  raise "'#{arg1}' found in output '#{$command_output}'" unless not $command_output.include? arg1
 end
 
 Then(/^I wait until mgr-sync refresh is finished$/) do

--- a/testsuite/run_sets/testsuite.yml
+++ b/testsuite/run_sets/testsuite.yml
@@ -68,6 +68,7 @@
 - features/trad_metadata_check.feature
 - features/srv_clone_channel_npn.feature
 - features/srv_delete_channel.feature
+- features/srv_spacewalk_remove_channel_tool.feature
 - features/trad_cve_id_new_syntax.feature
 - features/trad_weak_deps.feature
 - features/srv_cve_audit.feature

--- a/testsuite/run_sets/testsuite.yml
+++ b/testsuite/run_sets/testsuite.yml
@@ -67,6 +67,7 @@
 - features/min_docker_build_image.feature
 - features/trad_metadata_check.feature
 - features/srv_clone_channel_npn.feature
+- features/srv_delete_channel.feature
 - features/trad_cve_id_new_syntax.feature
 - features/trad_weak_deps.feature
 - features/srv_cve_audit.feature


### PR DESCRIPTION
## What does this PR change?

Prevent deletion of channels if they have a clone. Before deleting a channel verify if it have some clone based on it and blocks delete. 

- [X] web API
--  [X] Unit test
-- [X] Cumcuber tests-> see: /home/rmateus/projects/suma/spacewalk/testsuite
- [X] XML-RPC
--  [X]  Unit test
- [X] spacecmd (It uses the XML-RPC API)
- [x] spacewalk-remove-channel (https://github.com/SUSE/spacewalk/blob/Manager-3.2/backend/satellite_tools/spacewalk-remove-channel)
--  [X] Cucumber test

## GUI diff

@Loquacity can you check if the error message is ok?
I decided to add the first 3 channels that clone the base to help user knowing which channel to look at. 

After:
![deleteError2Clones](https://user-images.githubusercontent.com/2996004/62955569-2f4b3b80-bde9-11e9-9a44-00d2c57bf0b2.png)

![deleteError3Clones](https://user-images.githubusercontent.com/2996004/62955576-32dec280-bde9-11e9-99e8-480d35faf5df.png)

![deleteErrorMoreThen3Clones](https://user-images.githubusercontent.com/2996004/62955580-35411c80-bde9-11e9-835a-117c7a559c1a.png)



- [X] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)
@Loquacity and @moio Should I add some information to documentation saying you can only delete channels that don't have clones?

- [ ] **DONE**

## Test coverage
- Unit tests were added
- Cucumber tests were added (@srbarrios can you have a look in the cucumber test?)

- [ ] **DONE**

## Links

Fixes #
Tracks https://github.com/SUSE/spacewalk/issues/5844
Manager 4.0: https://github.com/SUSE/spacewalk/pull/9126
Manager 3.2: ?

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
