### PR TITLE
Take care of possible different "str/bytes" types on XML response data

### DIFF
--- a/client/rhel/rhnlib/rhn/transports.py
+++ b/client/rhel/rhnlib/rhn/transports.py
@@ -701,7 +701,7 @@ class BaseOutput:
             self.set_header("Content-Type", "text/base64")
             self.data = base64.encodestring(self.data).decode()
 
-        self.set_header("Content-Length", len(self.data.encode()))
+        self.set_header("Content-Length", len(bstr(self.data)))
 
         rpc_version = __version__
         if len(__version__.split()) > 1:


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue introduced by https://github.com/uyuni-project/uyuni/pull/1523 when `data` is already `bytes`. In order to avoid this, this PR wraps the "data" into `bstr` which takes care of encoding it properly to `bytes` regardless if it's already str or bytes.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**
- [x] **DONE**

## Test coverage
- No tests: **bugfix**
- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
