### PR TITLE
Remove oracle empty scripts

### DIFF
--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.0-to-susemanager-schema-4.1.1/000-use-blob-instead-of-varchar-rhnpackagechangelogdata.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.0-to-susemanager-schema-4.1.1/000-use-blob-instead-of-varchar-rhnpackagechangelogdata.sql
@@ -1,4 +1,3 @@
--- oracle equivalent source sha1 98c02e574d4346f7eecade4697a2b26a13abaa28
 --
 -- Copyright (c) 2019 SUSE LLC
 --

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.0-to-susemanager-schema-4.1.1/000-use-blob-instead-of-varchar-rhnpackagechangelogdata.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.0-to-susemanager-schema-4.1.1/000-use-blob-instead-of-varchar-rhnpackagechangelogdata.sql.oracle
@@ -1,2 +1,0 @@
--- intentionally left empty
-

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.0-to-susemanager-schema-4.1.1/002-refactor_suseChannelUserRoleView.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.0-to-susemanager-schema-4.1.1/002-refactor_suseChannelUserRoleView.sql
@@ -1,4 +1,3 @@
--- oracle equivalent source sha1 98c02e574d4346f7eecade4697a2b26a13abaa28
 --
 -- Copyright (c) 2019 SUSE LLC
 --

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.0-to-susemanager-schema-4.1.1/002-refactor_suseChannelUserRoleView.sql.oracle
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.0-to-susemanager-schema-4.1.1/002-refactor_suseChannelUserRoleView.sql.oracle
@@ -1,2 +1,0 @@
--- intentionally left empty
-


### PR DESCRIPTION
## What does this PR change?

Remove oracle empty schema migration scripts.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: just a removal of a script

- [x] **DONE**

## Test coverage
- No tests: just a removal of a script

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
