### PR TITLE
Reposync Release checksum verification mechnism

### DIFF
--- a/backend/common/repo.py
+++ b/backend/common/repo.py
@@ -24,10 +24,28 @@ class DpkgRepo:
     such as "flat", classic tree, PPA etc.
     """
 
+    class ReleaseEntry:
+        """
+        Release file entry
+        """
+        class Checksum:
+            """
+            Checksums of the Release file
+            """
+            md5: str = ""
+            sha1: str = ""
+            sha256: str = ""
+
+        def __init__(self, size: int, uri: str):
+            self.checksum = DpkgRepo.ReleaseEntry.Checksum()
+            self.size = size
+            self.uri = uri
+
     def __init__(self, url):
         self._url = url
         self._flat = None
         self._pkg_index = None, None
+        self._release = {}
 
     def get_pkg_index_raw(self) -> typing.Tuple[str, bytes]:
         """

--- a/backend/common/repo.py
+++ b/backend/common/repo.py
@@ -170,6 +170,24 @@ class DpkgRepo:
 
         return bool(self._flat)
 
+    def verify_packages_index(self) -> bool:
+        """
+        Verify Packages index against all listed checksum algorithms.
+
+        :param name: name of the packages index
+        :return: result (boolean)
+        """
+        res = False
+        if not self.is_flat():
+            name, data = self.get_pkg_index_raw()
+            entry = self.get_release_index().get(name)
+            for algorithm in ["md5", "sha1", "sha256"]:
+                res = getattr(hashlib, algorithm)(data).hexdigest() == getattr(entry.checksum, algorithm)
+                if not res:
+                    break
+        return res
+
+
 
 if __name__ == "__main__":
     d = DpkgRepo("http://ftp.halifax.rwth-aachen.de/ubuntu/dists/bionic/restricted/binary-amd64/")

--- a/backend/common/repo.py
+++ b/backend/common/repo.py
@@ -202,10 +202,3 @@ class DpkgRepo:
                 break
 
         return res
-
-
-
-if __name__ == "__main__":
-    d = DpkgRepo("http://ftp.halifax.rwth-aachen.de/ubuntu/dists/bionic/restricted/binary-amd64/")
-    print("Is flat:", d.is_flat())
-    print(d.decompress_pkg_index())

--- a/backend/common/repo.py
+++ b/backend/common/repo.py
@@ -148,7 +148,6 @@ class DpkgRepo:
 
         return self._release
 
-
     @staticmethod
     def _get_parent_url(url, depth=1, add_path=""):
         """

--- a/backend/common/repo.py
+++ b/backend/common/repo.py
@@ -93,10 +93,10 @@ class DpkgRepo:
                 cnt_data = zlib.decompress(cnt_data, 0x10 + zlib.MAX_WBITS)
             elif fname == DpkgRepo.PKG_XZ:
                 cnt_data = lzma.decompress(cnt_data)
-        except zlib.error as exc:
+        except (zlib.error, lzma.LZMAError) as exc:
             raise DpkgRepoException(exc)
         except Exception as exc:
-            raise DpkgRepoException("Unhandled exception occurred while decompressing {}: {}", fname, exc)
+            raise DpkgRepoException("Unhandled exception occurred while decompressing {}: {}".format(fname, exc))
 
         return cnt_data.decode("utf-8")
 

--- a/backend/common/repo.py
+++ b/backend/common/repo.py
@@ -78,6 +78,10 @@ class DpkgRepo:
                     self._pkg_index = cnt_fname, resp.content
                     break
                 resp.close()
+
+        if self._pkg_index == (None, None,):
+            raise DpkgRepoException("No variants of package index has been found on {} repo".format(self._url))
+
         return self._pkg_index
 
     def decompress_pkg_index(self) -> str:

--- a/backend/common/repo.py
+++ b/backend/common/repo.py
@@ -3,13 +3,16 @@ Repository tools
 """
 # coding: utf-8
 import typing
-import requests
 import http
 import os
 import zlib
 import lzma
 from urllib import parse
 import hashlib
+
+import requests
+
+# pylint:disable=W0612,W0212,C0301
 
 
 class DpkgRepoException(Exception):
@@ -28,11 +31,11 @@ class DpkgRepo:
     PKG_XZ = "Packages.xz"
     PKG_RW = "Packages"
 
-    class ReleaseEntry:
+    class ReleaseEntry:  # pylint: disable=W0612,R0903
         """
         Release file entry
         """
-        class Checksum:
+        class Checksum:  # pylint: disable=R0903
             """
             Checksums of the Release file
             """
@@ -50,7 +53,7 @@ class DpkgRepo:
         Parsed release container.
         """
         def __init__(self, repo: "DpkgRepo"):
-            dict(self)
+            super().__init__()
             self.__repo = repo
 
         def get(self, key: typing.Any) -> typing.Optional[typing.Any]:

--- a/backend/common/repo.py
+++ b/backend/common/repo.py
@@ -1,0 +1,93 @@
+"""
+Repository tools
+"""
+# coding: utf-8
+import typing
+import requests
+import http
+import os
+import zlib
+import lzma
+import hashlib
+
+
+class DpkgRepoException(Exception):
+    """
+    Dpkg repository exception
+    """
+
+
+class DpkgRepo:
+    """
+    Dpkg repository detection.
+    The repositories in Debian world have several layouts,
+    such as "flat", classic tree, PPA etc.
+    """
+
+    def __init__(self, url):
+        self._url = url
+        self._flat = None
+        self._pkg_index = None, None
+
+    def get_pkg_index_raw(self) -> typing.Tuple[str, bytes]:
+        """
+        Get Packages.gz or Packages.xz or Packages content, raw.
+
+        :return: bytes of the content
+        """
+        if self._pkg_index[0] is None:
+            for cnt_fname in ["Packages.gz", "Packages.xz", "Packages"]:
+                packages_url = os.path.join(self._url, cnt_fname)
+                resp = requests.get(packages_url)
+                if resp.status_code == http.HTTPStatus.OK:
+                    self._pkg_index = cnt_fname, resp.content
+                    break
+                resp.close()
+        return self._pkg_index
+
+    def decompress_pkg_index(self) -> str:
+        """
+        Find and return contents of Packages.gz file.
+
+        :raises DpkgRepoException if the Packages.gz file cannot be found.
+        :return: string
+        """
+        fname, cnt_data = self.get_pkg_index_raw()
+        try:
+            if fname.endswith(".gz"):
+                cnt_data = zlib.decompress(cnt_data, 0x10 + zlib.MAX_WBITS)
+            elif fname.endswith(".xz"):
+                cnt_data = lzma.decompress(cnt_data)
+        except zlib.error as exc:
+            raise DpkgRepoException(exc)
+        except Exception as exc:
+            raise DpkgRepoException("Unhandled exception occurred while decompressing {}: {}", fname, exc)
+
+        return cnt_data.decode("utf-8")
+
+    def get_release_index(self) -> str:
+        """
+        Find and return contents of Release file.
+
+        :raises DpkgRepoException if the Release file cannot be found.
+        :return: string
+        """
+
+    def is_flat(self) -> bool:
+        """
+        Detect if the repository has flat format.
+
+        :return:
+        """
+        if self._flat is None:
+            resp = requests.get(self._url)
+            if resp.status_code != http.HTTPStatus.OK:
+                raise DpkgRepoException("HTTP error {} occurred while connecting to the URL".format(resp.status_code))
+
+        return self._flat
+
+
+if __name__ == "__main__":
+    d = DpkgRepo("http://ftp.halifax.rwth-aachen.de/ubuntu/dists/bionic/restricted/binary-amd64/")
+    print("Is flat:", d.is_flat())
+    print(d.decompress_pkg_index())

--- a/backend/common/repo.py
+++ b/backend/common/repo.py
@@ -45,11 +45,24 @@ class DpkgRepo:
             self.size = size
             self.uri = uri
 
+    class EntryDict(dict):
+        """
+        Parsed release container.
+        """
+        def __init__(self, repo: "DpkgRepo"):
+            dict(self)
+            self.__repo = repo
+
+        def get(self, key: typing.Any) -> typing.Optional[typing.Any]:
+            if not self.__repo.is_flat():
+                key = "/".join(parse.urlparse(self.__repo._url).path.strip("/").split("/")[-2:] + [key])
+            return self[key]
+
     def __init__(self, url):
         self._url = url
         self._flat = None
         self._pkg_index = None, None
-        self._release = {}
+        self._release = DpkgRepo.EntryDict(self)
 
     def get_pkg_index_raw(self) -> typing.Tuple[str, bytes]:
         """

--- a/backend/common/repo.py
+++ b/backend/common/repo.py
@@ -159,7 +159,7 @@ class DpkgRepo:
         p_url = parse.urlparse(url)
         p_path = p_url.path.rstrip("/").split("/")
         return parse.urlunparse(parse.ParseResult(scheme=p_url.scheme, netloc=p_url.netloc,
-                                                  path="/".join(p_path[:-depth] + add_path.strip("/").split("/")),
+                                                  path="/".join(p_path[:-depth] + add_path.strip("/").split("/")) or "/",
                                                   params=p_url.params, query=p_url.query, fragment=p_url.fragment))
 
     def is_flat(self) -> bool:

--- a/backend/common/repo.py
+++ b/backend/common/repo.py
@@ -166,9 +166,10 @@ class DpkgRepo:
         """
         resp = requests.get(self._get_parent_url(self._url, 2, "Release"))
         try:
-            self._flat = resp.status_code == http.HTTPStatus.NOT_FOUND
+            self._flat = resp.status_code in [http.HTTPStatus.NOT_FOUND, http.HTTPStatus.FORBIDDEN]
+            self._flat_checked = 1
             self._release = self._parse_release_index(resp.content.decode("utf-8"))
-            if resp.status_code not in [http.HTTPStatus.NOT_FOUND, http.HTTPStatus.OK]:
+            if resp.status_code not in [http.HTTPStatus.NOT_FOUND, http.HTTPStatus.OK, http.HTTPStatus.FORBIDDEN]:
                 raise GeneralRepoException("HTTP error {} occurred while connecting to the URL".format(resp.status_code))
 
             if not self._release and self.is_flat():
@@ -180,8 +181,6 @@ class DpkgRepo:
 
         if not self._release:
             raise GeneralRepoException("Repository seems either broken or has unsupported format")
-
-        self._flat_checked = 1
 
         return self._release
 

--- a/backend/common/test/test_repo.py
+++ b/backend/common/test/test_repo.py
@@ -274,3 +274,21 @@ Some more irrelevant data
         assert not zdcmp.called
         assert xdcmp.called
         assert "/dev/null" in str(exc.value)
+
+    @patch("spacewalk.common.repo.DpkgRepo.get_pkg_index_raw", MagicMock(return_value=("Packages.gz", "content")))
+    def test_decompress_pkg_index_gz_failure(self):
+        """
+        Test decompression for Packages.gz file failure handling.
+
+        :return:
+        """
+        zdcmp = MagicMock(side_effect=zlib.error("Firewall currently too hot"))
+        xdcmp = MagicMock(side_effect=lzma.LZMAError(""))
+        with patch("spacewalk.common.repo.zlib.decompress", zdcmp) as m_zlib, \
+            patch("spacewalk.common.repo.lzma.decompress", xdcmp) as m_lzma:
+            with pytest.raises(DpkgRepoException) as exc:
+                DpkgRepo("http://dummy_url").decompress_pkg_index()
+
+        assert not xdcmp.called
+        assert zdcmp.called
+        assert "hot" in str(exc.value)

--- a/backend/common/test/test_repo.py
+++ b/backend/common/test/test_repo.py
@@ -56,9 +56,9 @@ class TestCommonRepo:
     """
     @patch("spacewalk.common.repo.DpkgRepo.get_pkg_index_raw", MagicMock(return_value=("Packages.gz", b"\x00")))
     @patch("spacewalk.common.repo.DpkgRepo.is_flat", MagicMock(return_value=False))
-    def test_get_pkg_index_raw(self):
+    def test_verify_packages_index(self):
         """
-        Test get_pkg_index_raw method.
+        Test verify_packages_index method.
 
         :return:
         """

--- a/backend/common/test/test_repo.py
+++ b/backend/common/test/test_repo.py
@@ -1,0 +1,31 @@
+# coding: utf-8
+"""
+Py-test based unit tests for common/repo
+"""
+from mock import MagicMock, patch
+from spacewalk.common.repo import DpkgRepo
+import hashlib
+
+
+class TestCommonRepo:
+    """
+    Test suite for common/repo.
+    """
+    @patch("spacewalk.common.repo.DpkgRepo.get_pkg_index_raw", MagicMock(return_value=("Packages.gz", b"\x00")))
+    @patch("spacewalk.common.repo.DpkgRepo.is_flat", MagicMock(return_value=False))
+    def test_get_pkg_index_raw(self):
+        """
+        Test get_pkg_index_raw method.
+
+        :return:
+        """
+        gri = DpkgRepo.ReleaseEntry(size=999, uri="restricted/binary-amd64")
+        gri.checksum.md5 = "93b885adfe0da089cdf634904fd59f71"
+        gri.checksum.sha1 = "5ba93c9db0cff93f52b521d7420e43f6eda2784f"
+        gri.checksum.sha256 = "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+
+        release_index = MagicMock()
+        release_index().get = MagicMock(return_value=gri)
+        with patch("spacewalk.common.repo.DpkgRepo.get_release_index", release_index):
+            repo = DpkgRepo("http://mygreathost.com/ubuntu/dists/bionic/restricted/binary-amd64/")
+            assert repo.verify_packages_index()

--- a/backend/common/test/test_repo.py
+++ b/backend/common/test/test_repo.py
@@ -214,9 +214,9 @@ Some more irrelevant data
         assert out == "макарони"
 
     @patch("spacewalk.common.repo.DpkgRepo.get_pkg_index_raw", MagicMock(return_value=("Packages.gz", "content")))
-    def test_decompress_pkg_index_gz_failure(self):
+    def test_decompress_pkg_index_gz_general_failure(self):
         """
-        Test decompression for Packages.gz file failure handling.
+        Test decompression for Packages.gz file general failure handling.
 
         :return:
         """
@@ -235,9 +235,9 @@ Some more irrelevant data
         assert "symlinks" in err
 
     @patch("spacewalk.common.repo.DpkgRepo.get_pkg_index_raw", MagicMock(return_value=("Packages.xz", "content")))
-    def test_decompress_pkg_index_xz_failure(self):
+    def test_decompress_pkg_index_xz_general_failure(self):
         """
-        Test decompression for Packages.xz file failure handling.
+        Test decompression for Packages.xz file general failure handling.
 
         :return:
         """

--- a/backend/common/test/test_repo.py
+++ b/backend/common/test/test_repo.py
@@ -112,3 +112,16 @@ class TestCommonRepo:
         repo = DpkgRepo("http://dummy/url")
         assert repo.get_release_index() == "Plasma conduit overflow"
         assert repo.is_flat()
+
+    @patch("spacewalk.common.repo.requests.get", MagicMock(
+        return_value=FakeRequests().conf(status_code=http.HTTPStatus.OK, content=b"")))
+    @patch("spacewalk.common.repo.DpkgRepo._parse_release_index", MagicMock(return_value="Plasma conduit overflow"))
+    def test_get_release_index_standard(self):
+        """
+        Get release index file contents.
+
+        :return:
+        """
+        repo = DpkgRepo("http://dummy/url")
+        assert repo.get_release_index() == "Plasma conduit overflow"
+        assert not repo.is_flat()

--- a/backend/common/test/test_repo.py
+++ b/backend/common/test/test_repo.py
@@ -194,3 +194,21 @@ Some more irrelevant data
         assert not xdcmp.called
         assert zdcmp.called
         assert out == "макарони"
+
+    @patch("spacewalk.common.repo.DpkgRepo.get_pkg_index_raw", MagicMock(return_value=("Packages.xz", "content")))
+    def test_decompress_pkg_index_xz(self):
+        """
+        Test decompression for Packages.xz file.
+
+        :return:
+        """
+        data = b'\xd0\xbc\xd0\xb0\xd0\xba\xd0\xb0\xd1\x80\xd0\xbe\xd0\xbd\xd0\xb8'
+        zdcmp = MagicMock(return_value=data)
+        xdcmp = MagicMock(return_value=data)
+        with patch("spacewalk.common.repo.zlib.decompress", zdcmp) as m_zlib, \
+            patch("spacewalk.common.repo.lzma.decompress", xdcmp) as m_lzma:
+            out = DpkgRepo("http://dummy_url").decompress_pkg_index()
+
+        assert not zdcmp.called
+        assert xdcmp.called
+        assert out == "макарони"

--- a/backend/common/test/test_repo.py
+++ b/backend/common/test/test_repo.py
@@ -3,7 +3,7 @@
 Py-test based unit tests for common/repo
 """
 from mock import MagicMock, patch
-from spacewalk.common.repo import DpkgRepo, DpkgRepoException
+from spacewalk.common.repo import DpkgRepo, GeneralRepoException
 import http
 import pytest
 import lzma
@@ -143,7 +143,7 @@ class TestCommonRepo:
         """
         repo = DpkgRepo("http://dummy/url")
 
-        with pytest.raises(DpkgRepoException) as exc:
+        with pytest.raises(GeneralRepoException) as exc:
             assert repo.get_release_index()
         assert str(exc.value) == "HTTP error 204 occurred while connecting to the URL"
 
@@ -225,11 +225,11 @@ Some more irrelevant data
 
         :return:
         """
-        zdcmp = MagicMock(side_effect=DpkgRepoException("Too many symlinks found in binary data"))
-        xdcmp = MagicMock(side_effect=DpkgRepoException(""))
+        zdcmp = MagicMock(side_effect=GeneralRepoException("Too many symlinks found in binary data"))
+        xdcmp = MagicMock(side_effect=GeneralRepoException(""))
         with patch("spacewalk.common.repo.zlib.decompress", zdcmp) as m_zlib, \
             patch("spacewalk.common.repo.lzma.decompress", xdcmp) as m_lzma:
-            with pytest.raises(DpkgRepoException) as exc:
+            with pytest.raises(GeneralRepoException) as exc:
                 DpkgRepo("http://dummy_url").decompress_pkg_index()
 
         assert not xdcmp.called
@@ -246,11 +246,11 @@ Some more irrelevant data
 
         :return:
         """
-        zdcmp = MagicMock(side_effect=DpkgRepoException(""))
-        xdcmp = MagicMock(side_effect=DpkgRepoException("Software design limitation"))
+        zdcmp = MagicMock(side_effect=GeneralRepoException(""))
+        xdcmp = MagicMock(side_effect=GeneralRepoException("Software design limitation"))
         with patch("spacewalk.common.repo.zlib.decompress", zdcmp) as m_zlib, \
             patch("spacewalk.common.repo.lzma.decompress", xdcmp) as m_lzma:
-            with pytest.raises(DpkgRepoException) as exc:
+            with pytest.raises(GeneralRepoException) as exc:
                 DpkgRepo("http://dummy_url").decompress_pkg_index()
 
         assert not zdcmp.called
@@ -271,7 +271,7 @@ Some more irrelevant data
         xdcmp = MagicMock(side_effect=lzma.LZMAError("/dev/null is busy while upgrading"))
         with patch("spacewalk.common.repo.zlib.decompress", zdcmp) as m_zlib, \
             patch("spacewalk.common.repo.lzma.decompress", xdcmp) as m_lzma:
-            with pytest.raises(DpkgRepoException) as exc:
+            with pytest.raises(GeneralRepoException) as exc:
                 DpkgRepo("http://dummy_url").decompress_pkg_index()
 
         assert not zdcmp.called
@@ -289,7 +289,7 @@ Some more irrelevant data
         xdcmp = MagicMock(side_effect=lzma.LZMAError(""))
         with patch("spacewalk.common.repo.zlib.decompress", zdcmp) as m_zlib, \
             patch("spacewalk.common.repo.lzma.decompress", xdcmp) as m_lzma:
-            with pytest.raises(DpkgRepoException) as exc:
+            with pytest.raises(GeneralRepoException) as exc:
                 DpkgRepo("http://dummy_url").decompress_pkg_index()
 
         assert not xdcmp.called
@@ -304,7 +304,7 @@ Some more irrelevant data
 
         :return:
         """
-        with pytest.raises(DpkgRepoException) as exc:
+        with pytest.raises(GeneralRepoException) as exc:
             DpkgRepo("http://dummy/url").get_pkg_index_raw()
 
         assert "No variants of package index has been found on http://dummy/url repo" == str(exc.value)

--- a/backend/common/test/test_repo.py
+++ b/backend/common/test/test_repo.py
@@ -176,3 +176,21 @@ Some more irrelevant data
         assert parsed["two/Release.gz"].checksum.sha1 == "70d7c8225fb5b6ee67ba089681425c5b712e0b19"
         assert parsed["two/Release.gz"].checksum.sha256 == "4843bbb823a63f3bde6104ceecc86daebf8b84efd4f6fb1373138b4589a84803"
         assert parsed["two/Release.gz"].size == 1298
+
+    @patch("spacewalk.common.repo.DpkgRepo.get_pkg_index_raw", MagicMock(return_value=("Packages.gz", "content")))
+    def test_decompress_pkg_index_gz(self):
+        """
+        Test decompression for Packages.gz file.
+
+        :return:
+        """
+        data = b'\xd0\xbc\xd0\xb0\xd0\xba\xd0\xb0\xd1\x80\xd0\xbe\xd0\xbd\xd0\xb8'
+        zdcmp = MagicMock(return_value=data)
+        xdcmp = MagicMock(return_value=data)
+        with patch("spacewalk.common.repo.zlib.decompress", zdcmp) as m_zlib, \
+            patch("spacewalk.common.repo.lzma.decompress", xdcmp) as m_lzma:
+            out = DpkgRepo("http://dummy_url").decompress_pkg_index()
+
+        assert not xdcmp.called
+        assert zdcmp.called
+        assert out == "макарони"

--- a/backend/common/test/test_repo.py
+++ b/backend/common/test/test_repo.py
@@ -294,3 +294,16 @@ Some more irrelevant data
         assert not xdcmp.called
         assert zdcmp.called
         assert "hot" in str(exc.value)
+
+    @patch("spacewalk.common.repo.requests.get", MagicMock(
+        return_value=FakeRequests().conf(status_code=http.HTTPStatus.NOT_FOUND, content=b"")))
+    def test_get_pkg_index_raw_exception(self):
+        """
+        Test getting package index file exception handling
+
+        :return:
+        """
+        with pytest.raises(DpkgRepoException) as exc:
+            DpkgRepo("http://dummy/url").get_pkg_index_raw()
+
+        assert "No variants of package index has been found on http://dummy/url repo" == str(exc.value)

--- a/backend/common/test/test_repo.py
+++ b/backend/common/test/test_repo.py
@@ -56,3 +56,15 @@ class TestCommonRepo:
         """
         url = "http://mygreathost.com/ubuntu/dists/bionic/restricted/binary-amd64/"
         assert DpkgRepo._get_parent_url(url) == "http://mygreathost.com/ubuntu/dists/bionic/restricted/"
+
+    def test_get_parent_url_no_subpath_with_depth(self):
+        """
+        Return parent URL without adding subpath with depth.
+
+        :return:
+        """
+        url = "http://mygreathost.com/ubuntu/dists/bionic/restricted/binary-amd64/"
+        assert DpkgRepo._get_parent_url(url, depth=2) == "http://mygreathost.com/ubuntu/dists/bionic/"
+        assert DpkgRepo._get_parent_url(url, depth=3) == "http://mygreathost.com/ubuntu/dists/"
+        assert DpkgRepo._get_parent_url(url, depth=4) == "http://mygreathost.com/ubuntu/"
+        assert DpkgRepo._get_parent_url(url, depth=5) == "http://mygreathost.com/"

--- a/backend/common/test/test_repo.py
+++ b/backend/common/test/test_repo.py
@@ -102,6 +102,8 @@ class TestCommonRepo:
         assert DpkgRepo._get_parent_url(url, depth=3) == "http://mygreathost.com/ubuntu/dists/"
         assert DpkgRepo._get_parent_url(url, depth=4) == "http://mygreathost.com/ubuntu/"
         assert DpkgRepo._get_parent_url(url, depth=5) == "http://mygreathost.com/"
+        assert DpkgRepo._get_parent_url(url, depth=6) == "http://mygreathost.com/"
+        assert DpkgRepo._get_parent_url(url, depth=7) == "http://mygreathost.com/"
 
     @patch("spacewalk.common.repo.requests.get", MagicMock(
         return_value=FakeRequests().conf(status_code=http.HTTPStatus.NOT_FOUND, content=b"")))

--- a/backend/common/test/test_repo.py
+++ b/backend/common/test/test_repo.py
@@ -4,7 +4,8 @@ Py-test based unit tests for common/repo
 """
 from mock import MagicMock, patch
 from spacewalk.common.repo import DpkgRepo
-import hashlib
+import http
+
 
 class FakeRequests:
     """
@@ -98,3 +99,16 @@ class TestCommonRepo:
         assert DpkgRepo._get_parent_url(url, depth=3) == "http://mygreathost.com/ubuntu/dists/"
         assert DpkgRepo._get_parent_url(url, depth=4) == "http://mygreathost.com/ubuntu/"
         assert DpkgRepo._get_parent_url(url, depth=5) == "http://mygreathost.com/"
+
+    @patch("spacewalk.common.repo.requests.get", MagicMock(
+        return_value=FakeRequests().conf(status_code=http.HTTPStatus.NOT_FOUND, content=b"")))
+    @patch("spacewalk.common.repo.DpkgRepo._parse_release_index", MagicMock(return_value="Plasma conduit overflow"))
+    def test_get_release_index(self):
+        """
+        Get release index file contents.
+
+        :return:
+        """
+        repo = DpkgRepo("http://dummy/url")
+        assert repo.get_release_index() == "Plasma conduit overflow"
+        assert repo.is_flat()

--- a/backend/common/test/test_repo.py
+++ b/backend/common/test/test_repo.py
@@ -330,3 +330,14 @@ Some more irrelevant data
         """
         url = "https://domainname.ext/PATH/Updates/Distro/version/arch/update/Packages.gz?very_long_auth_token"
         assert url == DpkgRepo(url).append_index_file(DpkgRepo.PKG_GZ)
+
+    def test_append_index_file_to_url_exception(self):
+        """
+        Test append index files to the given url, but exception happens due to unsupported URL
+        :return:
+        """
+        url = "https://domainname.ext/PATH/Updates/Distro/version/arch/Packages.gz/update?very_long_auth_token"
+        with pytest.raises(GeneralRepoException) as exc:
+            DpkgRepo(url).append_index_file(DpkgRepo.PKG_GZ)
+
+        assert str(exc.value) == "URL has already Packages.gz mentioned in it."

--- a/backend/common/test/test_repo.py
+++ b/backend/common/test/test_repo.py
@@ -141,3 +141,38 @@ class TestCommonRepo:
         with pytest.raises(DpkgRepoException) as exc:
             assert repo.get_release_index()
         assert str(exc.value) == "HTTP error 204 occurred while connecting to the URL"
+
+    def test_parse_release_index(self):
+        """
+        Parse release index.
+
+        :return:
+        """
+        release = """
+Irrelevant data
+9f067fc9044265ff132cefef4f741ede     999 one/Release.gz
+ee27992a1c0154454601fd8e5a808256    1298 two/Release.gz
+some more irrelevant data here
+c373e78514584fc3a6b3505aa0ce1525b83e4ceb     999 one/Release.gz
+70d7c8225fb5b6ee67ba089681425c5b712e0b19    1298 two/Release.gz
+something in between
+ef73ea0cc071ad4a13fb52717f99b1951bb41bc2198d2307b30cc0edfb3aed03     999 one/Release.gz
+4843bbb823a63f3bde6104ceecc86daebf8b84efd4f6fb1373138b4589a84803    1298 two/Release.gz
+Some more irrelevant data
+"""
+        repo = DpkgRepo("http://dummy/url")
+        parsed = repo._parse_release_index(release)
+
+        assert len(parsed) == 2
+        assert "one/Release.gz" in parsed
+        assert "two/Release.gz" in parsed
+
+        assert parsed["one/Release.gz"].checksum.md5 == "9f067fc9044265ff132cefef4f741ede"
+        assert parsed["one/Release.gz"].checksum.sha1 == "c373e78514584fc3a6b3505aa0ce1525b83e4ceb"
+        assert parsed["one/Release.gz"].checksum.sha256 == "ef73ea0cc071ad4a13fb52717f99b1951bb41bc2198d2307b30cc0edfb3aed03"
+        assert parsed["one/Release.gz"].size == 999
+
+        assert parsed["two/Release.gz"].checksum.md5 == "ee27992a1c0154454601fd8e5a808256"
+        assert parsed["two/Release.gz"].checksum.sha1 == "70d7c8225fb5b6ee67ba089681425c5b712e0b19"
+        assert parsed["two/Release.gz"].checksum.sha256 == "4843bbb823a63f3bde6104ceecc86daebf8b84efd4f6fb1373138b4589a84803"
+        assert parsed["two/Release.gz"].size == 1298

--- a/backend/common/test/test_repo.py
+++ b/backend/common/test/test_repo.py
@@ -322,3 +322,11 @@ Some more irrelevant data
 
         assert dpr.append_index_file(DpkgRepo.PKG_XZ) == \
             "https://domainname.ext/PATH/Updates/Distro/version/arch/update/Packages.xz?very_long_auth_token"
+
+    def test_append_index_file_to_url_no_difference(self):
+        """
+        Test append index files to the given url, but no changes has to be applied
+        :return:
+        """
+        url = "https://domainname.ext/PATH/Updates/Distro/version/arch/update/Packages.gz?very_long_auth_token"
+        assert url == DpkgRepo(url).append_index_file(DpkgRepo.PKG_GZ)

--- a/backend/common/test/test_repo.py
+++ b/backend/common/test/test_repo.py
@@ -6,6 +6,36 @@ from mock import MagicMock, patch
 from spacewalk.common.repo import DpkgRepo
 import hashlib
 
+class FakeRequests:
+    """
+    Fake requests object.
+    """
+
+    class FakeResponse:
+        """
+        Fake request's response struct
+        """
+
+    def close(self):
+        """
+        Close request. Does nothing actually.
+
+        :return:
+        """
+
+    def conf(self, **kwargs):
+        """
+        Configure response for the test purposes.
+
+        :param kwargs:
+        :return:
+        """
+        for kkw, vkw in kwargs.items():
+            setattr(self, kkw, vkw)
+
+        return self
+
+
 
 class TestCommonRepo:
     """

--- a/backend/common/test/test_repo.py
+++ b/backend/common/test/test_repo.py
@@ -36,6 +36,15 @@ class FakeRequests:
         return self
 
 
+def mock_release_index(self):
+    """
+    Set flat to True.
+
+    :param self:
+    :return:
+    """
+    self._flat = True
+
 
 class TestCommonRepo:
     """
@@ -60,22 +69,13 @@ class TestCommonRepo:
             repo = DpkgRepo("http://mygreathost.com/ubuntu/dists/bionic/restricted/binary-amd64/")
             assert repo.verify_packages_index()
 
+    @patch("spacewalk.common.repo.DpkgRepo.get_release_index", mock_release_index)
     def test_is_flat(self):
         """
         Return True or (False) if repo has flat (or not) format.
 
         :return:
         """
-        def mock_release_index(self):
-            """
-            Set flat to True
-
-            :param self:
-            :return:
-            """
-            self._flat = True
-
-        DpkgRepo.get_release_index = mock_release_index
         assert DpkgRepo("http://dummy").is_flat()
 
     def test_get_parent_url_no_subpath_default(self):

--- a/backend/common/test/test_repo.py
+++ b/backend/common/test/test_repo.py
@@ -308,3 +308,17 @@ Some more irrelevant data
             DpkgRepo("http://dummy/url").get_pkg_index_raw()
 
         assert "No variants of package index has been found on http://dummy/url repo" == str(exc.value)
+
+    def test_append_index_file_to_url(self):
+        """
+        Test append index files to the given url.
+        :return:
+        """
+        url = "https://domainname.ext/PATH/Updates/Distro/version/arch/update/?very_long_auth_token"
+        dpr = DpkgRepo(url)
+
+        assert dpr.append_index_file(DpkgRepo.PKG_GZ) == \
+            "https://domainname.ext/PATH/Updates/Distro/version/arch/update/Packages.gz?very_long_auth_token"
+
+        assert dpr.append_index_file(DpkgRepo.PKG_XZ) == \
+            "https://domainname.ext/PATH/Updates/Distro/version/arch/update/Packages.xz?very_long_auth_token"

--- a/backend/common/test/test_repo.py
+++ b/backend/common/test/test_repo.py
@@ -29,3 +29,21 @@ class TestCommonRepo:
         with patch("spacewalk.common.repo.DpkgRepo.get_release_index", release_index):
             repo = DpkgRepo("http://mygreathost.com/ubuntu/dists/bionic/restricted/binary-amd64/")
             assert repo.verify_packages_index()
+
+    def test_is_flat(self):
+        """
+        Return True or (False) if repo has flat (or not) format.
+
+        :return:
+        """
+        def mock_release_index(self):
+            """
+            Set flat to True
+
+            :param self:
+            :return:
+            """
+            self._flat = True
+
+        DpkgRepo.get_release_index = mock_release_index
+        assert DpkgRepo("http://dummy").is_flat()

--- a/backend/common/test/test_repo.py
+++ b/backend/common/test/test_repo.py
@@ -47,3 +47,12 @@ class TestCommonRepo:
 
         DpkgRepo.get_release_index = mock_release_index
         assert DpkgRepo("http://dummy").is_flat()
+
+    def test_get_parent_url_no_subpath_default(self):
+        """
+        Return parent URL without adding subpath and default params.
+
+        :return:
+        """
+        url = "http://mygreathost.com/ubuntu/dists/bionic/restricted/binary-amd64/"
+        assert DpkgRepo._get_parent_url(url) == "http://mygreathost.com/ubuntu/dists/bionic/restricted/"

--- a/backend/common/test/test_repo.py
+++ b/backend/common/test/test_repo.py
@@ -103,7 +103,7 @@ class TestCommonRepo:
     @patch("spacewalk.common.repo.requests.get", MagicMock(
         return_value=FakeRequests().conf(status_code=http.HTTPStatus.NOT_FOUND, content=b"")))
     @patch("spacewalk.common.repo.DpkgRepo._parse_release_index", MagicMock(return_value="Plasma conduit overflow"))
-    def test_get_release_index(self):
+    def test_get_release_index_flat(self):
         """
         Get release index file contents.
 

--- a/backend/common/test/test_repo.py
+++ b/backend/common/test/test_repo.py
@@ -105,7 +105,7 @@ class TestCommonRepo:
     @patch("spacewalk.common.repo.DpkgRepo._parse_release_index", MagicMock(return_value="Plasma conduit overflow"))
     def test_get_release_index_flat(self):
         """
-        Get release index file contents.
+        Get release index file contents, flat.
 
         :return:
         """
@@ -118,7 +118,7 @@ class TestCommonRepo:
     @patch("spacewalk.common.repo.DpkgRepo._parse_release_index", MagicMock(return_value="Plasma conduit overflow"))
     def test_get_release_index_standard(self):
         """
-        Get release index file contents.
+        Get release index file contents, standard.
 
         :return:
         """

--- a/backend/common/test/test_repo.py
+++ b/backend/common/test/test_repo.py
@@ -98,6 +98,7 @@ class TestCommonRepo:
         :return:
         """
         url = "http://mygreathost.com/ubuntu/dists/bionic/restricted/binary-amd64/"
+        assert DpkgRepo._get_parent_url(url, depth=0) == "http://mygreathost.com/ubuntu/dists/bionic/restricted/binary-amd64/"
         assert DpkgRepo._get_parent_url(url, depth=2) == "http://mygreathost.com/ubuntu/dists/bionic/"
         assert DpkgRepo._get_parent_url(url, depth=3) == "http://mygreathost.com/ubuntu/dists/"
         assert DpkgRepo._get_parent_url(url, depth=4) == "http://mygreathost.com/ubuntu/"

--- a/backend/satellite_tools/repo_plugins/deb_src.py
+++ b/backend/satellite_tools/repo_plugins/deb_src.py
@@ -126,7 +126,7 @@ class DebRepo(object):
                                     verify=self.sslcacert)
                 if not data.ok:
                     return ''
-                filename = self.basecachedir + '/' + os.path.basename(url)
+                filename = self.basecachedir + '/' + os.path.basename(urlparse.urlparse(url).path)
                 fd = open(filename, 'wb')
                 try:
                     for chunk in data.iter_content(chunk_size=1024):

--- a/backend/satellite_tools/repo_plugins/deb_src.py
+++ b/backend/satellite_tools/repo_plugins/deb_src.py
@@ -110,7 +110,7 @@ class DebRepo:
         """
         # TODO: Signature verification is not yet implemented here.
         if not repo.DpkgRepo(self.url).verify_packages_index():
-            raise repo.DpkgRepoException("Package index checksum failure")
+            raise repo.GeneralRepoException("Package index checksum failure")
 
     def _download(self, url):
         if url.startswith('file://'):

--- a/backend/satellite_tools/repo_plugins/deb_src.py
+++ b/backend/satellite_tools/repo_plugins/deb_src.py
@@ -29,6 +29,8 @@ from spacewalk.satellite_tools.download import get_proxies
 from spacewalk.satellite_tools.repo_plugins import ContentPackage, CACHE_DIR
 from spacewalk.satellite_tools.syncLib import log2
 from spacewalk.common.rhnConfig import CFG, initCFG
+from spacewalk.common import repo
+
 try:
     #  python 2 
     from urllib import unquote
@@ -99,6 +101,16 @@ class DebRepo:
         self.exclude = []
         self.pkgdir = pkg_dir
         self.http_headers = {}
+
+    def verify(self):
+        """
+        Verify package index checksum and signature.
+
+        :return:
+        """
+        # TODO: Signature verification is not yet implemented here.
+        if not repo.DpkgRepo(self.url).verify_packages_index():
+            raise repo.DpkgRepoException("Package index checksum failure")
 
     def _download(self, url):
         if url.startswith('file://'):
@@ -236,6 +248,7 @@ class ContentSource:
 
         self.repo = DebRepo(url, os.path.join(CACHE_DIR, self.org, name),
                             os.path.join(CFG.MOUNT_POINT, CFG.PREPENDED_DIR, self.org, 'stage'), self.proxy_addr, self.proxy_user, self.proxy_pass)
+        self.repo.verify()
 
         self.num_packages = 0
         self.num_excluded = 0

--- a/backend/satellite_tools/repo_plugins/deb_src.py
+++ b/backend/satellite_tools/repo_plugins/deb_src.py
@@ -126,7 +126,7 @@ class DebRepo(object):
                                     verify=self.sslcacert)
                 if not data.ok:
                     return ''
-                filename = self.basecachedir + '/' + os.path.basename(urlparse.urlparse(url).path)
+                filename = os.path.join(self.basecachedir, os.path.basename(urlparse.urlparse(url).path))
                 fd = open(filename, 'wb')
                 try:
                     for chunk in data.iter_content(chunk_size=1024):

--- a/backend/satellite_tools/repo_plugins/deb_src.py
+++ b/backend/satellite_tools/repo_plugins/deb_src.py
@@ -43,7 +43,7 @@ RETRY_DELAY = 1
 FORMAT_PRIORITY = ['.xz', '.gz', '']
 
 
-class DebPackage(object):
+class DebPackage:
     def __init__(self):
         self.name = None
         self.epoch = None
@@ -77,7 +77,7 @@ class DebPackage(object):
                                                             self.checksum)])
 
 
-class DebRepo(object):
+class DebRepo:
     # url example - http://ftp.debian.org/debian/dists/jessie/main/binary-amd64/
     def __init__(self, url, cache_dir, pkg_dir, proxy_addr="", proxy_user="", proxy_pass=""):
         self.url = url
@@ -215,7 +215,7 @@ class DebRepo(object):
         return to_return
 
 
-class ContentSource(object):
+class ContentSource:
 
     def __init__(self, url, name, insecure=False, interactive=True, yumsrc_conf=None,
                  org="1", channel_label="", no_mirrors=False, ca_cert_file=None,

--- a/backend/satellite_tools/repo_plugins/deb_src.py
+++ b/backend/satellite_tools/repo_plugins/deb_src.py
@@ -126,13 +126,13 @@ class DebRepo:
                 if self.proxy:
                     (scheme, netloc, path, query, fragid) = urlparse.urlsplit(self.proxy)
                     proxies = {
-                        'http' : 'http://'+netloc,
-                        'https' : 'http://'+netloc
+                        'http': 'http://' + netloc,
+                        'https': 'http://' + netloc
                     }
                     if self.proxy_username and self.proxy_password:
                         proxies = {
-                            'http' : 'http://'+self.proxy_username+":"+self.proxy_password+"@"+netloc,
-                            'https' : 'http://'+self.proxy_username+":"+self.proxy_password+"@"+netloc,
+                            'http': 'http://' + self.proxy_username + ":" + self.proxy_password + "@" + netloc,
+                            'https': 'http://' + self.proxy_username + ":" + self.proxy_password + "@" + netloc,
                         }
                 data = requests.get(url, proxies=proxies, cert=(self.sslclientcert, self.sslclientkey),
                                     verify=self.sslcacert)
@@ -147,8 +147,8 @@ class DebRepo:
                     if fd is not None:
                         fd.close()
                 return filename
-            except requests.exceptions.RequestException:
-                print("ERROR: requests.exceptions.RequestException occured")
+            except requests.exceptions.RequestException as exc:
+                print("ERROR: requests.exceptions.RequestException occurred:", exc)
                 time.sleep(RETRY_DELAY)
 
         return ''
@@ -159,7 +159,7 @@ class DebRepo:
         to_return = []
 
         for extension in FORMAT_PRIORITY:
-            (scheme, netloc, path, query, fragid) = urlparse.urlsplit(self.url)
+            scheme, netloc, path, query, fragid = urlparse.urlsplit(self.url)
             url = urlparse.urlunsplit((scheme, netloc,
                                        path + ('/' if not path.endswith('/') else '') + 'Packages' + extension, query, fragid))
             filename = self._download(url)
@@ -247,7 +247,8 @@ class ContentSource:
         self.authtoken = None
 
         self.repo = DebRepo(url, os.path.join(CACHE_DIR, self.org, name),
-                            os.path.join(CFG.MOUNT_POINT, CFG.PREPENDED_DIR, self.org, 'stage'), self.proxy_addr, self.proxy_user, self.proxy_pass)
+                            os.path.join(CFG.MOUNT_POINT, CFG.PREPENDED_DIR, self.org, 'stage'),
+                            self.proxy_addr, self.proxy_user, self.proxy_pass)
         self.repo.verify()
 
         self.num_packages = 0
@@ -259,7 +260,7 @@ class ContentSource:
             self.authtoken = query
 
     def get_md_checksum_type(self):
-        return None
+        pass
 
     def get_products(self):
         # No products
@@ -276,11 +277,10 @@ class ContentSource:
         self.num_packages = len(pkglist)
         if latest:
             latest_pkgs = {}
-            new_pkgs = []
             for pkg in pkglist:
-               ident = '{}.{}'.format(pkg.name, pkg.arch)
-               if ident not in latest_pkgs.keys() or LooseVersion(pkg.evr()) > LooseVersion(latest_pkgs[ident].evr()):
-                  latest_pkgs[ident] = pkg
+                ident = '{}.{}'.format(pkg.name, pkg.arch)
+                if ident not in latest_pkgs.keys() or LooseVersion(pkg.evr()) > LooseVersion(latest_pkgs[ident].evr()):
+                    latest_pkgs[ident] = pkg
             pkglist = list(latest_pkgs.values())
         pkglist.sort(key = cmp_to_key(self._sort_packages))
 
@@ -315,6 +315,7 @@ class ContentSource:
             return 0
         else:
             return -1
+
     @staticmethod
     def _filter_packages(packages, filters):
         """ implement include / exclude logic
@@ -377,12 +378,11 @@ class ContentSource:
     @staticmethod
     def get_updates():
         # There isn't any update info in the repository
-        return ('', [])
+        return '', []
 
     @staticmethod
     def get_groups():
-        # There aren't any
-        return None
+        pass
 
     # Get download parameters for threaded downloader
     def set_download_parameters(self, params, relative_path, target_file, checksum_type=None,
@@ -416,4 +416,3 @@ class ContentSource:
         # pylint: disable=W0613
         # Called from import_kickstarts, not working for deb repo
         log2(0, 0, "Unable to download path %s from deb repo." % path, stream=sys.stderr)
-        return None

--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -554,16 +554,23 @@ class RepoSync(object):
                             else:
                                 raise ValueError("No valid SSL certificates were found for repository.")
 
-                    plugin = self.repo_plugin(url, repo_name, insecure, self.interactive,
-                                              org=str(self.org_id or ''),
-                                              channel_label=self.channel_label,
-                                              ca_cert_file=ca_cert_file,
-                                              client_cert_file=client_cert_file,
-                                              client_key_file=client_key_file)
+                    try:
+                        plugin = self.repo_plugin(url, repo_name, insecure, self.interactive,
+                                                  org=str(self.org_id or ''),
+                                                  channel_label=self.channel_label,
+                                                  ca_cert_file=ca_cert_file,
+                                                  client_cert_file=client_cert_file,
+                                                  client_key_file=client_key_file)
+                    except repo.GeneralRepoException as exc:
+                        log(0, "Plugin error: {}".format(exc))
+                        sync_error = -1
+                    except Exception as exc:
+                        log(0, "Unhandled error occurred: {}".format(exc))
+                        sync_error = -1
 
                     if self.show_packages_only:
                         self.show_packages(plugin, repo_id)
-                    else:
+                    elif plugin is not None:
                         if update_repodata:
                             plugin.clear_cache()
 

--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -566,7 +566,7 @@ class RepoSync(object):
                         sync_error = -1
                     except Exception as exc:
                         log(0, "Unhandled error occurred: {}".format(exc))
-                        sync_error = -1
+                        raise
 
                     if self.show_packages_only:
                         self.show_packages(plugin, repo_id)

--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -523,7 +523,8 @@ class RepoSync(object):
                         relative_url = '_'.join(url.split('://')[1].split('/')[1:])
                         repo_name = relative_url.replace("?", "_").replace("&", "_").replace("=", "_")
 
-                    (ca_cert_file, client_cert_file, client_key_file) = (None, None, None)
+                    ca_cert_file = client_cert_file = client_key_file = repo_id = None
+
                     if data['id'] is not None:
                         h = rhnSQL.execute("""
                         select k1.description as ca_cert_name, k1.key as ca_cert, k1.org_id as ca_cert_org,

--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -43,6 +43,7 @@ from spacewalk.server import rhnPackage, rhnSQL, rhnChannel, suseEula
 from uyuni.common import fileutils
 from spacewalk.common import rhnLog, rhnCache, rhnMail, suseLib
 from spacewalk.common.rhnTB import fetchTraceback
+from spacewalk.common import repo
 from uyuni.common.rhnLib import isSUSE, utc
 from uyuni.common.checksum import getFileChecksum
 from spacewalk.common.rhnConfig import CFG, initCFG

--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -56,7 +56,6 @@ from spacewalk.satellite_tools.repo_plugins import CACHE_DIR
 from spacewalk.satellite_tools.repo_plugins import yum_src
 from spacewalk.server import taskomatic, rhnPackageUpload
 from spacewalk.satellite_tools.satCerts import verify_certificate_dates
-
 from spacewalk.satellite_tools.syncLib import log, log2, log2disk, dumpEMAIL_LOG, log2background
 
 translation = gettext.translation('spacewalk-backend-server', fallback=True)
@@ -936,7 +935,14 @@ class RepoSync(object):
         if saveurl.password:
             saveurl.password = "*******"
 
-        packages = plug.list_packages(filters, self.latest)
+        packages = []
+        try:
+            packages = plug.list_packages(filters, self.latest)
+        except repo.GeneralRepoException as exc:
+            log(0, "Repository failure: {}".format(exc))
+        except Exception as exc:
+            log(0, "Unhandled failure occurred while listing repository packages: {}".format(exc))
+
         to_disassociate = {}
         to_process = []
         num_passed = len(packages)

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Add Ubuntu repository checksum index checking for flat and default repository formats
 - Always use the same RPM database when running "spacewalk-repo-sync"
   from the command line or via taskomatic (bsc#1163468)
 - call mgr-create-bootstrap-repo after repo sync

--- a/backend/test/docker-backend-common-tests.sh
+++ b/backend/test/docker-backend-common-tests.sh
@@ -2,4 +2,4 @@
 
 touch /etc/rhn/rhn.conf
 mkdir -p /manager/backend/reports
-nosetests --with-xunit --xunit-file /manager/backend/reports/common_tests.xml -s /manager/backend/common/test/unit-test/
+nosetests -v --with-xunit --xunit-file /manager/backend/reports/common_tests.xml -s /manager/backend/common/test/unit-test/

--- a/backend/test/docker-backend-pgsql-tests.sh
+++ b/backend/test/docker-backend-pgsql-tests.sh
@@ -4,7 +4,7 @@
 su - postgres -c '/usr/lib/postgresql10/bin/pg_ctl start'
 cp /root/rhn.conf /etc/rhn/rhn.conf
 mkdir -p /manager/backend/reports
-nosetests --with-xunit --xunit-file /manager/backend/reports/pgsql_tests.xml /manager/backend/test/runtests-postgresql.py
+nosetests -v --with-xunit --xunit-file /manager/backend/reports/pgsql_tests.xml /manager/backend/test/runtests-postgresql.py
 EXIT=$?
 su - postgres -c '/usr/lib/postgresql10/bin/pg_ctl stop'
 exit $?


### PR DESCRIPTION
## What does this PR change?

Part of the implementation to verify GPG signature of the `Releases` file and the checksums of `Packages`

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/9881
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests" (Test skipped, there are no changes to test)
