### PR TITLE
Java api expects content as encoded string instead of encoded bytes.

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- Java api expects content as encoded string instead of encoded bytes like before (bsc#1153277)
 - Enable building and installing for Ubuntu 16.04 and Ubuntu 18.04
 - Fix building and installing on CentOS8/RES8/RHEL8
 - Check that a channel doesn't have clones before deleting it (bsc#1138454)

--- a/spacecmd/src/spacecmd/configchannel.py
+++ b/spacecmd/src/spacecmd/configchannel.py
@@ -1271,6 +1271,9 @@ def import_configchannel_fromdetails(self, ccdetails):
                         logging.debug("base64 encoding file")
                         filedetails['contents'] = \
                             base64.b64encode(filedetails['contents'].encode('utf8'))
+
+                        #change bytes to string before sending
+                        filedetails['contents'] =  filedetails['contents'].decode('utf8')
                         filedetails['contents_enc64'] = True
 
                 logging.debug("Creating %s %s" %


### PR DESCRIPTION
Port of https://github.com/SUSE/spacewalk/pull/9745