### PR TITLE
Move package installation on SSH minion to secondary

### DIFF
--- a/testsuite/features/core/min_salt_ssh.feature
+++ b/testsuite/features/core/min_salt_ssh.feature
@@ -54,28 +54,6 @@ Feature: Be able to bootstrap a Salt host managed via salt-ssh
     And I wait until event "Subscribe channels scheduled by admin" is completed
 
 @ssh_minion
-  Scenario: Schedule errata refresh to reflect channel assignment on SSH minion
-    Given I am authorized as "admin" with password "admin"
-    When I follow the left menu "Admin > Task Schedules"
-    And I follow "errata-cache-default"
-    And I follow "errata-cache-bunch"
-    And I click on "Single Run Schedule"
-    Then I should see a "bunch was scheduled" text
-    And I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows
-
-@ssh_minion
-  Scenario: Install a package on the SSH minion
-    Given I am on the Systems overview page of this "ssh-minion"
-    And I follow "Software" in the content area
-    And I follow "Install"
-    And I check "hoag-dummy-1.1-2.1" in the list
-    And I click on "Install Selected Packages"
-    And I click on "Confirm"
-    Then I should see a "1 package install has been scheduled" text
-    When I wait until event "Package Install/Upgrade scheduled by admin" is completed
-    Then "hoag-dummy-1.1-2.1" should be installed on "ssh-minion"
-
-@ssh_minion
   Scenario: Check events history for failures on SSH minion
     Given I am on the Systems overview page of this "ssh-minion"
     Then I check for failed events on history event page

--- a/testsuite/features/secondary/minssh_salt_install_package.feature
+++ b/testsuite/features/secondary/minssh_salt_install_package.feature
@@ -1,0 +1,27 @@
+# Copyright (c) 2019 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: Install a package on the SSH minion via Salt through the UI
+
+@ssh_minion
+  Scenario: Schedule errata refresh to reflect channel assignment on SSH minion
+    Given I am authorized as "admin" with password "admin"
+    When I follow the left menu "Admin > Task Schedules"
+    And I follow "errata-cache-default"
+    And I follow "errata-cache-bunch"
+    And I click on "Single Run Schedule"
+    Then I should see a "bunch was scheduled" text
+    And I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows
+
+@ssh_minion
+  Scenario: Install a package on the SSH minion
+    Given I am on the Systems overview page of this "ssh-minion"
+    And I follow "Software" in the content area
+    And I follow "Install"
+    And I check "hoag-dummy-1.1-2.1" in the list
+    And I click on "Install Selected Packages"
+    And I click on "Confirm"
+    Then I should see a "1 package install has been scheduled" text
+    When I wait until event "Package Install/Upgrade scheduled by admin" is completed
+    Then "hoag-dummy-1.1-2.1" should be installed on "ssh-minion"
+

--- a/testsuite/run_sets/secondary_parallelizable.yml
+++ b/testsuite/run_sets/secondary_parallelizable.yml
@@ -39,6 +39,7 @@
 - features/secondary/allcli_software_channels_dependencies.feature
 
 - features/secondary/minssh_centos_salt_install_package_and_patch.feature
+- features/secondary/minssh_salt_install_package.feature
 - features/secondary/min_ubuntu_salt_install_package.feature
 - features/secondary/min_bootstrap_xmlrpc.feature
 - features/secondary/min_salt_software_states.feature

--- a/testsuite/run_sets/testsuite.yml
+++ b/testsuite/run_sets/testsuite.yml
@@ -91,6 +91,7 @@
 # OS image build tests are required for proxy_retail_pxeboot feature
 - features/secondary/min_osimage_build_image.feature
 - features/secondary/min_salt_install_package.feature
+- features/secondary/minssh_salt_install_package.feature
 - features/secondary/srv_power_management.feature
 - features/secondary/srv_datepicker.feature
 - features/secondary/trad_openscap_audit.feature

--- a/testsuite/run_sets/uyuni.yml
+++ b/testsuite/run_sets/uyuni.yml
@@ -91,6 +91,7 @@
 # Disabled until the pxe-formula and branch-formula are compatible with openSUSE Leap 15.1
 #- features/secondary/min_osimage_build_image.feature
 - features/secondary/min_salt_install_package.feature
+- features/secondary/minssh_salt_install_package.feature
 - features/secondary/srv_power_management.feature
 - features/secondary/srv_datepicker.feature
 - features/secondary/trad_openscap_audit.feature


### PR DESCRIPTION
## What does this PR change?

This PR just moves some test suite code from core to secondary.
SSH minion was the last one to still have package installation tests in core.

Rationale:
 - make core faster
 - don't make core fail when there are package installation issues on SSH minion

## Links

* 3.2: SUSE/spacewalk#9466
* 4.0: SUSE/spacewalk#9463

## Changelogs

- [x] No changelog needed
