### PR TITLE
retail pattern has a different name in uyuni - make the tests pass

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -607,6 +607,9 @@ When(/^I install pattern "([^"]*)" on this "([^"]*)"$/) do |pattern, host|
 end
 
 When(/^I remove pattern "([^"]*)" from this "([^"]*)"$/) do |pattern, host|
+  if pattern.include?("suma") && $product == "Uyuni"
+    pattern.gsub! "suma", "uyuni"
+  end
   node = get_target(host)
   raise 'Not found: zypper' unless file_exists?(node, '/usr/bin/zypper')
   cmd = "zypper --non-interactive remove -t pattern #{pattern}"

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -636,6 +636,9 @@ Then(/^I wait for "([^"]*)" to be uninstalled on "([^"]*)"$/) do |package, host|
 end
 
 Then(/^I wait for "([^"]*)" to be installed on this "([^"]*)"$/) do |package, host|
+  if package.include?("suma") && $product == "Uyuni"
+    package.gsub! "suma", "uyuni"
+  end
   node = get_target(host)
   node.run_until_ok("rpm -q #{package}")
 end


### PR DESCRIPTION
## What does this PR change?

The retail pattern has a different name in Uyuni. So we need to test different.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **test**

- [x] **DONE**

## Test coverage
- fix tests

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
