### PR TITLE
Remove obsolete xml-apis as provided by Java 11

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -88,7 +88,6 @@
         <dependency org="suse" name="xalan-j2" rev="2.7.2" />
         <dependency org="suse" name="xalan-j2-serializer" rev="2.7.2" />
         <dependency org="suse" name="xerces-j2" rev="2.11.0" />
-        <dependency org="suse" name="xerces-j2-xml-apis" rev="2.11.0" />
         <dependency org="suse" name="xmlsec" rev="2.0.7" />
 
         <!-- Tomcat jars -->

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -956,7 +956,6 @@ fi
 %{jardir}/xalan-j2.jar
 %{jardir}/xalan-j2-serializer.jar
 %{jardir}/xerces-j2.jar
-%{jardir}/xml-commons-apis.jar
 
 %if 0%{suse_version}
 %{jardir}/struts.jar


### PR DESCRIPTION
## What does this PR change?

XML APIs (`org.xml.sax.*`) seem to be provided by Java 11 so we apparently no longer need the dependency on `xerces-j2-xml-apis` / `xml-commons-apis`. It seems to be the [`isorelax` package](https://build.opensuse.org/package/view_file/openSUSE:Leap:15.1/isorelax/isorelax.spec?expand=1) that explicitly requires `xml-commons-apis`, which leads to the package being installed.

@cbosdo: You might need to update #1139 accordingly after this will be merged.

## GUI diff

No difference.

## Documentation

No documentation needed, patch is affecting only dependencies.

## Test coverage

No additional tests needed as there is no new code.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test" 
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
