### PR TITLE
[WIP] Generate API docs in asciidoc format

### DIFF
--- a/java/build.xml
+++ b/java/build.xml
@@ -242,6 +242,12 @@
     <antcall target="apidoc" />
   </target>
 
+  <target name="apidoc-asciidoc" description="Generate asciidoc from the API">
+    <property name="doclet.class" value="AsciidocDoclet" />
+    <property name="template.dir" value="asciidoc" />
+    <antcall target="apidoc" />
+  </target>
+
   <target name="apidoc" description="Generate the api documentation" depends="init">
     <path id="javadocpath">
     <path refid="buildjars" />

--- a/java/buildconf/apidoc/asciidoc/api_index_ftr.txt
+++ b/java/buildconf/apidoc/asciidoc/api_index_ftr.txt
@@ -1,0 +1,2 @@
+
+Generated on: $current_date

--- a/java/buildconf/apidoc/asciidoc/api_index_hdr.txt
+++ b/java/buildconf/apidoc/asciidoc/api_index_hdr.txt
@@ -1,0 +1,21 @@
+= SUSE Manager API Documentation
+SUSE Manager
+4.0, <?dbtimestamp?>
+:homepage: http://www.suse.com/products/suse-manager
+
+Wecome to the SUSE Manager API. By using the included API calls, you can easily automate many of
+the tasks you perform everyday. All API calls are grouped by common functionality.
+
+== Legal Notice
+
+Copyright (c) 2014 Red Hat, Inc.
+Copyright (c) 2019 SUSE LLC
+
+This software is licensed to you under the GNU General Public License, version 2 (GPLv2). There is
+NO WARRANTY for this software, express or implied, including the implied warranties of MERCHANTABILITY
+or FITNESS FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2 along with this software;
+if not, see http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+Red Hat trademarks are not licensed under GPLv2. No permission is granted to use or replicate Red Hat
+trademarks that are incorporated in this software or its documentation.
+

--- a/java/buildconf/apidoc/asciidoc/apiindex.txt
+++ b/java/buildconf/apidoc/asciidoc/apiindex.txt
@@ -1,0 +1,5 @@
+#set ($path = "")
+#set ($xml = ".xml")
+#foreach ($handler in $handlers)
+* <<$handler.name>>
+#end

--- a/java/buildconf/apidoc/asciidoc/faqs.txt
+++ b/java/buildconf/apidoc/asciidoc/faqs.txt
@@ -1,0 +1,19 @@
+= Frequently Asked Questions
+
+== What programming languages are supported by the SUSE Manager API?
+
+Any language that provides an XMLRPC client interface will work with the SUSE Manager API. While
+Perl and Python are two of the most commonly used, an XMLRPC client implementation is available for every
+common language.
+
+== When trying to call a specific function, the error "Fault returned from XML RPC Server, fault code -1: Could not find method METHOD in class..."  is given. What is wrong?
+
+Typically this is seen when either a function name is being called that doesn't exist, the number
+of parameters for a particular function is incorrect, or the type of a passed parameter is incorrect (Such as
+an array is expected, but a String is passed). Check all of these things.
+
+== Should I call an API method using the naming scheme "methodName" or "method_name"?
+
+Both of these are valid names for the same method, so use whichever you prefer.
+
+

--- a/java/buildconf/apidoc/asciidoc/handler.txt
+++ b/java/buildconf/apidoc/asciidoc/handler.txt
@@ -1,0 +1,67 @@
+
+
+
+[#$handler.name]
+== $handler.name
+
+
+=== Available methods
+
+#foreach( $call in $handler.calls )
+* <<$handler.name-$call.name,$call.name>>
+#end
+
+=== Description
+
+$handler.desc
+
+*Namespace*:
+
+$handler.name
+
+'''
+
+#foreach( $call in $handler.calls )
+
+[#$handler.name-$call.name]
+#if($call.deprecated)
+=== Method: $call.name (Deprecated)
+#else
+=== Method: $call.name 
+#end
+
+Description:
+
+$call.doc
+
+
+#if($call.deprecated)
+Deprecated - $call.deprecatedReason
+#end
+
+
+Parameters:
+
+#foreach( $param in $call.params)
+#if ($param.trim().startsWith('*'))
+$param
+#else
+* $param
+#end
+#end
+
+Returns:
+
+#if ($call.returnDoc.trim().startsWith('*'))
+$call.returnDoc
+#else
+* $call.returnDoc
+#end
+
+#if($call.sinceAvailable)
+Available since API version: $call.sinceVersion
+#end
+
+'''
+
+#end

--- a/java/buildconf/apidoc/asciidoc/macros.txt
+++ b/java/buildconf/apidoc/asciidoc/macros.txt
@@ -1,0 +1,89 @@
+
+#set($date="dateTime.iso8601")
+
+#macro(serializer $serializer)
+* $serializer
+#end
+#macro(prop $type $value)
+* $type "$value"
+#end
+#macro(prop_desc $type $value $desc)
+* $type "$value" - $desc
+#end
+#macro(prop_array $key $type $desc)
+* array "$key"
+** $type - $desc
+#end
+#macro(prop_array_begin $key)
+* array "$key"
+#end
+#macro(prop_array_begin_desc $key $desc)
+* array "$key" - $desc
+#end
+#macro(prop_array_end)
+// no end needed
+#end
+#macro(struct $type)
+* struct - $type
+#end
+#macro(struct_end)
+// no end needed
+#end
+#macro(struct_desc $type $desc)
+* struct - $type $desc
+#end
+#macro(struct_desc_end)
+// no end needed
+#end
+#macro(array)
+* array:
+#end
+#macro(array_end)
+// no end needed
+#end
+#macro(array_desc $type $desc)
+* array $type - $desc
+#end
+#macro(array_desc_end)
+// no end needed
+#end
+#macro(array_single $type $desc)
+* array:
+** $type - $desc
+#end
+#macro(options)
+// no end needed
+#end
+#macro(item $item)
+* $item
+#end
+#macro(item_desc $item, $desc)
+* $item - $desc
+#end
+#macro(options_end)
+// no end needed
+#end
+#macro(param $type $value)
+* $type $value
+#end
+#macro(param_desc $type $value $desc)
+* $type $value - $desc
+#end
+#macro(session_key)
+  #param("string", "sessionKey")
+#end
+#macro(return_int_success)
+* int - 1 on success, exception thrown otherwise.
+#end
+#macro(itemlist)
+// no end needed
+#end
+#macro(itemlist_end)
+// no end needed
+#end
+#macro(paragraph)
+ 
+#end
+#macro(paragraph_end)
+ 
+#end

--- a/java/buildconf/apidoc/asciidoc/scripts.txt
+++ b/java/buildconf/apidoc/asciidoc/scripts.txt
@@ -1,0 +1,146 @@
+= Sample Scripts
+
+== Perl Example
+
+This Perl example shows the `system.listUserSystems` call being used to get a
+list of systems a user has access to. In the example below, the name of each system will be printed.
+
+[source,perl]
+----
+#!/usr/bin/perl
+use Frontier::Client;
+
+my $HOST = 'manager.example.com';
+my $user = 'username';
+my $pass = 'password';
+
+my $client = new Frontier::Client(url => "http://$HOST/rpc/api");
+my $session = $client->call('auth.login',$user, $pass);
+
+my $systems = $client->call('system.listUserSystems', $session);
+foreach my $system (@$systems) {
+   print $system->{'name'}."\n";
+}
+$client->call('auth.logout', $session);
+----
+
+
+== Python 2 Example
+
+Below is an example of the `user.listUsers` call being used. Only the login of each
+user is printed.
+
+[source,python]
+----
+#!/usr/bin/python
+import xmlrpclib
+
+MANAGER_URL = "http://manager.example.com/rpc/api"
+MANAGER_LOGIN = "username"
+MANAGER_PASSWORD = "password"
+
+client = xmlrpclib.Server(MANAGER_URL, verbose=0)
+
+key = client.auth.login(MANAGER_LOGIN, MANAGER_PASSWORD)
+list = client.user.list_users(key)
+for user in list:
+  print user.get('login')
+
+client.auth.logout(key)
+----
+
+The following code shows how to use date-time parameters. This code will schedule immediate installation of package rhnlib-2.5.22.9.el6.noarch to system with id 1000000001.
+
+[source,python]
+----
+#!/usr/bin/python
+from datetime import datetime
+import time
+import xmlrpclib
+
+MANAGER_URL = "http://manager.example.com/rpc/api"
+MANAGER_LOGIN = "username"
+MANAGER_PASSWORD = "password"
+
+client = xmlrpclib.Server(MANAGER_URL, verbose=0)
+
+key = client.auth.login(MANAGER_LOGIN, MANAGER_PASSWORD)
+package_list = client.packages.findByNvrea(key, 'rhnlib', '2.5.22', '9.el6', '', 'noarch')
+today = datetime.today()
+earliest_occurrence = xmlrpclib.DateTime(today)
+client.system.schedulePackageInstall(key, 1000000001, package_list[0]['id'], earliest_occurrence)
+
+client.auth.logout(key)
+----
+
+== Python 3 with SSL Example
+
+Below is an example of the `user.listUsers` call being called.
+
+[source,python]
+----
+#!/usr/bin/env python3
+from xmlrpc.client import ServerProxy
+import ssl
+
+MANAGER_URL = "https://manager.example.com/rpc/api"
+MANAGER_LOGIN = "username"
+MANAGER_PASSWORD = "password"
+
+# You might need to set to set other options depending on your
+# server SSL configuartion and your local SSL configuration
+context = ssl.create_default_context()
+client = ServerProxy(MANAGER_URL, context=context)
+key = client.auth.login(MANAGER_LOGIN, MANAGER_PASSWORD)
+
+print(client.user.list_users(key))
+
+client.auth.logout(key)
+----
+
+
+== Python 3 Example
+
+Below is an example of the `user.listUsers` call being called.
+
+[source,python]
+----
+#!/usr/bin/env python3
+from xmlrpc.client import ServerProxy
+
+MANAGER_URL = "http://manager.example.com/rpc/api"
+MANAGER_LOGIN = "username"
+MANAGER_PASSWORD = "password"
+
+client = ServerProxy(MANAGER_URL)
+key = client.auth.login(MANAGER_LOGIN, MANAGER_PASSWORD)
+
+print(client.user.list_users(key))
+
+client.auth.logout(key)
+----
+
+== Ruby Example
+
+Below is an example of the `channel.listAllChannels` API call. List of channel labels is printed.
+
+[source,ruby]
+----
+#!/usr/bin/ruby
+require "xmlrpc/client"
+
+@MANAGER_URL = "http://manager.example.com/rpc/api"
+@MANAGER_LOGIN = "username"
+@MANAGER_PASSWORD = "password"
+
+@client = XMLRPC::Client.new2(@MANAGER_URL)
+
+@key = @client.call('auth.login', @MANAGER_LOGIN, @MANAGER_PASSWORD)
+channels = @client.call('channel.listAllChannels', @key)
+for channel in channels do
+   p channel["label"]
+end
+
+@client.call('auth.logout', @key)
+----
+

--- a/java/code/internal/src/com/redhat/rhn/internal/doclet/ApiDoclet.java
+++ b/java/code/internal/src/com/redhat/rhn/internal/doclet/ApiDoclet.java
@@ -161,6 +161,9 @@ public class ApiDoclet {
         else if (docType.equals("docbook")) {
             writer = new DocBookWriter();
         }
+        else if (docType.equals("asciidoc")) {
+            writer = new AsciidocWriter();
+        }
         else {
             writer = new JSPWriter();
         }

--- a/java/code/internal/src/com/redhat/rhn/internal/doclet/AsciidocDoclet.java
+++ b/java/code/internal/src/com/redhat/rhn/internal/doclet/AsciidocDoclet.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.internal.doclet;
+
+import com.sun.javadoc.RootDoc;
+
+/**
+ *
+ * AsciidocDoclet
+ */
+public class AsciidocDoclet {
+
+    private AsciidocDoclet() {
+    }
+
+    /**
+     * Starts the wiki doclet
+     * @param root document root
+     * @return true if success
+     * @throws Exception e
+     */
+    public static boolean start(RootDoc root) throws Exception {
+
+        return ApiDoclet.start(root, "asciidoc");
+    }
+
+}

--- a/java/code/internal/src/com/redhat/rhn/internal/doclet/AsciidocWriter.java
+++ b/java/code/internal/src/com/redhat/rhn/internal/doclet/AsciidocWriter.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.internal.doclet;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ *
+ * AsciidocWriter
+ */
+public class AsciidocWriter extends DocWriter {
+
+
+    private static final String JSP_OUTPUT = "./build/reports/apidocs/asciidoc/";
+    private static final String JSP_TEMPLATES = "./buildconf/apidoc/asciidoc/";
+
+    /**
+     *
+     * {@inheritDoc}
+     */
+    public void write(List<Handler> handlers,
+            Map<String, String> serializers) throws Exception {
+
+
+
+        //First macro-tize the serializer's docs
+        renderSerializers(JSP_TEMPLATES, serializers);
+
+
+        //Lets do the index first
+
+        StringBuffer buffer = new StringBuffer();
+
+
+        buffer.append(generateIndex(handlers, JSP_TEMPLATES));
+
+        for (Handler handler : handlers) {
+            //writeFile(JSP_OUTPUT + "handlers/" + handler.getClassName() + ".html",
+                    buffer.append(generateHandler(handler, JSP_TEMPLATES));
+        }
+
+        writeFile(JSP_OUTPUT + "handlers/apilist.adoc", buffer.toString());
+
+        /*for (String file : OTHER_FILES) {
+            writeFile(JSP_OUTPUT + file + ".html", readFile(JSP_TEMPLATES + file + ".txt"));
+        }*/
+
+    }
+
+
+    /**
+     * Generate the index from the template dir from (API_HEADER/INDEX/FOOTER_FILE) files
+     * @param handlers list of the handlers
+     * @param templateDir directory of the templates
+     * @return a string representing the index
+     * @throws Exception e
+     */
+    public  String generateIndex(List<Handler> handlers, String templateDir)
+                throws Exception {
+
+        String output = "";
+        VelocityHelper vh = new VelocityHelper(templateDir);
+        vh.addMatch("handlers", handlers);
+
+        output += vh.renderTemplateFile(ApiDoclet.API_INDEX_FILE);
+
+        return output;
+    }
+
+
+
+
+}


### PR DESCRIPTION
## What does this PR change?

Try to generate asciidoc from the API docs.

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
