### PR TITLE
Improve perfromance manage channels bsc 1151399

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Channel_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Channel_queries.xml
@@ -519,36 +519,27 @@ ORDER BY UPPER(C.name)
 
 <mode name="owned_channels_tree" class="com.redhat.rhn.frontend.dto.ChannelTreeNode">
   <query params="user_id">
-SELECT CTV.name, CTV.id, CA.name AS arch_name, C.org_id,
-       (SELECT ORG.name
-            FROM web_customer ORG
-            WHERE ORG.id = C.org_id) AS org_name,
-       CASE WHEN NOT CTV.parent_or_self_id = CTV.id THEN CTV.parent_or_self_id END AS parent_id,
-       (SELECT COUNT (cp.package_id)
-          FROM rhnchannelpackage cp
-         WHERE cp.channel_id = CTV.id) AS package_count,
-       CTV.label AS channel_label
-  FROM rhnchannel C, rhnChannelTreeView CTV, rhnChannel C2, rhnChannelArch CA
- WHERE CTV.id = C.ID
-   AND  CTV.channel_arch_id = CA.id
-   AND  CTV.parent_or_self_id = C2.id
-   AND EXISTS (
-      SELECT 1
-          FROM suseChannelUserRoleView scur
-          WHERE
-              scur.channel_id = C.id AND
-              scur.user_id = :user_id AND
-              scur.role = 'manage' AND
-              deny_reason IS NULL
-          UNION
-              SELECT 1
-                  FROM suseChannelUserRoleView scur
-                  WHERE scur.channel_id IN (SELECT C2.id FROM rhnChannel C2 WHERE C2.parent_channel = C.id) AND
-                      scur.user_id = :user_id AND
-                      scur.role = 'manage' AND
-                      deny_reason IS NULL
-   )
- ORDER BY UPPER(C2.name), depth, UPPER(C.name)
+     SELECT CTV.name, CTV.id, CA.name AS arch_name, C.org_id,
+            (SELECT ORG.name
+             FROM web_customer ORG
+             WHERE ORG.id = C.org_id) AS org_name,
+            CASE WHEN NOT CTV.parent_or_self_id = CTV.id THEN CTV.parent_or_self_id END AS parent_id,
+            (SELECT COUNT (cp.package_id)
+             FROM rhnchannelpackage cp
+             WHERE cp.channel_id = CTV.id) AS package_count,
+            CTV.label AS channel_label
+     FROM rhnchannel C
+       INNER JOIN rhnChannelTreeView CTV ON (CTV.id = C.ID)
+       INNER JOIN rhnChannelArch CA ON (CTV.channel_arch_id = CA.id)
+     WHERE EXISTS (
+        SELECT 1
+        FROM suseChannelUserRoleView scur
+        WHERE (scur.channel_id = C.id OR scur.parent_channel_id = C.id)
+          AND scur.user_id = :user_id
+          AND scur.role = 'manage'
+          AND deny_reason IS NULL
+          )
+     ORDER BY UPPER(CTV.parent_or_self_label), depth, UPPER(C.name)
   </query>
   <elaborator name="visible_server_count"/>
 </mode>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Improve performance for 'Manage Software Channels' view (bsc#1151399)
 - Allow monitoring for managed systems running Ubuntu 18.04 and RedHat 6/7
 - use default value from systemd unit file if not set in /etc/rhn/rhn.conf
 - implement "keyword" filter for Content Lifecycle Management

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Refactor in suseChannelUserRoleView for retrieving the parent_channel_id (bsc#1151399)
 - Add tables rhnPackageExtraTag and rhnPackageExtraTagKey
 - Allow monitoring for Ubuntu systems
 - Add new types needed for Azure, Amazon EC2 and Google CE

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.0-to-susemanager-schema-4.1.1/002-refactor_suseChannelUserRoleView.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.0-to-susemanager-schema-4.1.1/002-refactor_suseChannelUserRoleView.sql.oracle
@@ -1,0 +1,2 @@
+-- intentionally left empty
+

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.0-to-susemanager-schema-4.1.1/002-refactor_suseChannelUserRoleView.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.0-to-susemanager-schema-4.1.1/002-refactor_suseChannelUserRoleView.sql.postgresql
@@ -1,5 +1,6 @@
+-- oracle equivalent source sha1 98c02e574d4346f7eecade4697a2b26a13abaa28
 --
--- Copyright (c) 2018 SUSE LLC
+-- Copyright (c) 2019 SUSE LLC
 --
 -- This software is licensed to you under the GNU General Public License,
 -- version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -8,6 +9,10 @@
 -- along with this software; if not, see
 -- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 --
+
+DROP VIEW IF EXISTS rhnUserChannel;
+
+DROP VIEW IF EXISTS suseChannelUserRoleView;
 
 CREATE OR REPLACE VIEW
 suseChannelUserRoleView
@@ -32,7 +37,7 @@ AS
       WHEN adminUsers.is_admin_user IS NOT NULL
         THEN NULL
       -- otherwise, if channel does not have the "not_globally_subscribable" bit set, user can subscribe it
-      WHEN combination.role = 'subscribe' AND notGloballySubscribableChannels.is_not_globally_subscribable IS NULL
+      WHEN combination.role = 'subscribe' AND notGlobSubsChannels.is_not_globally_subscribable IS NULL
         THEN NULL
       -- otherwise, user might have an explicit permission on this channel
       WHEN explicitPermissions.has_explicit_permission IS NOT NULL
@@ -70,8 +75,8 @@ AS
        (SELECT DISTINCT ocs.channel_id, ocs.org_id, 1 AS is_not_globally_subscribable
         FROM rhnOrgChannelSettings ocs
           JOIN rhnOrgChannelSettingsType ocst ON ocst.id = ocs.setting_id
-        WHERE ocst.label = 'not_globally_subscribable') notGloballySubscribableChannels
-     ON (notGloballySubscribableChannels.channel_id = combination.channel_id AND notGloballySubscribableChannels.org_id = combination.user_org_id)
+        WHERE ocst.label = 'not_globally_subscribable') notGlobSubsChannels
+     ON (notGlobSubsChannels.channel_id = combination.channel_id AND notGlobSubsChannels.org_id = combination.user_org_id)
      LEFT JOIN
        (SELECT cpr.label, cp.channel_id, cp.user_id, 1 AS has_explicit_permission
         FROM rhnChannelPermission cp


### PR DESCRIPTION
## What does this PR change?

Improve the performance of "Manage Software Channels" view.

Performance results, tested on a database with ~3150 channels:

Before: ~1 minute 55 seconds
After: ~1.33 seconds
**Speedup: 116x**

The changes actually where (at first glance) kind of obvious in the sense of realizing what the goal of the query was, which is "retrieve the channels a user has 'manage' permission on, and their base channel".

So after understanding what was actually the 'goal' of the query, from that point (even without analyzing the query plan) it's easy to see that the original query was doing some  extra processing that was actually not needed. In particular we were doing an 'extra' join with the rhnChannel table, only to get the 'base' channel, as in here: https://github.com/SUSE/spacewalk/pull/9552/files#diff-c6385a035f4290f7f4f535e939e5c82aL543-L549
This already performs N extra loops, where N is the channels count of the rhnChannel table.

On top of this we were also using the 'IN' clause, which under the hood causes the engine to apply a SORT function, and it's quite costly.

Running EXPLAIN ANALYZE confirmed my hypothesis.

By rewriting the query in the new way we avoid all these issues.
## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bugfixing
- [x] **DONE**

## Test coverage
- No tests: unit tests were there already 
- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/9552

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
