### PR TITLE
Reordering dependent features

### DIFF
--- a/testsuite/features/secondary/trad_need_reboot.feature
+++ b/testsuite/features/secondary/trad_need_reboot.feature
@@ -1,6 +1,9 @@
 # COPYRIGHT (c) 2017-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 
+# TODO: This feature must run before install a patch in the client
+# Feature dependency: trad_action_chain.feature
+
 Feature: Reboot required after patch
   In order to avoid systems with different running/installed kernel
   As an authorized user

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -27,6 +27,7 @@
 - features/secondary/min_salt_minions_page.feature
 - features/secondary/min_empty_system_profiles.feature
 - features/secondary/srv_power_management.feature
+- features/secondary/trad_need_reboot.feature
 - features/secondary/trad_action_chain.feature
 - features/secondary/min_action_chain.feature
 - features/secondary/minssh_action_chain.feature

--- a/testsuite/run_sets/secondary_parallelizable.yml
+++ b/testsuite/run_sets/secondary_parallelizable.yml
@@ -57,7 +57,6 @@
 - features/secondary/min_salt_pkgset_beacon.feature
 - features/secondary/min_custom_pkg_download_endpoint.feature
 
-- features/secondary/trad_need_reboot.feature
 - features/secondary/trad_metadata_check.feature
 - features/secondary/trad_cve_id_new_syntax.feature
 - features/secondary/trad_weak_deps.feature


### PR DESCRIPTION
## What does this PR change?

We have a feature that checks that we don't need to reboot a traditional client, also we have a feature that installs a patch in the client which requires a reboot. We changed the order so the tests don't collide. So, we reverted the order it has before the re-organization of features in stages.

Port of https://github.com/SUSE/spacewalk/pull/9824

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
