### PR TITLE
Enable spacecmd building and installing for Ubuntu 16.04 and Ubuntu 18.04

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- Enable building and installing for Ubuntu 16.04 and Ubuntu 18.04
 - Fix building and installing on CentOS8/RES8/RHEL8
 - Check that a channel doesn't have clones before deleting it (bsc#1138454)
 - Add unit test for schedule, errata, user, utils, misc, configchannel

--- a/spacecmd/spacecmd.spec
+++ b/spacecmd/spacecmd.spec
@@ -19,6 +19,9 @@
 
 
 %if ! (0%{?fedora} || 0%{?rhel} > 5)
+%if %{_vendor} == "debbuild"
+%global __python /usr/bin/python3
+%endif
 %{!?python_sitelib: %global python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
 %{!?python_sitearch: %global python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
 %endif
@@ -27,9 +30,11 @@
 %{!?pylint_check: %global pylint_check 0}
 %endif
 
-%if 0%{?fedora} || 0%{?suse_version} > 1320 || 0%{?rhel} >= 8
+%if 0%{?fedora} || 0%{?suse_version} > 1320 || 0%{?rhel} >= 8 || %{_vendor} == "debbuild"
 %global build_py3   1
+%if %{_vendor} != "debbuild"
 %global python_sitelib %{python3_sitelib}
+%endif
 %endif
 
 %if 0%{?fedora} || 0%{?rhel} >= 8
@@ -42,13 +47,17 @@ Name:           spacecmd
 Version:        4.0.12
 Release:        1%{?dist}
 Summary:        Command-line interface to Spacewalk and Red Hat Satellite servers
-License:        GPL-3.0-or-later
+%if %{_vendor} == "debbuild"
+Packager:       Uyuni packagers <uyuni-devel@lists.opensuse.org>
+Group:          admin
+%else
 Group:          Applications/System
-
+%endif
+License:        GPL-3.0-or-later
 Url:            https://github.com/uyuni-project/uyuni
 Source:         https://github.com/spacewalkproject/spacewalk/archive/%{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
-%if 0%{?fedora} || 0%{?rhel} || 0%{?suse_version} >= 1210
+%if 0%{?fedora} || 0%{?rhel} || 0%{?suse_version} >= 1210 || %{_vendor} == "debbuild"
 BuildArch:      noarch
 %endif
 
@@ -61,15 +70,27 @@ BuildRequires:  spacewalk-python2-pylint
 %endif
 %if 0%{?build_py3}
 BuildRequires:  python3
+%if %{_vendor} == "debbuild"
+BuildRequires:  python3-dev
+%else
 BuildRequires:  python3-devel
+%endif
 Requires:       python3-rpm
 Requires:       python3-simplejson
 Requires:       python3
 %else
 BuildRequires:  %{python2prefix}
+%if %{_vendor} == "debbuild"
+BuildRequires:  %{python2prefix}-dev
+%else
 BuildRequires:  %{python2prefix}-devel
+%endif
 Requires:       %{python2prefix}-simplejson
+%if %{_vendor} == "debbuild"
+Requires:       python-rpm
+%else
 Requires:       rpm-python
+%endif
 Requires:       %{python2prefix}
 %if 0%{?suse_version}
 BuildRequires:  python-xml


### PR DESCRIPTION
## What does this PR change?

Enable spacecmd building and installing for Ubuntu 16.04 and Ubuntu 18.04

```
$ apt show spacecmd
Package: spacecmd
Version: 4.0.12-1
Status: install ok installed
Priority: optional
Section: admin
Maintainer: Uyuni packagers <uyuni-devel@lists.opensuse.org>
Installed-Size: 706 kB
Depends: python3-rpm, python3-simplejson, python3, file
Homepage: https://github.com/uyuni-project/uyuni
Download-Size: desconocido
APT-Manual-Installed: yes
APT-Sources: /var/lib/dpkg/status
Description: Command-line interface to Spacewalk and Red Hat Satellite servers
 spacecmd is a command-line interface to Spacewalk and Red Hat Satellite servers
```
It seems debbuild does NOT support external .changelog files, so we should consider fixing it. But we should also schedule a task to fix the issue at salt as well (using `dsc` in that case), so I suggest we schedule an epic to -in general- add changelogs to `deb` packages.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: No, we don't document the clients that allow spacecmd, and in fact after this PR all of them will have it.

- [x] **DONE**

## Test coverage
- No tests: Covered by OBS.

- [x] **DONE**

## Links

Related: https://github.com/SUSE/spacewalk/issues/7196

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
