### PR TITLE
Copyright holder is SUSE LLC

### DIFF
--- a/testsuite/MIT-LICENSE.txt
+++ b/testsuite/MIT-LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2010-2011 Novell, Inc.
+Copyright (c) 2010-2019 SUSE LLC.
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/testsuite/features/secondary/srv_distro_cobbler.feature
+++ b/testsuite/features/secondary/srv_distro_cobbler.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2019 Novell, Inc.
+# Copyright (c) 2010-2019 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 Feature: Cobbler and distribution autoinstallation

--- a/testsuite/features/step_definitions/centos_tradclient.rb
+++ b/testsuite/features/step_definitions/centos_tradclient.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 SUSE Linux
+# Copyright (c) 2017-2019 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'xmlrpc/client'

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2019 SUSE
+# Copyright (c) 2014-2019 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'xmlrpc/client'

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2019 SUSE
+# Copyright (c) 2010-2019 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'jwt'

--- a/testsuite/features/step_definitions/datepicker_steps.rb
+++ b/testsuite/features/step_definitions/datepicker_steps.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2019 SUSE
+# Copyright (c) 2017-2019 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'date'

--- a/testsuite/features/step_definitions/docker_steps.rb
+++ b/testsuite/features/step_definitions/docker_steps.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 SUSE Linux
+# Copyright (c) 2017-2019 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'xmlrpc/client'

--- a/testsuite/features/step_definitions/lock_packages_on_client.rb
+++ b/testsuite/features/step_definitions/lock_packages_on_client.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2011 Novell, Inc.
+# Copyright (c) 2010-2019 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 Then(/^"(.*?)" is locked on this client$/) do |pkg|

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2019 Novell, Inc.
+# Copyright (c) 2010-2019 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 #

--- a/testsuite/features/step_definitions/smdba_steps.rb
+++ b/testsuite/features/step_definitions/smdba_steps.rb
@@ -1,4 +1,5 @@
-# Copyright 2011-2018 SUSE
+# Copyright 2011-2018 SUSE LLC.
+# Licensed under the terms of the MIT license.
 
 Given(/^a postgresql database is running$/) do
   $output = sshcmd('file /var/lib/pgsql/data/postgresql.conf', ignore_err: true)

--- a/testsuite/features/support/client_stack.rb
+++ b/testsuite/features/support/client_stack.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2019 SUSE-LINUX
+# Copyright (c) 2010-2019 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'nokogiri'

--- a/testsuite/features/support/cobbler_test.rb
+++ b/testsuite/features/support/cobbler_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2011 Novell, Inc.
+# Copyright (c) 2010-2017 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'xmlrpc/client'

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013-2019 Novell, Inc.
+# Copyright (c) 2013-2019 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'tempfile'

--- a/testsuite/features/support/pretty_formatter.rb
+++ b/testsuite/features/support/pretty_formatter.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013-2019 Novell, Inc.
+# Copyright (c) 2013-2019 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'cucumber/formatter/pretty'

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2019 SUSE-LINUX
+# Copyright (c) 2016-2019 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'twopence'


### PR DESCRIPTION
## What does this PR change?

Conform with today's email "[devel] Copyright attribution in source code" in test suite.

Update years according to git log.

## Links

* 3.2: SUSE/spacewalk#9825
* 4.0: SUSE/spacewalk#9826

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
