### PR TITLE
ignore pycache content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,8 @@ backend/satellite_tools/spacewalk-repo-syncc
 node_modules
 yarn-error.log
 
+rel-eng/custom/__pycache__
+
 # Intellij IDEA
 .idea/
 *.iml


### PR DESCRIPTION
## What does this PR change?

Submission often failed because jenkins could not reset the git because of pathon cache dir.
Try to ignore it.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **no code hanges**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/9782

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test" 
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
