### PR TITLE
add a checksum dir to the staging area to allow multiple packages with same name

### DIFF
--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -999,7 +999,7 @@ class RepoSync(object):
         for what in to_process:
             pack, to_download, to_link = what
             if to_download:
-                target_file = os.path.join(plug.repo.pkgdir, os.path.basename(pack.unique_id.relativepath))
+                target_file = os.path.join(plug.repo.pkgdir, pack.checksum, os.path.basename(pack.unique_id.relativepath))
                 pack.path = target_file
                 params = {}
                 checksum_type = pack.checksum_type
@@ -1134,8 +1134,12 @@ class RepoSync(object):
                 to_process[index] = (pack, False, False)
                 progress_bar.log(False, None)
             finally:
-                if is_non_local_repo and stage_path and os.path.exists(stage_path):
-                    os.remove(stage_path)
+                if is_non_local_repo and stage_path:
+                    if os.path.exists(stage_path):
+                        os.remove(stage_path)
+                    if os.path.exists(os.path.dirname(stage_path)):
+                        # remove the checksum directory
+                        os.rmdir(os.path.dirname(stage_path))
             pack.clear_header()
         if affected_channels:
             errataCache.schedule_errata_cache_update(affected_channels)

--- a/proxy/proxy/broker/rhnBroker.py
+++ b/proxy/proxy/broker/rhnBroker.py
@@ -18,6 +18,7 @@
 import time
 import socket
 import re
+import os
 try:
     # python 3
     from urllib.parse import urlparse, urlunparse
@@ -465,6 +466,8 @@ class BrokerHandler(SharedHandler):
         else:
             # Some other type of request
             (req_type, reqident, reqaction, reqparams) = self._split_url(req)
+            if reqaction == 'getPackage':
+                reqparams = tuple([os.path.join(*reqparams)])
 
         if req_type is None or (req_type not in
                                 ['$RHN', 'GET-REQ', 'tinyurl', 'ks-dist']):


### PR DESCRIPTION
## What does this PR change?

Follow up of https://github.com/uyuni-project/uyuni/pull/1438
During repo-sync we download the packages into a staging area. If we have multiple packages with the same name they overwrite each other and we get checksum errors.

This PR create a directory with the checksum in the staging area to prevent overwriting of packages with different checksum but same name.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **already covered**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/9312
Tracks https://github.com/SUSE/spacewalk/pull/9863

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
