### PR TITLE
Show loading spin while loading salt keys data (bsc#1150180)

### DIFF
--- a/web/html/src/manager/salt/keys/key-management.js
+++ b/web/html/src/manager/salt/keys/key-management.js
@@ -78,16 +78,19 @@ class KeyManagement extends React.Component {
     ["searchData", "rowKey", "reloadKeys"].forEach(method => this[method] = this[method].bind(this));
     this.state = {
       keys: [],
-      isOrgAdmin: false
+      isOrgAdmin: false,
+      loading: true,
     };
     this.reloadKeys();
   }
 
   reloadKeys() {
+    this.setState({loading: true});
     return listKeys().then(data => {
       this.setState({
         keys: data["minions"],
-        isOrgAdmin: data["isOrgAdmin"]
+        isOrgAdmin: data["isOrgAdmin"],
+        loading: false,
       });
     });
   }
@@ -122,6 +125,7 @@ class KeyManagement extends React.Component {
               identifier={this.rowKey}
               initialSortColumnKey="id"
               initialItemsPerPage={userPrefPageSize}
+              loading={this.state.loading}
               searchField={
                   <SearchField filter={this.searchData} criteria={""} />
               }>

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Show loading spin while loading salt keys data (bsc#1150180)
 - CLM - Disable clones by default of the shown CLM Project sources
 - Show virtual storage volumes and pools on salt minions
 - Migrate login to Spark


### PR DESCRIPTION
## What does this PR change?

Show loading spin while loading salt keys data

## GUI diff

Before:
`No items found` text while loading

After:
`Loading` spin while loading

- [x] **DONE**

## Documentation
- No documentation needed: nothing to document

- [x] **DONE**

## Test coverage
- No tests: nothing to test

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/9399
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
