### PR TITLE
[WIP] Feat: enable Ubuntu as container build host

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/services/docker.sls
+++ b/susemanager-utils/susemanager-sls/salt/services/docker.sls
@@ -2,19 +2,26 @@
 mgr_install_docker:
   pkg.installed:
     - pkgs:
+    {% if grains['os'] == 'SUSE' %}
       - git-core
       - docker: '>=1.9.0'
+    {% elif grains['os_family'] == 'Debian' and grains['os'] == 'Ubuntu' %}
+      - git
+      - docker.io
+    {% endif %}
 {%- if grains['pythonversion'][0] == 3 %}
-    {%- if grains['osmajorrelease'] == 12 %}
+    {%- if grains['os'] == 'SUSE' and grains['osmajorrelease'] == 12 %}
       - python3-docker-py: '>=1.6.0'
     {%- else %}
       - python3-docker: '>=1.6.0'
     {%- endif %}
 {%- else %}
+    {%- if grains['os'] == 'SUSE' %}
       - python-docker-py: '>=1.6.0'
+    {%- endif %}
 {%- endif %}
 {%- if grains['saltversioninfo'][0] >= 2018 %}
-    {%- if grains['osmajorrelease'] == 12 %}
+    {%- if (grains['os'] == 'SUSE' and grains['osmajorrelease'] == 12) or (grains['os_family'] == 'Debian' and grains['os'] == 'Ubuntu') %}
       - python3-salt
     {%- else %}
       - python2-salt


### PR DESCRIPTION
## What does this PR change?

Enable Ubuntu as container build host

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below) TBD

- [ ] **DONE**

## Test coverage

- Unit tests were added TBD
- Cucumber tests were added TBD

- [ ] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/397
Manager-4.0 TBD

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests" (Test skipped, there are no changes to test)
