### PR TITLE
Import additional fields for Debian packages

### DIFF
--- a/backend/server/importlib/backend.py
+++ b/backend/server/importlib/backend.py
@@ -59,7 +59,8 @@ sequences = {
     'suseEula': 'suse_eula_id_seq',
     'suseProducts': 'suse_products_id_seq',
     'suseSCCRepository': 'suse_sccrepository_id_seq',
-    'suseProductSCCRepository': 'suse_prdrepo_id_seq'
+    'suseProductSCCRepository': 'suse_prdrepo_id_seq',
+    'rhnPackageExtraTagKey': 'rhn_package_extra_tags_keys_id_seq'
 }
 
 
@@ -244,6 +245,42 @@ class Backend:
         sql = "insert into rhnCVE (id, name) values (:id, :name)"
         h = self.dbmodule.prepare(sql)
         h.executemany(id=toinsert[0], name=toinsert[1])
+
+    def processExtraTags(self, extraTags):
+        query_lookup = """
+            SELECT id
+              FROM rhnPackageExtraTagKey
+             WHERE name = :name
+        """
+        h_lookup = self.dbmodule.prepare(query_lookup)
+        toinsert = [[], []]
+
+        for name in list(extraTags.keys()):
+            val = {}
+            _buildExternalValue(val, { 'name'     : name},
+                                self.tables['rhnPackageExtraTagKey'])
+            h_lookup.execute(name=name)
+            row = h_lookup.fetchone_dict()
+            if row:
+                extraTags[name] = row['id']
+                continue
+
+            # Generate an id
+            id = self.sequences['rhnPackageExtraTagKey'].next()
+            extraTags[name] = id
+
+            toinsert[0].append(id)
+            toinsert[1].append(val['name'])
+
+        if not toinsert[0]:
+            # Nothing to do
+            return
+
+        query_insert = """
+            INSERT INTO rhnPackageExtraTagKey (id, name)
+            VALUES (:id, :name)"""
+        h_insert = self.dbmodule.prepare(query_insert)
+        h_insert.executemany(id=toinsert[0], name=toinsert[1])
 
     def lookupErrataFileTypes(self, hash):
         hash.clear()
@@ -830,6 +867,7 @@ class Backend:
             'rhnPackageChangeLogRec':  'package_id',
             'susePackageProductFile':  'package_id',
             'susePackageEula':         'package_id',
+            'rhnPackageExtraTag':     'package_id',
         }
 
         if CFG.has_key('package_import_skip_changelog') and CFG.package_import_skip_changelog:

--- a/backend/server/importlib/backendOracle.py
+++ b/backend/server/importlib/backendOracle.py
@@ -631,6 +631,23 @@ class OracleBackend(Backend):
             pk          = ['package_id', 'eula_id'],
             attribute   = 'eulas',
         ),
+        Table('rhnPackageExtraTagKey',
+              fields={
+                  'id'      : DBint(),
+                  'name'    : DBstring(256),
+              },
+              pk=['id'],
+              attribute='extra_tags',
+              ),
+        Table('rhnPackageExtraTag',
+            fields={
+              'package_id'  : DBint(),
+              'key_id'      : DBint(),
+              'value'       : DBstring(2048),
+            },
+            pk=['package_id', 'key_id'],
+            attribute='extra_tags',
+        ),
     )
 
     def __init__(self):

--- a/backend/server/importlib/debPackage.py
+++ b/backend/server/importlib/debPackage.py
@@ -100,6 +100,8 @@ class debBinaryPackage(headerSource.rpmBinaryPackage):
         self._populateChangeLog(header)
         # Channels
         self._populateChannels(channels)
+        # populate extraTags from headers not in already mapped fields
+        self._populateExtraTags(header)
 
         self['source_rpm'] = None
 
@@ -175,3 +177,39 @@ class debBinaryPackage(headerSource.rpmBinaryPackage):
             obj.populate(dict)
             l.append(obj)
         self['channels'] = l
+
+    def _populateExtraTags(self, header):
+        already_processed = ['arch',
+                            'name',
+                            'summary',
+                            'epoch',
+                            'version',
+                            'release',
+                            'payload_size',
+                            'vendor',
+                            'package_group',
+                            'requires',
+                            'obsoletes',
+                            'predepends',
+                            'package',
+                            'architecture',
+                            'description',
+                            'maintainer',
+                            'section',
+                            'version',
+                            'depends',
+                            'provides',
+                            'conflicts',
+                            'replaces',
+                            'recommends',
+                            'suggests',
+                            'breaks',
+                            'pre-depends',
+                            'installed-size',
+                            ]
+        l = []
+        for k, v in header.items():
+            if k.lower() not in already_processed and v:
+                l.append({'name': k, 'value': v})
+
+        self['extra_tags'] = l

--- a/backend/server/importlib/packageImport.py
+++ b/backend/server/importlib/packageImport.py
@@ -217,6 +217,7 @@ class PackageImport(ChannelPackageSubscription):
         self.changelog_data = {}
         self.suseProdfile_data = {}
         self.suseEula_data = {}
+        self.extraTags = {}
 
     def _skip_tag(self, package, tag):
         # Allow all tags in case of DEB packages
@@ -311,6 +312,10 @@ class PackageImport(ChannelPackageSubscription):
                 key = (eula['text'], eula['checksum'])
                 self.suseEula_data[key] = None
 
+        if package['extra_tags'] is not None:
+            for tag in package['extra_tags']:
+                self.extraTags[tag['name']] = None
+
     def fix(self):
         # If capabilities are available, process them
         if self.capabilities:
@@ -331,6 +336,7 @@ class PackageImport(ChannelPackageSubscription):
 
         self.backend.lookupSourceRPMs(self.sourceRPMs)
         self.backend.lookupPackageGroups(self.groups)
+        self.backend.processExtraTags(self.extraTags)
         # Postprocess the gathered information
         self.__postprocess()
 
@@ -409,6 +415,8 @@ class PackageImport(ChannelPackageSubscription):
         fileList = package['files']
         for f in fileList:
             f['checksum_id'] = self.checksums[(f['checksum_type'], f['checksum'])]
+        for t in package['extra_tags']:
+            t['key_id'] = self.extraTags[t['name']]
 
     def _comparePackages(self, package1, package2):
         if (package1['checksum_type'] == package2['checksum_type']

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Import additional fields for Deb packages
 - Prevent "reposync" crash when handling metadata on RPM repos (bsc#1138358)
 - Do not show expected WARNING messages from "c_rehash"
 - fix misspelling in spacewalk-repo-sync (bsc#1149633)

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Task_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Task_queries.xml
@@ -502,6 +502,16 @@ where snc.errata_id = :errata_id
     <elaborator name="repomdgenerator_package_elab" />
 </mode>
 
+<mode name="repomdgenerator_channel_package_extratags">
+    <query>
+        SELECT pet.package_id as package_id, petk.name as name, pet.value as value
+        FROM
+            rhnPackageExtraTag pet join rhnPackageExtraTagKey petk on pet.key_id = petk.id
+        WHERE
+            pet.package_id in (%s)
+    </query>
+</mode>
+
 <mode name="repomdgenerator_capability_files"
     class="com.redhat.rhn.frontend.dto.PackageCapabilityDto">
    <query params="package_id">

--- a/java/code/src/com/redhat/rhn/common/hibernate/AnnotationRegistry.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/AnnotationRegistry.java
@@ -40,6 +40,7 @@ import com.redhat.rhn.domain.image.ProfileCustomDataValue;
 import com.redhat.rhn.domain.notification.NotificationMessage;
 import com.redhat.rhn.domain.notification.UserNotification;
 import com.redhat.rhn.domain.product.SUSEProductSCCRepository;
+import com.redhat.rhn.domain.rhnpackage.PackageExtraTagsKeys;
 import com.redhat.rhn.domain.scc.SCCOrderItem;
 import com.redhat.rhn.domain.scc.SCCRepository;
 import com.redhat.rhn.domain.scc.SCCRepositoryAuth;
@@ -102,6 +103,7 @@ public class AnnotationRegistry {
         ANNOTATION_CLASSES.add(EnvironmentTarget.class);
         ANNOTATION_CLASSES.add(SoftwareEnvironmentTarget.class);
         ANNOTATION_CLASSES.add(ContentProjectHistoryEntry.class);
+        ANNOTATION_CLASSES.add(PackageExtraTagsKeys.class);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/Package.java
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/Package.java
@@ -29,7 +29,9 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -77,6 +79,8 @@ public class Package extends BaseDomainHelper {
     private Set<PackageRequires> requires = new HashSet();
     private Set<PackageObsoletes> obsoletes = new HashSet();
     private Set<PackageConflicts> conflicts = new HashSet();
+
+    private Map<PackageExtraTagsKeys, String> extraTags = new HashMap<>();
 
     /**
      * @param lockPendingIn Set pending status. Default is False.
@@ -680,6 +684,20 @@ public class Package extends BaseDomainHelper {
      */
     public void setHeaderEnd(Long headerEndIn) {
         this.headerEnd = headerEndIn;
+    }
+
+    /**
+     * @return extraTags to get
+     */
+    public Map<PackageExtraTagsKeys, String> getExtraTags() {
+        return extraTags;
+    }
+
+    /**
+     * @param extraTagsIn to set
+     */
+    public void setExtraTags(Map<PackageExtraTagsKeys, String> extraTagsIn) {
+        this.extraTags = extraTagsIn;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageExtraTagsKeys.java
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageExtraTagsKeys.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.domain.rhnpackage;
+
+import org.hibernate.annotations.CreationTimestamp;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * Entity bean for rhnPackageExtraTagsKeys.
+ */
+@Entity
+@Table(name = "rhnPackageExtraTagsKeys")
+public class PackageExtraTagsKeys implements Serializable {
+
+    private Long id;
+    private String name;
+    private Date created;
+
+    /**
+     * @return id to get
+     */
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "pkgxtratagkeys_seq")
+    @SequenceGenerator(name = "pkgxtratagkeys_seq", sequenceName = "rhn_package_extra_tags_keys_id_seq",
+            allocationSize = 1)
+    public Long getId() {
+        return id;
+    }
+
+    /**
+     * @param idIn to set
+     */
+    public void setId(Long idIn) {
+        this.id = idIn;
+    }
+
+    /**
+     * @return name to get
+     */
+    @Column(name = "name")
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param nameIn to set
+     */
+    public void setName(String nameIn) {
+        this.name = nameIn;
+    }
+
+    /**
+     * @return created to get
+     */
+    @CreationTimestamp
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "created")
+    public Date getCreated() {
+        return created;
+    }
+
+    /**
+     * @param createdIn to set
+     */
+    public void setCreated(Date createdIn) {
+        this.created = createdIn;
+    }
+}

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageFactory.java
@@ -148,6 +148,14 @@ public class PackageFactory extends HibernateFactory {
     }
 
     /**
+     * Store the package.
+     * @param pkg The object we are commiting.
+     */
+    public static void save(Package pkg) {
+        singleton.saveObject(pkg);
+    }
+
+    /**
      * Lookup a PackageArch by its id.
      * @param id package arch label id sought.
      * @return the PackageArch whose id matches the given id.

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/Package_satellite.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/Package_satellite.hbm.xml
@@ -103,7 +103,12 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                 class="com.redhat.rhn.domain.rhnpackage.PackageObsoletes" />
         </set>
 
-
+        <map name="extraTags"
+             table="rhnPackageExtraTag" lazy="true">
+            <key column="package_id"/>
+            <map-key-many-to-many column="key_id" class="com.redhat.rhn.domain.rhnpackage.PackageExtraTagsKeys"/>
+            <element column="value" type="string" not-null="true"/>
+        </map>
 
         <many-to-one name="checksum" class="com.redhat.rhn.domain.common.Checksum"
                      column="checksum_id" />

--- a/java/code/src/com/redhat/rhn/frontend/dto/PackageDto.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/PackageDto.java
@@ -23,6 +23,7 @@ import java.sql.Blob;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Map;
 import java.util.TimeZone;
 /**
  * PackageDto
@@ -61,6 +62,7 @@ public class PackageDto extends BaseDto {
     private Blob otherXml;
     private Blob filelistXml;
     private String cookie;
+    private Map<String, String> extraTags;
 
 
     // Pre-existing queries returning this as a string.
@@ -583,5 +585,19 @@ public class PackageDto extends BaseDto {
      */
     public String getFile() {
         return PackageHelper.getPackageFileFromPath(getPath());
+    }
+
+    /**
+     * @return extraTags to get
+     */
+    public Map<String, String> getExtraTags() {
+        return extraTags;
+    }
+
+    /**
+     * @param extraTagsIn to set
+     */
+    public void setExtraTags(Map<String, String> extraTagsIn) {
+        this.extraTags = extraTagsIn;
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/rhnpackage/test/PackageManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/rhnpackage/test/PackageManagerTest.java
@@ -29,6 +29,7 @@ import com.redhat.rhn.domain.rhnpackage.Package;
 import com.redhat.rhn.domain.rhnpackage.PackageCapability;
 import com.redhat.rhn.domain.rhnpackage.PackageEvr;
 import com.redhat.rhn.domain.rhnpackage.PackageEvrFactory;
+import com.redhat.rhn.domain.rhnpackage.PackageExtraTagsKeys;
 import com.redhat.rhn.domain.rhnpackage.PackageFactory;
 import com.redhat.rhn.domain.rhnpackage.PackageName;
 import com.redhat.rhn.domain.rhnpackage.test.PackageCapabilityTest;
@@ -687,5 +688,12 @@ public class PackageManagerTest extends BaseTestCaseWithUser {
         String other = dto.getOtherXml();
         assertEquals(prim, test);
         commitHappened();
+    }
+
+    public static PackageExtraTagsKeys createExtraTagKey(String name) {
+        PackageExtraTagsKeys tag1 = new PackageExtraTagsKeys();
+        tag1.setName(name);
+        HibernateFactory.getSession().save(tag1);
+        return tag1;
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/task/TaskManager.java
+++ b/java/code/src/com/redhat/rhn/manager/task/TaskManager.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  *
@@ -143,5 +144,19 @@ public class TaskManager {
     public static DataResult getTaskStatusInfo() {
         SelectMode m = ModeFactory.getMode("Task_queries", "taskomatic_task_status");
         return m.execute(new HashMap());
+    }
+
+    /**
+     * Load extra tags for the given packages.
+     * @param pkgIds the package ids
+     * @return a map of maps with the package id as key and a map of tagName -> tagValue as value.
+     */
+    public static Map<Long, Map<String, String>> getChannelPackageExtraTags(List<Long> pkgIds) {
+        SelectMode m = ModeFactory.getMode(TaskConstants.MODE_NAME,
+                TaskConstants.TASK_QUERY_CHANNEL_PACKAGE_EXTRATAGS);
+        DataResult<Map<String, Object>> dataResult = m.execute(pkgIds);
+        return dataResult.stream().collect(
+                Collectors.groupingBy(map -> (Long)map.get("package_id"),
+                        Collectors.toMap(map -> (String)map.get("name"), map -> (String)map.get("value"))));
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/task/test/TaskManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/task/test/TaskManagerTest.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.manager.task.test;
+
+import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
+import com.redhat.rhn.domain.rhnpackage.Package;
+import com.redhat.rhn.domain.rhnpackage.PackageExtraTagsKeys;
+import com.redhat.rhn.domain.rhnpackage.PackageFactory;
+import com.redhat.rhn.manager.rhnpackage.test.PackageManagerTest;
+import com.redhat.rhn.manager.task.TaskManager;
+import com.redhat.rhn.testing.ErrataTestUtils;
+import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
+
+import java.util.Arrays;
+import java.util.Map;
+
+public class TaskManagerTest extends JMockBaseTestCaseWithUser {
+
+    public void testGetChannelPackageExtraTags() throws Exception {
+        Channel channel = ChannelFactoryTest.createBaseChannel(user);
+
+        PackageExtraTagsKeys tag1 = PackageManagerTest.createExtraTagKey("Tag1");
+        PackageExtraTagsKeys tag2 = PackageManagerTest.createExtraTagKey("Tag2");
+        PackageExtraTagsKeys tag3 = PackageManagerTest.createExtraTagKey("Tag3");
+
+        Package pkg1 = ErrataTestUtils.createTestPackage(user, channel, "x86_64");
+        pkg1.getExtraTags().put(tag1, "value1");
+        pkg1.getExtraTags().put(tag2, "value2");
+        PackageFactory.save(pkg1);
+
+        Package pkg2 = ErrataTestUtils.createTestPackage(user, channel, "x86_64");
+        pkg2.getExtraTags().put(tag2, "value2");
+        pkg2.getExtraTags().put(tag3, "value3");
+        PackageFactory.save(pkg2);
+
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().clear();
+
+        pkg1 = PackageFactory.lookupByIdAndOrg(pkg1.getId(), user.getOrg());
+        pkg2 = PackageFactory.lookupByIdAndOrg(pkg2.getId(), user.getOrg());
+
+        assertEquals(2, pkg1.getExtraTags().size());
+        assertEquals("value1", pkg1.getExtraTags().get(tag1));
+        assertEquals("value2", pkg1.getExtraTags().get(tag2));
+
+        assertEquals(2, pkg2.getExtraTags().size());
+        assertEquals("value2", pkg2.getExtraTags().get(tag2));
+        assertEquals("value3", pkg2.getExtraTags().get(tag3));
+
+        Map<Long, Map<String, String>> tagsByPkg =
+                TaskManager.getChannelPackageExtraTags(Arrays.asList(pkg1.getId(), pkg2.getId()));
+
+        assertEquals(tagsByPkg.get(pkg1.getId()).get("Tag1"), "value1");
+        assertEquals(tagsByPkg.get(pkg1.getId()).get("Tag2"), "value2");
+
+        assertEquals(tagsByPkg.get(pkg2.getId()).get("Tag2"), "value2");
+        assertEquals(tagsByPkg.get(pkg2.getId()).get("Tag3"), "value3");
+    }
+
+}

--- a/java/code/src/com/redhat/rhn/taskomatic/task/TaskConstants.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/TaskConstants.java
@@ -210,5 +210,8 @@ public class TaskConstants {
     public static final String TASK_QUERY_DUPLICATED_VIRTUALINSTANCE_CLEANUP =
         "taskomatic_duplicated_virtualinstance_cleanup";
 
+    public static final String TASK_QUERY_CHANNEL_PACKAGE_EXTRATAGS =
+            "repomdgenerator_channel_package_extratags";
+
     private TaskConstants() { }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
@@ -177,14 +177,14 @@ public class DebPackageWriter {
             out.write(pkgDto.getPackageGroupName());
             out.newLine();
 
-            // Priority is not stored in DB
-            // out.write("Priority: ");
-            // out.write(pkgDto.get);
-            // out.newLine();
-
-            // out.write("Homepage: ");
-            // out.write(pkgDto.get);
-            // out.newLine();
+            if (pkgDto.getExtraTags() != null) {
+                for (var entry : pkgDto.getExtraTags().entrySet()) {
+                    out.write(entry.getKey());
+                    out.write(": ");
+                    out.write(entry.getValue());
+                    out.newLine();
+                }
+            }
 
             out.write("Description: ");
             out.write(pkgDto.getDescription());

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/test/DebPackageWriterTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/test/DebPackageWriterTest.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.taskomatic.task.repomd.test;
+
+import com.redhat.rhn.common.db.datasource.DataResult;
+import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
+import com.redhat.rhn.domain.rhnpackage.Package;
+import com.redhat.rhn.domain.rhnpackage.PackageExtraTagsKeys;
+import com.redhat.rhn.frontend.dto.PackageDto;
+import com.redhat.rhn.manager.rhnpackage.PackageManager;
+import com.redhat.rhn.manager.rhnpackage.test.PackageManagerTest;
+import com.redhat.rhn.manager.task.TaskManager;
+import com.redhat.rhn.taskomatic.task.repomd.DebPackageWriter;
+import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Map;
+
+public class DebPackageWriterTest extends JMockBaseTestCaseWithUser {
+
+    private Path tmpDir;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        tmpDir = Files.createTempDirectory("debPkgWriterTest");
+    }
+
+    public void testWritePackages() throws Exception {
+        Channel channel = ChannelFactoryTest.createBaseChannel(user);
+
+        PackageExtraTagsKeys tag1 = PackageManagerTest.createExtraTagKey("Tag1");
+        PackageExtraTagsKeys tag2 = PackageManagerTest.createExtraTagKey("Tag2");
+        PackageExtraTagsKeys tag3 = PackageManagerTest.createExtraTagKey("Tag3");
+
+        Package pkg1 = PackageManagerTest.addPackageToChannel("pkg_1", channel);
+        pkg1.getExtraTags().put(tag1, "value1");
+        pkg1.getExtraTags().put(tag2, "value2");
+
+        Package pkg2 = PackageManagerTest.addPackageToChannel("pkg_2", channel);
+        pkg2.getExtraTags().put(tag2, "value2");
+        pkg2.getExtraTags().put(tag3, "value3");
+
+        Package pkg3 = PackageManagerTest.addPackageToChannel("pkg_3", channel);
+
+        PackageManager.createRepoEntrys(channel.getId());
+
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().clear();
+
+        DebPackageWriter writer = new DebPackageWriter(channel, tmpDir.normalize().toString() + File.separator);
+
+        DataResult<PackageDto> packageBatch = TaskManager.getChannelPackageDtos(channel, 0, 100);
+        packageBatch.elaborate();
+        Map<Long, Map<String, String>> extraTags = TaskManager.getChannelPackageExtraTags(Arrays.asList(pkg1.getId(), pkg2.getId()));
+        for (PackageDto pkgDto : packageBatch) {
+            pkgDto.setExtraTags(extraTags.get(pkgDto.getId()));
+        }
+
+        packageBatch.forEach(pkgDto -> writer.addPackage(pkgDto));
+
+        String packagesContent = FileUtils.readFileToString(tmpDir.resolve("Packages").toFile());
+        packagesContent = packagesContent.replaceAll("Filename: channel.*/getPackage/", "Filename: channel/getPackage/");
+        packagesContent = packagesContent.replaceAll("MD5sum: .*\\s", "MD5sum: some-md5sum\n");
+        packagesContent = packagesContent.replaceAll("Section: .*\\s", "Section: some-section\n");
+
+        assertEquals("Package: pkg_1\n" +
+                        "Version: 1:1.0.0-1\n" +
+                        "Architecture: noarch\n" +
+                        "Maintainer: Rhn-Java\n" +
+                        "Installed-Size: 42\n" +
+                        "Filename: channel/getPackage/pkg_1_1:1.0.0-1.noarch.deb\n" +
+                        "Size: 42\n" +
+                        "MD5sum: some-md5sum\n" +
+                        "Section: some-section\n" +
+                        "Tag1: value1\n" +
+                        "Tag2: value2\n" +
+                        "Description: RHN-JAVA Package Test\n" +
+                        "\n" +
+                        "Package: pkg_2\n" +
+                        "Version: 1:1.0.0-1\n" +
+                        "Architecture: noarch\n" +
+                        "Maintainer: Rhn-Java\n" +
+                        "Installed-Size: 42\n" +
+                        "Filename: channel/getPackage/pkg_2_1:1.0.0-1.noarch.deb\n" +
+                        "Size: 42\n" +
+                        "MD5sum: some-md5sum\n" +
+                        "Section: some-section\n" +
+                        "Tag3: value3\n" +
+                        "Tag2: value2\n" +
+                        "Description: RHN-JAVA Package Test\n" +
+                        "\n" +
+                        "Package: pkg_3\n" +
+                        "Version: 1:1.0.0-1\n" +
+                        "Architecture: noarch\n" +
+                        "Maintainer: Rhn-Java\n" +
+                        "Installed-Size: 42\n" +
+                        "Filename: channel/getPackage/pkg_3_1:1.0.0-1.noarch.deb\n" +
+                        "Size: 42\n" +
+                        "MD5sum: some-md5sum\n" +
+                        "Section: some-section\n" +
+                        "Description: RHN-JAVA Package Test",
+                packagesContent.trim());
+    }
+
+    public void tearDown() throws Exception {
+        super.tearDown();
+        FileUtils.deleteDirectory(tmpDir.toFile());
+    }
+
+}

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/test/DebRepositoryWriterTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/test/DebRepositoryWriterTest.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.taskomatic.task.repomd.test;
+
+import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
+import com.redhat.rhn.domain.rhnpackage.Package;
+import com.redhat.rhn.domain.rhnpackage.PackageExtraTagsKeys;
+import com.redhat.rhn.manager.rhnpackage.PackageManager;
+import com.redhat.rhn.manager.rhnpackage.test.PackageManagerTest;
+import com.redhat.rhn.taskomatic.task.repomd.DebRepositoryWriter;
+import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
+import org.apache.commons.io.FileUtils;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class DebRepositoryWriterTest extends JMockBaseTestCaseWithUser {
+
+    private Path tmpDir;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        tmpDir = Files.createTempDirectory("debPkgWriterTest");
+    }
+
+    public void testWriteRepoMetadata() throws Exception {
+        Channel channel = ChannelFactoryTest.createBaseChannel(user);
+
+        PackageExtraTagsKeys multiArchTag = PackageManagerTest.createExtraTagKey("Multi-Arch");
+
+        Package pkg1 = PackageManagerTest.addPackageToChannel("pkg_1", channel);
+        pkg1.getExtraTags().put(multiArchTag, "same");
+        Package pkg2 = PackageManagerTest.addPackageToChannel("pkg_2", channel);
+        Package pkg3 = PackageManagerTest.addPackageToChannel("pkg_3", channel);
+
+        PackageManager.createRepoEntrys(channel.getId());
+
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().clear();
+
+        DebRepositoryWriter writer = new DebRepositoryWriter("rhn/repodata", tmpDir.normalize().toString());
+        writer.writeRepomdFiles(channel);
+        Path channelRepodataDir = tmpDir.resolve("rhn/repodata/" + channel.getLabel());
+        List<String> fileNames = Files.list(channelRepodataDir)
+                .map(path -> path.getFileName().toString())
+                .collect(Collectors.toList());
+        assertTrue(fileNames.contains("Release"));
+        assertTrue(fileNames.contains("Packages"));
+        assertTrue(fileNames.contains("Packages.gz"));
+
+//        String releaseContent = FileUtils.readFileToString(channelRepodataDir.resolve("Release").toFile());
+//        System.out.println(releaseContent);
+    }
+
+    public void tearDown() throws Exception {
+        super.tearDown();
+        FileUtils.deleteDirectory(tmpDir.toFile());
+    }
+
+}

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Import additional fields for Deb packages
 - replace requires susemanager with uyuni-base server for group(susemanager)
 - Add page to show virtual storage pools and volumes of a system
 - Migrate login to Spark

--- a/schema/spacewalk/common/tables/rhnPackageExtraTag.sql
+++ b/schema/spacewalk/common/tables/rhnPackageExtraTag.sql
@@ -1,0 +1,26 @@
+--
+-- Copyright (c) 2019 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+CREATE TABLE IF NOT EXISTS rhnPackageExtraTags
+(
+    package_id  NUMBER NOT NULL
+                    CONSTRAINT rhn_pkg_extratags_pid_fk
+                       REFERENCES rhnPackage (id)
+                       ON DELETE CASCADE,
+    key_id      NUMBER NOT NULL
+                       REFERENCES rhnPackageExtraTagKey (id)
+                       ON DELETE CASCADE,
+    value       VARCHAR2(2048) NOT NULL,
+    created     timestamp with local time zone
+                    DEFAULT (current_timestamp) NOT NULL,
+    primary key (package_id, key_id)
+)
+;

--- a/schema/spacewalk/common/tables/rhnPackageExtraTagKey.sql
+++ b/schema/spacewalk/common/tables/rhnPackageExtraTagKey.sql
@@ -1,0 +1,25 @@
+--
+-- Copyright (c) 2019 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+CREATE TABLE IF NOT EXISTS rhnPackageExtraTagKey
+(
+    id          NUMBER NOT NULL
+                    CONSTRAINT rhn_pkg_extra_tags_keys_id_pk PRIMARY KEY,
+    name        VARCHAR2(256) NOT NULL,
+    created     timestamp with local time zone
+                    DEFAULT (current_timestamp) NOT NULL
+)
+;
+
+CREATE SEQUENCE rhn_package_extra_tags_keys_id_seq;
+
+CREATE UNIQUE INDEX rhn_pkg_extra_tag_key_idx
+    ON rhnPackageExtraTagKey (name);

--- a/schema/spacewalk/common/tables/tables.deps
+++ b/schema/spacewalk/common/tables/tables.deps
@@ -139,6 +139,8 @@ rhnPackagePredepends           :: rhnPackage rhnPackageCapability
 rhnPackageSource               :: web_customer rhnSourceRPM rhnFile rhnPackageGroup \
                                   rhnChecksum
 rhnPackageSyncBlacklist        :: rhnPackageName web_customer
+rhnPackageExtraTagKey          :: rhnPackage
+rhnPackageExtraTag             :: rhnPackage rhnPackageExtraTagKey
 rhnProxyInfo                   :: rhnServer
 rhnPushClient                  :: rhnServer rhnPushClientState
 rhnRam                         :: rhnServer

--- a/schema/spacewalk/oracle/triggers/rhnPackageExtraTags.sql
+++ b/schema/spacewalk/oracle/triggers/rhnPackageExtraTags.sql
@@ -1,0 +1,22 @@
+--
+-- Copyright (c) 2019 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+create or replace trigger
+suseproductchannel_mod_trig
+before insert or update on rhnPackageExtraTags
+for each row
+begin
+    :new.modified := current_timestamp;
+end;
+/
+show errors
+
+

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.0-to-susemanager-schema-4.1.1/001-rhnPackageExtraTag.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.0-to-susemanager-schema-4.1.1/001-rhnPackageExtraTag.sql.oracle
@@ -1,0 +1,41 @@
+-- Copyright (c) 2019 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+CREATE TABLE IF NOT EXISTS rhnPackageExtraTagKey
+(
+    id          NUMBER NOT NULL
+                    CONSTRAINT rhn_pkg_extra_tags_keys_id_pk PRIMARY KEY,
+    name        VARCHAR2(256) NOT NULL,
+    created     timestamp with local time zone
+                    DEFAULT (current_timestamp) NOT NULL
+)
+;
+
+CREATE SEQUENCE rhn_package_extra_tags_keys_id_seq;
+
+CREATE UNIQUE INDEX rhn_pkg_extra_tag_key_idx
+    ON rhnPackageExtraTagKey (name);
+
+CREATE TABLE IF NOT EXISTS rhnPackageExtraTags
+(
+    package_id  NUMBER NOT NULL
+                    CONSTRAINT rhn_pkg_extratags_pid_fk
+                       REFERENCES rhnPackage (id)
+                       ON DELETE CASCADE,
+    key_id      NUMBER NOT NULL
+                       REFERENCES rhnPackageExtraTagKey (id)
+                       ON DELETE CASCADE,
+    value       VARCHAR2(2048) NOT NULL,
+    created     timestamp with local time zone
+                    DEFAULT (current_timestamp) NOT NULL,
+    primary key (package_id, name)
+)
+;
+

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.0-to-susemanager-schema-4.1.1/001-rhnPackageExtraTag.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.0-to-susemanager-schema-4.1.1/001-rhnPackageExtraTag.sql.postgresql
@@ -1,0 +1,45 @@
+-- oracle equivalent source sha1 924f3d4434ecc9005fac1e5d2bf998a641396644
+--
+-- Copyright (c) 2019 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+CREATE TABLE IF NOT EXISTS rhnPackageExtraTagKey
+(
+    id          NUMERIC NOT NULL
+                    CONSTRAINT rhn_pkg_extra_tags_keys_id_pk PRIMARY KEY,
+    name        VARCHAR(256) NOT NULL,
+    created     TIMESTAMPTZ
+                     DEFAULT (current_timestamp) NOT NULL
+)
+;
+
+CREATE SEQUENCE rhn_package_extra_tags_keys_id_seq;
+
+CREATE UNIQUE INDEX rhn_pkg_extra_tag_key_idx
+    ON rhnPackageExtraTagKey (name);
+
+CREATE TABLE IF NOT EXISTS rhnPackageExtraTag
+(
+    package_id  NUMERIC NOT NULL
+                    CONSTRAINT rhn_pkg_extratags_pid_fk
+                       REFERENCES rhnPackage (id)
+                       ON DELETE CASCADE,
+    key_id      NUMERIC NOT NULL
+                       REFERENCES rhnPackageExtraTagKey (id)
+                       ON DELETE CASCADE,
+    value       VARCHAR(2048) NOT NULL,
+    created     TIMESTAMPTZ
+                     DEFAULT (current_timestamp) NOT NULL,
+    primary key (package_id, key_id)
+)
+;
+
+
+


### PR DESCRIPTION
## What does this PR change?

Import additional fields for Debian packages, notably `Multi-Arch`.

## GUI diff

No difference.

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/1030

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
