### PR TITLE
Fix the 'include recommended' button on channels selection in SSM (bsc#1145086)

### DIFF
--- a/web/html/src/manager/systems/ssm/ssm-subscribe-channels.js
+++ b/web/html/src/manager/systems/ssm/ssm-subscribe-channels.js
@@ -336,21 +336,19 @@ class ChildChannelPage extends React.Component<ChildChannelProps, ChildChannelSt
   }
 
   toggleRecommended = (change: SsmAllowedChildChannelsDto) => {
-    const recommendedChangeIds = change.childChannels
+    const recommendedChildChannelIds = change.childChannels
       .filter(channel => channel.recommended)
-      .map(channel => getAllowedChangeId(change, channel.id));
+      .map(channel => channel.id)
 
     if (this.areRecommendedChildrenSelected(change)) {
-      recommendedChangeIds
-        .filter(changeId => this.state.selections.get(changeId) === "SUBSCRIBE")
-        .forEach(changeId => this.state.selections.set(changeId, "NO_CHANGE"));
+      recommendedChildChannelIds
+        .filter(channelId => this.state.selections.get(getAllowedChangeId(change, channelId)) === "SUBSCRIBE")
+        .forEach(channelId => this.onChangeChild(change, channelId, "NO_CHANGE"));
     } else {
-      recommendedChangeIds
-        .filter(changeId => this.state.selections.get(changeId) !== "SUBSCRIBE")
-        .forEach(changeId => this.state.selections.set(changeId, "SUBSCRIBE"));
+      recommendedChildChannelIds
+        .filter(channelId => this.state.selections.get(getAllowedChangeId(change, channelId)) !== "SUBSCRIBE")
+        .forEach(channelId => this.onChangeChild(change, channelId, "SUBSCRIBE"));
     }
-
-    this.setState({selections: this.state.selections});
   }
 
   areRecommendedChildrenSelected = (change: SsmAllowedChildChannelsDto) => {

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fix the 'include recommended' button on channels selection in SSM (bsc#1145086)
 - implement "patch contains package" Filter for Content Lifecycle Management
 - implement Filter Patch "by type" Content Lifecycle Management
 - Implement filtering errata by synopsis in Content Lifecycle Management


### PR DESCRIPTION
the problem was that the state wasn't propagated from the `ChildChannelPage` component.
Fixed by using the same callback function as in the case when user clicks the radio button.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: bugfix
- [x] **DONE**

## Test coverage
- No tests: no tests in frontend

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/9020

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"