### PR TITLE
Add spacecmd missing runtime dependencies (bsc#1148311)

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -2,6 +2,8 @@
 - Add unit test for schedule, errata, user, utils, misc, configchannel
   and kickstart modules
 - Multiple minor bugfixes alongside the unit tests
+- Fix missing runtime dependencies that made spacecmd return old versions of
+  packages in some cases, even if newer ones were available (bsc#1148311)
 
 -------------------------------------------------------------------
 Wed Jul 31 17:30:30 CEST 2019 - jgonzalez@suse.com

--- a/spacecmd/spacecmd.spec
+++ b/spacecmd/spacecmd.spec
@@ -56,14 +56,14 @@ BuildRequires:  spacewalk-python2-pylint
 %if 0%{?build_py3}
 BuildRequires:  python3
 BuildRequires:  python3-devel
-BuildRequires:  python3-rpm
-BuildRequires:  python3-simplejson
+Requires:       python3-rpm
+Requires:       python3-simplejson
 Requires:       python3
 %else
 BuildRequires:  python
 BuildRequires:  python-devel
-BuildRequires:  python-simplejson
-BuildRequires:  rpm-python
+Requires:       python-simplejson
+Requires:       rpm-python
 Requires:       python
 %if 0%{?suse_version}
 BuildRequires:  python-xml


### PR DESCRIPTION
## What does this PR change?

Some BuildRequires in spacecmd are actually Requires, as they are used at runtime

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: this fixes a regression from 3.2 to 4.0

- [x] **DONE**

## Test coverage
- No tests (but they should be added, I'll create an issue for Bo)
- [x] **DONE**

## Links

Fixes bsc#1148311

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
