### PR TITLE
Add debug logging to salt calles

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
@@ -667,6 +667,7 @@ public class SaltSSHService {
             extraFilerefs.ifPresent(filerefs -> sshConfigBuilder.extraFilerefs(filerefs));
             SaltSSHConfig sshConfig = sshConfigBuilder.build();
 
+            LOG.debug("Local callSyncSSH: " + SaltService.localCallToString(call));
             return SaltService.adaptException(call.callSyncSSH(saltClient, target, sshConfig, PW_AUTH)
                     .whenComplete((r, e) -> {
                         try {

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -283,6 +283,7 @@ public class SaltService {
     public <R> Optional<R> callSync(RunnerCall<R> call,
                                     Function<SaltError, Optional<R>> errorHandler) {
         try {
+            LOG.debug("Runner callSync: " + runnerCallToString(call));
             Result<R> result = adaptException(call.callSync(SALT_CLIENT, PW_AUTH));
             return result.fold(p -> errorHandler.apply(p),
                     r -> Optional.of(r)
@@ -354,6 +355,7 @@ public class SaltService {
     public <R> Optional<R> callSync(WheelCall<R> call,
                                      Function<SaltError, Optional<R>> errorHandler) {
         try {
+            LOG.debug("Wheel callSync: " + wheelCallToString(call));
             WheelResult<Result<R>> result = adaptException(call.callSync(SALT_CLIENT, PW_AUTH));
             return result.getData().getResult().fold(
                     err -> errorHandler.apply(err),
@@ -747,6 +749,7 @@ public class SaltService {
 
         if (!regularMinionIds.isEmpty()) {
             ScheduleMetadata metadata = ScheduleMetadata.getDefaultMetadata().withBatchMode();
+            LOG.debug("Local callSync: " + SaltService.localCallToString(callIn));
             List<Map<String, Result<T>>> callResult =
                     adaptException(callIn.withMetadata(metadata).callSync(SALT_CLIENT,
                             new MinionList(regularMinionIds), PW_AUTH, defaultBatch));
@@ -758,6 +761,18 @@ public class SaltService {
         }
 
         return results;
+    }
+
+    /**
+     * Return local call options as a string (for debugging)
+     *
+     * @param call the local call
+     * @return string representation
+     */
+    public static String localCallToString(LocalCall<?> call) {
+        return "[" + call.getModuleName() + "." +
+                call.getFunctionName() + "] with payload [" +
+                call.getPayload() + "]";
     }
 
     /**
@@ -802,6 +817,7 @@ public class SaltService {
             Optional<ScheduleMetadata> metadataIn) throws SaltException {
         ScheduleMetadata metadata =
                 Opt.fold(metadataIn, () -> ScheduleMetadata.getDefaultMetadata(), Function.identity()).withBatchMode();
+        LOG.debug("Local callAsync: " + SaltService.localCallToString(callIn));
         return adaptException(callIn.withMetadata(metadata).callAsync(SALT_CLIENT, target, PW_AUTH, defaultBatch));
     }
 


### PR DESCRIPTION
## What does this PR change?

Add debug logging for all calls to the salt API

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **debugging**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/9697

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
