### PR TITLE
Restore i586 repositories tests

### DIFF
--- a/testsuite/features/secondary/srv_check_channels_page.feature
+++ b/testsuite/features/secondary/srv_check_channels_page.feature
@@ -35,7 +35,9 @@ Feature: The channels page
     And I follow "Test-Channel-x86_64"
     And I follow "Packages"
     Then I should see package "andromeda-dummy-2.0-1.1.noarch"
+    And I should see package "hoag-dummy-1.1-1.1.i586"
     And I should see package "hoag-dummy-1.1-1.1.x86_64"
+    And I should see package "milkyway-dummy-2.0-1.1.i586"
     And I should see package "milkyway-dummy-2.0-1.1.x86_64"
     And I should see package "virgo-dummy-2.0-1.1.noarch"
 


### PR DESCRIPTION
## What does this PR change?

Partial revert of #1461 after I added the i586 repositories to https://build.opensuse.org/project/show/systemsmanagement:Uyuni:Test-Packages:Pool and https://build.opensuse.org/project/show/systemsmanagement:Uyuni:Test-Packages:Updates . Apparently, the checksum has not changed again :sweat: .

## Links

* 3.2: SUSE/spacewalk#9692
* 4.O: SUSE/spacewalk#9691

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

