### PR TITLE
enable rhnsd after rename (bsc#1150216)

### DIFF
--- a/client/rhel/mgr-daemon/mgr-daemon.spec
+++ b/client/rhel/mgr-daemon/mgr-daemon.spec
@@ -282,6 +282,8 @@ fi
 if [ -f %{_unitdir}/spacewalk-update-status.service ]; then
     # take care that this is always enabled if it exists
     /usr/bin/systemctl --quiet enable spacewalk-update-status.service 2>&1 ||:
+elif [ -f /etc/init.d/rhnsd ]; then
+    /sbin/chkconfig --add rhnsd 2>&1 ||:
 fi
 
 


### PR DESCRIPTION
## What does this PR change?

After rename of spacewalksd to mgr-daemon, on sys-v systems the service rhnsd seems to be disabled. Force it to be enabled. Duplicate of bug 1143789 where it happend with the systemd service.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **hard to test**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/9671

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
