### PR TITLE
Prevent "reposync" crash when handling metadata on RPM repos

### DIFF
--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -612,7 +612,7 @@ type=rpm-md
             rhnLog.log_clean(0, msg)
             sys.stdout.write(str(msg) + "\n")
             os.system("awk 'BEGIN {{c=0;}} /BEGIN CERT/{{c++}} {{ print > \"{0}/cert.\" c \".pem\"}}' < {1}".format(_ssl_capath, self.sslcacert))
-            os.system("c_rehash {}".format(_ssl_capath))
+            os.system("c_rehash {} 2&>1 /dev/null".format(_ssl_capath))
             query_params['ssl_capath'] = _ssl_capath
         if self.sslclientcert:
             query_params['ssl_clientcert'] = self.sslclientcert

--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -746,7 +746,7 @@ class RepoSync(object):
         log(0, "*** NOTE: Importing comps file for the channel '%s'. Previous comps will be discarded." % (self.channel['label']))        
 
         repoDataKey = 'group' if comps_type == 'comps' else comps_type
-        file_timestamp = plug.repo.repoXML.repoData[repoDataKey].timestamp
+        file_timestamp = os.path.getmtime(filename)
         last_modified = datetime.fromtimestamp(float(file_timestamp), utc)
 
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue in "reposync" when handling group/comps metadata from RPM repositories:

```
suma4:~ # spacewalk-repo-sync -c native-rhel7-x86_64-serveros
11:26:37 ======================================
11:26:37 | Channel: native-rhel7-x86_64-serveros
11:26:37 ======================================
11:26:37 Sync of channel started.
Preparing custom SSL CAPATH at /var/cache/rhn/reposync/.ssl-certs/1
Doing /var/cache/rhn/reposync/.ssl-certs/1
WARNING: Skipping duplicate certificate redhat-uep.pem
WARNING: rhel7-test-20190909-key.pem does not contain a certificate or CRL: skipping
Retrieving repository 'native-rhel7-x86_64-serveros' metadata ................................................................[done]
Building repository 'native-rhel7-x86_64-serveros' cache .....................................................................[done]
All repositories have been refreshed.
11:31:03 
11:31:03   Importing comps file 3aa8e7a4e8d5abad723e1cbe1c13a56749a0760c-comps.xml.
11:31:03   Renaming non-standard filename 3aa8e7a4e8d5abad723e1cbe1c13a56749a0760c-comps.xml to comps.xml.
11:31:03 Unexpected error: <class 'AttributeError'>
11:31:03 Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/spacewalk/satellite_tools/reposync.py", line 565, in sync
    self.import_groups(plugin)
  File "/usr/lib/python3.6/site-packages/spacewalk/satellite_tools/reposync.py", line 784, in import_groups
    abspath = self.copy_metadata_file(plug, groupsfile, 'comps', relative_comps_dir)
  File "/usr/lib/python3.6/site-packages/spacewalk/satellite_tools/reposync.py", line 748, in copy_metadata_file
    file_timestamp = plug.repo.repoXML.repoData[repoDataKey].timestamp
AttributeError: 'ZypperRepo' object has no attribute 'repoXML'

11:31:03 Total time: 0:04:26
```

Besides of that, this changes also remove confusing WARNING messages produced by the underlying call to `c_rehash`:

```
Doing /var/cache/rhn/reposync/.ssl-certs/1
WARNING: Skipping duplicate certificate redhat-uep.pem
WARNING: rhel7-test-20190909-key.pem does not contain a certificate or CRL: skipping 
```

Those messages are expected and always shown and this might be confusing, since there is no actual WARNING or issue.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **bugfix**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/8545

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
