### PR TITLE
Manager diskcheck

### DIFF
--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Add Requires: systemd for completeness
 - create /usr/lib/systemd/systemd during build
 - BuildRequires: systemd for spacewalk-diskcheck
 - add option spacecheck_shutdown; tidy up wording of notifications

--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -448,6 +448,7 @@ Group:          Applications/Internet
 Requires:       %{name}
 Requires:       %{name}-app = %{version}-%{release}
 Requires:       %{name}-xmlrpc = %{version}-%{release}
+Requires:       systemd
 BuildRequires:  systemd
 %{?systemd_requires}
 


### PR DESCRIPTION
## What does this PR change?

systemd is also needed at runtime. While this dependency is fulfilled anyway, this is more or less cosmetic, but more correct.