### PR TITLE
Fix in schema migration script when recreating the 'suseUserRoleView' (bsc#1151280)

### DIFF
--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Fix in schema migration script when recreating the 'suseUserRoleView' (bsc#1151280)
 - Fix: handle special deb package names (bsc#1150113)
 - Refactor in suseChannelUserRoleView for retrieving the parent_channel_id (bsc#1151399)
 - Add tables rhnPackageExtraTag and rhnPackageExtraTagKey

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.2-to-susemanager-schema-4.0.3/199-drop_rhnUserChannel.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.2-to-susemanager-schema-4.0.3/199-drop_rhnUserChannel.sql
@@ -1,0 +1,12 @@
+--
+-- Copyright (c) 2018 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+DROP VIEW IF EXISTS rhnUserChannel;


### PR DESCRIPTION
## What does this PR change?

Fix in schema migration script when recreating the 'suseUserRoleView'.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bugfixing

- [x] **DONE**

## Test coverage
- No tests: schema migration script

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/9686

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
