### PR TITLE
Import .yaml metadata files with the Zypper plugin

### DIFF
--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -647,9 +647,13 @@ type=rpm-md
         """
         if not self.repo.is_configured:
             self.setup_repo(self.repo)
-        _md_files = glob.glob(self._get_repodata_path() + "/*{}.xml.gz".format(tag)) or glob.glob(self._get_repodata_path() + "/*{}.xml".format(tag))
-        if _md_files:
-            return _md_files[0]
+
+        _repodata_path = self._get_repodata_path()
+        _file_globs = ["/*{}.xml.gz", "/*{}.xml", "/*{}.yaml.gz", "/*{}.yaml"]
+        for f in _file_globs:
+            _md_files = glob.glob(_repodata_path + f.format(tag))
+            if _md_files:
+                return _md_files[0]
         return None
 
     def _get_repodata_path(self):

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Add basic support for importing modular repositories
 - Add script to update additional fields in the DB for existing Deb packages
 - use active values for diskchecker mails
 - parse restart_suggested flag from patches and set it as keywords (bsc#1151467)

--- a/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/BaseSystemPackagesAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/BaseSystemPackagesAction.java
@@ -106,7 +106,7 @@ public abstract class BaseSystemPackagesAction extends RhnAction {
             }
         }
         if (hasModules) {
-            addMessage(request, "packagelist.jsp.modulespresent");
+            createErrorMessage(request, "packagelist.jsp.modulespresent", null);
         }
         return mapping.findForward(RhnHelper.DEFAULT_FORWARD);
     }

--- a/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-www.conf
+++ b/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-www.conf
@@ -76,6 +76,7 @@ ProxyPass "/rhn/websocket" "ws://localhost:8080/rhn/websocket"
 XSendFile on
 XSendFilePath /var/spacewalk/packages
 XSendFilePath /var/spacewalk/rhn/comps
+XSendFilePath /var/spacewalk/rhn/modules
 XSendFilePath /var/cache/rhn/repodata
 <Directory /var/spacewalk/packages>
     <IfVersion <= 2.2>

--- a/spacewalk/config/spacewalk-config.changes
+++ b/spacewalk/config/spacewalk-config.changes
@@ -1,3 +1,4 @@
+- Resolve modules.yaml file for modular repositories
 - remove superfluous 'apache' entries from sudoers configuration (bsc#1151632)
 - Migrate login to Spark
 - Require uyuni-base-common for /etc/rhn


### PR DESCRIPTION
The Zypper plugin only checks `xml` files when looking for metadata. This patch adds `yaml` extension to the list. This is required to find the `modules.yaml` file for RHEL 8 repositories.

When `modules.yaml` is imported correctly, SUMA displays a warning bubble about modular repositories (see below).

See: https://github.com/uyuni-project/uyuni/issues/805#issuecomment-520817637

## GUI diff
![rhel8-modules-warning](https://user-images.githubusercontent.com/1103552/65063660-ffaac880-d97e-11e9-90fd-1bca54bc96ef.png)

## Documentation
- https://github.com/SUSE/spacewalk/issues/9574

## Test coverage
- Unit tests were added

## Links

Fixes https://github.com/SUSE/spacewalk/issues/9149

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
