### PR TITLE
Manager bsc1151097

### DIFF
--- a/java/scripts/taskomatic
+++ b/java/scripts/taskomatic
@@ -2,7 +2,7 @@
 # TaskomaticDaemon start script
 . /etc/rhn/taskomatic.conf
 
-TASKO_MEM_LINE=`grep ^taskomatic.java.maxmemory /etc/rhn/rhn.conf | sed -e "s/.*=[[:blank:]]*//"`
+TASKO_MEM_LINE=`grep ^[[:blank:]]taskomatic.java.maxmemory /etc/rhn/rhn.conf | sed -e "s/.*=[[:blank:]]*//"`
 
 TASKO_PARAMS="-Dibm.dst.compatibility=true -Dfile.encoding=UTF-8 -Xms${TASKO_INIT_MEMORY}m -Xmx${TASKO_MAX_MEMORY}m ${TASKO_CRASH_PARAMS} ${TASKO_JAVA_OPTS}"
 TASKO_CLASSPATH="${TASKO_RHN_CLASSPATH}:${TASKO_RHN_JARS}:${TASKO_JARS}"

--- a/java/scripts/taskomatic
+++ b/java/scripts/taskomatic
@@ -2,12 +2,7 @@
 # TaskomaticDaemon start script
 . /etc/rhn/taskomatic.conf
 
-TASKO_MEM_LINE=$(grep "taskomatic.java.maxmemory" /etc/rhn/rhn.conf)
-# Check if commented out
-if [[ $TASKO_MEM_LINE != \#* ]]; then
-  # strip whitespace and then get value after =
-  TASKO_MAX_MEMORY=$(echo $TASKO_MEM_LINE | sed -r 's/\s+//g' | sed 's/^.*=//');
-fi
+TASKO_MEM_LINE=`grep ^taskomatic.java.maxmemory /etc/rhn/rhn.conf | sed -e "s/.*=[[:blank:]]*//"`
 
 TASKO_PARAMS="-Dibm.dst.compatibility=true -Dfile.encoding=UTF-8 -Xms${TASKO_INIT_MEMORY}m -Xmx${TASKO_MAX_MEMORY}m ${TASKO_CRASH_PARAMS} ${TASKO_JAVA_OPTS}"
 TASKO_CLASSPATH="${TASKO_RHN_CLASSPATH}:${TASKO_RHN_JARS}:${TASKO_JARS}"

--- a/java/scripts/taskomatic
+++ b/java/scripts/taskomatic
@@ -2,7 +2,7 @@
 # TaskomaticDaemon start script
 . /etc/rhn/taskomatic.conf
 
-TASKO_MEM_LINE=`grep ^[[:blank:]]*taskomatic.java.maxmemory /etc/rhn/rhn.conf | sed -e "s/.*=[[:blank:]]*//"`
+TASKO_MAX_MEMORY=`grep ^[[:blank:]]*taskomatic.java.maxmemory /etc/rhn/rhn.conf | sed -e "s/.*=[[:blank:]]*//"`
 
 TASKO_PARAMS="-Dibm.dst.compatibility=true -Dfile.encoding=UTF-8 -Xms${TASKO_INIT_MEMORY}m -Xmx${TASKO_MAX_MEMORY}m ${TASKO_CRASH_PARAMS} ${TASKO_JAVA_OPTS}"
 TASKO_CLASSPATH="${TASKO_RHN_CLASSPATH}:${TASKO_RHN_JARS}:${TASKO_JARS}"

--- a/java/scripts/taskomatic
+++ b/java/scripts/taskomatic
@@ -2,7 +2,7 @@
 # TaskomaticDaemon start script
 . /etc/rhn/taskomatic.conf
 
-TASKO_MEM_LINE=`grep ^[[:blank:]]taskomatic.java.maxmemory /etc/rhn/rhn.conf | sed -e "s/.*=[[:blank:]]*//"`
+TASKO_MEM_LINE=`grep ^[[:blank:]]*taskomatic.java.maxmemory /etc/rhn/rhn.conf | sed -e "s/.*=[[:blank:]]*//"`
 
 TASKO_PARAMS="-Dibm.dst.compatibility=true -Dfile.encoding=UTF-8 -Xms${TASKO_INIT_MEMORY}m -Xmx${TASKO_MAX_MEMORY}m ${TASKO_CRASH_PARAMS} ${TASKO_JAVA_OPTS}"
 TASKO_CLASSPATH="${TASKO_RHN_CLASSPATH}:${TASKO_RHN_JARS}:${TASKO_JARS}"

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- fix parsing of /etc/rhn/rhn.conf for taskomatic.java.maxmemory (bsc#1151097)
 - replace requires susemanager with uyuni-base server for group(susemanager)
 - Add page to show virtual storage pools and volumes of a system
 - Migrate login to Spark


### PR DESCRIPTION
## What does this PR change?

If /etc/rhn/rhn.conf contains several lines with the keyword, such as:

\#taskomatic.java.maxmemory = 1024
taskomatic.java.maxmemory=2048

the parsing will fail. This PR fixes this. Like many other places it assumes that the keyword is starting on column 1, which is common anyway.