### PR TITLE
Add placeholders for salt remote command inputs

### DIFF
--- a/web/html/src/manager/salt/cmd/remote-commands.js
+++ b/web/html/src/manager/salt/cmd/remote-commands.js
@@ -209,7 +209,7 @@ class RemoteCommand extends React.Component {
             <div className="panel-body" style={this.state.result.minions.size ? style : undefined}>
               {(() => {
                 if (!this.state.result.minions.size && !this.state.result.waitForSSH) {
-                   return(<span>{this.state.previewed.state() != "pending" ? t("No target systems previewed") : t("No target systems have been found")}</span>)
+                   return(<span>{this.state.previewed.state() != "pending" ? t("No target systems previewed") : t("No target systems found")}</span>)
                 } else {
                   return(this.commandResult(this.state.result))
                 }

--- a/web/html/src/manager/salt/cmd/remote-commands.js
+++ b/web/html/src/manager/salt/cmd/remote-commands.js
@@ -187,10 +187,10 @@ class RemoteCommand extends React.Component {
                 <div className="col-lg-12">
                   <div className="input-group">
                       <input id="command" className="form-control" type="text" defaultValue={this.state.command} onChange={this.commandChanged}
-                            disabled={this.state.executing.state() == "pending" ? "disabled" : ""}/>
+                            disabled={this.state.executing.state() == "pending" ? "disabled" : ""} placeholder={t('Type the command here')} />
                       <span className="input-group-addon">@</span>
                       <input id="target" className="form-control" type="text" defaultValue={this.state.target} onChange={this.targetChanged}
-                            disabled={this.state.executing.state() == "pending" ? "disabled" : ""}/>
+                            disabled={this.state.executing.state() == "pending" ? "disabled" : ""} placeholder={t('Type the minion_id pattern to target here')}/>
                       <div className="input-group-btn">
                         { button }
                       </div>


### PR DESCRIPTION
## What does this PR change?

Add `placeholder` text for input fields

Related to https://github.com/SUSE/doc-susemanager/pull/670#discussion_r316992179

@Loquacity, @keichwa : suggestions for a better text are more than welcome. I'd not add any `input` label above or on the `input` field side because it needs to change the interface and it's a bit more complex to have aligned. So I'd go for simple `placeholder` visible whenever the field value gets empty. What do you think?


## GUI diff

Before:

No placeholders

After:
![Screenshot from 2019-08-23 11-21-25](https://user-images.githubusercontent.com/7080830/64910246-6d06f100-d714-11e9-8c3e-a742c16712cf.png)



- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"  
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
