### PR TITLE
Faketagger: Always use the same date, so we don't rebuild each time we submit

### DIFF
--- a/rel-eng/build-packages-for-obs.sh
+++ b/rel-eng/build-packages-for-obs.sh
@@ -103,7 +103,7 @@ while read PKG_NAME PKG_VER PKG_DIR; do
   eval $(awk '/^Wrote:.*src.rpm/{srpm=$2}/^Wrote:.*.changes/{changes=$2}END{ printf "SRPM=\"%s\"\n",srpm; printf "CHANGES=\"%s\"\n",changes; }' "$T_LOG")
   if [ "$(head -n1 ${CHANGES}|grep '^- ')" != "" ]; then
     echo "*** Untagged package, adding fake header..."
-    sed -i "1i $(LANG=en_EN date '+%a %b %d %H:%M:%S %Z %Y') - faketagger@suse.inet\n" ${CHANGES}
+    sed -i "1i Fri Jan 01 00:00:00 CEST 2100 - faketagger@suse.inet\n" ${CHANGES}
     sed -i '1i -------------------------------------------------------------------' ${CHANGES}
   fi
   if [ -e "$SRPM" -a -e "$CHANGES" ]; then


### PR DESCRIPTION
## What does this PR change?

Faketagger: Always use the same date, so we don't rebuild each time we submit

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Fix.

- [x] **DONE**

## Test coverage
- No tests: Tool not covered.

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/9444

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
