### PR TITLE
Fixes for bsc#1144889 and bsc#1148125

### DIFF
--- a/backend/server/importlib/packageImport.py
+++ b/backend/server/importlib/packageImport.py
@@ -282,9 +282,10 @@ class PackageImport(ChannelPackageSubscription):
         unique_package_changelog_hash = {}
         unique_package_changelog = []
         for changelog in package['changelog']:
-            key = (self._fix_encoding(changelog['name']), self._fix_encoding(changelog['time']), self._fix_encoding(changelog['text']))
+            key = (self._fix_encoding(changelog['name']), self._fix_encoding(changelog['time']), self._fix_encoding(changelog['text'])[:3000])
             if key not in unique_package_changelog_hash:
                 self.changelog_data[key] = None
+                changelog['text'] = changelog['text'][:3000]
                 unique_package_changelog.append(changelog)
                 unique_package_changelog_hash[key] = 1
         package['changelog'] = unique_package_changelog

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,4 +1,8 @@
 - Don't skip Deb package tags on package import (bsc#1130040)
+- For backend-libs subpackages, exclude files for the server
+  (already part of spacewalk-backend) to avoid conflicts (bsc#1148125)
+- prevent duplicate key violates on repo-sync with long changelog
+  entries (bsc#1144889)
 - spacewalk-remove-channel check that channel doesn't have cloned channels before deleting it (bsc#1138454)
 - Fix broken spacewalk-data-fsck utility
 - /etc/rhn also was packaged for spacewalk-backend-tools

--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -616,6 +616,7 @@ rm -f $RPM_BUILD_ROOT%{python2rhnroot}/common/__init__.py*
 %endif
 %endif
 
+
 %check
 # Copy spacewalk-usix python files to allow unit tests to run
 cp %{pythonrhnroot}/common/usix* $RPM_BUILD_ROOT%{pythonrhnroot}/common/
@@ -946,8 +947,8 @@ rm -f %{rhnconf}/rhnSecret.py*
 %defattr(-,root,root)
 %doc LICENSE
 %if 0%{?build_py3}
-%{python2rhnroot}
-%{python2rhnroot}/common
+%dir %{python2rhnroot}
+%dir %{python2rhnroot}/common
 %endif
 %{python2rhnroot}/common/checksum.py*
 %{python2rhnroot}/common/cli.py*
@@ -964,7 +965,7 @@ rm -f %{rhnconf}/rhnSecret.py*
 %files -n python3-%{name}-libs
 %defattr(-,root,root)
 %doc LICENSE
-%dir %{python3rhnroot}/common/__pycache__
+%dir %{python3rhnroot}/common
 %{python3rhnroot}/common/checksum.py
 %{python3rhnroot}/common/cli.py
 %{python3rhnroot}/common/fileutils.py
@@ -975,7 +976,17 @@ rm -f %{rhnconf}/rhnSecret.py*
 %{python3rhnroot}/common/stringutils.py
 %{python3rhnroot}/common/rhnLib.py*
 %{python3rhnroot}/common/timezone_utils.py*
-%{python3rhnroot}/common
+%dir %{python3rhnroot}/common/__pycache__
+%{python3rhnroot}/common/__pycache__/checksum.*
+%{python3rhnroot}/common/__pycache__/cli.*
+%{python3rhnroot}/common/__pycache__/fileutils.*
+%{python3rhnroot}/common/__pycache__/rhn_deb.*
+%{python3rhnroot}/common/__pycache__/rhn_mpm.*
+%{python3rhnroot}/common/__pycache__/rhn_pkg.*
+%{python3rhnroot}/common/__pycache__/rhn_rpm.*
+%{python3rhnroot}/common/__pycache__/stringutils.*
+%{python3rhnroot}/common/__pycache__/rhnLib.*
+%{python3rhnroot}/common/__pycache__/timezone_utils.*
 %endif
 
 %files config-files-common

--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -616,7 +616,6 @@ rm -f $RPM_BUILD_ROOT%{python2rhnroot}/common/__init__.py*
 %endif
 %endif
 
-
 %check
 # Copy spacewalk-usix python files to allow unit tests to run
 cp %{pythonrhnroot}/common/usix* $RPM_BUILD_ROOT%{pythonrhnroot}/common/


### PR DESCRIPTION
## What does this PR change?

- For backend-libs subpackages, exclude files for the server
  (already part of spacewalk-backend) to avoid conflicts (bsc#1148125)
- prevent duplicate key violates on repo-sync with long changelog
  entries (bsc#1144889)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Bugfixing

- [x] **DONE**

## Test coverage
- No tests: Bugfixing

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/9186

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
