### PR TITLE
Handle refreshing hardware of VM with changed UUID

### DIFF
--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Handle refreshing hardware of VM with changed UUID (bsc#1135380)
 - fix problems with Package Hub repos having multiple rpms with same NEVRA
   but different checksums (bsc#1146683)
 - Add check/message for project not found (bsc#1145755)


### PR DESCRIPTION
## What does this PR change?

For some reason, like an external script redefining VMs, we may end up
with a VM that changed UUID. In such a case the hardware mapper would
create a new entry for in the rhnVirtualInstance table and we would get
an error like:

    More than one row with the given identifier was found: 1000012177,
    for class: com.redhat.rhn.domain.server.VirtualInstance.

In such a case, the VM was already a registered guest and already has a
virtual system id that we can use to retrieve the VirtualInstance and
update it.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: bug fix.

- [X] **DONE**

## Test coverage
- No tests: Complex to automate

- [X] **DONE**

## Links

Fixes SUSE/spacewalk#7865

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
