### PR TITLE
Port GitHub actions

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,36 @@
+#Dev Labels
+java: java/**/*
+ui: web/**/*
+webapp: java/code/webapp/**/*
+cobbler: java/code/src/org/cobbler/**/*
+documentation: documentation/**/*
+proxy: proxy/**/*
+API: java/code/src/com/redhat/rhn/frontend/**/*
+Virtualization management: java/code/src/com/suse/manager/virtualization/**/*
+monitoring: 
+- java/code/src/com/suse/manager/webui/services/impl/test/monitoring/**/*
+- java/code/src/com/redhat/rhn/frontend/xmlrpc/admin/monitoring/**/*
+python3: 
+- java/**/*.py
+- backend/**/*.py
+- client/**/*.py
+- susemanager/**/*.py
+- spacecmd/**/*
+database: schema/spacewalk/**/*
+content-management: java/code/src/com/suse/manager/webui/controllers/contentmanagement/**/*
+
+#QA Labels
+testing: testsuite/**/*
+core-features: testsuite/features/core/**/*
+secondary-features: testsuite/features/secondary/**/*
+ci-pipelines: testsuite/**/*.yml
+
+#Unit tests
+backend_unittests_pgsql: backend/**/*
+javascript_lint: web/**/*
+java_lint_checkstyle: java/**/*
+java_pgsql_tests: java/**/*
+ruby_rubocop: testsuite/**/*
+schema_migration_test_oracle: schema/spacewalk/**/*
+schema_migration_test_pgsql: schema/spacewalk/**/*
+susemanager_unittests: susemanager/**/*

--- a/.github/scripts/changelog.rb
+++ b/.github/scripts/changelog.rb
@@ -1,0 +1,16 @@
+#! /usr/bin/ruby
+require 'json'
+
+# if true we exit with 0, so the test is sucessefull. otherwise the test fail.
+def check_changelog?(pr_body, files)
+  return true if pr_body.match(/\[x\]\s+No\s+changelog\s+needed/i)
+  
+  puts 'Looking for a .changes file...'
+  files.any? { |f| f.include? '.changes' } 
+end
+
+github_event = JSON.parse(File.read(ENV['GITHUB_EVENT_PATH']))
+files = ARGV[0].split(' ')
+puts "-" * 20, "PR Description: #{github_event['pull_request']['body']}"
+puts "-" * 20, "Files modified: #{files}"
+check_changelog?(github_event['pull_request']['body'], files) ?  exit(0) : exit(1)

--- a/.github/workflows/changelog_checker.yml
+++ b/.github/workflows/changelog_checker.yml
@@ -1,0 +1,20 @@
+name: changelog_test
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+    - uses: actions/setup-ruby@v1
+    - name: Run a changelog checker
+      run: |
+        files_modified=`git diff --name-only "origin/$GITHUB_BASE_REF..HEAD" | xargs`
+        ruby .github/scripts/changelog.rb $files_modified

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,12 @@
+name: Labeler
+on: [pull_request]
+
+jobs:
+  label:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/9667 and https://github.com/SUSE/spacewalk/pull/9489

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
