### PR TITLE
allow channel names to start with numbers

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -20051,7 +20051,7 @@ given channel.</source>
         Channel name and label are required.&lt;br&gt;
         They each must be at least 6 characters in length.&lt;br&gt;
         Channel name must not be longer than 256 characters and channel label must not be longer than 128 characters.&lt;br&gt;
-        Channel name must begin with a letter and channel label may begin with a letter or digit.&lt;br&gt;
+        Channel name and label may begin with a letter or digit.&lt;br&gt;
         They each must not begin with rhn, redhat or red hat.&lt;br&gt;
         They each must contain only lowercase letters, hyphens ('-'), periods ('.'), underscores ('_'), and numerals.&lt;br&gt;
         Channel name may also contain spaces, parentheses () and forward slashes ('/').

--- a/java/code/src/com/redhat/rhn/manager/channel/CreateChannelCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/CreateChannelCommand.java
@@ -45,7 +45,7 @@ public class CreateChannelCommand {
     public static final int CHANNEL_LABEL_MIN_LENGTH = 6;
 
     public static final String CHANNEL_NAME_REGEX =
-        "^[a-zA-Z][\\w\\d\\s\\-\\.\\'\\(\\)\\/\\_]*$";
+        "^[a-zA-Z\\d][\\w\\d\\s\\-\\.\\'\\(\\)\\/\\_]*$";
     public static final String CHANNEL_LABEL_REGEX =
         "^[a-z\\d][a-z\\d\\-\\.\\_]*$";
 

--- a/java/code/src/com/redhat/rhn/manager/channel/test/CreateCommandTest.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/test/CreateCommandTest.java
@@ -58,8 +58,6 @@ public class CreateCommandTest extends RhnBaseTestCase {
         invalidChannelName("abc123\\");
         invalidChannelName(null);
         invalidChannelName("_123456");
-        invalidChannelName("0longerthansix");
-
 
         // V A L I D
         validChannelName("dude where's my car"); // we allow ' just don't advertise it
@@ -70,6 +68,7 @@ public class CreateCommandTest extends RhnBaseTestCase {
         validChannelName("bin/channel/ok");
         validChannelName("abc 123-foo/bar_under.ALPHA");
         validChannelName("Jesusrs API Test Channel");
+        validChannelName("0longerthansix");
 
         // we allow the following characters but don't advertise them
         // ' ( )

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Allow channels names to start with numbers
 - Fix: handle special deb package names (bsc#1150113)
 - Remove extra spaces in dependencies fields in Debian repo Packages file (bsc#1145551)
 - Improve performance for 'Manage Software Channels' view (bsc#1151399)


### PR DESCRIPTION
## What does this PR change?
already merged in #9687 spacewalk
**add description**

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test" 
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
