### PR TITLE
Add check for url input when creating/editing repositories

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/channel/manage/repo/RepoDetailsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/channel/manage/repo/RepoDetailsAction.java
@@ -13,7 +13,7 @@
  * in this software or its documentation.
  */
 /*
- * Copyright (c) 2010 SUSE LLC
+ * Copyright (c) 2010-2019 SUSE LLC
  */
 package com.redhat.rhn.frontend.action.channel.manage.repo;
 
@@ -58,6 +58,7 @@ import com.redhat.rhn.frontend.struts.RhnValidationHelper;
 import com.redhat.rhn.frontend.xmlrpc.InvalidParameterException;
 import com.redhat.rhn.frontend.xmlrpc.channel.repo.InvalidRepoLabelException;
 import com.redhat.rhn.frontend.xmlrpc.channel.repo.InvalidRepoUrlException;
+import com.redhat.rhn.frontend.xmlrpc.channel.repo.InvalidRepoUrlInputException;
 import com.redhat.rhn.manager.channel.repo.BaseRepoCommand;
 import com.redhat.rhn.manager.channel.repo.CreateRepoCommand;
 import com.redhat.rhn.manager.channel.repo.EditRepoCommand;
@@ -358,6 +359,10 @@ public class RepoDetailsAction extends RhnAction {
         catch (InvalidRepoUrlException e) {
             errors.add(ActionMessages.GLOBAL_MESSAGE, new ActionMessage(
                     "edit.channel.repo.repourlinuse", null));
+        }
+        catch (InvalidRepoUrlInputException e) {
+            errors.add(ActionMessages.GLOBAL_MESSAGE, new ActionMessage(
+                    "edit.channel.repo.repourlinvalid"));
         }
         catch (InvalidRepoLabelException e) {
             errors.add(ActionMessages.GLOBAL_MESSAGE, new ActionMessage(

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -8139,6 +8139,9 @@ Follow this url to see the full list of inactive systems:
       <trans-unit id="edit.channel.repo.repourlinuse">
         <source>There's already a defined repository with given url, please reuse it.</source>
       </trans-unit>
+      <trans-unit id="edit.channel.repo.repourlinvalid">
+        <source>The given url is invalid. Please enter an url with valid syntax (e.g. specify the protocol).</source>
+      </trans-unit>
       <trans-unit id="edit.channel.repo.clientcertmissing">
         <source>Please set SSL Client Certificate, if you've set SSL Client Key.</source>
       </trans-unit>

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/repo/InvalidRepoUrlInputException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/repo/InvalidRepoUrlInputException.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.frontend.xmlrpc.channel.repo;
+
+import com.redhat.rhn.FaultException;
+
+/**
+ * InvalidRepoUrlInputException
+ */
+public class InvalidRepoUrlInputException extends FaultException {
+
+    /**
+     * Constructor
+     * @param repoUrl Repository url invalid
+     */
+    public InvalidRepoUrlInputException(String repoUrl) {
+        super(1, "Invalid url detected", "edit.channel.repo.repourlinvalid",
+                new Object[] {repoUrl});
+    }
+}

--- a/java/code/src/com/redhat/rhn/manager/channel/repo/BaseRepoCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/repo/BaseRepoCommand.java
@@ -13,9 +13,11 @@
  * in this software or its documentation.
  */
 /*
- * Copyright (c) 2010 SUSE LLC
+ * Copyright (c) 2010-2019 SUSE LLC
  */
 package com.redhat.rhn.manager.channel.repo;
+
+import org.apache.commons.validator.UrlValidator;
 
 import com.redhat.rhn.common.client.InvalidCertificateException;
 import com.redhat.rhn.domain.channel.ChannelFactory;
@@ -28,6 +30,7 @@ import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.frontend.xmlrpc.channel.repo.InvalidRepoLabelException;
 import com.redhat.rhn.frontend.xmlrpc.channel.repo.InvalidRepoTypeException;
 import com.redhat.rhn.frontend.xmlrpc.channel.repo.InvalidRepoUrlException;
+import com.redhat.rhn.frontend.xmlrpc.channel.repo.InvalidRepoUrlInputException;
 
 import java.util.Date;
 import java.util.HashSet;
@@ -189,9 +192,10 @@ public abstract class BaseRepoCommand {
      * in the org
      * @throws InvalidRepoTypeException in case repo wih given type already exists
      * in the org
+     * @throws InvalidRepoUrlInputException in case the user entered an invalid repo url
      */
     public void store() throws InvalidRepoUrlException, InvalidRepoLabelException,
-            InvalidRepoTypeException {
+            InvalidRepoTypeException, InvalidRepoUrlInputException {
 
         // create new repository
         if (repo == null) {
@@ -216,6 +220,10 @@ public abstract class BaseRepoCommand {
         }
 
         if (this.url != null && this.type != null) {
+            UrlValidator urlValidator = new UrlValidator();
+            if (!urlValidator.isValid(this.url)) {
+                throw new InvalidRepoUrlInputException(url);
+            }
             ContentSourceType cst = ChannelFactory.lookupContentSourceType(this.type);
             boolean alreadyExists = !ChannelFactory.lookupContentSourceByOrgAndRepo(
                     org, cst, url).isEmpty();

--- a/java/code/src/com/redhat/rhn/manager/channel/test/BaseRepoCommandTest.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/test/BaseRepoCommandTest.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.redhat.rhn.manager.channel.test;
+
+import com.redhat.rhn.domain.org.Org;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.xmlrpc.channel.repo.InvalidRepoLabelException;
+import com.redhat.rhn.frontend.xmlrpc.channel.repo.InvalidRepoTypeException;
+import com.redhat.rhn.frontend.xmlrpc.channel.repo.InvalidRepoUrlException;
+import com.redhat.rhn.frontend.xmlrpc.channel.repo.InvalidRepoUrlInputException;
+import com.redhat.rhn.manager.channel.repo.BaseRepoCommand;
+import com.redhat.rhn.manager.channel.repo.CreateRepoCommand;
+import com.redhat.rhn.testing.RhnBaseTestCase;
+import com.redhat.rhn.testing.UserTestUtils;
+
+/**
+ * BaseRepoCommandTest
+ */
+public class BaseRepoCommandTest extends RhnBaseTestCase {
+
+    private BaseRepoCommand ccc = null;
+    private int label_count = 0;
+    private User user = null;
+
+    public void setUp() throws Exception {
+        super.setUp();
+        Long oid = UserTestUtils.createOrg("testOrg" + this.getClass().getSimpleName());
+        user = UserTestUtils.createUser("testUser", oid);
+        Org org = user.getOrg();
+        ccc = new CreateRepoCommand(org);
+    }
+
+    public void testVerifyUrlInput() {
+
+        // Url must begin with a valid protocol (http, https, ftp, ...),
+        //  end with a valid TLD and contain only valid characters
+
+        // I N V A L I D
+        invalidUrlInput("");
+        invalidUrlInput("example.com");
+        invalidUrlInput("htp://some_test_url.com");
+        invalidUrlInput("www.example.com");
+        invalidUrlInput("http://test123/example.net");
+        invalidUrlInput("ftp://example@test123.com");
+        invalidUrlInput("http://example_1.com");
+        invalidUrlInput("http://example#2.com");
+        invalidUrlInput("http://example;3.com");
+        invalidUrlInput("http://example:4.com");
+        invalidUrlInput("http://example=5.com");
+        invalidUrlInput("http://example,6.com");
+        invalidUrlInput("http://example$7.com");
+        invalidUrlInput("http://example$8.com");
+        invalidUrlInput("http://example(9).com");
+        invalidUrlInput("http://example[0].com");
+        invalidUrlInput("http://example.123");
+
+
+        // V A L I D
+        validUrlInput("http://www.example.com");
+        validUrlInput("http://www.example.co.uk");
+        validUrlInput("https://www3.example.com");
+        validUrlInput("https://test123.com");
+        validUrlInput("http://example.com");
+        validUrlInput("http://another-one.de/example");
+        validUrlInput("https://another-one.de/example%20");
+        validUrlInput("http://another-one.de/example?v=10");
+        validUrlInput("ftp://exampleABC.com");
+    }
+
+    private void invalidUrlInput(String url) {
+        // give it an invalid url
+        ccc.setUrl(url);
+        // give it a valid label
+        ccc.setLabel("valid-label-name");
+        // need to specify a type
+        ccc.setType("yum");
+        // need to specify MetadataSigned
+        ccc.setMetadataSigned(Boolean.FALSE);
+
+        try {
+            ccc.store();
+            fail("invalid url should have thrown error");
+        }
+        catch (InvalidRepoUrlException e) {
+            fail("non duplicate url caused error");
+        }
+        catch (InvalidRepoUrlInputException expected) {
+            // expected
+        }
+        catch (InvalidRepoLabelException e) {
+            fail("valid repo label caused error");
+        }
+        catch (InvalidRepoTypeException e) {
+            fail("valid repo type caused error");
+        }
+    }
+
+    private void validUrlInput(String url) {
+        // give it a valid url
+        ccc.setUrl(url);
+        // need to create unique label names.
+        ccc.setLabel("valid-label-name-" + label_count++);
+        // need to specify a type
+        ccc.setType("yum");
+        // need to specify MetadataSigned
+        ccc.setMetadataSigned(Boolean.FALSE);
+
+        try {
+            ccc.store();
+        }
+        catch (InvalidRepoUrlException e) {
+            fail("non duplicate url caused error");
+        }
+        catch (InvalidRepoUrlInputException e) {
+            fail("valid repo url input caused error");
+        }
+        catch (InvalidRepoLabelException e) {
+            fail("valid repo label caused error");
+        }
+        catch (InvalidRepoTypeException e) {
+            fail("valid repo type caused error");
+        }
+    }
+}

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add check for url input when creating/editing repositories
 - Fqdns are coming from salt network module instead of fqdns grain (bsc#1134860)
 - Consider timeout value in salt remote script (bsc#1153181)
 - rename SUSE Products to just Products in UI


### PR DESCRIPTION
## What does this PR change?

Add a check for url input when creating/editing repositories in Software>Manage>Repositories
Unit tests and error messages were added.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **Only adds an error message on faulty input**

- [x] **DONE**

## Test coverage

- Unit tests were added

- [x] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/7511

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
