### PR TITLE
Prevent error when piping "spacecmd" stdout in Python 2 (bsc#1153090)

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- Prevent error when piping stdout in Python 2 (bsc#1153090)
 - Java api expects content as encoded string instead of encoded bytes like before (bsc#1153277)
 - Enable building and installing for Ubuntu 16.04 and Ubuntu 18.04
 - Fix building and installing on CentOS8/RES8/RHEL8

--- a/spacecmd/src/bin/spacecmd
+++ b/spacecmd/src/bin/spacecmd
@@ -74,7 +74,10 @@ if __name__ == '__main__':
     # pylint: disable=E1101
 
     if not sys.stdout.isatty():
-        sys.stdout = codecs.getwriter(locale.getpreferredencoding())(sys.stdout.buffer)
+        try: # Python 3
+            sys.stdout = codecs.getwriter(locale.getpreferredencoding())(sys.stdout.buffer)
+        except AttributeError: # Python 2
+            sys.stdout = codecs.getwriter(locale.getpreferredencoding())(sys.stdout)
 
     usage = '%(prog)s [options] [command]'
     parser = argparse.ArgumentParser(usage=usage)


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue on `spacecmd` when this command line tools is been executed on a Python 2 system:

```console
py2system:~ # spacecmd -s suma-server -u admin -p admin system_list > /tmp/test
Traceback (most recent call last):
  File "/usr/bin/spacecmd", line 55, in <module>
    sys.stdout = codecs.getwriter(locale.getpreferredencoding())(sys.stdout.buffer)
AttributeError: 'file' object has no attribute 'buffer'
```

After this PR, the `spacecmd` stdout pipe would work as expected.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **bugfix**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/9702

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
