### PR TITLE
[WIP] Handle reposync varification errors

### DIFF
--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.0-to-susemanager-schema-4.1.1/200-rhnChannelError.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.0-to-susemanager-schema-4.1.1/200-rhnChannelError.sql
@@ -9,18 +9,18 @@
 -- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 --
 
-CREATE TABLE IF NOT EXISTS rhnPackageError
+CREATE TABLE IF NOT EXISTS rhnChannelError
 (
     id          NUMERIC NOT NULL
                     CONSTRAINT rhn_pkg_errs_id_pk PRIMARY KEY,
-    package_id  NUMERIC NOT NULL
-                    CONSTRAINT rhn_pkg_err_pid_fk
-                       REFERENCES rhnPackage (id)
+    channel_id  NUMERIC NOT NULL
+                    CONSTRAINT rhn_channel_err_pid_fk
+                       REFERENCES rhnChannel (id)
                        ON DELETE CASCADE,
-    error       VARCHAR(2048) NOT NULL,
+    error       VARCHAR(4096) NOT NULL,
     created     TIMESTAMPTZ
                      DEFAULT (current_timestamp) NOT NULL
 )
 ;
 
-CREATE SEQUENCE IF NOT EXISTS rhn_package_err_id_seq;
+CREATE SEQUENCE IF NOT EXISTS rhn_channel_err_id_seq;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.0-to-susemanager-schema-4.1.1/200-rhnPackageErrors.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.0-to-susemanager-schema-4.1.1/200-rhnPackageErrors.sql
@@ -1,0 +1,26 @@
+--
+-- Copyright (c) 2019 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+CREATE TABLE IF NOT EXISTS rhnPackageError
+(
+    id          NUMERIC NOT NULL
+                    CONSTRAINT rhn_pkg_errs_id_pk PRIMARY KEY,
+    package_id  NUMERIC NOT NULL
+                    CONSTRAINT rhn_pkg_err_pid_fk
+                       REFERENCES rhnPackage (id)
+                       ON DELETE CASCADE,
+    error       VARCHAR(2048) NOT NULL,
+    created     TIMESTAMPTZ
+                     DEFAULT (current_timestamp) NOT NULL
+)
+;
+
+CREATE SEQUENCE IF NOT EXISTS rhn_package_err_id_seq;


### PR DESCRIPTION
## What does this PR change?

Handle reposync varification errors.

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests" (Test skipped, there are no changes to test)
