### PR TITLE
More logs in the step implementations

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -371,7 +371,7 @@ Then(/^I wait until mgr-sync refresh is finished$/) do
 end
 
 Then(/^I should see "(.*?)" in the output$/) do |arg1|
-  assert_includes(@command_output, arg1)
+  raise "Command Output #{@command_output} don't include #{arg1}" unless @command_output.include? arg1
 end
 
 Then(/^service "([^"]*)" is enabled on "([^"]*)"$/) do |service, host|

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -525,14 +525,14 @@ end
 When(/^I set the activation key "([^"]*)" in the bootstrap script on the server$/) do |key|
   $server.run("sed -i '/^ACTIVATION_KEYS=/c\\ACTIVATION_KEYS=#{key}' /srv/www/htdocs/pub/bootstrap/bootstrap.sh")
   output, code = $server.run('cat /srv/www/htdocs/pub/bootstrap/bootstrap.sh')
-  assert(output.include?(key))
+  raise "Key: #{key} not included" unless output.include? key
 end
 
 When(/^I create bootstrap script and set the activation key "([^"]*)" in the bootstrap script on the proxy$/) do |key|
   $proxy.run('mgr-bootstrap')
   $proxy.run("sed -i '/^ACTIVATION_KEYS=/c\\ACTIVATION_KEYS=#{key}' /srv/www/htdocs/pub/bootstrap/bootstrap.sh")
   output, code = $proxy.run('cat /srv/www/htdocs/pub/bootstrap/bootstrap.sh')
-  assert(output.include?(key))
+  raise "Key: #{key} not included" unless output.include? key
 end
 
 When(/^I bootstrap pxeboot minion via bootstrap script on the proxy$/) do

--- a/testsuite/features/step_definitions/docker_steps.rb
+++ b/testsuite/features/step_definitions/docker_steps.rb
@@ -128,13 +128,13 @@ end
 When(/^I list image store types and image stores via XML-RPC$/) do
   cont_op.login('admin', 'admin')
   store_typ = cont_op.list_image_store_types
-  assert_equal(store_typ.length, 2, 'we have only type support for Registry and OS Image Store type! New method added?! please update the tests')
-  assert_equal(store_typ[0]['label'], 'registry', 'imagestore label type should be registry!')
-  assert_equal(store_typ[1]['label'], 'os_image', 'imagestore label type should be OS image!')
+  raise 'We have only type support for Registry and OS Image Store type! New method added?! please update the tests' unless store_typ.length == 2
+  raise "imagestore label type should be 'registry' but is #{store_typ[0]['label']}" unless store_typ[0]['label'] == 'registry'
+  raise "imagestore label type should be 'os_image' but is #{store_typ[1]['label']}" unless store_typ[1]['label'] == 'os_image'
+
   registry_list = cont_op.list_image_stores
-  puts registry_list
-  assert_equal(registry_list[0]['label'], 'galaxy-registry', 'label is galaxy!')
-  assert_equal(registry_list[0]['uri'], 'registry.mgr.suse.de', 'uri should be registry.mgr.suse.de')
+  raise "Label #{registry_list[0]['label']} is different than 'galaxy-registry'" unless registry_list[0]['label'] == 'galaxy-registry'
+  raise "URI #{registry_list[0]['uri']} is different than 'registry.mgr.suse.de'" unless registry_list[0]['uri'] == 'registry.mgr.suse.de'
 end
 
 When(/^I set and get details of image store via XML-RPC$/) do
@@ -149,8 +149,8 @@ When(/^I set and get details of image store via XML-RPC$/) do
   cont_op.set_details('Norimberga', details_store)
   # test getDetails call
   details = cont_op.get_details_store('Norimberga')
-  assert_equal(details['uri'], 'Germania', 'uri should be Germania')
-  assert_equal(details['username'], '', 'username should be empty')
+  raise "uri should be Germania but is #{details['uri']}" unless details['uri'] == 'Germania'
+  raise "username should be empty but is #{details['username']}" unless details['username'] == ''
   cont_op.delete_store('Norimberga')
 end
 
@@ -171,11 +171,11 @@ When(/^I create and delete profile custom values via XML-RPC$/) do
   values['arancio'] = 'arancia xmlrpc tests'
   cont_op.set_profile_custom_values('fakeone', values)
   pro_det = cont_op.get_profile_custom_values('fakeone')
-  assert_equal(pro_det['arancio'], 'arancia xmlrpc tests', 'setting custom profile value failed')
+  raise "setting custom profile value failed: #{pro_det['arancio']} != 'arancia xmlrpc tests'" unless pro_det['arancio'] == 'arancia xmlrpc tests'
   pro_type = cont_op.list_image_profile_types
-  assert_equal(pro_type.length, 2, 'support for Dockerfile and Kiwi profiles')
-  assert_equal(pro_type[0], 'dockerfile', 'type is not dockerfile?')
-  assert_equal(pro_type[1], 'kiwi', 'type is not kiwi?')
+  raise "Number of image profile types is #{pro_type.length}" unless pro_type.length == 2
+  raise "type #{pro_type[0]} is not dockerfile" unless pro_type[0] == 'dockerfile'
+  raise "type #{pro_type[1]} is not kiwi" unless pro_type[1] == 'kiwi'
   key = ['arancio']
   cont_op.delete_profile_custom_values('fakeone', key)
 end
@@ -185,7 +185,7 @@ When(/^I list image profiles via XML-RPC$/) do
   puts cont_op.list_image_profiles
   ima_profiles = cont_op.list_image_profiles
   imagelabel = ima_profiles.select { |image| image['label'] = 'fakeone' }
-  assert_equal(imagelabel[0]['label'], 'fakeone', 'label of container should be fakeone!')
+  raise "label of container should be fakeone! #{imagelabel[0]['label']} != 'fakeone'" unless imagelabel[0]['label'] == 'fakeone'
 end
 
 When(/^I set and get profile details via XML-RPC$/) do
@@ -196,7 +196,7 @@ When(/^I set and get profile details via XML-RPC$/) do
   details['activationKey'] = ''
   cont_op.set_profile_details('fakeone', details)
   cont_detail = cont_op.get_details('fakeone')
-  assert_equal(cont_detail['label'], 'fakeone', 'label test fail!')
-  assert_equal(cont_detail['imageType'], 'dockerfile', 'imagetype test fail!')
+  raise "label test fail! #{cont_detail['label']} != 'fakeone'" unless cont_detail['label'] == 'fakeone'
+  raise "imagetype test fail! #{cont_detail['imageType']} != 'dockerfile'" unless cont_detail['imageType'] == 'dockerfile'
   cont_op.delete_profile('fakeone')
 end

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -475,13 +475,13 @@ Then(/^the timezone on "([^"]*)" should be "([^"]*)"$/) do |minion, timezone|
   output, _code = node.run('date +%Z')
   result = output.strip
   result = 'CET' if result == 'CEST'
-  raise unless result == timezone
+  raise "The timezone #{timezone} is different to #{result}" unless result == timezone
 end
 
 Then(/^the keymap on "([^"]*)" should be "([^"]*)"$/) do |minion, keymap|
   node = get_target(minion)
   output, _code = node.run('cat /etc/vconsole.conf')
-  raise unless output.strip == "KEYMAP=#{keymap}"
+  raise "The keymap #{keymap} is different to the output: #{output.strip}" unless output.strip == "KEYMAP=#{keymap}"
 end
 
 Then(/^the language on "([^"]*)" should be "([^"]*)"$/) do |minion, language|
@@ -489,7 +489,7 @@ Then(/^the language on "([^"]*)" should be "([^"]*)"$/) do |minion, language|
   output, _code = node.run("grep 'RC_LANG=' /etc/sysconfig/language")
   unless output.strip == "RC_LANG=\"#{language}\""
     output, _code = node.run("grep 'LANG=' /etc/locale.conf")
-    raise unless output.strip == "LANG=#{language}"
+    raise "The language #{language} is different to the output: #{output.strip}" unless output.strip == "LANG=#{language}"
   end
 end
 
@@ -511,13 +511,13 @@ Then(/^the pillar data for "([^"]*)" should (be|contain|not contain) "([^"]*)" o
   end
   output, _code = $server.run("#{cmd} '#{system_name}' pillar.get '#{key}' #{extra_cmd}")
   if verb == 'be' && value == ''
-    raise unless output.split("\n").length == 1
+    raise "Output has more than one line: #{output}" unless output.split("\n").length == 1
   elsif verb == 'be'
-    raise unless output.split("\n")[1].strip == value
+    raise "Output value is different than #{value}: #{output}" unless output.split("\n")[1].strip == value
   elsif verb == 'contain'
-    raise unless output.include? value
+    raise "Output doesn't contain #{value}: #{output}" unless output.include? value
   elsif verb == 'not contain'
-    raise if output.include? value
+    raise "Output contains #{value}: #{output}" if output.include? value
   else
     raise 'Invalid verb'
   end


### PR DESCRIPTION
## What does this PR change?

Adding more logs into some salt and docker steps
Port of https://github.com/SUSE/spacewalk/pull/9794

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
