### PR TITLE
Enable Kiwi NG on SLE15

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
@@ -127,7 +127,7 @@ public class MinionServer extends Server implements SaltConfigurable {
      * Return <code>true</code> if OS on this system supports OS Image building,
      * <code>false</code> otherwise.
      * <p>
-     * Note: For SLES, we are only checking if it's not 10 nor 11 nor 15.
+     * Note: For SLES, we are only checking if it's not 10.
      * Older than SLES 10 are not being checked.
      * </p>
      *
@@ -135,7 +135,7 @@ public class MinionServer extends Server implements SaltConfigurable {
      */
     @Override
     public boolean doesOsSupportsOSImageBuilding() {
-        return !isSLES10() && !isSLES15();
+        return !isSLES10();
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- enable Kiwi NG on SLE15
 - allow ssl connections from Tomcat to Postgres (bsc#1149210)
 - use default in case taskomatic.java.maxmemory is unset
 - fix parsing of /etc/rhn/rhn.conf for taskomatic.java.maxmemory (bsc#1151097)

--- a/susemanager-utils/susemanager-sls/salt/images/kiwi-image-build.sls
+++ b/susemanager-utils/susemanager-sls/salt/images/kiwi-image-build.sls
@@ -13,7 +13,6 @@
 {%- set bundle_dir = root_dir + '/images/' %}
 {%- set bundle_id  = pillar.get('build_id') %}
 {%- set activation_key = pillar.get('activation_key') %}
-{%- set kiwi_help = salt['cmd.run']('kiwi --help') %}
 
 # on SLES11 and SLES12 use legacy Kiwi, use Kiwi NG elsewhere
 {%- set use_kiwi_ng = not (salt['grains.get']('osfullname') == 'SLES' and salt['grains.get']('osmajorrelease')|int() < 15) %}
@@ -77,6 +76,7 @@ mgr_buildimage_kiwi_bundle:
 # KIWI Legacy
 #
 
+{%- set kiwi_help = salt['cmd.run']('kiwi --help') %}
 {%- set have_bundle_build = kiwi_help.find('--bundle-build') > 0 %}
 
 # i586 build on x86_64 host must be called with linux32

--- a/susemanager-utils/susemanager-sls/salt/images/kiwi-image-build.sls
+++ b/susemanager-utils/susemanager-sls/salt/images/kiwi-image-build.sls
@@ -41,9 +41,13 @@ mgr_buildimage_prepare_activation_key_in_source:
 #
 {%- set kiwi = 'kiwi-ng' %}
 
+{%- set profile_opt = '' %}
+{%- if pillar.get('kiwi_profile') %}
+{%-   set profile_opt = '--profile ' + pillar.get('kiwi_profile') %}
+{%- endif %}
 
 {%- macro kiwi_params() -%}
-  --add-repo file:{{ common_repo }},rpm-dir,common_repo,90,false,false {{ ' ' }}
+  --ignore-repos-used-for-build --add-repo file:{{ common_repo }},rpm-dir,common_repo,90,false,false --add-bootstrap-package rhn-org-trusted-ssl-cert-osimage {{ ' ' }}
 {%- for repo in pillar.get('kiwi_repositories') -%}
   --add-repo {{ repo }},rpm-md,key_repo{{ loop.index }},90,false,false {{ ' ' }}
 {%- endfor -%}
@@ -51,14 +55,14 @@ mgr_buildimage_prepare_activation_key_in_source:
 
 mgr_buildimage_kiwi_prepare:
   cmd.run:
-    - name: "{{ kiwi }} --logfile={{ root_dir }}/prepare.log  system prepare --description {{ source_dir }} --root {{ chroot_dir }} {{ kiwi_params() }}"
+    - name: "{{ kiwi }} --logfile={{ root_dir }}/prepare.log {{ profile_opt }} system prepare --description {{ source_dir }} --root {{ chroot_dir }} {{ kiwi_params() }}"
     - require:
       - module: mgr_buildimage_prepare_source
       - file: mgr_buildimage_prepare_activation_key_in_source
 
 mgr_buildimage_kiwi_create:
   cmd.run:
-    - name: "{{ kiwi }} --logfile={{ root_dir }}/create.log system create --root {{ chroot_dir }} --target-dir  {{ dest_dir }}"
+    - name: "{{ kiwi }} --logfile={{ root_dir }}/create.log {{ profile_opt }} system create --root {{ chroot_dir }} --target-dir  {{ dest_dir }}"
     - require:
       - cmd: mgr_buildimage_kiwi_prepare
 

--- a/susemanager-utils/susemanager-sls/src/modules/kiwi_info.py
+++ b/susemanager-utils/susemanager-sls/src/modules/kiwi_info.py
@@ -75,6 +75,10 @@ def parse_kiwi_result(dest):
     ret = {}
     if __salt__['file.file_exists'](path):
         try:
+            # pickle depends on availability of python kiwi modules
+            # which are not under our control so there is certain risk of failure
+            # return empty dict in such case
+            # the caller should handle all values as optional
             with open(path, 'rb') as f:
                 result = pickle.load(f)
                 ret['arch'] = result.xml_state.host_architecture
@@ -84,8 +88,8 @@ def parse_kiwi_result(dest):
                 ret['initrd_system'] = result.xml_state.build_type.initrd_system
         except:
             log.exception("Loading kiwi.result")
+            # continue with empty dict
     return ret
-
 
 def parse_packages(path):
     ret = []

--- a/susemanager-utils/susemanager-sls/src/modules/kiwi_info.py
+++ b/susemanager-utils/susemanager-sls/src/modules/kiwi_info.py
@@ -2,6 +2,8 @@ import salt.exceptions
 import logging
 import os
 import re
+import hashlib
+import pickle
 
 log = logging.getLogger(__name__)
 
@@ -37,22 +39,53 @@ def parse_buildinfo(dest):
                 group[match.group('name')] = match.group('val')
     return ret
 
-# fallback for SLES11 Kiwi that does not create the buildinfo file
+# fallback for SLES11 Kiwi and for Kiwi NG that does not create the buildinfo file
 def guess_buildinfo(dest):
     ret = {'main': {}}
     files = __salt__['file.readdir'](dest)
 
     pattern_basename = re.compile(r"^(?P<basename>.*)\.packages$")
-    pattern_pxe = re.compile(r"^initrd-netboot")
+    pattern_pxe_initrd = re.compile(r"^initrd-netboot.*")
+    pattern_pxe_kiwi_ng_initrd = re.compile(r".*\.initrd\..*")
+    pattern_pxe_kernel = re.compile(r".*\.kernel\..*")
+    pattern_pxe_kiwi_ng_kernel = re.compile(r".*\.kernel$")
+    have_kernel = False
+    have_initrd = False
+
     for f in files:
         match = pattern_basename.match(f)
         if match:
             ret['main']['image.basename'] = match.group('basename')
 
-        match = pattern_pxe.match(f)
+        match = pattern_pxe_initrd.match(f) or pattern_pxe_kiwi_ng_initrd.match(f)
         if match:
-            ret['main']['image.type'] = 'pxe'
+            have_initrd = True
+
+        match = pattern_pxe_kernel.match(f) or pattern_pxe_kiwi_ng_kernel.match(f)
+        if match:
+            have_kernel = True
+
+    if have_kernel and have_initrd:
+        ret['main']['image.type'] = 'pxe'
     return ret
+
+# Kiwi NG
+def parse_kiwi_result(dest):
+    path = os.path.join(dest, 'kiwi.result')
+    ret = {}
+    if __salt__['file.file_exists'](path):
+        try:
+            with open(path, 'rb') as f:
+                result = pickle.load(f)
+                ret['arch'] = result.xml_state.host_architecture
+                ret['basename'] = result.xml_state.xml_data.name
+                ret['type'] = result.xml_state.build_type.image
+                ret['filesystem'] = result.xml_state.build_type.filesystem
+                ret['initrd_system'] = result.xml_state.build_type.initrd_system
+        except:
+            log.exception("Loading kiwi.result")
+    return ret
+
 
 def parse_packages(path):
     ret = []
@@ -75,6 +108,14 @@ def parse_packages(path):
                 ret.append(d)
     return ret
 
+def get_md5(path):
+    res = {}
+    if not __salt__['file.file_exists'](path):
+        return res
+
+    res['hash'] = __salt__['file.get_hash'](path, form='md5')
+    res['size'] = __salt__['file.stats'](path).get('size')
+    return res
 
 def parse_kiwi_md5(path, compressed = False):
     res = {}
@@ -109,9 +150,11 @@ _compression_types = [
 def image_details(dest, bundle_dest = None):
     res = {}
     buildinfo = parse_buildinfo(dest) or guess_buildinfo(dest)
+    kiwiresult = parse_kiwi_result(dest)
 
     basename = buildinfo.get('main', {}).get('image.basename', '')
-    image_type = buildinfo.get('main', {}).get('image.type', 'unknown')
+    image_type = kiwiresult.get('type') or buildinfo.get('main', {}).get('image.type', 'unknown')
+    fstype = kiwiresult.get('filesystem')
 
     pattern = re.compile(r"^(?P<name>.*)\.(?P<arch>.*)-(?P<version>.*)$")
     match = pattern.match(basename)
@@ -141,7 +184,8 @@ def image_details(dest, bundle_dest = None):
         'version': version,
         'compression': compression,
         'filename': filename,
-        'filepath': filepath
+        'filepath': filepath,
+        'fstype': fstype
     }
 
     res['image'].update(parse_kiwi_md5(os.path.join(dest, basename + '.md5'), compression is not None))
@@ -178,6 +222,7 @@ def inspect_boot_image(dest):
     files = __salt__['file.readdir'](dest)
 
     pattern = re.compile(r"^(?P<name>.*)\.(?P<arch>.*)-(?P<version>.*)\.kernel\.(?P<kernelversion>.*)\.md5$")
+    pattern_kiwi_ng = re.compile(r"^(?P<name>[^-]*)\.(?P<arch>[^-]*)-(?P<version>[^-]*)-(?P<kernelversion>.*)\.kernel$")
     for f in files:
         match = pattern.match(f)
         if match:
@@ -191,7 +236,24 @@ def inspect_boot_image(dest):
                     },
                 'kernel': {
                     'version': match.group('kernelversion')
-                }
+                    },
+                'kiwi_ng': False
+            }
+            break
+        match = pattern_kiwi_ng.match(f)
+        if match:
+            basename = match.group('name') + '.' + match.group('arch') + '-' + match.group('version')
+            res = {
+                'name': match.group('name'),
+                'arch': match.group('arch'),
+                'basename': basename,
+                'initrd': {
+                    'version': match.group('version')
+                    },
+                'kernel': {
+                    'version': match.group('kernelversion')
+                },
+                'kiwi_ng': True
             }
             break
 
@@ -199,17 +261,29 @@ def inspect_boot_image(dest):
         return None
 
     for c in _compression_types:
-        path = os.path.join(dest, basename + c['suffix'])
-        if __salt__['file.file_exists'](path):
-            res['initrd']['filename'] = basename + c['suffix']
+        if res['kiwi_ng']:
+            path = basename + '.initrd' + c['suffix']
+        else:
+            path = basename + c['suffix']
+        if __salt__['file.file_exists'](os.path.join(dest, path)):
+            res['initrd']['filename'] = path
+
+            if res['kiwi_ng']:
+                res['initrd'].update(get_md5(os.path.join(dest, path)))
+            else:
+                res['initrd'].update(parse_kiwi_md5(os.path.join(dest, basename + '.md5')))
             break
 
-    res['initrd'].update(parse_kiwi_md5(os.path.join(dest, basename + '.md5')))
-
-    path = os.path.join(dest, basename + '.kernel.' + res['kernel']['version'])
-    if __salt__['file.file_exists'](path):
-        res['kernel']['filename'] = basename + '.kernel.' + res['kernel']['version']
-        res['kernel'].update(parse_kiwi_md5(path + '.md5'))
+    if res['kiwi_ng']:
+        path = os.path.join(dest, basename + '-' + res['kernel']['version'] + '.kernel')
+        if __salt__['file.file_exists'](path):
+            res['kernel']['filename'] = basename + '-' + res['kernel']['version'] + '.kernel'
+            res['kernel'].update(get_md5(path))
+    else:
+        path = os.path.join(dest, basename + '.kernel.' + res['kernel']['version'])
+        if __salt__['file.file_exists'](path):
+            res['kernel']['filename'] = basename + '.kernel.' + res['kernel']['version']
+            res['kernel'].update(parse_kiwi_md5(path + '.md5'))
 
     return res
 
@@ -217,7 +291,7 @@ def inspect_bundle(dest, basename):
     res = None
     files = __salt__['file.readdir'](dest)
 
-    pattern = re.compile(r"^(?P<basename>" + re.escape(basename) + r")-(?P<id>.*)\.(?P<suffix>[^.]*)\.sha256$")
+    pattern = re.compile(r"^(?P<basename>" + re.escape(basename) + r")-(?P<id>[^.]*)\.(?P<suffix>.*)\.sha256$")
     for f in files:
         match = pattern.match(f)
         if match:
@@ -235,5 +309,14 @@ def inspect_bundle(dest, basename):
         d['hash'] = 'sha256:{0}'.format(d['hash'])
         res.update(d)
         res['filepath'] = os.path.join(dest, res['filename'])
+
+    else:
+        # only hash without file name
+        pattern = re.compile(r"^(?P<hash>[0-9a-f]+)$")
+        match = pattern.match(sha256_str)
+        if match:
+            res['hash'] = 'sha256:{0}'.format(match.groupdict()['hash'])
+            res['filename'] = sha256_file[0:-len('.sha256')]
+            res['filepath'] = os.path.join(dest, res['filename'])
 
     return res

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- enable Kiwi NG on SLE15
 - disable legacy startup events for new minions
 - implement provisioning for salt clients
 - Bootstrapping RES6/RHEL6/SLE11 with TLS1.2 now shows error message. (bsc#1147126)


### PR DESCRIPTION
## What does this PR change?

Enable Kiwi NG on SLE15.
Image build sls has been updated to handle Kiwi NG command line.
Image inspect sls has been updated to handle output from  Kiwi NG.

## GUI diff

No difference.

## Documentation
- TBD: Devel Tools module must be added to the machine before enabling image build host on SLES15

- [ ] **DONE**

## Test coverage
- TBD
- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/8316

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
