### PR TITLE
Fix combinatorial explosion when generating migrations (bsc#1151888)

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/distupgrade/DistUpgradeManager.java
+++ b/java/code/src/com/redhat/rhn/manager/distupgrade/DistUpgradeManager.java
@@ -29,7 +29,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
-import java.util.stream.Collectors;
 import static java.util.stream.Collectors.toList;
 
 import com.redhat.rhn.FaultException;
@@ -238,53 +237,7 @@ public class DistUpgradeManager extends BaseManager {
                         .compare(tgt2.getAddonProducts(), tgt1.getAddonProducts());
             }
         });
-        return addMissingChannels(
-                removeIncompatibleCombinations(migrationTargets), arch, user);
-    }
-
-    /**
-     * Remove target combinations that are not compatible
-     *
-     * Please note that ruby syntax comments in the code are referred
-     * to the private project source at:
-     * - https://github.com/SUSE/happy-customer/blob/
-     *       761eaad2bcb0fcc506c545442ea860a041debf27/glue/app/models/migration_engine.rb
-     *
-     * @param migrations a target list of all {@link SUSEProductSet}
-     * @return the List of compatible {@link SUSEProductSet}
-     */
-    private static List<SUSEProductSet> removeIncompatibleCombinations(
-            List<SUSEProductSet> migrations) {
-        final List<SUSEProductSet> result = new ArrayList<>(migrations);
-        // migrations.clone.each do |combination|
-        for (SUSEProductSet combination : migrations) {
-            // combination_base_product = combination.first
-            // (combination - [combination_base_product]).each do |product|
-            for (SUSEProduct product : combination.getAddonProducts()) {
-                //if (product.bases & combination).empty?
-                //        migrations.delete(combination)
-                //        break
-                //end
-                //SUSEProductFactory.findAllSUSEProductExtensionsOf(product);
-                HashSet<SUSEProduct> intersection = new HashSet<>(
-                        SUSEProductFactory.findAllBaseProductsOf(product));
-                intersection.retainAll(combination.getAddonProducts());
-                if (intersection.isEmpty() &&
-                        !SUSEProductFactory.findAllBaseProductsOf(product).contains(combination.getBaseProduct())) {
-                    result.remove(combination);
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("Remove incompatible target: " +
-                                combination.toString());
-                        logger.debug("Base product of '" + product.getFriendlyName() +
-                                "': " + combination.getBaseProduct().getFriendlyName());
-                        SUSEProductFactory.findAllBaseProductsOf(product).forEach(base ->
-                            logger.debug("Possible bases: " + base.getFriendlyName()));
-                        logger.debug("--------------------------");
-                    }
-                }
-            }
-        }
-        return Collections.unmodifiableList(result);
+        return addMissingChannels(migrationTargets, arch, user);
     }
 
     private static List<SUSEProductSet> addMissingChannels(
@@ -370,18 +323,50 @@ public class DistUpgradeManager extends BaseManager {
                     }
                 }
 
+                // base_successors.each do |base|
+                //   available_extensions = installed_extensions.map do |ext|
+                //     options = ext.successors.merge(migration_path_scope)
+                //     options += [ext] if migration_kind == :online
+                //     options.select { |succ| succ.available_for?(base) }
+                //   end
+                //   combinations += [base].product(*available_extensions)
+                // end
+                List<List<SUSEProduct>> combinations = baseSuccessors.stream().flatMap(baseSucc -> {
+                    // first compute extensions successors compatible with the base successor
+                    List<List<SUSEProduct>> compatibleExtensionSuccessors = extensionSuccessors.stream()
+                            .map(extensionSucc -> extensionSucc.stream()
+                                    .filter(succ -> extAvailableForRoot(succ, baseSucc))
+                                    .collect(toList()))
+                            .filter(list -> !list.isEmpty())
+                            .collect(toList());
+
+                    if (logger.isDebugEnabled()) {
+                        if (compatibleExtensionSuccessors.isEmpty()) {
+                            logger.debug("No extension successors for base successor " +
+                                    baseSucc.getFriendlyName());
+                        }
+                        else {
+                            logger.debug("Found extension successors for base successor " +
+                                    baseSucc.getFriendlyName() + ":");
+                            // let's print out list of list with friendly names
+                            compatibleExtensionSuccessors.stream()
+                                    .map(css -> css.stream().map(cs -> cs.getFriendlyName()).collect(toList()))
+                                    .forEach(css -> logger.debug(css));
+                            logger.debug("-----------------------");
+                        }
+                    }
+
+                    // the base successor will be always on the 1st position in the combinations below
+                    compatibleExtensionSuccessors.add(0, List.of(baseSucc));
+
+                    return Lists.combinations(compatibleExtensionSuccessors).stream();
+                }).collect(toList());
+
                 final List<SUSEProduct> currentCombination = new ArrayList<>(installedExtensions.size() + 1);
                 currentCombination.add(baseProduct);
                 currentCombination.addAll(installedExtensions);
 
-                // combinations = base_successors.product(*extension_successors)
-                // combinations.delete([base_product] + installed_extensions)
-
-                final List<List<SUSEProduct>> comb = new ArrayList<>(extensionSuccessors.size() + 1);
-                comb.add(baseSuccessors);
-                comb.addAll(extensionSuccessors);
-
-                for (List<SUSEProduct> combination : Lists.combinations(comb)) {
+                for (List<SUSEProduct> combination : combinations) {
                     if (!combination.equals(currentCombination)) {
                         SUSEProduct base = combination.get(0);
                         if (!ContentSyncManager.isProductAvailable(base, base)) {
@@ -418,6 +403,16 @@ public class DistUpgradeManager extends BaseManager {
         );
     }
 
+    /**
+     * Returns true if the extension is linked with given root product.
+     *
+     * @param extension the extension product
+     * @param root the root product
+     * @return true if the extension is linked with given root product, false otherwise
+     */
+    private static boolean extAvailableForRoot(SUSEProduct extension, SUSEProduct root) {
+        return !SUSEProductFactory.findAllBaseProductsOf(extension, root).isEmpty();
+    }
 
     /**
      * Return *all* clones of a given channel.

--- a/java/code/src/com/redhat/rhn/manager/distupgrade/DistUpgradeManager.java
+++ b/java/code/src/com/redhat/rhn/manager/distupgrade/DistUpgradeManager.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
+import static java.util.stream.Collectors.toList;
 
 import com.redhat.rhn.FaultException;
 import com.redhat.rhn.common.util.RpmVersionComparator;
@@ -309,7 +310,7 @@ public class DistUpgradeManager extends BaseManager {
                                 .map(pr -> {
                                     logger.warn("Mandatory channel not synced: " + pr.getChannelLabel());
                                     return pr.getChannelLabel();
-                                }).collect(Collectors.toList());
+                                }).collect(toList());
                         target.addMissingChannels(missing);
                     }
                 }

--- a/java/code/src/com/redhat/rhn/manager/distupgrade/DistUpgradeManager.java
+++ b/java/code/src/com/redhat/rhn/manager/distupgrade/DistUpgradeManager.java
@@ -227,18 +227,14 @@ public class DistUpgradeManager extends BaseManager {
     public static List<SUSEProductSet> getTargetProductSets(
             Optional<SUSEProductSet> installedProducts, ChannelArch arch, User user) {
         List<SUSEProductSet> migrationTargets = migrationTargets(installedProducts);
-        Collections.sort(migrationTargets, new Comparator<SUSEProductSet>() {
-            @Override
-            public int compare(SUSEProductSet o1, SUSEProductSet o2) {
-                int i = PRODUCT_VERSION_COMPARATOR
-                        .compare(o2.getBaseProduct(), o1.getBaseProduct());
-                if (i != 0) {
-                    return i;
-                }
-                else {
-                    return PRODUCT_LIST_VERSION_COMPARATOR
-                            .compare(o2.getAddonProducts(), o1.getAddonProducts());
-                }
+        Collections.sort(migrationTargets, (tgt1, tgt2) -> {
+            int i = PRODUCT_VERSION_COMPARATOR.compare(tgt2.getBaseProduct(), tgt1.getBaseProduct());
+            if (i != 0) {
+                return i;
+            }
+            else {
+                return PRODUCT_LIST_VERSION_COMPARATOR
+                        .compare(tgt2.getAddonProducts(), tgt1.getAddonProducts());
             }
         });
         return addMissingChannels(

--- a/java/code/src/com/redhat/rhn/manager/distupgrade/DistUpgradeManager.java
+++ b/java/code/src/com/redhat/rhn/manager/distupgrade/DistUpgradeManager.java
@@ -360,7 +360,9 @@ public class DistUpgradeManager extends BaseManager {
                     compatibleExtensionSuccessors.add(0, List.of(baseSucc));
 
                     return Lists.combinations(compatibleExtensionSuccessors).stream();
-                }).collect(toList());
+                })
+                        .filter(comb -> !comb.equals(List.of(baseProduct)))
+                        .collect(toList());
 
                 final List<SUSEProduct> currentCombination = new ArrayList<>(installedExtensions.size() + 1);
                 currentCombination.add(baseProduct);

--- a/java/code/src/com/redhat/rhn/manager/distupgrade/DistUpgradeManager.java
+++ b/java/code/src/com/redhat/rhn/manager/distupgrade/DistUpgradeManager.java
@@ -273,8 +273,7 @@ public class DistUpgradeManager extends BaseManager {
                         SUSEProductFactory.findAllBaseProductsOf(product));
                 intersection.retainAll(combination.getAddonProducts());
                 if (intersection.isEmpty() &&
-                        !SUSEProductFactory.findAllBaseProductsOf(product).contains(
-                                combination.getBaseProduct())) {
+                        !SUSEProductFactory.findAllBaseProductsOf(product).contains(combination.getBaseProduct())) {
                     result.remove(combination);
                     if (logger.isDebugEnabled()) {
                         logger.debug("Remove incompatible target: " +
@@ -295,8 +294,7 @@ public class DistUpgradeManager extends BaseManager {
             List<SUSEProductSet> migrationTargets, ChannelArch arch, User user) {
         for (SUSEProductSet target : migrationTargets) {
             // Look for the target product's base channel
-            Channel baseChannel = getProductBaseChannel(target.getBaseProduct().getId(),
-                    arch, user);
+            Channel baseChannel = getProductBaseChannel(target.getBaseProduct().getId(), arch, user);
 
             if (baseChannel == null) {
                 // No base channel found
@@ -353,19 +351,16 @@ public class DistUpgradeManager extends BaseManager {
                 // installed_extensions = @installed_products - [base_product]
                 List<SUSEProduct> installedExtensions = prd.getAddonProducts();
                 // base_successors = [base_product] + base_product.successors
-                final List<SUSEProduct> baseSuccessors = new ArrayList<>(
-                        baseProduct.getUpgrades().size() + 1);
+                final List<SUSEProduct> baseSuccessors = new ArrayList<>(baseProduct.getUpgrades().size() + 1);
                 baseSuccessors.add(baseProduct);
                 baseSuccessors.addAll(baseProduct.getUpgrades());
                 if (logger.isDebugEnabled()) {
-                    logger.debug("Found '" + baseSuccessors.size() +
-                            "' successors for the base product.");
+                    logger.debug("Found '" + baseSuccessors.size() + "' successors for the base product.");
                     baseSuccessors.stream().forEach(bp -> logger.debug(bp.getFriendlyName()));
                 }
 
                 // extension_successors = installed_extensions.map {|e| [e] + e.successors }
-                final List<List<SUSEProduct>> extensionSuccessors =
-                        new ArrayList<>(installedExtensions.size());
+                final List<List<SUSEProduct>> extensionSuccessors = new ArrayList<>(installedExtensions.size());
                 for (SUSEProduct e : installedExtensions) {
                     final List<SUSEProduct> s = new ArrayList<>(e.getUpgrades().size() + 1);
                     s.add(e);
@@ -373,34 +368,28 @@ public class DistUpgradeManager extends BaseManager {
                     extensionSuccessors.add(s);
                     if (logger.isDebugEnabled()) {
                         logger.debug("Extension: " + e.getFriendlyName());
-                        e.getUpgrades().forEach(ex -> {
-                            logger.debug("Extension successor: " + ex.getFriendlyName());
-                        });
+                        e.getUpgrades().forEach(ex -> logger.debug("Extension successor: " + ex.getFriendlyName()));
                         logger.debug("-----------------------");
                     }
                 }
 
-                final List<SUSEProduct> currentCombination =
-                        new ArrayList<>(installedExtensions.size() + 1);
+                final List<SUSEProduct> currentCombination = new ArrayList<>(installedExtensions.size() + 1);
                 currentCombination.add(baseProduct);
                 currentCombination.addAll(installedExtensions);
 
                 // combinations = base_successors.product(*extension_successors)
                 // combinations.delete([base_product] + installed_extensions)
 
-                final List<List<SUSEProduct>> comb =
-                        new ArrayList<>(extensionSuccessors.size() + 1);
+                final List<List<SUSEProduct>> comb = new ArrayList<>(extensionSuccessors.size() + 1);
                 comb.add(baseSuccessors);
                 comb.addAll(extensionSuccessors);
-
 
                 for (List<SUSEProduct> combination : Lists.combinations(comb)) {
                     if (!combination.equals(currentCombination)) {
                         SUSEProduct base = combination.get(0);
                         if (!ContentSyncManager.isProductAvailable(base, base)) {
                             // No Product Channels means, no subscription to access the channels
-                            logger.debug("No SUSE Product Channels for " + base.getFriendlyName() +
-                                    ". Skipping");
+                            logger.debug("No SUSE Product Channels for " + base.getFriendlyName() + ". Skipping");
                             continue;
                         }
                         if (combination.size() == 1) {
@@ -408,8 +397,7 @@ public class DistUpgradeManager extends BaseManager {
                             result.add(new SUSEProductSet(base, Collections.emptyList()));
                         }
                         else {
-                            List<SUSEProduct> addonProducts = combination
-                                    .subList(1, combination.size());
+                            List<SUSEProduct> addonProducts = combination.subList(1, combination.size());
                             //No Product Channels means, no subscription to access the channels
                             if (addonProducts.stream()
                                     .anyMatch(ap -> !ContentSyncManager.isProductAvailable(ap, base))) {
@@ -423,8 +411,7 @@ public class DistUpgradeManager extends BaseManager {
                                 continue;
                             }
                             logger.debug("Found Target: " + base.getFriendlyName());
-                            addonProducts.forEach(ext -> logger.debug("   - " +
-                                    ext.getFriendlyName()));
+                            addonProducts.forEach(ext -> logger.debug("   - " + ext.getFriendlyName()));
                             result.add(new SUSEProductSet(base, addonProducts));
                         }
                     }

--- a/java/code/src/com/redhat/rhn/manager/distupgrade/test/DistUpgradeManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/distupgrade/test/DistUpgradeManagerTest.java
@@ -141,8 +141,7 @@ public class DistUpgradeManagerTest extends BaseTestCaseWithUser {
         SUSEProduct sourceProduct = SUSEProductTestUtils.createTestSUSEProduct(family);
         SUSEProductTestUtils.createBaseChannelForBaseProduct(sourceProduct, user);
         sourceProduct = TestUtils.saveAndReload(sourceProduct);
-        SUSEProductSet sourceProducts = new SUSEProductSet(
-                sourceProduct, Collections.emptyList());
+        SUSEProductSet sourceProducts = new SUSEProductSet(sourceProduct, Collections.emptyList());
 
         SUSEProduct targetBaseProduct = SUSEProductTestUtils.createTestSUSEProduct(family);
         SUSEProductTestUtils.createBaseChannelForBaseProduct(targetBaseProduct, user);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix combinatorial explosion when generating migrations (bsc#1151888)
 - Change the default value of taskomatic maxmemory to 4GB
 - Return result in compatible type to what defined in database procedure (bsc#1150729)
 - Allow channels names to start with numbers


### PR DESCRIPTION
## What does this PR change?

When generating migrations for a system, SUMA generated very long list of
combinations describing the possible migrations. Illegal migrations were
afterwards filtered out of this list.

We encountered a situation when the code for generating the carthesian product
generated more than 40K lists - these were then passed to the filtering code,
which took too long to be processed.

This PR utilizes an algorithm based on current SCC code, that avoids generating
illegal combinations in the first place.


See also:
- https://github.com/SUSE/happy-customer/pull/4376
- https://github.com/SUSE/happy-customer/commit/f65d368ea9af0478d73f889881fee871babb4e4b#diff-ab3850f702129928674fba99763f033aR94

Review commit-by-commit should be fine.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
- Unit tests were adjusted

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/9567

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test" 
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"                 
- [ ] Re-run test "java_pgsql_tests"             
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"          
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"