### PR TITLE
Opensuse as vendor channel bootstrap data

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -294,7 +294,36 @@ RES7 = [
     "dmidecode",
 ]
 
-PKGLIST15 = [
+PKGLIST15_SALT = [
+    "libpgm-5_2-0",
+    "libsodium23",
+    "libzmq5",
+    "python3-Babel",
+    "python3-certifi",
+    "python3-chardet",
+    "python3-idna",
+    "python3-Jinja2",
+    "python3-MarkupSafe",
+    "python3-msgpack",
+    "python3-psutil",
+    "python3-py",
+    "python3-pycrypto",
+    "python3-pytz",
+    "python3-PyYAML",
+    "python3-pyzmq",
+    "python3-requests",
+    "python3-rpm",
+    "python3-simplejson",
+    "python3-six",
+    "python3-tornado",
+    "python3-urllib3",
+    "timezone",
+    "salt",
+    "python3-salt",
+    "salt-minion",
+]
+
+PKGLIST15_TRAD = [
     "libgudev-1_0-0",
     "libnewt0_52",
     "libslang2",
@@ -304,7 +333,6 @@ PKGLIST15 = [
     "python3-cryptography",
     "python-dmidecode",
     "python3-dmidecode",
-    "python3-idna",
     "python3-libxml2-python",
     "python3-netifaces",
     "python3-newt",
@@ -312,7 +340,6 @@ PKGLIST15 = [
     "python3-pycparser",
     "python3-pyOpenSSL",
     "python3-pyudev",
-    "python3-rpm",
     "python3-packaging",
     "python3-setuptools",
     "python3-appdirs",
@@ -333,30 +360,6 @@ PKGLIST15 = [
     "zypp-plugin-spacewalk",
     "python3-zypp-plugin",
     "python3-zypp-plugin-spacewalk",
-    "libpgm-5_2-0",
-    "libsodium23",
-    "libzmq5",
-    "python3-Babel",
-    "python3-certifi",
-    "python3-chardet",
-    "python3-Jinja2",
-    "python3-MarkupSafe",
-    "python3-msgpack",
-    "python3-psutil",
-    "python3-py",
-    "python3-pycrypto",
-    "python3-pytz",
-    "python3-PyYAML",
-    "python3-pyzmq",
-    "python3-requests",
-    "python3-simplejson",
-    "python3-six",
-    "python3-tornado",
-    "python3-urllib3",
-    "timezone",
-    "salt",
-    "python3-salt",
-    "salt-minion",
 ]
 
 PKGLIST15_X86_ARM = [
@@ -735,35 +738,35 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/3/bootstrap/'
     },
     'SLE-15-aarch64' : {
-        'PDID' : [1589, 1709], 'PKGLIST' : PKGLIST15 + PKGLIST15_X86_ARM,
+        'PDID' : [1589, 1709], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/0/bootstrap/'
     },
     'SLE-15-ppc64le' : {
-        'PDID' : [1588, 1710], 'PKGLIST' : PKGLIST15 + PKGLIST15_PPC,
+        'PDID' : [1588, 1710], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_PPC,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/0/bootstrap/'
     },
     'SLE-15-s390x' : {
-        'PDID' : [1587, 1711], 'PKGLIST' : PKGLIST15 + PKGLIST15_Z,
+        'PDID' : [1587, 1711], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_Z,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/0/bootstrap/'
     },
     'SLE-15-x86_64' : {
-        'PDID' : [1576, 1712], 'PKGLIST' : PKGLIST15 + PKGLIST15_X86_ARM,
+        'PDID' : [1576, 1712], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/0/bootstrap/'
     },
     'SLE-15-SP1-aarch64' : {
-        'PDID' : [1769, 1709], 'PKGLIST' : PKGLIST15 + PKGLIST15_X86_ARM,
+        'PDID' : [1769, 1709], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/1/bootstrap/'
     },
     'SLE-15-SP1-ppc64le' : {
-        'PDID' : [1770, 1710], 'PKGLIST' : PKGLIST15 + PKGLIST15_PPC,
+        'PDID' : [1770, 1710], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_PPC,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/1/bootstrap/'
     },
     'SLE-15-SP1-s390x' : {
-        'PDID' : [1771, 1711], 'PKGLIST' : PKGLIST15 + PKGLIST15_Z,
+        'PDID' : [1771, 1711], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_Z,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/1/bootstrap/'
     },
     'SLE-15-SP1-x86_64' : {
-        'PDID' : [1772, 1712], 'PKGLIST' : PKGLIST15 + PKGLIST15_X86_ARM,
+        'PDID' : [1772, 1712], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/1/bootstrap/'
     },
     'openSUSE-Leap-42.3-x86_64' : {
@@ -775,15 +778,15 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/opensuse/15/0/bootstrap/'
     },
     'openSUSE-Leap-15.1-x86_64-uyuni' : {
-        'BASECHANNEL' : 'opensuse_leap15_1-x86_64', 'PKGLIST' : PKGLIST15 + PKGLIST15_X86_ARM,
+        'BASECHANNEL' : 'opensuse_leap15_1-x86_64', 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/opensuse/15/1/bootstrap/'
     },
     'openSUSE-Leap-15.1-x86_64' : {
-        'PDID' : [1929], 'PKGLIST' : PKGLIST15 + PKGLIST15_X86_ARM,
+        'PDID' : [1929], 'PKGLIST' : PKGLIST15_SALT + PKGLIST15_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/opensuse/15/1/bootstrap/'
     },
     'openSUSE-Leap-15.2-x86_64' : {
-        'PDID' : [2001], 'PKGLIST' : PKGLIST15 + PKGLIST15_X86_ARM,
+        'PDID' : [2001], 'PKGLIST' : PKGLIST15_SALT + PKGLIST15_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/opensuse/15/2/bootstrap/'
     },
     'centos-6-x86_64' : {

--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -774,7 +774,7 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/opensuse/42/3/bootstrap/'
     },
     'openSUSE-Leap-15-x86_64' : {
-        'BASECHANNEL' : 'opensuse_leap15_0-x86_64', 'PKGLIST' : PKGLIST15 + PKGLIST15_X86_ARM,
+        'BASECHANNEL' : 'opensuse_leap15_0-x86_64', 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/opensuse/15/0/bootstrap/'
     },
     'openSUSE-Leap-15.1-x86_64-uyuni' : {

--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -782,6 +782,10 @@ DATA = {
         'PDID' : [1929], 'PKGLIST' : PKGLIST15 + PKGLIST15_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/opensuse/15/1/bootstrap/'
     },
+    'openSUSE-Leap-15.2-x86_64' : {
+        'PDID' : [2001], 'PKGLIST' : PKGLIST15 + PKGLIST15_X86_ARM,
+        'DEST' : '/srv/www/htdocs/pub/repositories/opensuse/15/2/bootstrap/'
+    },
     'centos-6-x86_64' : {
         'BASECHANNEL' : 'centos6-x86_64', 'PKGLIST' : RES6,
         'DEST' : '/srv/www/htdocs/pub/repositories/centos/6/bootstrap/'

--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -774,8 +774,12 @@ DATA = {
         'BASECHANNEL' : 'opensuse_leap15_0-x86_64', 'PKGLIST' : PKGLIST15 + PKGLIST15_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/opensuse/15/0/bootstrap/'
     },
-    'openSUSE-Leap-15.1-x86_64' : {
+    'openSUSE-Leap-15.1-x86_64-uyuni' : {
         'BASECHANNEL' : 'opensuse_leap15_1-x86_64', 'PKGLIST' : PKGLIST15 + PKGLIST15_X86_ARM,
+        'DEST' : '/srv/www/htdocs/pub/repositories/opensuse/15/1/bootstrap/'
+    },
+    'openSUSE-Leap-15.1-x86_64' : {
+        'PDID' : [1929], 'PKGLIST' : PKGLIST15 + PKGLIST15_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/opensuse/15/1/bootstrap/'
     },
     'centos-6-x86_64' : {

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,6 @@
+- prepare bootstrap data for upcoming openSUSE 15.2
+- add bootstrap data for openSUSE 15.1 when mirrored as
+  Vendor Channels (bsc#1154474)
 - Require dmidecode only for SLE12 aarch64 and x86_64 (bsc#1152170)
 - Require pmtools only for SLE11 i586 and x86_64 (bsc#1150314)
 - fix test for btrfs subvolume for new btrfs version (bsc#1151666)


### PR DESCRIPTION
## What does this PR change?

Create bootstrap data for openSUSE 15.1 when mirrored as Vendor Channel

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/9830
Tracks https://github.com/SUSE/spacewalk/pull/9846

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
