### PR TITLE
fix quoting and restart DNS server

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -743,9 +743,11 @@ Then(/^name resolution should work on terminal "([^"]*)"$/) do |host|
     STDOUT.puts "#{output}"
   end
   repeat_until_timeout(message: "reverse lookup of #{host} not working") do
-      output, return_code = node.run("host $(ip -4 a s eth0 | grep -Po 'inet \K[\d.]+')", fatal = false)
+      output, return_code = node.run("host $(ip -4 a s eth0 | grep -Po 'inet \\K[\\d.]+')", fatal = false)
       STDOUT.puts "#{output}"
       break if return_code.zero?
+      # reason for this is mostly a not 100% working nameserver
+      $proxy.run('rcnamed restart', fatal = false)
       sleep 3
   end
 end


### PR DESCRIPTION
## What does this PR change?

Fix command quoting and restart the nameserver if resolution is not working

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **testsuite**

- [x] **DONE**

## Test coverage
- Cucumber tests

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/9680

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
