### PR TITLE
better error message when removing channels

### DIFF
--- a/backend/satellite_tools/contentRemove.py
+++ b/backend/satellite_tools/contentRemove.py
@@ -297,6 +297,19 @@ def delete_channels(channelLabels, force=0, justdb=0, skip_packages=0, skip_chan
     if not channel_ids:
         return
 
+    clp = rhnSQL.prepare("""
+       select id
+       from susecontentenvironmenttarget
+       where channel_id = :cid
+       """)
+
+    for cid in channel_ids:
+        clp.execute(cid=cid)
+        row = clp.fetchone()
+        if row:
+            print("Channel belongs to a Content Lifecycle Project. Please use the web UI or API.")
+            return
+
     indirect_tables = [
         ['rhnKickstartableTree', 'channel_id', 'rhnKSTreeFile', 'kstree_id'],
     ]

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Improve error message when deleting channel that's in a content lifecycle project (bsc#1145769)
 - fix problems with Package Hub repos having multiple rpms with same NEVRA
   but different checksums (bsc#1146683)
 - fix re-registration with re-activation key (bsc#1154275)


### PR DESCRIPTION
## What does this PR change?

port from manager... 9315
## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
