### PR TITLE
Filter products recursively by channels summary and extension label

### DIFF
--- a/web/html/src/manager/admin/setup/products/products.js
+++ b/web/html/src/manager/admin/setup/products/products.js
@@ -1,6 +1,8 @@
 /* eslint-disable */
 'use strict';
 
+import {searchCriteriaInExtension} from "./products.utils";
+
 const {SectionToolbar} = require("components/section-toolbar/section-toolbar");
 const React = require('react');
 const ReactDOM = require('react-dom');
@@ -424,13 +426,6 @@ class Products extends React.Component {
     this.props.handleUnSelectedItems(items);
   };
 
-  searchData = (datum, criteria) => {
-    if (criteria && datum.label) {
-      return (datum.label).toLowerCase().includes(criteria.toLowerCase());
-    }
-    return true;
-  };
-
   buildRows = (message) => {
     return Object.keys(message).map((id) => message[id]);
   };
@@ -465,7 +460,7 @@ class Products extends React.Component {
           loading={this.props.loading}
           additionalFilters={[archFilter]}
           searchField={
-              <SearchField filter={this.searchData}
+              <SearchField filter={searchCriteriaInExtension}
                   criteria={''}
                   placeholder={t('Filter by product Description')}
                   name='product-description-filter'

--- a/web/html/src/manager/admin/setup/products/products.test.js
+++ b/web/html/src/manager/admin/setup/products/products.test.js
@@ -1,0 +1,84 @@
+import {searchCriteriaInExtension} from "./products.utils";
+
+const extension = {
+  label: "suse base 1 2 asd",
+  channels: [{summary: 'suse base 1 channel 1  '}, {summary: 'suse base 1 channel 2  '}],
+  extensions: [
+    {
+      label: "suse extension 1 child 1",
+      channels: [{summary: 'suse extension 1 child 1 channel 1'}, {summary: 'suse extension 1 child 1 channel 2'}],
+      extensions: []
+    },
+    {
+      label: "suse extension 1 child 2",
+      channels: [{summary: 'suse extension 1 child 2 channel 1'}, {summary: 'suse extension 1 child 2 channel 2'}],
+      extensions: [
+        {
+          label: "suse extension 2 child 1",
+          channels: [{summary: 'suse extension 2 child 1 channel 1'}, {summary: 'suse extension 2 child 1 channel 2'}],
+          extensions: [
+            {
+              label: "suse extension 3 child 1",
+              channels: [{summary: 'suse extension 3 child 1 channel 1'}, {summary: 'suse extension 3 child 1 channel 2'}],
+              extensions: []
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+
+describe('Testing searchCriteriaInExtension', () => {
+  test('check criteria in base extension label and channels', () => {
+
+    const criteriaLabel = "base 1";
+    const criteriaChannel1 = "base 1 channel 1";
+    const criteriaChannel2 = "base 1 channel 2";
+    const criteriaWrong = "redhat";
+
+    expect(searchCriteriaInExtension(extension, criteriaLabel)).toBeTruthy();
+    expect(searchCriteriaInExtension(extension, criteriaChannel1)).toBeTruthy();
+    expect(searchCriteriaInExtension(extension, criteriaChannel2)).toBeTruthy();
+    expect(searchCriteriaInExtension(extension, criteriaWrong)).toBeFalsy();
+  })
+
+  test('check criteria in first level extension label and channels', () => {
+
+    const criteriaLabel = "extension 1 child 1";
+    const criteriaChannel1 = "extension 1 child 1 channel 1";
+    const criteriaChannel2 = "extension 1 child 1 channel 1";
+    const criteriaWrong = "redhat";
+
+    expect(searchCriteriaInExtension(extension, criteriaLabel)).toBeTruthy();
+    expect(searchCriteriaInExtension(extension, criteriaChannel1)).toBeTruthy();
+    expect(searchCriteriaInExtension(extension, criteriaChannel2)).toBeTruthy();
+    expect(searchCriteriaInExtension(extension, criteriaWrong)).toBeFalsy();
+  })
+
+  test('check criteria in second level extension label and channels', () => {
+
+    const criteriaLabel = "suse extension 2 child 1";
+    const criteriaChannel1 = "extension 2 child 1 channel 1";
+    const criteriaChannel2 = "suse extension 2 child 1 channel 2";
+    const criteriaWrong = "redhat";
+
+    expect(searchCriteriaInExtension(extension, criteriaLabel)).toBeTruthy();
+    expect(searchCriteriaInExtension(extension, criteriaChannel1)).toBeTruthy();
+    expect(searchCriteriaInExtension(extension, criteriaChannel2)).toBeTruthy();
+    expect(searchCriteriaInExtension(extension, criteriaWrong)).toBeFalsy();
+  })
+
+  test('check criteria in third level extension label and channels', () => {
+
+    const criteriaLabel = "extension 3";
+    const criteriaChannel1 = "extension 3";
+    const criteriaChannel2 = "extension 3";
+    const criteriaWrong = "redhat 3 extension";
+
+    expect(searchCriteriaInExtension(extension, criteriaLabel)).toBeTruthy();
+    expect(searchCriteriaInExtension(extension, criteriaChannel1)).toBeTruthy();
+    expect(searchCriteriaInExtension(extension, criteriaChannel2)).toBeTruthy();
+    expect(searchCriteriaInExtension(extension, criteriaWrong)).toBeFalsy();
+  })
+})

--- a/web/html/src/manager/admin/setup/products/products.utils.js
+++ b/web/html/src/manager/admin/setup/products/products.utils.js
@@ -1,0 +1,22 @@
+const _isEmpty = require("lodash/isEmpty");
+
+export function searchCriteriaInExtension(baseExtension, criteria) {
+  if (criteria) {
+    function checkExtension(extension) {
+      const isCriteriaInLabel = extension.label && (extension.label).toLowerCase().includes(criteria.toLowerCase());
+      const isCriteriaInChannels = !_isEmpty(extension.channels) &&
+        extension.channels.some(c => c.summary && (c.summary).toLowerCase().includes(criteria.toLowerCase()));
+      return isCriteriaInLabel || isCriteriaInChannels;
+    }
+
+    // returns true, if at least one extension matches the criteria
+    function extensionRecursiveIterator(extension) {
+      return checkExtension(extension) ||
+        (!_isEmpty(extension.extensions) && extension.extensions.some(ext => extensionRecursiveIterator(ext)));
+    }
+
+    return extensionRecursiveIterator(baseExtension);
+  }
+
+  return true;
+}

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Filter by description on the Products page works recursively
 - Add check/message for project not found (bsc#1145755)
 - Fix sorting issues on content filter list page (bsc#1145591)
 - Remove/change text on edit filters for clp (bsc#1145608)


### PR DESCRIPTION
## What does this PR change?

Filter products recursively by channels summary and extension label.

@mcalmer @ncounter 

@joesusecom also mentioned we could do: 

> For products like CaaSP that are add-ons, we may want to go further than that and offer some kind of "product filter" to start with.

I think I need some help on that one, I am not sure I understood it. 

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed

- [ ] **DONE**

## Test coverage
- Unit tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks https://github.com/SUSE/spacewalk/issues/4391

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
