### PR TITLE
Fix mgr-virtualization timer

### DIFF
--- a/client/tools/mgr-virtualization/mgr-virtualization.changes
+++ b/client/tools/mgr-virtualization/mgr-virtualization.changes
@@ -1,3 +1,5 @@
+- Fix mgr-virtualization timer
+
 -------------------------------------------------------------------
 Thu Aug 01 17:33:46 CEST 2019 - jgonzalez@suse.com
 

--- a/client/tools/mgr-virtualization/mgr-virtualization.spec
+++ b/client/tools/mgr-virtualization/mgr-virtualization.spec
@@ -202,13 +202,13 @@ make -f Makefile.rhn-virtualization DESTDIR=$RPM_BUILD_ROOT PKGDIR0=%{_initrddir
 install -d %{buildroot}%{_unitdir}
 install -D -m 0644 scripts/mgr-virtualization.timer %{buildroot}%{_unitdir}/mgr-virtualization.timer
 install -D -m 0644 scripts/mgr-virtualization.service %{buildroot}%{_unitdir}/mgr-virtualization.service
-sed -i 's,@PYTHON@,python3,; s,@PYTHONPATH@,%{python3_sitelib},;' \
+sed -i 's,@PYTHON@,/usr/bin/python3,; s,@PYTHONPATH@,%{python3_sitelib},;' \
        %{buildroot}%{_unitdir}/mgr-virtualization.service
 
 %else
 install -d $RPM_BUILD_ROOT%{cron_dir}
 install -D -m 0644 scripts/rhn-virtualization.cron $RPM_BUILD_ROOT%{cron_dir}/rhn-virtualization.cron
-sed -i 's,@PYTHON@,python,; s,@PYTHONPATH@,%{python_sitelib},;' \
+sed -i 's,@PYTHON@,/usr/bin/python,; s,@PYTHONPATH@,%{python_sitelib},;' \
         $RPM_BUILD_ROOT/%{cron_dir}/rhn-virtualization.cron
 %endif
 

--- a/client/tools/mgr-virtualization/scripts/mgr-virtualization.service
+++ b/client/tools/mgr-virtualization/scripts/mgr-virtualization.service
@@ -3,4 +3,4 @@ Description=Check libvirtd for VMs and report it to Uyuni Server
 
 [Service]
 Type=oneshot
-ExecStart=@PYTHON@ < @PYTHONPATH@/virtualization/poller.py
+ExecStart=@PYTHON@ @PYTHONPATH@/virtualization/poller.py

--- a/client/tools/mgr-virtualization/scripts/mgr-virtualization.timer
+++ b/client/tools/mgr-virtualization/scripts/mgr-virtualization.timer
@@ -2,7 +2,7 @@
 Description=Check libvirtd for VMs and report it to Uyuni Server
 
 [Timer]
-OnCalendar=*:*/2:00
+OnCalendar=*:0/2
 Persistent=true
 
 [Install]


### PR DESCRIPTION
## What does this PR change?

There were two problems: the OnCalendar rule was not correct and the
service file needs an absolute path.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: just gets `mgr-virtualization` back to work

- [X] **DONE**

## Test coverage
- No tests: virtualization is not tested on traditional clients

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
