### PR TITLE
Add default conf to disable missing_cache_strategy warning

### DIFF
--- a/java/conf/default/rhn_hibernate.conf.SUSE
+++ b/java/conf/default/rhn_hibernate.conf.SUSE
@@ -35,7 +35,4 @@ hibernate.jdbc.batch_size=0
 hibernate.cache.provider_class=org.hibernate.cache.EhCacheProvider
 hibernate.cache.region.factory_class=org.hibernate.cache.ehcache.SingletonEhCacheRegionFactory
 hibernate.id.new_generator_mappings = false
-<<<<<<< HEAD
-=======
 hibernate.cache.ehcache.missing_cache_strategy=create
->>>>>>> bdbecee744... Add default conf to disable missing_cache_strategy warning

--- a/java/conf/default/rhn_hibernate.conf.SUSE
+++ b/java/conf/default/rhn_hibernate.conf.SUSE
@@ -1,7 +1,7 @@
 ############################################################################
 ## HIBERNATE CONFIGURATION
 ##
-## This is not the only way to configure hibernate.  You can 
+## This is not the only way to configure hibernate.  You can
 ## create a hibernate.cfg.xml file or you can create your own
 ## custom file which you parse and create a new Configuration object.
 ##
@@ -35,3 +35,7 @@ hibernate.jdbc.batch_size=0
 hibernate.cache.provider_class=org.hibernate.cache.EhCacheProvider
 hibernate.cache.region.factory_class=org.hibernate.cache.ehcache.SingletonEhCacheRegionFactory
 hibernate.id.new_generator_mappings = false
+<<<<<<< HEAD
+=======
+hibernate.cache.ehcache.missing_cache_strategy=create
+>>>>>>> bdbecee744... Add default conf to disable missing_cache_strategy warning


### PR DESCRIPTION
## What does this PR change?

Adds default config ```hibernate.cache.ehcache.missing_cache_strategy=create``` to the file in the server ```/usr/share/rhn/config-defaults/rhn_hibernate.conf``` to disable this warning in the logs:
```
2019-07-25 15:45:41,547 [main] WARN  org.hibernate.orm.cache - HHH90001006: Missing cache[com.redhat.rhn.domain.kickstart.KickstartTreeType] was created on-the-fly. The created cache will use a provider-specific default configuration: make sure you defined one. You can disable this warning by setting 'hibernate.cache.ehcache.missing_cache_strategy' to 'create'.
```
Also removed one whitespace from the file

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **There is nothing changing for the user, nothing to document**

- [x] **DONE**

## Test coverage
- No tests: **Changes nothing for user, nothing for GUI**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/9371

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
