### PR TITLE
fix handling of extra_tags in case of importing rpm packages

### DIFF
--- a/backend/server/importlib/headerSource.py
+++ b/backend/server/importlib/headerSource.py
@@ -143,6 +143,7 @@ class rpmBinaryPackage(Package, rpmPackage):
         'package_id': None,
         'product_files': None,
         'eulas': None,
+        'extra_tags': None,
     })
 
     def populate(self, header, size, checksum_type, checksum, path=None, org_id=None,

--- a/backend/server/importlib/importLib.py
+++ b/backend/server/importlib/importLib.py
@@ -531,6 +531,7 @@ class Package(IncompletePackage):
         # And initialize the specific ones
         for k in list(self.attributeTypes.keys()):
             self[k] = None
+        self['extra_tags'] = None
 
 
 class SourcePackage(IncompletePackage):

--- a/backend/server/importlib/packageImport.py
+++ b/backend/server/importlib/packageImport.py
@@ -415,8 +415,9 @@ class PackageImport(ChannelPackageSubscription):
         fileList = package['files']
         for f in fileList:
             f['checksum_id'] = self.checksums[(f['checksum_type'], f['checksum'])]
-        for t in package['extra_tags']:
-            t['key_id'] = self.extraTags[t['name']]
+        if package['extra_tags'] is not None:
+            for t in package['extra_tags']:
+                t['key_id'] = self.extraTags[t['name']]
 
     def _comparePackages(self, package1, package2):
         if (package1['checksum_type'] == package2['checksum_type']


### PR DESCRIPTION
## What does this PR change?

In case of RPM the key "extra_tags" does not exist and we have a case where it is expected.
This cause import errors.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **fixes cucumber tests**

- [x] **DONE**

## Links

Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
