### PR TITLE
Improve the way we show the filters attached to a CLM Project

### DIFF
--- a/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project.css
+++ b/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project.css
@@ -1,5 +1,6 @@
 .wrapper {
-  position: relative
+  position: relative;
+  padding: 10px
 }
 
 .icon_wrapper_vertical_center {

--- a/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project.js
+++ b/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project.js
@@ -19,7 +19,7 @@ type FiltersProps = {
   onChange: Function,
 };
 
-const renderFilterEntry = (filter, projectId) => {
+const renderFilterEntry = (filter, projectId, symbol, last) => {
   const descr = getClmFilterDescription(filter);
   const filterButton =
     <div className={styles.icon_wrapper_vertical_center}>
@@ -28,51 +28,37 @@ const renderFilterEntry = (filter, projectId) => {
         icon='fa-edit'
         title={t(`Edit Filter ${filter.name}`)}
         className='pull-right js-spa'
-        text={t("Edit")}
         href={`/rhn/manager/contentmanagement/filters?openFilterId=${filter.id}&projectLabel=${projectId}`}
       />
     </div>;
 
+  let filterClassName = null;
+  let filterIconName = null;
+
   if (filter.state === statesEnum.enum.ATTACHED.key) {
-    return (
-      <li
-        key={`filter_list_item_${filter.id}`}
-        className={`list-group-item text-success ${styles.wrapper}`}>
-        <i className='fa fa-plus'/>
-        <b>{descr}</b>
-        {filterButton}
-      </li>
-    );
+    filterClassName = `text-success`;
+    filterIconName = 'fa-plus';
+  } else if (filter.state === statesEnum.enum.EDITED.key) {
+    filterClassName = `text-warning`;
+    filterIconName = 'fa-edit';
+  } else if (filter.state === statesEnum.enum.DETACHED.key) {
+    filterClassName = `text-danger ${styles.dettached}`;
+    filterIconName = 'fa-minus';
+  } else {
+    filterClassName = `${styles.wrapper}`;
   }
-  if (filter.state === statesEnum.enum.EDITED.key) {
-    return (
-      <li
-        key={`filter_list_item_${filter.id}`}
-        className={`list-group-item text-warning ${styles.wrapper}`}>
-        <i className='fa fa-edit'/>
-        <b>{descr}</b>
-        {filterButton}
-      </li>
-    );
-  }
-  if (filter.state === statesEnum.enum.DETACHED.key) {
-    return (
-      <li
-        key={`filter_list_item_${filter.id}`}
-        className={`list-group-item text-danger ${styles.wrapper} ${styles.dettached}`}>
-        <i className='fa fa-minus'/>
-        <b>{descr}</b>
-        {filterButton}
-      </li>
-    );
-  }
+
   return (
-    <li
-      key={`filter_list_item_${filter.id}`}
-      className={`list-group-item text-sucess ${styles.wrapper}`}>
-      {descr}
-      {filterButton}
-    </li>
+    <>
+      <li
+        key={`filter_list_item_${filter.id}`}
+        className={`list-group-item ${styles.wrapper} ${filterClassName}`}>
+        {filterIconName && <i class={`fa ${filterIconName}`}></i>}
+        {descr}
+        {filterButton}
+      </li>
+      {!last && <div style={{margin: "4px"}} className="row text-center">{symbol}</div>}
+    </>
   );
 }
 
@@ -86,6 +72,9 @@ const FiltersProject = (props:  FiltersProps) => {
 
   const displayingFilters = [...props.selectedFilters];
   displayingFilters.sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
+
+  const allowFilters = displayingFilters.filter(filter => filter.rule === "allow");
+  const denyFilters = displayingFilters.filter(filter => filter.rule === "deny");
 
   return (
 
@@ -131,11 +120,36 @@ const FiltersProject = (props:  FiltersProps) => {
       }}
       renderContent={() =>
         <div className="min-height-panel">
-          <ul className="list-group">
+          <div className="col-md-6">
             {
-              displayingFilters.map(filter => renderFilterEntry(filter, props.projectId))
+              denyFilters.length > 0 &&
+              <>
+                <h4>Deny <small>filter out</small></h4>
+                <ul className="list-group">
+                  {
+                    denyFilters.map((filter, index) => renderFilterEntry(filter, props.projectId,
+                      <i class="fa fa-filter"/>, index === denyFilters.length - 1))
+                  }
+                </ul>
+              </>
             }
-          </ul>
+          </div>
+
+          <div className="col-md-6">
+            {
+              allowFilters.length > 0 &&
+                <>
+                  <h4>Allow <small>select from the full source even if you have excluded them before with deny</small>
+                  </h4>
+                  <ul className="list-group">
+                    {
+                      allowFilters.map((filter, index) => renderFilterEntry(filter, props.projectId,
+                        <i className="fa fa-plus-circle"/>, index === allowFilters.length - 1))
+                    }
+                  </ul>
+                </>
+            }
+          </div>
         </div>
       }
     />

--- a/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project.js
+++ b/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project.js
@@ -32,19 +32,22 @@ const renderFilterEntry = (filter, projectId, symbol, last) => {
       />
     </div>;
 
-  let filterClassName = null;
-  let filterIconName = null;
+  let filterClassName;
+  let filterIconName;
 
   if (filter.state === statesEnum.enum.ATTACHED.key) {
     filterClassName = `text-success`;
     filterIconName = 'fa-plus';
-  } else if (filter.state === statesEnum.enum.EDITED.key) {
+  }
+  else if (filter.state === statesEnum.enum.EDITED.key) {
     filterClassName = `text-warning`;
     filterIconName = 'fa-edit';
-  } else if (filter.state === statesEnum.enum.DETACHED.key) {
+  }
+  else if (filter.state === statesEnum.enum.DETACHED.key) {
     filterClassName = `text-danger ${styles.dettached}`;
     filterIconName = 'fa-minus';
-  } else {
+  }
+  else {
     filterClassName = `${styles.wrapper}`;
   }
 

--- a/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project.js
+++ b/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project.js
@@ -124,7 +124,7 @@ const FiltersProject = (props:  FiltersProps) => {
             {
               denyFilters.length > 0 &&
               <>
-                <h4>Deny <small>filter out</small></h4>
+                <h4>{t("Deny")} <small>{t("filter out")}</small></h4>
                 <ul className="list-group">
                   {
                     denyFilters.map((filter, index) => renderFilterEntry(filter, props.projectId,
@@ -139,7 +139,7 @@ const FiltersProject = (props:  FiltersProps) => {
             {
               allowFilters.length > 0 &&
                 <>
-                  <h4>Allow <small>select from the full source even if you have excluded them before with deny</small>
+                  <h4>{t("Allow")} <small>{t("select from the full source even if you have excluded them before with deny")}</small>
                   </h4>
                   <ul className="list-group">
                     {

--- a/web/html/src/manager/content-management/shared/type/project.type.js
+++ b/web/html/src/manager/content-management/shared/type/project.type.js
@@ -36,7 +36,7 @@ export type ProjectFilterServerType = {
   criteriaKey: string,
   criteriaValue: string,
   entityType: string,
-  deny: boolean,
+  rule: "deny" | "allow",
   state: string,
 }
 

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Better visualization of the filters attached to a CLM Project. Allow/deny are now split
 - Fix ui issues with content lifecycle project list page (bsc#1145587)
 - implement "keyword" filter for Content Lifecycle Management
 - Enable Azure, Amazon EC2 and Google Compute Engine as available Virtual host Managers


### PR DESCRIPTION
## What does this PR change?

Improve the way we show the filters attached to a CLM Project. Split the allow/deny filters
# GUI diff

No difference.

![Screenshot from 2019-09-20 12-01-06](https://user-images.githubusercontent.com/1140720/65322343-7376ec00-db9e-11e9-92e2-a75a10e2b7f9.png)


- [ ] **DONE**

## Documentation
- No documentation needed

- [ ] **DONE**

## Test coverage
- No tests

- [ ] **DONE**

## Links

Fixes #
Tracks https://github.com/SUSE/spacewalk/issues/9441

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
