### PR TITLE
Manager uyuni base

### DIFF
--- a/uyuni/base/uyuni-base.changes
+++ b/uyuni/base/uyuni-base.changes
@@ -1,3 +1,5 @@
+- uyuni-base-common is not really required at buildtime, so
+  remove respective BuildRequires
 - move /usr/share/rhn/config-defaults to uyuni-base-common
 - make packages distribution agnostic
 - fix permission of /etc/rhn; add Requires and BuildRequires

--- a/uyuni/base/uyuni-base.spec
+++ b/uyuni/base/uyuni-base.spec
@@ -53,7 +53,6 @@ Basic filesystem hierarchy for Uyuni server and proxy.
 %package server
 Summary:        Base structure for Uyuni server
 Group:          System/Fhs
-BuildRequires:  uyuni-base-common
 Requires(pre):  uyuni-base-common
 
 %description server
@@ -62,7 +61,6 @@ Basic filesystem hierarchy for Uyuni server.
 %package proxy
 Summary:        Base structure for Uyuni proxy
 Group:          System/Fhs
-BuildRequires:  uyuni-base-common
 Requires(pre):  uyuni-base-common
 
 %description proxy


### PR DESCRIPTION
## What does this PR change?

uyuni-base-common is not really required at build time, so remove respective BuildRequires to fix issue with initial builds where no version exists at all.