### PR TITLE
Refactor of click methods for spa support

### DIFF
--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -113,34 +113,40 @@ end
 
 def click_button_and_wait(locator = nil, **options)
   page.click_button(locator, options)
-  # TODO: Rid of sleep in those wrappers, sometimes .senna-loading still not loaded,
-  #       so we don't wait for the ajax transition. We added this sleep because using:
-  #       > has_css?('.senna-loading', wait: 0.3)
-  #       raise the error:
-  #       > stale element reference: element is not attached to the page document
-  #       We couldn't bring a better solution for now
-  sleep 0.5
-  raise 'Timeout: Waiting AJAX transition (click button)' unless page.has_no_css?('.senna-loading')
+  begin
+    raise 'Timeout: Waiting AJAX transition (click link)' unless page.has_no_css?('.senna-loading', wait: 1)
+  rescue StandardError => e
+    puts e.message # Skip errors related to .senna-loading element
+  end
 end
 
 def click_link_and_wait(locator = nil, **options)
   page.click_link(locator, options)
-  sleep 0.5
-  raise 'Timeout: Waiting AJAX transition (click link)' unless page.has_no_css?('.senna-loading')
+  begin
+    raise 'Timeout: Waiting AJAX transition (click link)' unless page.has_no_css?('.senna-loading', wait: 1)
+  rescue StandardError => e
+    puts e.message # Skip errors related to .senna-loading element
+  end
 end
 
 def click_link_or_button_and_wait(locator = nil, **options)
   page.click_link_or_button(locator, options)
-  sleep 0.5
-  raise 'Timeout: Waiting AJAX transition (click link or button)' unless page.has_no_css?('.senna-loading')
+  begin
+    raise 'Timeout: Waiting AJAX transition (click link)' unless page.has_no_css?('.senna-loading', wait: 1)
+  rescue StandardError => e
+    puts e.message # Skip errors related to .senna-loading element
+  end
 end
 
 # Capybara Node Element extension to override click method, clicking and then waiting for ajax transition
 module CapybaraNodeElementExtension
   def click
     super
-    sleep 0.5
-    raise 'Timeout: Waiting AJAX transition (find::click)' unless has_no_css?('.senna-loading')
+    begin
+      raise 'Timeout: Waiting AJAX transition (click link)' unless page.has_no_css?('.senna-loading', wait: 1)
+    rescue StandardError => e
+      puts e.message # Skip errors related to .senna-loading element
+    end
   end
 end
 


### PR DESCRIPTION
## What does this PR change?

We dimension the scope of the rescue to just the capybara method related to senna-loading element.
Otherwise, we were skipping a real issue with elements to click not found.

As we reduced the use of those click methods to only the actions with a spa transition, I removed the sleep and added a timeout of 1 sec to wait until the element has been removed from the page.

Port of https://github.com/SUSE/spacewalk/pull/9620

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
