### PR TITLE
Manager sudo

### DIFF
--- a/spacewalk/config/etc/sudoers.d/spacewalk
+++ b/spacewalk/config/etc/sudoers.d/spacewalk
@@ -9,15 +9,12 @@ Cmnd_Alias CONFIG_RHN = /usr/sbin/rhn-sat-restart-silent,\
 # The CONFIG_RHN commands are required for reconfiguration of a
 # running Red Hat Satellite.  They should be enabled for proper operation
 # of the Red Hat Satellite.
-apache  ALL=(root)      NOPASSWD: CONFIG_RHN
 tomcat  ALL=(root)      NOPASSWD: CONFIG_RHN
 
 # These two directives allow tomcat and apache to invoke CONFIG_RHN
 # commands via sudo even without a real tty
 Defaults:tomcat !requiretty
-Defaults:apache !requiretty
 
 # These two commands allow tomcat and apache to check permissions of
 # the minion bootstrap ssh-known_hosts file
-apache  ALL=(root)      NOPASSWD: /usr/bin/ls -la /var/lib/salt/.ssh/known_hosts
 tomcat  ALL=(root)      NOPASSWD: /usr/bin/ls -la /var/lib/salt/.ssh/known_hosts

--- a/spacewalk/config/spacewalk-config.changes
+++ b/spacewalk/config/spacewalk-config.changes
@@ -1,4 +1,4 @@
-- remove superfluous 'apache' entries from sudoers configuration
+- remove superfluous 'apache' entries from sudoers configuration (bsc#1151632)
 - Migrate login to Spark
 - Require uyuni-base-common for /etc/rhn
 

--- a/spacewalk/config/spacewalk-config.changes
+++ b/spacewalk/config/spacewalk-config.changes
@@ -1,3 +1,4 @@
+- remove superfluous 'apache' entries from sudoers configuration
 - Migrate login to Spark
 - Require uyuni-base-common for /etc/rhn
 


### PR DESCRIPTION
## What does this PR change?

These 'apache' entries are a no-op on SUSE systems since this user is named "wwwrun". Obviously these are no longer needed, so let's remove them because it is security relevant and customers are wondering what this is good for.

I checked the postinstall script to ensure really only one file will be present in the sudoers directory after an update.