### PR TITLE
Fix malformed XML response when data contains non-ASCII chars (bsc#1154968)

### DIFF
--- a/client/rhel/rhnlib/rhn/transports.py
+++ b/client/rhel/rhnlib/rhn/transports.py
@@ -701,7 +701,7 @@ class BaseOutput:
             self.set_header("Content-Type", "text/base64")
             self.data = base64.encodestring(self.data).decode()
 
-        self.set_header("Content-Length", len(self.data))
+        self.set_header("Content-Length", len(self.data.encode()))
 
         rpc_version = __version__
         if len(__version__.split()) > 1:

--- a/client/rhel/rhnlib/rhnlib.changes
+++ b/client/rhel/rhnlib/rhnlib.changes
@@ -1,3 +1,4 @@
+- Fix malformed XML response when data contains non-ASCII chars (bsc#1154968)
 - fix initialize ssl connection (bsc#1144155)
 - Add SNI support for clients
 - Fix bootstrapping SLE11SP4 trad client with SSL enabled (bsc#1148177)


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue that happens when calculating the value for the `Content-Length` header for a XML response.

When the data contains non-ASCII characters, the current data length calculation is wrong because, on Python 3, it counts the number of "utf8" characters instead the amount of bytes used.

Here you can see the difference on this regards between Python 2 and 3:

```
Python 2.7.16 (default, Mar 04 2019, 07:13:50) [GCC] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> tmp = "á"
>>> tmp
'\xc3\xa1'
>>> len(tmp)
2

Python 3.7.3 (default, Apr 09 2019, 05:18:21) [GCC] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> tmp = "á"
>>> tmp
'á'
>>> len(tmp)
1
>>> len(tmp.encode())
2
>>> 
```

A wrong `Content-Length` caused the XML response is truncated by the client, and therefore, causing a XML parsing error.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **bugfix**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/9878

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
