### PR TITLE
Testsuite - temporary fix for empty-zones-enable

### DIFF
--- a/testsuite/features/secondary/proxy_retail_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_mass_import.feature
@@ -53,6 +53,10 @@ Feature: Mass import Retail terminals
     Given I am on the Systems overview page of this "proxy"
     When I follow "Formulas" in the content area
     And I follow first "Bind" in the content area
+    #HACK bsc1150657 Temporary fix as "empty-zones-enable" option is rewritten by retail_yaml command
+    And I press "Add Item" in config options section
+    And I enter "empty-zones-enable" in first option field
+    And I enter "no" in first value field
     And I press "Add Item" in configured zones section
     And I enter "tf.local" in third configured zone name field
     And I press "Add Item" in available zones section


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/9428

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
