### PR TITLE
Parse restart suggested flag

### DIFF
--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -243,7 +243,8 @@ class UpdateNotice(object):
             'solution'         : '',
             'references'       : [],
             'pkglist'          : [],
-            'reboot_suggested' : False
+            'reboot_suggested' : False,
+            'restart_suggested' : False
         }
 
         if elem is not None:
@@ -349,7 +350,7 @@ class UpdateNotice(object):
     def _parse_package(self, elem):
         """
         Parse an individual package::
-            <!ELEMENT package (filename, sum, reboot_suggested)>
+            <!ELEMENT package (filename, sum, reboot_suggested, restart_suggested)>
                 <!ATTLIST package name CDATA #REQUIRED>
                 <!ATTLIST package version CDATA #REQUIRED>
                 <!ATTLIST package release CDATA #REQUIRED>
@@ -357,6 +358,7 @@ class UpdateNotice(object):
                 <!ATTLIST package epoch CDATA #REQUIRED>
                 <!ATTLIST package src CDATA #REQUIRED>
             <!ELEMENT reboot_suggested (#PCDATA)>
+            <!ELEMENT restart_suggested (#PCDATA)>
             <!ELEMENT filename (#PCDATA)>
             <!ELEMENT sum (#PCDATA)>
                 <!ATTLIST sum type (md5|sha1) "sha1">
@@ -377,6 +379,8 @@ class UpdateNotice(object):
                 package['sum'] = (child.attrib.get('type'), child.text)
             elif child.tag == 'reboot_suggested':
                 self._md['reboot_suggested'] = True
+            elif child.tag == 'restart_suggested':
+                self._md['restart_suggested'] = True
         return package
 
 

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- parse restart_suggested flag from patches and set it as keywords (bsc#1151467)
 - Import additional fields for Deb packages
 - do not require parameters to start on column 1
 - Add Requires: systemd for completeness


### PR DESCRIPTION
## What does this PR change?

We need to parse the restart_suggested flag. It indicate a package manager update.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/9523
Tracks https://github.com/SUSE/spacewalk/pull/9524

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
