### PR TITLE
CLM - Filter UI Improvements and Refactor

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/mappers/ResponseMappers.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/mappers/ResponseMappers.java
@@ -236,7 +236,7 @@ public class ResponseMappers {
                     contentProjectFilterResponse.setMatcher(filter.getCriteria().getMatcher().getLabel());
                     contentProjectFilterResponse.setCriteriaKey(filter.getCriteria().getField());
                     contentProjectFilterResponse.setCriteriaValue(filter.getCriteria().getValue());
-                    contentProjectFilterResponse.setDeny(filter.getRule() == ContentFilter.Rule.DENY);
+                    contentProjectFilterResponse.setRule(filter.getRule().getLabel());
                     contentProjectFilterResponse.setState(projectFilter.getState().toString());
                     return contentProjectFilterResponse;
                 })

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/response/ProjectFilterResponse.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/response/ProjectFilterResponse.java
@@ -25,7 +25,7 @@ public class ProjectFilterResponse {
     private String matcher;
     private String criteriaKey;
     private String criteriaValue;
-    private Boolean deny;
+    private String rule;
     private String state;
 
     public void setId(Long idIn) {
@@ -48,8 +48,8 @@ public class ProjectFilterResponse {
         this.criteriaValue = criteriaValueIn;
     }
 
-    public void setDeny(Boolean denyIn) {
-        this.deny = denyIn;
+    public void setRule(String ruleIn) {
+        this.rule = ruleIn;
     }
 
     public void setName(String nameIn) {

--- a/web/html/src/components/input/DateTime.js
+++ b/web/html/src/components/input/DateTime.js
@@ -22,13 +22,17 @@ function DateTime(props: Props) {
           const onChange = (value) => {
             setValue(props.name, value);
           };
-          return (
-            <DateTimePicker
-              onChange={onChange}
-              value={props.value}
-              timezone={timezone}
-            />
-          );
+          if(props.value instanceof Date) {
+            return (
+              <DateTimePicker
+                onChange={onChange}
+                value={props.value}
+                timezone={timezone}
+              />
+            );
+          } else {
+            return null
+          }
         }
       }
     </InputBase>

--- a/web/html/src/components/input/Form.js
+++ b/web/html/src/components/input/Form.js
@@ -113,14 +113,14 @@ class Form extends React.Component<Props, State> {
   }
 
   unregisterInput(component: React.ElementRef<any>) {
-    if (component.props && component.props.name) {
-      delete this.inputs[component.props.name];
+    if (component.props && component.props.name && this.inputs[component.props.name] === component) {
+        delete this.inputs[component.props.name];
 
-      this.setState((prevState) => {
-        const { model } = prevState;
-        delete model[component.props.name];
-        return { model };
-      });
+        this.setState((prevState) => {
+          const { model } = prevState;
+          delete model[component.props.name];
+          return { model };
+        });
     }
   }
 

--- a/web/html/src/jest.config.js
+++ b/web/html/src/jest.config.js
@@ -3,5 +3,6 @@ module.exports = {
     "^core/(.*)$": "<rootDir>/core/$1",
     "^components/(.*)$": "<rootDir>/components/$1",
     "^utils/(.*)$": "<rootDir>/utils/$1"
-  }
+  },
+  setupFiles: ["./testSetupFile.js"]
 }

--- a/web/html/src/manager/content-management/list-filters/filter-form.js
+++ b/web/html/src/manager/content-management/list-filters/filter-form.js
@@ -10,7 +10,6 @@ import type {ClmFilterOptionType, FilterMatcherType} from "../shared/business/fi
 import {clmFilterOptions, findClmFilterByKey, getClmFiltersOptions} from "../shared/business/filters.enum";
 import useUserLocalization from "core/user-localization/use-user-localization";
 import Functions from "utils/functions";
-import _isEmpty from "lodash/isEmpty";
 import produce from "immer";
 
 type Props = {

--- a/web/html/src/manager/content-management/list-filters/filter-form.js
+++ b/web/html/src/manager/content-management/list-filters/filter-form.js
@@ -33,6 +33,12 @@ const FilterForm = (props: Props) => {
           } else {
             delete draft.matcher
           }
+          if(clmFilterOptions.ADVISORY_TYPE.key === props.filter.type) {
+            draft[clmFilterOptions.ADVISORY_TYPE.key] = "Security Advisory";
+          }
+          if(clmFilterOptions.ISSUE_DATE.key === props.filter.type) {
+            draft[clmFilterOptions.ISSUE_DATE.key] = Functions.Utils.dateWithTimezone(localTime);
+          }
         })
       )
     };
@@ -73,9 +79,7 @@ const FilterForm = (props: Props) => {
           label={t("Filter Type")}
           labelClass="col-md-3"
           divClass="col-md-6"
-          defaultValue={""}
           required
-          onChange
           disabled={props.editing}
         >
           <option disabled selected value=""> -- select a filter type -- </option>
@@ -98,7 +102,6 @@ const FilterForm = (props: Props) => {
             label={t("Matcher")}
             labelClass="col-md-3"
             divClass="col-md-6"
-            defaultValue={""}
             required
             disabled={props.editing}
           >
@@ -212,7 +215,7 @@ const FilterForm = (props: Props) => {
           clmFilterOptions.ADVISORY_TYPE.key === props.filter.type &&
           <Radio
             name={clmFilterOptions.ADVISORY_TYPE.key}
-            defaultValue="Security Advisory"
+            required
             items={[
               {"label": t("Security Advisory"), "value": "Security Advisory"},
               {"label": t("Bug Fix Advisory"), "value": "Bug Fix Advisory"},
@@ -232,7 +235,6 @@ const FilterForm = (props: Props) => {
             divClass="col-md-6"
             required
             timezone={timezone}
-            defaultValue={Functions.Utils.dateWithTimezone(localTime)}
           />
         }
 
@@ -261,7 +263,6 @@ const FilterForm = (props: Props) => {
         <Radio
           inline
           name="rule"
-          defaultValue="deny"
           items={[
             {"label": t("Deny"), "value": "deny"},
             {"label": t("Allow"), "value": "allow"}

--- a/web/html/src/manager/content-management/list-filters/filter.utils.js
+++ b/web/html/src/manager/content-management/list-filters/filter.utils.js
@@ -1,18 +1,34 @@
 //@flow
 /* global moment */
 import _isEmpty from "lodash/isEmpty";
-import filtersEnum from "../shared/business/filters.enum";
+import {clmFilterOptions, findClmFilterByKey} from "../shared/business/filters.enum";
 import type {FilterFormType, FilterServerType} from "../shared/type/filter.type";
 import Functions from "utils/functions";
 
 export function mapFilterFormToRequest(filterForm: FilterFormType, projectLabel: string, localTime: string): FilterServerType {
   const requestForm = {};
   requestForm.projectLabel = projectLabel;
-  requestForm.name = filterForm.name;
+  requestForm.name = filterForm.filter_name;
   requestForm.rule = filterForm.rule;
-  requestForm.entityType = filtersEnum.findByKey(filterForm.type).entityType;
-  requestForm.matcher = filtersEnum.findByKey(filterForm.type).matcher;
-  if (filterForm.type === filtersEnum.enum.PACKAGE_NEVRA.key) {
+  requestForm.matcher = filterForm.matcher;
+
+  const selectedFilterOption = findClmFilterByKey(filterForm.type);
+  if(selectedFilterOption) {
+    // By default the enum KEY is used either for the criteriaKey and to map the form field into the criteriaValue
+    requestForm.entityType = selectedFilterOption.entityType.key;
+    requestForm.criteriaKey = selectedFilterOption.key;
+    requestForm.criteriaValue = filterForm[selectedFilterOption.key];
+  }
+
+  // Custom filters mappers for complex filter forms
+  // If this starts growing we could define mapper functions in the enum itself, for now it's enough. (ex: mapCriteriaValueToRequest())
+  if (filterForm.type === clmFilterOptions.ISSUE_DATE.key) {
+    const formDateValue = filterForm[clmFilterOptions.ISSUE_DATE.key];
+    requestForm.criteriaValue = formDateValue
+      ? moment(Functions.Utils.dateWithoutTimezone(formDateValue, localTime)).format("YYYY-MM-DDTHH:mm:ss.SSSZ")
+      :  "";
+  } else if (filterForm.type === clmFilterOptions.NEVRA.key) {
+    // UI filter NEVRA form can map either into nevr or nevra
     const epochName = !_isEmpty(filterForm.epoch) ? `${filterForm.epoch}:` : '';
     if(_isEmpty(filterForm.architecture)){
       requestForm.criteriaKey = "nevr"
@@ -23,36 +39,12 @@ export function mapFilterFormToRequest(filterForm: FilterFormType, projectLabel:
       requestForm.criteriaValue =
         `${filterForm.packageName || ""}-${epochName}${filterForm.version || ""}-${filterForm.release || ""}.${filterForm.architecture}`;
     }
-  } else if (filterForm.type === filtersEnum.enum.ERRATUM_PKG_NAME.key) {
-    requestForm.criteriaKey = "package_name";
-    requestForm.criteriaValue = filterForm.criteria;
-  } else if (filterForm.type === filtersEnum.enum.ERRATUM_PKG_LT_EVR.key ||
-             filterForm.type === filtersEnum.enum.ERRATUM_PKG_LE_EVR.key ||
-             filterForm.type === filtersEnum.enum.ERRATUM_PKG_EQ_EVR.key ||
-             filterForm.type === filtersEnum.enum.ERRATUM_PKG_GE_EVR.key ||
-             filterForm.type === filtersEnum.enum.ERRATUM_PKG_GT_EVR.key) {
+  } else if (filterForm.type === clmFilterOptions.PACKAGE_NEVR.key) {
     const epochName = !_isEmpty(filterForm.epoch) ? `${filterForm.epoch}:` : '';
-    requestForm.criteriaKey = "package_nevr"
     requestForm.criteriaValue =
       `${filterForm.packageName || ""} ${epochName}${filterForm.version|| ""}-${filterForm.release|| ""}`;
-  } else if (filterForm.type === filtersEnum.enum.ERRATUM.key) {
-    requestForm.criteriaKey = "advisory_name";
-    requestForm.criteriaValue = filterForm.advisoryName;
-  } else if (filterForm.type === filtersEnum.enum.ERRATUM_BYTYPE.key) {
-    requestForm.criteriaKey = "advisory_type";
-    requestForm.criteriaValue = filterForm.advisoryType;
-  } else if (filterForm.type === filtersEnum.enum.ERRATUM_BYDATE.key) {
-    requestForm.criteriaKey = "issue_date";
-    requestForm.criteriaValue = filterForm.issueDate
-      ? moment(Functions.Utils.dateWithoutTimezone(filterForm.issueDate, localTime)).format("YYYY-MM-DDTHH:mm:ss.SSSZ")
-      :  "";
-  } else if (filterForm.type === filtersEnum.enum.ERRATUM_BYSYNOPSIS.key || filterForm.type === filtersEnum.enum.ERRATUM_BYSYNOPSIS_CONTAINS.key) {
-    requestForm.criteriaKey = "synopsis";
-    requestForm.criteriaValue = filterForm.synopsis;
-  } else {
-    requestForm.criteriaKey = "name";
-    requestForm.criteriaValue = filterForm.criteria;
   }
+
   return requestForm;
 }
 
@@ -60,14 +52,25 @@ export function mapResponseToFilterForm(filtersResponse: Array<FilterServerType>
   return filtersResponse.map(filterResponse => {
     let filterForm = {};
     filterForm.id = filterResponse.id;
-    filterForm.name = filterResponse.name;
+    filterForm.filter_name= filterResponse.name;
     filterForm.rule = filterResponse.rule;
     filterForm.matcher = filterResponse.matcher;
     filterForm.projects = filterResponse.projects;
 
-    if(filterResponse.criteriaKey === "nevr") {
-      filterForm.type = filtersEnum.enum.PACKAGE_NEVRA.key;
+    const selectedFilterOption = findClmFilterByKey(filterResponse.criteriaKey);
+    // If we can find a filter option using the CriteriaKey we assume the default behavior
+    if(selectedFilterOption) {
+      filterForm.type = selectedFilterOption && selectedFilterOption.key;
+      filterForm[selectedFilterOption.key] = filterResponse.criteriaValue;
+    }
 
+    // Custom filters mappers for complex filter forms
+    // If this starts growing we could define mapper functions in the enum itself, for now it's enough. (ex: mapCriteriaValueToRequest())
+    if (filterResponse.criteriaKey === clmFilterOptions.ISSUE_DATE.key) {
+      filterForm[clmFilterOptions.ISSUE_DATE.key] = Functions.Utils.dateWithTimezone(filterResponse.criteriaValue);
+    } else if(filterResponse.criteriaKey === "nevr") {
+    // NEVR filter is mapped into NEVRA in the UI
+      filterForm.type = clmFilterOptions.NEVRA.key;
       if(!_isEmpty(filterResponse.criteriaValue)) {
         const [
           ,
@@ -83,9 +86,23 @@ export function mapResponseToFilterForm(filtersResponse: Array<FilterServerType>
         filterForm.version = version;
         filterForm.release = release;
       }
-    } else if (filterResponse.criteriaKey === "nevra") {
-      filterForm.type = filtersEnum.enum.PACKAGE_NEVRA.key;
+    } else if (filterResponse.criteriaKey === clmFilterOptions.PACKAGE_NEVR.key) {
+      if(!_isEmpty(filterResponse.criteriaValue)) {
+        const [
+          ,
+          packageName,
+          ,
+          epoch,
+          version,
+          release
+        ] = filterResponse.criteriaValue.match(/(.*) ((.*):)?(.*)-(.*)/);
 
+        filterForm.packageName = packageName;
+        filterForm.epoch = epoch;
+        filterForm.version = version;
+        filterForm.release = release;
+      }
+    } else if(filterResponse.criteriaKey === clmFilterOptions.NEVRA.key) {
       if(!_isEmpty(filterResponse.criteriaValue)) {
         const [
           ,
@@ -103,56 +120,6 @@ export function mapResponseToFilterForm(filtersResponse: Array<FilterServerType>
         filterForm.release = release;
         filterForm.architecture = architecture;
       }
-    } else if(filterResponse.criteriaKey === "package_nevr") {
-      if (filterForm.matcher === "contains_pkg_lt_evr") {
-        filterForm.type = filtersEnum.enum.ERRATUM_PKG_LT_EVR.key;
-      } else if (filterForm.matcher === "contains_pkg_le_evr") {
-        filterForm.type = filtersEnum.enum.ERRATUM_PKG_LE_EVR.key;
-      } else if (filterForm.matcher === "contains_pkg_eq_evr") {
-        filterForm.type = filtersEnum.enum.ERRATUM_PKG_EQ_EVR.key;
-      } else if (filterForm.matcher === "contains_pkg_ge_evr") {
-        filterForm.type = filtersEnum.enum.ERRATUM_PKG_GE_EVR.key;
-      } else if (filterForm.matcher === "contains_pkg_gt_evr") {
-        filterForm.type = filtersEnum.enum.ERRATUM_PKG_GT_EVR.key;
-      }
-
-      if(!_isEmpty(filterResponse.criteriaValue)) {
-        const [
-          ,
-          packageName,
-          ,
-          epoch,
-          version,
-          release
-        ] = filterResponse.criteriaValue.match(/(.*) ((.*):)?(.*)-(.*)/);
-
-        filterForm.packageName = packageName;
-        filterForm.epoch = epoch;
-        filterForm.version = version;
-        filterForm.release = release;
-      }
-    } else if (filterResponse.criteriaKey === "advisory_name") {
-      filterForm.type = filtersEnum.enum.ERRATUM.key;
-      filterForm["advisoryName"] = filterResponse.criteriaValue;
-    } else if (filterResponse.criteriaKey === "advisory_type") {
-      filterForm.type = filtersEnum.enum.ERRATUM_BYTYPE.key;
-      filterForm["advisoryType"] = filterResponse.criteriaValue;
-    } else if (filterResponse.criteriaKey === "synopsis") {
-      if (filterResponse.matcher === "equals") {
-          filterForm.type = filtersEnum.enum.ERRATUM_BYSYNOPSIS.key;
-      } else if (filterResponse.matcher === "contains") {
-          filterForm.type = filtersEnum.enum.ERRATUM_BYSYNOPSIS_CONTAINS.key;
-      }
-      filterForm["synopsis"] = filterResponse.criteriaValue;
-    } else if (filterResponse.criteriaKey === "issue_date") {
-      filterForm.type = filtersEnum.enum.ERRATUM_BYDATE.key;
-      filterForm["issueDate"] = Functions.Utils.dateWithTimezone(filterResponse.criteriaValue);
-    } else if (filterResponse.criteriaKey === "package_name") {
-      filterForm.type = filtersEnum.enum.ERRATUM_PKG_NAME.key
-      filterForm.criteria = filterResponse.criteriaValue;
-    } else if (filterResponse.criteriaKey === "name") {
-      filterForm.type = filtersEnum.enum.PACKAGE.key;
-      filterForm.criteria = filterResponse.criteriaValue;
     }
 
     return filterForm;

--- a/web/html/src/manager/content-management/list-filters/filter.utils.js
+++ b/web/html/src/manager/content-management/list-filters/filter.utils.js
@@ -5,6 +5,8 @@ import {clmFilterOptions, findClmFilterByKey} from "../shared/business/filters.e
 import type {FilterFormType, FilterServerType} from "../shared/type/filter.type";
 import Functions from "utils/functions";
 
+declare var Loggerhead: any;
+
 export function mapFilterFormToRequest(filterForm: FilterFormType, projectLabel: string, localTime: string): FilterServerType {
   const requestForm = {};
   requestForm.projectLabel = projectLabel;
@@ -18,6 +20,8 @@ export function mapFilterFormToRequest(filterForm: FilterFormType, projectLabel:
     requestForm.entityType = selectedFilterOption.entityType.key;
     requestForm.criteriaKey = selectedFilterOption.key;
     requestForm.criteriaValue = filterForm[selectedFilterOption.key];
+  } else {
+    Loggerhead.error(`${filterForm.filter_name}: We couldn't find a matching filter for the form ${filterForm.type}`);
   }
 
   // Custom filters mappers for complex filter forms
@@ -52,7 +56,7 @@ export function mapResponseToFilterForm(filtersResponse: Array<FilterServerType>
   return filtersResponse.map(filterResponse => {
     let filterForm = {};
     filterForm.id = filterResponse.id;
-    filterForm.filter_name= filterResponse.name;
+    filterForm.filter_name = filterResponse.name;
     filterForm.rule = filterResponse.rule;
     filterForm.matcher = filterResponse.matcher;
     filterForm.projects = filterResponse.projects;
@@ -62,6 +66,8 @@ export function mapResponseToFilterForm(filtersResponse: Array<FilterServerType>
     if(selectedFilterOption) {
       filterForm.type = selectedFilterOption && selectedFilterOption.key;
       filterForm[selectedFilterOption.key] = filterResponse.criteriaValue;
+    } else {
+      Loggerhead.error(`${filterResponse.name}: We couldn't find a matching filter for ${filterResponse.criteriaKey}`);
     }
 
     // Custom filters mappers for complex filter forms

--- a/web/html/src/manager/content-management/list-filters/filter.utils.test.js
+++ b/web/html/src/manager/content-management/list-filters/filter.utils.test.js
@@ -101,9 +101,9 @@ describe('Testing filters form <> request mappers', () => {
     expect(mapFilterFormToRequest(filterForm).rule).toEqual("allow");
   });
 
-  test('test patch by date', () => {
+  // test('test patch by date', () => {
     // TODO: add this test when moment isn't a global dependency and comes from NPM
-  });
+  // });
 
   test('test Patch (contains Package) - package_nevr', () => {
     let filterForm = {

--- a/web/html/src/manager/content-management/list-filters/filter.utils.test.js
+++ b/web/html/src/manager/content-management/list-filters/filter.utils.test.js
@@ -1,0 +1,169 @@
+import {mapFilterFormToRequest, mapResponseToFilterForm} from "./filter.utils";
+
+describe('Testing filters form <> request mappers', () => {
+  test('test filter package name', () => {
+    const filterForm = {
+      filter_name: "filter packageName",
+      matcher: "contains",
+      type: "name",
+      name: "package_contains",
+      rule: "deny"
+    }
+    expect(mapResponseToFilterForm([mapFilterFormToRequest(filterForm)])[0])
+      .toEqual(expect.objectContaining(filterForm));
+  });
+
+  test('test filter NEVRA', () => {
+    let filterForm = {
+      filter_name: "filter nevra name",
+      matcher: "equals",
+      type: "nevra",
+      packageName: "asd",
+      epoch: "123",
+      version: "123",
+      release: "123",
+      architecture: "123",
+      rule: "deny"
+    };
+    expect(mapResponseToFilterForm([mapFilterFormToRequest(filterForm)])[0])
+      .toEqual(expect.objectContaining(filterForm));
+    expect(mapFilterFormToRequest(filterForm).criteriaKey).toEqual("nevra");
+    expect(mapFilterFormToRequest(filterForm).criteriaValue).toEqual("asd-123:123-123.123");
+
+    delete filterForm.architecture;
+    delete filterForm.epoch;
+    filterForm.rule = "allow";
+
+    expect(mapResponseToFilterForm([mapFilterFormToRequest(filterForm)])[0])
+      .toEqual(expect.objectContaining(filterForm));
+    expect(mapFilterFormToRequest(filterForm).criteriaKey).toEqual("nevr");
+    expect(mapFilterFormToRequest(filterForm).criteriaValue).toEqual("asd-123-123");
+  });
+
+  test('test filter advisory name', () => {
+    const filterForm = {
+      filter_name: "filter advisory_name name",
+      matcher: "equals",
+      type: "advisory_name",
+      advisory_name: "advisory_name_12",
+      rule: "deny"
+    }
+    expect(mapResponseToFilterForm([mapFilterFormToRequest(filterForm)])[0])
+      .toEqual(expect.objectContaining(filterForm));
+    expect(mapFilterFormToRequest(filterForm).criteriaKey).toEqual("advisory_name");
+    expect(mapFilterFormToRequest(filterForm).criteriaValue).toEqual("advisory_name_12");
+  });
+
+  test('test filter advisory type', () => {
+    const filterForm = {
+      filter_name: "filter advisory_type name",
+      matcher: "equals",
+      type: "advisory_type",
+      advisory_type: "Security Advisory",
+      rule: "deny"
+    }
+    expect(mapResponseToFilterForm([mapFilterFormToRequest(filterForm)])[0])
+      .toEqual(expect.objectContaining(filterForm));
+    expect(mapFilterFormToRequest(filterForm).criteriaKey).toEqual("advisory_type");
+    expect(mapFilterFormToRequest(filterForm).criteriaValue).toEqual("Security Advisory");
+
+    filterForm.rule = "allow";
+    filterForm.advisory_type = "Product Enhancement Advisory";
+
+    expect(mapResponseToFilterForm([mapFilterFormToRequest(filterForm)])[0])
+      .toEqual(expect.objectContaining(filterForm));
+    expect(mapFilterFormToRequest(filterForm).criteriaKey).toEqual("advisory_type");
+    expect(mapFilterFormToRequest(filterForm).criteriaValue).toEqual("Product Enhancement Advisory");
+  });
+
+  test('test filter synopsis', () => {
+    const filterForm = {
+      filter_name: "filter synopsis name",
+      matcher: "equals",
+      type: "synopsis",
+      synopsis: "synopsis_name",
+      rule: "deny"
+    }
+    expect(mapResponseToFilterForm([mapFilterFormToRequest(filterForm)])[0])
+      .toEqual(expect.objectContaining(filterForm));
+    expect(mapFilterFormToRequest(filterForm).criteriaKey).toEqual("synopsis");
+    expect(mapFilterFormToRequest(filterForm).criteriaValue).toEqual("synopsis_name");
+    expect(mapFilterFormToRequest(filterForm).matcher).toEqual("equals");
+
+    filterForm.rule = "allow";
+    filterForm.matcher = "contains";
+
+    expect(mapResponseToFilterForm([mapFilterFormToRequest(filterForm)])[0])
+      .toEqual(expect.objectContaining(filterForm));
+    expect(mapFilterFormToRequest(filterForm).criteriaKey).toEqual("synopsis");
+    expect(mapFilterFormToRequest(filterForm).criteriaValue).toEqual("synopsis_name");
+    expect(mapFilterFormToRequest(filterForm).matcher).toEqual("contains");
+    expect(mapFilterFormToRequest(filterForm).rule).toEqual("allow");
+  });
+
+  test('test patch by date', () => {
+    const filterForm = {
+      filter_name: "filter by date",
+      matcher: "equals",
+      type: "issue_date",
+      issue_date: "2017-10-01T00:00+01",
+      rule: "deny"
+    }
+    // TODO: add this test when moment isn't a global dependency and comes from NPM
+  });
+
+  test('test Patch (contains Package) - package_nevr', () => {
+    let filterForm = {
+      filter_name: "filter contains package name",
+      matcher: "contains_pkg_lt_evr",
+      type: "package_nevr",
+      packageName: "asd",
+      epoch: "123",
+      version: "123",
+      release: "123",
+      rule: "deny"
+    };
+    expect(mapResponseToFilterForm([mapFilterFormToRequest(filterForm)])[0])
+      .toEqual(expect.objectContaining(filterForm));
+    expect(mapFilterFormToRequest(filterForm).criteriaKey).toEqual("package_nevr");
+    expect(mapFilterFormToRequest(filterForm).criteriaValue).toEqual("asd 123:123-123");
+    expect(mapFilterFormToRequest(filterForm).matcher).toEqual("contains_pkg_lt_evr");
+
+    delete filterForm.epoch;
+    filterForm.rule = "allow";
+    filterForm.matcher = "contains_pkg_eq_evr";
+
+    expect(mapResponseToFilterForm([mapFilterFormToRequest(filterForm)])[0])
+      .toEqual(expect.objectContaining(filterForm));
+    expect(mapFilterFormToRequest(filterForm).criteriaKey).toEqual("package_nevr");
+    expect(mapFilterFormToRequest(filterForm).criteriaValue).toEqual("asd 123-123");
+    expect(mapFilterFormToRequest(filterForm).matcher).toEqual("contains_pkg_eq_evr");
+  });
+
+  test('test Patch (contains Package Name) - package_name', () => {
+    const filterForm = {
+      filter_name: "filter patch contains package name",
+      matcher: "contains",
+      type: "package_name",
+      package_name: "package name",
+      rule: "deny"
+    }
+    expect(mapResponseToFilterForm([mapFilterFormToRequest(filterForm)])[0])
+      .toEqual(expect.objectContaining(filterForm));
+    expect(mapFilterFormToRequest(filterForm).criteriaKey).toEqual("package_name");
+    expect(mapFilterFormToRequest(filterForm).criteriaValue).toEqual("package name");
+    expect(mapFilterFormToRequest(filterForm).matcher).toEqual("contains");
+    expect(mapFilterFormToRequest(filterForm).rule).toEqual("deny");
+
+    filterForm.rule = "allow";
+
+    expect(mapResponseToFilterForm([mapFilterFormToRequest(filterForm)])[0])
+      .toEqual(expect.objectContaining(filterForm));
+    expect(mapFilterFormToRequest(filterForm).criteriaKey).toEqual("package_name");
+    expect(mapFilterFormToRequest(filterForm).criteriaValue).toEqual("package name");
+    expect(mapFilterFormToRequest(filterForm).matcher).toEqual("contains");
+    expect(mapFilterFormToRequest(filterForm).rule).toEqual("allow");
+  });
+
+})
+

--- a/web/html/src/manager/content-management/list-filters/filter.utils.test.js
+++ b/web/html/src/manager/content-management/list-filters/filter.utils.test.js
@@ -102,13 +102,6 @@ describe('Testing filters form <> request mappers', () => {
   });
 
   test('test patch by date', () => {
-    const filterForm = {
-      filter_name: "filter by date",
-      matcher: "equals",
-      type: "issue_date",
-      issue_date: "2017-10-01T00:00+01",
-      rule: "deny"
-    }
     // TODO: add this test when moment isn't a global dependency and comes from NPM
   });
 

--- a/web/html/src/manager/content-management/list-filters/list-filters.js
+++ b/web/html/src/manager/content-management/list-filters/list-filters.js
@@ -20,7 +20,6 @@ type Props = {
 };
 
 const ListFilters = (props: Props) => {
-
   const [displayedFilters, setDisplayedFilters]: [Array<FilterFormType>, Function] =
     useState(mapResponseToFilterForm(props.filters));
 
@@ -62,7 +61,7 @@ const ListFilters = (props: Props) => {
     <TopPanel title={t('Content Lifecycle Filters')} icon="fa-filter" button={panelButtons} helpUrl="/docs/reference/clm/clm-filters.html">
       <Table
         data={displayedFilters}
-        identifier={row => row.name}
+        identifier={row => row.filter_name}
         searchField={(
           <SearchField
             filter={searchData}
@@ -71,10 +70,10 @@ const ListFilters = (props: Props) => {
         )}
       >
         <Column
-          columnKey="name"
+          columnKey="filter_name"
           comparator={Functions.Utils.sortByText}
           header={t('Name')}
-          cell={row => row.name}
+          cell={row => row.filter_name}
         />
         <Column
           columnKey="projects"

--- a/web/html/src/manager/content-management/list-filters/list-filters.js
+++ b/web/html/src/manager/content-management/list-filters/list-filters.js
@@ -46,7 +46,7 @@ const ListFilters = (props: Props) => {
         hasEditingPermissions &&
         <FilterEdit
           id="create-filter-button"
-          initialFilterForm={{deny:true}}
+          initialFilterForm={{rule: "deny"}}
           icon='fa-plus'
           buttonText='Create Filter'
           openFilterId={props.openFilterId}

--- a/web/html/src/manager/content-management/project/project.js
+++ b/web/html/src/manager/content-management/project/project.js
@@ -22,7 +22,7 @@ import useInterval from "core/hooks/use-interval";
 import useLifecycleActionsApi from "../shared/api/use-lifecycle-actions-api";
 import FiltersProject from "../shared/components/panels/filters-project/filters-project";
 import statesEnum from "../shared/business/states.enum";
-import filtersEnum from "../shared/business/filters.enum";
+import {getClmFilterDescription} from "../shared/business/filters.enum";
 
 type Props = {
   project: ProjectType,
@@ -60,7 +60,7 @@ const Project = (props: Props) => {
       .filters
       .filter(filter => statesEnum.isEdited(filter.state))
       .map(filter =>
-        `${filtersEnum.getFilterDescription(filter)} ${statesEnum.findByKey(filter.state).description}`
+        `${getClmFilterDescription(filter)} ${statesEnum.findByKey(filter.state).description}`
       )
   );
   const isProjectEdited = changesToBuild.length > 0;

--- a/web/html/src/manager/content-management/shared/business/filters.enum.js
+++ b/web/html/src/manager/content-management/shared/business/filters.enum.js
@@ -25,47 +25,47 @@ export const filterMatchers : FilterMatcherEnumType = {
   CONTAINS: {
     key: 'contains',
     text: 'contains (><)',
-    longDescription: ' containing '
+    longDescription: 'containing'
   },
   CONTAINS_PKG_NAME: {
     key: 'contains_pkg_name',
     text: 'contains (><)',
-    longDescription: ' contains package name '
+    longDescription: 'contains package name'
   },
   CONTAINS_PKG_LT_EVR: {
     key: 'contains_pkg_lt_evr',
     text: 'version lower than (<)',
-    longDescription: ' contains package with version lower than '
+    longDescription: 'contains package with version lower than'
   },
   CONTAINS_PKG_LE_EVR: {
     key: 'contains_pkg_le_evr',
     text: 'version lower or equal than (<=)',
-    longDescription: ' contains package with version lower or equal than '
+    longDescription: 'contains package with version lower or equal than'
   },
   CONTAINS_PKG_EQ_EVR: {
     key: 'contains_pkg_eq_evr',
     text: 'version equal (=)',
-    longDescription: ' contains package with version equal than '
+    longDescription: 'contains package with version equal than'
   },
   CONTAINS_PKG_GE_EVR: {
     key: 'contains_pkg_ge_evr',
     text: 'version greater or equal than (>=)',
-    longDescription: ' contains package with version greater or equal than '
+    longDescription: 'contains package with version greater or equal than'
   },
   CONTAINS_PKG_GT_EVR: {
     key: 'contains_pkg_gt_evr',
     text: 'version greater than (>)',
-    longDescription: ' contains package with version greater than '
+    longDescription: 'contains package with version greater than'
   },
   EQUALS: {
     key: 'equals',
     text: 'matches (=)',
-    longDescription: ' containing '
+    longDescription: 'matching'
   },
   GREATEREQ: {
     key: 'greatereq',
     text: 'greater or equal (>=)',
-    longDescription: ' greater or equal '
+    longDescription: 'greater or equal than'
   },
 
 };
@@ -139,5 +139,5 @@ function findFilterMatcherByKey(key: ?string): FilterMatcherType {
 
 export function getClmFilterDescription (filter: Object): string {
   const filterMatcher = findFilterMatcherByKey(filter.matcher);
-  return `${filter.name}: deny ${filter.entityType} ${filterMatcher.longDescription || ''} ${filter.criteriaValue} (${filter.criteriaKey})`;
+  return `${filter.name}: ${filter.rule} ${filter.entityType} ${filterMatcher.longDescription || ''} ${filter.criteriaValue} (${filter.criteriaKey})`;
 }

--- a/web/html/src/manager/content-management/shared/business/filters.enum.js
+++ b/web/html/src/manager/content-management/shared/business/filters.enum.js
@@ -24,12 +24,12 @@ export const filterEntity : FilterEntityEnumType = {
 export const filterMatchers : FilterMatcherEnumType = {
   CONTAINS: {
     key: 'contains',
-    text: 'contains (><)',
+    text: 'contains',
     longDescription: 'containing'
   },
   CONTAINS_PKG_NAME: {
     key: 'contains_pkg_name',
-    text: 'contains (><)',
+    text: 'contains',
     longDescription: 'contains package name'
   },
   CONTAINS_PKG_LT_EVR: {

--- a/web/html/src/manager/content-management/shared/business/filters.enum.js
+++ b/web/html/src/manager/content-management/shared/business/filters.enum.js
@@ -21,51 +21,51 @@ export const filterEntity : FilterEntityEnumType = {
   }
 };
 
-export const filterMatchers : FilterMatcherEnumType = {
+const filterMatchers : FilterMatcherEnumType = {
   CONTAINS: {
     key: 'contains',
-    text: 'contains',
-    longDescription: 'containing'
+    text: t('contains'),
+    longDescription: t('containing')
   },
   CONTAINS_PKG_NAME: {
     key: 'contains_pkg_name',
-    text: 'contains',
-    longDescription: 'contains package name'
+    text: t('contains'),
+    longDescription: t('contains package name')
   },
   CONTAINS_PKG_LT_EVR: {
     key: 'contains_pkg_lt_evr',
-    text: 'version lower than (<)',
-    longDescription: 'contains package with version lower than'
+    text: t('version lower than (<)'),
+    longDescription: t('contains package with version lower than')
   },
   CONTAINS_PKG_LE_EVR: {
     key: 'contains_pkg_le_evr',
-    text: 'version lower or equal than (<=)',
-    longDescription: 'contains package with version lower or equal than'
+    text: t('version lower or equal than (<=)'),
+    longDescription: t('contains package with version lower or equal than')
   },
   CONTAINS_PKG_EQ_EVR: {
     key: 'contains_pkg_eq_evr',
-    text: 'version equal (=)',
-    longDescription: 'contains package with version equal than'
+    text: t('version equal (=)'),
+    longDescription: t('contains package with version equal than')
   },
   CONTAINS_PKG_GE_EVR: {
     key: 'contains_pkg_ge_evr',
-    text: 'version greater or equal than (>=)',
-    longDescription: 'contains package with version greater or equal than'
+    text: t('version greater or equal than (>=)'),
+    longDescription: t('contains package with version greater or equal than')
   },
   CONTAINS_PKG_GT_EVR: {
     key: 'contains_pkg_gt_evr',
     text: 'version greater than (>)',
-    longDescription: 'contains package with version greater than'
+    longDescription: t('contains package with version greater than')
   },
   EQUALS: {
     key: 'equals',
-    text: 'matches (=)',
-    longDescription: 'matching'
+    text: t('matches (=)'),
+    longDescription: t('matching')
   },
   GREATEREQ: {
     key: 'greatereq',
-    text: 'greater or equal (>=)',
-    longDescription: 'greater or equal than'
+    text: t('greater or equal (>=)'),
+    longDescription: t('greater or equal than')
   },
 
 };
@@ -103,7 +103,7 @@ export const clmFilterOptions : ClmFilterOptionsEnumType = {
   },
   ISSUE_DATE: {
     key: 'issue_date',
-    text: t('Issued after'),
+    text: t('Issue date'),
     entityType: filterEntity.ERRATUM,
     matchers: [filterMatchers.GREATEREQ],
   },

--- a/web/html/src/manager/content-management/shared/business/filters.enum.js
+++ b/web/html/src/manager/content-management/shared/business/filters.enum.js
@@ -1,128 +1,143 @@
 //@flow
 import _find from "lodash/find";
-import {objectDefaultValueHandler} from "core/utils/objects";
-import type {ProjectFilterServerType} from "../type/project.type";
 
-export type FilterOptionType = {key: string, entityType: string, matcher: string, text: string}
-type FiltersOptionEnumType = { [key: string]: FilterOptionType }
+type FilterEntityType = { key: string, text: string };
+type FilterEntityEnumType = { [key: string]: FilterEntityType };
 
-const defaultState = {};
+export type FilterMatcherType =  {key: string, text: string, longDescription: string};
+type FilterMatcherEnumType = { [key: string]: FilterMatcherType };
 
-export const filtersOptionsEnum : FiltersOptionEnumType = new Proxy({
-    PACKAGE: {
-      key: 'package',
-      entityType: 'package',
-      matcher: 'contains',
-      text: 'Package (contains Name)',
-    },
-    PACKAGE_NEVRA: {
-      key: 'package_nevra',
-      entityType: 'package',
-      matcher: 'equals',
-      text: 'Package (matches NEVRA)',
-    },
-    ERRATUM: {
-      key: 'erratum',
-      entityType: 'erratum',
-      matcher: 'equals',
-      text: 'Patch (matches Advisory Name)',
-    },
-    ERRATUM_BYTYPE: {
-      key: 'erratum_bytype',
-      entityType: 'erratum',
-      matcher: 'equals',
-      text: 'Patch (matches Advisory Type)',
-    },
-    ERRATUM_BYDATE: {
-      key: 'erratum_bydate',
-      entityType: 'erratum',
-      matcher: 'greatereq',
-      text: 'Patch (issued after)',
-    },
-    ERRATUM_BYSYNOPSIS: {
-      key: 'erratum_bysynopsis',
-      entityType: 'erratum',
-      matcher: 'equals',
-      text: 'Patch (equals Synopsis)',
-    },
-    ERRATUM_BYSYNOPSIS_CONTAINS: {
-      key: 'erratum_bysynopsis_contains',
-      entityType: 'erratum',
-      matcher: 'contains',
-      text: 'Patch (contains Synopsis)',
-    },
-    ERRATUM_PKG_NAME: {
-      key: 'erratum_pkg_name',
-      entityType: 'erratum',
-      matcher: 'contains_pkg_name',
-      text: 'Patch contains package name',
-    },
-    ERRATUM_PKG_LT_EVR: {
-      key: 'erratum_pkg_lt_evr',
-      entityType: 'erratum',
-      matcher: 'contains_pkg_lt_evr',
-      text: 'Patch contains package with version lower than',
-    },
-    ERRATUM_PKG_LE_EVR: {
-      key: 'erratum_pkg_le_evr',
-      entityType: 'erratum',
-      matcher: 'contains_pkg_le_evr',
-      text: 'Patch contains package with version lower or equal than',
-    },
-    ERRATUM_PKG_EQ_EVR: {
-      key: 'erratum_pkg_eq_evr',
-      entityType: 'erratum',
-      matcher: 'contains_pkg_eq_evr',
-      text: 'Patch contains package with version equal',
-    },
-    ERRATUM_PKG_GE_EVR: {
-      key: 'erratum_pkg_ge_evr',
-      entityType: 'erratum',
-      matcher: 'contains_pkg_ge_evr',
-      text: 'Patch contains package with version greater or equal than',
-    },
-    ERRATUM_PKG_GT_EVR: {
-      key: 'erratum_pkg_gt_evr',
-      entityType: 'erratum',
-      matcher: 'contains_pkg_gt_evr',
-      text: 'Patch contains package with version greater than',
-    }
+export type ClmFilterOptionType = {key: string, entityType: FilterEntityType, matchers: Array<FilterMatcherType>, text: string}
+type ClmFilterOptionsEnumType = { [key: string]: ClmFilterOptionType }
+
+export const filterEntity : FilterEntityEnumType = {
+  PACKAGE: {
+    key: 'package',
+    text: t('Package')
   },
-  objectDefaultValueHandler(defaultState)
-);
-
-function getFiltersOptions(): Array<FilterOptionType> {
-  return (Object.values(filtersOptionsEnum): any);
-}
-
-function findByKey(key: string): FilterOptionType {
-  return _find(filtersOptionsEnum, entry => entry.key === key) || defaultState;
-}
-
-function getFilterDescription (filter: Object): string {
-  const matcherDescription = {
-    equals: " matching ",
-    contains: " containing ",
-    greatereq: " greater or equal ",
-    contains_pkg_name: " contains package name ",
-    contains_pkg_lt_evr: " contains package with version lower than ",
-    contains_pkg_le_evr: " contains package with version lower or equal than ",
-    contains_pkg_eq_evr: " contains package with version equal than ",
-    contains_pkg_ge_evr: " contains package with version greater or equal than ",
-    contains_pkg_gt_evr: " contains package with version greater than "
+  ERRATUM: {
+    key: 'erratum',
+    text: t('Patch')
   }
+};
 
-  return `${filter.name}: deny ${filter.entityType} ${matcherDescription[filter.matcher] || ""} ${filter.criteriaValue} (${filter.criteriaKey})`;
+export const filterMatchers : FilterMatcherEnumType = {
+  CONTAINS: {
+    key: 'contains',
+    text: 'contains (><)',
+    longDescription: ' containing '
+  },
+  CONTAINS_PKG_NAME: {
+    key: 'contains_pkg_name',
+    text: 'contains (><)',
+    longDescription: ' contains package name '
+  },
+  CONTAINS_PKG_LT_EVR: {
+    key: 'contains_pkg_lt_evr',
+    text: 'version lower than (<)',
+    longDescription: ' contains package with version lower than '
+  },
+  CONTAINS_PKG_LE_EVR: {
+    key: 'contains_pkg_le_evr',
+    text: 'version lower or equal than (<=)',
+    longDescription: ' contains package with version lower or equal than '
+  },
+  CONTAINS_PKG_EQ_EVR: {
+    key: 'contains_pkg_eq_evr',
+    text: 'version equal (=)',
+    longDescription: ' contains package with version equal than '
+  },
+  CONTAINS_PKG_GE_EVR: {
+    key: 'contains_pkg_ge_evr',
+    text: 'version greater or equal than (>=)',
+    longDescription: ' contains package with version greater or equal than '
+  },
+  CONTAINS_PKG_GT_EVR: {
+    key: 'contains_pkg_gt_evr',
+    text: 'version greater than (>)',
+    longDescription: ' contains package with version greater than '
+  },
+  EQUALS: {
+    key: 'equals',
+    text: 'matches (=)',
+    longDescription: ' containing '
+  },
+  GREATEREQ: {
+    key: 'greatereq',
+    text: 'greater or equal (>=)',
+    longDescription: ' greater or equal '
+  },
+
+};
+
+export const clmFilterOptions : ClmFilterOptionsEnumType = {
+  NAME: {
+    key: 'name',
+    text: t('name'),
+    entityType: filterEntity.PACKAGE,
+    matchers: [filterMatchers.CONTAINS],
+  },
+  NEVRA: {
+    key: 'nevra',
+    text: t('NEVRA'),
+    entityType: filterEntity.PACKAGE,
+    matchers: [filterMatchers.EQUALS]
+  },
+  ADVISORY_NAME: {
+    key: 'advisory_name',
+    text: t('Advisory Name'),
+    entityType: filterEntity.ERRATUM,
+    matchers: [filterMatchers.EQUALS]
+  },
+  ADVISORY_TYPE: {
+    key: 'advisory_type',
+    text: t('Advisory Type'),
+    entityType: filterEntity.ERRATUM,
+    matchers: [filterMatchers.EQUALS]
+  },
+  SYNOPSIS: {
+    key: 'synopsis',
+    text: t('synopsis'),
+    entityType: filterEntity.ERRATUM,
+    matchers: [filterMatchers.EQUALS, filterMatchers.CONTAINS]
+  },
+  ISSUE_DATE: {
+    key: 'issue_date',
+    text: t('issued after'),
+    entityType: filterEntity.ERRATUM,
+    matchers: [filterMatchers.GREATEREQ],
+  },
+  PACKAGE_NAME: {
+    key: 'package_name',
+    text: t('contains Package Name'),
+    entityType: filterEntity.ERRATUM,
+    matchers: [filterMatchers.CONTAINS_PKG_NAME]
+  },
+  PACKAGE_NEVR: {
+    key: 'package_nevr',
+    text: t('contains Package'),
+    entityType: filterEntity.ERRATUM,
+    matchers: [
+      filterMatchers.CONTAINS_PKG_LT_EVR, filterMatchers.CONTAINS_PKG_LE_EVR,
+      filterMatchers.CONTAINS_PKG_EQ_EVR, filterMatchers.CONTAINS_PKG_GE_EVR,
+      filterMatchers.CONTAINS_PKG_GT_EVR
+    ]
+  }
+};
+
+export function findClmFilterByKey(key: ?string): ?ClmFilterOptionType  {
+  return _find(clmFilterOptions, entry => entry.key === key);
 }
 
-export default ({
-  enum: filtersOptionsEnum,
-  findByKey,
-  getFiltersOptions,
-  getFilterDescription
-}: {
-  enum: FiltersOptionEnumType,
-  findByKey: (string) => FilterOptionType,
-  getFiltersOptions: () => Array<FilterOptionType>,
-  getFilterDescription: (ProjectFilterServerType) => string
-});
+export function getClmFiltersOptions(): Array<ClmFilterOptionType> {
+  return (Object.values(clmFilterOptions): any);
+}
+
+function findFilterMatcherByKey(key: ?string): FilterMatcherType {
+  return _find(filterMatchers, entry => entry.key === key) || {};
+}
+
+export function getClmFilterDescription (filter: Object): string {
+  const filterMatcher = findFilterMatcherByKey(filter.matcher);
+  return `${filter.name}: deny ${filter.entityType} ${filterMatcher.longDescription || ''} ${filter.criteriaValue} (${filter.criteriaKey})`;
+}

--- a/web/html/src/manager/content-management/shared/business/filters.enum.js
+++ b/web/html/src/manager/content-management/shared/business/filters.enum.js
@@ -73,7 +73,7 @@ export const filterMatchers : FilterMatcherEnumType = {
 export const clmFilterOptions : ClmFilterOptionsEnumType = {
   NAME: {
     key: 'name',
-    text: t('name'),
+    text: t('Name'),
     entityType: filterEntity.PACKAGE,
     matchers: [filterMatchers.CONTAINS],
   },
@@ -97,25 +97,25 @@ export const clmFilterOptions : ClmFilterOptionsEnumType = {
   },
   SYNOPSIS: {
     key: 'synopsis',
-    text: t('synopsis'),
+    text: t('Synopsis'),
     entityType: filterEntity.ERRATUM,
     matchers: [filterMatchers.EQUALS, filterMatchers.CONTAINS]
   },
   ISSUE_DATE: {
     key: 'issue_date',
-    text: t('issued after'),
+    text: t('Issued after'),
     entityType: filterEntity.ERRATUM,
     matchers: [filterMatchers.GREATEREQ],
   },
   PACKAGE_NAME: {
     key: 'package_name',
-    text: t('contains Package Name'),
+    text: t('Contains Package Name'),
     entityType: filterEntity.ERRATUM,
     matchers: [filterMatchers.CONTAINS_PKG_NAME]
   },
   PACKAGE_NEVR: {
     key: 'package_nevr',
-    text: t('contains Package'),
+    text: t('Contains Package'),
     entityType: filterEntity.ERRATUM,
     matchers: [
       filterMatchers.CONTAINS_PKG_LT_EVR, filterMatchers.CONTAINS_PKG_LE_EVR,

--- a/web/html/src/manager/content-management/shared/business/filters.enum.test.js
+++ b/web/html/src/manager/content-management/shared/business/filters.enum.test.js
@@ -1,0 +1,128 @@
+import {getClmFilterDescription} from "./filters.enum";
+
+describe('Testing filters enum and descriptions', () => {
+  test('test filter package name description', () => {
+    const filter = {
+      name: "filter by package name",
+      criteriaKey: "name",
+      criteriaValue: "package name",
+      entityType: "package",
+      rule: "deny",
+      matcher: "contains"
+    }
+
+    expect(getClmFilterDescription(filter)).toEqual("filter by package name: deny package containing package name (name)")
+  });
+
+  test('test filter NEVRA description', () => {
+    const filter = {
+      name: "filter by nevra name",
+      criteriaKey: "nevra",
+      criteriaValue: "asd-123:123-123.123",
+      entityType: "package",
+      rule: "allow",
+      matcher: "equals"
+    }
+
+    expect(getClmFilterDescription(filter)).toEqual("filter by nevra name: allow package matching asd-123:123-123.123 (nevra)")
+    filter.criteriaKey = "nevr";
+    filter.criteriaValue = "asd-123-123";
+    filter.rule = "deny";
+    expect(getClmFilterDescription(filter)).toEqual("filter by nevra name: deny package matching asd-123-123 (nevr)")
+  });
+
+  test('test filter advisory name description', () => {
+    const filter = {
+      name: "filter by advisory name",
+      criteriaKey: "advisory_name",
+      criteriaValue: "advisory_name_12",
+      entityType: "patch",
+      rule: "allow",
+      matcher: "equals"
+    }
+
+    expect(getClmFilterDescription(filter)).toEqual("filter by advisory name: allow patch matching advisory_name_12 (advisory_name)")
+  });
+
+  test('test filter advisory type description', () => {
+    const filter = {
+      name: "filter by advisory type",
+      criteriaKey: "advisory_type",
+      criteriaValue: "Security Advisory",
+      entityType: "patch",
+      rule: "allow",
+      matcher: "equals"
+    }
+
+    expect(getClmFilterDescription(filter)).toEqual("filter by advisory type: allow patch matching Security Advisory (advisory_type)")
+    filter.criteriaValue = "Product Enhancement Advisory";
+    filter.rule = "deny";
+    expect(getClmFilterDescription(filter)).toEqual("filter by advisory type: deny patch matching Product Enhancement Advisory (advisory_type)")
+  });
+
+  test('test filter synopsis description', () => {
+    const filter = {
+      name: "filter by synopsis type",
+      criteriaKey: "synopsis",
+      criteriaValue: "namesynopsis_123",
+      entityType: "patch",
+      rule: "allow",
+      matcher: "equals"
+    }
+
+    expect(getClmFilterDescription(filter)).toEqual("filter by synopsis type: allow patch matching namesynopsis_123 (synopsis)")
+    filter.criteriaValue = "namesynopsis_1234";
+    filter.matcher = "contains";
+    filter.rule = "deny";
+    expect(getClmFilterDescription(filter)).toEqual("filter by synopsis type: deny patch containing namesynopsis_1234 (synopsis)")
+  });
+
+  test('test patch by date description', () => {
+    const filter = {
+      name: "filter by date",
+      criteriaKey: "issue_date",
+      criteriaValue: "2018-09-10T00:00+01:00",
+      entityType: "patch",
+      rule: "deny",
+      matcher: "greatereq"
+    }
+
+    expect(getClmFilterDescription(filter)).toEqual("filter by date: deny patch greater or equal than 2018-09-10T00:00+01:00 (issue_date)")
+  });
+
+  test('test Patch (contains Package) - package_nevr - description', () => {
+    const filter = {
+      name: "filter contains package name",
+      criteriaKey: "package_nevr",
+      criteriaValue: "asd 123:123-123",
+      entityType: "patch",
+      rule: "allow",
+      matcher: "contains_pkg_lt_evr"
+    }
+
+    expect(getClmFilterDescription(filter)).toEqual("filter contains package name: allow patch contains package with version lower than asd 123:123-123 (package_nevr)")
+    filter.matcher = "contains_pkg_le_evr";
+    filter.rule = "deny";
+    expect(getClmFilterDescription(filter)).toEqual("filter contains package name: deny patch contains package with version lower or equal than asd 123:123-123 (package_nevr)")
+    filter.matcher = "contains_pkg_eq_evr";
+    expect(getClmFilterDescription(filter)).toEqual("filter contains package name: deny patch contains package with version equal than asd 123:123-123 (package_nevr)")
+    filter.matcher = "contains_pkg_ge_evr";
+    expect(getClmFilterDescription(filter)).toEqual("filter contains package name: deny patch contains package with version greater or equal than asd 123:123-123 (package_nevr)")
+    filter.matcher = "contains_pkg_gt_evr";
+    expect(getClmFilterDescription(filter)).toEqual("filter contains package name: deny patch contains package with version greater than asd 123:123-123 (package_nevr)")
+  });
+
+  test('test Patch (contains Package Name) - package_name', () => {
+    const filter = {
+      name: "filter patch contains package name",
+      criteriaKey: "package_name",
+      criteriaValue: "package name",
+      entityType: "patch",
+      rule: "allow",
+      matcher: "contains"
+    };
+
+    expect(getClmFilterDescription(filter)).toEqual("filter patch contains package name: allow patch containing package name (package_name)");
+  })
+});
+

--- a/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-view.js
+++ b/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-view.js
@@ -1,5 +1,4 @@
 //@flow
-/* global moment */
 import React from 'react';
 import _isEmpty from "lodash/isEmpty"
 

--- a/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project-selection.js
+++ b/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project-selection.js
@@ -6,7 +6,7 @@ import useLifecycleActionsApi from "../../../api/use-lifecycle-actions-api";
 import type {ProjectFilterServerType} from "../../../type/project.type";
 import {Loading} from "components/loading/loading";
 import _xor from "lodash/xor";
-import filtersEnum from "../../../business/filters.enum";
+import {getClmFilterDescription} from "../../../business/filters.enum";
 
 type FiltersProps = {
   projectId: string,
@@ -60,7 +60,7 @@ const FiltersProjectSelection = (props:  FiltersProps): Node => {
             />
             <label
               htmlFor={"child_" + filter.id}>
-              {filtersEnum.getFilterDescription(filter)}
+              {getClmFilterDescription(filter)}
             </label>
           </div>
       )

--- a/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project.js
+++ b/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project.js
@@ -9,7 +9,7 @@ import CreatorPanel from "components/panels/CreatorPanel";
 import type {ProjectFilterServerType} from "../../../type/project.type";
 import FiltersProjectSelection from "./filters-project-selection";
 import statesEnum from "../../../business/states.enum";
-import filtersEnum from "../../../business/filters.enum";
+import {getClmFilterDescription} from "../../../business/filters.enum";
 import useRoles from "core/auth/use-roles";
 import {isOrgAdmin} from "core/auth/auth.utils";
 
@@ -20,7 +20,7 @@ type FiltersProps = {
 };
 
 const renderFilterEntry = (filter, projectId) => {
-  const descr = filtersEnum.getFilterDescription(filter);
+  const descr = getClmFilterDescription(filter);
   const filterButton =
     <div className={styles.icon_wrapper_vertical_center}>
       <LinkButton

--- a/web/html/src/manager/content-management/shared/type/filter.type.js
+++ b/web/html/src/manager/content-management/shared/type/filter.type.js
@@ -3,9 +3,9 @@ export type FilterServerType = {
   entityType: string,
   matcher: string,
   id: number,
-  name?: string,
-  criteriaKey?: string,
-  criteriaValue?: string,
+  name: string,
+  criteriaKey: string,
+  criteriaValue: string,
   rule: string,
   projects?: Array<string>
 }
@@ -15,7 +15,7 @@ export type FilterFormType = {
   matcher: string,
   rule: string,
   id?: number,
-  filter_name?: string,
+  filter_name: string,
   projects?: Array<string>,
   packageName?: string,
   epoch?: string,

--- a/web/html/src/manager/content-management/shared/type/filter.type.js
+++ b/web/html/src/manager/content-management/shared/type/filter.type.js
@@ -15,7 +15,7 @@ export type FilterFormType = {
   matcher: string,
   rule: string,
   id?: number,
-  name?: string,
+  filter_name?: string,
   projects?: Array<string>,
   packageName?: string,
   epoch?: string,

--- a/web/html/src/testSetupFile.js
+++ b/web/html/src/testSetupFile.js
@@ -1,1 +1,8 @@
 global.t = string => string;
+
+global.Loggerhead = {
+  error: (string) => {console.log(string)},
+  warning: (string) => {console.log(string)},
+  debug: (string) => {console.log(string)},
+  info: (string) => {console.log(string)}
+}

--- a/web/html/src/testSetupFile.js
+++ b/web/html/src/testSetupFile.js
@@ -1,0 +1,1 @@
+global.t = string => string;


### PR DESCRIPTION
## What does this PR change?

- [x] [WIP] - Missing javascript unit tests for mappers+enums

- [x] Refactor filter UI enum and extract Matchers from filter dropdown 

- [x] fix bug on \<Form /\> when you have dynamic fields with the same name. We can't rely on the order of componentWillUnmount to unregister the old input: https://github.com/facebook/react/issues/11106 - basically the componentWillUnmount of the old field was unregistering the second new field, because they had the same name.

## GUI diff

![Screenshot from 2019-08-15 13-17-48](https://user-images.githubusercontent.com/1140720/63094168-87a44980-bf5f-11e9-9a33-3c6496bd8e3a.png)
![Screenshot from 2019-08-15 13-17-36](https://user-images.githubusercontent.com/1140720/63094170-87a44980-bf5f-11e9-97b2-962ebd5493d0.png)
![Screenshot from 2019-08-15 13-17-26](https://user-images.githubusercontent.com/1140720/63094171-87a44980-bf5f-11e9-96d0-31944aab6759.png)


- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test" 
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
