### PR TITLE
Manager bsc1151666

### DIFF
--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -221,7 +221,7 @@ fi
 FSTYPE=`df -T $DIR | tail -1 | awk '{print $2}'`
 echo -n "Filesystem type for $DIR is $FSTYPE - "
 if [ $FSTYPE == "btrfs" ]; then
-    TESTDIR=`echo $DIR | cut -b 2-`
+    TESTDIR=`basename $DIR`
     btrfs subvolume list /var | grep "$TESTDIR" > /dev/null
     if [ ! $? -eq 0 ]; then
         echo "creating subvolume."

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- fix test for btrfs subvolume for new btrfs version (bsc#1151666)
 - enable and start disk space checker script during setup
 - remove creating group susemanager and require uyuni-base-server
   which does it now


### PR DESCRIPTION
## What does this PR change?

The output of "btrfs subvolume list" has changed between SLES12SP4 and SLES15SP1. So the mgr-setup script fails to detect that there is already a subvolume for /var/cache when called multiple times which is very useful in case of migrations as users want to run "mgr-setup -r" before the actual migration to minimize downtime. So this change makes the test more generic to work also with the newer btrfs tools. We are only considering subvolumes of /var, so just using the basename is safe.