### PR TITLE
Fix bootstrapping SLE11SP4 trad client with SSL enabled (bsc#1148177)

### DIFF
--- a/client/rhel/rhnlib/rhn/SSL.py
+++ b/client/rhel/rhnlib/rhn/SSL.py
@@ -112,7 +112,7 @@ class SSLSocket:
         self._connection = SSL.Connection(self._ctx, self._sock)
         # Set server name if defined. This allows connections to
         # SNI-enabled servers
-        if server_name is not None:
+        if server_name is not None and getattr(self._connection, "set_tlsext_host_name", None):
             self._connection.set_tlsext_host_name(bstr(server_name))
         # Place the connection in client mode
         self._connection.set_connect_state()

--- a/client/rhel/rhnlib/rhnlib.changes
+++ b/client/rhel/rhnlib/rhnlib.changes
@@ -1,5 +1,6 @@
 - fix initialize ssl connection (bsc#1144155)
 - Add SNI support for clients
+- Fix bootstrapping SLE11SP4 trad client with SSL enabled (bsc#1148177)
 
 -------------------------------------------------------------------
 Wed May 15 15:04:15 CEST 2019 - jgonzalez@suse.com


### PR DESCRIPTION
## What does this PR change?

Porting: https://github.com/SUSE/spacewalk/pull/9232/commits/0055ee4c3ff87028c6410b66a92e772fdd058617

## GUI diff

No difference.

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
