### PR TITLE
Change perms on engine configuration (bsc#1150154)

### DIFF
--- a/spacewalk/admin/mgr-events-config.py
+++ b/spacewalk/admin/mgr-events-config.py
@@ -33,4 +33,4 @@ config = {
 with open("/etc/salt/master.d/susemanager_engine.conf", "w") as f:
     f.write(yaml.safe_dump(config, default_flow_style=False, allow_unicode=True))
     os.fchown(f.fileno(), pwd.getpwnam("salt").pw_uid, grp.getgrnam("salt").gr_gid)
-    os.fchmod(f.fileno(), 0o600)
+    os.fchmod(f.fileno(), 0o640)

--- a/spacewalk/admin/spacewalk-admin.changes
+++ b/spacewalk/admin/spacewalk-admin.changes
@@ -1,3 +1,5 @@
+- avoid a "Permission denied" salt error when publisher_acl
+  is set (bsc#1150154)
 - Require uyuni-base-common for /etc/rhn
 
 -------------------------------------------------------------------


### PR DESCRIPTION
##  What does this PR change?

This changes permissions of the /etc/salt/master.d/susemanager_engine.conf file to be group-readable.

This is not expected to have any security downside, while being nicer to users who set `publisher_acl`.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal change**

- [x] **DONE**

## Test coverage
- No tests: **only happens at customers that set non-standard conf variable `publisher_acl`**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/9624

- [x] **DONE**


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
