### PR TITLE
Require pmtools only for SLE11 i586 and x86_64 (bsc#1150314), require dmidecode only for SLE12 aarch64 and x86_64 (bsc#1152170)

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -145,7 +145,7 @@ mgr_update_basic_pkgs:
   pkg.latest:
     - pkgs:
       - openssl
-{%- if grains['os_family'] == 'Suse' and grains['osrelease'] in ['11.3', '11.4'] %}
+{%- if grains['os_family'] == 'Suse' and grains['osrelease'] in ['11.3', '11.4'] and grains['cpuarch'] in ['i586', 'x86_64'] %}
       - pmtools
 {%- elif grains['cpuarch'] in ['aarch64', 'x86_64'] %}
       - dmidecode

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Require pmtools only for SLE11 i586 and x86_65 (bsc#1150314)
 - do not break Servers registering to a Server
 - Introduce dnf-susemanager-plugin for RHEL8 minions
 - Provide custom grain to report "instance id" when running on Public Cloud instances

--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -43,7 +43,6 @@ PKGLIST11 = [
     "libzypp",
     "newt",
     "openssl",
-    "pmtools",
     "python",
     "python-dmidecode",
     "python-ethtool",
@@ -91,9 +90,12 @@ ENHANCE11 = [
     "salt-minion"
 ]
 
+PKGLIST11_X86_I586 = [
+    "pmtools",
+]
+
 PKGLIST12 = [
     "dbus-1-python",
-    "dmidecode",
     "hwdata",
     "libcurl4",
     "libgudev-1_0-0",
@@ -171,6 +173,10 @@ ONLYSLE12 = [
     "libzmq3",
     "gio-branding-SLE",
     "wallpaper-branding-SLE"
+]
+
+PKGLIST12_X86_ARM = [
+    "dmidecode",
 ]
 
 ONLYOPENSUSE42 = [
@@ -449,7 +455,7 @@ PKGLISTUBUNTU1804 = [
 
 DATA = {
     'SLE-11-SP1-i586' : {
-        'PDID' : 684, 'PKGLIST' : PKGLIST11,
+        'PDID' : 684, 'PKGLIST' : PKGLIST11 + PKGLIST11_X86_I586,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/11/1/bootstrap/'
     },
     'SLE-11-SP1-ia64' : {
@@ -465,11 +471,11 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/11/1/bootstrap/'
     },
     'SLE-11-SP1-x86_64' : {
-        'PDID' : 769, 'PKGLIST' : PKGLIST11,
+        'PDID' : 769, 'PKGLIST' : PKGLIST11 + PKGLIST11_X86_I586,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/11/1/bootstrap/'
     },
     'SLE-11-SP2-i586' : {
-        'PDID' : 811, 'PKGLIST' : PKGLIST11,
+        'PDID' : 811, 'PKGLIST' : PKGLIST11 + PKGLIST11_X86_I586,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/11/2/bootstrap/'
     },
     'SLE-11-SP2-ia64' : {
@@ -485,11 +491,11 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/11/2/bootstrap/'
     },
     'SLE-11-SP2-x86_64' : {
-        'PDID' : 690, 'PKGLIST' : PKGLIST11,
+        'PDID' : 690, 'PKGLIST' : PKGLIST11 + PKGLIST11_X86_I586,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/11/2/bootstrap/'
     },
     'SLE-11-SP3-i586' : {
-        'PDID' : 793, 'PKGLIST' : PKGLIST11 + ENHANCE11,
+        'PDID' : 793, 'PKGLIST' : PKGLIST11 + ENHANCE11 + PKGLIST11_X86_I586,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/11/3/bootstrap/'
     },
     'SLE-11-SP3-ia64' : {
@@ -505,11 +511,11 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/11/3/bootstrap/'
     },
     'SLE-11-SP3-x86_64' : {
-        'PDID' : 814, 'PKGLIST' : PKGLIST11 + ENHANCE11,
+        'PDID' : 814, 'PKGLIST' : PKGLIST11 + ENHANCE11 + PKGLIST11_X86_I586,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/11/3/bootstrap/'
     },
     'SLE-11-SP4-i586' : {
-        'PDID' : 1299, 'PKGLIST' : PKGLIST11 + ENHANCE11,
+        'PDID' : 1299, 'PKGLIST' : PKGLIST11 + ENHANCE11 + PKGLIST11_X86_I586,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/11/4/bootstrap/'
     },
     'SLE-11-SP4-ia64' : {
@@ -525,7 +531,7 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/11/4/bootstrap/'
     },
     'SLE-11-SP4-x86_64' : {
-        'PDID' : 1300, 'PKGLIST' : PKGLIST11 + ENHANCE11,
+        'PDID' : 1300, 'PKGLIST' : PKGLIST11 + ENHANCE11 + PKGLIST11_X86_I586,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/11/4/bootstrap/'
     },
     'SLE-10-SP3-i586' : {
@@ -569,19 +575,19 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/10/4/bootstrap/'
     },
     'SLES4SAP-11-SP1-x86_64' : {
-        'PDID' : 1129, 'PKGLIST' : PKGLIST11,
+        'PDID' : 1129, 'PKGLIST' : PKGLIST11 + PKGLIST11_X86_I586,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/11/1/bootstrap/'
     },
     'SLES4SAP-11-SP2-x86_64' : {
-        'PDID' : 1130, 'PKGLIST' : PKGLIST11,
+        'PDID' : 1130, 'PKGLIST' : PKGLIST11 + PKGLIST11_X86_I586,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/11/2/bootstrap/'
     },
     'SLES4SAP-11-SP3-x86_64' : {
-        'PDID' : 1131, 'PKGLIST' : PKGLIST11 + ENHANCE11,
+        'PDID' : 1131, 'PKGLIST' : PKGLIST11 + ENHANCE11 + PKGLIST11_X86_I586,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/11/3/bootstrap/'
     },
     'SLES4SAP-11-SP4-x86_64' : {
-        'PDID' : 1329, 'PKGLIST' : PKGLIST11 + ENHANCE11,
+        'PDID' : 1329, 'PKGLIST' : PKGLIST11 + ENHANCE11 + PKGLIST11_X86_I586,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/11/4/bootstrap/'
     },
     'SLES4SAP-11-SP4-ppc64' : {
@@ -597,11 +603,11 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/0/bootstrap/'
     },
     'SLE-12-x86_64' : {
-        'PDID' : 1117, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12,
+        'PDID' : 1117, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/0/bootstrap/'
     },
     'SLES4SAP-12-x86_64' : {
-        'PDID' : 1319, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12,
+        'PDID' : 1319, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/0/1/bootstrap/'
     },
     'SLE-12-SP1-ppc64le' : {
@@ -613,7 +619,7 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/1/bootstrap/'
     },
     'SLE-12-SP1-x86_64' : {
-        'PDID' : 1322, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
+        'PDID' : 1322, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/1/bootstrap/'
     },
     'SLES4SAP-12-SP1-ppc64le' : {
@@ -621,7 +627,7 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/1/0/1/bootstrap/'
     },
     'SLES4SAP-12-SP1-x86_64' : {
-        'PDID' : 1346, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
+        'PDID' : 1346, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/1/0/1/bootstrap/'
     },
     'RES6-x86_64' : {
@@ -633,11 +639,11 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/res/7/bootstrap/'
     },
     'SLE-12-SP2-aarch64' : {
-        'PDID' : 1375, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
+        'PDID' : 1375, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/2/bootstrap/'
     },
     'SLES_RPI-12-SP2-aarch64' : {
-        'PDID' : 1418, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
+        'PDID' : 1418, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/2/bootstrap/'
     },
     'SLE-12-SP2-ppc64le' : {
@@ -649,11 +655,11 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/2/bootstrap/'
     },
     'SLE-12-SP2-x86_64' : {
-        'PDID' : 1357, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
+        'PDID' : 1357, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/2/bootstrap/'
     },
     'SLES4SAP-12-SP2-x86_64' : {
-        'PDID' : 1414, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
+        'PDID' : 1414, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/2/bootstrap/'
     },
     'SLES4SAP-12-SP2-ppc64le' : {
@@ -661,7 +667,7 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/2/bootstrap/'
     },
     'SLE-12-SP3-aarch64' : {
-        'PDID' : 1424, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
+        'PDID' : 1424, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/3/bootstrap/'
     },
     'SLE-12-SP3-ppc64le' : {
@@ -673,11 +679,11 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/3/bootstrap/'
     },
     'SLE-12-SP3-x86_64' : {
-        'PDID' : 1421, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
+        'PDID' : 1421, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/3/bootstrap/'
     },
     'SLES4SAP-12-SP3-x86_64' : {
-        'PDID' : 1426, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
+        'PDID' : 1426, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/3/bootstrap/'
     },
     'SLES4SAP-12-SP3-ppc64le' : {
@@ -685,7 +691,7 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/3/bootstrap/'
     },
     'SLE-12-SP4-aarch64' : {
-        'PDID' : 1628, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
+        'PDID' : 1628, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/4/bootstrap/'
     },
     'SLE-12-SP4-ppc64le' : {
@@ -697,15 +703,15 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/4/bootstrap/'
     },
     'SLE-12-SP4-x86_64' : {
-        'PDID' : 1625, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
+        'PDID' : 1625, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/4/bootstrap/'
     },
     'SLED-12-SP4-x86_64' : {
-        'PDID' : 1629, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
+        'PDID' : 1629, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/4/bootstrap/'
     },
     'SLES4SAP-12-SP4-x86_64' : {
-        'PDID' : 1755, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
+        'PDID' : 1755, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/4/bootstrap/'
     },
     'SLES4SAP-12-SP4-ppc64le' : {
@@ -713,19 +719,19 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/4/bootstrap/'
     },
     'SLE4HPC-12-SP4-x86_64' : {
-        'PDID' : 1759, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
+        'PDID' : 1759, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/4/bootstrap/'
     },
     'SLE4HPC-12-SP4-aarch64' : {
-        'PDID' : 1758, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
+        'PDID' : 1758, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/4/bootstrap/'
     },
     'OES2018-x86_64' : {
-        'PDID' : 45, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
+        'PDID' : 45, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/2/bootstrap/'
     },
     'OES2018-SP1-x86_64' : {
-        'PDID' : 46, 'PKGLIST' : PKGLIST12 + ENHANCE12SP1,
+        'PDID' : 46, 'PKGLIST' : PKGLIST12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/3/bootstrap/'
     },
     'SLE-15-aarch64' : {
@@ -761,7 +767,7 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/1/bootstrap/'
     },
     'openSUSE-Leap-42.3-x86_64' : {
-        'BASECHANNEL' : 'opensuse_leap42_3-x86_64', 'PKGLIST' : PKGLIST12 + ONLYOPENSUSE42 + ENHANCE12SP1,
+        'BASECHANNEL' : 'opensuse_leap42_3-x86_64', 'PKGLIST' : PKGLIST12 + ONLYOPENSUSE42 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/opensuse/42/3/bootstrap/'
     },
     'openSUSE-Leap-15-x86_64' : {

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- Require dmidecode only for SLE12 aarch64 and x86_64 (bsc#1152170)
+- Require pmtools only for SLE11 i586 and x86_64 (bsc#1150314)
 - fix test for btrfs subvolume for new btrfs version (bsc#1151666)
 - enable and start disk space checker script during setup
 - remove creating group susemanager and require uyuni-base-server


### PR DESCRIPTION
## What does this PR change?

- Require pmtools only for SLE11 i586 and x86_64 (bsc#1150314)
- Require dmidecode only for SLE12 aarch64 and x86_64 (bsc#1152170)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Bugfixing

- [x] **DONE**

## Test coverage
- No tests: Not covered

- [x] **DONE**

## Links

Tracks:
https://github.com/SUSE/spacewalk/pull/9614
https://github.com/SUSE/spacewalk/issues/9432
https://github.com/SUSE/spacewalk/issues/9603

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
