### PR TITLE
Testsuite - Check of i586 packages removed

### DIFF
--- a/testsuite/features/secondary/srv_check_channels_page.feature
+++ b/testsuite/features/secondary/srv_check_channels_page.feature
@@ -35,9 +35,7 @@ Feature: The channels page
     And I follow "Test-Channel-x86_64"
     And I follow "Packages"
     Then I should see package "andromeda-dummy-2.0-1.1.noarch"
-    And I should see package "hoag-dummy-1.1-1.1.i586"
     And I should see package "hoag-dummy-1.1-1.1.x86_64"
-    And I should see package "milkyway-dummy-2.0-1.1.i586"
     And I should see package "milkyway-dummy-2.0-1.1.x86_64"
     And I should see package "virgo-dummy-2.0-1.1.noarch"
 


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/9663

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
