### PR TITLE
trim version compare to apply also for debian versions

### DIFF
--- a/java/code/src/com/redhat/rhn/common/util/RpmVersionComparator.java
+++ b/java/code/src/com/redhat/rhn/common/util/RpmVersionComparator.java
@@ -14,7 +14,9 @@
  */
 package com.redhat.rhn.common.util;
 
+import java.util.Arrays;
 import java.util.Comparator;
+import java.util.List;
 
 /**
  * Implement the rpmvercmp function provided by librpm
@@ -48,6 +50,25 @@ public class RpmVersionComparator implements Comparator<String> {
 
         String str1 = (String) o1;
         String str2 = (String) o2;
+
+        if (str1.contains("-") || str2.contains("-")) {
+            List<String> vl1 = Arrays.asList(str1.split("-"));
+            List<String> vl2 = Arrays.asList(str2.split("-"));
+            int n = vl1.size() < vl2.size() ? vl1.size() : vl2.size();
+            int c = 0;
+            while (c < n) {
+                if (!vl1.get(c).equals(vl2.get(c))) {
+                    return compare(vl1.get(c), vl2.get(c));
+                }
+                c++;
+            }
+            if (vl1.size() == vl2.size()) {
+                return 0;
+            }
+            else {
+                return vl1.size() > vl2.size() ? 1 : -1;
+            }
+        }
         int b1 = 0;
         int b2 = 0;
 

--- a/java/code/src/com/redhat/rhn/common/util/test/RpmVersionComparatorTest.java
+++ b/java/code/src/com/redhat/rhn/common/util/test/RpmVersionComparatorTest.java
@@ -40,13 +40,13 @@ public class RpmVersionComparatorTest extends TestCase {
         // Some equality
         assertCompareSymm(0, "0", "0");
         assertCompareSymm(0, "1-a.1", "1-a.1");
-        assertCompareSymm(0, "1-a.1", "1.a-1");
+        assertCompareSymm(0, "1_a.1", "1.a_1");
         assertCompareSymm(0, "", "");
 
         // all not alphanum signs are treated as the same
-        assertCompareSymm(0, "-", ".");
-        assertCompareSymm(0, "--", "-");
-        assertCompareSymm(0, "1-1-", "1-1.");
+        assertCompareSymm(0, "_", ".");
+        assertCompareSymm(0, "__", ".");
+        assertCompareSymm(0, "1-1_", "1-1.");
 
         // Some asymmetry .. not really a total ordering
         assertCompareSymm(1, "1.1", "1a");
@@ -108,6 +108,22 @@ public class RpmVersionComparatorTest extends TestCase {
         assertCompareSymm(1, "1.0^git1", "1.0^git1~pre");
     }
 
+    public void testDebianVersionCompare() {
+        assertCompareSymm(-1, "8-20180414-1ubuntu2", "8.2.0-1ubuntu2~18.04");
+        assertCompareSymm(1, "0.2017-01-15.gdad1bbc6-1", "0.2017-01-15.gdad1bbc6");
+        assertCompareSymm(0, "0.2017-01-15.gdad1bbc6-1", "0.2017-01-15.gdad1bbc6-1");
+        /*
+        assertCompareSymm(1, "", "");
+        assertCompareSymm(1, "", "");
+        assertCompareSymm(1, "", "");
+        assertCompareSymm(1, "", "");
+        assertCompareSymm(1, "", "");
+        assertCompareSymm(1, "", "");
+        assertCompareSymm(1, "", "");
+        assertCompareSymm(1, "", "");
+        assertCompareSymm(1, "", "");
+        */
+    }
     private void assertCompareAsym(int exp, String v1, String v2) {
         assertCompare(exp, v1, v2);
         assertCompare(exp, v2, v1);


### PR DESCRIPTION
## What does this PR change?

Another try

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
