### PR TITLE
CLM: implement filter for patch keywords

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ErrataFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ErrataFilter.java
@@ -135,6 +135,13 @@ public class ErrataFilter extends ContentFilter<Errata> {
                     default:
                         throw new UnsupportedOperationException("Matcher " + matcher + " not supported");
                 }
+            case "keyword":
+                switch (matcher) {
+                    case CONTAINS:
+                        return erratum.hasKeyword(value);
+                    default:
+                        throw new UnsupportedOperationException("Matcher " + matcher + " not supported");
+                }
             default:
                 throw new UnsupportedOperationException("Field " + field + " not supported");
         }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
@@ -75,6 +75,7 @@ public class FilterCriteria {
         validCombinations.add(Triple.of(ERRATUM, MATCHES, "advisory_name"));
         validCombinations.add(Triple.of(ERRATUM, MATCHES, "synopsis"));
         validCombinations.add(Triple.of(ERRATUM, CONTAINS, "synopsis"));
+        validCombinations.add(Triple.of(ERRATUM, CONTAINS, "keyword"));
         validCombinations.add(Triple.of(ERRATUM, GREATER, "issue_date"));
         validCombinations.add(Triple.of(ERRATUM, GREATEREQ, "issue_date"));
         validCombinations.add(Triple.of(ERRATUM, MATCHES_PKG_NAME, "package_name"));

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentFilterTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentFilterTest.java
@@ -360,4 +360,31 @@ public class ContentFilterTest extends JMockBaseTestCaseWithUser {
         filter = ContentManager.createFilter("contains-eq-nevr-filter2", DENY, ERRATUM, criteria, user);
         assertFalse(filter.test(erratum1));
     }
+
+    /**
+     * Test basic Errata filtering: match keywords
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testErrataContainsKeywordFilter() throws Exception {
+        String cveName1 = TestUtils.randomString().substring(0, 13);
+        Errata erratum1 = ErrataTestUtils.createTestErrata(user, Collections.singleton(ErrataTestUtils.createTestCve(cveName1)));
+        erratum1.setSynopsis("recommended update: " + cveName1);
+        erratum1.addKeyword("reboot_suggested");
+        String cveName2 = TestUtils.randomString().substring(0, 13);
+        Errata erratum2 = ErrataTestUtils.createTestErrata(user, Collections.singleton(ErrataTestUtils.createTestCve(cveName2)));
+        erratum2.setSynopsis("recommended update: " + cveName2);
+        erratum2.addKeyword("restart_suggested");
+
+        FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.CONTAINS, "keyword", "reboot_suggested");
+        ContentFilter filter = ContentManager.createFilter("reboot-filter", DENY, ERRATUM, criteria, user);
+        assertTrue(filter.test(erratum1));
+        assertFalse(filter.test(erratum2));
+
+        FilterCriteria criteria2 = new FilterCriteria(FilterCriteria.Matcher.CONTAINS, "keyword", "restart_suggested");
+        ContentFilter filter2 = ContentManager.createFilter("restart-filter2", DENY, ERRATUM, criteria2, user);
+        assertFalse(filter2.test(erratum1));
+        assertTrue(filter2.test(erratum2));
+    }
+
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
@@ -543,6 +543,7 @@ public class ContentManagementHandler extends BaseHandler {
      * #itemlist()
      *   #item("by advisory name - field:advisory_name matcher:equals")
      *   #item("by synopsis - field:synopsis matcher:equals or contains")
+     *   #item("by keyword - field:keyword matcher:contains")
      *   #item("by date - field:issue_date matcher:greater or greatereq")
      *   #item("by type - field:advisory_type matcher:equals")
      *   #item("by affected package name - field:package_name matcher:contains_pkg_name")

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- implement "keyword" filter for Content Lifecycle Management
 - Add support for Azure, Amazon EC2, and Google Compute Engine as Virtual Host Managers.
 - Import additional fields for Deb packages
 - enable Kiwi NG on SLE15

--- a/web/html/src/components/input/Radio.css
+++ b/web/html/src/components/input/Radio.css
@@ -1,0 +1,25 @@
+.radio label {
+    font-weight: normal;
+}
+
+.open_option_wrapper{
+    padding-left: 0px;
+}
+
+.open_option_wrapper label {
+    vertical-align: middle
+}
+.open_option_wrapper input[type=text] {
+    width: 200px;
+    display:inline-block;
+}
+
+.open_option_wrapper_align_wrapper {
+    position: relative;
+}
+
+.open_option_wrapper_align_content {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+}

--- a/web/html/src/components/input/Radio.js
+++ b/web/html/src/components/input/Radio.js
@@ -1,15 +1,21 @@
 // @flow
 
 const React = require('react');
+const {useState, useEffect} = require('react');
 const { InputBase } = require('./InputBase');
+
+const styles = require('./Radio.css');
 
 type Props = {
   items: Array<{label: string, value: string}>,
   inline?: boolean,
+  openOption?: boolean,
   inputClass?: string,
 } & InputBase.Props;
 
 function Radio(props: Props) {
+  const [isPristine, setIsPristine] = useState(true);
+
   const {
     items,
     inputClass,
@@ -22,12 +28,19 @@ function Radio(props: Props) {
            setValue,
            onBlur,
          }) => {
-          const onChange = (event: Object) => {
-            setValue(event.target.name, event.target.value);
+
+          const onChange = (name, value) => {
+            setValue(name, value);
+            setIsPristine(false);
           };
+
+          const isOpenOption = props.openOption
+            && !props.items.some(item => item.value === props.value)
+            && (props.value || !isPristine);
+
           const radioClass = props.inline ? "radio-inline" : "radio";
           return (
-            <>
+            <span className={styles.radio}>
               {
                 props.items.map(({label, value}) =>
                   <label className={radioClass}>
@@ -38,12 +51,35 @@ function Radio(props: Props) {
                       checked={props.value === value}
                       className={inputClass}
                       onBlur={onBlur}
-                      onChange={onChange} />
+                      onChange={event => onChange(event.target.name, event.target.value)} />
                     {label}
                   </label>
                 )
               }
-            </>
+
+              {
+                props.openOption &&
+                <div className={`radio ${styles['open_option_wrapper']}`}>
+                  <label className={`radio-inline ${styles.open_option_wrapper_align_wrapper}`}>
+                    <input
+                      className={styles.open_option_wrapper_align_content}
+                      type="radio"
+                      name={props.name}
+                      checked={isOpenOption}
+                      onChange={() => onChange(props.name, '')}
+                    />
+                    {"Other keyword: "}
+                  </label>
+                  <input
+                    name={props.name}
+                    type="text"
+                    disabled={!isOpenOption}
+                    value={isOpenOption ? props.value : ''}
+                    onChange={event => onChange(event.target.name, event.target.value)}
+                  />
+                </div>
+              }
+              </span>
           );
         }
       }

--- a/web/html/src/manager/content-management/list-filters/filter-form.js
+++ b/web/html/src/manager/content-management/list-filters/filter-form.js
@@ -257,11 +257,12 @@ const FilterForm = (props: Props) => {
             items={[
               {"label": t("Reboot Required"), "value": "reboot_suggested"},
               {"label": t("Package Manager Restart Required"), "value": "restart_suggested"},
-              {"label": t("Other Keyword:"), "value": ""}
             ]}
+            openOption
             label={t("Advisory Keywords")}
             labelClass="col-md-3"
-            divClass="col-md-6" />
+            divClass="col-md-6"
+          />
         }
 
         {

--- a/web/html/src/manager/content-management/list-filters/filter-form.js
+++ b/web/html/src/manager/content-management/list-filters/filter-form.js
@@ -250,6 +250,21 @@ const FilterForm = (props: Props) => {
         }
 
         {
+          clmFilterOptions.KEYWORD.key === props.filter.type &&
+          <Radio
+            name={clmFilterOptions.KEYWORD.key}
+            required
+            items={[
+              {"label": t("Reboot Required"), "value": "reboot_suggested"},
+              {"label": t("Package Manager Restart Required"), "value": "restart_suggested"},
+              {"label": t("Other Keyword:"), "value": ""}
+            ]}
+            label={t("Advisory Keywords")}
+            labelClass="col-md-3"
+            divClass="col-md-6" />
+        }
+
+        {
           clmFilterOptions.PACKAGE_NAME.key === props.filter.type &&
           <Text
             name={clmFilterOptions.PACKAGE_NAME.key}

--- a/web/html/src/manager/content-management/shared/business/filters.enum.js
+++ b/web/html/src/manager/content-management/shared/business/filters.enum.js
@@ -111,6 +111,12 @@ export const clmFilterOptions : ClmFilterOptionsEnumType = {
     entityType: filterEntity.ERRATUM,
     matchers: [filterMatchers.EQUALS, filterMatchers.CONTAINS, filterMatchers.MATCHES]
   },
+  KEYWORD: {
+    key: 'keyword',
+    text: t('Keyword'),
+    entityType: filterEntity.ERRATUM,
+    matchers: [filterMatchers.CONTAINS]
+  },
   ISSUE_DATE: {
     key: 'issue_date',
     text: t('Issue date'),

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- implement "keyword" filter for Content Lifecycle Management
 - Enable Azure, Amazon EC2 and Google Compute Engine as available Virtual host Managers
 - Trim strings when creating/updating image stores/profiles (bsc#1133429)
 - Show loading spin while loading salt keys data (bsc#1150180)


### PR DESCRIPTION
## What does this PR change?

Add filter for keywords in patches. We have two standard keywords `reboot_suggested` and `restart_suggested` which are directly selectable. But patches could contain any keyword so we have also a free text option.

## GUI diff

![Screenshot_20190917_135516](https://user-images.githubusercontent.com/1038917/65039577-e0964180-d952-11e9-962c-999606baa45b.png)


- [x] **DONE**

## Documentation
- https://github.com/SUSE/doc-susemanager/pull/720

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/9253
Tracks https://github.com/SUSE/spacewalk/pull/9525

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
