### PR TITLE
Faketagger: Old RPM does not recognize 2100 as valid date

### DIFF
--- a/rel-eng/build-packages-for-obs.sh
+++ b/rel-eng/build-packages-for-obs.sh
@@ -103,7 +103,7 @@ while read PKG_NAME PKG_VER PKG_DIR; do
   eval $(awk '/^Wrote:.*src.rpm/{srpm=$2}/^Wrote:.*.changes/{changes=$2}END{ printf "SRPM=\"%s\"\n",srpm; printf "CHANGES=\"%s\"\n",changes; }' "$T_LOG")
   if [ "$(head -n1 ${CHANGES}|grep '^- ')" != "" ]; then
     echo "*** Untagged package, adding fake header..."
-    sed -i "1i Fri Jan 01 00:00:00 CEST 2100 - faketagger@suse.inet\n" ${CHANGES}
+    sed -i "1i Fri Jan 01 00:00:00 CEST 2038 - faketagger@suse.inet\n" ${CHANGES}
     sed -i '1i -------------------------------------------------------------------' ${CHANGES}
   fi
   if [ -e "$SRPM" -a -e "$CHANGES" ]; then


### PR DESCRIPTION
## What does this PR change?

Faketagger: Old RPM does not recognize 2100 as valid date

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: Tool fix.

- [x] **DONE**

## Test coverage
- No tests: Not covered.

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
