### PR TITLE
Use image default pylint atm

### DIFF
--- a/rel-eng/Makefile.python
+++ b/rel-eng/Makefile.python
@@ -3,8 +3,8 @@
 define update_pip_env
 	rpm -e python3-pylint &>/dev/null || true
 	pip3 install --upgrade pip
-	pip3 uninstall -y pylint
-	pip3 install pylint==2.3.1
+	#pip3 uninstall -y pylint
+	#pip3 install pylint==2.3.1
 	mkdir -p reports
 endef
 


### PR DESCRIPTION
## What does this PR change?

Disables installation of local newer pylint, reuses packaged default one.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test" 
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
