### PR TITLE
Fix spacewalk-search tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,11 +34,14 @@ java/**/*.iml
 thrift/gen-*
 search-server/spacewalk-search/.classpath
 search-server/spacewalk-search/.project
+search-server/spacewalk-search/.checkstyle
+search-server/spacewalk-search/.settings
 search-server/spacewalk-search/build
 search-server/spacewalk-search/lib
 search-server/spacewalk-search/dist
 search-server/spacewalk-search/rhn-search.pid
 search-server/spacewalk-search/rhn_search_daemon.log
+search-server/spacewalk-search/buildconf/repository/
 *~
 *#*#*
 .project

--- a/search-server/spacewalk-search/build.xml
+++ b/search-server/spacewalk-search/build.xml
@@ -24,15 +24,13 @@
     <target name="make-eclipse-project" depends="resolve-ivy"
             description="Generate eclipse project files">
       <copy file="buildconf/eclipse.project" tofile=".project" />
-      <exec executable="../../scripts/gen-eclipse.py" output=".classpath" >
-        <arg value="src/java:src/config"/>
-        <arg value="
-          ${java.lib.dir}:
-          ${env.JAVA_HOME}/lib/tools.jar:
-          ${env.JAVA_HOME}/lib/ant.jar:
-          ${env.JAVA_HOME}/lib/ant-junit.jar
-        "/>
-      </exec>
+      <copy file="buildconf/eclipse.classpath" tofile=".classpath" />
+      <copy toDir="${basedir}">
+        <fileset dir="${basedir}/../../java/conf/eclipse">
+          <include name=".checkstyle"/>
+          <include name=".settings/*"/>
+        </fileset>
+      </copy>
     </target>
 
     <target name="check-testcase-name" if="testcase" depends="">
@@ -77,9 +75,16 @@
     <target name="resolve-local" description="resolve jars via jpackage" if="installbuild">
         <jpackage-deps jars="${jpackage.jars}" dir="${java.lib.dir}" />
     </target>
+    
+    <target name="obs-to-maven" description="Updates local maven repository with OBS jars">
+      <exec failonerror="true" executable="obs-to-maven">
+        <arg line="${basedir}/buildconf/obs-maven-config.yaml ${basedir}/buildconf/repository" />
+      </exec>
+    </target>
+
 
     <target name="resolve-ivy" description="retrieve dependencies with ivy"
-              depends="init-ivy" unless="installbuild">
+              depends="init-ivy,obs-to-maven" unless="installbuild">
         <!-- properties set here to show we are overriding default ivy values -->
         <property name="ivy.default.ivy.user.dir" value="${user.home}/.ivy/search-server"/>
         <property name="ivy.local.default.artifact.pattern" value="[artifact]-[revision].[ext]" />

--- a/search-server/spacewalk-search/buildconf/eclipse.classpath
+++ b/search-server/spacewalk-search/buildconf/eclipse.classpath
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src/java"/>
+	<classpathentry kind="src" path="src/config"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.apache.ivyde.eclipse.cpcontainer.IVYDE_CONTAINER/?project=spacewalk-search&amp;ivyXmlPath=ivy.xml&amp;confs=*&amp;ivySettingsPath=buildconf%2Fivyconf.xml&amp;loadSettingsOnDemand=false&amp;ivyUserDir=&amp;propertyFiles=&amp;acceptedTypes=jar%2Cbundle%2Cejb%2Cmaven-plugin&amp;alphaOrder=false&amp;resolveInWorkspace=false&amp;transitiveResolve=true&amp;readOSGiMetadata=false&amp;retrievedClasspath=true&amp;retrievedClasspathPattern=lib%2F%5Bartifact%5D-%5Brevision%5D.%5Bext%5D&amp;retrievedClasspathSync=true&amp;retrievedClasspathTypes=jar"/>
+	<classpathentry kind="output" path="build/classes"/>
+</classpath>

--- a/search-server/spacewalk-search/buildconf/ivyconf.xml
+++ b/search-server/spacewalk-search/buildconf/ivyconf.xml
@@ -1,8 +1,12 @@
 <ivysettings>
-  <settings defaultResolver="default" />
+  <settings defaultResolver="central" />
   <resolvers>
-    <url name="default">
-      <artifact pattern="http://ramrod.mgr.suse.de/ivy/[artifact]-[revision].[ext]" />
-    </url>
+    <filesystem name="suse" m2compatible="true" local="true">
+      <artifact pattern="${ivy.conf.dir}/repository/[organization]/[artifact]/[revision]/[artifact]-[revision].[ext]" />
+    </filesystem>
+    <ibiblio name="central" m2compatible="true"/>
   </resolvers>
+  <modules>
+    <module organisation="suse" name="*" resolver="suse"/>
+  </modules>
 </ivysettings>

--- a/search-server/spacewalk-search/buildconf/obs-maven-config.yaml
+++ b/search-server/spacewalk-search/buildconf/obs-maven-config.yaml
@@ -1,0 +1,50 @@
+repositories:
+  Leap:
+    project: openSUSE:Leap:15.1
+    repository: standard
+  Uyuni_Other:
+    project: systemsmanagement:Uyuni:Master:Other
+    repository: openSUSE_Leap_15.1
+  Uyuni:
+    project: systemsmanagement:Uyuni:Master
+    repository: openSUSE_Leap_15.1
+artifacts:
+  - artifact: simple-core
+    # How comes that package is not noarch?
+    arch: x86_64
+    jar: simple-core
+    repository: Uyuni_Other
+  - artifact: lucene-core
+    jar: lucene-core
+    package: lucene
+    repository: Uyuni_Other
+  - artifact: lucene-analyzers
+    jar: lucene-analyzers
+    package: lucene
+    repository: Uyuni_Other
+  - artifact: commons-lang3
+    package: apache-commons-lang3
+    repository: Leap
+  - artifact: commons-logging
+    package: apache-commons-logging
+    jar: apache-commons-logging\.jar
+    repository: Leap
+  - artifact: redstone-xmlrpc
+    jar: redstone-xmlrpc-[0-9.]+
+    repository: Uyuni_Other
+  - artifact: mybatis
+    package: apache-mybatis
+    repository: Uyuni_Other
+  - artifact: quartz
+    repository: Uyuni
+  - artifact: log4j
+    repository: Leap
+  - artifact: nutch-core
+    jar: nutch-core
+    repository: Uyuni_Other
+  - artifact: c3p0
+    repository: Uyuni_Other
+  - artifact: picocontainer
+    repository: Uyuni_Other
+  - artifact: hadoop
+    repository: Uyuni_Other

--- a/search-server/spacewalk-search/ivy.xml
+++ b/search-server/spacewalk-search/ivy.xml
@@ -2,18 +2,19 @@
     <info organisation="suse" module="manager" />
     <dependencies>
         <dependency org="suse" name="simple-core" rev="3.1.3" />
-        <dependency org="suse" name="lucene-core" rev="2.3.2" />
-        <dependency org="suse" name="lucene-analyzers" rev="2.3.2" />
-        <dependency org="suse" name="commons-lang3" rev="3.1" />
-        <dependency org="suse" name="commons-logging" rev="1.1.3" />
+        <dependency org="suse" name="lucene-core" rev="2.4" />
+        <dependency org="suse" name="lucene-analyzers" rev="2.4" />
+        <dependency org="suse" name="commons-lang3" rev="3.4" />
+        <dependency org="suse" name="commons-logging" rev="1.2" />
         <dependency org="suse" name="redstone-xmlrpc" rev="1.1_20071120" />
         <dependency org="suse" name="mybatis" rev="3.2.3" />
         <dependency org="suse" name="quartz" rev="2.3.0" />
-        <dependency org="suse" name="log4j" rev="1.2.15" />
-        <dependency org="suse" name="nutch-core" rev="1.0" />
-        <dependency org="suse" name="junit" rev="3.8.2" />
-        <dependency org="suse" name="c3p0" rev="0.9.1.2" />
+        <dependency org="suse" name="log4j" rev="1.2.17" />
+        <dependency org="suse" name="nutch-core" rev="1.0.1" />
+        <dependency org="suse" name="c3p0" rev="0.9.5.2" />
         <dependency org="suse" name="picocontainer" rev="1.3" />
-        <dependency org="suse" name="hadoop" rev="0.18.1-core" />
+        <dependency org="suse" name="hadoop" rev="0.18.1" />
+
+        <dependency org="junit" name="junit" rev="3.8.2" transitive="false"/>
     </dependencies>
 </ivy-module>


### PR DESCRIPTION
## What does this PR change?

Use obs-to-maven rather than ramrod repos in spacewalk-search. Also fix
the eclipse project setting.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: will need some wiki update once merged

- [ ] **DONE**

## Test coverage
- No tests: tooling changes

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
