### PR TITLE
init clients happens in parallel - wait with 15 sec difference to stretch the load

### DIFF
--- a/testsuite/features/core/centos_salt_ssh.feature
+++ b/testsuite/features/core/centos_salt_ssh.feature
@@ -10,6 +10,7 @@ Feature: Bootstrap a SSH-managed CentOS minion and do some basic operations on i
   Scenario: Bootstrap a SSH-managed CentOS minion
     Given I am authorized
     When I go to the bootstrapping page
+    And I wait for "45" seconds
     Then I should see a "Bootstrap Minions" text
     When I check "manageWithSSH"
     And I enter the hostname of "ceos-ssh-minion" as "hostname"

--- a/testsuite/features/core/min_bootstrap.feature
+++ b/testsuite/features/core/min_bootstrap.feature
@@ -6,6 +6,7 @@ Feature: Be able to bootstrap a Salt minion via the GUI
   Scenario: Create the bootstrap repository for a Salt client
      Given I am authorized
      And I create the "x86_64" bootstrap repository for "sle-minion" on the server
+     And I wait for "15" seconds
 
   Scenario: Bootstrap a SLES minion with wrong hostname
      Given I am authorized

--- a/testsuite/features/core/min_salt_ssh.feature
+++ b/testsuite/features/core/min_salt_ssh.feature
@@ -7,6 +7,7 @@ Feature: Be able to bootstrap a Salt host managed via salt-ssh
   Scenario: Bootstrap a SLES system managed via salt-ssh
     Given I am authorized
     And I go to the bootstrapping page
+    And I wait for "30" seconds
     Then I should see a "Bootstrap Minions" text
     And I check "manageWithSSH"
     And I enter the hostname of "ssh-minion" as "hostname"

--- a/testsuite/features/core/ubuntu_salt_ssh.feature
+++ b/testsuite/features/core/ubuntu_salt_ssh.feature
@@ -10,6 +10,7 @@ Feature: Bootstrap a SSH-managed Ubuntu minion and do some basic operations on i
   Scenario: Bootstrap a SSH-managed Ubuntu minion
     Given I am authorized
     When I go to the bootstrapping page
+    And I wait for "60" seconds
     Then I should see a "Bootstrap Minions" text
     When I check "manageWithSSH"
     And I enter the hostname of "ubuntu-minion" as "hostname"


### PR DESCRIPTION
## What does this PR change?

Init clients run in parallel and it seems it failes very often. Try if 15 seconds difference between
^tests makes a difference.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **tests**

- [x] **DONE**

## Test coverage
- should stabelize tests

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
