### PR TITLE
Fix: install git-core on a container build host

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/services/docker.sls
+++ b/susemanager-utils/susemanager-sls/salt/services/docker.sls
@@ -2,6 +2,7 @@
 mgr_install_docker:
   pkg.installed:
     - pkgs:
+      - git-core
       - docker: '>=1.9.0'
 {%- if grains['pythonversion'][0] == 3 %}
     {%- if grains['osmajorrelease'] == 12 %}


### PR DESCRIPTION
## What does this PR change?

When we provision a container build host we should install `git-core` package in the build host to correctly fetch container build sources (Dockerfile) from a git repo.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: internal

- [X] **DONE**

## Test coverage
- No tests: no tests for Salt state

- [X] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/9052

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
