### PR TITLE
Disable clones by default of the shown CLM sources

### DIFF
--- a/web/html/src/manager/content-management/shared/components/panels/sources/channels/channels-selection.state.js
+++ b/web/html/src/manager/content-management/shared/components/panels/sources/channels/channels-selection.state.js
@@ -8,7 +8,7 @@ import type {ChannelType} from "core/channels/type/channels.type";
 import {getAllRecommentedIdsByBaseId} from "core/channels/utils/channels-state.utils";
 import {getChannelsToToggleWithDependencies} from "core/channels/utils/channels-dependencies.utils";
 
-export type FilterType = {id: string, text: string, isVisible: (ChannelType) => boolean}
+export type FilterType = {id: string, text: string, isVisible: (ChannelType) => boolean, selectedByDefault: boolean}
 export type FiltersType = { [key: string]: FilterType }
 
 export const channelsFiltersAvailable: FiltersType = {
@@ -16,22 +16,27 @@ export const channelsFiltersAvailable: FiltersType = {
     id: 'vendors',
     text: 'Vendors',
     isVisible: (c: ChannelType) => !c.custom,
+    selectedByDefault: true,
   },
   custom: {
     id: 'custom',
     text: 'Custom',
     isVisible: (c: ChannelType) => c.custom && !c.isCloned,
+    selectedByDefault: true,
   },
   clones: {
     id: 'clones',
     text: 'Clones',
     isVisible: (c: ChannelType) => c.isCloned,
+    selectedByDefault: false,
   }
 }
 
 export const getChannelsFiltersAvailableValues = (): Array<FilterType> => (Object.values(channelsFiltersAvailable) : any);
 
-export const getInitialFiltersState = (): Array<string> => Object.keys(channelsFiltersAvailable);
+export const getInitialFiltersState = (): Array<string> => getChannelsFiltersAvailableValues()
+  .filter(filter => filter.selectedByDefault)
+  .map(filter => filter.id) || [];
 
 
 export type StateChannelsSelectionType = {

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- CLM - Disable clones by default of the shown CLM Project sources
 - Show virtual storage volumes and pools on salt minions
 - Migrate login to Spark
 - Add UI message when salt-formulas system folders are unreachable (bsc#1142309)


### PR DESCRIPTION
## What does this PR change?

Disable clones by default of the shown CLM sources

## GUI diff

![Screenshot from 2019-09-16 14-05-31](https://user-images.githubusercontent.com/1140720/64960414-27206900-d88b-11e9-883d-c6c8e5e8345f.png)


- [ ] **DONE**

## Documentation
- No documentation needed
- [ ] **DONE**

## Test coverage
- No tests

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint" (Test skipped, there are no changes to test)		 
- [ ] Re-run test "spacecmd_unittests"