### PR TITLE
Manager bsc1154275

### DIFF
--- a/backend/server/handlers/xmlrpc/registration.py
+++ b/backend/server/handlers/xmlrpc/registration.py
@@ -319,7 +319,7 @@ class Registration(rhnHandler):
                 newserv.dispose_packages()
                 # The new server may have a different base channel
                 suse_products = None
-                if data.has_key('suse_products'):
+                if 'suse_products' in data:
                     suse_products = data['suse_products']
                 newserv.change_base_channel(release, suse_products=suse_products)
 

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- fix re-registration with re-activation key (bsc#1154275)
 - Add basic support for importing modular repositories
 - Add script to update additional fields in the DB for existing Deb packages
 - use active values for diskchecker mails


### PR DESCRIPTION
## What does this PR change?

Re-registering an existing traditional client via re-activation key fails because of python 3. This patch fixes the issue.

Port of https://github.com/SUSE/spacewalk/pull/9814