### PR TITLE
Fix issue with click extension

### DIFF
--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -117,7 +117,7 @@ module CapybaraNodeElementExtension
   def click
     super
     sleep 0.5
-    raise 'Timeout: Waiting AJAX transition (find::click)' unless page.has_no_css?('.senna-loading')
+    raise 'Timeout: Waiting AJAX transition (find::click)' unless has_no_css?('.senna-loading')
   end
 end
 


### PR DESCRIPTION
## What does this PR change?

Fix an issue related with `page.` out of its scope, inside the click extension

- [x] No changelog needed
