### PR TITLE
verify the checksum when looking up packages in the DB

### DIFF
--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -944,9 +944,14 @@ class RepoSync(object):
             ident = "%s-%s%s-%s.%s" % (pack.name, epoch, pack.version, pack.release, pack.arch)
             self.available_packages[ident] = 1
 
-            db_pack = rhnPackage.get_info_for_package(
+            packs = rhnPackage.get_info_for_package(
                 [pack.name, pack.version, pack.release, pack.epoch, pack.arch],
                 channel_id, self.org_id)
+            db_pack = None
+            for p in packs:
+                if p['checksum'] == pack.checksum:
+                    db_pack = p
+                    break
 
             to_download = True
             to_link = True
@@ -1201,9 +1206,14 @@ class RepoSync(object):
 
         for pack in packages:
 
-            db_pack = rhnPackage.get_info_for_package(
+            packs = rhnPackage.get_info_for_package(
                 [pack.name, pack.version, pack.release, pack.epoch, pack.arch],
                 channel_id, self.org_id)
+            db_pack = None
+            for p in packs:
+                if p['checksum'] == pack.checksum:
+                    db_pack = p
+                    break
 
             pack_status = " + "  # need to be downloaded by default
             pack_full_name = "%-60s\t" % (pack.name + "-" + pack.version + "-" + pack.release + "." +

--- a/backend/server/rhnPackage.py
+++ b/backend/server/rhnPackage.py
@@ -249,13 +249,14 @@ def get_info_for_package(pkg, channel_id, org_id):
     h = rhnSQL.prepare(statement)
     h.execute(**params)
 
-    ret = h.fetchone_dict()
+    ret = h.fetchall_dict() or []
     if not ret:
         return ret
-    if ret['org_id'] == None:
-        ret['org_id'] = ''
-    else:
-        ret['org_id'] = str(ret['org_id'])
+    for i in ret:
+        if i['org_id'] == None:
+            i['org_id'] = ''
+        else:
+            i['org_id'] = str(i['org_id'])
     return ret
 
 


### PR DESCRIPTION
## What does this PR change?

Verify the checksum when lookup packages in the database
Take 3 for https://github.com/uyuni-project/uyuni/pull/1438

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **already covered**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/9885

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
