### PR TITLE
Fix unit test authentication - moch request getHeader

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/servlets/test/AuthFilterTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/test/AuthFilterTest.java
@@ -84,6 +84,8 @@ public class AuthFilterTest extends MockObjectTestCase {
             will(returnValue(null));
             allowing(mockRequest).getServletPath();
             will(returnValue("/YourRhn.do"));
+            allowing(mockRequest).getHeader(with(any(String.class)));
+            will(returnValue(null));
         } });
 
         filter.setAuthenticationService(mockAuthService);


### PR DESCRIPTION
## What does this PR change?

Fix unit test authentication - mock request getHeader

## GUI diff

No difference.

- [ ] **DONE**


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
