### PR TITLE
Fix backend DB types after schema migration

### DIFF
--- a/backend/server/importlib/backendOracle.py
+++ b/backend/server/importlib/backendOracle.py
@@ -147,7 +147,7 @@ class OracleBackend(Backend):
               fields={
                   'id': DBint(),
                   'name': DBstring(128),
-                  'text': DBstring(3000),
+                  'text': DBblob(),
                   'time': DBdateTime()
               },
               ),


### PR DESCRIPTION
## What does this PR change?

This PR follows https://github.com/uyuni-project/uyuni/pull/1282 since there was still a change needed on the Python DB backend types in order to make it aware of using the new introduced `text` type.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **bugfix**
- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
