### PR TITLE
Add tests of spacecmd to softwarechannel module

### DIFF
--- a/spacecmd/src/spacecmd/errata.py
+++ b/spacecmd/src/spacecmd/errata.py
@@ -188,7 +188,7 @@ def do_errata_apply(self, args, only_systems=None):
                     to_apply.setdefault(erratum_id, []).append(system_id)
 
         # apply the errata
-        for erratum in to_apply:
+        for erratum in sorted(to_apply):
             self.client.system.scheduleApplyErrata(self.session,
                                                    to_apply[erratum],
                                                    [erratum],

--- a/spacecmd/src/spacecmd/misc.py
+++ b/spacecmd/src/spacecmd/misc.py
@@ -598,8 +598,8 @@ def generate_package_cache(self, force=False):
     # We assume that package IDs are unique, so one ID is only
     # refering one package.
     self.all_packages_by_id = {}
-    for k, v in self.all_packages.items():
-        for i in v:
+    for k, v in sorted(self.all_packages.items()):
+        for i in sorted(v):
             # Alert in case of non-unique ID is detected.
             if i in self.all_packages_by_id:
                 logging.debug(
@@ -796,7 +796,7 @@ def get_system_id(self, name):
 
         id_list = '%s = ' % name
 
-        for system_id in systems:
+        for system_id in sorted(systems):
             id_list = id_list + '%i, ' % system_id
 
         logging.warning('')

--- a/spacecmd/src/spacecmd/report.py
+++ b/spacecmd/src/spacecmd/report.py
@@ -203,7 +203,7 @@ def do_report_ipaddresses(self, args):
         return 1
 
     report = {}
-    for system in systems:
+    for system in sorted(systems):
         system_id = self.get_system_id(system)
         network = self.client.system.getNetwork(self.session, system_id)
         report[system] = {'hostname': network.get('hostname'),
@@ -267,7 +267,7 @@ def do_report_kernels(self, args):
         return 1
 
     report = {}
-    for system in systems:
+    for system in sorted(systems):
         system_id = self.get_system_id(system)
         kernel = self.client.system.getRunningKernel(self.session, system_id)
         report[system] = kernel

--- a/spacecmd/src/spacecmd/softwarechannel.py
+++ b/spacecmd/src/spacecmd/softwarechannel.py
@@ -91,7 +91,7 @@ def do_softwarechannel_list(self, args, doreturn=False):
                 details = self.client.channel.software.getDetails(
                     self.session, l)
                 print("%s : %s" % (l, details['summary']))
-                if (options.tree):
+                if options.tree:
                     for c in self.list_child_channels(parent=l):
                         cdetails = self.client.channel.software.getDetails(
                             self.session, c)

--- a/spacecmd/src/spacecmd/softwarechannel.py
+++ b/spacecmd/src/spacecmd/softwarechannel.py
@@ -244,7 +244,7 @@ def complete_softwarechannel_listpackages(self, text, line, beg, end):
 def do_softwarechannel_listpackages(self, args, doreturn=False):
     args, _ = parse_command_arguments(args, get_argument_parser())
 
-    if not args:
+    if len(args) != 1:
         self.help_softwarechannel_listpackages()
         return
 

--- a/spacecmd/src/spacecmd/softwarechannel.py
+++ b/spacecmd/src/spacecmd/softwarechannel.py
@@ -242,26 +242,20 @@ def complete_softwarechannel_listpackages(self, text, line, beg, end):
 
 
 def do_softwarechannel_listpackages(self, args, doreturn=False):
-    arg_parser = get_argument_parser()
-
-    (args, _options) = parse_command_arguments(args, arg_parser)
+    args, _ = parse_command_arguments(args, get_argument_parser())
 
     if not args:
         self.help_softwarechannel_listpackages()
         return
 
-    channel = args[0]
-
-    packages = self.client.channel.software.listLatestPackages(self.session,
-                                                               channel)
-
-    packages = build_package_names(packages)
+    packages = list(sorted(build_package_names(
+        self.client.channel.software.listLatestPackages(self.session, args[0]))))
 
     if doreturn:
         return packages
     else:
         if packages:
-            print('\n'.join(sorted(packages)))
+            print('\n'.join(packages))
 
 ####################
 

--- a/spacecmd/src/spacecmd/softwarechannel.py
+++ b/spacecmd/src/spacecmd/softwarechannel.py
@@ -326,28 +326,20 @@ def complete_softwarechannel_listlatestpackages(self, text, line, beg, end):
 
 
 def do_softwarechannel_listlatestpackages(self, args, doreturn=False):
-    arg_parser = get_argument_parser()
+    args, _ = parse_command_arguments(args, get_argument_parser())
 
-    (args, _options) = parse_command_arguments(args, arg_parser)
-
-    if not args:
+    if len(args) != 1:
         self.help_softwarechannel_listlatestpackages()
         return
 
-    channel = args[0]
-
-    allpackages = self.client.channel.software.listAllPackages(self.session,
-                                                               channel)
-
-    latestpackages = filter_latest_packages(allpackages)
-
-    packages = build_package_names(latestpackages)
+    packages = list(sorted(build_package_names(filter_latest_packages(
+        self.client.channel.software.listAllPackages(self.session, args[0])))))
 
     if doreturn:
         return packages
     else:
         if packages:
-            print('\n'.join(sorted(packages)))
+            print('\n'.join(packages))
 
 ####################
 

--- a/spacecmd/src/spacecmd/softwarechannel.py
+++ b/spacecmd/src/spacecmd/softwarechannel.py
@@ -68,9 +68,9 @@ def do_softwarechannel_list(self, args, doreturn=False):
     arg_parser.add_argument('-v', '--verbose', action='store_true')
     arg_parser.add_argument('-t', '--tree', action='store_true')
 
-    (args, options) = parse_command_arguments(args, arg_parser)
+    args, options = parse_command_arguments(args, arg_parser)
 
-    if (options.tree):
+    if options.tree:
         labels = self.list_base_channels()
     else:
         channels = self.client.channel.listAllChannels(self.session)
@@ -83,7 +83,7 @@ def do_softwarechannel_list(self, args, doreturn=False):
     if doreturn:
         return labels
     elif labels:
-        if (options.verbose):
+        if options.verbose:
             for l in sorted(labels):
                 details = self.client.channel.software.getDetails(
                     self.session, l)
@@ -96,7 +96,7 @@ def do_softwarechannel_list(self, args, doreturn=False):
         else:
             for l in sorted(labels):
                 print("%s" % l)
-                if (options.tree):
+                if options.tree:
                     for c in self.list_child_channels(parent=l):
                         print(" |-%s" % c)
 

--- a/spacecmd/src/spacecmd/softwarechannel.py
+++ b/spacecmd/src/spacecmd/softwarechannel.py
@@ -274,26 +274,19 @@ def complete_softwarechannel_listallpackages(self, text, line, beg, end):
 
 
 def do_softwarechannel_listallpackages(self, args, doreturn=False):
-    arg_parser = get_argument_parser()
+    args, _ = parse_command_arguments(args, get_argument_parser())
 
-    (args, _options) = parse_command_arguments(args, arg_parser)
-
-    if not args:
+    if len(args) != 1:
         self.help_softwarechannel_listallpackages()
         return
 
-    channel = args[0]
-
-    packages = self.client.channel.software.listAllPackages(self.session,
-                                                            channel)
-
-    packages = build_package_names(packages)
+    packages = list(sorted(build_package_names(self.client.channel.software.listAllPackages(self.session, args[0]))))
 
     if doreturn:
         return packages
     else:
         if packages:
-            print('\n'.join(sorted(packages)))
+            print('\n'.join(packages))
 
 ####################
 

--- a/spacecmd/src/spacecmd/softwarechannel.py
+++ b/spacecmd/src/spacecmd/softwarechannel.py
@@ -212,7 +212,7 @@ def complete_softwarechannel_listsystems(self, text, line, beg, end):
 def do_softwarechannel_listsystems(self, args, doreturn=False):
     args, _options = parse_command_arguments(args, get_argument_parser())
 
-    if not args:
+    if len(args) != 1:
         self.help_softwarechannel_listsystems()
         return
 

--- a/spacecmd/src/spacecmd/softwarechannel.py
+++ b/spacecmd/src/spacecmd/softwarechannel.py
@@ -210,27 +210,19 @@ def complete_softwarechannel_listsystems(self, text, line, beg, end):
 
 
 def do_softwarechannel_listsystems(self, args, doreturn=False):
-    arg_parser = get_argument_parser()
-
-    (args, _options) = parse_command_arguments(args, arg_parser)
+    args, _options = parse_command_arguments(args, get_argument_parser())
 
     if not args:
         self.help_softwarechannel_listsystems()
         return
 
-    channel = args[0]
-
-    systems = \
-        self.client.channel.software.listSubscribedSystems(self.session,
-                                                           channel)
-
-    systems = [s.get('name') for s in systems]
+    systems = sorted([s.get('name') for s in self.client.channel.software.listSubscribedSystems(self.session, args[0])])
 
     if doreturn:
         return systems
     else:
         if systems:
-            print('\n'.join(sorted(systems)))
+            print('\n'.join(systems))
 
 ####################
 

--- a/spacecmd/src/spacecmd/softwarechannel.py
+++ b/spacecmd/src/spacecmd/softwarechannel.py
@@ -79,12 +79,15 @@ def do_softwarechannel_list(self, args, doreturn=False):
     # filter the list if arguments were passed
     if args:
         labels = filter_results(labels, args, True)
+    if labels:
+        labels = sorted(labels)
 
     if doreturn:
         return labels
+
     elif labels:
         if options.verbose:
-            for l in sorted(labels):
+            for l in labels:
                 details = self.client.channel.software.getDetails(
                     self.session, l)
                 print("%s : %s" % (l, details['summary']))
@@ -94,7 +97,7 @@ def do_softwarechannel_list(self, args, doreturn=False):
                             self.session, c)
                         print(" |-%s : %s" % (c, cdetails['summary']))
         else:
-            for l in sorted(labels):
+            for l in labels:
                 print("%s" % l)
                 if options.tree:
                     for c in self.list_child_channels(parent=l):

--- a/spacecmd/src/spacecmd/softwarechannel.py
+++ b/spacecmd/src/spacecmd/softwarechannel.py
@@ -332,8 +332,8 @@ def do_softwarechannel_listlatestpackages(self, args, doreturn=False):
         self.help_softwarechannel_listlatestpackages()
         return
 
-    packages = list(sorted(build_package_names(filter_latest_packages(
-        self.client.channel.software.listAllPackages(self.session, args[0])))))
+    packages = list(sorted(build_package_names(list(filter_latest_packages(
+        self.client.channel.software.listAllPackages(self.session, args[0]))))))
 
     if doreturn:
         return packages

--- a/spacecmd/src/spacecmd/softwarechannel.py
+++ b/spacecmd/src/spacecmd/softwarechannel.py
@@ -183,20 +183,16 @@ def do_softwarechannel_listchildchannels(self, args):
     arg_parser = get_argument_parser()
     arg_parser.add_argument('-v', '--verbose', action='store_true')
 
-    (args, options) = parse_command_arguments(args, arg_parser)
-    if not args:
-        channels = self.list_child_channels()
-    else:
-        channels = self.list_child_channels(parent=args[0])
+    args, options = parse_command_arguments(args, arg_parser)
+    channels = sorted(self.list_child_channels() if not args else self.list_child_channels(parent=args[0]))
 
     if channels:
-        if (options.verbose):
-            for c in sorted(channels):
-                details = \
-                    self.client.channel.software.getDetails(self.session, c)
+        if options.verbose:
+            for c in channels:
+                details = self.client.channel.software.getDetails(self.session, c)
                 print("%s : %s" % (c, details['summary']))
         else:
-            print('\n'.join(sorted(channels)))
+            print('\n'.join(channels))
 
     return 0
 

--- a/spacecmd/src/spacecmd/softwarechannel.py
+++ b/spacecmd/src/spacecmd/softwarechannel.py
@@ -118,10 +118,8 @@ def do_softwarechannel_listmanageablechannels(self, args, doreturn=False):
     arg_parser = get_argument_parser()
     arg_parser.add_argument('-v', '--verbose', action='store_true')
 
-    (args, options) = parse_command_arguments(args, arg_parser)
-
-    channels = self.client.channel.listManageableChannels(self.session)
-    labels = [c.get('label') for c in channels]
+    args, options = parse_command_arguments(args, arg_parser)
+    labels = list(sorted([c.get('label') for c in self.client.channel.listManageableChannels(self.session)]))
 
     # filter the list if arguments were passed
     if args:
@@ -129,15 +127,14 @@ def do_softwarechannel_listmanageablechannels(self, args, doreturn=False):
 
     if doreturn:
         return labels
+
     elif labels:
         if options.verbose:
-            for l in sorted(labels):
-                details = \
-                    self.client.channel.software.getDetails(self.session, l)
-
+            for l in labels:
+                details = self.client.channel.software.getDetails(self.session, l)
                 print("%s : %s" % (l, details['summary']))
         else:
-            for l in sorted(labels):
+            for l in labels:
                 print("%s" % l)
 
 ####################

--- a/spacecmd/src/spacecmd/softwarechannel.py
+++ b/spacecmd/src/spacecmd/softwarechannel.py
@@ -300,7 +300,7 @@ def filter_latest_packages(pkglist):
     # for each arch.  This approach avoids nested loops :)
     latest = {}
     for p in pkglist:
-        tuplekey = p['name'], p['arch_label']
+        tuplekey = p['name'], p.get('arch_label', p.get("arch"))
         if tuplekey not in latest:
             latest[tuplekey] = p
         else:

--- a/spacecmd/tests/helpers.py
+++ b/spacecmd/tests/helpers.py
@@ -115,3 +115,20 @@ def assert_args_expect(calls, expectations):
         assert kw == _kw, "{} is not as expected {}".format(str(kw), str(_kw))
         expectations.pop(0)
     assert not expectations
+
+
+def exc2str(exc):
+    """
+    Get string from the exception.
+
+    :param exc:
+    :return:
+    """
+    if hasattr(exc, "value"):
+        errmsg = str(exc.value)
+    elif hasattr(exc, "message"):
+        errmsg = exc.message
+    else:
+        errmsg = str(exc)
+
+    return errmsg

--- a/spacecmd/tests/test_activationkey.py
+++ b/spacecmd/tests/test_activationkey.py
@@ -8,7 +8,7 @@ import time
 import hashlib
 import spacecmd.activationkey
 from xmlrpc import client as xmlrpclib
-from helpers import shell
+from helpers import shell, exc2str
 
 
 class TestSCActivationKey:
@@ -585,7 +585,7 @@ class TestSCActivationKeyMethods:
         with pytest.raises(Exception) as exc:
             spacecmd.activationkey.do_activationkey_addconfigchannels(shell, "--you-shall-not-pass=True")
 
-        assert "unrecognized arguments" in str(exc)
+        assert "unrecognized arguments" in exc2str(exc)
         assert not shell.help_activationkey_addconfigchannels.called
         assert not shell.client.activationkey.addConfigChannels.called
 
@@ -1575,7 +1575,7 @@ class TestSCActivationKeyMethods:
         with pytest.raises(Exception) as exc:
             spacecmd.activationkey.do_activationkey_clone(shell, "--nonsense=true")
 
-        assert "Exception: unrecognized arguments: --nonsense=true" in str(exc)
+        assert "unrecognized arguments: --nonsense=true" in exc2str(exc)
 
     @patch("spacecmd.activationkey.is_interactive", MagicMock(return_value=False))
     @patch("spacecmd.activationkey.prompt_user", MagicMock(side_effect=["original_key", "cloned_key"]))

--- a/spacecmd/tests/test_argumentparser.py
+++ b/spacecmd/tests/test_argumentparser.py
@@ -4,6 +4,7 @@ Test argument parser.
 """
 import pytest
 import spacecmd.argumentparser
+from helpers import exc2str
 
 
 class TestSCArgumentParser:
@@ -18,4 +19,4 @@ class TestSCArgumentParser:
         argparse = spacecmd.argumentparser.SpacecmdArgumentParser()
         with pytest.raises(Exception) as exc:
             argparse.error(msg)
-        assert msg in str(exc)
+        assert msg in exc2str(exc)

--- a/spacecmd/tests/test_custominfo.py
+++ b/spacecmd/tests/test_custominfo.py
@@ -4,7 +4,7 @@ Test suite for custominfo source
 """
 from mock import MagicMock, patch, mock_open
 from spacecmd import custominfo
-from helpers import shell
+from helpers import shell, exc2str
 import pytest
 
 
@@ -23,7 +23,7 @@ class TestSCCusomInfo:
             with pytest.raises(Exception) as exc:
                 custominfo.do_custominfo_createkey(shell, "")
 
-        assert "Empty key" in str(exc)
+        assert "Empty key" in exc2str(exc)
 
 
     def test_do_custominfo_createkey_no_descr(self, shell):
@@ -89,7 +89,7 @@ class TestSCCusomInfo:
             with pytest.raises(Exception) as exc:
                 custominfo.do_custominfo_deletekey(shell, "")
 
-        assert errmsg in str(exc)
+        assert errmsg in exc2str(exc)
 
     @patch("spacecmd.custominfo.print", MagicMock())
     def test_do_custominfo_deletekey_args(self, shell):
@@ -165,7 +165,7 @@ class TestSCCusomInfo:
             with pytest.raises(Exception) as exc:
                 custominfo.do_custominfo_details(shell, "")
 
-        assert "Help info" in str(exc)
+        assert "Help info" in exc2str(exc)
         assert not logger.debug.called
         assert not logger.error.called
         assert not shell.client.system.custominfo.listAllKeys.called
@@ -285,7 +285,7 @@ class TestSCCusomInfo:
             with pytest.raises(Exception) as exc:
                 custominfo.do_custominfo_updatekey(shell, "")
 
-        assert "interactive mode" in str(exc)
+        assert "interactive mode" in exc2str(exc)
 
     def test_custominfo_updatekey_noarg_descr(self, shell):
         """
@@ -297,7 +297,7 @@ class TestSCCusomInfo:
             with pytest.raises(Exception) as exc:
                 custominfo.do_custominfo_updatekey(shell, "")
 
-        assert "interactive mode for descr" in str(exc)
+        assert "interactive mode for descr" in exc2str(exc)
 
     def test_custominfo_updatekey_keyonly_arg(self, shell):
         """
@@ -309,7 +309,7 @@ class TestSCCusomInfo:
             with pytest.raises(Exception) as exc:
                 custominfo.do_custominfo_updatekey(shell, "keyname")
 
-        assert "interactive mode for descr" in str(exc)
+        assert "interactive mode for descr" in exc2str(exc)
 
     def test_custominfo_updatekey_all_args(self, shell):
         """

--- a/spacecmd/tests/test_report.py
+++ b/spacecmd/tests/test_report.py
@@ -4,7 +4,7 @@ Tests for report.
 """
 from unittest.mock import MagicMock, patch
 import pytest
-from helpers import shell, assert_expect
+from helpers import shell, assert_expect, exc2str
 import spacecmd.report
 
 

--- a/spacecmd/tests/test_shell.py
+++ b/spacecmd/tests/test_shell.py
@@ -8,6 +8,7 @@ import time
 import readline
 import pytest
 from spacecmd.shell import SpacewalkShell, UnknownCallException
+from helpers import exc2str
 
 
 class TestSCShell:
@@ -83,7 +84,7 @@ class TestSCShell:
         for cmd in ["exit", "quit", "eof"]:
             with pytest.raises(Exception) as exc:
                 shell.precmd(cmd)
-            assert "Exit attempt" in str(exc)
+            assert "Exit attempt" in exc2str(exc)
 
     @patch("spacecmd.shell.atexit", MagicMock())
     @patch("spacecmd.shell.readline.set_completer_delims", MagicMock())
@@ -127,7 +128,7 @@ class TestSCShell:
 
         with pytest.raises(Exception) as exc:
             shell.precmd("system_list")
-        assert "login attempt" in str(exc)
+        assert "login attempt" in exc2str(exc)
 
     @patch("spacecmd.shell.atexit", MagicMock())
     @patch("spacecmd.shell.readline.set_completer_delims", MagicMock())

--- a/spacecmd/tests/test_softwarechannel.py
+++ b/spacecmd/tests/test_softwarechannel.py
@@ -74,6 +74,37 @@ class TestSCSoftwareChannel:
         assert_list_args_expect(mprint.call_args_list,
                                 ["label-last", "label-one", "label-three", "label-two"])
 
+    def test_softwarechannel_list_noreturn_labels_verbose(self, shell):
+        """
+        Test do_softwarechannel_list with label, no return data, verbose output.
+
+        :param shell:
+        :return:
+        """
+        shell.client.channel.listAllChannels = MagicMock(return_value=[
+            {"label": "test_channel"},
+        ])
+        shell.client.channel.software.getDetails = MagicMock(side_effect=[
+            {"summary": "Summary of test_channel"},
+            {"summary": "Summary of child_channel"},
+        ])
+        shell.list_child_channels = MagicMock(return_value=[
+            "child_channel"
+        ])
+
+        mprint = MagicMock()
+        with patch("spacecmd.softwarechannel.print", mprint) as prt:
+            out = spacecmd.softwarechannel.do_softwarechannel_list(
+                shell, "-v", doreturn=False)
+
+        assert out is None
+        assert not shell.help_softwarechannel_list.called
+        assert not shell.list_child_channels.called
+        assert shell.client.channel.software.getDetails.called
+        assert shell.client.channel.listAllChannels.called
+
+        assert_expect(mprint.call_args_list,
+                      'test_channel : Summary of test_channel')
 
     def test_softwarechannel_list_noreturn_labels_verbose_tree(self, shell):
         """

--- a/spacecmd/tests/test_softwarechannel.py
+++ b/spacecmd/tests/test_softwarechannel.py
@@ -616,3 +616,30 @@ class TestSCSoftwareChannel:
 
         assert_list_args_expect(mprint.call_args_list,
                                 ['emacs-42.0-9.x86_64\nemacs-nox-42.0-10.x86_64\ntiff-1.0-11:3.x86_64'])
+
+    def test_listlatestpackages_channel_packages_as_data(self, shell):
+        """
+        Test do_softwarechannel_listlatestpackages with channel supplied. Return as data.
+
+        :return:
+        """
+        shell.client.channel.software.listAllPackages = MagicMock(
+            return_value=[
+                {"name": "emacs", "version": "42.0",
+                 "release": "9", "epoch": "", "arch": "x86_64"},
+                {"name": "emacs-nox", "version": "42.0",
+                 "release": "10", "epoch": "", "arch_label": "x86_64"},
+                {"name": "tiff", "version": "1.0",
+                 "release": "11", "epoch": "3", "arch": "amd64"},
+            ]
+        )
+        mprint = MagicMock()
+        with patch("spacecmd.softwarechannel.print", mprint) as prt:
+            out = spacecmd.softwarechannel.do_softwarechannel_listlatestpackages(
+                shell, "some_channel", doreturn=True)
+
+        assert out is not None
+        assert not shell.help_softwarechannel_listlatestpackages.called
+        assert shell.client.channel.software.listAllPackages.called
+
+        assert out == ['emacs-42.0-9.x86_64', 'emacs-nox-42.0-10.x86_64', 'tiff-1.0-11:3.x86_64']

--- a/spacecmd/tests/test_softwarechannel.py
+++ b/spacecmd/tests/test_softwarechannel.py
@@ -334,3 +334,25 @@ class TestSCSoftwareChannel:
         assert shell.client.channel.software.listSubscribedSystems.called
         assert_list_args_expect(mprint.call_args_list,
                                 ['one.acme.lan\nthird.zoo.lan\ntwo.acme.lan\nzetta.acme.lan'])
+
+    def test_listsystems_noargs_channel_data_return(self, shell):
+        """
+        Test do_softwarechannel_listsystems one channel, data return.
+
+        :param shell:
+        :return:
+        """
+        shell.client.channel.software.listSubscribedSystems = MagicMock(return_value=[
+            {"name": "one.acme.lan"},
+            {"name": "two.acme.lan"},
+            {"name": "zetta.acme.lan"},
+            {"name": "third.zoo.lan"},
+        ])
+        mprint = MagicMock()
+        with patch("spacecmd.softwarechannel.print", mprint) as prt:
+            out = spacecmd.softwarechannel.do_softwarechannel_listsystems(shell, "my_channel", doreturn=True)
+
+        assert not shell.help_softwarechannel_listsystems.called
+        assert not mprint.called
+        assert out is not None
+        assert out == ['one.acme.lan', 'third.zoo.lan', 'two.acme.lan', 'zetta.acme.lan']

--- a/spacecmd/tests/test_softwarechannel.py
+++ b/spacecmd/tests/test_softwarechannel.py
@@ -143,3 +143,26 @@ class TestSCSoftwareChannel:
                                 ['base_channel : Summary of test_channel',
                                  ' |-child_channel : Summary of child_channel'])
 
+    def test_softwarechannel_listmanageablechannels_noarg(self, shell):
+        """
+        Test do_softwarechannel_listmanageablechannels without arguments.
+
+        :param shell:
+        :return:
+        """
+        shell.client.channel.listManageableChannels = MagicMock(return_value=[
+            {"label": "x_channel"},
+            {"label": "z_channel"},
+            {"label": "a_channel"},
+        ])
+
+        mprint = MagicMock()
+        with patch("spacecmd.softwarechannel.print", mprint) as prt:
+            out = spacecmd.softwarechannel.do_softwarechannel_listmanageablechannels(shell, "")
+
+        assert out is None
+        assert not shell.client.channel.software.getDetails.called
+        assert shell.client.channel.listManageableChannels.called
+        assert_list_args_expect(mprint.call_args_list,
+                                ["a_channel", "x_channel", "z_channel"])
+

--- a/spacecmd/tests/test_softwarechannel.py
+++ b/spacecmd/tests/test_softwarechannel.py
@@ -473,3 +473,30 @@ class TestSCSoftwareChannel:
         assert out is None
         assert not shell.client.channel.software.listAllPackages.called
         assert shell.help_softwarechannel_listallpackages.called
+
+    def test_listallpackages_one_channel_no_data(self, shell):
+        """
+        Test do_softwarechannel_listallpackages with one channel. No data return.
+
+        :param shell:
+        :return:
+        """
+        shell.client.channel.software.listAllPackages = MagicMock(
+            return_value=[
+                {"name": "emacs", "version": "42.0",
+                 "release": "9", "epoch": "", "arch": "x86_64"},
+                {"name": "emacs-nox", "version": "42.0",
+                 "release": "10", "epoch": "", "arch_label": "x86_64"},
+                {"name": "tiff", "version": "1.0",
+                 "release": "11", "epoch": "3", "arch": "amd64"},
+            ]
+        )
+        mprint = MagicMock()
+        with patch("spacecmd.softwarechannel.print", mprint) as prt:
+            out = spacecmd.softwarechannel.do_softwarechannel_listallpackages(shell, "one_channel")
+
+        assert out is None
+        assert not shell.help_softwarechannel_listallpackages.called
+        assert shell.client.channel.software.listAllPackages.called
+        assert_list_args_expect(mprint.call_args_list,
+                                ['emacs-42.0-9.x86_64\nemacs-nox-42.0-10.x86_64\ntiff-1.0-11:3.x86_64'])

--- a/spacecmd/tests/test_softwarechannel.py
+++ b/spacecmd/tests/test_softwarechannel.py
@@ -6,7 +6,7 @@ Test software channel module.
 from mock import MagicMock, patch
 import spacecmd.softwarechannel
 from xmlrpc import client as xmlrpclib
-from helpers import shell
+from helpers import shell, assert_expect, assert_list_args_expect, assert_args_expect
 
 
 class TestSCSoftwareChannel:
@@ -47,4 +47,30 @@ class TestSCSoftwareChannel:
         assert not shell.client.channel.software.getDetails.called
         assert not shell.list_child_channels.called
         assert not shell.list_base_channels.called
+
+    def test_softwarechannel_list_noreturn_labels_std(self, shell):
+        """
+        Test do_softwarechannel_list with label, no return data, standard output.
+
+        :param shell:
+        :return:
+        """
+        shell.client.channel.listAllChannels = MagicMock(return_value=[
+            {"label": "label-one"}, {"label": "label-last"},
+            {"label": "label-two"}, {"label": "label-three"},
+        ])
+
+        mprint = MagicMock()
+        with patch("spacecmd.softwarechannel.print", mprint) as prt:
+            out = spacecmd.softwarechannel.do_softwarechannel_list(
+                shell, "", doreturn=False)
+
+        assert out is None
+        assert not shell.help_softwarechannel_list.called
+        assert not shell.client.channel.software.getDetails.called
+        assert not shell.list_child_channels.called
+        assert shell.client.channel.listAllChannels.called
+
+        assert_list_args_expect(mprint.call_args_list,
+                                ["label-last", "label-one", "label-three", "label-two"])
 

--- a/spacecmd/tests/test_softwarechannel.py
+++ b/spacecmd/tests/test_softwarechannel.py
@@ -11,635 +11,631 @@ import pytest
 import rpm
 
 
-class TestSCSoftwareChannel:
+def test_softwarechannel_list_doreturn_nolabels(shell):
     """
-    Test suite for software channel.
+    Test do_softwarechannel_list no labels, return data.
+
+    :param shell:
+    :return:
     """
-    def test_softwarechannel_list_doreturn_nolabels(self, shell):
-        """
-        Test do_softwarechannel_list no labels, return data.
-
-        :param shell:
-        :return:
-        """
-        shell.client.channel.listAllChannels = MagicMock(return_value=[])
-        mprint = MagicMock()
-        with patch("spacecmd.softwarechannel.print", mprint) as prt:
-            out = spacecmd.softwarechannel.do_softwarechannel_list(shell, "", doreturn=True)
-        assert out is not None
-        assert out == []
-        assert not shell.help_softwarechannel_list.called
-        assert not shell.client.channel.software.getDetails.called
-        assert not shell.list_child_channels.called
-        assert not shell.list_base_channels.called
-
-    def test_softwarechannel_list_noreturn_nolabels(self, shell):
-        """
-        Test do_softwarechannel_list no labels, no return data.
-
-        :param shell:
-        :return:
-        """
-        shell.client.channel.listAllChannels = MagicMock(return_value=[])
-        mprint = MagicMock()
-        with patch("spacecmd.softwarechannel.print", mprint) as prt:
-            out = spacecmd.softwarechannel.do_softwarechannel_list(shell, "", doreturn=False)
-        assert out is None
-        assert not shell.help_softwarechannel_list.called
-        assert not shell.client.channel.software.getDetails.called
-        assert not shell.list_child_channels.called
-        assert not shell.list_base_channels.called
-
-    def test_softwarechannel_list_noreturn_labels_std(self, shell):
-        """
-        Test do_softwarechannel_list with label, no return data, standard output.
-
-        :param shell:
-        :return:
-        """
-        shell.client.channel.listAllChannels = MagicMock(return_value=[
-            {"label": "label-one"}, {"label": "label-last"},
-            {"label": "label-two"}, {"label": "label-three"},
-        ])
-
-        mprint = MagicMock()
-        with patch("spacecmd.softwarechannel.print", mprint) as prt:
-            out = spacecmd.softwarechannel.do_softwarechannel_list(
-                shell, "", doreturn=False)
-
-        assert out is None
-        assert not shell.help_softwarechannel_list.called
-        assert not shell.client.channel.software.getDetails.called
-        assert not shell.list_child_channels.called
-        assert shell.client.channel.listAllChannels.called
-
-        assert_list_args_expect(mprint.call_args_list,
-                                ["label-last", "label-one", "label-three", "label-two"])
-
-    def test_softwarechannel_list_noreturn_labels_verbose(self, shell):
-        """
-        Test do_softwarechannel_list with label, no return data, verbose output.
-
-        :param shell:
-        :return:
-        """
-        shell.client.channel.listAllChannels = MagicMock(return_value=[
-            {"label": "test_channel"},
-        ])
-        shell.client.channel.software.getDetails = MagicMock(side_effect=[
-            {"summary": "Summary of test_channel"},
-            {"summary": "Summary of child_channel"},
-        ])
-        shell.list_child_channels = MagicMock(return_value=[
-            "child_channel"
-        ])
-
-        mprint = MagicMock()
-        with patch("spacecmd.softwarechannel.print", mprint) as prt:
-            out = spacecmd.softwarechannel.do_softwarechannel_list(
-                shell, "-v", doreturn=False)
-
-        assert out is None
-        assert not shell.help_softwarechannel_list.called
-        assert not shell.list_child_channels.called
-        assert shell.client.channel.software.getDetails.called
-        assert shell.client.channel.listAllChannels.called
-
-        assert_expect(mprint.call_args_list,
-                      'test_channel : Summary of test_channel')
-
-    def test_softwarechannel_list_noreturn_labels_verbose_tree(self, shell):
-        """
-        Test do_softwarechannel_list with label, no return data, verbose output with tree.
-
-        :param shell:
-        :return:
-        """
-        shell.client.channel.listAllChannels = MagicMock(return_value=[
-            {"any_channel": "any_channel"},
-        ])
-        shell.client.channel.software.getDetails = MagicMock(side_effect=[
-            {"summary": "Summary of test_channel"},
-            {"summary": "Summary of child_channel"},
-        ])
-        shell.list_child_channels = MagicMock(return_value=[
-            "child_channel"
-        ])
-
-        shell.list_base_channels = MagicMock(return_value=[
-            "base_channel"
-        ])
-
-        mprint = MagicMock()
-        with patch("spacecmd.softwarechannel.print", mprint) as prt:
-            out = spacecmd.softwarechannel.do_softwarechannel_list(
-                shell, "-v -t", doreturn=False)
-
-        assert out is None
-        assert not shell.client.channel.listAllChannels.called
-        assert not shell.help_softwarechannel_list.called
-        assert shell.list_child_channels.called
-        assert shell.client.channel.software.getDetails.called
-
-        assert_list_args_expect(mprint.call_args_list,
-                                ['base_channel : Summary of test_channel',
-                                 ' |-child_channel : Summary of child_channel'])
-
-    def test_softwarechannel_listmanageablechannels_noarg(self, shell):
-        """
-        Test do_softwarechannel_listmanageablechannels without arguments.
-
-        :param shell:
-        :return:
-        """
-        shell.client.channel.listManageableChannels = MagicMock(return_value=[
-            {"label": "x_channel"},
-            {"label": "z_channel"},
-            {"label": "a_channel"},
-        ])
-
-        mprint = MagicMock()
-        with patch("spacecmd.softwarechannel.print", mprint) as prt:
-            out = spacecmd.softwarechannel.do_softwarechannel_listmanageablechannels(shell, "")
-
-        assert out is None
-        assert not shell.client.channel.software.getDetails.called
-        assert shell.client.channel.listManageableChannels.called
-        assert_list_args_expect(mprint.call_args_list,
-                                ["a_channel", "x_channel", "z_channel"])
-
-    def test_softwarechannel_listmanageablechannels_default_verbose(self, shell):
-        """
-        Test do_softwarechannel_listmanageablechannels with verbose arg (all).
-
-        :param shell:
-        :return:
-        """
-        shell.client.channel.listManageableChannels = MagicMock(return_value=[
-            {"label": "x_channel"},
-            {"label": "z_channel"},
-            {"label": "b_channel"},
-            {"label": "a_channel"},
-        ])
-        shell.client.channel.software.getDetails = MagicMock(side_effect=[
-            {"summary": "A summary"},
-            {"summary": "B summary"},
-            {"summary": "X summary"},
-            {"summary": "Z summary"},
-        ])
-
-        mprint = MagicMock()
-        with patch("spacecmd.softwarechannel.print", mprint) as prt:
-            out = spacecmd.softwarechannel.do_softwarechannel_listmanageablechannels(
-                shell, "--verbose")
-
-        assert out is None
-        assert shell.client.channel.software.getDetails.called
-        assert shell.client.channel.listManageableChannels.called
-        assert_list_args_expect(mprint.call_args_list,
-                                ["a_channel : A summary",
-                                 "b_channel : B summary",
-                                 "x_channel : X summary",
-                                 "z_channel : Z summary"])
-
-    def test_softwarechannel_listmanageablechannels_data_sparse(self, shell):
-        """
-        Test do_softwarechannel_listmanageablechannels data out, short.
-
-        :param shell:
-        :return:
-        """
-        shell.client.channel.listManageableChannels = MagicMock(return_value=[
-            {"label": "x_channel"},
-            {"label": "z_channel"},
-            {"label": "a_channel"},
-        ])
-
-        mprint = MagicMock()
-        with patch("spacecmd.softwarechannel.print", mprint) as prt:
-            out = spacecmd.softwarechannel.do_softwarechannel_listmanageablechannels(shell, "", doreturn=True)
-
-        assert out is not None
-        assert not shell.client.channel.software.getDetails.called
-        assert shell.client.channel.listManageableChannels.called
-        assert out == ["a_channel", "x_channel", "z_channel"]
-
-    def test_softwarechannel_listmanageablechannels_data_verbose(self, shell):
-        """
-        Test do_softwarechannel_listmanageablechannels with verbose arg (all).
-
-        :param shell:
-        :return:
-        """
-        shell.client.channel.listManageableChannels = MagicMock(return_value=[
-            {"label": "x_channel"},
-            {"label": "z_channel"},
-            {"label": "b_channel"},
-            {"label": "a_channel"},
-        ])
-        shell.client.channel.software.getDetails = MagicMock(side_effect=[
-            {"summary": "A summary"},
-            {"summary": "B summary"},
-            {"summary": "X summary"},
-            {"summary": "Z summary"},
-        ])
-
-        mprint = MagicMock()
-        with patch("spacecmd.softwarechannel.print", mprint) as prt:
-            out = spacecmd.softwarechannel.do_softwarechannel_listmanageablechannels(
-                shell, "--verbose", doreturn=True)
-
-        assert out is not None
-        assert not shell.client.channel.software.getDetails.called
-        assert shell.client.channel.listManageableChannels.called
-        assert out == ["a_channel", "b_channel", "x_channel", "z_channel"]
-
-    def test_listchildchannels(self, shell):
-        """
-        Test do_softwarechannel_listchildchannels noargs.
-
-        :param shell:
-        :return:
-        """
-        shell.list_child_channels = MagicMock(return_value=["x_child_channel", "z_child_channel",
-                                                            "b_child_channel", "a_child_channel",])
-        mprint = MagicMock()
-        with patch("spacecmd.softwarechannel.print", mprint) as prt:
-            spacecmd.softwarechannel.do_softwarechannel_listchildchannels(shell, "")
-
-        assert not shell.client.channel.software.getDetails.called
-        assert_list_args_expect(mprint.call_args_list,
-                                ['a_child_channel\nb_child_channel\nx_child_channel\nz_child_channel'])
-
-    def test_listchildchannels_verbose(self, shell):
-        """
-        Test do_softwarechannel_listchildchannels verbose.
-
-        :param shell:
-        :return:
-        """
-        shell.list_child_channels = MagicMock(return_value=["x_child_channel", "z_child_channel",
-                                                            "b_child_channel", "a_child_channel",])
-        shell.client.channel.software.getDetails = MagicMock(side_effect=[
-            {"summary": "A summary"},
-            {"summary": "B summary"},
-            {"summary": "X summary"},
-            {"summary": "Z summary"},
-        ])
-        mprint = MagicMock()
-        with patch("spacecmd.softwarechannel.print", mprint) as prt:
-            spacecmd.softwarechannel.do_softwarechannel_listchildchannels(shell, "--verbose")
-
-        assert shell.client.channel.software.getDetails.called
-        assert_list_args_expect(mprint.call_args_list,
-                                ['a_child_channel : A summary',
-                                 'b_child_channel : B summary',
-                                 'x_child_channel : X summary',
-                                 'z_child_channel : Z summary'])
-
-    def test_listsystems_noargs(self, shell):
-        """
-        Test do_softwarechannel_listsystems no args.
-
-        :param shell:
-        :return:
-        """
-        mprint = MagicMock()
-        with patch("spacecmd.softwarechannel.print", mprint) as prt:
-            out = spacecmd.softwarechannel.do_softwarechannel_listsystems(shell, "")
-
-        assert out is None
-        assert not mprint.called
-        assert not shell.client.channel.software.listSubscribedSystems.called
-        assert shell.help_softwarechannel_listsystems.called
-
-    def test_listsystems_noargs_channel_no_data(self, shell):
-        """
-        Test do_softwarechannel_listsystems one channel, no data.
-
-        :param shell:
-        :return:
-        """
-        shell.client.channel.software.listSubscribedSystems = MagicMock(return_value=[
-            {"name": "one.acme.lan"},
-            {"name": "two.acme.lan"},
-            {"name": "zetta.acme.lan"},
-            {"name": "third.zoo.lan"},
-        ])
-        mprint = MagicMock()
-        with patch("spacecmd.softwarechannel.print", mprint) as prt:
-            out = spacecmd.softwarechannel.do_softwarechannel_listsystems(shell, "my_channel")
-
-        assert not shell.help_softwarechannel_listsystems.called
-        assert out is None
-        assert mprint.called
-        assert shell.client.channel.software.listSubscribedSystems.called
-        assert_list_args_expect(mprint.call_args_list,
-                                ['one.acme.lan\nthird.zoo.lan\ntwo.acme.lan\nzetta.acme.lan'])
-
-    def test_listsystems_noargs_channel_data_return(self, shell):
-        """
-        Test do_softwarechannel_listsystems one channel, data return.
-
-        :param shell:
-        :return:
-        """
-        shell.client.channel.software.listSubscribedSystems = MagicMock(return_value=[
-            {"name": "one.acme.lan"},
-            {"name": "two.acme.lan"},
-            {"name": "zetta.acme.lan"},
-            {"name": "third.zoo.lan"},
-        ])
-        mprint = MagicMock()
-        with patch("spacecmd.softwarechannel.print", mprint) as prt:
-            out = spacecmd.softwarechannel.do_softwarechannel_listsystems(shell, "my_channel", doreturn=True)
-
-        assert not shell.help_softwarechannel_listsystems.called
-        assert not mprint.called
-        assert out is not None
-        assert out == ['one.acme.lan', 'third.zoo.lan', 'two.acme.lan', 'zetta.acme.lan']
-
-    def test_listpackages_noargs_nodata(self, shell):
-        """
-        Test do_softwarechannel_listpackages no args. No data return.
-
-        :param shell:
-        :return:
-        """
-        mprint = MagicMock()
-        with patch("spacecmd.softwarechannel.print", mprint) as prt:
-            out = spacecmd.softwarechannel.do_softwarechannel_listpackages(shell, "")
-
-        assert out is None
-        assert not shell.client.channel.software.listLatestPackages.called
-        assert shell.help_softwarechannel_listpackages.called
-
-    def test_listpackages_too_much_args_nodata(self, shell):
-        """
-        Test do_softwarechannel_listpackages with too much much arguments.
-
-        :param shell:
-        :return:
-        """
-        mprint = MagicMock()
-        with patch("spacecmd.softwarechannel.print", mprint) as prt:
-            out = spacecmd.softwarechannel.do_softwarechannel_listpackages(
-                shell, "one_channel other_channel somemore_channels")
-
-        assert out is None
-        assert not shell.client.channel.software.listLatestPackages.called
-        assert shell.help_softwarechannel_listpackages.called
-
-    def test_listpackages_one_channel_no_data(self, shell):
-        """
-        Test do_softwarechannel_listpackages with one channel. No data return.
-
-        :param shell:
-        :return:
-        """
-        shell.client.channel.software.listLatestPackages = MagicMock(
-            return_value=[
-                {"name": "emacs", "version": "42.0",
-                 "release": "9", "epoch": "", "arch": "x86_64"},
-                {"name": "emacs-nox", "version": "42.0",
-                 "release": "10", "epoch": "", "arch_label": "x86_64"},
-                {"name": "tiff", "version": "1.0",
-                 "release": "11", "epoch": "3", "arch": "amd64"},
-            ]
-        )
-        mprint = MagicMock()
-        with patch("spacecmd.softwarechannel.print", mprint) as prt:
-            out = spacecmd.softwarechannel.do_softwarechannel_listpackages(shell, "one_channel")
-
-        assert out is None
-        assert not shell.help_softwarechannel_listpackages.called
-        assert shell.client.channel.software.listLatestPackages.called
-        assert_list_args_expect(mprint.call_args_list,
-                                ['emacs-42.0-9.x86_64\nemacs-nox-42.0-10.x86_64\ntiff-1.0-11:3.x86_64'])
-
-    def test_listpackages_one_channel_with_data(self, shell):
-        """
-        Test do_softwarechannel_listpackages with one channel. With data return.
-
-        :param shell:
-        :return:
-        """
-        shell.client.channel.software.listLatestPackages = MagicMock(
-            return_value=[
-                {"name": "emacs", "version": "42.0",
-                 "release": "9", "epoch": "", "arch": "x86_64"},
-                {"name": "emacs-nox", "version": "42.0",
-                 "release": "10", "epoch": "", "arch_label": "x86_64"},
-                {"name": "tiff", "version": "1.0",
-                 "release": "11", "epoch": "3", "arch": "amd64"},
-            ]
-        )
-        mprint = MagicMock()
-        with patch("spacecmd.softwarechannel.print", mprint) as prt:
-            out = spacecmd.softwarechannel.do_softwarechannel_listpackages(
-                shell, "one_channel", doreturn=True)
-
-        assert out is not None
-        assert not shell.help_softwarechannel_listpackages.called
-        assert shell.client.channel.software.listLatestPackages.called
-        assert out == ['emacs-42.0-9.x86_64', 'emacs-nox-42.0-10.x86_64',
-                       'tiff-1.0-11:3.x86_64']
-
-    def test_listallpackages_noargs_nodata(self, shell):
-        """
-        Test do_softwarechannel_listallpackages no args. No data return.
-
-        :param shell:
-        :return:
-        """
-        mprint = MagicMock()
-        with patch("spacecmd.softwarechannel.print", mprint) as prt:
-            out = spacecmd.softwarechannel.do_softwarechannel_listallpackages(shell, "")
-
-        assert out is None
-        assert not shell.client.channel.software.listAllPackages.called
-        assert shell.help_softwarechannel_listallpackages.called
-
-    def test_listallpackages_too_much_args_nodata(self, shell):
-        """
-        Test do_softwarechannel_listallpackages with too much much arguments.
-
-        :param shell:
-        :return:
-        """
-        mprint = MagicMock()
-        with patch("spacecmd.softwarechannel.print", mprint) as prt:
-            out = spacecmd.softwarechannel.do_softwarechannel_listallpackages(
-                shell, "one_channel other_channel somemore_channels")
-
-        assert out is None
-        assert not shell.client.channel.software.listAllPackages.called
-        assert shell.help_softwarechannel_listallpackages.called
-
-    def test_listallpackages_one_channel_no_data(self, shell):
-        """
-        Test do_softwarechannel_listallpackages with one channel. No data return.
-
-        :param shell:
-        :return:
-        """
-        shell.client.channel.software.listAllPackages = MagicMock(
-            return_value=[
-                {"name": "emacs", "version": "42.0",
-                 "release": "9", "epoch": "", "arch": "x86_64"},
-                {"name": "emacs-nox", "version": "42.0",
-                 "release": "10", "epoch": "", "arch_label": "x86_64"},
-                {"name": "tiff", "version": "1.0",
-                 "release": "11", "epoch": "3", "arch": "amd64"},
-            ]
-        )
-        mprint = MagicMock()
-        with patch("spacecmd.softwarechannel.print", mprint) as prt:
-            out = spacecmd.softwarechannel.do_softwarechannel_listallpackages(shell, "one_channel")
-
-        assert out is None
-        assert not shell.help_softwarechannel_listallpackages.called
-        assert shell.client.channel.software.listAllPackages.called
-        assert_list_args_expect(mprint.call_args_list,
-                                ['emacs-42.0-9.x86_64\nemacs-nox-42.0-10.x86_64\ntiff-1.0-11:3.x86_64'])
-
-    def test_listallpackages_one_channel_with_data(self, shell):
-        """
-        Test do_softwarechannel_listallpackages with one channel. With data return.
-
-        :param shell:
-        :return:
-        """
-        shell.client.channel.software.listAllPackages = MagicMock(
-            return_value=[
-                {"name": "emacs", "version": "42.0",
-                 "release": "9", "epoch": "", "arch": "x86_64"},
-                {"name": "emacs-nox", "version": "42.0",
-                 "release": "10", "epoch": "", "arch_label": "x86_64"},
-                {"name": "tiff", "version": "1.0",
-                 "release": "11", "epoch": "3", "arch": "amd64"},
-            ]
-        )
-        mprint = MagicMock()
-        with patch("spacecmd.softwarechannel.print", mprint) as prt:
-            out = spacecmd.softwarechannel.do_softwarechannel_listallpackages(
-                shell, "one_channel", doreturn=True)
-
-        assert out is not None
-        assert not shell.help_softwarechannel_listallpackages.called
-        assert shell.client.channel.software.listAllPackages.called
-        assert out == ['emacs-42.0-9.x86_64', 'emacs-nox-42.0-10.x86_64',
-                       'tiff-1.0-11:3.x86_64']
-
-    @pytest.mark.skipif(not hasattr(rpm, "labelCompare"), reason="Full RPM bindings required")
-    def test_filter_latest_packages(self):
-        """
-        Test filter_latest_packages function.
-
-        :return:
-        """
-        data = [
+    shell.client.channel.listAllChannels = MagicMock(return_value=[])
+    mprint = MagicMock()
+    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+        out = spacecmd.softwarechannel.do_softwarechannel_list(shell, "", doreturn=True)
+    assert out is not None
+    assert out == []
+    assert not shell.help_softwarechannel_list.called
+    assert not shell.client.channel.software.getDetails.called
+    assert not shell.list_child_channels.called
+    assert not shell.list_base_channels.called
+
+def test_softwarechannel_list_noreturn_nolabels(shell):
+    """
+    Test do_softwarechannel_list no labels, no return data.
+
+    :param shell:
+    :return:
+    """
+    shell.client.channel.listAllChannels = MagicMock(return_value=[])
+    mprint = MagicMock()
+    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+        out = spacecmd.softwarechannel.do_softwarechannel_list(shell, "", doreturn=False)
+    assert out is None
+    assert not shell.help_softwarechannel_list.called
+    assert not shell.client.channel.software.getDetails.called
+    assert not shell.list_child_channels.called
+    assert not shell.list_base_channels.called
+
+def test_softwarechannel_list_noreturn_labels_std(shell):
+    """
+    Test do_softwarechannel_list with label, no return data, standard output.
+
+    :param shell:
+    :return:
+    """
+    shell.client.channel.listAllChannels = MagicMock(return_value=[
+        {"label": "label-one"}, {"label": "label-last"},
+        {"label": "label-two"}, {"label": "label-three"},
+    ])
+
+    mprint = MagicMock()
+    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+        out = spacecmd.softwarechannel.do_softwarechannel_list(
+            shell, "", doreturn=False)
+
+    assert out is None
+    assert not shell.help_softwarechannel_list.called
+    assert not shell.client.channel.software.getDetails.called
+    assert not shell.list_child_channels.called
+    assert shell.client.channel.listAllChannels.called
+
+    assert_list_args_expect(mprint.call_args_list,
+                            ["label-last", "label-one", "label-three", "label-two"])
+
+def test_softwarechannel_list_noreturn_labels_verbose(shell):
+    """
+    Test do_softwarechannel_list with label, no return data, verbose output.
+
+    :param shell:
+    :return:
+    """
+    shell.client.channel.listAllChannels = MagicMock(return_value=[
+        {"label": "test_channel"},
+    ])
+    shell.client.channel.software.getDetails = MagicMock(side_effect=[
+        {"summary": "Summary of test_channel"},
+        {"summary": "Summary of child_channel"},
+    ])
+    shell.list_child_channels = MagicMock(return_value=[
+        "child_channel"
+    ])
+
+    mprint = MagicMock()
+    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+        out = spacecmd.softwarechannel.do_softwarechannel_list(
+            shell, "-v", doreturn=False)
+
+    assert out is None
+    assert not shell.help_softwarechannel_list.called
+    assert not shell.list_child_channels.called
+    assert shell.client.channel.software.getDetails.called
+    assert shell.client.channel.listAllChannels.called
+
+    assert_expect(mprint.call_args_list,
+                    'test_channel : Summary of test_channel')
+
+def test_softwarechannel_list_noreturn_labels_verbose_tree(shell):
+    """
+    Test do_softwarechannel_list with label, no return data, verbose output with tree.
+
+    :param shell:
+    :return:
+    """
+    shell.client.channel.listAllChannels = MagicMock(return_value=[
+        {"any_channel": "any_channel"},
+    ])
+    shell.client.channel.software.getDetails = MagicMock(side_effect=[
+        {"summary": "Summary of test_channel"},
+        {"summary": "Summary of child_channel"},
+    ])
+    shell.list_child_channels = MagicMock(return_value=[
+        "child_channel"
+    ])
+
+    shell.list_base_channels = MagicMock(return_value=[
+        "base_channel"
+    ])
+
+    mprint = MagicMock()
+    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+        out = spacecmd.softwarechannel.do_softwarechannel_list(
+            shell, "-v -t", doreturn=False)
+
+    assert out is None
+    assert not shell.client.channel.listAllChannels.called
+    assert not shell.help_softwarechannel_list.called
+    assert shell.list_child_channels.called
+    assert shell.client.channel.software.getDetails.called
+
+    assert_list_args_expect(mprint.call_args_list,
+                            ['base_channel : Summary of test_channel',
+                                ' |-child_channel : Summary of child_channel'])
+
+def test_softwarechannel_listmanageablechannels_noarg(shell):
+    """
+    Test do_softwarechannel_listmanageablechannels without arguments.
+
+    :param shell:
+    :return:
+    """
+    shell.client.channel.listManageableChannels = MagicMock(return_value=[
+        {"label": "x_channel"},
+        {"label": "z_channel"},
+        {"label": "a_channel"},
+    ])
+
+    mprint = MagicMock()
+    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+        out = spacecmd.softwarechannel.do_softwarechannel_listmanageablechannels(shell, "")
+
+    assert out is None
+    assert not shell.client.channel.software.getDetails.called
+    assert shell.client.channel.listManageableChannels.called
+    assert_list_args_expect(mprint.call_args_list,
+                            ["a_channel", "x_channel", "z_channel"])
+
+def test_softwarechannel_listmanageablechannels_default_verbose(shell):
+    """
+    Test do_softwarechannel_listmanageablechannels with verbose arg (all).
+
+    :param shell:
+    :return:
+    """
+    shell.client.channel.listManageableChannels = MagicMock(return_value=[
+        {"label": "x_channel"},
+        {"label": "z_channel"},
+        {"label": "b_channel"},
+        {"label": "a_channel"},
+    ])
+    shell.client.channel.software.getDetails = MagicMock(side_effect=[
+        {"summary": "A summary"},
+        {"summary": "B summary"},
+        {"summary": "X summary"},
+        {"summary": "Z summary"},
+    ])
+
+    mprint = MagicMock()
+    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+        out = spacecmd.softwarechannel.do_softwarechannel_listmanageablechannels(
+            shell, "--verbose")
+
+    assert out is None
+    assert shell.client.channel.software.getDetails.called
+    assert shell.client.channel.listManageableChannels.called
+    assert_list_args_expect(mprint.call_args_list,
+                            ["a_channel : A summary",
+                                "b_channel : B summary",
+                                "x_channel : X summary",
+                                "z_channel : Z summary"])
+
+def test_softwarechannel_listmanageablechannels_data_sparse(shell):
+    """
+    Test do_softwarechannel_listmanageablechannels data out, short.
+
+    :param shell:
+    :return:
+    """
+    shell.client.channel.listManageableChannels = MagicMock(return_value=[
+        {"label": "x_channel"},
+        {"label": "z_channel"},
+        {"label": "a_channel"},
+    ])
+
+    mprint = MagicMock()
+    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+        out = spacecmd.softwarechannel.do_softwarechannel_listmanageablechannels(shell, "", doreturn=True)
+
+    assert out is not None
+    assert not shell.client.channel.software.getDetails.called
+    assert shell.client.channel.listManageableChannels.called
+    assert out == ["a_channel", "x_channel", "z_channel"]
+
+def test_softwarechannel_listmanageablechannels_data_verbose(shell):
+    """
+    Test do_softwarechannel_listmanageablechannels with verbose arg (all).
+
+    :param shell:
+    :return:
+    """
+    shell.client.channel.listManageableChannels = MagicMock(return_value=[
+        {"label": "x_channel"},
+        {"label": "z_channel"},
+        {"label": "b_channel"},
+        {"label": "a_channel"},
+    ])
+    shell.client.channel.software.getDetails = MagicMock(side_effect=[
+        {"summary": "A summary"},
+        {"summary": "B summary"},
+        {"summary": "X summary"},
+        {"summary": "Z summary"},
+    ])
+
+    mprint = MagicMock()
+    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+        out = spacecmd.softwarechannel.do_softwarechannel_listmanageablechannels(
+            shell, "--verbose", doreturn=True)
+
+    assert out is not None
+    assert not shell.client.channel.software.getDetails.called
+    assert shell.client.channel.listManageableChannels.called
+    assert out == ["a_channel", "b_channel", "x_channel", "z_channel"]
+
+def test_listchildchannels(shell):
+    """
+    Test do_softwarechannel_listchildchannels noargs.
+
+    :param shell:
+    :return:
+    """
+    shell.list_child_channels = MagicMock(return_value=["x_child_channel", "z_child_channel",
+                                                        "b_child_channel", "a_child_channel",])
+    mprint = MagicMock()
+    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+        spacecmd.softwarechannel.do_softwarechannel_listchildchannels(shell, "")
+
+    assert not shell.client.channel.software.getDetails.called
+    assert_list_args_expect(mprint.call_args_list,
+                            ['a_child_channel\nb_child_channel\nx_child_channel\nz_child_channel'])
+
+def test_listchildchannels_verbose(shell):
+    """
+    Test do_softwarechannel_listchildchannels verbose.
+
+    :param shell:
+    :return:
+    """
+    shell.list_child_channels = MagicMock(return_value=["x_child_channel", "z_child_channel",
+                                                        "b_child_channel", "a_child_channel",])
+    shell.client.channel.software.getDetails = MagicMock(side_effect=[
+        {"summary": "A summary"},
+        {"summary": "B summary"},
+        {"summary": "X summary"},
+        {"summary": "Z summary"},
+    ])
+    mprint = MagicMock()
+    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+        spacecmd.softwarechannel.do_softwarechannel_listchildchannels(shell, "--verbose")
+
+    assert shell.client.channel.software.getDetails.called
+    assert_list_args_expect(mprint.call_args_list,
+                            ['a_child_channel : A summary',
+                                'b_child_channel : B summary',
+                                'x_child_channel : X summary',
+                                'z_child_channel : Z summary'])
+
+def test_listsystems_noargs(shell):
+    """
+    Test do_softwarechannel_listsystems no args.
+
+    :param shell:
+    :return:
+    """
+    mprint = MagicMock()
+    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+        out = spacecmd.softwarechannel.do_softwarechannel_listsystems(shell, "")
+
+    assert out is None
+    assert not mprint.called
+    assert not shell.client.channel.software.listSubscribedSystems.called
+    assert shell.help_softwarechannel_listsystems.called
+
+def test_listsystems_noargs_channel_no_data(shell):
+    """
+    Test do_softwarechannel_listsystems one channel, no data.
+
+    :param shell:
+    :return:
+    """
+    shell.client.channel.software.listSubscribedSystems = MagicMock(return_value=[
+        {"name": "one.acme.lan"},
+        {"name": "two.acme.lan"},
+        {"name": "zetta.acme.lan"},
+        {"name": "third.zoo.lan"},
+    ])
+    mprint = MagicMock()
+    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+        out = spacecmd.softwarechannel.do_softwarechannel_listsystems(shell, "my_channel")
+
+    assert not shell.help_softwarechannel_listsystems.called
+    assert out is None
+    assert mprint.called
+    assert shell.client.channel.software.listSubscribedSystems.called
+    assert_list_args_expect(mprint.call_args_list,
+                            ['one.acme.lan\nthird.zoo.lan\ntwo.acme.lan\nzetta.acme.lan'])
+
+def test_listsystems_noargs_channel_data_return(shell):
+    """
+    Test do_softwarechannel_listsystems one channel, data return.
+
+    :param shell:
+    :return:
+    """
+    shell.client.channel.software.listSubscribedSystems = MagicMock(return_value=[
+        {"name": "one.acme.lan"},
+        {"name": "two.acme.lan"},
+        {"name": "zetta.acme.lan"},
+        {"name": "third.zoo.lan"},
+    ])
+    mprint = MagicMock()
+    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+        out = spacecmd.softwarechannel.do_softwarechannel_listsystems(shell, "my_channel", doreturn=True)
+
+    assert not shell.help_softwarechannel_listsystems.called
+    assert not mprint.called
+    assert out is not None
+    assert out == ['one.acme.lan', 'third.zoo.lan', 'two.acme.lan', 'zetta.acme.lan']
+
+def test_listpackages_noargs_nodata(shell):
+    """
+    Test do_softwarechannel_listpackages no args. No data return.
+
+    :param shell:
+    :return:
+    """
+    mprint = MagicMock()
+    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+        out = spacecmd.softwarechannel.do_softwarechannel_listpackages(shell, "")
+
+    assert out is None
+    assert not shell.client.channel.software.listLatestPackages.called
+    assert shell.help_softwarechannel_listpackages.called
+
+def test_listpackages_too_much_args_nodata(shell):
+    """
+    Test do_softwarechannel_listpackages with too much much arguments.
+
+    :param shell:
+    :return:
+    """
+    mprint = MagicMock()
+    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+        out = spacecmd.softwarechannel.do_softwarechannel_listpackages(
+            shell, "one_channel other_channel somemore_channels")
+
+    assert out is None
+    assert not shell.client.channel.software.listLatestPackages.called
+    assert shell.help_softwarechannel_listpackages.called
+
+def test_listpackages_one_channel_no_data(shell):
+    """
+    Test do_softwarechannel_listpackages with one channel. No data return.
+
+    :param shell:
+    :return:
+    """
+    shell.client.channel.software.listLatestPackages = MagicMock(
+        return_value=[
             {"name": "emacs", "version": "42.0",
-             "release": "9", "epoch": "", "arch": "x86_64"},
-            {"name": "emacs", "version": "42.0",
-             "release": "10", "epoch": "", "arch_label": "x86_64"},
-            {"name": "emacs", "version": "42.0",
-             "release": "8", "epoch": "", "arch": "x86_64"},
-            {"name": "emacs", "version": "42.1",
-             "release": "7", "epoch": "", "arch": "x86_64"},
-            {"name": "emacs", "version": "41.9",
-             "release": "11", "epoch": "", "arch_label": "x86_64"},
+                "release": "9", "epoch": "", "arch": "x86_64"},
+            {"name": "emacs-nox", "version": "42.0",
+                "release": "10", "epoch": "", "arch_label": "x86_64"},
+            {"name": "tiff", "version": "1.0",
+                "release": "11", "epoch": "3", "arch": "amd64"},
         ]
-        out = list(spacecmd.softwarechannel.filter_latest_packages(data))
-        assert len(out) == 1
-        res = out[0]
+    )
+    mprint = MagicMock()
+    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+        out = spacecmd.softwarechannel.do_softwarechannel_listpackages(shell, "one_channel")
 
-        assert res["release"] == "7"
-        assert res["version"] == "42.1"
-        assert res["name"] == "emacs"
-        assert res["arch"] == "x86_64"
-        assert res["epoch"] == ""
+    assert out is None
+    assert not shell.help_softwarechannel_listpackages.called
+    assert shell.client.channel.software.listLatestPackages.called
+    assert_list_args_expect(mprint.call_args_list,
+                            ['emacs-42.0-9.x86_64\nemacs-nox-42.0-10.x86_64\ntiff-1.0-11:3.x86_64'])
 
-    def test_listlatestpackages_noargs_nodata(self, shell):
-        """
-        Test do_softwarechannel_listlatestpackages without args. No data return.
+def test_listpackages_one_channel_with_data(shell):
+    """
+    Test do_softwarechannel_listpackages with one channel. With data return.
 
-        :return:
-        """
-        mprint = MagicMock()
-        with patch("spacecmd.softwarechannel.print", mprint) as prt:
-            out = spacecmd.softwarechannel.do_softwarechannel_listlatestpackages(shell, "")
+    :param shell:
+    :return:
+    """
+    shell.client.channel.software.listLatestPackages = MagicMock(
+        return_value=[
+            {"name": "emacs", "version": "42.0",
+                "release": "9", "epoch": "", "arch": "x86_64"},
+            {"name": "emacs-nox", "version": "42.0",
+                "release": "10", "epoch": "", "arch_label": "x86_64"},
+            {"name": "tiff", "version": "1.0",
+                "release": "11", "epoch": "3", "arch": "amd64"},
+        ]
+    )
+    mprint = MagicMock()
+    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+        out = spacecmd.softwarechannel.do_softwarechannel_listpackages(
+            shell, "one_channel", doreturn=True)
 
-        assert out is None
-        assert not shell.client.channel.software.listAllPackages.called
-        assert shell.help_softwarechannel_listlatestpackages.called
+    assert out is not None
+    assert not shell.help_softwarechannel_listpackages.called
+    assert shell.client.channel.software.listLatestPackages.called
+    assert out == ['emacs-42.0-9.x86_64', 'emacs-nox-42.0-10.x86_64',
+                    'tiff-1.0-11:3.x86_64']
 
-    def test_listlatestpackages_wrongargs_nodata(self, shell):
-        """
-        Test do_softwarechannel_listlatestpackages with wrong amount of args. No data return.
+def test_listallpackages_noargs_nodata(shell):
+    """
+    Test do_softwarechannel_listallpackages no args. No data return.
 
-        :return:
-        """
-        mprint = MagicMock()
-        with patch("spacecmd.softwarechannel.print", mprint) as prt:
-            out = spacecmd.softwarechannel.do_softwarechannel_listlatestpackages(
-                shell, "one two three")
+    :param shell:
+    :return:
+    """
+    mprint = MagicMock()
+    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+        out = spacecmd.softwarechannel.do_softwarechannel_listallpackages(shell, "")
 
-        assert out is None
-        assert not shell.client.channel.software.listAllPackages.called
-        assert shell.help_softwarechannel_listlatestpackages.called
+    assert out is None
+    assert not shell.client.channel.software.listAllPackages.called
+    assert shell.help_softwarechannel_listallpackages.called
 
-    def test_listlatestpackages_channel_packages(self, shell):
-        """
-        Test do_softwarechannel_listlatestpackages with channel supplied.
+def test_listallpackages_too_much_args_nodata(shell):
+    """
+    Test do_softwarechannel_listallpackages with too much much arguments.
 
-        :return:
-        """
-        shell.client.channel.software.listAllPackages = MagicMock(
-            return_value=[
-                {"name": "emacs", "version": "42.0",
-                 "release": "9", "epoch": "", "arch": "x86_64"},
-                {"name": "emacs-nox", "version": "42.0",
-                 "release": "10", "epoch": "", "arch_label": "x86_64"},
-                {"name": "tiff", "version": "1.0",
-                 "release": "11", "epoch": "3", "arch": "amd64"},
-            ]
-        )
-        mprint = MagicMock()
-        with patch("spacecmd.softwarechannel.print", mprint) as prt:
-            out = spacecmd.softwarechannel.do_softwarechannel_listlatestpackages(
-                shell, "some_channel")
+    :param shell:
+    :return:
+    """
+    mprint = MagicMock()
+    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+        out = spacecmd.softwarechannel.do_softwarechannel_listallpackages(
+            shell, "one_channel other_channel somemore_channels")
 
-        assert out is None
-        assert not shell.help_softwarechannel_listlatestpackages.called
-        assert shell.client.channel.software.listAllPackages.called
+    assert out is None
+    assert not shell.client.channel.software.listAllPackages.called
+    assert shell.help_softwarechannel_listallpackages.called
 
-        assert_list_args_expect(mprint.call_args_list,
-                                ['emacs-42.0-9.x86_64\nemacs-nox-42.0-10.x86_64\ntiff-1.0-11:3.x86_64'])
+def test_listallpackages_one_channel_no_data(shell):
+    """
+    Test do_softwarechannel_listallpackages with one channel. No data return.
 
-    def test_listlatestpackages_channel_packages_as_data(self, shell):
-        """
-        Test do_softwarechannel_listlatestpackages with channel supplied. Return as data.
+    :param shell:
+    :return:
+    """
+    shell.client.channel.software.listAllPackages = MagicMock(
+        return_value=[
+            {"name": "emacs", "version": "42.0",
+                "release": "9", "epoch": "", "arch": "x86_64"},
+            {"name": "emacs-nox", "version": "42.0",
+                "release": "10", "epoch": "", "arch_label": "x86_64"},
+            {"name": "tiff", "version": "1.0",
+                "release": "11", "epoch": "3", "arch": "amd64"},
+        ]
+    )
+    mprint = MagicMock()
+    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+        out = spacecmd.softwarechannel.do_softwarechannel_listallpackages(shell, "one_channel")
 
-        :return:
-        """
-        shell.client.channel.software.listAllPackages = MagicMock(
-            return_value=[
-                {"name": "emacs", "version": "42.0",
-                 "release": "9", "epoch": "", "arch": "x86_64"},
-                {"name": "emacs-nox", "version": "42.0",
-                 "release": "10", "epoch": "", "arch_label": "x86_64"},
-                {"name": "tiff", "version": "1.0",
-                 "release": "11", "epoch": "3", "arch": "amd64"},
-            ]
-        )
-        mprint = MagicMock()
-        with patch("spacecmd.softwarechannel.print", mprint) as prt:
-            out = spacecmd.softwarechannel.do_softwarechannel_listlatestpackages(
-                shell, "some_channel", doreturn=True)
+    assert out is None
+    assert not shell.help_softwarechannel_listallpackages.called
+    assert shell.client.channel.software.listAllPackages.called
+    assert_list_args_expect(mprint.call_args_list,
+                            ['emacs-42.0-9.x86_64\nemacs-nox-42.0-10.x86_64\ntiff-1.0-11:3.x86_64'])
 
-        assert out is not None
-        assert not shell.help_softwarechannel_listlatestpackages.called
-        assert shell.client.channel.software.listAllPackages.called
+def test_listallpackages_one_channel_with_data(shell):
+    """
+    Test do_softwarechannel_listallpackages with one channel. With data return.
 
-        assert out == ['emacs-42.0-9.x86_64', 'emacs-nox-42.0-10.x86_64', 'tiff-1.0-11:3.x86_64']
+    :param shell:
+    :return:
+    """
+    shell.client.channel.software.listAllPackages = MagicMock(
+        return_value=[
+            {"name": "emacs", "version": "42.0",
+                "release": "9", "epoch": "", "arch": "x86_64"},
+            {"name": "emacs-nox", "version": "42.0",
+                "release": "10", "epoch": "", "arch_label": "x86_64"},
+            {"name": "tiff", "version": "1.0",
+                "release": "11", "epoch": "3", "arch": "amd64"},
+        ]
+    )
+    mprint = MagicMock()
+    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+        out = spacecmd.softwarechannel.do_softwarechannel_listallpackages(
+            shell, "one_channel", doreturn=True)
+
+    assert out is not None
+    assert not shell.help_softwarechannel_listallpackages.called
+    assert shell.client.channel.software.listAllPackages.called
+    assert out == ['emacs-42.0-9.x86_64', 'emacs-nox-42.0-10.x86_64',
+                    'tiff-1.0-11:3.x86_64']
+
+@pytest.mark.skipif(not hasattr(rpm, "labelCompare"), reason="Full RPM bindings required")
+def test_filter_latest_packages():
+    """
+    Test filter_latest_packages function.
+
+    :return:
+    """
+    data = [
+        {"name": "emacs", "version": "42.0",
+            "release": "9", "epoch": "", "arch": "x86_64"},
+        {"name": "emacs", "version": "42.0",
+            "release": "10", "epoch": "", "arch_label": "x86_64"},
+        {"name": "emacs", "version": "42.0",
+            "release": "8", "epoch": "", "arch": "x86_64"},
+        {"name": "emacs", "version": "42.1",
+            "release": "7", "epoch": "", "arch": "x86_64"},
+        {"name": "emacs", "version": "41.9",
+            "release": "11", "epoch": "", "arch_label": "x86_64"},
+    ]
+    out = list(spacecmd.softwarechannel.filter_latest_packages(data))
+    assert len(out) == 1
+    res = out[0]
+
+    assert res["release"] == "7"
+    assert res["version"] == "42.1"
+    assert res["name"] == "emacs"
+    assert res["arch"] == "x86_64"
+    assert res["epoch"] == ""
+
+def test_listlatestpackages_noargs_nodata(shell):
+    """
+    Test do_softwarechannel_listlatestpackages without args. No data return.
+
+    :return:
+    """
+    mprint = MagicMock()
+    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+        out = spacecmd.softwarechannel.do_softwarechannel_listlatestpackages(shell, "")
+
+    assert out is None
+    assert not shell.client.channel.software.listAllPackages.called
+    assert shell.help_softwarechannel_listlatestpackages.called
+
+def test_listlatestpackages_wrongargs_nodata(shell):
+    """
+    Test do_softwarechannel_listlatestpackages with wrong amount of args. No data return.
+
+    :return:
+    """
+    mprint = MagicMock()
+    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+        out = spacecmd.softwarechannel.do_softwarechannel_listlatestpackages(
+            shell, "one two three")
+
+    assert out is None
+    assert not shell.client.channel.software.listAllPackages.called
+    assert shell.help_softwarechannel_listlatestpackages.called
+
+def test_listlatestpackages_channel_packages(shell):
+    """
+    Test do_softwarechannel_listlatestpackages with channel supplied.
+
+    :return:
+    """
+    shell.client.channel.software.listAllPackages = MagicMock(
+        return_value=[
+            {"name": "emacs", "version": "42.0",
+                "release": "9", "epoch": "", "arch": "x86_64"},
+            {"name": "emacs-nox", "version": "42.0",
+                "release": "10", "epoch": "", "arch_label": "x86_64"},
+            {"name": "tiff", "version": "1.0",
+                "release": "11", "epoch": "3", "arch": "amd64"},
+        ]
+    )
+    mprint = MagicMock()
+    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+        out = spacecmd.softwarechannel.do_softwarechannel_listlatestpackages(
+            shell, "some_channel")
+
+    assert out is None
+    assert not shell.help_softwarechannel_listlatestpackages.called
+    assert shell.client.channel.software.listAllPackages.called
+
+    assert_list_args_expect(mprint.call_args_list,
+                            ['emacs-42.0-9.x86_64\nemacs-nox-42.0-10.x86_64\ntiff-1.0-11:3.x86_64'])
+
+def test_listlatestpackages_channel_packages_as_data(shell):
+    """
+    Test do_softwarechannel_listlatestpackages with channel supplied. Return as data.
+
+    :return:
+    """
+    shell.client.channel.software.listAllPackages = MagicMock(
+        return_value=[
+            {"name": "emacs", "version": "42.0",
+                "release": "9", "epoch": "", "arch": "x86_64"},
+            {"name": "emacs-nox", "version": "42.0",
+                "release": "10", "epoch": "", "arch_label": "x86_64"},
+            {"name": "tiff", "version": "1.0",
+                "release": "11", "epoch": "3", "arch": "amd64"},
+        ]
+    )
+    mprint = MagicMock()
+    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+        out = spacecmd.softwarechannel.do_softwarechannel_listlatestpackages(
+            shell, "some_channel", doreturn=True)
+
+    assert out is not None
+    assert not shell.help_softwarechannel_listlatestpackages.called
+    assert shell.client.channel.software.listAllPackages.called
+
+    assert out == ['emacs-42.0-9.x86_64', 'emacs-nox-42.0-10.x86_64', 'tiff-1.0-11:3.x86_64']

--- a/spacecmd/tests/test_softwarechannel.py
+++ b/spacecmd/tests/test_softwarechannel.py
@@ -500,3 +500,31 @@ class TestSCSoftwareChannel:
         assert shell.client.channel.software.listAllPackages.called
         assert_list_args_expect(mprint.call_args_list,
                                 ['emacs-42.0-9.x86_64\nemacs-nox-42.0-10.x86_64\ntiff-1.0-11:3.x86_64'])
+
+    def test_listallpackages_one_channel_with_data(self, shell):
+        """
+        Test do_softwarechannel_listallpackages with one channel. With data return.
+
+        :param shell:
+        :return:
+        """
+        shell.client.channel.software.listAllPackages = MagicMock(
+            return_value=[
+                {"name": "emacs", "version": "42.0",
+                 "release": "9", "epoch": "", "arch": "x86_64"},
+                {"name": "emacs-nox", "version": "42.0",
+                 "release": "10", "epoch": "", "arch_label": "x86_64"},
+                {"name": "tiff", "version": "1.0",
+                 "release": "11", "epoch": "3", "arch": "amd64"},
+            ]
+        )
+        mprint = MagicMock()
+        with patch("spacecmd.softwarechannel.print", mprint) as prt:
+            out = spacecmd.softwarechannel.do_softwarechannel_listallpackages(
+                shell, "one_channel", doreturn=True)
+
+        assert out is not None
+        assert not shell.help_softwarechannel_listallpackages.called
+        assert shell.client.channel.software.listAllPackages.called
+        assert out == ['emacs-42.0-9.x86_64', 'emacs-nox-42.0-10.x86_64',
+                       'tiff-1.0-11:3.x86_64']

--- a/spacecmd/tests/test_softwarechannel.py
+++ b/spacecmd/tests/test_softwarechannel.py
@@ -559,3 +559,17 @@ class TestSCSoftwareChannel:
         assert res["name"] == "emacs"
         assert res["arch"] == "x86_64"
         assert res["epoch"] == ""
+
+    def test_listlatestpackages_noargs_nodata(self, shell):
+        """
+        Test do_softwarechannel_listlatestpackages without args. No data return.
+
+        :return:
+        """
+        mprint = MagicMock()
+        with patch("spacecmd.softwarechannel.print", mprint) as prt:
+            out = spacecmd.softwarechannel.do_softwarechannel_listlatestpackages(shell, "")
+
+        assert out is None
+        assert not shell.client.channel.software.listAllPackages.called
+        assert shell.help_softwarechannel_listlatestpackages.called

--- a/spacecmd/tests/test_softwarechannel.py
+++ b/spacecmd/tests/test_softwarechannel.py
@@ -414,3 +414,31 @@ class TestSCSoftwareChannel:
         assert shell.client.channel.software.listLatestPackages.called
         assert_list_args_expect(mprint.call_args_list,
                                 ['emacs-42.0-9.x86_64\nemacs-nox-42.0-10.x86_64\ntiff-1.0-11:3.x86_64'])
+
+    def test_listpackages_one_channel_with_data(self, shell):
+        """
+        Test do_softwarechannel_listpackages with one channel. With data return.
+
+        :param shell:
+        :return:
+        """
+        shell.client.channel.software.listLatestPackages = MagicMock(
+            return_value=[
+                {"name": "emacs", "version": "42.0",
+                 "release": "9", "epoch": "", "arch": "x86_64"},
+                {"name": "emacs-nox", "version": "42.0",
+                 "release": "10", "epoch": "", "arch_label": "x86_64"},
+                {"name": "tiff", "version": "1.0",
+                 "release": "11", "epoch": "3", "arch": "amd64"},
+            ]
+        )
+        mprint = MagicMock()
+        with patch("spacecmd.softwarechannel.print", mprint) as prt:
+            out = spacecmd.softwarechannel.do_softwarechannel_listpackages(
+                shell, "one_channel", doreturn=True)
+
+        assert out is not None
+        assert not shell.help_softwarechannel_listpackages.called
+        assert shell.client.channel.software.listLatestPackages.called
+        assert out == ['emacs-42.0-9.x86_64', 'emacs-nox-42.0-10.x86_64',
+                       'tiff-1.0-11:3.x86_64']

--- a/spacecmd/tests/test_softwarechannel.py
+++ b/spacecmd/tests/test_softwarechannel.py
@@ -268,3 +268,29 @@ class TestSCSoftwareChannel:
         assert not shell.client.channel.software.getDetails.called
         assert_list_args_expect(mprint.call_args_list,
                                 ['a_child_channel\nb_child_channel\nx_child_channel\nz_child_channel'])
+
+    def test_listchildchannels_verbose(self, shell):
+        """
+        Test do_softwarechannel_listchildchannels verbose.
+
+        :param shell:
+        :return:
+        """
+        shell.list_child_channels = MagicMock(return_value=["x_child_channel", "z_child_channel",
+                                                            "b_child_channel", "a_child_channel",])
+        shell.client.channel.software.getDetails = MagicMock(side_effect=[
+            {"summary": "A summary"},
+            {"summary": "B summary"},
+            {"summary": "X summary"},
+            {"summary": "Z summary"},
+        ])
+        mprint = MagicMock()
+        with patch("spacecmd.softwarechannel.print", mprint) as prt:
+            spacecmd.softwarechannel.do_softwarechannel_listchildchannels(shell, "--verbose")
+
+        assert shell.client.channel.software.getDetails.called
+        assert_list_args_expect(mprint.call_args_list,
+                                ['a_child_channel : A summary',
+                                 'b_child_channel : B summary',
+                                 'x_child_channel : X summary',
+                                 'z_child_channel : Z summary'])

--- a/spacecmd/tests/test_softwarechannel.py
+++ b/spacecmd/tests/test_softwarechannel.py
@@ -243,7 +243,7 @@ class TestSCSoftwareChannel:
         ])
 
         mprint = MagicMock()
-        with patch("spacecmd.softwarechannel.dir", mprint) as prt:
+        with patch("spacecmd.softwarechannel.print", mprint) as prt:
             out = spacecmd.softwarechannel.do_softwarechannel_listmanageablechannels(
                 shell, "--verbose", doreturn=True)
 

--- a/spacecmd/tests/test_softwarechannel.py
+++ b/spacecmd/tests/test_softwarechannel.py
@@ -442,3 +442,18 @@ class TestSCSoftwareChannel:
         assert shell.client.channel.software.listLatestPackages.called
         assert out == ['emacs-42.0-9.x86_64', 'emacs-nox-42.0-10.x86_64',
                        'tiff-1.0-11:3.x86_64']
+
+    def test_listallpackages_noargs_nodata(self, shell):
+        """
+        Test do_softwarechannel_listallpackages no args. No data return.
+
+        :param shell:
+        :return:
+        """
+        mprint = MagicMock()
+        with patch("spacecmd.softwarechannel.print", mprint) as prt:
+            out = spacecmd.softwarechannel.do_softwarechannel_listallpackages(shell, "")
+
+        assert out is None
+        assert not shell.client.channel.software.listAllPackages.called
+        assert shell.help_softwarechannel_listallpackages.called

--- a/spacecmd/tests/test_softwarechannel.py
+++ b/spacecmd/tests/test_softwarechannel.py
@@ -19,7 +19,7 @@ def test_softwarechannel_list_doreturn_nolabels(shell):
     """
     shell.client.channel.listAllChannels = MagicMock(return_value=[])
     mprint = MagicMock()
-    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+    with patch("spacecmd.softwarechannel.print", mprint):
         out = spacecmd.softwarechannel.do_softwarechannel_list(shell, "", doreturn=True)
     assert out is not None
     assert out == []
@@ -37,7 +37,7 @@ def test_softwarechannel_list_noreturn_nolabels(shell):
     """
     shell.client.channel.listAllChannels = MagicMock(return_value=[])
     mprint = MagicMock()
-    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+    with patch("spacecmd.softwarechannel.print", mprint):
         out = spacecmd.softwarechannel.do_softwarechannel_list(shell, "", doreturn=False)
     assert out is None
     assert not shell.help_softwarechannel_list.called
@@ -58,7 +58,7 @@ def test_softwarechannel_list_noreturn_labels_std(shell):
     ])
 
     mprint = MagicMock()
-    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+    with patch("spacecmd.softwarechannel.print", mprint):
         out = spacecmd.softwarechannel.do_softwarechannel_list(
             shell, "", doreturn=False)
 
@@ -90,7 +90,7 @@ def test_softwarechannel_list_noreturn_labels_verbose(shell):
     ])
 
     mprint = MagicMock()
-    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+    with patch("spacecmd.softwarechannel.print", mprint):
         out = spacecmd.softwarechannel.do_softwarechannel_list(
             shell, "-v", doreturn=False)
 
@@ -126,7 +126,7 @@ def test_softwarechannel_list_noreturn_labels_verbose_tree(shell):
     ])
 
     mprint = MagicMock()
-    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+    with patch("spacecmd.softwarechannel.print", mprint):
         out = spacecmd.softwarechannel.do_softwarechannel_list(
             shell, "-v -t", doreturn=False)
 
@@ -154,7 +154,7 @@ def test_softwarechannel_listmanageablechannels_noarg(shell):
     ])
 
     mprint = MagicMock()
-    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+    with patch("spacecmd.softwarechannel.print", mprint):
         out = spacecmd.softwarechannel.do_softwarechannel_listmanageablechannels(shell, "")
 
     assert out is None
@@ -184,7 +184,7 @@ def test_softwarechannel_listmanageablechannels_default_verbose(shell):
     ])
 
     mprint = MagicMock()
-    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+    with patch("spacecmd.softwarechannel.print", mprint):
         out = spacecmd.softwarechannel.do_softwarechannel_listmanageablechannels(
             shell, "--verbose")
 
@@ -211,7 +211,7 @@ def test_softwarechannel_listmanageablechannels_data_sparse(shell):
     ])
 
     mprint = MagicMock()
-    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+    with patch("spacecmd.softwarechannel.print", mprint):
         out = spacecmd.softwarechannel.do_softwarechannel_listmanageablechannels(shell, "", doreturn=True)
 
     assert out is not None
@@ -240,7 +240,7 @@ def test_softwarechannel_listmanageablechannels_data_verbose(shell):
     ])
 
     mprint = MagicMock()
-    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+    with patch("spacecmd.softwarechannel.print", mprint):
         out = spacecmd.softwarechannel.do_softwarechannel_listmanageablechannels(
             shell, "--verbose", doreturn=True)
 
@@ -259,7 +259,7 @@ def test_listchildchannels(shell):
     shell.list_child_channels = MagicMock(return_value=["x_child_channel", "z_child_channel",
                                                         "b_child_channel", "a_child_channel",])
     mprint = MagicMock()
-    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+    with patch("spacecmd.softwarechannel.print", mprint):
         spacecmd.softwarechannel.do_softwarechannel_listchildchannels(shell, "")
 
     assert not shell.client.channel.software.getDetails.called
@@ -282,7 +282,7 @@ def test_listchildchannels_verbose(shell):
         {"summary": "Z summary"},
     ])
     mprint = MagicMock()
-    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+    with patch("spacecmd.softwarechannel.print", mprint):
         spacecmd.softwarechannel.do_softwarechannel_listchildchannels(shell, "--verbose")
 
     assert shell.client.channel.software.getDetails.called
@@ -300,7 +300,7 @@ def test_listsystems_noargs(shell):
     :return:
     """
     mprint = MagicMock()
-    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+    with patch("spacecmd.softwarechannel.print", mprint):
         out = spacecmd.softwarechannel.do_softwarechannel_listsystems(shell, "")
 
     assert out is None
@@ -322,7 +322,7 @@ def test_listsystems_noargs_channel_no_data(shell):
         {"name": "third.zoo.lan"},
     ])
     mprint = MagicMock()
-    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+    with patch("spacecmd.softwarechannel.print", mprint):
         out = spacecmd.softwarechannel.do_softwarechannel_listsystems(shell, "my_channel")
 
     assert not shell.help_softwarechannel_listsystems.called
@@ -346,7 +346,7 @@ def test_listsystems_noargs_channel_data_return(shell):
         {"name": "third.zoo.lan"},
     ])
     mprint = MagicMock()
-    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+    with patch("spacecmd.softwarechannel.print", mprint):
         out = spacecmd.softwarechannel.do_softwarechannel_listsystems(shell, "my_channel", doreturn=True)
 
     assert not shell.help_softwarechannel_listsystems.called
@@ -362,7 +362,7 @@ def test_listpackages_noargs_nodata(shell):
     :return:
     """
     mprint = MagicMock()
-    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+    with patch("spacecmd.softwarechannel.print", mprint):
         out = spacecmd.softwarechannel.do_softwarechannel_listpackages(shell, "")
 
     assert out is None
@@ -377,7 +377,7 @@ def test_listpackages_too_much_args_nodata(shell):
     :return:
     """
     mprint = MagicMock()
-    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+    with patch("spacecmd.softwarechannel.print", mprint):
         out = spacecmd.softwarechannel.do_softwarechannel_listpackages(
             shell, "one_channel other_channel somemore_channels")
 
@@ -403,7 +403,7 @@ def test_listpackages_one_channel_no_data(shell):
         ]
     )
     mprint = MagicMock()
-    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+    with patch("spacecmd.softwarechannel.print", mprint):
         out = spacecmd.softwarechannel.do_softwarechannel_listpackages(shell, "one_channel")
 
     assert out is None
@@ -430,7 +430,7 @@ def test_listpackages_one_channel_with_data(shell):
         ]
     )
     mprint = MagicMock()
-    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+    with patch("spacecmd.softwarechannel.print", mprint):
         out = spacecmd.softwarechannel.do_softwarechannel_listpackages(
             shell, "one_channel", doreturn=True)
 
@@ -448,7 +448,7 @@ def test_listallpackages_noargs_nodata(shell):
     :return:
     """
     mprint = MagicMock()
-    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+    with patch("spacecmd.softwarechannel.print", mprint):
         out = spacecmd.softwarechannel.do_softwarechannel_listallpackages(shell, "")
 
     assert out is None
@@ -463,7 +463,7 @@ def test_listallpackages_too_much_args_nodata(shell):
     :return:
     """
     mprint = MagicMock()
-    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+    with patch("spacecmd.softwarechannel.print", mprint):
         out = spacecmd.softwarechannel.do_softwarechannel_listallpackages(
             shell, "one_channel other_channel somemore_channels")
 
@@ -489,7 +489,7 @@ def test_listallpackages_one_channel_no_data(shell):
         ]
     )
     mprint = MagicMock()
-    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+    with patch("spacecmd.softwarechannel.print", mprint):
         out = spacecmd.softwarechannel.do_softwarechannel_listallpackages(shell, "one_channel")
 
     assert out is None
@@ -516,7 +516,7 @@ def test_listallpackages_one_channel_with_data(shell):
         ]
     )
     mprint = MagicMock()
-    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+    with patch("spacecmd.softwarechannel.print", mprint):
         out = spacecmd.softwarechannel.do_softwarechannel_listallpackages(
             shell, "one_channel", doreturn=True)
 
@@ -562,7 +562,7 @@ def test_listlatestpackages_noargs_nodata(shell):
     :return:
     """
     mprint = MagicMock()
-    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+    with patch("spacecmd.softwarechannel.print", mprint):
         out = spacecmd.softwarechannel.do_softwarechannel_listlatestpackages(shell, "")
 
     assert out is None
@@ -576,7 +576,7 @@ def test_listlatestpackages_wrongargs_nodata(shell):
     :return:
     """
     mprint = MagicMock()
-    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+    with patch("spacecmd.softwarechannel.print", mprint):
         out = spacecmd.softwarechannel.do_softwarechannel_listlatestpackages(
             shell, "one two three")
 
@@ -601,7 +601,7 @@ def test_listlatestpackages_channel_packages(shell):
         ]
     )
     mprint = MagicMock()
-    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+    with patch("spacecmd.softwarechannel.print", mprint):
         out = spacecmd.softwarechannel.do_softwarechannel_listlatestpackages(
             shell, "some_channel")
 
@@ -629,7 +629,7 @@ def test_listlatestpackages_channel_packages_as_data(shell):
         ]
     )
     mprint = MagicMock()
-    with patch("spacecmd.softwarechannel.print", mprint) as prt:
+    with patch("spacecmd.softwarechannel.print", mprint):
         out = spacecmd.softwarechannel.do_softwarechannel_listlatestpackages(
             shell, "some_channel", doreturn=True)
 

--- a/spacecmd/tests/test_softwarechannel.py
+++ b/spacecmd/tests/test_softwarechannel.py
@@ -387,3 +387,30 @@ class TestSCSoftwareChannel:
         assert out is None
         assert not shell.client.channel.software.listLatestPackages.called
         assert shell.help_softwarechannel_listpackages.called
+
+    def test_listpackages_one_channel_no_data(self, shell):
+        """
+        Test do_softwarechannel_listpackages with one channel. No data return.
+
+        :param shell:
+        :return:
+        """
+        shell.client.channel.software.listLatestPackages = MagicMock(
+            return_value=[
+                {"name": "emacs", "version": "42.0",
+                 "release": "9", "epoch": "", "arch": "x86_64"},
+                {"name": "emacs-nox", "version": "42.0",
+                 "release": "10", "epoch": "", "arch_label": "x86_64"},
+                {"name": "tiff", "version": "1.0",
+                 "release": "11", "epoch": "3", "arch": "amd64"},
+            ]
+        )
+        mprint = MagicMock()
+        with patch("spacecmd.softwarechannel.print", mprint) as prt:
+            out = spacecmd.softwarechannel.do_softwarechannel_listpackages(shell, "one_channel")
+
+        assert out is None
+        assert not shell.help_softwarechannel_listpackages.called
+        assert shell.client.channel.software.listLatestPackages.called
+        assert_list_args_expect(mprint.call_args_list,
+                                ['emacs-42.0-9.x86_64\nemacs-nox-42.0-10.x86_64\ntiff-1.0-11:3.x86_64'])

--- a/spacecmd/tests/test_softwarechannel.py
+++ b/spacecmd/tests/test_softwarechannel.py
@@ -5,8 +5,7 @@ Test software channel module.
 
 from mock import MagicMock, patch
 import spacecmd.softwarechannel
-from xmlrpc import client as xmlrpclib
-from helpers import shell, assert_expect, assert_list_args_expect, assert_args_expect
+from helpers import shell, assert_expect, assert_list_args_expect
 import pytest
 import rpm
 

--- a/spacecmd/tests/test_softwarechannel.py
+++ b/spacecmd/tests/test_softwarechannel.py
@@ -588,3 +588,31 @@ class TestSCSoftwareChannel:
         assert out is None
         assert not shell.client.channel.software.listAllPackages.called
         assert shell.help_softwarechannel_listlatestpackages.called
+
+    def test_listlatestpackages_channel_packages(self, shell):
+        """
+        Test do_softwarechannel_listlatestpackages with channel supplied.
+
+        :return:
+        """
+        shell.client.channel.software.listAllPackages = MagicMock(
+            return_value=[
+                {"name": "emacs", "version": "42.0",
+                 "release": "9", "epoch": "", "arch": "x86_64"},
+                {"name": "emacs-nox", "version": "42.0",
+                 "release": "10", "epoch": "", "arch_label": "x86_64"},
+                {"name": "tiff", "version": "1.0",
+                 "release": "11", "epoch": "3", "arch": "amd64"},
+            ]
+        )
+        mprint = MagicMock()
+        with patch("spacecmd.softwarechannel.print", mprint) as prt:
+            out = spacecmd.softwarechannel.do_softwarechannel_listlatestpackages(
+                shell, "some_channel")
+
+        assert out is None
+        assert not shell.help_softwarechannel_listlatestpackages.called
+        assert shell.client.channel.software.listAllPackages.called
+
+        assert_list_args_expect(mprint.call_args_list,
+                                ['emacs-42.0-9.x86_64\nemacs-nox-42.0-10.x86_64\ntiff-1.0-11:3.x86_64'])

--- a/spacecmd/tests/test_softwarechannel.py
+++ b/spacecmd/tests/test_softwarechannel.py
@@ -251,3 +251,20 @@ class TestSCSoftwareChannel:
         assert not shell.client.channel.software.getDetails.called
         assert shell.client.channel.listManageableChannels.called
         assert out == ["a_channel", "b_channel", "x_channel", "z_channel"]
+
+    def test_listchildchannels(self, shell):
+        """
+        Test do_softwarechannel_listchildchannels noargs.
+
+        :param shell:
+        :return:
+        """
+        shell.list_child_channels = MagicMock(return_value=["x_child_channel", "z_child_channel",
+                                                            "b_child_channel", "a_child_channel",])
+        mprint = MagicMock()
+        with patch("spacecmd.softwarechannel.print", mprint) as prt:
+            spacecmd.softwarechannel.do_softwarechannel_listchildchannels(shell, "")
+
+        assert not shell.client.channel.software.getDetails.called
+        assert_list_args_expect(mprint.call_args_list,
+                                ['a_child_channel\nb_child_channel\nx_child_channel\nz_child_channel'])

--- a/spacecmd/tests/test_softwarechannel.py
+++ b/spacecmd/tests/test_softwarechannel.py
@@ -573,3 +573,18 @@ class TestSCSoftwareChannel:
         assert out is None
         assert not shell.client.channel.software.listAllPackages.called
         assert shell.help_softwarechannel_listlatestpackages.called
+
+    def test_listlatestpackages_wrongargs_nodata(self, shell):
+        """
+        Test do_softwarechannel_listlatestpackages with wrong amount of args. No data return.
+
+        :return:
+        """
+        mprint = MagicMock()
+        with patch("spacecmd.softwarechannel.print", mprint) as prt:
+            out = spacecmd.softwarechannel.do_softwarechannel_listlatestpackages(
+                shell, "one two three")
+
+        assert out is None
+        assert not shell.client.channel.software.listAllPackages.called
+        assert shell.help_softwarechannel_listlatestpackages.called

--- a/spacecmd/tests/test_softwarechannel.py
+++ b/spacecmd/tests/test_softwarechannel.py
@@ -31,3 +31,20 @@ class TestSCSoftwareChannel:
         assert not shell.list_child_channels.called
         assert not shell.list_base_channels.called
 
+    def test_softwarechannel_list_noreturn_nolabels(self, shell):
+        """
+        Test do_softwarechannel_list without args.
+
+        :param shell:
+        :return:
+        """
+        shell.client.channel.listAllChannels = MagicMock(return_value=[])
+        mprint = MagicMock()
+        with patch("spacecmd.softwarechannel.print", mprint) as prt:
+            out = spacecmd.softwarechannel.do_softwarechannel_list(shell, "", doreturn=False)
+        assert out is None
+        assert not shell.help_softwarechannel_list.called
+        assert not shell.client.channel.software.getDetails.called
+        assert not shell.list_child_channels.called
+        assert not shell.list_base_channels.called
+

--- a/spacecmd/tests/test_softwarechannel.py
+++ b/spacecmd/tests/test_softwarechannel.py
@@ -457,3 +457,19 @@ class TestSCSoftwareChannel:
         assert out is None
         assert not shell.client.channel.software.listAllPackages.called
         assert shell.help_softwarechannel_listallpackages.called
+
+    def test_listallpackages_too_much_args_nodata(self, shell):
+        """
+        Test do_softwarechannel_listallpackages with too much much arguments.
+
+        :param shell:
+        :return:
+        """
+        mprint = MagicMock()
+        with patch("spacecmd.softwarechannel.print", mprint) as prt:
+            out = spacecmd.softwarechannel.do_softwarechannel_listallpackages(
+                shell, "one_channel other_channel somemore_channels")
+
+        assert out is None
+        assert not shell.client.channel.software.listAllPackages.called
+        assert shell.help_softwarechannel_listallpackages.called

--- a/spacecmd/tests/test_softwarechannel.py
+++ b/spacecmd/tests/test_softwarechannel.py
@@ -310,3 +310,27 @@ class TestSCSoftwareChannel:
         assert not mprint.called
         assert not shell.client.channel.software.listSubscribedSystems.called
         assert shell.help_softwarechannel_listsystems.called
+
+    def test_listsystems_noargs_channel_no_data(self, shell):
+        """
+        Test do_softwarechannel_listsystems one channel, no data.
+
+        :param shell:
+        :return:
+        """
+        shell.client.channel.software.listSubscribedSystems = MagicMock(return_value=[
+            {"name": "one.acme.lan"},
+            {"name": "two.acme.lan"},
+            {"name": "zetta.acme.lan"},
+            {"name": "third.zoo.lan"},
+        ])
+        mprint = MagicMock()
+        with patch("spacecmd.softwarechannel.print", mprint) as prt:
+            out = spacecmd.softwarechannel.do_softwarechannel_listsystems(shell, "my_channel")
+
+        assert not shell.help_softwarechannel_listsystems.called
+        assert out is None
+        assert mprint.called
+        assert shell.client.channel.software.listSubscribedSystems.called
+        assert_list_args_expect(mprint.call_args_list,
+                                ['one.acme.lan\nthird.zoo.lan\ntwo.acme.lan\nzetta.acme.lan'])

--- a/spacecmd/tests/test_softwarechannel.py
+++ b/spacecmd/tests/test_softwarechannel.py
@@ -1,0 +1,33 @@
+# coding: utf-8
+"""
+Test software channel module.
+"""
+
+from mock import MagicMock, patch
+import spacecmd.softwarechannel
+from xmlrpc import client as xmlrpclib
+from helpers import shell
+
+
+class TestSCSoftwareChannel:
+    """
+    Test suite for software channel.
+    """
+    def test_softwarechannel_list_doreturn_nolabels(self, shell):
+        """
+        Test do_softwarechannel_list without args.
+
+        :param shell:
+        :return:
+        """
+        shell.client.channel.listAllChannels = MagicMock(return_value=[])
+        mprint = MagicMock()
+        with patch("spacecmd.softwarechannel.print", mprint) as prt:
+            out = spacecmd.softwarechannel.do_softwarechannel_list(shell, "", doreturn=True)
+        assert out is not None
+        assert out == []
+        assert not shell.help_softwarechannel_list.called
+        assert not shell.client.channel.software.getDetails.called
+        assert not shell.list_child_channels.called
+        assert not shell.list_base_channels.called
+

--- a/spacecmd/tests/test_softwarechannel.py
+++ b/spacecmd/tests/test_softwarechannel.py
@@ -15,7 +15,7 @@ class TestSCSoftwareChannel:
     """
     def test_softwarechannel_list_doreturn_nolabels(self, shell):
         """
-        Test do_softwarechannel_list without args.
+        Test do_softwarechannel_list no labels, return data.
 
         :param shell:
         :return:
@@ -33,7 +33,7 @@ class TestSCSoftwareChannel:
 
     def test_softwarechannel_list_noreturn_nolabels(self, shell):
         """
-        Test do_softwarechannel_list without args.
+        Test do_softwarechannel_list no labels, no return data.
 
         :param shell:
         :return:

--- a/spacecmd/tests/test_softwarechannel.py
+++ b/spacecmd/tests/test_softwarechannel.py
@@ -200,3 +200,24 @@ class TestSCSoftwareChannel:
                                  "x_channel : X summary",
                                  "z_channel : Z summary"])
 
+    def test_softwarechannel_listmanageablechannels_data_sparse(self, shell):
+        """
+        Test do_softwarechannel_listmanageablechannels data out, short.
+
+        :param shell:
+        :return:
+        """
+        shell.client.channel.listManageableChannels = MagicMock(return_value=[
+            {"label": "x_channel"},
+            {"label": "z_channel"},
+            {"label": "a_channel"},
+        ])
+
+        mprint = MagicMock()
+        with patch("spacecmd.softwarechannel.print", mprint) as prt:
+            out = spacecmd.softwarechannel.do_softwarechannel_listmanageablechannels(shell, "", doreturn=True)
+
+        assert out is not None
+        assert not shell.client.channel.software.getDetails.called
+        assert shell.client.channel.listManageableChannels.called
+        assert out == ["a_channel", "x_channel", "z_channel"]

--- a/spacecmd/tests/test_softwarechannel.py
+++ b/spacecmd/tests/test_softwarechannel.py
@@ -356,3 +356,18 @@ class TestSCSoftwareChannel:
         assert not mprint.called
         assert out is not None
         assert out == ['one.acme.lan', 'third.zoo.lan', 'two.acme.lan', 'zetta.acme.lan']
+
+    def test_listpackages_noargs_nodata(self, shell):
+        """
+        Test do_softwarechannel_listpackages no args. No data return.
+
+        :param shell:
+        :return:
+        """
+        mprint = MagicMock()
+        with patch("spacecmd.softwarechannel.print", mprint) as prt:
+            out = spacecmd.softwarechannel.do_softwarechannel_listpackages(shell, "")
+
+        assert out is None
+        assert not shell.client.channel.software.listLatestPackages.called
+        assert shell.help_softwarechannel_listpackages.called

--- a/spacecmd/tests/test_softwarechannel.py
+++ b/spacecmd/tests/test_softwarechannel.py
@@ -221,3 +221,33 @@ class TestSCSoftwareChannel:
         assert not shell.client.channel.software.getDetails.called
         assert shell.client.channel.listManageableChannels.called
         assert out == ["a_channel", "x_channel", "z_channel"]
+
+    def test_softwarechannel_listmanageablechannels_data_verbose(self, shell):
+        """
+        Test do_softwarechannel_listmanageablechannels with verbose arg (all).
+
+        :param shell:
+        :return:
+        """
+        shell.client.channel.listManageableChannels = MagicMock(return_value=[
+            {"label": "x_channel"},
+            {"label": "z_channel"},
+            {"label": "b_channel"},
+            {"label": "a_channel"},
+        ])
+        shell.client.channel.software.getDetails = MagicMock(side_effect=[
+            {"summary": "A summary"},
+            {"summary": "B summary"},
+            {"summary": "X summary"},
+            {"summary": "Z summary"},
+        ])
+
+        mprint = MagicMock()
+        with patch("spacecmd.softwarechannel.dir", mprint) as prt:
+            out = spacecmd.softwarechannel.do_softwarechannel_listmanageablechannels(
+                shell, "--verbose", doreturn=True)
+
+        assert out is not None
+        assert not shell.client.channel.software.getDetails.called
+        assert shell.client.channel.listManageableChannels.called
+        assert out == ["a_channel", "b_channel", "x_channel", "z_channel"]

--- a/spacecmd/tests/test_softwarechannel.py
+++ b/spacecmd/tests/test_softwarechannel.py
@@ -371,3 +371,19 @@ class TestSCSoftwareChannel:
         assert out is None
         assert not shell.client.channel.software.listLatestPackages.called
         assert shell.help_softwarechannel_listpackages.called
+
+    def test_listpackages_too_much_args_nodata(self, shell):
+        """
+        Test do_softwarechannel_listpackages with too much much arguments.
+
+        :param shell:
+        :return:
+        """
+        mprint = MagicMock()
+        with patch("spacecmd.softwarechannel.print", mprint) as prt:
+            out = spacecmd.softwarechannel.do_softwarechannel_listpackages(
+                shell, "one_channel other_channel somemore_channels")
+
+        assert out is None
+        assert not shell.client.channel.software.listLatestPackages.called
+        assert shell.help_softwarechannel_listpackages.called

--- a/spacecmd/tests/test_softwarechannel.py
+++ b/spacecmd/tests/test_softwarechannel.py
@@ -294,3 +294,19 @@ class TestSCSoftwareChannel:
                                  'b_child_channel : B summary',
                                  'x_child_channel : X summary',
                                  'z_child_channel : Z summary'])
+
+    def test_listsystems_noargs(self, shell):
+        """
+        Test do_softwarechannel_listsystems no args.
+
+        :param shell:
+        :return:
+        """
+        mprint = MagicMock()
+        with patch("spacecmd.softwarechannel.print", mprint) as prt:
+            out = spacecmd.softwarechannel.do_softwarechannel_listsystems(shell, "")
+
+        assert out is None
+        assert not mprint.called
+        assert not shell.client.channel.software.listSubscribedSystems.called
+        assert shell.help_softwarechannel_listsystems.called

--- a/spacecmd/tests/test_softwarechannel.py
+++ b/spacecmd/tests/test_softwarechannel.py
@@ -166,3 +166,37 @@ class TestSCSoftwareChannel:
         assert_list_args_expect(mprint.call_args_list,
                                 ["a_channel", "x_channel", "z_channel"])
 
+    def test_softwarechannel_listmanageablechannels_default_verbose(self, shell):
+        """
+        Test do_softwarechannel_listmanageablechannels with verbose arg (all).
+
+        :param shell:
+        :return:
+        """
+        shell.client.channel.listManageableChannels = MagicMock(return_value=[
+            {"label": "x_channel"},
+            {"label": "z_channel"},
+            {"label": "b_channel"},
+            {"label": "a_channel"},
+        ])
+        shell.client.channel.software.getDetails = MagicMock(side_effect=[
+            {"summary": "A summary"},
+            {"summary": "B summary"},
+            {"summary": "X summary"},
+            {"summary": "Z summary"},
+        ])
+
+        mprint = MagicMock()
+        with patch("spacecmd.softwarechannel.print", mprint) as prt:
+            out = spacecmd.softwarechannel.do_softwarechannel_listmanageablechannels(
+                shell, "--verbose")
+
+        assert out is None
+        assert shell.client.channel.software.getDetails.called
+        assert shell.client.channel.listManageableChannels.called
+        assert_list_args_expect(mprint.call_args_list,
+                                ["a_channel : A summary",
+                                 "b_channel : B summary",
+                                 "x_channel : X summary",
+                                 "z_channel : Z summary"])
+

--- a/spacecmd/tests/test_utils.py
+++ b/spacecmd/tests/test_utils.py
@@ -4,7 +4,7 @@ Test spacecmd.utils
 """
 from unittest.mock import MagicMock, patch, mock_open
 import pytest
-from helpers import shell, assert_expect, assert_list_args_expect, assert_args_expect
+from helpers import shell, assert_expect, assert_list_args_expect, assert_args_expect, exc2str
 import spacecmd.utils
 from xmlrpc import client as xmlrpclib
 import os
@@ -730,7 +730,7 @@ class TestSCUtils:
         for value in [b"", 1, {}, [], ()]:
             with pytest.raises(IOError) as exc:
                 spacecmd.utils.string_to_bool(value)
-            assert "Parameter" in str(exc)
+            assert "Parameter" in exc2str(exc)
 
     def test_string_to_bool_correct_type(self):
         """


### PR DESCRIPTION
## What does this PR change?

Adds unit tests, ongoing bug fixes and minor refactorings to `spacecmd.softwarechannel` module.

NOTE: Changelog entry will be added after the work-in-progress is over.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed (only adds tests plus minor refactors that are not visible to the user)

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
