### PR TITLE
[WIP] Catch salt api error and display the error

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/renderers/TasksRenderer.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/renderers/TasksRenderer.java
@@ -21,6 +21,7 @@ import com.redhat.rhn.frontend.listview.PageControl;
 import com.redhat.rhn.manager.system.SystemManager;
 
 import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.salt.netapi.exception.SaltException;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -39,8 +40,13 @@ public class TasksRenderer extends BaseFragmentRenderer {
     protected void render(User user, PageControl pc, HttpServletRequest request) {
         request.setAttribute(TASKS, Boolean.TRUE);
         request.setAttribute("documentation", ConfigDefaults.get().isDocAvailable());
-        request.setAttribute("amountOfMinions",
-                SaltService.INSTANCE.getKeys().getUnacceptedMinions().size());
+        try {
+            request.setAttribute("amountOfMinions",
+                    SaltService.INSTANCE.getKeys().getUnacceptedMinions().size());
+        }
+        catch (SaltException e) {
+            request.setAttribute("amountOfMinions", 0);
+        }
         request.setAttribute("requiringReboot", SystemManager.requiringRebootList(user).size());
         RendererHelper.setTableStyle(request, null);
     }

--- a/java/code/src/com/suse/manager/utils/SaltKeyUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltKeyUtils.java
@@ -20,6 +20,7 @@ import com.redhat.rhn.frontend.xmlrpc.PermissionCheckFailureException;
 
 import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.salt.netapi.calls.wheel.Key;
+import com.suse.salt.netapi.exception.SaltException;
 
 import java.util.stream.Stream;
 
@@ -43,7 +44,13 @@ public class SaltKeyUtils {
             throws PermissionCheckFailureException {
 
         //Note: since salt only allows globs we have to do our own strict matching
-        Key.Names keys = SALT_SERVICE.getKeys();
+        Key.Names keys = null;
+        try {
+            keys = SALT_SERVICE.getKeys();
+        }
+        catch (SaltException e) {
+            return false;
+        }
         boolean exists = Stream.concat(
                 Stream.concat(
                         keys.getDeniedMinions().stream(),

--- a/java/code/src/com/suse/manager/webui/controllers/utils/AbstractMinionBootstrapper.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/AbstractMinionBootstrapper.java
@@ -264,10 +264,16 @@ public abstract class AbstractMinionBootstrapper {
             return Collections.singletonList(activationKeyErrorMessage.get());
         }
 
-        if (saltService.keyExists(input.getHost(), KeyStatus.ACCEPTED, KeyStatus.DENIED, KeyStatus.REJECTED)) {
-            return Collections.singletonList("A salt key for this" +
-                    " host (" + input.getHost() +
-                    ") seems to already exist, please check!");
+        try {
+            if (saltService.keyExists(input.getHost(), KeyStatus.ACCEPTED, KeyStatus.DENIED, KeyStatus.REJECTED)) {
+                return Collections.singletonList("A salt key for this" +
+                        " host (" + input.getHost() +
+                        ") seems to already exist, please check!");
+            }
+        }
+        catch (RuntimeException e) {
+            return Collections.singletonList("Server Error: unable to check existing keys: " +
+                    e.getMessage());
         }
 
         return MinionServerFactory.findByMinionId(input.getHost())

--- a/java/code/src/com/suse/manager/webui/controllers/utils/AbstractMinionBootstrapper.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/AbstractMinionBootstrapper.java
@@ -271,7 +271,7 @@ public abstract class AbstractMinionBootstrapper {
                         ") seems to already exist, please check!");
             }
         }
-        catch (RuntimeException e) {
+        catch (SaltException e) {
             return Collections.singletonList("Server Error: unable to check existing keys: " +
                     e.getMessage());
         }


### PR DESCRIPTION
## What does this PR change?

When API throw an exception we need to handle it properly and show the error in the UI

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
