### PR TITLE
log invalid database versions

### DIFF
--- a/java/code/src/com/suse/manager/webui/utils/LoginHelper.java
+++ b/java/code/src/com/suse/manager/webui/utils/LoginHelper.java
@@ -366,9 +366,11 @@ public class LoginHelper {
             LocalizationService ls = LocalizationService.getInstance();
             if (serverVersion < MIN_PG_DB_VERSION) {
                 validationErrors.add(ls.getMessage("error.unsupported_db", pgVersion, MIN_PG_DB_VERSION_STRING));
+                log.error(ls.getMessage("error.unsupported_db", pgVersion, MIN_PG_DB_VERSION_STRING));
             }
             else if (!ConfigDefaults.get().isUyuni() && serverVersion < 100001 && osVersion >= 12.4) {
                 validationErrors.add(ls.getMessage("error.unsupported_db_on_os", pgVersion, osName, "10"));
+                log.error(ls.getMessage("error.unsupported_db_on_os", pgVersion, osName, "10"));
             }
         }
         return validationErrors;


### PR DESCRIPTION
## What does this PR change?

Not only show invalid DB versions in the UI but also log it

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **just help debugging customer problems**

- [x] **DONE**

## Links

Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
