### PR TITLE
Enable monitoring for RedHat systems (RHEL and CentOS)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
@@ -155,7 +155,7 @@ public class MinionServer extends Server implements SaltConfigurable {
 
     @Override
     public boolean doesOsSupportsMonitoring() {
-        return isSLES12() || isSLES15() || isLeap15() || isUbuntu1804();
+        return isSLES12() || isSLES15() || isLeap15() || isUbuntu1804() || isRedHat6() || isRedHat7();
     }
 
     /**
@@ -192,6 +192,17 @@ public class MinionServer extends Server implements SaltConfigurable {
 
     private boolean isUbuntu1804() {
         return ServerConstants.UBUNTU.equalsIgnoreCase(getOs()) && getRelease().equals("18.04");
+    }
+
+    /**
+     * This is supposed to cover all RedHat flavors (incl. RHEL, RES and CentOS Linux)
+     */
+    private boolean isRedHat6() {
+        return ServerConstants.REDHAT.equals(getOsFamily()) && getRelease().equals("6");
+    }
+
+    private boolean isRedHat7() {
+        return ServerConstants.REDHAT.equals(getOsFamily()) && getRelease().equals("7");
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
@@ -191,7 +191,7 @@ public class MinionServer extends Server implements SaltConfigurable {
     }
 
     private boolean isUbuntu1804() {
-        return ServerConstants.UBUNTU.equalsIgnoreCase(getOs()) && getRelease().equals("18.04");
+        return ServerConstants.UBUNTU.equals(getOs()) && getRelease().equals("18.04");
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/server/ServerConstants.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerConstants.java
@@ -27,6 +27,7 @@ public class ServerConstants {
     public static final String SLES = "SLES";
     public static final String LEAP = "Leap";
     public static final String UBUNTU = "Ubuntu";
+    public static final String REDHAT = "RedHat";
 
     private ServerConstants() {
 

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerTest.java
@@ -18,6 +18,7 @@ import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.server.ClientCapability;
 import com.redhat.rhn.domain.server.EntitlementServerGroup;
+import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.NetworkInterface;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerConstants;
@@ -179,6 +180,30 @@ public class ServerTest extends BaseTestCaseWithUser {
                 ServerFactoryTest.TYPE_SERVER_MINION);
         s.setOs("Ubuntu");
         s.setRelease("18.04");
+        assertTrue(s.doesOsSupportsMonitoring());
+    }
+
+    /**
+     * Test for {@link Server#doesOsSupportsMonitoring()} for RedHat 6.
+     */
+    public void testOsSupportsMonitoringRedHat6() throws Exception {
+        MinionServer s = (MinionServer) ServerFactoryTest.createTestServer(user, true,
+                ServerConstants.getServerGroupTypeSaltEntitled(),
+                ServerFactoryTest.TYPE_SERVER_MINION);
+        s.setOsFamily("RedHat");
+        s.setRelease("6");
+        assertTrue(s.doesOsSupportsMonitoring());
+    }
+
+    /**
+     * Test for {@link Server#doesOsSupportsMonitoring()} for RedHat 7.
+     */
+    public void testOsSupportsMonitoringRedHat7() throws Exception {
+        MinionServer s = (MinionServer) ServerFactoryTest.createTestServer(user, true,
+                ServerConstants.getServerGroupTypeSaltEntitled(),
+                ServerFactoryTest.TYPE_SERVER_MINION);
+        s.setOsFamily("RedHat");
+        s.setRelease("7");
         assertTrue(s.doesOsSupportsMonitoring());
     }
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,4 +1,4 @@
-- Allow monitoring for managed systems running Ubuntu 18.04
+- Allow monitoring for managed systems running Ubuntu 18.04 and RedHat 6/7
 - use default value from systemd unit file if not set in /etc/rhn/rhn.conf
 - implement "keyword" filter for Content Lifecycle Management
 - Add support for Azure, Amazon EC2, and Google Compute Engine as Virtual Host Managers.


### PR DESCRIPTION
## What does this PR change?

This patch enables monitoring for managed systems with `os_family = RedHat` as a follow up to #1355. This should include RHEL and CentOS releases 6 and 7.

## GUI diff

After:
![monitoring-centos](https://user-images.githubusercontent.com/729454/65525029-22912b80-deef-11e9-940f-c31f3b7f3036.png)

- [x] **DONE**

## Documentation

Affected would be the matrix of supported features, existing documentation stays valid.

- [x] **DONE**

## Test coverage

Unit tests were updated.

- [x] **DONE**

## Links

Part of this downstream issue: https://github.com/SUSE/spacewalk/issues/9246

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests" 		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
