### PR TITLE
Create Kiwi cache dir if not present

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/services/kiwi-image-server.sls
+++ b/susemanager-utils/susemanager-sls/salt/services/kiwi-image-server.sls
@@ -69,6 +69,7 @@ mgr_osimage_cert_deployed:
 mgr_kiwi_clear_cache:
   file.directory:
     - name: /var/cache/kiwi/zypper/
+    - makedirs: True
     - clean: True
 
 mgr_sshd_installed_enabled:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Create Kiwi cache dir if not present
 - Require pmtools only for SLE11 i586 and x86_64 (bsc#1150314)
 - do not break Servers registering to a Server
 - Introduce dnf-susemanager-plugin for RHEL8 minions


### PR DESCRIPTION
## What does this PR change?
python-kiwi does not package `/var/cache/kiwi/` directory which is cleaned by highstate. When this directory was missing, highstate failed when trying to provision SLE15/Leap15 build host.

## GUI diff
No difference.
- [X] **DONE**

## Documentation
- No documentation needed: no user facing changes

- [X] **DONE**

## Test coverage
- Cucumber tests in progress

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
