### PR TITLE
Fix incomplete Packages.gz file

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
@@ -20,18 +20,16 @@ import com.redhat.rhn.frontend.dto.PackageDto;
 import com.redhat.rhn.manager.task.TaskManager;
 import com.redhat.rhn.taskomatic.task.TaskConstants;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 
 import java.io.BufferedWriter;
 import java.io.Closeable;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.zip.GZIPOutputStream;
 
 /**
  *
@@ -48,29 +46,13 @@ public class DebPackageWriter implements Closeable {
      *
      * @param channel debian channel
      * @param prefix path to repository
+     * @throws IOException in case of IO error
      */
-    public DebPackageWriter(Channel channel, String prefix) {
+    public DebPackageWriter(Channel channel, String prefix) throws IOException {
         log.debug("DebPackageWriter created");
-        try {
-            channelLabel = channel.getLabel();
-            filenamePackages = prefix + "Packages";
-            File f = new File(filenamePackages);
-            if (f.exists()) {
-                f.delete();
-            }
-            f.createNewFile();
-        }
-        catch (Exception e) {
-            log.error("Create file Packages failed " + e.toString());
-        }
-    }
-
-    /**
-     * Begin writing Packages file
-     * @param channel the channel
-     * @throws IOException in case of IO errors
-     */
-    public void begin(Channel channel) throws IOException {
+        channelLabel = channel.getLabel();
+        filenamePackages = prefix + "Packages";
+        FileUtils.deleteQuietly(new File(filenamePackages));
         out = new BufferedWriter(new FileWriter(
                 filenamePackages, true));
     }
@@ -292,31 +274,10 @@ public class DebPackageWriter implements Closeable {
     }
 
     /**
-     * Create Packages.gz from Packages
+     * @return filenamePackages to get
      */
-    public void generatePackagesGz() {
-        // Create the GZIP output stream
-        String outFilename = filenamePackages + ".gz";
-        try (GZIPOutputStream outGz = new GZIPOutputStream(new FileOutputStream(
-                outFilename, false))) {
-
-            // Open the input file
-            FileInputStream in = new FileInputStream(filenamePackages);
-
-            // Transfer bytes from the input file to the GZIP output stream
-            byte[] buf = new byte[1024];
-            int len;
-            while ((len = in.read(buf)) > 0) {
-                outGz.write(buf, 0, len);
-            }
-            in.close();
-
-            // Complete the GZIP file
-            outGz.finish();
-        }
-        catch (IOException e) {
-            log.error("Failed to create Packages.gz " + e.toString());
-        }
+    public String getFilenamePackages() {
+        return filenamePackages;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/test/DebPackageWriterTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/test/DebPackageWriterTest.java
@@ -67,9 +67,6 @@ public class DebPackageWriterTest extends JMockBaseTestCaseWithUser {
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().clear();
 
-        DebPackageWriter writer = new DebPackageWriter(channel, tmpDir.normalize().toString() + File.separator);
-        writer.begin(channel);
-
         DataResult<PackageDto> packageBatch = TaskManager.getChannelPackageDtos(channel, 0, 100);
         packageBatch.elaborate();
         Map<Long, Map<String, String>> extraTags = TaskManager.getChannelPackageExtraTags(Arrays.asList(pkg1.getId(), pkg2.getId()));
@@ -77,15 +74,14 @@ public class DebPackageWriterTest extends JMockBaseTestCaseWithUser {
             pkgDto.setExtraTags(extraTags.get(pkgDto.getId()));
         }
 
-        for (PackageDto pkgDto: packageBatch) {
-            writer.addPackage(pkgDto);
+        try (DebPackageWriter writer = new DebPackageWriter(channel, tmpDir.normalize().toString() + File.separator)) {
+            for (PackageDto pkgDto: packageBatch) {
+                writer.addPackage(pkgDto);
+            }
         }
-        writer.close();
 
         String packagesContent = FileUtils.readFileToString(tmpDir.resolve("Packages").toFile());
-        packagesContent = packagesContent.replaceAll("Filename: channel.*/getPackage/", "Filename: channel/getPackage/");
-        packagesContent = packagesContent.replaceAll("MD5sum: .*\\s", "MD5sum: some-md5sum\n");
-        packagesContent = packagesContent.replaceAll("Section: .*\\s", "Section: some-section\n");
+        packagesContent = cleanupContent(packagesContent);
 
         assertEquals("Package: pkg_1\n" +
                         "Version: 1:1.0.0-1\n" +
@@ -126,6 +122,14 @@ public class DebPackageWriterTest extends JMockBaseTestCaseWithUser {
                 packagesContent.trim());
     }
 
+    public static String cleanupContent(String packagesContent) {
+        packagesContent = packagesContent.replaceAll("Filename: channel.*/getPackage/", "Filename: channel/getPackage/");
+        packagesContent = packagesContent.replaceAll("MD5sum: .*\\s", "MD5sum: some-md5sum\n");
+        packagesContent = packagesContent.replaceAll("Section: .*\\s", "Section: some-section\n");
+        return packagesContent;
+    }
+
+    @Override
     public void tearDown() throws Exception {
         super.tearDown();
         FileUtils.deleteDirectory(tmpDir.toFile());

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/test/DebReleaseWriterTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/test/DebReleaseWriterTest.java
@@ -24,6 +24,7 @@ import com.redhat.rhn.domain.rhnpackage.PackageFactory;
 import com.redhat.rhn.manager.rhnpackage.test.PackageManagerTest;
 import com.redhat.rhn.taskomatic.task.repomd.DebPackageWriter;
 import com.redhat.rhn.taskomatic.task.repomd.DebReleaseWriter;
+import com.redhat.rhn.taskomatic.task.repomd.DebRepositoryWriter;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 
 import java.io.File;
@@ -55,10 +56,13 @@ public class DebReleaseWriterTest extends BaseTestCaseWithUser {
         pkg1.setPackageArch(pa);
 
         DebPackageWriter pkgWriter = new DebPackageWriter(channel, prefix);
-        pkgWriter.generatePackagesGz();
+        pkgWriter.close();
 
-        DebReleaseWriter writer = new DebReleaseWriter(channel, prefix);
-        writer.generateRelease();
+        DebRepositoryWriter repoWriter = new DebRepositoryWriter("", prefix);
+        repoWriter.gzipCompress(pkgWriter.getFilenamePackages());
+
+        DebReleaseWriter releaseWriter = new DebReleaseWriter(channel, prefix);
+        releaseWriter.generateRelease();
         String releaseDatetime = DebReleaseWriter.RFC822_DATE_FORMAT.format(ZonedDateTime.now());
 
         String releaseContent = FileUtils.readStringFromFile(prefix + "Release");


### PR DESCRIPTION
## What does this PR change?

This fixes a bug introduced in https://github.com/uyuni-project/uyuni/pull/1348.
The content of the `Packages.gz` is incomplete due to the file being compressed before writing of `Packages` is done.

## GUI diff

No difference.

## Documentation
- No documentation needed: bugfix

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes #

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
