### PR TITLE
No longer symlink xml-commons-apis.jar

### DIFF
--- a/java/buildconf/build-props.xml
+++ b/java/buildconf/build-props.xml
@@ -124,7 +124,7 @@
   <property name="run.jar.dependencies"
       value="antlr objectweb-asm/asm cglib c3p0 commons-discovery dom4j jaf jta ojdbc14 sitemesh
              taglibs-standard-impl taglibs-standard-jstlel taglibs-standard-spec
-             xalan-j2 xalan-j2-serializer xerces-j2 xml-commons-apis ${common.jar.dependencies}" />
+             xalan-j2 xalan-j2-serializer xerces-j2 ${common.jar.dependencies}" />
 
   <!-- =================== RPM build, use jpackage syntax ======================= -->
   <!-- property name="install.test.jar.dependencies"
@@ -146,7 +146,7 @@
   <property name="install.run.jar.dependencies"
       value="antlr objectweb-asm/asm cglib c3p0 commons-discovery dom4j dwr jaf jta sitemesh
              taglibs-standard-impl taglibs-standard-jstlel taglibs-standard-spec
-             xalan-j2 xalan-j2-serializer xerces-j2 xml-commons-apis ${install.common.jar.dependencies}" />
+             xalan-j2 xalan-j2-serializer xerces-j2 ${install.common.jar.dependencies}" />
 
   <property name="install.common.jar.dependencies"
       value="bcel cglib commons-beanutils commons-cli commons-codec
@@ -171,7 +171,7 @@
              taglibs-standard-impl taglibs-standard-jstlel taglibs-standard-spec
              postgresql-jdbc snakeyaml simple-xml
              ${suse-common-jars} ${suse-runtime-jars}
-	     xalan-j2 xalan-j2-serializer xerces-j2 xml-commons-apis simple-core ${ehcache}" />
+	     xalan-j2 xalan-j2-serializer xerces-j2 simple-core ${ehcache}" />
 
   <property name="taskomatic.jar.dependencies"
       value="${dist.jar.dependencies} jsch" />


### PR DESCRIPTION
## What does this PR change?

This patch is a fixup for #1289. It takes care that no symlink is created for `xml-commons-apis` in order to fix the following build error:

```
[ 293s] error: Installed (but unpackaged) file(s) found:
[ 293s] /srv/tomcat/webapps/rhn/WEB-INF/lib/xml-commons-apis.jar
```

## GUI diff

No difference.

## Documentation

No documentation needed.

## Test coverage

No tests needed.

## Links

Fixup for #1289

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
