### PR TITLE
Checksum in metadata

### DIFF
--- a/backend/server/apacheRequest.py
+++ b/backend/server/apacheRequest.py
@@ -16,6 +16,7 @@
 #
 
 # system modules
+import os
 import sys
 import base64
 try:
@@ -623,7 +624,10 @@ class GetHandler(apacheRequest):
             raise rhnFault(21, _("Invalid URI %s" % self.req.path_info))
 
         self.channel, method = (array[2], array[3])
-        params = tuple(array[4:])
+        if method == "getPackage":
+            params = tuple([os.path.join(*array[4:])])
+        else:
+            params = tuple(array[4:])
         return method, params
 
     # send the response out for the GET requests

--- a/backend/server/rhnPackage.py
+++ b/backend/server/rhnPackage.py
@@ -42,7 +42,7 @@ def get_package_path(server_id, pkg_spec, channel):
         pkg.insert(1, None)
     else:
         if "/" in pkg_spec:
-            checksum, pkg_spec = pkg_spec.split('/', 1)
+            org, checksum, pkg_spec = pkg_spec.split('/', 2)
         pkg = parseRPMFilename(pkg_spec)
         if pkg is None:
             log_debug(4, "Error", "Requested weird package", pkg_spec)

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- fix problems with Package Hub repos having multiple rpms with same NEVRA
+  but different checksums (bsc#1146683)
 - fix re-registration with re-activation key (bsc#1154275)
 - Change the default value of taskomatic maxmemory to 4GB
 - Add basic support for importing modular repositories

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Task_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Task_queries.xml
@@ -450,7 +450,7 @@ where snc.errata_id = :errata_id
 </mode>
 
 <query name="repomdgenerator_package_elab" class="com.redhat.rhn.frontend.dto.PackageDto">
-  SELECT p.id, pn.name as name, pevr.epoch as epoch,
+  SELECT p.id, p.org_id, pn.name as name, pevr.epoch as epoch,
          pevr.version as version, pevr.release as release,
          p.summary, p.description, pa.label as arch_label,
          p.build_time, p.path, p.package_size, p.payload_size, p.installed_size,

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageFactory.java
@@ -39,6 +39,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.persistence.criteria.CriteriaBuilder;
@@ -302,25 +303,27 @@ public class PackageFactory extends HibernateFactory {
     }
 
     /**
-     * Find a package based off of the channel and NEVRA
+     * Find a package based off of the channel, NEVRA and checksum
      * @param channel the channel label
      * @param name the name to search for
      * @param version the version to search for
      * @param release the release to search for
      * @param epoch if epoch is null, the best match for epoch will be used.
      * @param arch the arch to search for
+     * @param checksum Optional the checksum to search for
      * @return the requested Package
      */
-    public static Package lookupByChannelLabelNevra(String channel, String name,
-            String version, String release, String epoch, String arch) {
+    public static Package lookupByChannelLabelNevraCs(String channel, String name,
+            String version, String release, String epoch, String arch, Optional<String> checksum) {
         @SuppressWarnings("unchecked")
         List<Package> packages = HibernateFactory.getSession()
-                .getNamedQuery("Package.lookupByChannelLabelNevra")
+                .getNamedQuery("Package.lookupByChannelLabelNevraCs")
                 .setString("channel", channel)
                 .setString("name", name)
                 .setString("version", version)
                 .setString("release", release)
                 .setString("arch", arch)
+                .setString("checksum", checksum.orElse(null))
                 .list();
 
         if (packages.isEmpty()) {

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/Package_satellite.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/Package_satellite.hbm.xml
@@ -175,12 +175,13 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         ]]>
     </query>
 
-    <sql-query name="Package.lookupByChannelLabelNevra">
+    <sql-query name="Package.lookupByChannelLabelNevraCs">
         <![CDATA[ select {p.*}
                 from
                   rhnPackageArch pa,
                   rhnChannelPackage cp,
                   rhnPackage p,
+                  rhnChecksum cs,
                   rhnPackageEVR pe,
                   rhnPackageName pn,
                   rhnChannel c
@@ -195,6 +196,8 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
             and p.id = cp.package_id
             and p.evr_id = pe.id
             and p.package_arch_id = pa.id
+            and p.checksum_id = cs.id
+            and (:checksum is null or cs.checksum = :checksum)
         ]]>
         <return alias="p" class="com.redhat.rhn.domain.rhnpackage.Package" />
     </sql-query>

--- a/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
@@ -560,6 +560,12 @@ public class DownloadFile extends DownloadAction {
         if (path.endsWith(".rpm")) {
             String[] split = StringUtils.split(path, '/');
             fileName = split[split.length - 1];
+            String checksum = split[split.length - 2];
+            if (checksum.matches("^[0-9a-f]{32,}$")) {
+                // ChannelFactory.lookupPackageByFilename* uses "like" for the path
+                // this works also with checksum/fileName
+                fileName = checksum + "/" + fileName;
+            }
             if (log.isDebugEnabled()) {
                 log.debug("RPM filename: " + fileName);
             }

--- a/java/code/src/com/redhat/rhn/frontend/dto/PackageDto.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/PackageDto.java
@@ -35,6 +35,7 @@ import java.util.TimeZone;
 public class PackageDto extends BaseDto {
 
     private Long id;
+    private Long orgId;
     private String name;
     private String version;
     private String release;
@@ -80,6 +81,27 @@ public class PackageDto extends BaseDto {
      */
     public void setId(Long idIn) {
         this.id = idIn;
+    }
+
+    /**
+     * @return the orgId as string
+     */
+    public String getOrgIdAsString() {
+        return orgId == null ? "NULL" : orgId.toString();
+    }
+
+    /**
+     * @return the orgId
+     */
+    public Long getOrgId() {
+        return orgId;
+    }
+
+    /**
+     * @param orgIdIn the org id to set
+     */
+    public void setOrgId(Long orgIdIn) {
+        this.orgId = orgIdIn;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/PrimaryXmlWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/PrimaryXmlWriter.java
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2009--2015 Red Hat, Inc.
+ * Copyright (c) 2019 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -216,7 +217,8 @@ public class PrimaryXmlWriter extends RepomdWriter {
         String pkgFile = sanitize(pkgId, getProxyFriendlyFilename(pkgDto));
 
         attr.clear();
-        attr.addAttribute("href", "getPackage/" + sanitize(pkgId, pkgDto.getChecksum()) + "/" + pkgFile);
+        attr.addAttribute("href", "getPackage/" + pkgDto.getOrgIdAsString() + "/" +
+                sanitize(pkgId, pkgDto.getChecksum()) + "/" + pkgFile);
         localHandler.startElement("location", attr);
         localHandler.endElement("location");
     }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/PrimaryXmlWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/PrimaryXmlWriter.java
@@ -216,7 +216,7 @@ public class PrimaryXmlWriter extends RepomdWriter {
         String pkgFile = sanitize(pkgId, getProxyFriendlyFilename(pkgDto));
 
         attr.clear();
-        attr.addAttribute("href", "getPackage/" + pkgFile);
+        attr.addAttribute("href", "getPackage/" + sanitize(pkgId, pkgDto.getChecksum()) + "/" + pkgFile);
         localHandler.startElement("location", attr);
         localHandler.endElement("location");
     }

--- a/java/code/src/com/suse/manager/webui/Router.java
+++ b/java/code/src/com/suse/manager/webui/Router.java
@@ -222,9 +222,13 @@ public class Router implements SparkApplication {
         // Download endpoint
         get("/manager/download/:channel/getPackage/:file",
                 DownloadController::downloadPackage);
+        get("/manager/download/:channel/getPackage/:org/:checksum/:file",
+                DownloadController::downloadPackage);
         get("/manager/download/:channel/repodata/:file",
                 DownloadController::downloadMetadata);
         head("/manager/download/:channel/getPackage/:file",
+                DownloadController::downloadPackage);
+        head("/manager/download/:channel/getPackage/:org/:checksum/:file",
                 DownloadController::downloadPackage);
         head("/manager/download/:channel/repodata/:file",
                 DownloadController::downloadMetadata);

--- a/java/code/src/com/suse/manager/webui/controllers/DownloadController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/DownloadController.java
@@ -87,6 +87,7 @@ public class DownloadController {
         private String release;
         private String epoch;
         private String arch;
+        private Optional<Long> orgId = Optional.empty();
         private Optional<String> checksum = Optional.empty();
 
         /**
@@ -154,6 +155,35 @@ public class DownloadController {
          */
         public Optional<String> getChecksum() {
             return checksum;
+        }
+
+        /**
+         * Set the org id
+         * @param orgIdIn the org id
+         */
+        public void setOrgId(Long orgIdIn) {
+            orgId = Optional.ofNullable(orgIdIn);
+        }
+
+        /**
+         * Set the org id as string
+         * @param orgIdIn the org is as string
+         */
+        public void setOrgId(String orgIdIn) {
+            try {
+                orgId = Optional.of(Long.valueOf(orgIdIn));
+            }
+            catch (NumberFormatException e) {
+                orgId = Optional.empty();
+            }
+        }
+
+        /**
+         * Return the org id if available
+         * @return the optional org id
+         */
+        public Optional<Long> getOrgId() {
+            return orgId;
         }
     }
 
@@ -332,9 +362,10 @@ public class DownloadController {
             epoch = null;
         }
         PkgInfo p = new PkgInfo(name, epoch, version, release, arch);
-        // path has checksum
-        if (parts.size() == 6 && parts.get(4).equals("getPackage")) {
-            p.setChecksum(parts.get(5));
+        // path is getPackage/<org>/<checksum>/filename
+        if (parts.size() == 9 && parts.get(5).equals("getPackage")) {
+            p.setOrgId(parts.get(6));
+            p.setChecksum(parts.get(7));
         }
         return p;
     }

--- a/java/code/src/com/suse/manager/webui/controllers/DownloadController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/DownloadController.java
@@ -44,6 +44,7 @@ import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.Key;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
@@ -86,6 +87,7 @@ public class DownloadController {
         private String release;
         private String epoch;
         private String arch;
+        private Optional<String> checksum = Optional.empty();
 
         /**
          * Constructor
@@ -136,6 +138,22 @@ public class DownloadController {
          */
         public String getArch() {
             return arch;
+        }
+
+        /**
+         * Set the checksum
+         * @param checksumIn the checksum
+         */
+        public void setChecksum(String checksumIn) {
+            checksum = Optional.ofNullable(checksumIn);
+        }
+
+        /**
+         * Return the checksum if available
+         * @return the optional checksum
+         */
+        public Optional<String> getChecksum() {
+            return checksum;
         }
     }
 
@@ -265,16 +283,17 @@ public class DownloadController {
             validateToken(token, channel, basename);
         }
 
+        String mountPoint = Config.get().getString(ConfigDefaults.MOUNT_POINT);
         PkgInfo pkgInfo = parsePackageFileName(path);
-        Package pkg = PackageFactory.lookupByChannelLabelNevra(channel,
-                pkgInfo.getName(), pkgInfo.getVersion(), pkgInfo.getRelease(), pkgInfo.getEpoch(), pkgInfo.getArch());
+        Package pkg = PackageFactory.lookupByChannelLabelNevraCs(channel, pkgInfo.getName(),
+                pkgInfo.getVersion(), pkgInfo.getRelease(), pkgInfo.getEpoch(), pkgInfo.getArch(),
+                pkgInfo.getChecksum());
         if (pkg == null) {
             halt(HttpStatus.SC_NOT_FOUND,
                  String.format("%s not found in %s", basename, channel));
         }
 
-        File file = new File(Config.get().getString(ConfigDefaults.MOUNT_POINT),
-                pkg.getPath()).getAbsoluteFile();
+        File file = new File(mountPoint, pkg.getPath()).getAbsoluteFile();
 
         return downloadFile(request, response, file);
     }
@@ -286,6 +305,7 @@ public class DownloadController {
      * @return name, epoch, vesion, release, arch of package
      */
     public static PkgInfo parsePackageFileName(String path) {
+        List<String> parts = Arrays.asList(path.split("/"));
         String extension = FilenameUtils.getExtension(path);
         String basename = FilenameUtils.getBaseName(path);
         String arch = StringUtils.substringAfterLast(basename, ".");
@@ -311,7 +331,12 @@ public class DownloadController {
             name = StringUtils.substringBeforeLast(rest, "-");
             epoch = null;
         }
-        return new PkgInfo(name, epoch, version, release, arch);
+        PkgInfo p = new PkgInfo(name, epoch, version, release, arch);
+        // path has checksum
+        if (parts.size() == 6 && parts.get(4).equals("getPackage")) {
+            p.setChecksum(parts.get(5));
+        }
+        return p;
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- fix problems with Package Hub repos having multiple rpms with same NEVRA
+  but different checksums (bsc#1146683)
 - Add check/message for project not found (bsc#1145755)
 - Fix sorting issues on content filter list page (bsc#1145591)
 - Fix combinatorial explosion when generating migrations (bsc#1151888)


### PR DESCRIPTION
## What does this PR change?

There are cases where a repository has multiple packages with the same nevra.
This exotic case creates problems as we have to select one of it and do not know if this
was the requested one. The package manager on the client might get a package with a different checksum and abort.

We add now the checksum to the location as path to allow this and get a unique result for the requested package.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- no documentation needed : mostly internal. 
- added note for the release notes https://github.com/SUSE/spacewalk/issues/9636

- [x] **DONE**

## Test coverage
- No tests: **manually tested**

- [x] **DONE**

## Links

Fixes http://bugzilla.suse.com/show_bug.cgi?id=1146683
Tracks https://github.com/SUSE/spacewalk/pull/9838

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
