### PR TITLE
When calling mgr-sync without a sub-command, exit 1 and show help message (bsc#1134708 )

### DIFF
--- a/susemanager/src/mgr_sync/cli.py
+++ b/susemanager/src/mgr_sync/cli.py
@@ -45,7 +45,8 @@ def _create_parser():
                         choices=["1", "2", "3"],
                         help="Log additional debug information depending on DEBUG")
 
-    subparsers = parser.add_subparsers(title='Subcommands')
+    subparsers = parser.add_subparsers(title='Subcommands', dest='subcommands')
+    subparsers.required = True
 
     _create_list_subparser(subparsers)
     _create_add_subparser(subparsers)

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,6 +1,7 @@
 - dmidecode does not exist on s390x (bsc#1145119)
 - move /usr/share/rhn/config-defaults to uyuni-base-common
 - Add missing bootstrap repo entries for Ubuntu repositories
+- Show help message when missing sub-command in  mgr-sync call (bsc#1134708)
 
 -------------------------------------------------------------------
 Wed Jul 31 17:45:28 CEST 2019 - jgonzalez@suse.com


### PR DESCRIPTION
## What does this PR change?
When calling mgr-sync without a sub-command, exit 1 and show help message


## GUI diff

No difference.



## Documentation
- No documentation needed: 


## Test coverage


## Links

Fixes # https://github.com/SUSE/spacewalk/issues/9191


- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
