### PR TITLE
Packages changed checksum when they moved to build.opensuse.org

### DIFF
--- a/testsuite/features/secondary/trad_check_patches_install.feature
+++ b/testsuite/features/secondary/trad_check_patches_install.feature
@@ -38,7 +38,7 @@ Feature: Patches display
     And I follow "Packages"
     Then I should see a "Test-Channel-x86_64" link
     And I should see a "Test-Channel-i586" link
-    And I should see a "sha256:9150047f536ea98655f3a4bb23ddfcedb4dbdff32cb5130c2e18e5caf0e6fd66" text
+    And I should see a "sha256:4d9d095fb1865ae56cad2ccc3476cbca5664330be054b10e5927723247109641" text
     And I should see a "andromeda-dummy-2.0-1.1-noarch" link
 
   Scenario: Check relevant patches for this client


### PR DESCRIPTION
## What does this PR change?

The "fake" packages moved from IBS to OBS. That changed their checksums, and the test suite needs to be aware of that change.

## Links

* 3.2: SUSE/spacewalk#9626
* 4.0: SUSE/spacewalk#9627

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
