### PR TITLE
 Testsuite - retail slaac fix for imported yaml file

### DIFF
--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -253,7 +253,7 @@ Feature: PXE boot a Retail terminal
 @pxeboot_minion
   Scenario: Install a package on the new Retail terminal
     Given I am on the Systems overview page of this "pxeboot-minion"
-    When I install the GPG key of the server on the PXE boot minion
+    When I install the GPG key of the test packages repository on the PXE boot minion
     And I follow "Software" in the content area
     And I follow "Install"
     And I check "virgo-dummy-2.0-1.1" in the list
@@ -267,7 +267,7 @@ Feature: PXE boot a Retail terminal
 @pxeboot_minion
   Scenario: Cleanup: remove a package on the new Retail terminal
     Given I am on the Systems page
-    When I follow "pxeboot" terminal
+    When I follow "pxeboot-minion" terminal
     And I follow "Software" in the content area
     And I follow "List / Remove"
     And I enter "virgo" in the css "input[placeholder='Filter by Package Name: ']"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -270,7 +270,7 @@ When(/^I stop salt-minion on the PXE boot minion$/) do
   $proxy.run("expect -f /tmp/#{file} #{ipv4}")
 end
 
-When(/^I install the GPG key of the server on the PXE boot minion$/) do
+When(/^I install the GPG key of the test packages repository on the PXE boot minion$/) do
   file = 'uyuni.key'
   source = File.dirname(__FILE__) + '/../upload_files/' + file
   dest = "/tmp/" + file

--- a/testsuite/features/upload_files/massive-import-terminals.yml
+++ b/testsuite/features/upload_files/massive-import-terminals.yml
@@ -4,6 +4,8 @@ branches:
     branch_prefix: example.org
     dedicated_nic: true
     configure_firewall: true
+    firewall:
+      enable_SLAAC_with_routing: true
     dyn_range:
     - <NET_PREFIX><RANGE_BEGIN>
     - <NET_PREFIX><RANGE_END>


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/9750

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
