### PR TITLE
Assign a Test Channel which has the required packages

### DIFF
--- a/testsuite/features/secondary/minssh_centos_salt_install_package_and_patch.feature
+++ b/testsuite/features/secondary/minssh_centos_salt_install_package_and_patch.feature
@@ -16,6 +16,20 @@ Feature: Install a patch on the CentOS SSH minion via Salt through the UI
     Then spacecmd should show packages "virgo-dummy-1.0" installed on "ceos-ssh-minion"
 
 @centos_minion
+  Scenario: Pre-requisite: re-subscribe the SSH-managed CentOS minion to a base channel
+    Given I am on the Systems overview page of this "ceos-ssh-minion"
+    When I follow "Software" in the content area
+    And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
+    And I check radio button "Test-Channel-x86_64"
+    And I wait until I do not see "Loading..." text
+    And I click on "Next"
+    Then I should see a "Confirm Software Channel Change" text
+    When I click on "Confirm"
+    Then I should see a "Changing the channels has been scheduled." text
+    And I wait until event "Subscribe channels scheduled by admin" is completed
+
+@centos_minion
   Scenario: Schedule errata refresh to reflect channel assignment on Centos SSH minion
     Given I am on the Systems overview page of this "ceos-ssh-minion"
     When I follow "Software" in the content area


### PR DESCRIPTION

## What does this PR change?

Assign a Test Channel which has the required packages
By default "Test Base Channel" is assigned but has not the needed packages

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- fixes tests

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/9758

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
