### PR TITLE
fix cobbler unit tests by migrating old default config

### DIFF
--- a/susemanager-utils/testing/docker/scripts/test_cobbler.sh
+++ b/susemanager-utils/testing/docker/scripts/test_cobbler.sh
@@ -13,6 +13,9 @@ cp /root/cobbler_web.conf /etc/apache2/vhosts.d/cobbler_web.conf
 cp /root/apache2 /etc/sysconfig/apache2
 cp /root/sample.ks /var/lib/cobbler/kickstarts/sample.ks
 
+# migrate modules.conf
+/usr/share/cobbler/bin/settings-migration-v1-to-v2.sh -s
+
 # start apache - required by cobbler tests
 /usr/sbin/start_apache2 -D SYSTEMD  -k start
 


### PR DESCRIPTION
## What does this PR change?

The cobbler unit tests run with an old config which is part of the container.
Let's call the migration script (as test) and migrate the config.

In future we should change the container to put a correct config in place.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- fixes tests

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/9832
Tracks https://github.com/SUSE/spacewalk/pull/9837

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
