### PR TITLE
Fix issues with content life cycle project page

### DIFF
--- a/web/html/src/manager/content-management/list-projects/list-projects.js
+++ b/web/html/src/manager/content-management/list-projects/list-projects.js
@@ -9,6 +9,7 @@ import withPageWrapper from 'components/general/with-page-wrapper';
 import {hot} from 'react-hot-loader';
 import useRoles from "core/auth/use-roles";
 import {isOrgAdmin} from "core/auth/auth.utils";
+import _truncate from "lodash/truncate";
 
 type ContentProjectOverviewType = {
   properties: {
@@ -47,7 +48,7 @@ const ListProjects = (props: Props) => {
     label: project.properties.label,
     name: project.properties.name,
     description: project.properties.description,
-    environmentLifecycle: project.environments.join(' - ')
+    environmentLifecycle: project.environments.join(' > ')
   }));
 
   const panelButtons = (
@@ -71,6 +72,7 @@ const ListProjects = (props: Props) => {
         <Table
           data={normalizedProjects}
           identifier={row => row.label}
+          initialSortColumnKey="name"
           searchField={(
             <SearchField
               filter={searchData}
@@ -94,7 +96,7 @@ const ListProjects = (props: Props) => {
             columnKey="description"
             comparator={Functions.Utils.sortByText}
             header={t('Description')}
-            cell={row => row.description}
+            cell={row => _truncate(row.description,{length: 120})}
           />
           <Column
             columnKey="environmentLifecycle"

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fix ui issues with content lifecycle project list page (bsc#1145587)
 - implement "keyword" filter for Content Lifecycle Management
 - Enable Azure, Amazon EC2 and Google Compute Engine as available Virtual host Managers
 - Trim strings when creating/updating image stores/profiles (bsc#1133429)


### PR DESCRIPTION
merged in spacewalk already... 
9549


## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
