### PR TITLE
Fix: initialize the hibernate transaction when merging errata via XMLRPC API (bsc#1145584)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/events/CloneErrataAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/CloneErrataAction.java
@@ -46,6 +46,10 @@ public class CloneErrataAction implements MessageAction {
      */
     public void execute(EventMessage msgIn) {
         CloneErrataEvent msg = (CloneErrataEvent) msgIn;
+        cloneErrata(msg);
+    }
+
+    private void cloneErrata(CloneErrataEvent msg) {
         Channel currChan = msg.getChan();
         if (currChan == null) {
             log.error("Failed to clone errata " + msg.getErrata() +
@@ -93,7 +97,6 @@ public class CloneErrataAction implements MessageAction {
                     "java::cloneErrata", "Errata cloned");
         }
     }
-
 
 
 }

--- a/java/code/src/com/redhat/rhn/frontend/events/CloneErrataAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/CloneErrataAction.java
@@ -18,14 +18,10 @@ import com.redhat.rhn.common.messaging.EventMessage;
 import com.redhat.rhn.common.messaging.MessageAction;
 import com.redhat.rhn.manager.errata.ErrataManager;
 
-import org.apache.log4j.Logger;
-
 /**
  * CloneErrataAction
  */
 public class CloneErrataAction implements MessageAction {
-
-    private static Logger log = Logger.getLogger(CloneErrataAction.class);
 
     /**
      * {@inheritDoc}
@@ -34,6 +30,5 @@ public class CloneErrataAction implements MessageAction {
         CloneErrataEvent msg = (CloneErrataEvent) msgIn;
         ErrataManager.cloneErrata(msg.getChannelId(), msg.getErrata(), msg.isRequestRepodataRegen(), msg.getUser());
     }
-
 
 }

--- a/java/code/src/com/redhat/rhn/frontend/events/CloneErrataAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/CloneErrataAction.java
@@ -16,24 +16,9 @@ package com.redhat.rhn.frontend.events;
 
 import com.redhat.rhn.common.messaging.EventMessage;
 import com.redhat.rhn.common.messaging.MessageAction;
-import com.redhat.rhn.domain.channel.Channel;
-import com.redhat.rhn.domain.channel.ChannelFactory;
-import com.redhat.rhn.domain.errata.Errata;
-import com.redhat.rhn.domain.errata.ErrataFactory;
-import com.redhat.rhn.domain.user.User;
-import com.redhat.rhn.frontend.action.channel.manage.PublishErrataHelper;
-import com.redhat.rhn.manager.channel.ChannelManager;
 import com.redhat.rhn.manager.errata.ErrataManager;
-import com.redhat.rhn.manager.errata.cache.ErrataCacheManager;
 
 import org.apache.log4j.Logger;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 
 /**
  * CloneErrataAction
@@ -47,56 +32,7 @@ public class CloneErrataAction implements MessageAction {
      */
     public void execute(EventMessage msgIn) {
         CloneErrataEvent msg = (CloneErrataEvent) msgIn;
-        cloneErrata(msg.getChannelId(), msg.getErrata(), msg.isRequestRepodataRegen(), msg.getUser());
-    }
-
-    private void cloneErrata(Long channelId, Collection<Long> errataToClone, boolean requestRepodataRegen, User user) {
-        Channel channel = ChannelFactory.lookupById(channelId);
-        if (channel == null) {
-            log.error("Failed to clone errata " + errataToClone +
-                    " Didn't find channel with id: " + channelId.toString());
-            return;
-        }
-        Collection<Long> list = errataToClone;
-        List<Long> cids = new ArrayList<Long>();
-        cids.add(channel.getId());
-        // let's avoid deadlocks please
-        ChannelFactory.lock(channel);
-
-        for (Long eid : list) {
-            Errata errata = ErrataFactory.lookupById(eid);
-            // we merge custom errata directly (non Redhat and cloned)
-            if (errata.getOrg() != null) {
-                errata.addChannel(channel);
-                ErrataCacheManager.insertCacheForChannelErrata(cids, errata);
-                errata.addChannelNotification(channel, new Date());
-            }
-            else {
-                Set<Channel> channelSet = new HashSet<Channel>();
-                channelSet.add(channel);
-
-                List<Errata> clones = ErrataManager.lookupPublishedByOriginal(user, errata);
-                if (clones.size() == 0) {
-                    log.debug("Cloning errata");
-                    Errata published = PublishErrataHelper.cloneErrataFast(errata,
-                            user.getOrg());
-                    published.setChannels(channelSet);
-                    ErrataCacheManager.insertCacheForChannelErrata(cids, published);
-                    published.addChannelNotification(channel, new Date());
-                }
-                else {
-                    log.debug("Re-publishing clone");
-                    ErrataManager.publish(clones.get(0), cids, user);
-                }
-            }
-        }
-        // Trigger channel repodata re-generation
-        if (list.size() > 0 && requestRepodataRegen) {
-            channel.setLastModified(new Date());
-            ChannelFactory.save(channel);
-            ChannelManager.queueChannelChange(channel.getLabel(),
-                    "java::cloneErrata", "Errata cloned");
-        }
+        ErrataManager.cloneErrata(msg.getChannelId(), msg.getErrata(), msg.isRequestRepodataRegen(), msg.getUser());
     }
 
 

--- a/java/code/src/com/redhat/rhn/frontend/events/CloneErrataEvent.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/CloneErrataEvent.java
@@ -17,7 +17,6 @@ package com.redhat.rhn.frontend.events;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.messaging.EventDatabaseMessage;
 import com.redhat.rhn.domain.channel.Channel;
-import com.redhat.rhn.domain.channel.ChannelFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.domain.user.UserFactory;
 

--- a/java/code/src/com/redhat/rhn/frontend/events/CloneErrataEvent.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/CloneErrataEvent.java
@@ -97,14 +97,6 @@ public class CloneErrataEvent implements EventDatabaseMessage {
     }
 
     /**
-     * @return Returns the chan.
-     */
-    public Channel getChan() {
-        return ChannelFactory.lookupById(chanId);
-    }
-
-
-    /**
      * @param chanIn The chan to set.
      */
     public void setChan(Channel chanIn) {

--- a/java/code/src/com/redhat/rhn/frontend/events/CloneErrataEvent.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/CloneErrataEvent.java
@@ -49,7 +49,7 @@ public class CloneErrataEvent implements EventDatabaseMessage {
         chanId = chanIn.getId();
         errata = errataIn;
         userId = userIn.getId();
-        this.txn = HibernateFactory.getSession().getTransaction();
+        txn = HibernateFactory.getSession().getTransaction();
     }
 
     /**
@@ -60,9 +60,7 @@ public class CloneErrataEvent implements EventDatabaseMessage {
      * @param userIn the user
      */
     public CloneErrataEvent(Channel chanIn, Collection<Long> errataIn, boolean requestRepodataRegenIn, User userIn) {
-        this.chanId = chanIn.getId();
-        this.errata = errataIn;
-        this.userId = userIn.getId();
+        this(chanIn, errataIn, userIn);
         this.requestRepodataRegen = requestRepodataRegenIn;
     }
 

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -56,7 +56,6 @@ import com.redhat.rhn.frontend.dto.OwnedErrata;
 import com.redhat.rhn.frontend.dto.PackageDto;
 import com.redhat.rhn.frontend.dto.PackageOverview;
 import com.redhat.rhn.frontend.dto.SystemOverview;
-import com.redhat.rhn.frontend.events.CloneErrataAction;
 import com.redhat.rhn.frontend.events.CloneErrataEvent;
 import com.redhat.rhn.frontend.events.NewCloneErrataEvent;
 import com.redhat.rhn.frontend.listview.PageControl;

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -2249,4 +2249,52 @@ public class ErrataManager extends BaseManager {
         params.put("earliest", new Timestamp(System.currentTimeMillis()));
         mode.executeUpdate(params);
     }
+
+    public static void cloneErrata(Long channelId, Collection<Long> errataToClone, boolean requestRepodataRegen,
+            User user) {
+        Channel channel = ChannelFactory.lookupById(channelId);
+        if (channel == null) {
+            log.error("Failed to clone errata " + errataToClone + " Didn't find channel with id: " +
+                    channelId.toString());
+            return;
+        }
+        Collection<Long> list = errataToClone;
+        List<Long> cids = new ArrayList<Long>();
+        cids.add(channel.getId());
+        // let's avoid deadlocks please
+        ChannelFactory.lock(channel);
+
+        for (Long eid : list) {
+            Errata errata = ErrataFactory.lookupById(eid);
+            // we merge custom errata directly (non Redhat and cloned)
+            if (errata.getOrg() != null) {
+                errata.addChannel(channel);
+                ErrataCacheManager.insertCacheForChannelErrata(cids, errata);
+                errata.addChannelNotification(channel, new Date());
+            }
+            else {
+                Set<Channel> channelSet = new HashSet<>();
+                channelSet.add(channel);
+
+                List<Errata> clones = lookupPublishedByOriginal(user, errata);
+                if (clones.size() == 0) {
+                    log.debug("Cloning errata");
+                    Errata published = PublishErrataHelper.cloneErrataFast(errata, user.getOrg());
+                    published.setChannels(channelSet);
+                    ErrataCacheManager.insertCacheForChannelErrata(cids, published);
+                    published.addChannelNotification(channel, new Date());
+                }
+                else {
+                    log.debug("Re-publishing clone");
+                    publish(clones.get(0), cids, user);
+                }
+            }
+        }
+        // Trigger channel repodata re-generation
+        if (list.size() > 0 && requestRepodataRegen) {
+            channel.setLastModified(new Date());
+            ChannelFactory.save(channel);
+            ChannelManager.queueChannelChange(channel.getLabel(), "java::cloneErrata", "Errata cloned");
+        }
+    }
 }

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -2250,6 +2250,14 @@ public class ErrataManager extends BaseManager {
         mode.executeUpdate(params);
     }
 
+    /**
+     * Clone errata to given channel.
+     *
+     * @param channelId the channel id
+     * @param errataToClone the errata ids to clone
+     * @param requestRepodataRegen if channel repodata should be regenerated after the cloning
+     * @param user the user
+     */
     public static void cloneErrata(Long channelId, Collection<Long> errataToClone, boolean requestRepodataRegen,
             User user) {
         Channel channel = ChannelFactory.lookupById(channelId);

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -290,12 +290,13 @@ public class ErrataManager extends BaseManager {
         errataToMerge.removeAll(clones);
 
         log.debug("Publishing");
-        CloneErrataEvent eve = new CloneErrataEvent(toChannel, getErrataIds(errataToMerge), repoRegen, user);
+        Set<Long> errataIds = getErrataIds(errataToMerge);
         if (async) {
+            CloneErrataEvent eve = new CloneErrataEvent(toChannel, errataIds, repoRegen, user);
             MessageQueue.publish(eve);
         }
         else {
-            new CloneErrataAction().execute(eve);
+            cloneErrata(toChannel.getId(), errataIds, repoRegen, user);
         }
 
         // no need to regenerate errata cache, because we didn't touch any packages

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix: initialize the hibernate transaction when merging errata via XMLRPC API (bsc#1145584)
 - Fix documentation of contentmanagement handler (bsc#1145753)
 - Add new API endpoint to list available Filter Criteria
 - improve API documentation of Filter Criteria


### PR DESCRIPTION
## What does this PR change?

The aim of the PR is twofold:
- 1st commit: fix the bug when calling `channel.software.mergeErrata` XMLRPC endpoint (the hibernate transaction of `CloneErrataEvent` was not initialized, thus leading in NPEx in `ActionExecutor`)
- rest of the commits: extract the functionality of `CloneErrataAction` to `ErrataManager`, so that it can be executed separately, without the need of calling it via instantiating the `CloneErrataEvent`. `CloneErrataAction` is now just a dumb class that executes the functionality from the `ErrataManager`.

Review commit-by-commit please!

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/9068

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"