### PR TITLE
Use only 3 threads for parallel cucumber execution

### DIFF
--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -30,7 +30,7 @@ namespace :parallel do
       timestamp = Time.now.strftime('%Y%m%d%H%M%S')
       features = YAML.safe_load(File.read(File.join(Dir.pwd, 'run_sets', "#{run_set}.yml"))).join(' ')
       cucumber_opts = "-f html -o output_#{timestamp}-#{run_set}-$TEST_ENV_NUMBER.html -f json -o output_#{timestamp}-#{run_set}-$TEST_ENV_NUMBER.json #{junit_results} -f rerun --out failed.txt -f CustomFormatter::PrettyFormatter -r features "
-      sh "bundle exec parallel_cucumber -n 5 -o '#{cucumber_opts}' #{features}"
+      sh "bundle exec parallel_cucumber -n 3 -o '#{cucumber_opts}' #{features}"
     end
   end
   at_exit { post_nodejs_report }


### PR DESCRIPTION
## What does this PR change?

This PR sets the parallel cucumber execution to use only 3 threads instead of 5. This change should prevent from getting some of the issues we're currently facing during parallel cucumber execution.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **testsuite changes**

- [x] **DONE**

## Test coverage
- No tests: **testsuite changes**
- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
