### PR TITLE
Package checksum changed once again

### DIFF
--- a/testsuite/features/secondary/trad_check_patches_install.feature
+++ b/testsuite/features/secondary/trad_check_patches_install.feature
@@ -38,7 +38,7 @@ Feature: Patches display
     And I follow "Packages"
     Then I should see a "Test-Channel-x86_64" link
     And I should see a "Test-Channel-i586" link
-    And I should see a "sha256:a1ccca3cbb363b50682ef46a5def7784b0dc356dfb692b01241ffca4e321b5b7" text
+    And I should see a "sha256:2a293b61a3d6adecb1642b8b982869eef8e02750550a1042f160264e92424d1a" text
     And I should see a "andromeda-dummy-2.0-1.1-noarch" link
 
   Scenario: Check relevant patches for this client


### PR DESCRIPTION
## What does this PR change?

Due to addition of i586 target, package checksum checked by test suite changed once again.

Hopefully this is last time!

## Links

* 3.2: SUSE/spacewalk#9696
* 4.0: SUSE/spacewalk#9695

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
