### PR TITLE
Add a rule to generate only containers that don't need IBS

### DIFF
--- a/susemanager-utils/testing/docker/master/Makefile
+++ b/susemanager-utils/testing/docker/master/Makefile
@@ -5,7 +5,10 @@ BUILDOPTS=
 #--no-cache=true
 PUSH_IT=false
 
-all: uyuni-master-root uyuni-master-base uyuni-master-cobbler uyuni-master-gatherer uyuni-master-spacewalkkoan uyuni-master-pgsql uyuni-master-pgsql-4eclipse uyuni-master-nodejs uyuni-push-to-obs
+public_containers: uyuni-master-root uyuni-master-base uyuni-master-cobbler uyuni-master-gatherer uyuni-master-spacewalkkoan uyuni-master-pgsql uyuni-master-pgsql-4eclipse uyuni-master-nodejs
+
+all: public_containers uyuni-push-to-obs
+
 
 uyuni-master-root::
 	@echo "=================================="


### PR DESCRIPTION
## What does this PR change?

The reason behind this is to allow people from outside SUSE to easily
generate the containers that are needed to run the tests. Since those
containers are stored in the internal registry, they don't have access
to it, but then having the images built locally works around that.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: build script change

- [X] **DONE**

## Test coverage
- No tests: build script change

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
