### PR TITLE
Silence cache strategy Hibernate warning

### DIFF
--- a/java/conf/default/rhn_hibernate.conf
+++ b/java/conf/default/rhn_hibernate.conf
@@ -35,3 +35,4 @@ hibernate.jdbc.batch_size=0
 hibernate.cache.provider_class=org.hibernate.cache.EhCacheProvider
 hibernate.cache.region.factory_class=org.hibernate.cache.ehcache.SingletonEhCacheRegionFactory
 hibernate.id.new_generator_mappings = false
+hibernate.cache.ehcache.missing_cache_strategy = create

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Silence cache strategy Hibernate warning
 - Fix: handle special deb package names (bsc#1150113)
 - Remove extra spaces in dependencies fields in Debian repo Packages file (bsc#1145551)
 - Improve performance for 'Manage Software Channels' view (bsc#1151399)


### PR DESCRIPTION
## What does this PR change?

It silences the following warning at startup in `rhn_web_ui.log`:
```
2019-09-19 10:49:59,805 [main] WARN  org.hibernate.orm.cache - HHH90001006: Missing cache[com.redhat.rhn.domain.server.ServerArch] was created on-the-fly. The created cache will use a provider-specific default configuration: make sure you defined one. You can disable this warning by setting 'hibernate.cache.ehcache.missing_cache_strategy' to 'create'.
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **fix**

- [x] **DONE**

## Test coverage
- No tests: **just logging**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/9661

- [x] **DONE**

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
