### PR TITLE
Re-enable Ubuntu + Proxy tests

### DIFF
--- a/testsuite/features/core/ubuntu_salt_ssh.feature
+++ b/testsuite/features/core/ubuntu_salt_ssh.feature
@@ -21,22 +21,21 @@ Feature: Bootstrap a SSH-managed Ubuntu minion and do some basic operations on i
     And I wait until I see the name of "ubuntu-minion", refreshing the page
     And I wait until onboarding is completed for "ubuntu-minion"
 
-#TODO: Enable again the proxy, and test with it before deliver the feature
-#@proxy
-#@ubuntu_minion
-#  Scenario: Check connection from SSH-managed Ubuntu minion to proxy
-#    Given I am on the Systems overview page of this "ubuntu-minion"
-#    When I follow "Details" in the content area
-#    And I follow "Connection" in the content area
-#    Then I should see "proxy" hostname
+@proxy
+@ubuntu_minion
+  Scenario: Check connection from SSH-managed Ubuntu minion to proxy
+    Given I am on the Systems overview page of this "ubuntu-minion"
+    When I follow "Details" in the content area
+    And I follow "Connection" in the content area
+    Then I should see "proxy" hostname
 
-#@proxy
-#@ubuntu_minion
-#  Scenario: Check registration on proxy of SSH-managed Ubuntu minion
-#    Given I am on the Systems overview page of this "proxy"
-#    When I follow "Details" in the content area
-#    And I follow "Proxy" in the content area
-#    Then I should see "ubuntu-minion" hostname
+@proxy
+@ubuntu_minion
+  Scenario: Check registration on proxy of SSH-managed Ubuntu minion
+    Given I am on the Systems overview page of this "proxy"
+    When I follow "Details" in the content area
+    And I follow "Proxy" in the content area
+    Then I should see "ubuntu-minion" hostname
 
 @ubuntu_minion
   Scenario: Subscribe the SSH-managed Ubuntu minion to a base channel


### PR DESCRIPTION
## What does this PR change?

Connection of Ubuntu through proxy has been re-enabled in a previous PR. Test it works.

## Links

 - 3.2: SUSE/spacewalk#9324
 - 4.0: SUSE/spacewalk#9325

## Changelogs

- [x] No changelog needed
