### PR TITLE
Make test steps that deal with host names uniform

### DIFF
--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -337,7 +337,8 @@ The check box can be identified by name, id or label text.
 * Select an item from a selection box
 
 ```cucumber
-  Then I select "Mr." from "prefix"
+  When I select "Mr." from "prefix"
+  When I select the hostname of "proxy" from "proxies"
 ```
 
 * Make sure an item in a selection box is selected
@@ -362,6 +363,7 @@ The check box can be identified by name, id or label text.
 ```cucumber
   When I enter "SUSE Test Key x86_64" as "description"
   When I enter "CVE-1999-12345" as "search_string" in the content area
+  When I enter the hostname of "proxy" as "hostname"
 ```
 
 * Make sure a text is in a given input field of a form

--- a/testsuite/features/core/centos_salt_ssh.feature
+++ b/testsuite/features/core/centos_salt_ssh.feature
@@ -14,7 +14,7 @@ Feature: Bootstrap a SSH-managed CentOS minion and do some basic operations on i
     When I check "manageWithSSH"
     And I enter the hostname of "ceos-ssh-minion" as "hostname"
     And I enter "linux" as "password"
-    And I select the hostname of the proxy from "proxies"
+    And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
     And I navigate to "rhn/systems/Overview.do" page

--- a/testsuite/features/core/min_bootstrap.feature
+++ b/testsuite/features/core/min_bootstrap.feature
@@ -52,7 +52,7 @@ Feature: Be able to bootstrap a Salt minion via the GUI
      And I enter "22" as "port"
      And I enter "root" as "user"
      And I enter "linux" as "password"
-     And I select the hostname of the proxy from "proxies"
+     And I select the hostname of "proxy" from "proxies"
      And I click on "Bootstrap"
      And I wait until I see "Successfully bootstrapped host!" text
 

--- a/testsuite/features/core/min_salt_ssh.feature
+++ b/testsuite/features/core/min_salt_ssh.feature
@@ -11,7 +11,7 @@ Feature: Be able to bootstrap a Salt host managed via salt-ssh
     And I check "manageWithSSH"
     And I enter the hostname of "ssh-minion" as "hostname"
     And I enter "linux" as "password"
-    And I select the hostname of the proxy from "proxies"
+    And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
     And I navigate to "rhn/systems/Overview.do" page

--- a/testsuite/features/core/ubuntu_salt_ssh.feature
+++ b/testsuite/features/core/ubuntu_salt_ssh.feature
@@ -14,7 +14,7 @@ Feature: Bootstrap a SSH-managed Ubuntu minion and do some basic operations on i
     When I check "manageWithSSH"
     And I enter the hostname of "ubuntu-minion" as "hostname"
     And I enter "linux" as "password"
-    #    And I select the hostname of the proxy from "proxies"
+    And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
     And I navigate to "rhn/systems/Overview.do" page

--- a/testsuite/features/secondary/min_activationkey.feature
+++ b/testsuite/features/secondary/min_activationkey.feature
@@ -58,7 +58,7 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
     And I enter "root" as "user"
     And I enter "linux" as "password"
     And I select "1-MINION-TEST" from "activationKeys"
-    And I select the hostname of the proxy from "proxies"
+    And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
     When I navigate to "rhn/systems/Overview.do" page

--- a/testsuite/features/secondary/min_centos_salt.feature
+++ b/testsuite/features/secondary/min_centos_salt.feature
@@ -27,7 +27,7 @@ Feature: Be able to bootstrap a CentOS minion and do some basic operations on it
     And I enter "root" as "user"
     And I enter "linux" as "password"
     And I select "1-SUSE-PKG-x86_64" from "activationKeys"
-    And I select the hostname of the proxy from "proxies"
+    And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
     And I navigate to "rhn/systems/Overview.do" page
@@ -127,7 +127,7 @@ Feature: Be able to bootstrap a CentOS minion and do some basic operations on it
     When I check "manageWithSSH"
     And I enter the hostname of "ceos-ssh-minion" as "hostname"
     And I enter "linux" as "password"
-    And I select the hostname of the proxy from "proxies"
+    And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
     And I navigate to "rhn/systems/Overview.do" page

--- a/testsuite/features/secondary/min_docker_auth_registry.feature
+++ b/testsuite/features/secondary/min_docker_auth_registry.feature
@@ -27,7 +27,7 @@ Feature: Build image with authenticated registry
     When I navigate to images build webpage
     And I select "portus_profile" from "profileId"
     And I enter "latest" as "version"
-    And I select sle-minion hostname in Build Host
+    And I select the hostname of "sle-minion" from "buildHostId"
     And I click on "submit-btn"
     Then I wait until I see "portus_profile" text
     # Verify the status of images in the authenticated image store

--- a/testsuite/features/secondary/min_docker_build_image.feature
+++ b/testsuite/features/secondary/min_docker_build_image.feature
@@ -39,7 +39,7 @@ Feature: Build container images
     When I navigate to images build webpage
     And I select "suse_real_key" from "profileId"
     And I enter "GUI_BUILT_IMAGE" as "version"
-    And I select sle-minion hostname in Build Host
+    And I select the hostname of "sle-minion" from "buildHostId"
     And I click on "submit-btn"
     Then I wait until I see "GUI_BUILT_IMAGE" text
 
@@ -48,7 +48,7 @@ Feature: Build container images
     When I navigate to images build webpage
     And I select "suse_real_key" from "profileId"
     And I enter "GUI_DOCKERADMIN" as "version"
-    And I select sle-minion hostname in Build Host
+    And I select the hostname of "sle-minion" from "buildHostId"
     And I click on "submit-btn"
     Then I wait until I see "GUI_DOCKERADMIN" text
 

--- a/testsuite/features/secondary/min_osimage_build_image.feature
+++ b/testsuite/features/secondary/min_osimage_build_image.feature
@@ -15,7 +15,7 @@ Feature: Build OS images
     Given I am authorized as "kiwikiwi" with password "kiwikiwi"
     When I navigate to images build webpage
     And I select "suse_os_image" from "profileId"
-    And I select sle-minion hostname in Build Host
+    And I select the hostname of "sle-minion" from "buildHostId"
     And I click on "submit-btn"
     # Check the OS image built as Kiwi image administrator
     Given I am on the Systems overview page of this "sle-minion"

--- a/testsuite/features/secondary/min_salt_minions_page.feature
+++ b/testsuite/features/secondary/min_salt_minions_page.feature
@@ -77,7 +77,7 @@ Feature: Management of minion keys
     And I enter "22" as "port"
     And I enter "root" as "user"
     And I enter "linux" as "password"
-    And I select the hostname of the proxy from "proxies"
+    And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "sle-minion"

--- a/testsuite/features/secondary/min_ubuntu_salt.feature
+++ b/testsuite/features/secondary/min_ubuntu_salt.feature
@@ -36,7 +36,7 @@ Feature: Be able to bootstrap an Ubuntu minion and do some basic operations on i
     And I enter "root" as "user"
     And I enter "linux" as "password"
     And I select "1-UBUNTU-TEST" from "activationKeys"
-    And I select the hostname of the proxy from "proxies"
+    And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
     And I navigate to "rhn/systems/Overview.do" page
@@ -137,7 +137,7 @@ Feature: Be able to bootstrap an Ubuntu minion and do some basic operations on i
     When I check "manageWithSSH"
     And I enter the hostname of "ubuntu-ssh-minion" as "hostname"
     And I enter "linux" as "password"
-    And I select the hostname of the proxy from "proxies"
+    And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
     And I navigate to "rhn/systems/Overview.do" page

--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -13,7 +13,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I enter "root" as "user"
     And I enter "kvm-server" password
     And I select "1-SUSE-PKG-x86_64" from "activationKeys"
-    And I select the hostname of the proxy from "proxies"
+    And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "kvm-server"

--- a/testsuite/features/secondary/minxen_guests.feature
+++ b/testsuite/features/secondary/minxen_guests.feature
@@ -13,7 +13,7 @@ Feature: Be able to manage XEN virtual machines via the GUI
     And I enter "root" as "user"
     And I enter "xen-server" password
     And I select "1-SUSE-PKG-x86_64" from "activationKeys"
-    And I select the hostname of the proxy from "proxies"
+    And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "xen-server"

--- a/testsuite/features/secondary/trad_centos_client.feature
+++ b/testsuite/features/secondary/trad_centos_client.feature
@@ -110,7 +110,7 @@ Feature: Be able to register a CentOS 7 traditional client and do some basic ope
     When I check "manageWithSSH"
     And I enter the hostname of "ceos-ssh-minion" as "hostname"
     And I enter "linux" as "password"
-    And I select the hostname of the proxy from "proxies"
+    And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
     And I navigate to "rhn/systems/Overview.do" page

--- a/testsuite/features/secondary/trad_migrate_to_minion.feature
+++ b/testsuite/features/secondary/trad_migrate_to_minion.feature
@@ -14,7 +14,7 @@ Feature: Migrate a traditional client into a Salt minion
     And I enter "root" as "user"
     And I enter "linux" as "password"
     And I select "1-SUSE-PKG-x86_64" from "activationKeys"
-    And I select the hostname of the proxy from "proxies"
+    And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
 

--- a/testsuite/features/secondary/trad_migrate_to_sshminion.feature
+++ b/testsuite/features/secondary/trad_migrate_to_sshminion.feature
@@ -34,7 +34,7 @@ Feature: Migrate a traditional client into a Salt SSH minion
     And I enter "root" as "user"
     And I enter "linux" as "password"
     And I select "1-SUSE-PKG-x86_64" from "activationKeys"
-    And I select the hostname of the proxy from "proxies"
+    And I select the hostname of "proxy" from "proxies"
     And I check "manageWithSSH"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text

--- a/testsuite/features/step_definitions/docker_steps.rb
+++ b/testsuite/features/step_definitions/docker_steps.rb
@@ -22,10 +22,6 @@ def retrieve_minion_id
   minion_id
 end
 
-When(/^I select sle-minion hostname in Build Host$/) do
-  select($minion.full_hostname, from: 'buildHostId')
-end
-
 When(/^I navigate to images webpage$/) do
   visit("https://#{$server.full_hostname}/rhn/manager/cm/images")
 end

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -324,6 +324,23 @@ Given(/^I am on the "([^"]*)" page of this "([^"]*)"$/) do |page, host|
   )
 end
 
+When(/^I enter the hostname of "([^"]*)" as "([^"]*)"$/) do |host, hostname|
+  system_name = get_system_name(host)
+  puts "The hostname of #{host} is #{system_name}"
+  step %(I enter "#{system_name}" as "#{hostname}")
+end
+
+When(/^I select the hostname of "([^"]*)" from "([^"]*)"$/) do |host, hostname|
+  case host
+  when 'proxy'
+    # don't select anything if not in the list
+    next if $proxy.nil?
+    step %(I select "#{$proxy.full_hostname}" from "#{hostname}")
+  when 'sle-minion'
+    step %(I select "#{$minion.full_hostname}" from "#{hostname}")
+  end
+end
+
 When(/^I follow this "([^"]*)" link$/) do |host|
   system_name = get_system_name(host)
   step %(I follow "#{system_name}")

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -661,17 +661,6 @@ When(/^I install Salt packages from "(.*?)"$/) do |host|
 end
 
 # minion bootstrap steps
-When(/^I enter the hostname of "([^"]*)" as "([^"]*)"$/) do |host, hostname|
-  system_name = get_system_name(host)
-  puts "The hostname of #{host} is #{system_name}"
-  step %(I enter "#{system_name}" as "#{hostname}")
-end
-
-When(/^I select the hostname of the proxy from "([^"]*)"$/) do |proxy|
-  next if $proxy.nil?
-  step %(I select "#{$proxy.full_hostname}" from "#{proxy}")
-end
-
 Then(/^I run spacecmd listevents for "([^"]*)"$/) do |host|
   system_name = get_system_name(host)
   $server.run('spacecmd -u admin -p admin clear_caches')


### PR DESCRIPTION
## What does this PR change?

In the sake of simplicity, and also in preparation of openSUSE support (to remove "sle-minion" from a step name)

group:
* `I select the hostname of the proxy from "proxies"`
* `I select sle-minion hostname in Build Host`

into a generic step `I select the hostname of ".*" from ".*"`

on the model of `I enter the of hostname ".*" as ".*"`

IMPORTANT: this PR also re-enables the testing of bootstrapping Ubuntu **behind a proxy**.

## Links

* 3.2 SUSE/spacewalk#9281
* 4.0 SUSE/spacewalk#9282

## Changelogs

- [x] No changelog needed
