### PR TITLE
search: don't run obs-to-maven on install builds

### DIFF
--- a/search-server/spacewalk-search/build.xml
+++ b/search-server/spacewalk-search/build.xml
@@ -76,7 +76,7 @@
         <jpackage-deps jars="${jpackage.jars}" dir="${java.lib.dir}" />
     </target>
     
-    <target name="obs-to-maven" description="Updates local maven repository with OBS jars">
+    <target name="obs-to-maven" description="Updates local maven repository with OBS jars" unless="installbuild">
       <exec failonerror="true" executable="obs-to-maven">
         <arg line="${basedir}/buildconf/obs-maven-config.yaml ${basedir}/buildconf/repository" />
       </exec>


### PR DESCRIPTION
## What does this PR change?

Fix spacewalk-search OBS build: we don't want it to use `obs-to-maven` since it will have no network.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: build fix

- [X] **DONE**

## Test coverage
- No tests: build fix

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
