### PR TITLE
Avoid changing users during uyuni-server pre on SLE11

### DIFF
--- a/uyuni/base/uyuni-base.spec
+++ b/uyuni/base/uyuni-base.spec
@@ -89,11 +89,12 @@ mkdir -p %{buildroot}/var/spacewalk
 mkdir -p %{buildroot}/%{_prefix}/share/rhn/config-defaults
 
 %pre server
+%if ! 0%{?suse_version} == 1110
 getent group susemanager >/dev/null || %{_sbindir}/groupadd -r susemanager
 getent passwd salt >/dev/null && %{_sbindir}/usermod -a -G susemanager salt
 getent passwd tomcat >/dev/null && %{_sbindir}/usermod -a -G susemanager tomcat
 getent passwd wwwrun >/dev/null && %{_sbindir}/usermod -a -G susemanager wwwrun
-
+%endif
 
 %files common
 %defattr(-,root,root)


### PR DESCRIPTION
## What does this PR change?

Otherwise building uyuni-base for SLE11 fails, when packages are installed:
```
[   77s] ... installing all built rpms
[   78s] Preparing packages for installation...
[   78s] uyuni-base-common-1.0.0-400.33.1.develHead
[   78s] uyuni-base-proxy-1.0.0-400.33.1.develHead
[   78s] /usr/sbin/usermod: invalid option -- 'a'
[   78s] Try `usermod --help' or `usermod --usage' for more information.
[   78s] /usr/sbin/usermod: invalid option -- 'a'
[   78s] Try `usermod --help' or `usermod --usage' for more information.
[   78s] error: %pre(uyuni-base-server-1.0.0-400.33.1.develHead.i586) scriptlet failed, exit status 2
[   78s] error:   install: %pre scriptlet failed (2), skipping uyuni-base-server-1.0.0-400.33.1.develHead
[   78s] failed to install rpms, aborting build
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Fix

- [x] **DONE**

## Test coverage
- No tests: Fix

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
