### PR TITLE
Introduce "dnf-susemanager-plugin" for RHEL8

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/channels/dnf-susemanager-plugin/susemanagerplugin.conf
+++ b/susemanager-utils/susemanager-sls/salt/channels/dnf-susemanager-plugin/susemanagerplugin.conf
@@ -1,0 +1,2 @@
+[main]
+enabled=1

--- a/susemanager-utils/susemanager-sls/salt/channels/dnf-susemanager-plugin/susemanagerplugin.py
+++ b/susemanager-utils/susemanager-sls/salt/channels/dnf-susemanager-plugin/susemanagerplugin.py
@@ -1,0 +1,15 @@
+import dnf
+
+class Susemanager(dnf.Plugin):
+
+    name = 'susemanager'
+
+    def __init__(self, base, cli):
+        super(Susemanager, self).__init__(base, cli)
+        base.read_all_repos()
+        for repo in base.repos.get_matching("susemanager:*"):
+            try:
+                susemanager_token = repo.cfg.getValue(section=repo.id, key="susemanager_token")
+                repo.set_http_headers(["X-Mgr-Auth: %s" % susemanager_token])
+            except:
+                pass

--- a/susemanager-utils/susemanager-sls/salt/channels/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/init.sls
@@ -1,18 +1,34 @@
 {%- if grains['os_family'] == 'RedHat' %}
 mgrchannels_susemanagerplugin:
   file.managed:
+  {%- if grains['osmajorrelease']|int == 8 %}
+    - name: /usr/lib/python3.6/site-packages/dnf-plugins/susemanagerplugin.py
+  {%- else %}
     - name: /usr/share/yum-plugins/susemanagerplugin.py
+  {%- endif %}
     - source:
+  {%- if grains['osmajorrelease']|int == 8 %}
+      - salt://channels/dnf-susemanager-plugin/susemanagerplugin.py
+  {%- else %}
       - salt://channels/yum-susemanager-plugin/susemanagerplugin.py
+  {%- endif %}
     - user: root
     - group: root
     - mode: 644
 
 mgrchannels_susemanagerplugin_conf:
   file.managed:
+  {%- if grains['osmajorrelease']|int == 8 %}
+    - name: /etc/dnf/plugins/susemanagerplugin.conf
+  {%- else %}
     - name: /etc/yum/pluginconf.d/susemanagerplugin.conf
+  {%- endif %}
     - source:
+  {%- if grains['osmajorrelease']|int == 8 %}
+      - salt://channels/dnf-susemanager-plugin/susemanagerplugin.conf
+  {%- else %}
       - salt://channels/yum-susemanager-plugin/susemanagerplugin.conf
+  {%- endif %}
     - user: root
     - group: root
     - mode: 644
@@ -40,13 +56,21 @@ mgrchannels_repo:
 {%- endif %}
 
 {%- if grains['os_family'] == 'RedHat' %}
-mgrchannels_yum_clean_all:
+mgrchannels_yum_dnf_clean_all:
   cmd.run:
+  {%- if grains['osmajorrelease']|int == 8 %}
+    - name: /usr/bin/dnf clean all
+  {%- else %}
     - name: /usr/bin/yum clean all
+  {%- endif %}
     - runas: root
     - onchanges: 
        - file: "/etc/yum.repos.d/susemanager:channels.repo"
+  {%- if grains['osmajorrelease']|int == 8 %}
+    -  unless: "/usr/bin/dnf repolist | grep \"repolist: 0$\""
+  {%- else %}
     -  unless: "/usr/bin/yum repolist | grep \"repolist: 0$\""
+  {%- endif %}
 {%- elif grains['os_family'] == 'Debian' %}
 {%- include 'channels/debiankeyring.sls' %}
 {%- endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Introduce dnf-susemanager-plugin for RHEL8 minions
 - Provide custom grain to report "instance id" when running on Public Cloud instances
 - enable Kiwi NG on SLE15
 - disable legacy startup events for new minions


### PR DESCRIPTION
## What does this PR change?

This PR introduces `dnf-susemanager-plugin`, a DNF-migrated version of `yum-susemanager-plugin`, in order to access SUSE Manager channels from RHEL8.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **this backend code does not need documentation**

- [x] **DONE**

## Test coverage
- No tests: **this should be tested via cucumber once we enable RHEL8**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/9528

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
