### PR TITLE
CLM: normalize the api urls to start with API - We need this to return a 401 code when the session is lost instead of a redirect.

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/EnvironmentApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/EnvironmentApiController.java
@@ -49,13 +49,13 @@ public class EnvironmentApiController {
 
     /** Init routes for ContentManagement Environment Api.*/
     public static void initRoutes() {
-        post("/manager/contentmanagement/api/projects/:projectId/environments",
+        post("/manager/api/contentmanagement/projects/:projectId/environments",
                 withUser(EnvironmentApiController::createContentEnvironemnt));
 
-        put("/manager/contentmanagement/api/projects/:projectId/environments",
+        put("/manager/api/contentmanagement/projects/:projectId/environments",
                 withUser(EnvironmentApiController::updateContentEnvironemnt));
 
-        delete("/manager/contentmanagement/api/projects/:projectId/environments",
+        delete("/manager/api/contentmanagement/projects/:projectId/environments",
                 withUser(EnvironmentApiController::removeContentEnvironemnt));
     }
 

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/FilterApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/FilterApiController.java
@@ -61,19 +61,19 @@ public class FilterApiController {
     /** Init routes for ContentManagement Filter Api.*/
     public static void initRoutes() {
 
-        put("/manager/contentmanagement/api/projects/:projectId/filters",
+        put("/manager/api/contentmanagement/projects/:projectId/filters",
                 withUser(FilterApiController::updateFiltersOfProject));
 
-        get("/manager/contentmanagement/api/filters",
+        get("/manager/api/contentmanagement/filters",
                 withUser(FilterApiController::getContentFilters));
 
-        post("/manager/contentmanagement/api/filters",
+        post("/manager/api/contentmanagement/filters",
                 withUser(FilterApiController::createContentFilter));
 
-        put("/manager/contentmanagement/api/filters/:filterId",
+        put("/manager/api/contentmanagement/filters/:filterId",
                 withUser(FilterApiController::updateContentFilter));
 
-        delete("/manager/contentmanagement/api/filters/:filterId",
+        delete("/manager/api/contentmanagement/filters/:filterId",
                 withUser(FilterApiController::removeContentFilter));
     }
 

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ProjectActionsApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ProjectActionsApiController.java
@@ -49,11 +49,11 @@ public class ProjectActionsApiController {
 
     /** Init routes for ContentManagement Sources Api.*/
     public static void initRoutes() {
-        get("/manager/contentmanagement/api/projects/:projectId",
+        get("/manager/api/contentmanagement/projects/:projectId",
                 withUser(ProjectActionsApiController::project));
-        post("/manager/contentmanagement/api/projects/:projectId/build",
+        post("/manager/api/contentmanagement/projects/:projectId/build",
                 withUser(ProjectActionsApiController::buildProject));
-        post("/manager/contentmanagement/api/projects/:projectId/promote",
+        post("/manager/api/contentmanagement/projects/:projectId/promote",
                 withUser(ProjectActionsApiController::promoteProject));
     }
 

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ProjectApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ProjectApiController.java
@@ -55,13 +55,13 @@ public class ProjectApiController {
 
     /** Init routes for ContentManagement Project Api.*/
     public static void initRoutes() {
-        post("/manager/contentmanagement/api/projects",
+        post("/manager/api/contentmanagement/projects",
                 withUser(ProjectApiController::createContentProject));
 
-        delete("/manager/contentmanagement/api/projects/:projectId",
+        delete("/manager/api/contentmanagement/projects/:projectId",
                 withUser(ProjectApiController::removeContentProject));
 
-        put("/manager/contentmanagement/api/projects/:projectId/properties",
+        put("/manager/api/contentmanagement/projects/:projectId/properties",
                 withUser(ProjectApiController::updateContentProjectProperties));
 
     }

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ProjectSourcesApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ProjectSourcesApiController.java
@@ -43,7 +43,7 @@ public class ProjectSourcesApiController {
 
     /** Init routes for ContentManagement Sources Api.*/
     public static void initRoutes() {
-        put("/manager/contentmanagement/api/projects/:projectId/softwaresources",
+        put("/manager/api/contentmanagement/projects/:projectId/softwaresources",
                 withUser(ProjectSourcesApiController::updateContentSoftwareSources));
     }
 

--- a/web/html/src/manager/content-management/shared/api/use-lifecycle-actions-api.js
+++ b/web/html/src/manager/content-management/shared/api/use-lifecycle-actions-api.js
@@ -24,12 +24,12 @@ const networkAction = {
 
 const getApiUrl = (resource, nestedResource, id) => {
   if (!id) {
-    return `/rhn/manager/contentmanagement/api/${resource}`;
+    return `/rhn/manager/api/contentmanagement/${resource}`;
   } else {
     if(!nestedResource) {
-      return `/rhn/manager/contentmanagement/api/${resource}/${id}`;
+      return `/rhn/manager/api/contentmanagement/${resource}/${id}`;
     } else {
-      return `/rhn/manager/contentmanagement/api/${resource}/${id}/${nestedResource}`;
+      return `/rhn/manager/api/contentmanagement/${resource}/${id}/${nestedResource}`;
     }
   }
 }


### PR DESCRIPTION
## What does this PR change?

CLM: normalize the api urls to start with API - We need this to return a 401 code when the session is lost instead of a redirect.

More info: https://github.com/uyuni-project/uyuni/blob/adcc2b75d5f908a257cd002ddc3db13f0909cfec/java/code/src/com/redhat/rhn/frontend/servlets/AuthFilter.java#L121

With this change, we will show now a better error message when the session is lost on an ajax call

## GUI diff

![Screenshot from 2019-09-22 14-05-09](https://user-images.githubusercontent.com/1140720/65387755-4ebb7980-dd42-11e9-925f-20fe29c63b89.png)


- [ ] **DONE**

## Documentation
- No documentation needed
- [ ] **DONE**

## Test coverage
- No tests

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
