### PR TITLE
Fix building and installing on CentOS8/RES8/RHEL8

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- Fix building and installing on CentOS8/RES8/RHEL8
 - Check that a channel doesn't have clones before deleting it (bsc#1138454)
 - Add unit test for schedule, errata, user, utils, misc, configchannel
   and kickstart modules

--- a/spacecmd/spacecmd.spec
+++ b/spacecmd/spacecmd.spec
@@ -24,12 +24,18 @@
 %endif
 
 %if 0%{?fedora} || 0%{?rhel} >= 8
-%{!?pylint_check: %global pylint_check 1}
+%{!?pylint_check: %global pylint_check 0}
 %endif
 
-%if 0%{?fedora} || 0%{?suse_version} > 1320
+%if 0%{?fedora} || 0%{?suse_version} > 1320 || 0%{?rhel} >= 8
 %global build_py3   1
 %global python_sitelib %{python3_sitelib}
+%endif
+
+%if 0%{?fedora} || 0%{?rhel} >= 8
+%global python2prefix python2
+%else
+%global python2prefix python
 %endif
 
 Name:           spacecmd
@@ -60,11 +66,11 @@ Requires:       python3-rpm
 Requires:       python3-simplejson
 Requires:       python3
 %else
-BuildRequires:  python
-BuildRequires:  python-devel
-Requires:       python-simplejson
+BuildRequires:  %{python2prefix}
+BuildRequires:  %{python2prefix}-devel
+Requires:       %{python2prefix}-simplejson
 Requires:       rpm-python
-Requires:       python
+Requires:       %{python2prefix}
 %if 0%{?suse_version}
 BuildRequires:  python-xml
 Requires:       python-xml


### PR DESCRIPTION
## What does this PR change?

Fix building and installing on CentOS8/RES8/RHEL8

Tested generating the package at IBS and installing at a CentOS8 VM. I am able to show spacecmd's help.

## GUI diff

- [x] **DONE**

## Documentation
- No documentation needed: I can't find a list of the OS supported by spaccecmd, so we should not need doc change.

- [x] **DONE**

## Test coverage
- No tests: Not covered

- [x] **DONE**

## Links

Related: https://github.com/SUSE/spacewalk/issues/9248

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
