### PR TITLE
fix dependencies for older distributions

### DIFF
--- a/uyuni/base/uyuni-base.spec
+++ b/uyuni/base/uyuni-base.spec
@@ -57,9 +57,13 @@ Provides:       group(susemanager)
 Requires(pre):  uyuni-base-common
 Requires(pre):  %{_sbindir}/groupadd
 Requires(pre):  %{_sbindir}/usermod
+%if ! (0%{rhel} == 6 || 0%{suse_version} == 1110)
 Requires(pre):  tomcat
+%endif
 Requires(pre):  salt
+%if 0%{?suse_version} >= 1500
 Requires(pre):  user(wwwrun)
+%endif
 
 %description server
 Basic filesystem hierarchy for Uyuni server.


### PR DESCRIPTION
## What does this PR change?

In older SUSE distros the user "wwwrun" was created in one of the packages which were installed first. No need for a dependency.

We ignore the tomcat dependency for rhel 6 and SLES 11 because we do not want to make the server available for it.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **just dependency fun**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
