### PR TITLE
Reverting cucumber and capybara gems

### DIFF
--- a/testsuite/Gemfile
+++ b/testsuite/Gemfile
@@ -1,9 +1,9 @@
 source 'https://rubygems.org'
 
-gem 'cucumber', '3.1.2'
+gem 'cucumber', '2.0.0'
 gem 'rack', '2.0.7'
 gem 'rack-test', '1.1.0'
-gem 'capybara', '2.18.0'
+gem 'capybara', '2.16.0'
 gem 'jwt', '2.2.1'
 gem 'mime-types', '3.2.2'
 gem 'net-ssh', '5.2.0'


### PR DESCRIPTION
## What does this PR change?

Reverting temporarily Cucumber and Capybara to recover screenshots in the report.

Port of https://github.com/SUSE/spacewalk/pull/9424

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #
Tracks https://github.com/SUSE/spacewalk/pull/9424

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
