### PR TITLE
Opensuse clients (first part)

### DIFF
--- a/testsuite/features/core/centos_salt_ssh.feature
+++ b/testsuite/features/core/centos_salt_ssh.feature
@@ -52,10 +52,9 @@ Feature: Bootstrap a SSH-managed CentOS minion and do some basic operations on i
     And I wait until event "Subscribe channels scheduled by admin" is completed
 
 @centos_minion
-  Scenario: Prepare a SSH-managed CentOS minion
+  Scenario: Prepare the SSH-managed CentOS minion
     Given I am authorized
-    When I enable repository "Devel_Galaxy_Manager_Head_RES-Manager-Tools-7-x86_64" on this "ceos-client"
-    And  I enable repository "SLE-Manager-Tools-RES-7-x86_64" on this "ceos-client"
+    When I enable SUSE Manager tools repositories on "ceos-client"
     And  I enable repository "CentOS-Base" on this "ceos-client"
     And  I install package "hwdata m2crypto wget" on this "ceos-client"
     And  I install package "rhn-client-tools rhn-check rhn-setup rhnsd mgr-osad rhncfg-actions" on this "ceos-client"

--- a/testsuite/features/core/trad_register_client.feature
+++ b/testsuite/features/core/trad_register_client.feature
@@ -25,7 +25,7 @@ Feature: Register a traditional client
     And I should see a "Add to SSM" link
     And I should see a "Delete System" link
     And I should see a "Initial Registration Parameters:" text
-    And I should see a "OS: sles-release" text
+    And I should see a text describing the OS release
 
 @proxy
   Scenario: Check connection from traditional to proxy

--- a/testsuite/features/secondary/trad_centos_client.feature
+++ b/testsuite/features/secondary/trad_centos_client.feature
@@ -20,10 +20,9 @@ Feature: Be able to register a CentOS 7 traditional client and do some basic ope
     Then "ceos-ssh-minion" should not be registered
 
 @centos_minion
-  Scenario: Prepare a CentOS 7 traditional client
+  Scenario: Prepare the CentOS 7 traditional client
     Given I am authorized
-    When I enable repository "Devel_Galaxy_Manager_Head_RES-Manager-Tools-7-x86_64" on this "ceos-client"
-    And I enable repository "SLE-Manager-Tools-RES-7-x86_64" on this "ceos-client"
+    When I enable SUSE Manager tools repositories on "ceos-client"
     And I enable repository "CentOS-Base" on this "ceos-client"
     And I install package "hwdata m2crypto wget" on this "ceos-client"
     And I install package "rhn-client-tools rhn-check rhn-setup rhnsd mgr-osad rhncfg-actions" on this "ceos-client"

--- a/testsuite/features/secondary/trad_migrate_to_minion.feature
+++ b/testsuite/features/secondary/trad_migrate_to_minion.feature
@@ -90,7 +90,7 @@ Feature: Migrate a traditional client into a Salt minion
     Then "sle-migrated-minion" should not be registered
 
   Scenario: Cleanup: register minion again as traditional client
-    When I enable SUSE Manager tools repository on "sle-client"
+    When I enable SUSE Manager tools repositories on "sle-client"
     And I install package "spacewalk-client-setup spacewalk-oscap rhncfg-actions" on this "sle-client"
     And I remove package "salt-minion" from this "sle-client"
     And I register using "1-SUSE-DEV-x86_64" key

--- a/testsuite/features/secondary/trad_migrate_to_sshminion.feature
+++ b/testsuite/features/secondary/trad_migrate_to_sshminion.feature
@@ -116,7 +116,7 @@ Feature: Migrate a traditional client into a Salt SSH minion
     Then "sle-migrated-minion" should not be registered
 
   Scenario: Cleanup: register SSH minion again as traditional client
-    When I enable SUSE Manager tools repository on "sle-client"
+    When I enable SUSE Manager tools repositories on "sle-client"
     And I install package "spacewalk-client-setup spacewalk-oscap rhncfg-actions" on this "sle-client"
     And I register using "1-SUSE-DEV-x86_64" key
 

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -564,7 +564,7 @@ When(/^I enable repository "([^"]*)" on this "([^"]*)"$/) do |repo, host|
   if file_exists?(node, '/usr/bin/zypper')
     cmd = "zypper mr --enable #{repo}"
   elsif file_exists?(node, '/usr/bin/yum')
-    cmd = "test -f /etc/yum.repos.d/#{repo}.repo && sed -i 's/enabled=.*/enabled=1/g' /etc/yum.repos.d/#{repo}.repo"
+    cmd = "sed -i 's/enabled=.*/enabled=1/g' /etc/yum.repos.d/#{repo}.repo"
   elsif file_exists?(node, '/usr/bin/apt-get')
     cmd = "sed -i '/^#\\s*deb.*/ s/^#\\s*deb /deb /' /etc/apt/sources.list.d/#{repo}.list"
   else

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -724,6 +724,12 @@ Then(/^I should see "([^"]*)" as link$/) do |host|
   step %(I should see a "#{system_name}" link)
 end
 
+Then(/^I should see a text describing the OS release$/) do
+  os_version, os_family = get_os_version($client)
+  release = os_family =~ /^opensuse/ ? 'openSUSE-release' : 'sles-release'
+  step %(I should see a "OS: #{release}" text)
+end
+
 Then(/^config-actions are enabled$/) do
   unless file_exists?($client, '/etc/sysconfig/rhn/allowed-actions/configfiles/all')
     raise 'config actions are disabled: /etc/sysconfig/rhn/allowed-actions/configfiles/all does not exist on client'

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -601,16 +601,19 @@ end
 
 # Repository steps
 
-When(/^I enable SUSE Manager tools repository on "([^"]*)"$/) do |host|
+# Enable tools repositories (both stable and development)
+When(/^I enable SUSE Manager tools repositories on "([^"]*)"$/) do |host|
   node = get_target(host)
   os_version, os_family = get_os_version(node)
-  if os_family =~ /^opensuse/
-    repos, _code = $minion.run('zypper lr | grep Uyuni-Client-Tools | cut -d"|" -f2')
-  else
-    repos, _code = $minion.run('zypper lr | grep SLE-Manager-Tools | cut -d"|" -f2')
-    # This enables tools development repository too if it exists
+  if os_family =~ /^opensuse/ || os_family =~ /^sles/
+    repos, _code = node.run('zypper lr | grep Tools | cut -d"|" -f2')
+    node.run("zypper mr --enable #{repos.gsub(/\s/, ' ')}")
+  elsif os_family =~ /^centos/
+    repos, _code = node.run('yum repolist 2>/dev/null | grep Tools | cut -d" " -f1')
+    repos.gsub(/\s/, ' ').split.each do |repo|
+      node.run("sed -i 's/enabled=.*/enabled=1/g' /etc/yum.repos.d/#{repo}.repo")
+    end
   end
-  node.run("zypper mr --enable #{repos.gsub(/\s/, ' ')}")
 end
 
 When(/^I enable repositories before installing Docker$/) do
@@ -629,11 +632,7 @@ When(/^I enable repositories before installing Docker$/) do
   end
 
   # Tools
-  if os_family =~ /^opensuse/
-    repos, _code = $minion.run('zypper lr | grep Uyuni-Client-Tools | cut -d"|" -f2')
-  else
-    repos, _code = $minion.run('zypper lr | grep SLE-Manager-Tools | cut -d"|" -f2')
-  end
+  repos, _code = $minion.run('zypper lr | grep Tools | cut -d"|" -f2')
   puts $minion.run("zypper mr --enable #{repos.gsub(/\s/, ' ')}")
 
   # Container repositories
@@ -662,11 +661,7 @@ When(/^I disable repositories after installing Docker$/) do
   end
 
   # Tools
-  if os_family =~ /^opensuse/
-    repos, _code = $minion.run('zypper lr | grep Uyuni-Client-Tools | cut -d"|" -f2')
-  else
-    repos, _code = $minion.run('zypper lr | grep SLE-Manager-Tools | cut -d"|" -f2')
-  end
+  repos, _code = $minion.run('zypper lr | grep Tools | cut -d"|" -f2')
   puts $minion.run("zypper mr --disable #{repos.gsub(/\s/, ' ')}")
 
   # Container repositories

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -603,9 +603,14 @@ end
 
 When(/^I enable SUSE Manager tools repository on "([^"]*)"$/) do |host|
   node = get_target(host)
-  out, _code = node.run('zypper lr | grep SLE-Manager-Tools | cut -d"|" -f2')
-  # This enables tools development repository too if it exists
-  node.run("zypper mr --enable #{out.gsub(/\s/, ' ')}")
+  os_version, os_family = get_os_version(node)
+  if os_family =~ /^opensuse/
+    repos, _code = $minion.run('zypper lr | grep Uyuni-Client-Tools | cut -d"|" -f2')
+  else
+    repos, _code = $minion.run('zypper lr | grep SLE-Manager-Tools | cut -d"|" -f2')
+    # This enables tools development repository too if it exists
+  end
+  node.run("zypper mr --enable #{repos.gsub(/\s/, ' ')}")
 end
 
 When(/^I enable repositories before installing Docker$/) do
@@ -624,14 +629,16 @@ When(/^I enable repositories before installing Docker$/) do
   end
 
   # Tools
-  repos, _code = $minion.run('zypper lr | grep SLE-Manager-Tools | cut -d"|" -f2')
+  if os_family =~ /^opensuse/
+    repos, _code = $minion.run('zypper lr | grep Uyuni-Client-Tools | cut -d"|" -f2')
+  else
+    repos, _code = $minion.run('zypper lr | grep SLE-Manager-Tools | cut -d"|" -f2')
+  end
   puts $minion.run("zypper mr --enable #{repos.gsub(/\s/, ' ')}")
 
   # Container repositories
   # They don't exist for SLES11 systems, only for SLES12 and upper systems
   unless os_version =~ /^11/
-    repos, _code = $minion.run('zypper lr | grep SLE-Manager-Tools | cut -d"|" -f2')
-    $minion.run("zypper mr --enable #{repos.gsub(/\s/, ' ')}")
     repos, _code = $minion.run('zypper lr | grep SLE-Module-Containers | cut -d"|" -f2')
     $minion.run("zypper mr --enable #{repos.gsub(/\s/, ' ')}")
   end
@@ -655,14 +662,16 @@ When(/^I disable repositories after installing Docker$/) do
   end
 
   # Tools
-  repos, _code = $minion.run('zypper lr | grep SLE-Manager-Tools | cut -d"|" -f2')
+  if os_family =~ /^opensuse/
+    repos, _code = $minion.run('zypper lr | grep Uyuni-Client-Tools | cut -d"|" -f2')
+  else
+    repos, _code = $minion.run('zypper lr | grep SLE-Manager-Tools | cut -d"|" -f2')
+  end
   puts $minion.run("zypper mr --disable #{repos.gsub(/\s/, ' ')}")
 
   # Container repositories
   # They don't exist for SLES11 systems, only for SLES12 and upper systems
   unless os_version =~ /^11/
-    repos, _code = $minion.run('zypper lr | grep SLE-Manager-Tools | cut -d"|" -f2')
-    $minion.run("zypper mr --disable #{repos.gsub(/\s/, ' ')}")
     repos, _code = $minion.run('zypper lr | grep SLE-Module-Containers | cut -d"|" -f2')
     $minion.run("zypper mr --disable #{repos.gsub(/\s/, ' ')}")
   end

--- a/testsuite/features/step_definitions/docker_steps.rb
+++ b/testsuite/features/step_definitions/docker_steps.rb
@@ -62,7 +62,7 @@ When(/^I wait at most (\d+) seconds until all "([^"]*)" container images are bui
     end
   end
   # don't run this for sles11 (docker feature is not there)
-  ck_container_imgs(timeout, count) unless sle11family($minion)
+  ck_container_imgs(timeout, count) unless sle11family?($minion)
 end
 
 When(/^I check the first image$/) do

--- a/testsuite/features/support/client_stack.rb
+++ b/testsuite/features/support/client_stack.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2017 SUSE-LINUX
+# Copyright (c) 2010-2019 SUSE-LINUX
 # Licensed under the terms of the MIT license.
 
 require 'nokogiri'
@@ -23,11 +23,6 @@ def client_raw_repodata_dir(channel)
   else
     "/var/cache/yum/#{channel}"
   end
-end
-
-def sle11family(node)
-  _out, code = node.run('pidof systemd', false)
-  return true if code.nonzero?
 end
 
 def client_system_id_to_i
@@ -84,4 +79,15 @@ def get_os_version(node)
   os_version.gsub!(/\./, '-SP') if os_family =~ /^sles/
 
   [os_version, os_family]
+end
+
+def sle11family?(node)
+  _out, code = node.run('pidof systemd', false)
+  code.nonzero?
+end
+
+def sle15family?(node)
+  os_version, os_family = get_os_version(node)
+  return false if os_version.nil? || os_family.nil?
+  (os_version =~ /^15/) && (os_family =~ /^sles/)
 end

--- a/testsuite/features/support/minion_checks.rb
+++ b/testsuite/features/support/minion_checks.rb
@@ -1,7 +1,0 @@
-# check if the minion is a SLE-15
-def minion_is_sle15
-  node = get_target('sle-minion')
-  os_version, os_family = get_os_version(node)
-  return false if os_version.nil? || os_family.nil?
-  (os_version =~ /^15/) && (os_family =~ /^sles/)
-end

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -129,7 +129,7 @@ def file_inject(node, local_file, remote_file)
 end
 
 # Other global variables
-$sle15_minion = minion_is_sle15
+$sle15_minion = sle15family?($minion)
 $pxeboot_mac = ENV['PXEBOOTMAC']
 $private_net = ENV['PRIVATENET'] if ENV['PRIVATENET']
 $mirror = ENV['MIRROR']


### PR DESCRIPTION
## What does this PR change?

This PR:
* accepts openSUSE as OS in client summary
* enables openSUSE tools on SLE clients
* enables openSUSE tools on CentOS clients

## Links

* First part of issue #8356
* 3.2: SUSE/spacewalk#9394
* 4.0: SUSE/spacewalk#9393

(note: openSUSE will not be tested on 3.2 nor 4.0 in the immediate)

## Changelogs

- [x] No changelog needed

