### PR TITLE
Add a workflow for running checkstyle

### DIFF
--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -1,0 +1,17 @@
+name: Checkstyle
+
+on:
+  push:
+    paths:
+      - 'java/**.java'
+
+jobs:
+  checkstyle:
+    runs-on: ubuntu-latest
+    container: registry.opensuse.org/systemsmanagement/uyuni/master/docker/containers/uyuni-master-pgsql:latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Prepare the config file for osc
+      run: echo '${{ secrets.OSCRC_CONTENTS }}' > ~/.oscrc
+    - name: Run checkstyle
+      run: ant -f java/manager-build.xml ivy checkstyle

--- a/.github/workflows/java-checkstyle.yml
+++ b/.github/workflows/java-checkstyle.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     container: registry.opensuse.org/systemsmanagement/uyuni/master/docker/containers/uyuni-master-pgsql:latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Prepare the config file for osc
       run: echo '${{ secrets.OSCRC_CONTENTS }}' > ~/.oscrc
     - name: Run checkstyle

--- a/.github/workflows/java-checkstyle.yml
+++ b/.github/workflows/java-checkstyle.yml
@@ -9,9 +9,22 @@ jobs:
   checkstyle:
     runs-on: ubuntu-latest
     container: registry.opensuse.org/systemsmanagement/uyuni/master/docker/containers/uyuni-master-pgsql:latest
+
     steps:
     - uses: actions/checkout@v2
-    - name: Prepare the config file for osc
-      run: echo '${{ secrets.OSCRC_CONTENTS }}' > ~/.oscrc
+
+    - name: Cache dependencies
+      id: cache-dependencies
+      uses: actions/cache@v2
+      with:
+        path: java/lib
+        key: ${{ runner.os }}-jars-${{ hashFiles('java/buildconf/ivy/*.*') }}
+
+    - name: Resolve dependencies
+      if: steps.cache-dependencies.outputs.cache-hit != 'true'
+      run: |
+        echo '${{ secrets.OSCRC_CONTENTS }}' > ~/.oscrc
+        ant -f java/manager-build.xml ivy
+
     - name: Run checkstyle
-      run: ant -f java/manager-build.xml ivy checkstyle
+      run: ant -f java/manager-build.xml checkstyle

--- a/.github/workflows/java-checkstyle.yml
+++ b/.github/workflows/java-checkstyle.yml
@@ -1,4 +1,4 @@
-name: Checkstyle
+name: Java checkstyle
 
 on:
   push:

--- a/.github/workflows/java-checkstyle.yml
+++ b/.github/workflows/java-checkstyle.yml
@@ -1,7 +1,7 @@
 name: Java checkstyle
 
 on:
-  push:
+  pull_request:
     paths:
       - 'java/**.java'
 


### PR DESCRIPTION
## What does this PR change?

This patch is adding a workflow to run checkstyle on all changes made to the Java code. This should make the corresponding jenkins job obsolete. Configuration needed for osc (`obs-to-maven`) is stored as a `secret` in the repository. We are building the necessary containers in this OBS project:

https://build.opensuse.org/project/show/systemsmanagement:Uyuni:Master:Docker

## Links

Fixes #

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below).

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"  
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"                 
- [ ] Re-run test "java_pgsql_tests"             
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"          
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"              
- [ ] Re-run test "spacecmd_unittests"
