### PR TITLE
Fix tree component row alignment

### DIFF
--- a/web/html/src/components/tree/tree.js
+++ b/web/html/src/components/tree/tree.js
@@ -90,14 +90,14 @@ export const Tree = (props: Props) => {
               />
             </CustomDiv>
           }
-          { (children.length > 0) &&
           <CustomDiv className="col" width="2" um="em">
-            <i
-              className={`fa ${openSubListIconClass} fa-1-5x pointer product-hover`}
-              onClick={() => handleVisibleSublist(item.id)}
-            />
+            { (children.length > 0) &&
+              <i
+                className={`fa ${openSubListIconClass} fa-1-5x pointer product-hover`}
+                onClick={() => handleVisibleSublist(item.id)}
+              />
+            }
           </CustomDiv>
-          }
           {props.renderItem(item, renderNameColumn)}
         </div>
         { children.length > 0 && sublistVisible &&


### PR DESCRIPTION
## What does this PR change?

Rows with no children should be aligned with rows with children. For
this we need to output the column of the expanding arrow, with nothing in
it for rows with no children

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: Tiny alignment issue in a component that is not yet used

- [X] **DONE**

## Test coverage
- No tests: Tiny alignment issue in a component that is not yet used

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
