### PR TITLE
Do not break Servers registered against a Server

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/bootstrap/remove_traditional_stack.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/remove_traditional_stack.sls
@@ -46,6 +46,7 @@ remove_traditional_stack:
       - module: disable_repo*
 {%- endif %}
     - unless: rpm -q spacewalk-proxy-common
+    - unless: rpm -q spacewalk-common
 
 # only removing apt-transport-spacewalk above
 # causes apt-get update to 'freeze' if this

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- do not break Servers registering to a Server
 - Introduce dnf-susemanager-plugin for RHEL8 minions
 - Provide custom grain to report "instance id" when running on Public Cloud instances
 - enable Kiwi NG on SLE15


### PR DESCRIPTION
## What does this PR change?

Registering (onboarding) a Server against another Server currently breaks its functionality, as the removal of the traditional stack includes packages vital for the Server to work properly.

This patch prevents breaking the Server.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **documentation will be added when managing Servers via Servers is actually fully tested. At the moment this is just a first step**

- [x] **DONE**

## Test coverage
- No tests: **proper integration tests will be added when managing Servers via Servers is actually fully tested. At the moment this is just a first step**

- [x] **DONE**

## Links

No downstream PR yet.

- [X] **DONE**

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
