### PR TITLE
provide user as a string

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -603,7 +603,7 @@ When(/^I install pattern "([^"]*)" on this "([^"]*)"$/) do |pattern, host|
   node = get_target(host)
   raise 'Not found: zypper' unless file_exists?(node, '/usr/bin/zypper')
   cmd = "zypper --non-interactive install -t pattern #{pattern}"
-  node.run(cmd, true, DEFAULT_TIMEOUT, root, [0, 100, 101, 102, 103, 106])
+  node.run(cmd, true, DEFAULT_TIMEOUT, 'root', [0, 100, 101, 102, 103, 106])
 end
 
 When(/^I remove pattern "([^"]*)" from this "([^"]*)"$/) do |pattern, host|
@@ -613,7 +613,7 @@ When(/^I remove pattern "([^"]*)" from this "([^"]*)"$/) do |pattern, host|
   node = get_target(host)
   raise 'Not found: zypper' unless file_exists?(node, '/usr/bin/zypper')
   cmd = "zypper --non-interactive remove -t pattern #{pattern}"
-  node.run(cmd, true, DEFAULT_TIMEOUT, root, [0, 100, 101, 102, 103, 104, 106])
+  node.run(cmd, true, DEFAULT_TIMEOUT, 'root', [0, 100, 101, 102, 103, 104, 106])
 end
 
 When(/^I install package "([^"]*)" on this "([^"]*)"$/) do |package, host|
@@ -629,7 +629,7 @@ When(/^I install package "([^"]*)" on this "([^"]*)"$/) do |package, host|
   else
     raise 'Not found: zypper, yum or apt-get'
   end
-  node.run(cmd, true, DEFAULT_TIMEOUT, root, successcodes)
+  node.run(cmd, true, DEFAULT_TIMEOUT, 'root', successcodes)
 end
 
 When(/^I remove package "([^"]*)" from this "([^"]*)"$/) do |package, host|
@@ -645,7 +645,7 @@ When(/^I remove package "([^"]*)" from this "([^"]*)"$/) do |package, host|
   else
     raise 'Not found: zypper, yum or dpkg'
   end
-  node.run(cmd, true, DEFAULT_TIMEOUT, root, successcodes)
+  node.run(cmd, true, DEFAULT_TIMEOUT, 'root', successcodes)
 end
 
 When(/^I wait until the package "(.*?)" has been cached on this "(.*?)"$/) do |pkg_name, host|


### PR DESCRIPTION
## What does this PR change?

Fix typo. user should be a string not a variable.

## Links


- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
