### PR TITLE
Fix PackageManagerTest.testRepodata

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/rhnpackage/test/PackageManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/rhnpackage/test/PackageManagerTest.java
@@ -649,8 +649,6 @@ public class PackageManagerTest extends BaseTestCaseWithUser {
 
     public void testRepodata() throws Exception {
 
-        // *Some*body in here is doing a commit :(
-
         OutputStream st = new ByteArrayOutputStream();
         SimpleContentHandler tmpHandler = getTemporaryHandler(st);
 
@@ -687,7 +685,6 @@ public class PackageManagerTest extends BaseTestCaseWithUser {
         String prim = dto.getPrimaryXml();
         String other = dto.getOtherXml();
         assertEquals(prim, test);
-        commitHappened();
     }
 
     public static PackageExtraTagsKeys createExtraTagKey(String name) {


### PR DESCRIPTION
## What does this PR change?

Fixes `PackageManagerTest.testRepodata` unit test.

## GUI diff

No difference.

## Documentation
- No documentation needed

- [ ] **DONE**

## Test coverage
- Unit tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
