### PR TITLE
Cleanup spacewalk search spec

### DIFF
--- a/search-server/spacewalk-search/spacewalk-search.spec
+++ b/search-server/spacewalk-search/spacewalk-search.spec
@@ -16,6 +16,11 @@
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
+%if 0%{?suse_version}
+%define java_version   11
+%else
+%define java_version   1:11
+%endif
 
 Name:           spacewalk-search
 Summary:        Spacewalk Full Text Search Server
@@ -46,7 +51,7 @@ BuildRequires:  doc-indexes
 BuildRequires:  hadoop
 BuildRequires:  jakarta-commons-httpclient
 BuildRequires:  jakarta-oro
-BuildRequires:  java-devel >= 11
+BuildRequires:  java-devel >= %{java_version}
 BuildRequires:  javapackages-tools
 BuildRequires:  junit
 BuildRequires:  lucene == 2.4.1

--- a/search-server/spacewalk-search/spacewalk-search.spec
+++ b/search-server/spacewalk-search/spacewalk-search.spec
@@ -17,8 +17,6 @@
 #
 
 
-%{!?__redhat_release:%define __redhat_release UNKNOWN}
-
 Name:           spacewalk-search
 Summary:        Spacewalk Full Text Search Server
 License:        GPL-2.0-only AND Apache-2.0
@@ -59,9 +57,6 @@ Requires:       jakarta-oro
 Requires:       javapackages-tools
 #Requires: lucene
 Requires:       objectweb-asm
-%if 0%{?fedora} || 0%{?rhel} >=7
-Requires:       mchange-commons
-%endif
 Requires:       quartz >= 2.0
 Requires:       redstone-xmlrpc
 #Requires: picocontainer
@@ -82,7 +77,6 @@ BuildRequires:  redstone-xmlrpc
 #BuildRequires: picocontainer
 BuildRequires:  simple-core
 BuildRequires:  slf4j
-%if 0%{?fedora} || 0%{?rhel} >=7 || 0%{?suse_version} >= 1315
 Requires:       apache-commons-cli
 Requires:       apache-commons-codec
 Requires:       apache-commons-lang3
@@ -91,36 +85,19 @@ BuildRequires:  apache-commons-cli
 BuildRequires:  apache-commons-codec
 BuildRequires:  apache-commons-lang3
 BuildRequires:  apache-commons-logging
-%else
-Requires:       jakarta-commons-cli
-Requires:       jakarta-commons-codec
-Requires:       jakarta-commons-lang
-Requires:       jakarta-commons-logging
-BuildRequires:  jakarta-commons-cli
-BuildRequires:  jakarta-commons-codec
-BuildRequires:  jakarta-commons-lang
-BuildRequires:  jakarta-commons-logging
+BuildRequires:  zip
+BuildRequires:  systemd
+BuildRequires:  doc-indexes
+Requires:       nutch-core
+%if 0%{?fedora} || 0%{?rhel} >=7
+Requires:       mchange-commons
 %endif
-%if 0%{?fedora} && 0%{?fedora} >= 21
+%if 0%{?fedora} >= 21
 Requires:       log4j12
 BuildRequires:  log4j12
 %else
 Requires:       log4j
 BuildRequires:  log4j
-%endif
-BuildRequires:  zip
-%if 0%{?rhel} && 0%{?rhel} < 7
-Requires(post): chkconfig
-Requires(preun): chkconfig
-# This is for /sbin/service
-Requires(preun): initscripts
-%endif
-%if 0%{?fedora} || 0%{?rhel} >=7 || 0%{?suse_version} >= 1210
-BuildRequires:  systemd
-%endif
-%if 0%{?suse_version}
-BuildRequires:  doc-indexes
-Requires:       nutch-core
 %endif
 
 %description
@@ -146,11 +123,7 @@ install -d -m 755 $RPM_BUILD_ROOT%{_var}/lib/rhn/search
 install -d -m 755 $RPM_BUILD_ROOT%{_var}/lib/rhn/search/indexes
 ln -s -f %{_prefix}/share/rhn/search/indexes/docs $RPM_BUILD_ROOT%{_var}/lib/rhn/search/indexes/docs
 install -d -m 755 $RPM_BUILD_ROOT%{_sbindir}
-%if 0%{?fedora} || 0%{?rhel} >=7 || 0%{?suse_version} >= 1210
 install -d -m 755 $RPM_BUILD_ROOT%{_unitdir}
-%else
-install -d -m 755 $RPM_BUILD_ROOT%{_initrddir}
-%endif
 install -d -m 755 $RPM_BUILD_ROOT%{_bindir}
 install -d -m 755 $RPM_BUILD_ROOT%{_var}/log/rhn/search
 install -d -m 755 $RPM_BUILD_ROOT%{_prefix}/share/rhn/search/nutch
@@ -161,46 +134,24 @@ cp -d lib/* $RPM_BUILD_ROOT/%{_prefix}/share/rhn/search/lib
 
 install -p -m 644 src/config/etc/logrotate.d/rhn-search $RPM_BUILD_ROOT%{_sysconfdir}/logrotate.d/rhn-search
 install -p -m 755 src/config/rhn-search $RPM_BUILD_ROOT%{_sbindir}
-%if 0%{?fedora} || 0%{?rhel} >=7 || 0%{?suse_version} >= 1210
 install -p -m 644 src/config/rhn-search.service $RPM_BUILD_ROOT%{_unitdir}
-%else
-install -p -m 755 src/config/rhn-search.init $RPM_BUILD_ROOT%{_initrddir}/rhn-search
-%endif
 install -p -m 644 src/config/search/rhn_search.conf $RPM_BUILD_ROOT%{_prefix}/share/rhn/config-defaults/rhn_search.conf
 install -p -m 644 src/config/search/rhn_search_daemon.conf $RPM_BUILD_ROOT%{_prefix}/share/rhn/config-defaults/rhn_search_daemon.conf
 ln -s -f %{_prefix}/share/rhn/search/lib/spacewalk-search-%{version}.jar $RPM_BUILD_ROOT%{_prefix}/share/rhn/search/lib/spacewalk-search.jar
-%if 0%{?fedora} && 0%{?fedora} >= 21
-sed -i 's/log4j.jar/log4j-1.jar/' $RPM_BUILD_ROOT%{_prefix}/share/rhn/config-defaults/rhn_search_daemon.conf
-%endif
 %if 0%{?suse_version} >= 1315
 sed -i 's/^wrapper.java.classpath.19=.*/wrapper.java.classpath.19=\/usr\/share\/nutch\/nutch-core-1.0.jar/' $RPM_BUILD_ROOT%{_prefix}/share/rhn/config-defaults/rhn_search_daemon.conf
 %endif
 
 # add rc link
 mkdir -p  $RPM_BUILD_ROOT/%{_sbindir}/
-%if 0%{?suse_version} >= 1210
 ln -sf service $RPM_BUILD_ROOT/%{_sbindir}/rcrhn-search
-%else
-ln -sf ../../etc/init.d/rhn-search $RPM_BUILD_ROOT/%{_sbindir}/rcrhn-search
-%endif
 
 # mybatis is build with newer API. This statements needs to stay, until we have a build with 1.5
 export NO_BRP_CHECK_BYTECODE_VERSION=true
 
 %post
 was_running=0
-%if 0%{?suse_version} >= 1210
 %service_add_post rhn-search.service
-%else
-if [ -f /etc/init.d/rhn-search ]; then
-   # This adds the proper /etc/rc*.d links for the script
-   /sbin/chkconfig --add rhn-search
-
-   if /sbin/service rhn-search status > /dev/null 2>&1 ; then
-       was_running=1
-   fi
-fi
-%endif
 
 # Migrate original /usr/share/rhn/search/indexes/*
 # to /var/lib/rhn/search/indexes
@@ -228,48 +179,31 @@ if [ -f /etc/init.d/rhn-search ]; then
 fi
 
 %preun
-%if 0%{?suse_version} >= 1210
 %service_del_preun rhn-search.service
-%else
-if [ $1 = 0 ] ; then
-    if [ -f /etc/init.d/rhn-search ]; then
-       /sbin/service rhn-search stop >/dev/null 2>&1
-       /sbin/chkconfig --del rhn-search
-    fi
-fi
-%endif
 
-%if 0%{?suse_version} >= 1210
 %postun
 %service_del_postun rhn-search.service
 
 %pre
 %service_add_pre rhn-search.service
-%endif
 
 %files
 %defattr(644,root,root,755)
 %attr(755, root, root) %{_var}/log/rhn/search
 %{_prefix}/share/rhn/search/lib/*
 %attr(755, root, root) %{_sbindir}/rhn-search
-%if 0%{?fedora} || 0%{?rhel} >=7 || 0%{?suse_version} >= 1210
 %attr(644, root, root) %{_unitdir}/rhn-search.service
-%else
-%attr(755, root, root) %{_initrddir}/rhn-search
-%endif
 %{_prefix}/share/rhn/config-defaults/rhn_search.conf
 %{_prefix}/share/rhn/config-defaults/rhn_search_daemon.conf
 %{_sysconfdir}/logrotate.d/rhn-search
 %dir %attr(755, root, root) %{_var}/lib/rhn/search
 %dir %attr(755, root, root) %{_var}/lib/rhn/search/indexes
 %{_var}/lib/rhn/search/indexes/docs
-%if 0%{?suse_version}
 %dir %attr(755, root, root) %{_var}/lib/rhn
 %dir /usr/share/rhn
 %dir /usr/share/rhn/search
 %dir /usr/share/rhn/search/lib
 %attr(770,root,www) %dir /var/log/rhn
 %{_sbindir}/rcrhn-search
-%endif
 
 %changelog

--- a/search-server/spacewalk-search/spacewalk-search.spec
+++ b/search-server/spacewalk-search/spacewalk-search.spec
@@ -133,9 +133,6 @@ install -p -m 644 src/config/rhn-search.service $RPM_BUILD_ROOT%{_unitdir}
 install -p -m 644 src/config/search/rhn_search.conf $RPM_BUILD_ROOT%{_prefix}/share/rhn/config-defaults/rhn_search.conf
 install -p -m 644 src/config/search/rhn_search_daemon.conf $RPM_BUILD_ROOT%{_prefix}/share/rhn/config-defaults/rhn_search_daemon.conf
 ln -s -f %{_prefix}/share/rhn/search/lib/spacewalk-search-%{version}.jar $RPM_BUILD_ROOT%{_prefix}/share/rhn/search/lib/spacewalk-search.jar
-%if 0%{?suse_version} >= 1315
-sed -i 's/^wrapper.java.classpath.19=.*/wrapper.java.classpath.19=\/usr\/share\/nutch\/nutch-core-1.0.jar/' $RPM_BUILD_ROOT%{_prefix}/share/rhn/config-defaults/rhn_search_daemon.conf
-%endif
 
 # add rc link
 mkdir -p  $RPM_BUILD_ROOT/%{_sbindir}/

--- a/search-server/spacewalk-search/spacewalk-search.spec
+++ b/search-server/spacewalk-search/spacewalk-search.spec
@@ -34,61 +34,53 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 ExcludeArch:    aarch64
 
-BuildRequires:  apache-mybatis
-BuildRequires:  hadoop
-BuildRequires:  lucene == 2.4.1
-BuildRequires:  nutch-core
-BuildRequires:  picocontainer
-Requires:       apache-mybatis
-Requires:       hadoop
-Requires:       lucene == 2.4.1
-Requires:       nutch-core
-Requires:       picocontainer
-BuildRequires:  uyuni-base-common
-Requires(pre):  uyuni-base-common
-
-BuildRequires:  junit
-#Requires: apache-ibatis-sqlmap
-Requires:       c3p0 >= 0.9.1
-Requires:       cglib
-Requires(pre): doc-indexes
-Requires:       jakarta-commons-httpclient
-Requires:       jakarta-oro
-Requires:       javapackages-tools
-#Requires: lucene
-Requires:       objectweb-asm
-Requires:       quartz >= 2.0
-Requires:       redstone-xmlrpc
-#Requires: picocontainer
-Requires:       simple-core
-Obsoletes:      rhn-search < 5.3.0
 BuildRequires:  ant
-#BuildRequires: apache-ibatis-sqlmap
-BuildRequires:  c3p0 >= 0.9.1
-BuildRequires:  cglib
-BuildRequires:  jakarta-commons-httpclient
-BuildRequires:  jakarta-oro
-BuildRequires:  java-devel >= 11
-BuildRequires:  javapackages-tools
-#BuildRequires: lucene
-BuildRequires:  objectweb-asm
-BuildRequires:  quartz >= 2.0
-BuildRequires:  redstone-xmlrpc
-#BuildRequires: picocontainer
-BuildRequires:  simple-core
-BuildRequires:  slf4j
-Requires:       apache-commons-cli
-Requires:       apache-commons-codec
-Requires:       apache-commons-lang3
-Requires:       apache-commons-logging
 BuildRequires:  apache-commons-cli
 BuildRequires:  apache-commons-codec
 BuildRequires:  apache-commons-lang3
 BuildRequires:  apache-commons-logging
-BuildRequires:  zip
-BuildRequires:  systemd
+BuildRequires:  apache-mybatis
+BuildRequires:  c3p0 >= 0.9.1
+BuildRequires:  cglib
 BuildRequires:  doc-indexes
+BuildRequires:  hadoop
+BuildRequires:  jakarta-commons-httpclient
+BuildRequires:  jakarta-oro
+BuildRequires:  java-devel >= 11
+BuildRequires:  javapackages-tools
+BuildRequires:  junit
+BuildRequires:  lucene == 2.4.1
+BuildRequires:  nutch-core
+BuildRequires:  objectweb-asm
+BuildRequires:  picocontainer
+BuildRequires:  quartz >= 2.0
+BuildRequires:  redstone-xmlrpc
+BuildRequires:  simple-core
+BuildRequires:  slf4j
+BuildRequires:  systemd
+BuildRequires:  uyuni-base-common
+BuildRequires:  zip
+Requires(pre):  doc-indexes
+Requires(pre):  uyuni-base-common
+Requires:       apache-commons-cli
+Requires:       apache-commons-codec
+Requires:       apache-commons-lang3
+Requires:       apache-commons-logging
+Requires:       apache-mybatis
+Requires:       c3p0 >= 0.9.1
+Requires:       cglib
+Requires:       hadoop
+Requires:       jakarta-commons-httpclient
+Requires:       jakarta-oro
+Requires:       javapackages-tools
+Requires:       lucene == 2.4.1
 Requires:       nutch-core
+Requires:       objectweb-asm
+Requires:       picocontainer
+Requires:       quartz >= 2.0
+Requires:       redstone-xmlrpc
+Requires:       simple-core
+Obsoletes:      rhn-search < 5.3.0
 %if 0%{?fedora} || 0%{?rhel} >=7
 Requires:       mchange-commons
 %endif
@@ -106,7 +98,6 @@ Spacewalk Server.
 
 %prep
 %setup -n %{name}-%{version}
-
 
 %install
 rm -fr ${RPM_BUILD_ROOT}
@@ -137,7 +128,6 @@ ln -s -f %{_prefix}/share/rhn/search/lib/spacewalk-search-%{version}.jar $RPM_BU
 # add rc link
 mkdir -p  $RPM_BUILD_ROOT/%{_sbindir}/
 ln -sf service $RPM_BUILD_ROOT/%{_sbindir}/rcrhn-search
-
 
 %post
 %service_add_post rhn-search.service

--- a/search-server/spacewalk-search/spacewalk-search.spec
+++ b/search-server/spacewalk-search/spacewalk-search.spec
@@ -138,8 +138,6 @@ ln -s -f %{_prefix}/share/rhn/search/lib/spacewalk-search-%{version}.jar $RPM_BU
 mkdir -p  $RPM_BUILD_ROOT/%{_sbindir}/
 ln -sf service $RPM_BUILD_ROOT/%{_sbindir}/rcrhn-search
 
-# mybatis is build with newer API. This statements needs to stay, until we have a build with 1.5
-export NO_BRP_CHECK_BYTECODE_VERSION=true
 
 %post
 %service_add_post rhn-search.service


### PR DESCRIPTION
## What does this PR change?

When getting the spec from spacewalk project it had a lot of macros for different RedHat versions and SUSE inside.
Uyuni introduced a lot of new java dependencies which are required but not available for RedHat.
They were not maintained.

In case the community wants to bring back support for other distributions it is much easier to start with a clean specfile where all wrong dependencies and special tasks are removed.

This is the reason why I propose the cleanup and remove as much macros as we can to get again a readable specfile.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **just spec work**

- [x] **DONE**

## Links

Also buildservice team requested cleanup work in: SUSE/spacewalk#7861

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
