### PR TITLE
Do not crash 'rhn-satellite-exporter' with ModuleNotFound error (bsc#1146869)

### DIFF
--- a/backend/satellite_tools/disk_dumper/iss.py
+++ b/backend/satellite_tools/disk_dumper/iss.py
@@ -106,7 +106,7 @@ class FileMapper:
             'suse_products': xmlDiskSource.SuseProductsDiskSource(self.mp),
             'suse_product_channels': xmlDiskSource.SuseProductChannelsDiskSource(self.mp),
             'suse_upgrade_paths': xmlDiskSource.SuseUpgradePathsDiskSource(self.mp),
-            'suse_product_extensions': xmlDiskSource.SuseProductEntensionsDiskSource(self.mp),
+            'suse_product_extensions': xmlDiskSource.SuseProductExtensionsDiskSource(self.mp),
             'suse_product_repositories': xmlDiskSource.SuseProductRepositoriesDiskSource(self.mp),
             'scc_repositories': xmlDiskSource.SCCRepositoriesDiskSource(self.mp),
             'suse_subscriptions': xmlDiskSource.SuseSubscriptionsDiskSource(self.mp),

--- a/backend/satellite_tools/disk_dumper/iss.py
+++ b/backend/satellite_tools/disk_dumper/iss.py
@@ -26,7 +26,7 @@ try:
 except ImportError:
     #  python3
     import io as cStringIO
-import dumper
+from . import dumper
 from spacewalk.common.usix import raise_with_tb
 from spacewalk.common import rhnMail
 from spacewalk.common.rhnConfig import CFG, initCFG
@@ -37,12 +37,15 @@ from spacewalk.server.rhnSQL import SQLError, SQLSchemaError, SQLConnectError
 from spacewalk.satellite_tools.exporter import xmlWriter
 from spacewalk.satellite_tools import xmlDiskSource, diskImportLib, progress_bar
 from spacewalk.satellite_tools.syncLib import initEMAIL_LOG, dumpEMAIL_LOG, log2email, log2stderr, log2stdout
-from iss_ui import UI
-from iss_actions import ActionDeps
-import iss_isos
+from .iss_ui import UI
+from .iss_actions import ActionDeps
+from . import iss_isos
 
 t = gettext.translation('spacewalk-backend-server', fallback=True)
-_ = t.ugettext
+try:
+    _ = t.ugettext
+except AttributeError:
+    _ = t.gettext
 
 # bare-except and broad-except
 # pylint: disable=W0702,W0703
@@ -1561,7 +1564,7 @@ def compress_file(f):
     """
     Gzip the given file and then remove the file.
     """
-    datafile = open(f, 'r')
+    datafile = open(f, 'rb')
     gzipper = gzip.GzipFile(f + '.gz', 'w', 9)
     gzipper.write(datafile.read())
     gzipper.flush()

--- a/backend/satellite_tools/disk_dumper/iss_actions.py
+++ b/backend/satellite_tools/disk_dumper/iss_actions.py
@@ -65,7 +65,7 @@ class ActionDeps:
             'kickstarts',
             'supportinfo',
             'suse-products',
-            'scc-repositories'
+            'scc-repositories',
             'suse-product-channels',
             'suse-upgrade-paths',
             'suse-product-extensions',

--- a/backend/satellite_tools/disk_dumper/iss_actions.py
+++ b/backend/satellite_tools/disk_dumper/iss_actions.py
@@ -15,7 +15,7 @@
 
 import sys
 
-import iss_ui
+from . import iss_ui
 
 
 class ActionDeps:

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Do not crash 'rhn-satellite-exporter' with ModuleNotFound error (bsc#1146869)
 - Don't skip Deb package tags on package import (bsc#1130040)
 - For backend-libs subpackages, exclude files for the server
   (already part of spacewalk-backend) to avoid conflicts (bsc#1148125)


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue which is currently making `rhn-satellite-exporter` to crash and not work properly:

```
# rhn-satellite-exporter
Traceback (most recent call last):
  File "/usr/bin/rhn-satellite-exporter", line 32, in <module>
    from spacewalk.satellite_tools.disk_dumper import iss
  File "/usr/lib/python3.6/site-packages/spacewalk/satellite_tools/disk_dumper/iss.py", line 29, in <module>
    import dumper
ModuleNotFoundError: No module named 'dumper'
```

Also, the PR fixes some typos with the list of actions and action mapping that were producing errors when exporting.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **no tests for rhn-satellite-exporter**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/9268

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
