### PR TITLE
Fix some hardcoded SUSE Manager mentions in mails

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/events/NewUserAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/NewUserAction.java
@@ -15,6 +15,7 @@
 
 package com.redhat.rhn.frontend.events;
 
+import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.common.messaging.EventMessage;
 import com.redhat.rhn.common.messaging.MessageAction;
@@ -56,11 +57,14 @@ public class NewUserAction extends BaseMailAction implements MessageAction {
         Map map = new HashMap();
         map.put("login", evt.getUser().getLogin());
         map.put("email-address", evt.getUser().getEmail());
+        map.put("product_name", Config.get().getString("web.product_name"));
 
         //set url and account info for email to accountOwner
         //url.append();
         String accountInfo = StringUtil.replaceTags(OrgFactory
                 .EMAIL_ACCOUNT_INFO.getValue(), map);
+        String emailFooter = StringUtil.replaceTags(OrgFactory
+                .EMAIL_FOOTER.getValue(), map);
 
         //gather information for the email to accountOwner
         Object[] subjectArgs = new Object[4];
@@ -72,7 +76,7 @@ public class NewUserAction extends BaseMailAction implements MessageAction {
         Object[] bodyArgs = new Object[3];
         bodyArgs[0] = accountInfo;
         bodyArgs[1] = evt.getUrl() + "rhn/users/ActiveList.do";
-        bodyArgs[2] = OrgFactory.EMAIL_FOOTER.getValue();
+        bodyArgs[2] = emailFooter;
 
         //Get the admin details(email) from the event message
         //and set in recipients to send the mail

--- a/schema/spacewalk/common/data/rhnTemplateString.sql
+++ b/schema/spacewalk/common/data/rhnTemplateString.sql
@@ -19,7 +19,7 @@ INSERT INTO rhnTemplateString (id, category_id, label, value, description)
              (SELECT TC.id 
                 FROM rhnTemplateCategory TC
 	       WHERE TC.label = 'email_strings'),
-	     'email_footer', '-' || '-the SUSE Manager Team', 'Footer for SUSE Manager e-mail');
+	     'email_footer', '-' || '-the <product_name /> Team', 'Footer for <product_name /> e-mail');
 
 INSERT INTO rhnTemplateString (id, category_id, label, value, description) 
      VALUES (sequence_nextval('rhn_template_str_id_seq'),
@@ -28,6 +28,6 @@ INSERT INTO rhnTemplateString (id, category_id, label, value, description)
 	       WHERE TC.label = 'email_strings'),
 	     'email_account_info', '
 Account Information:
-  Your SUSE Manager login:         <login />
-  Your SUSE Manager email address: <email-address />', 'Account info lines for SUSE Manager e-mail');
+  Your <product_name /> login:         <login />
+  Your <product_name /> email address: <email-address />', 'Account info lines for <product_name /> e-mail');
 

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Replace some hardcoded SUSE Manager mentions in mails with the set product name
 - Migrate login to Spark
 - enable provisioning for salt clients
 - Bump version to 4.1.0

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.0-to-susemanager-schema-4.1.1/012-rhntemplatestring.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.0-to-susemanager-schema-4.1.1/012-rhntemplatestring.sql
@@ -1,0 +1,9 @@
+update rhntemplatestring set value = '-' || '-<product_name /> Team', description = 'Footer for <product_name /> e-mail'  where label = 'email_footer';
+update rhntemplatestring set value = 'Account Information:
+Your <product_name /> login:         <login />
+Your <product_name /> email address: <email-address />', description = 'Account info lines for <product_name /> e-mail' where label = 'email_account_info';
+
+
+commit;
+
+


### PR DESCRIPTION
## What does this PR change?

`SUSE Manager` is still hardcoded in some places used by uyuni during mail generation.
Replace them with `product_name` set in `/usr/share/rhn/config-defaults/rhn.conf` which defaults
to SUSE Manager.
This PR does **not** fix the hardcoded SUSE Manager displayed as the sender of these mails.
See #1354 for further information.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **Changes nothing for user**

- [x] **DONE**

## Test coverage
- No tests: **Changes nothing for user, nothing for GUI**

- [x] **DONE**

## Links
- This partly addresses #250. To fix it #1354 needs to be fixed first.

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql" 		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
