### PR TITLE
pre require group www for uyuni-base-common

### DIFF
--- a/uyuni/base/uyuni-base.spec
+++ b/uyuni/base/uyuni-base.spec
@@ -46,6 +46,9 @@ inventory, provision, update and control your Linux machines.
 %package common
 Summary:        Base structure for Uyuni server and proxy
 Group:          System/Fhs
+%if 0%{?suse_version} >= 1500
+Requires(pre):  group(www)
+%endif
 
 %description common
 Basic filesystem hierarchy for Uyuni server and proxy.


### PR DESCRIPTION
## What does this PR change?

/etc/rhn should get read permission for group www. This requires, that the group is created before installing this package. 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- fix tests

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
