### PR TITLE
Change the default value for taskomatic maxmemory to 4GB

### DIFF
--- a/backend/rhn-conf/rhn.conf
+++ b/backend/rhn-conf/rhn.conf
@@ -30,7 +30,7 @@ db_host =
 db_port =
 
 # Adjust taskomatic jvm max memory 
-# taskomatic.java.maxmemory=2048
+# taskomatic.java.maxmemory=4096
 
 # If set to 1 all generated repository metadata will be signed
 sign_metadata = 0

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Change the default value of taskomatic maxmemory to 4GB
 - Add basic support for importing modular repositories
 - Add script to update additional fields in the DB for existing Deb packages
 - use active values for diskchecker mails

--- a/java/conf/default/rhn_taskomatic_daemon.conf
+++ b/java/conf/default/rhn_taskomatic_daemon.conf
@@ -9,4 +9,4 @@ TASKO_RHN_JARS="/usr/share/rhn/lib/spacewalk-asm.jar:/usr/share/rhn/lib/rhn.jar:
 TASKO_JARS="/usr/share/spacewalk/taskomatic/*"
 TASKO_JAVA_OPTS="--add-modules java.annotation,com.sun.xml.bind --add-exports java.annotation/javax.annotation.security=ALL-UNNAMED --add-opens java.annotation/javax.annotation.security=ALL-UNNAMED"
 TASKO_INIT_MEMORY=256
-TASKO_MAX_MEMORY=2048
+TASKO_MAX_MEMORY=4096

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Change the default value of taskomatic maxmemory to 4GB
 - Return result in compatible type to what defined in database procedure (bsc#1150729)
 - Allow channels names to start with numbers
 - Fix: handle special deb package names (bsc#1150113)

--- a/spacewalk/config/spacewalk-config.changes
+++ b/spacewalk/config/spacewalk-config.changes
@@ -1,3 +1,4 @@
+- Change the default value of taskomatic maxmemory to 4GB
 - Resolve modules.yaml file for modular repositories
 - remove superfluous 'apache' entries from sudoers configuration (bsc#1151632)
 - Migrate login to Spark

--- a/spacewalk/config/usr/share/man/man5/rhn.conf.5
+++ b/spacewalk/config/usr/share/man/man5/rhn.conf.5
@@ -219,7 +219,7 @@ then the job will be queued.
 The maximum amount of memory (MB) that Taskomatic can use. If you find that Taskomatic is running out of memory, consider increasing this.
 .IP
 .B Default:
-1024
+4096
 
 .TP
 .B "taskomatic.java.initmemory" (integer)

--- a/spacewalk/config/var/lib/rhn/rhn-satellite-prep/etc/rhn/rhn.conf
+++ b/spacewalk/config/var/lib/rhn/rhn-satellite-prep/etc/rhn/rhn.conf
@@ -77,5 +77,5 @@ server.susemanager.mirrcred_user = @@serverDOTsusemanagerDOTmirrcred_user@@
 server.susemanager.mirrcred_pass = @@serverDOTsusemanagerDOTmirrcred_pass@@
 
 # Maximum Java Heap Size (in MB)
-# taskomatic.java.maxmemory=2048
+# taskomatic.java.maxmemory=4096
 


### PR DESCRIPTION
## What does this PR change?

Port of  https://github.com/SUSE/spacewalk/pull/9793


