### PR TITLE
Support monitoring for managed systems running Ubuntu 18.04

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
@@ -155,7 +155,7 @@ public class MinionServer extends Server implements SaltConfigurable {
 
     @Override
     public boolean doesOsSupportsMonitoring() {
-        return isSLES12() || isSLES15() || isLeap15();
+        return isSLES12() || isSLES15() || isLeap15() || isUbuntu1804();
     }
 
     /**
@@ -188,6 +188,10 @@ public class MinionServer extends Server implements SaltConfigurable {
 
     private boolean isLeap15() {
         return ServerConstants.LEAP.equalsIgnoreCase(getOs()) && getRelease().startsWith("15");
+    }
+
+    private boolean isUbuntu1804() {
+        return ServerConstants.UBUNTU.equalsIgnoreCase(getOs()) && getRelease().equals("18.04");
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/server/ServerConstants.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerConstants.java
@@ -26,6 +26,7 @@ public class ServerConstants {
     public static final String FEATURE_KICKSTART = "ftr_kickstart";
     public static final String SLES = "SLES";
     public static final String LEAP = "Leap";
+    public static final String UBUNTU = "Ubuntu";
 
     private ServerConstants() {
 

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerTest.java
@@ -145,6 +145,31 @@ public class ServerTest extends BaseTestCaseWithUser {
         s.setRelease("12.1");
         assertTrue(s.doesOsSupportsOSImageBuilding());
     }
+
+    /**
+     * Test for {@link Server#doesOsSupportsMonitoring()} for SLES.
+     */
+    public void testOsSupportsMonitoring() throws Exception {
+        Server s = ServerFactoryTest.createTestServer(user, true,
+                ServerConstants.getServerGroupTypeSaltEntitled(),
+                ServerFactoryTest.TYPE_SERVER_MINION);
+        s.setOs("SLES");
+        s.setRelease("12.1");
+        assertTrue(s.doesOsSupportsMonitoring());
+    }
+
+    /**
+     * Test for {@link Server#doesOsSupportsMonitoring()} for Leap.
+     */
+    public void testOsSupportsMonitoringLeap() throws Exception {
+        Server s = ServerFactoryTest.createTestServer(user, true,
+                ServerConstants.getServerGroupTypeSaltEntitled(),
+                ServerFactoryTest.TYPE_SERVER_MINION);
+        s.setOs("Leap");
+        s.setRelease("15.0");
+        assertTrue(s.doesOsSupportsMonitoring());
+    }
+
     /**
      * Test for {@link Server#doesOsSupportsOSImageBuilding()}.
      */
@@ -155,6 +180,18 @@ public class ServerTest extends BaseTestCaseWithUser {
         s.setOs("SLES");
         s.setRelease("11.4");
         assertFalse(s.doesOsSupportsContainerization());
+    }
+
+    /**
+     * Test for {@link Server#doesOsSupportsMonitoring()} for Ubuntu.
+     */
+    public void testOsDoesNotSupportsMonitoring() throws Exception {
+        Server s = ServerFactoryTest.createTestServer(user, true,
+                ServerConstants.getServerGroupTypeSaltEntitled(),
+                ServerFactoryTest.TYPE_SERVER_MINION);
+        s.setOs("Ubuntu");
+        s.setRelease("18.04");
+        assertFalse(s.doesOsSupportsMonitoring());
     }
 
     public void testGetIpAddress() throws Exception {

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerTest.java
@@ -171,6 +171,18 @@ public class ServerTest extends BaseTestCaseWithUser {
     }
 
     /**
+     * Test for {@link Server#doesOsSupportsMonitoring()} for Ubuntu.
+     */
+    public void testOsSupportsMonitoringUbuntu() throws Exception {
+        Server s = ServerFactoryTest.createTestServer(user, true,
+                ServerConstants.getServerGroupTypeSaltEntitled(),
+                ServerFactoryTest.TYPE_SERVER_MINION);
+        s.setOs("Ubuntu");
+        s.setRelease("18.04");
+        assertTrue(s.doesOsSupportsMonitoring());
+    }
+
+    /**
      * Test for {@link Server#doesOsSupportsOSImageBuilding()}.
      */
     public void testOsDoesNotSupportsOSImageBuilding() throws Exception {
@@ -183,14 +195,14 @@ public class ServerTest extends BaseTestCaseWithUser {
     }
 
     /**
-     * Test for {@link Server#doesOsSupportsMonitoring()} for Ubuntu.
+     * Test for {@link Server#doesOsSupportsMonitoring()}.
      */
     public void testOsDoesNotSupportsMonitoring() throws Exception {
         Server s = ServerFactoryTest.createTestServer(user, true,
                 ServerConstants.getServerGroupTypeSaltEntitled(),
                 ServerFactoryTest.TYPE_SERVER_MINION);
-        s.setOs("Ubuntu");
-        s.setRelease("18.04");
+        s.setOs("SLES");
+        s.setRelease("11.4");
         assertFalse(s.doesOsSupportsMonitoring());
     }
 

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerTest.java
@@ -148,28 +148,6 @@ public class ServerTest extends BaseTestCaseWithUser {
     /**
      * Test for {@link Server#doesOsSupportsOSImageBuilding()}.
      */
-    public void testOsSupportsMonitoring() throws Exception {
-        Server s = ServerFactoryTest.createTestServer(user, true,
-                ServerConstants.getServerGroupTypeSaltEntitled(),
-                ServerFactoryTest.TYPE_SERVER_MINION);
-        s.setOs("SLES");
-        s.setRelease("12.1");
-        assertTrue(s.doesOsSupportsMonitoring());
-    }
-    /**
-     * Test for {@link Server#doesOsSupportsOSImageBuilding()}.
-     */
-    public void testOsSupportsMonitoringLeap() throws Exception {
-        Server s = ServerFactoryTest.createTestServer(user, true,
-                ServerConstants.getServerGroupTypeSaltEntitled(),
-                ServerFactoryTest.TYPE_SERVER_MINION);
-        s.setOs("Leap");
-        s.setRelease("15.0");
-        assertTrue(s.doesOsSupportsMonitoring());
-    }
-    /**
-     * Test for {@link Server#doesOsSupportsOSImageBuilding()}.
-     */
     public void testOsDoesNotSupportsOSImageBuilding() throws Exception {
         Server s = ServerFactoryTest.createTestServer(user, true,
                 ServerConstants.getServerGroupTypeSaltEntitled(),
@@ -178,17 +156,7 @@ public class ServerTest extends BaseTestCaseWithUser {
         s.setRelease("11.4");
         assertFalse(s.doesOsSupportsContainerization());
     }
-    /**
-     * Test for {@link Server#doesOsSupportsOSImageBuilding()}.
-     */
-    public void testOsDoesNotSupportsMonitoring() throws Exception {
-        Server s = ServerFactoryTest.createTestServer(user, true,
-                ServerConstants.getServerGroupTypeSaltEntitled(),
-                ServerFactoryTest.TYPE_SERVER_MINION);
-        s.setOs("Ubuntu");
-        s.setRelease("18.04");
-        assertFalse(s.doesOsSupportsMonitoring());
-    }
+
     public void testGetIpAddress() throws Exception {
         Server s = ServerTestUtils.createTestSystem(user);
         assertNull(s.getIpAddress());

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Allow monitoring for managed systems running Ubuntu 18.04
 - use default value from systemd unit file if not set in /etc/rhn/rhn.conf
 - implement "keyword" filter for Content Lifecycle Management
 - Add support for Azure, Amazon EC2, and Google Compute Engine as Virtual Host Managers.

--- a/schema/spacewalk/common/data/rhnServerServerGroupArchCompat.sql
+++ b/schema/spacewalk/common/data/rhnServerServerGroupArchCompat.sql
@@ -847,4 +847,8 @@ insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type)
     values (lookup_server_arch('x86_64-redhat-linux'),
             lookup_sg_type('monitoring_entitled'));
 
+insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type)
+    values (lookup_server_arch('amd64-debian-linux'),
+            lookup_sg_type('monitoring_entitled'));
+
 commit;

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Allow monitoring for Ubuntu systems
 - Add new types needed for Azure, Amazon EC2 and Google CE
 - Migrate login to Spark
 - enable provisioning for salt clients

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.0-to-susemanager-schema-4.1.1/020-monitoring-entitlement-debian.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.0-to-susemanager-schema-4.1.1/020-monitoring-entitlement-debian.sql
@@ -1,0 +1,8 @@
+insert into rhnServerServerGroupArchCompat (server_arch_id, server_group_type)
+    select lookup_server_arch('amd64-debian-linux'),
+            lookup_sg_type('monitoring_entitled')
+    from dual where not exists (
+        select 1 from rhnServerServerGroupArchCompat where
+        server_arch_id=lookup_server_arch('amd64-debian-linux') and
+        server_group_type=lookup_sg_type('monitoring_entitled')
+    );


### PR DESCRIPTION
## What does this PR change?

This patch adds the necessary server-side support for monitoring to work with `Ubuntu 18.04`
 based managed systems.

## GUI diff

The monitoring add-on system entitlement checkbox will now be available and visible also for `Ubuntu 18.04` systems.

After:

![monitoring-system-type-ubuntu](https://user-images.githubusercontent.com/729454/64795844-07cdc700-d57f-11e9-8098-a7b5630036a3.png)

- [x] **DONE**

## Documentation

Affected would be the matrix of supported features, existing documentation stays valid.

- [x] **DONE**

## Test coverage

Unit tests are being updated with this PR to cover the changes.

- [x] **DONE**

## Links

Part of this downstream issue: https://github.com/SUSE/spacewalk/issues/9246

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
