### PR TITLE
Log if function is null in JobReturnEvent

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/JobReturnEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/JobReturnEventMessageAction.java
@@ -49,6 +49,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Stack;
 import java.util.function.Function;
@@ -88,6 +89,10 @@ public class JobReturnEventMessageAction implements MessageAction {
 
         // React according to the function the minion ran
         String function = jobReturnEvent.getData().getFun();
+
+        if (Objects.isNull(function)) {
+            LOG.error("Unexpected: Function is Null in JobReturnEvent ->" + jobReturnEvent);
+        }
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("Job return event for minion: " +


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/9563


- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
