### PR TITLE
Trim strings when creating/updating image stores/profiles

### DIFF
--- a/web/html/src/manager/images/image-profile-edit.js
+++ b/web/html/src/manager/images/image-profile-edit.js
@@ -169,6 +169,8 @@ class CreateImageProfile extends React.Component {
 
     Object.assign(model, {customData: this.state.customData});
 
+    model.label = model.label.trim();
+    model.path = model.path.trim();
     return Network.post(
       "/rhn/manager/api/cm/imageprofiles/update/" + profileId,
       JSON.stringify(model),
@@ -193,6 +195,8 @@ class CreateImageProfile extends React.Component {
 
     Object.assign(model, {customData: this.state.customData});
 
+    model.label = model.label.trim();
+    model.path = model.path.trim();
     return Network.post(
       "/rhn/manager/api/cm/imageprofiles/create",
       JSON.stringify(model),

--- a/web/html/src/manager/images/image-store-edit.js
+++ b/web/html/src/manager/images/image-store-edit.js
@@ -82,6 +82,8 @@ class CreateImageStore extends React.Component {
       return false;
     }
 
+    model.label = model.label.trim();
+    model.uri = model.uri.trim();
     return Network.post(
       "/rhn/manager/api/cm/imagestores/update/" + storeId,
       JSON.stringify(model),
@@ -104,6 +106,8 @@ class CreateImageStore extends React.Component {
       return false;
     }
 
+    model.label = model.label.trim();
+    model.uri = model.uri.trim();
     return Network.post(
       "/rhn/manager/api/cm/imagestores/create",
       JSON.stringify(model),

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Trim strings when creating/updating image stores/profiles (bsc#1133429)
 - Show loading spin while loading salt keys data (bsc#1150180)
 - CLM - Disable clones by default of the shown CLM Project sources
 - Show virtual storage volumes and pools on salt minions


### PR DESCRIPTION
## What does this PR change?

Make sure that whitespace is trimmed from the label and path values when
creating/editing an image store/profile.

Trailing whispace in image profile labels caused docker build to fail
For further information see: https://bugzilla.suse.com/show_bug.cgi?id=1133429&GoAheadAndLogIn=1

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **Changes nothing for user**

- [x] **DONE**

## Test coverage
- No tests: **No new tests needed**

- [x] **DONE**

## Links

Fixes: # https://github.com/SUSE/spacewalk/issues/9287

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
