### PR TITLE
Move push-to-obs cleaning to its own script, and run it always

### DIFF
--- a/susemanager-utils/testing/automation/push-to-obs.sh
+++ b/susemanager-utils/testing/automation/push-to-obs.sh
@@ -51,6 +51,7 @@ if [ ! -f ${CREDENTIALS} ]; then
 fi
 
 PUSH_CMD="/manager/susemanager-utils/testing/docker/scripts/push-to-obs.sh -d '${DESTINATIONS}' -c /tmp/.oscrc ${VERBOSE} ${TEST}"
+CLEAN_CMD="cd /manager; /manager/susemanager-utils/testing/docker/scripts/clean-push-to-obs.sh"
 
 docker pull $REGISTRY/$PUSH2OBS_CONTAINER
-docker run --rm=true -v "$GITROOT:/manager" -v "/srv/mirror:/srv/mirror" --mount type=bind,source=${CREDENTIALS},target=/tmp/.oscrc $REGISTRY/$PUSH2OBS_CONTAINER /bin/bash -c "${PUSH_CMD}"
+docker run --rm=true -v "$GITROOT:/manager" -v "/srv/mirror:/srv/mirror" --mount type=bind,source=${CREDENTIALS},target=/tmp/.oscrc $REGISTRY/$PUSH2OBS_CONTAINER /bin/bash -c "${PUSH_CMD}; RET=\${?}; ${CLEAN_CMD} && exit \${RET}"

--- a/susemanager-utils/testing/docker/scripts/clean-push-to-obs.sh
+++ b/susemanager-utils/testing/docker/scripts/clean-push-to-obs.sh
@@ -1,0 +1,8 @@
+#/bin/bash -e
+echo "*************** CLEANING DIRECTORIES GENERATED AS USER ROOT  ***************"
+rm -rf susemanager-frontend/susemanager-nodejs-sdk-devel/node_modules
+rm -rf susemanager-frontend/node_modules
+rm -rf web/html/src/node_modules
+rm -rf web/html/src/dist
+rm -f susemanager-frontend/susemanager-nodejs-sdk-devel/susemanager-nodejs-modules.tar.gz
+rm -rf rel-eng/custom/*

--- a/susemanager-utils/testing/docker/scripts/push-to-obs.sh
+++ b/susemanager-utils/testing/docker/scripts/push-to-obs.sh
@@ -67,10 +67,3 @@ for DESTINATION in $(echo ${DESTINATIONS}|tr ',' ' '); do
   echo "*************** PUSHING TO ${OBS_PROJ} ***************"
   ./push-packages-to-obs.sh
 done
-
-# Clean directories generated as user root
-rm -r ../susemanager-frontend/susemanager-nodejs-sdk-devel/node_modules ||:
-rm -r ../susemanager-frontend/node_modules ||:
-rm -r ../web/html/src/node_modules ||:
-rm -r ../web/html/src/dist ||:
-rm ../susemanager-frontend/susemanager-nodejs-sdk-devel/susemanager-nodejs-modules.tar.gz ||:


### PR DESCRIPTION
## What does this PR change?

Move push-to-obs cleaning to its own script, and run it always
## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: CI script

- [x] **DONE**

## Test coverage
- No tests: No testing for such scripts.

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
