### PR TITLE
When building packages for OBS, add a fake header if isn't one present already

### DIFF
--- a/rel-eng/build-packages-for-obs.sh
+++ b/rel-eng/build-packages-for-obs.sh
@@ -101,6 +101,11 @@ while read PKG_NAME PKG_VER PKG_DIR; do
   ${VERBOSE:+cat "$T_LOG"}
 
   eval $(awk '/^Wrote:.*src.rpm/{srpm=$2}/^Wrote:.*.changes/{changes=$2}END{ printf "SRPM=\"%s\"\n",srpm; printf "CHANGES=\"%s\"\n",changes; }' "$T_LOG")
+  if [ "$(head -n1 ${CHANGES}|grep '^- ')" != "" ]; then
+    echo "*** Untagged package, adding fake header..."
+    sed -i "1i $(LANG=en_EN date '+%a %b %d %H:%M:%S %Z %Y') - faketagger@suse.inet\n" ${CHANGES}
+    sed -i '1i -------------------------------------------------------------------' ${CHANGES}
+  fi
   if [ -e "$SRPM" -a -e "$CHANGES" ]; then
     mkdir "$T_DIR"
     ( set -e; cd "$T_DIR"; unrpm "$SRPM"; ) >/dev/null 2>&1


### PR DESCRIPTION
## What does this PR change?

This allow to inspect full changelogs for development packages installed at development machines, as otherwise rpm will only show the changelog until the most recent header.

This doesn't affect packages with a header on top.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Changes to rel-eng tool.

- [x] **DONE**

## Test coverage
- No tests: Tool not covered.

- [x] **DONE**

## Links

Tracks: https://github.com/SUSE/spacewalk/issues/6918 (needs port to 4.0 and 3.2)

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
