### PR TITLE
Revert the naming of content management handler and align the XMLRPC API doc

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
@@ -45,7 +45,7 @@ import static java.util.Optional.ofNullable;
 /**
  * Content Management XMLRPC handler
  *
- * @xmlrpc.namespace contentmgmt
+ * @xmlrpc.namespace contentmanagement
  * @xmlrpc.doc Provides methods to access and modify Content Lifecycle Management related entities
  * (Projects, Environments, Filters, Sources).
  */

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/handler-manifest.xml
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/handler-manifest.xml
@@ -10,7 +10,7 @@
   <template name="channel.org" classname="com.redhat.rhn.frontend.xmlrpc.channel.org.ChannelOrgHandler"/>
   <template name="channel.software" classname="com.redhat.rhn.frontend.xmlrpc.channel.software.ChannelSoftwareHandler"/>
   <template name="configchannel" classname="com.redhat.rhn.frontend.xmlrpc.configchannel.ConfigChannelHandler"/>
-  <template name="contentmgmt" classname="com.redhat.rhn.frontend.xmlrpc.contentmgmt.ContentManagementHandler"/>
+  <template name="contentmanagement" classname="com.redhat.rhn.frontend.xmlrpc.contentmgmt.ContentManagementHandler"/>
   <template name="distchannel" classname="com.redhat.rhn.frontend.xmlrpc.distchannel.DistChannelHandler" />
   <template name="errata" classname="com.redhat.rhn.frontend.xmlrpc.errata.ErrataHandler" />
   <template name="formula" classname="com.redhat.rhn.frontend.xmlrpc.formula.FormulaHandler" />

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,6 +1,6 @@
+- Fix documentation of contentmanagement handler (bsc#1145753)
 - Add new API endpoint to list available Filter Criteria
 - improve API documentation of Filter Criteria
-- Fix registration of contentmgmt handler (bsc#1145753)
 - implement "patch contains package" Filter for Content Lifecycle Management
 - implement Filter Patch "by type" Content Lifecycle Management
 - Improve websocket authentication to prevent errors in logs (bsc#1138454)


### PR DESCRIPTION
## What does this PR change?

Originally, the endpoint was prefixed with `contentmanagement` string, but the documentation pointed to `contentmgmt`.
In https://github.com/uyuni-project/uyuni/pull/1295, this was aligned to `contentmgmt`, but the released code already used `contentmanagement`.

This PR unifies the naming to `contentmanagement`.

## TODO
- [x] check building docs
- [ ] port to 4.0

## GUI diff

No difference.
- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
- No tests in that area.

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"