### PR TITLE
Manager bsc1148169

### DIFF
--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- ensure working directory is /root during setup (bsc#1148169)
 - dmidecode does not exist on s390x (bsc#1145119)
 - move /usr/share/rhn/config-defaults to uyuni-base-common
 - Add missing bootstrap repo entries for Ubuntu repositories

--- a/susemanager/yast/susemanager_setup.rb
+++ b/susemanager/yast/susemanager_setup.rb
@@ -62,4 +62,5 @@ module Yast
   end
 end
 
+Dir.chdir("/root")
 Yast::SusemanagerSetupClient.new.main


### PR DESCRIPTION
## What does this PR change?

setup expects several files in /root (especially "/root/ssl-build" is hardcoded in various places), so if user starts setup in a directory different from his home, it might fail. Could only be reproduced with external certificates, but we should ensure in any case that working directory is /root, since the answer file also contains sensitive data.