### PR TITLE
Obsolete python2-* instead of python-* for mgr-cfg and mgr-osad packages, to avoid conflicts

### DIFF
--- a/client/tools/mgr-cfg/mgr-cfg.changes
+++ b/client/tools/mgr-cfg/mgr-cfg.changes
@@ -1,3 +1,4 @@
+- Obsolete all old python2-rhncfg* packages to avoid conflicts (bsc#1152290)
 - Fix data type issue to correctly decode if needed (bsc#1150320)
 - Add mgr manpage links
 - Require mgr-daemon (new name of spacewalksd). So systems with

--- a/client/tools/mgr-cfg/mgr-cfg.spec
+++ b/client/tools/mgr-cfg/mgr-cfg.spec
@@ -122,8 +122,8 @@ Summary:        Spacewalk Configuration Client Libraries
 Group:          Applications/System
 Provides:       python-%{name} = %{oldversion}
 Obsoletes:      python-%{name} < %{oldversion}
-Provides:       python-%{oldname} = %{oldversion}
-Obsoletes:      python-%{oldname} < %{oldversion}
+Provides:       python2-%{oldname} = %{oldversion}
+Obsoletes:      python2-%{oldname} < %{oldversion}
 Requires:       %{name} = %{version}-%{release}
 Requires:       python
 Requires:       python2-rhn-client-tools >= 2.8.4
@@ -187,8 +187,8 @@ Summary:        Spacewalk Configuration Client
 Group:          Applications/System
 Provides:       python-%{name}-client = %{oldversion}
 Obsoletes:      python-%{name}-client < %{oldversion}
-Provides:       python-%{oldname}-client = %{oldversion}
-Obsoletes:      python-%{oldname}-client < %{oldversion}
+Provides:       python2-%{oldname}-client = %{oldversion}
+Obsoletes:      python2-%{oldname}-client < %{oldversion}
 Requires:       %{name}-client = %{version}-%{release}
 %if %{_vendor} == "debbuild"
 # For scriptlets
@@ -234,8 +234,8 @@ Summary:        Spacewalk Configuration Management Client
 Group:          Applications/System
 Provides:       python-%{name}-management = %{oldversion}
 Obsoletes:      python-%{name}-management < %{oldversion}
-Provides:       python-%{oldname}-management = %{oldversion}
-Obsoletes:      python-%{oldname}-management < %{oldversion}
+Provides:       python2-%{oldname}-management = %{oldversion}
+Obsoletes:      python2-%{oldname}-management < %{oldversion}
 Requires:       %{name}-management = %{version}-%{release}
 %if %{_vendor} == "debbuild"
 # For scriptlets
@@ -281,8 +281,8 @@ Summary:        Spacewalk Configuration Client Actions
 Group:          Applications/System
 Provides:       python-%{name}-actions = %{oldversion}
 Obsoletes:      python-%{name}-actions < %{oldversion}
-Provides:       python-%{oldname}-actions = %{oldversion}
-Obsoletes:      python-%{oldname}-actions < %{oldversion}
+Provides:       python2-%{oldname}-actions = %{oldversion}
+Obsoletes:      python2-%{oldname}-actions < %{oldversion}
 Requires:       %{name}-actions = %{version}-%{release}
 Requires:       python2-%{name}-client
 %if %{_vendor} == "debbuild"

--- a/client/tools/mgr-osad/mgr-osad.changes
+++ b/client/tools/mgr-osad/mgr-osad.changes
@@ -1,3 +1,4 @@
+- Obsolete all old python2-osa* packages to avoid conflicts (bsc#1152290)
 - move /usr/share/rhn/config-defaults to uyuni-base-common
 - Require uyuni-base-common for /etc/rhn (for osa-dispatcher)
 

--- a/client/tools/mgr-osad/mgr-osad.spec
+++ b/client/tools/mgr-osad/mgr-osad.spec
@@ -116,8 +116,8 @@ Summary:        Open Source Architecture Daemon
 Group:          System Environment/Daemons
 Provides:       python-%{name} = %{oldversion}
 Obsoletes:      python-%{name} < %{oldversion}
-Provides:       python-%{oldname} = %{oldversion}
-Obsoletes:      python-%{oldname} < %{oldversion}
+Provides:       python2-%{oldname} = %{oldversion}
+Obsoletes:      python2-%{oldname} < %{oldversion}
 Requires:       %{name} = %{version}-%{release}
 Requires:       python
 Requires:       python-jabberpy


### PR DESCRIPTION
## What does this PR change?

Obsolete `python2-*` instead of `python-*` for mgr-cfg and mgr-osad packages, to avoid conflicts.

Otherwise there can be problems migrating from old client tools.

Name of the old packages was `python2-*`, so I don't think we need also the old `python-*`:

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: SPEC change.

- [x] **DONE**

## Test coverage
- No tests: Not covered by automated testing.

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/9609
Tracks https://github.com/SUSE/spacewalk/pull/9582

- [ ] **DONE**