### PR TITLE
allow multiple success codes and modify zypper calls

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -603,20 +603,22 @@ When(/^I install pattern "([^"]*)" on this "([^"]*)"$/) do |pattern, host|
   node = get_target(host)
   raise 'Not found: zypper' unless file_exists?(node, '/usr/bin/zypper')
   cmd = "zypper --non-interactive install -t pattern #{pattern}"
-  node.run(cmd)
+  node.run(cmd, true, DEFAULT_TIMEOUT, root, [0, 100, 101, 102, 103, 106])
 end
 
 When(/^I remove pattern "([^"]*)" from this "([^"]*)"$/) do |pattern, host|
   node = get_target(host)
   raise 'Not found: zypper' unless file_exists?(node, '/usr/bin/zypper')
   cmd = "zypper --non-interactive remove -t pattern #{pattern}"
-  node.run(cmd)
+  node.run(cmd, true, DEFAULT_TIMEOUT, root, [0, 100, 101, 102, 103, 104, 106])
 end
 
 When(/^I install package "([^"]*)" on this "([^"]*)"$/) do |package, host|
   node = get_target(host)
+  successcodes = [0]
   if file_exists?(node, '/usr/bin/zypper')
     cmd = "zypper --non-interactive install -y #{package}"
+    successcodes = [0, 100, 101, 102, 103, 106]
   elsif file_exists?(node, '/usr/bin/yum')
     cmd = "yum -y install #{package}"
   elsif file_exists?(node, '/usr/bin/apt-get')
@@ -624,13 +626,15 @@ When(/^I install package "([^"]*)" on this "([^"]*)"$/) do |package, host|
   else
     raise 'Not found: zypper, yum or apt-get'
   end
-  node.run(cmd)
+  node.run(cmd, true, DEFAULT_TIMEOUT, root, successcodes)
 end
 
 When(/^I remove package "([^"]*)" from this "([^"]*)"$/) do |package, host|
   node = get_target(host)
+  successcodes = [0]
   if file_exists?(node, '/usr/bin/zypper')
     cmd = "zypper --non-interactive remove -y #{package}"
+    successcodes = [0, 100, 101, 102, 103, 104, 106]
   elsif file_exists?(node, '/usr/bin/yum')
     cmd = "yum -y remove #{package}"
   elsif file_exists?(node, '/usr/bin/dpkg')
@@ -638,7 +642,7 @@ When(/^I remove package "([^"]*)" from this "([^"]*)"$/) do |package, host|
   else
     raise 'Not found: zypper, yum or dpkg'
   end
-  node.run(cmd)
+  node.run(cmd, true, DEFAULT_TIMEOUT, root, successcodes)
 end
 
 When(/^I wait until the package "(.*?)" has been cached on this "(.*?)"$/) do |pkg_name, host|

--- a/testsuite/features/support/lavanda.rb
+++ b/testsuite/features/support/lavanda.rb
@@ -35,10 +35,10 @@ module LavandaBasic
   end
 
   # run functions
-  def run(cmd, fatal = true, timeout = DEFAULT_TIMEOUT, user = 'root')
+  def run(cmd, fatal = true, timeout = DEFAULT_TIMEOUT, user = 'root', successcodes = [0])
     out, _lo, _rem, code = test_and_store_results_together(cmd, user, timeout)
     if fatal
-      raise "FAIL: #{cmd} returned #{code}. output : #{out}" if code != 0
+      raise "FAIL: #{cmd} returned #{code}. output : #{out}" unless successcodes.include?(code)
     end
     [out, code]
   end


### PR DESCRIPTION
## What does this PR change?

zypper uses multiple exit codes and not all > 0 are errors. A lot are just to pass informations.
We need to allow to specify multiple success exit codes when we use zypper.

Example:
```
And I remove package "zypp-plugin-spacewalk" from this "proxy" # features/step_definitions/command_steps.rb:630
      FAIL: zypper --non-interactive remove -y zypp-plugin-spacewalk returned 104. output :
      Loading repository data...
      Warning: No repositories defined. Operating only with the installed resolvables. Nothing can be installed.
      Reading installed packages...
      'zypp-plugin-spacewalk' not found in package names. Trying capabilities.
      No provider of 'zypp-plugin-spacewalk' found.
      Resolving package dependencies...
      
      Nothing to do.
       (RuntimeError)
```

The goal was to remove "zypp-plugin-spacewalk" but it was not installed. 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **tests**

- [x] **DONE**

## Test coverage
- fixes tests

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
