### PR TITLE
Enable new uyuni versioning spacewalk-web

### DIFF
--- a/web/conf/rhn_web.conf
+++ b/web/conf/rhn_web.conf
@@ -67,8 +67,14 @@ web.traceback_mail =
 web.config_delim_start = {|
 web.config_delim_end = |}
 
-# the version of this RHN install as a whole
+# the version of SUSE Manager to show at the WebUI
 web.version = 4.1.0 Alpha1
+
+# the version of Uyuni to show at the WebUI, it will be prepended
+# to web.version as version for the SPECs, when building them
+# for Uyuni
+web.version.uyuni =  201910
+
 web.buildtimestamp = _OBS_BUILD_TIMESTAMP_
 
 # maximum size for a config file


### PR DESCRIPTION
## What does this PR change?

Enable new uyuni versioning spacewalk-web

If `web.version.uyuni` is present at `web/conf/rhn_web` config, and if the OS is openSUSE, the WebUI needs to use this new value. That's part of another PR that is still pending.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: We don't talk about package versioning at the doc.

- [x] **DONE**

## Test coverage
- No tests: Submission itself covers it.

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/9560
Fixes https://github.com/SUSE/spacewalk/issues/9561

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql" 		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
