### PR TITLE
Fixing a missing step in order to clean systems selected

### DIFF
--- a/testsuite/features/secondary/allcli_config_channel.feature
+++ b/testsuite/features/secondary/allcli_config_channel.feature
@@ -253,4 +253,5 @@ Feature: Management of configuration of all types of clients in a single channel
     And I destroy "/etc/s-mgr" directory on "sle-minion"
 
   Scenario: Cleanup: remove remaining systems from SSM
-    When I follow "Clear"
+    When I am authorized as "admin" with password "admin"
+    And I follow "Clear"

--- a/testsuite/features/secondary/allcli_software_channels.feature
+++ b/testsuite/features/secondary/allcli_software_channels.feature
@@ -6,7 +6,7 @@ Feature: Chanel subscription via SSM
   Scenario: Change child channels for two systems subscribed to a base channel
     Given I am authorized as "admin" with password "admin"
     When I am on the System Overview page
-    When I follow "Clear"
+    And I follow "Clear"
     And I check the "sle-minion" client
     And I check the "sle-client" client
     And I should see "2" systems selected for SSM
@@ -215,4 +215,5 @@ Feature: Chanel subscription via SSM
     Then channel "Test-Channel-x86_64 Child Channel" should not be enabled on "sle-client"
 
   Scenario: Cleanup: remove remaining systems from SSM
-    When I follow "Clear"
+    When I am authorized as "admin" with password "admin"
+    And I follow "Clear"

--- a/testsuite/features/secondary/allcli_software_channels_dependencies.feature
+++ b/testsuite/features/secondary/allcli_software_channels_dependencies.feature
@@ -47,4 +47,5 @@ Feature: Chanel subscription with recommended/required dependencies
     And I should see "No change" "unselected" for the "SLE-Module-Basesystem15-Pool for x86_64" channel
 
   Scenario: Cleanup: remove remaining systems from SSM
-    When I follow "Clear"
+    When I am authorized as "admin" with password "admin"
+    And I follow "Clear"

--- a/testsuite/features/secondary/min_action_chain.feature
+++ b/testsuite/features/secondary/min_action_chain.feature
@@ -315,4 +315,5 @@ Feature: Action chain on salt minions
     And I run "rm -f /tmp/action_chain_one_system_done" on "sle-minion" without error control
 
   Scenario: Cleanup: remove remaining systems from SSM
-    When I follow "Clear"
+    When I am authorized as "admin" with password "admin"
+    And I follow "Clear"

--- a/testsuite/features/secondary/min_osimage_build_image.feature
+++ b/testsuite/features/secondary/min_osimage_build_image.feature
@@ -47,4 +47,5 @@ Feature: Build OS images
     When I disable repositories after installing branch server
 
   Scenario: Cleanup: remove remaining systems from SSM
-    When I follow "Clear"
+    When I am authorized as "admin" with password "admin"
+    And I follow "Clear"

--- a/testsuite/features/secondary/min_salt_formulas.feature
+++ b/testsuite/features/secondary/min_salt_formulas.feature
@@ -164,4 +164,5 @@ Feature: Use salt formulas
      And I manually uninstall the "locale" formula from the server
 
   Scenario: Cleanup: remove remaining systems from SSM
-     When I follow "Clear"
+     When I am authorized as "admin" with password "admin"
+     And I follow "Clear"

--- a/testsuite/features/secondary/minssh_action_chain.feature
+++ b/testsuite/features/secondary/minssh_action_chain.feature
@@ -295,4 +295,5 @@ Feature: Salt SSH action chain
     And I run "rm -f /tmp/action_chain_one_system_done" on "ssh-minion" without error control
 
   Scenario: Cleanup: remove remaining systems from SSM
-    When I follow "Clear"
+    When I am authorized as "admin" with password "admin"
+    And I follow "Clear"

--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -519,4 +519,5 @@ Feature: PXE boot a Retail terminal
 @proxy
 @private_net
   Scenario: Cleanup: remove remaining systems from SSM
-    When I follow "Clear"
+  When I am authorized as "admin" with password "admin"
+  And I follow "Clear"

--- a/testsuite/features/secondary/srv_clone_channel_npn.feature
+++ b/testsuite/features/secondary/srv_clone_channel_npn.feature
@@ -124,4 +124,5 @@ Feature: Clone a channel
     And I should see a "has been deleted." text
 
   Scenario: Cleanup: remove remaining systems from SSM
-    When I follow "Clear"
+    When I am authorized as "admin" with password "admin"
+    And I follow "Clear"

--- a/testsuite/features/secondary/srv_cve_audit.feature
+++ b/testsuite/features/secondary/srv_cve_audit.feature
@@ -112,4 +112,5 @@ Feature: CVE Audit
     And I run "rhn_check -vvv" on "sle-client" without error control
 
   Scenario: Cleanup: remove remaining systems from SSM
-    When I follow "Clear"
+    When I am authorized as "admin" with password "admin"
+    And I follow "Clear"

--- a/testsuite/features/secondary/srv_group_union_intersection.feature
+++ b/testsuite/features/secondary/srv_group_union_intersection.feature
@@ -154,4 +154,5 @@ Feature: Work with Union and Intersection buttons in the group list
     Then I should see a "deleted" text
 
   Scenario: Cleanup: remove remaining systems from SSM
-    When I follow "Clear"
+    When I am authorized as "admin" with password "admin"
+    And I follow "Clear"

--- a/testsuite/features/secondary/srv_power_management.feature
+++ b/testsuite/features/secondary/srv_power_management.feature
@@ -86,4 +86,5 @@ Feature: Power management
     Given the server stops mocking an IPMI host
 
   Scenario: Cleanup: remove remaining systems from SSM
-    When I follow "Clear"
+    When I am authorized as "admin" with password "admin"
+    And I follow "Clear"

--- a/testsuite/features/secondary/trad_action_chain.feature
+++ b/testsuite/features/secondary/trad_action_chain.feature
@@ -258,4 +258,5 @@ Feature: Action chain on traditional clients
     When I run "rm -f /tmp/action_chain.log" on "sle-client" without error control
 
   Scenario: Cleanup: remove remaining systems from SSM
-    When I follow "Clear"
+    When I am authorized as "admin" with password "admin"
+    And I follow "Clear"

--- a/testsuite/features/secondary/trad_baremetal_discovery.feature
+++ b/testsuite/features/secondary/trad_baremetal_discovery.feature
@@ -121,4 +121,5 @@ Feature: Bare metal discovery
     Then I should see "sle-client" in spacewalk
 
   Scenario: Cleanup: remove remaining systems from SSM
-    When I follow "Clear"
+    When I am authorized as "admin" with password "admin"
+    And I follow "Clear"

--- a/testsuite/features/secondary/trad_config_channel.feature
+++ b/testsuite/features/secondary/trad_config_channel.feature
@@ -287,4 +287,5 @@ Feature: Configuration management of traditional clients
     When I remove "/etc/mgr-test-file.cnf" from "sle-client"
 
   Scenario: Cleanup: remove remaining systems from SSM
-    When I follow "Clear"
+    When I am authorized as "admin" with password "admin"
+    And I follow "Clear"


### PR DESCRIPTION
## What does this PR change?

That's a fix for a previous PR #1478  where I missed a step.
Port of https://github.com/SUSE/spacewalk/pull/9774

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test" 
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
