### PR TITLE
Redirect to project when cancelikng creating a filter  

### DIFF
--- a/web/html/src/manager/content-management/list-filters/filter-edit.js
+++ b/web/html/src/manager/content-management/list-filters/filter-edit.js
@@ -130,7 +130,11 @@ const FilterEdit = (props: FilterEditProps) => {
                         text={t('Cancel')}
                         handler={() => {
                           cancelAction();
-                          closeDialog(modalNameId);
+                          if(!_isEmpty(props.projectLabel)) {
+                            redirectToProject(props.projectLabel);
+                          } else {
+                           closeDialog(modalNameId);
+                          }
                         }}
                       />
                       <Button
@@ -146,7 +150,6 @@ const FilterEdit = (props: FilterEditProps) => {
                               onAction(mapFilterFormToRequest(item, props.projectLabel, localTime), "update", item.id)
                                 .then((updatedListOfFilters) => {
                                   if(!_isEmpty(props.projectLabel)){
-                                    closeDialog(modalNameId);
                                     redirectToProject(props.projectLabel);
                                   } else {
                                     closeDialog(modalNameId);
@@ -161,7 +164,6 @@ const FilterEdit = (props: FilterEditProps) => {
                               onAction(mapFilterFormToRequest(item, props.projectLabel, localTime), "create")
                                 .then((updatedListOfFilters) => {
                                   if(!_isEmpty(props.projectLabel)){
-                                    closeDialog(modalNameId);
                                     redirectToProject(props.projectLabel);
                                   } else {
                                     closeDialog(modalNameId);

--- a/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project-selection.js
+++ b/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project-selection.js
@@ -69,7 +69,7 @@ const FiltersProjectSelection = (props:  FiltersProps): Node => {
         id={`create-new-filter-link`}
         icon='fa-plus'
         className="btn-link js-spa"
-        text={t("Create new Filter")}
+        text={t("Create New Filter")}
         href={`/rhn/manager/contentmanagement/filters?openFilterId=-1&projectLabel=${props.projectId}`}
     />
     </React.Fragment>

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Redirect to project when canceling creating a filter (bsc#1145750)
 - Better visualization of the filters attached to a CLM Project. Allow/deny are now split
 - Fix ui issues with content lifecycle project list page (bsc#1145587)
 - implement "keyword" filter for Content Lifecycle Management


### PR DESCRIPTION
## What does this PR change?

port of 9461

Redirect to project when canceling creating a filter when starting from the project

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
