### PR TITLE
change disabled button color on clp 

### DIFF
--- a/web/html/src/manager/content-management/shared/components/panels/build/build.js
+++ b/web/html/src/manager/content-management/shared/components/panels/build/build.js
@@ -48,7 +48,7 @@ const Build = ({projectId, onBuild, currentHistoryEntry = {}, changesToBuild, di
       <div className="text-center">
         <ModalButton
           id={`build-contentmngt-modal-link`}
-          className="btn-success"
+          className={ disabled ? `btn-secondary` : `btn-success` }
           text={changesToBuild.length > 0 ? `Build (${changesToBuild.length})` : `Build`}
           disabled={disabled}
           target={modalNameId}

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Change color of disabled build button on clp page (bsc#1145626)
 - New Single Page Application engine for the UI
 - Fix the 'include recommended' button on channels selection in SSM (bsc#1145086)
 - implement "patch contains package" Filter for Content Lifecycle Management


### PR DESCRIPTION
## What does this PR change?
already merged in 4.0 

**add description**

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
