### PR TITLE
Test reverse lookup of client ip

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -742,6 +742,16 @@ Then(/^name resolution should work on terminal "([^"]*)"$/) do |host|
     raise "Reverse name resolution of #{dest} on terminal #{host} doesn't work: #{output}" unless return_code.zero?
     STDOUT.puts "#{output}"
   end
+  repeat_until_timeout(message: "reverse lookup of client not working") do
+      all_resolved = true
+      ["10.84.80.136", "10.162.210.122"].each do |ip|
+          output, return_code = node.run("host #{ip}")
+          STDOUT.puts "#{output}"
+          all_resolved = false unless return_code.zero?
+      end
+      break if all_resolved
+      sleep 3
+  end
 end
 
 When(/^I configure the proxy$/) do

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -730,7 +730,7 @@ Then(/^name resolution should work on terminal "([^"]*)"$/) do |host|
   step "I install package \"bind-utils\" on this \"#{host}\""
   # direct name resolution
   ["proxy.example.org", "download.suse.de"].each do |dest|
-    output, return_code = node.run("host #{dest}")
+    output, return_code = node.run("host #{dest}", fatal = false)
     raise "Direct name resolution of #{dest} on terminal #{host} doesn't work: #{output}" unless return_code.zero?
     STDOUT.puts "#{output}"
   end
@@ -738,18 +738,14 @@ Then(/^name resolution should work on terminal "([^"]*)"$/) do |host|
   net_prefix = $private_net.sub(%r{\.0+/24$}, ".")
   client = net_prefix + "2"
   [client, "149.44.176.1"].each do |dest|
-    output, return_code = node.run("host #{dest}")
+    output, return_code = node.run("host #{dest}", fatal = false)
     raise "Reverse name resolution of #{dest} on terminal #{host} doesn't work: #{output}" unless return_code.zero?
     STDOUT.puts "#{output}"
   end
-  repeat_until_timeout(message: "reverse lookup of client not working") do
-      all_resolved = true
-      ["10.84.80.136", "10.162.210.122"].each do |ip|
-          output, return_code = node.run("host #{ip}")
-          STDOUT.puts "#{output}"
-          all_resolved = false unless return_code.zero?
-      end
-      break if all_resolved
+  repeat_until_timeout(message: "reverse lookup of #{host} not working") do
+      output, return_code = node.run("host $(ip -4 a s eth0 | grep -Po 'inet \K[\d.]+')", fatal = false)
+      STDOUT.puts "#{output}"
+      break if return_code.zero?
       sleep 3
   end
 end


### PR DESCRIPTION
## What does this PR change?

Test, if reverse lookup of the client IP address is working. This is to prevent a race condition which might happen as the DNS server is changed in the test before.
A failed reverse lookup cause a wrong name of the client shown in the UI and make the next tests fail.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **testsuite**

- [x] **DONE**

## Test coverage
- Cucumber tests

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/9678

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
