### PR TITLE
Pools fix

### DIFF
--- a/java/code/webapp/WEB-INF/nav/system_detail.xml
+++ b/java/code/webapp/WEB-INF/nav/system_detail.xml
@@ -189,7 +189,7 @@
     <rhn-tab-url>/rhn/manager/systems/details/virtualization/guests/${sid}</rhn-tab-url>
     <rhn-tab name="Guests" url="/rhn/manager/systems/details/virtualization/guests/${sid}"/>
     <rhn-tab name="Storage" url="/rhn/manager/systems/details/virtualization/storage/${sid}" acl="system_has_salt_entitlement()"/>
-    <rhn-tab name="Provisioning" url="/rhn/systems/details/virtualization/ProvisionVirtualizationWizard.do" acl="system_feature(ftr_kickstart) or system_feature(ftr_snapshotting)"/>
+    <rhn-tab name="Provisioning" url="/rhn/systems/details/virtualization/ProvisionVirtualizationWizard.do" acl="system_has_management_entitlement(); system_feature(ftr_kickstart) or system_feature(ftr_snapshotting)"/>
     <rhn-tab name="Deployment" url="/rhn/systems/details/virtualization/Deployment.do" acl="not system_is_virtual(); system_has_management_entitlement()"/>
   </rhn-tab>
 

--- a/web/html/src/manager/virtualization/pools/list/pools-list.js
+++ b/web/html/src/manager/virtualization/pools/list/pools-list.js
@@ -177,7 +177,7 @@ export function PoolsList(props: Props) {
             <DataHandler
               data={getPoolsAndVolumes(tree)}
               identifier={(raw) => raw.id}
-              initialItemsPerPage={props.pageSize}
+              initialItemsPerPage={Number(props.pageSize)}
               loading={tree == null}
               additionalFilters={[]}
               searchField={


### PR DESCRIPTION
## What does this PR change?

* Hide the Virualization > Provisioning tab on Salt systems since this is not supported.
* parse the pageSize in the pool list to a number

## GUI diff

One broken tab removed.

- [X] **DONE**

## Documentation
- No documentation needed: that tab was not documented for Salt systems

- [X] **DONE**

## Test coverage
- No tests: super tiny change

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
