### PR TITLE
Re-enable "abort all sync" feature

### DIFF
--- a/testsuite/run_sets/reposync.yml
+++ b/testsuite/run_sets/reposync.yml
@@ -12,6 +12,6 @@
 - features/reposync/srv_sync_channels.feature
 - features/reposync/srv_sync_products.feature
 - features/reposync/srv_enable_sync_products.feature
-#- features/reposync/srv_abort_all_sync.feature
+- features/reposync/srv_abort_all_sync.feature
 
 ## Channels and Product synchronization features END ###


### PR DESCRIPTION
## What does this PR change?

This PR makes sure to run again `features/reposync/srv_abort_all_sync.feature` in yaml files.

**Important note**: on 3.2 and 4.0 branches, the whole "reposync" stage is currently disabled, and this change will therefore have no practical effect in production test suites.

 In those branches, the PR is mostly there to prevent us from forgetting to reenable the feature when we reenable the whole stage.

Ping @moio for awareness.


## Links

Tracks 3.2 SUSE/spacewalk#9135
    4.0 SUSE/spacewalk#9136

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
