### PR TITLE
Replace references from spacewalksd to mgr-daemon (bsc#1149353)

### DIFF
--- a/client/debian/apt-spacewalk/apt-spacewalk.spec
+++ b/client/debian/apt-spacewalk/apt-spacewalk.spec
@@ -34,7 +34,7 @@ Requires: python-apt
 Requires: rhn-client-tools
 Requires: python-six
 
-Recommends: rhnsd
+Recommends: mgr-daemon
 
 %description -n apt-transport-spacewalk
  Supplies the APT method for fetching packages from Spacewalk.

--- a/client/rhel/mgr-daemon/mgr-daemon.changes
+++ b/client/rhel/mgr-daemon/mgr-daemon.changes
@@ -1,3 +1,5 @@
+- Adjust current name of the package to mgr-daemon and not
+  spacewalksd (bsc#1149353)
 - enable spacewalk-update-service on package installation
   (bsc#1143789)
 

--- a/client/rhel/mgr-daemon/mgr-daemon.spec
+++ b/client/rhel/mgr-daemon/mgr-daemon.spec
@@ -28,7 +28,7 @@
 %define rhn_client_tools spacewalk-client-tools
 %define rhn_setup	 spacewalk-client-setup
 %define rhn_check	 spacewalk-check
-%define rhnsd		 spacewalksd
+%define rhnsd		 mgr-daemon
 #
 Name:           mgr-daemon
 Version:        4.0.6

--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes
@@ -1,3 +1,5 @@
+- Require mgr-daemon (new name of spacewalksd) so we systems with
+  spacewalksd get always the new package installed (bsc#1149353)
 - enable spacewalk-update-service on package installation
   (bsc#1143789)
 - Invalidate cache 5 minutes before actual expiration(bsc#1143562)

--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.spec
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.spec
@@ -60,7 +60,7 @@
 %define rhn_client_tools spacewalk-client-tools
 %define rhn_setup	 spacewalk-client-setup
 %define rhn_check	 spacewalk-check
-%define rhnsd		 spacewalksd
+%define rhnsd		 mgr-daemon
 #
 %define without_rhn_register 1
 %bcond_with    test

--- a/client/rhel/yum-rhn-plugin/yum-rhn-plugin.changes
+++ b/client/rhel/yum-rhn-plugin/yum-rhn-plugin.changes
@@ -1,3 +1,6 @@
+- Require mgr-daemon (new name of spacewalksd) so we systems with
+  spacewalksd get always the new package installed (bsc#1149353)
+
 -------------------------------------------------------------------
 Wed May 15 15:37:55 CEST 2019 - jgonzalez@suse.com
 

--- a/client/rhel/yum-rhn-plugin/yum-rhn-plugin.spec
+++ b/client/rhel/yum-rhn-plugin/yum-rhn-plugin.spec
@@ -21,7 +21,7 @@
 %define rhn_client_tools spacewalk-client-tools
 %define rhn_setup	 spacewalk-client-setup
 %define rhn_check	 spacewalk-check
-%define rhnsd		 spacewalksd
+%define rhnsd		 mgr-daemon
 #
 Summary:        Spacewalk support for yum
 License:        GPL-2.0-only

--- a/client/tools/mgr-cfg/mgr-cfg.changes
+++ b/client/tools/mgr-cfg/mgr-cfg.changes
@@ -1,3 +1,6 @@
+- Require mgr-daemon (new name of spacewalksd) so we systems with
+  spacewalksd get always the new package installed (bsc#1149353)
+
 -------------------------------------------------------------------
 Wed Jul 31 17:25:43 CEST 2019 - jgonzalez@suse.com
 

--- a/client/tools/mgr-cfg/mgr-cfg.spec
+++ b/client/tools/mgr-cfg/mgr-cfg.spec
@@ -21,7 +21,7 @@
 %define rhn_client_tools spacewalk-client-tools
 %define rhn_setup	 spacewalk-client-setup
 %define rhn_check	 spacewalk-check
-%define rhnsd		 spacewalksd
+%define rhnsd		 mgr-daemon
 # Old name and version+1 before renaming to mgr-cfg
 %define oldname          rhncfg
 %define oldversion       5.10.123

--- a/client/tools/mgr-virtualization/mgr-virtualization.changes
+++ b/client/tools/mgr-virtualization/mgr-virtualization.changes
@@ -1,3 +1,5 @@
+- Require mgr-daemon (new name of spacewalksd) so we systems with
+  spacewalksd get always the new package installed (bsc#1149353)
 - Fix mgr-virtualization timer
 
 -------------------------------------------------------------------

--- a/client/tools/mgr-virtualization/mgr-virtualization.spec
+++ b/client/tools/mgr-virtualization/mgr-virtualization.spec
@@ -21,7 +21,7 @@
 %define rhn_client_tools spacewalk-client-tools
 %define rhn_setup	 spacewalk-client-setup
 %define rhn_check	 spacewalk-check
-%define rhnsd		 spacewalksd
+%define rhnsd		 mgr-daemon
 # Old name and version+1 before renaming to mgr-push
 %define oldname          rhn-virtualization
 %define oldversion       5.4.73

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,6 @@
+- Require mgr-daemon (new name of spacewalksd) so we systems with
+  spacewalksd get always the new package installed (bsc#1149353)
+
 -------------------------------------------------------------------
 Wed Jul 31 17:32:10 CEST 2019 - jgonzalez@suse.com
 

--- a/spacewalk/certs-tools/spacewalk-certs-tools.spec
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.spec
@@ -22,7 +22,7 @@
 %define rhn_client_tools spacewalk-client-tools
 %define rhn_setup	 spacewalk-client-setup
 %define rhn_check	 spacewalk-check
-%define rhnsd		 spacewalksd
+%define rhnsd		 mgr-daemon
 #
 %if 0%{?suse_version}
 %global pub_bootstrap_dir /srv/www/htdocs/pub/bootstrap


### PR DESCRIPTION
## What does this PR change?

Replace references from `spacewalksd` package to `mgr-daemon` package (bsc#1149353) so `mgr-daemon` gets installed even if `spacewalksd` is already present.

To be honest, I think that some of the macros could just get removed, as I see the macro definition, but can't find where that macro is used at the spec.

I also updated some other references, even for packages we don't build. Just in case we need them for the future.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Documentation already mentions mgr-daemon.

- [x] **DONE**

## Test coverage
- No tests: Not covered by testsuite. This only happens with RES, not with RHEL or CentOS.

- [x] **DONE**

## Links

After we port this for 4.0, this will fix https://github.com/SUSE/spacewalk/issues/9331

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
