### PR TITLE
Do not lose domain name on DHCP updates on CentOS host

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -608,31 +608,26 @@ end
 When(/^I set up the private network on the terminals$/) do
   net_prefix = $private_net.sub(%r{\.0+/24$}, ".")
   proxy = net_prefix + "254"
-  # /etc/sysconfig/network/ifcfg-eth1
+  # /etc/sysconfig/network/ifcfg-eth1 and /etc/resolv.conf
   nodes = [$client, $minion]
   conf = "STARTMODE='auto'\\nBOOTPROTO='dhcp'"
   file = "/etc/sysconfig/network/ifcfg-eth1"
+  script2 = "-e '/^#/d' -e 's/^search /search example.org /' -e '$anameserver #{proxy}' -e '/^nameserver /d'"
+  file2 = "/etc/resolv.conf"
   nodes.each do |node|
     next if node.nil?
-    node.run("echo -e \"#{conf}\" > #{file} && ifup eth1")
+    node.run("echo -e \"#{conf}\" > #{file} && sed -i #{script2} #{file2} && ifup eth1")
   end
   # /etc/sysconfig/network-scripts/ifcfg-eth1 and /etc/sysconfig/network
   nodes = [$ceos_minion]
-  conf = "DEVICE='eth1'\\nSTARTMODE='auto'\\nBOOTPROTO='dhcp'\\nDNS1='#{proxy}'"
   file = "/etc/sysconfig/network-scripts/ifcfg-eth1"
   conf2 = "GATEWAYDEV=eth0"
   file2 = "/etc/sysconfig/network"
   nodes.each do |node|
     next if node.nil?
+    domain, _code = node.run("grep '^search' /etc/resolv.conf | sed 's/^search//'")
+    conf = "DOMAIN='#{domain.strip}'\\nDEVICE='eth1'\\nSTARTMODE='auto'\\nBOOTPROTO='dhcp'\\nDNS1='#{proxy}'"
     node.run("echo -e \"#{conf}\" > #{file} && echo -e \"#{conf2}\" > #{file2} && systemctl restart network")
-  end
-  # /etc/resolv.conf
-  nodes = [$client, $minion, $ceos_minion]
-  script = "-e '/^#/d' -e 's/^search /search example.org /' -e '$anameserver #{proxy}' -e '/^nameserver /d'"
-  file = "/etc/resolv.conf"
-  nodes.each do |node|
-    next if node.nil?
-    node.run("sed -i #{script} #{file}")
   end
 end
 


### PR DESCRIPTION
## What does this PR change?

On Centos, the domain search list is lost on each DHCP update. This test suite PR makes sure this list is kept.

## Links

Fixes SUSE/spacewalk#9087
3.2 port SUSE/spacewalk#9198
4.0 port SUSE/spacewalk#9199

## Changelogs

- [x] No changelog needed
