### PR TITLE
Manager bsc1152298

### DIFF
--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -158,7 +158,7 @@ MYNAME=`hostname -f`
 LCMYNAME=`echo $MYNAME | tr '[:upper:]' '[:lower:]'`
 LCHOSTNAME=`echo $HOSTNAME | tr '[:upper:]' '[:lower:]'`
 
-if [ $LCMYNAME == $LCHOSTNAME ]; then
+if [ "$LCMYNAME" == "$LCHOSTNAME" ]; then
     echo "Name of client and of SUSE Manager server are the same."
     echo "Do not try to register a SUSE Manager server at itself!"
     echo "Aborting."

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,4 @@
+- make traditional bootstrap more robust for unknown hostname (bsc#1152298)
 - Require mgr-daemon (new name of spacewalksd) so we systems with
   spacewalksd get always the new package installed (bsc#1149353)
 


### PR DESCRIPTION
## What does this PR change?

Make the bootstrap script for traditional clients more robust; in case of a missing hostname, the test would fail. Not really that important, but if we do not fix this, we will never get rid of the bug :/