### PR TITLE
Always install latest available salt during salt bootstrap

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -118,7 +118,7 @@ trust_suse_manager_tools_deb_gpg_key:
 {%- endif %}
 
 salt-minion-package:
-  pkg.installed:
+  pkg.latest:
     - name: salt-minion
     - require:
       - file: bootstrap_repo

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Always install latest available salt during bootstrap
 - Create Kiwi cache dir if not present
 - Require pmtools only for SLE11 i586 and x86_64 (bsc#1150314)
 - do not break Servers registering to a Server


### PR DESCRIPTION
## What does this PR change?

Always install latest available salt during salt bootstrap

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Bootstrap procedure internal details not explained on the doc.

- [x] **DONE**

## Test coverage
- No tests: Already covered by testsuite

- [x] **DONE**

## Links

None.

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
