### PR TITLE
Fix: match image_id with newer k8s (bsc#1149741)

### DIFF
--- a/java/code/src/com/suse/manager/kubernetes/KubernetesManager.java
+++ b/java/code/src/com/suse/manager/kubernetes/KubernetesManager.java
@@ -112,66 +112,63 @@ public class KubernetesManager {
                     // Loop through 'running' containers (with container id present)
                     containers.get().getContainers().stream()
                             .filter(c -> c.getContainerId().isPresent()).forEach(container -> {
-
+                        String imgDigest = container.getImageId();
                         if (container.getImageId().startsWith(DOCKER_PULLABLE)) {
-                            String imgDigest = StringUtils
-                                    .removeStart(container.getImageId(), DOCKER_PULLABLE);
-                            ImageBuildHistory imgBuildHistory =
-                                    digestToHistory.get(imgDigest);
-                            Optional<Integer> imgBuildRevision = Optional.empty();
-                            Optional<ImageUsage> usage;
-                            if (imgBuildHistory != null) {
-                                imgBuildRevision =
-                                        Optional.of(imgBuildHistory.getRevisionNumber());
-                                usage = Optional.of(imgToUsage.computeIfAbsent(
-                                        imgBuildHistory.getImageInfo().getId(),
-                                        (infoId) -> new ImageUsage(
-                                                imgBuildHistory.getImageInfo())));
-                            }
-                            else {
-                                LOG.debug("Image build history not found for digest: " +
-                                        imgDigest + " (maybe the image was not built " +
-                                        "by SUSE Manager).");
-                                String[] tokens =
-                                        StringUtils.split(container.getImage(), "/", 2);
-                                if (tokens.length < 2) {
-                                    LOG.warn("No repository available in the image name '" +
-                                            container.getImage() +
-                                            "'. Ignoring the image.");
-                                    return;
-                                }
-
-                                String repo = tokens[0];
-                                String[] imgTag = StringUtils.split(tokens[1], ":", 2);
-                                String name = imgTag[0];
-                                String tag = imgTag.length > 1 ? imgTag[1] : "latest";
-
-                                Optional<ImageInfo> imgByRepoNameTag =
-                                        ImageStoreFactory.lookupBylabelAndOrg(repo, virtHostMgr.getOrg())
-                                                .flatMap(st -> ImageInfoFactory.lookupByName(name, tag, st.getId()));
-                                usage = imgByRepoNameTag
-                                        .map(imgInfo -> imgToUsage.get(imgInfo.getId()))
-                                        .map(Optional::of).orElseGet(() -> imgByRepoNameTag
-                                                .map(imgInfo -> new ImageUsage(imgInfo))
-                                                .map(usg -> {
-                                                    imgToUsage
-                                                            .put(usg.getImageInfo().getId(),
-                                                                    usg);
-                                                    return usg;
-                                                }));
-                                if (!usage.isPresent()) {
-                                    return;
-                                }
-                            }
-
-                            ContainerInfo containerUsage = new ContainerInfo();
-                            containerUsage.setContainerId(container.getContainerId().get());
-                            containerUsage.setPodName(container.getPodName());
-                            containerUsage.setPodNamespace(container.getPodNamespace());
-                            containerUsage.setBuildRevision(imgBuildRevision);
-                            containerUsage.setVirtualHostManager(virtHostMgr);
-                            usage.ifPresent(u -> u.getContainerInfos().add(containerUsage));
+                            imgDigest = StringUtils.removeStart(container.getImageId(), DOCKER_PULLABLE);
                         }
+                        ImageBuildHistory imgBuildHistory = digestToHistory.get(imgDigest);
+                        Optional<Integer> imgBuildRevision = Optional.empty();
+                        Optional<ImageUsage> usage;
+                        if (imgBuildHistory != null) {
+                            imgBuildRevision = Optional.of(imgBuildHistory.getRevisionNumber());
+                            usage = Optional.of(imgToUsage.computeIfAbsent(
+                                    imgBuildHistory.getImageInfo().getId(),
+                                    (infoId) -> new ImageUsage(
+                                            imgBuildHistory.getImageInfo())));
+                        }
+                        else {
+                            LOG.debug("Image build history not found for digest: " +
+                                    imgDigest + " (maybe the image was not built " +
+                                    "by SUSE Manager).");
+                            String[] tokens =
+                                    StringUtils.split(container.getImage(), "/", 2);
+                            if (tokens.length < 2) {
+                                LOG.warn("No repository available in the image name '" +
+                                        container.getImage() +
+                                        "'. Ignoring the image.");
+                                return;
+                            }
+
+                            String repo = tokens[0];
+                            String[] imgTag = StringUtils.split(tokens[1], ":", 2);
+                            String name = imgTag[0];
+                            String tag = imgTag.length > 1 ? imgTag[1] : "latest";
+
+                            Optional<ImageInfo> imgByRepoNameTag =
+                                    ImageStoreFactory.lookupBylabelAndOrg(repo, virtHostMgr.getOrg())
+                                            .flatMap(st -> ImageInfoFactory.lookupByName(name, tag, st.getId()));
+                            usage = imgByRepoNameTag
+                                    .map(imgInfo -> imgToUsage.get(imgInfo.getId()))
+                                    .map(Optional::of).orElseGet(() -> imgByRepoNameTag
+                                            .map(imgInfo -> new ImageUsage(imgInfo))
+                                            .map(usg -> {
+                                                imgToUsage
+                                                        .put(usg.getImageInfo().getId(),
+                                                                usg);
+                                                return usg;
+                                            }));
+                            if (!usage.isPresent()) {
+                                return;
+                            }
+                        }
+
+                        ContainerInfo containerUsage = new ContainerInfo();
+                        containerUsage.setContainerId(container.getContainerId().get());
+                        containerUsage.setPodName(container.getPodName());
+                        containerUsage.setPodNamespace(container.getPodNamespace());
+                        containerUsage.setBuildRevision(imgBuildRevision);
+                        containerUsage.setVirtualHostManager(virtHostMgr);
+                        usage.ifPresent(u -> u.getContainerInfos().add(containerUsage));
                     });
                 }
                 else {

--- a/java/code/src/com/suse/manager/kubernetes/KubernetesManager.java
+++ b/java/code/src/com/suse/manager/kubernetes/KubernetesManager.java
@@ -113,7 +113,7 @@ public class KubernetesManager {
                     containers.get().getContainers().stream()
                             .filter(c -> c.getContainerId().isPresent()).forEach(container -> {
                         String imgDigest = container.getImageId();
-                        if (container.getImageId().startsWith(DOCKER_PULLABLE)) {
+                        if (imgDigest.startsWith(DOCKER_PULLABLE)) {
                             imgDigest = StringUtils.removeStart(container.getImageId(), DOCKER_PULLABLE);
                         }
                         ImageBuildHistory imgBuildHistory = digestToHistory.get(imgDigest);

--- a/java/code/src/com/suse/manager/kubernetes/test/get_all_containers.caasp4.json
+++ b/java/code/src/com/suse/manager/kubernetes/test/get_all_containers.caasp4.json
@@ -1,0 +1,249 @@
+{
+  "containers": [
+    {
+      "container_id": "cri-o://ec6e122db8b4659c82fe5d5f2862d7e4247bb868918cff14f314433826fe7a6f",
+      "image": "staging.registry.howdoi.website/splatform/stratos-postflight-job:2.5.2-5b47569cf-cap",
+      "image_id": "staging.registry.howdoi.website/splatform/stratos-postflight-job@sha256:f840e5a8cb8b98a678a6ce95d31119ecb461b14a4a01819308b91d272c3d75ce",
+      "pod_name": "stratos-0",
+      "pod_namespace": "console"
+    },
+    {
+      "container_id": "cri-o://e5a7ad638cb8757d2577c0985e631b2353798019cf02ab4d867fa37250ec36ae",
+      "image": "staging.registry.howdoi.website/splatform/stratos-jetstream:2.5.2-5b47569cf-cap",
+      "image_id": "staging.registry.howdoi.website/splatform/stratos-jetstream@sha256:ab09f78a40a7b14f08364ce4588eeefca1b1fb500ee4a3a1cfdd864635df0566",
+      "pod_name": "stratos-0",
+      "pod_namespace": "console"
+    },
+    {
+      "container_id": "cri-o://fa72a496bad3e5081c12d73923a2fbf50038143cc02ec2c73278626fa58a7327",
+      "image": "staging.registry.howdoi.website/splatform/stratos-console:2.5.2-5b47569cf-cap",
+      "image_id": "staging.registry.howdoi.website/splatform/stratos-console@sha256:e1c02b0a9c1934b58db68d59a8f03a231c7cf44ff74835f025da065e4dbe8172",
+      "pod_name": "stratos-0",
+      "pod_namespace": "console"
+    },
+    {
+      "container_id": "cri-o://bcefee41063fe075d271ef9e1e87a746736a6219b06c1f09d24bc47b4ebb602d",
+      "image": "staging.registry.howdoi.website/splatform/stratos-mariadb:2.5.2-5b47569cf-cap",
+      "image_id": "staging.registry.howdoi.website/splatform/stratos-mariadb@sha256:b75a13420fc47b515b1b76f5065bdaab73122520320412f1f2bbff1da65166d8",
+      "pod_name": "stratos-db-6dc68d995d-p674k",
+      "pod_namespace": "console"
+    },
+    {
+      "container_id": "cri-o://cb5877e5d73e3e4df36de7c0edcdd181fcad4eee83c855744dbd1e57bad1c3d7",
+      "image": "ip-172-31-8-0.eu-central-1.compute.internal:5000/apache-production:latest",
+      "image_id": "ip-172-31-8-0.eu-central-1.compute.internal:5000/apache-production@sha256:362f5f5d8d3670c9c499ae171ce059e9fa1889c879bfc2db78b97f37998dc717",
+      "pod_name": "hello-web-6b49476bb8-cb9dl",
+      "pod_namespace": "default"
+    },
+    {
+      "container_id": "cri-o://39e6085ce734a53841c59d5da68298295e52ec6b826215bc44aed5291ac14cb1",
+      "image": "ip-172-31-8-0.eu-central-1.compute.internal:5000/apache-production:latest",
+      "image_id": "ip-172-31-8-0.eu-central-1.compute.internal:5000/apache-production@sha256:362f5f5d8d3670c9c499ae171ce059e9fa1889c879bfc2db78b97f37998dc717",
+      "pod_name": "hello-web-6b49476bb8-cz24n",
+      "pod_namespace": "default"
+    },
+    {
+      "container_id": "cri-o://debcb5ddb7f9babf8924c6f98dc0463170a8d91a0b1954efacbf6d5303e3e8a8",
+      "image": "ip-172-31-8-0.eu-central-1.compute.internal:5000/apache-production:latest",
+      "image_id": "ip-172-31-8-0.eu-central-1.compute.internal:5000/apache-production@sha256:362f5f5d8d3670c9c499ae171ce059e9fa1889c879bfc2db78b97f37998dc717",
+      "pod_name": "hello-web-6b49476bb8-fwshg",
+      "pod_namespace": "default"
+    },
+    {
+      "container_id": "cri-o://b1b76f0807eba625934bf515d5502195075ff0322407016ee0fd07bed7464522",
+      "image": "ip-172-31-8-0.eu-central-1.compute.internal:5000/apache-production:latest",
+      "image_id": "ip-172-31-8-0.eu-central-1.compute.internal:5000/apache-production@sha256:thisisanoldversion",
+      "pod_name": "hello-web-6b49476bb8-lrx7j",
+      "pod_namespace": "default"
+    },
+    {
+      "container_id": "cri-o://bbf74e60535238fe3a7258095754725dea0778d8819bbe8774fc1de9b3f0d5d0",
+      "image": "ip-172-31-8-0.eu-central-1.compute.internal:5000/apache-production:latest",
+      "image_id": "ip-172-31-8-0.eu-central-1.compute.internal:5000/apache-production@sha256:362f5f5d8d3670c9c499ae171ce059e9fa1889c879bfc2db78b97f37998dc717",
+      "pod_name": "hello-web-6b49476bb8-qw9g9",
+      "pod_namespace": "default"
+    },
+    {
+      "container_id": "cri-o://5eb404c101906422407420de5297c4adc80236ab7d639492f00cc273ff47d295",
+      "image": "registry.suse.com/caasp/v4/cilium:1.5.3",
+      "image_id": "registry.suse.com/caasp/v4/cilium@sha256:5c8ed0cf209ba1d55173d91306eda6cc59612a91bfa346350271e0c006eceb0d",
+      "pod_name": "cilium-2nvhb",
+      "pod_namespace": "kube-system"
+    },
+    {
+      "container_id": "cri-o://7f7102102dcb3e09dc45ba713c0520ebda66a2db34137f9c47fa7b6fd7e72cbc",
+      "image": "registry.suse.com/caasp/v4/cilium-operator:1.5.3",
+      "image_id": "registry.suse.com/caasp/v4/cilium-operator@sha256:02ba730698cba66dbd71d66b68aa3fd9ce9a78ece55e246bd837a0a444ebaaed",
+      "pod_name": "cilium-operator-77885968c8-4s98v",
+      "pod_namespace": "kube-system"
+    },
+    {
+      "container_id": "cri-o://efc3b67928f79f6d129db0fffcf0e37e98255c9022b3eb02c8549c961824007d",
+      "image": "registry.suse.com/caasp/v4/cilium:1.5.3",
+      "image_id": "registry.suse.com/caasp/v4/cilium@sha256:5c8ed0cf209ba1d55173d91306eda6cc59612a91bfa346350271e0c006eceb0d",
+      "pod_name": "cilium-s8s47",
+      "pod_namespace": "kube-system"
+    },
+    {
+      "container_id": "cri-o://cf432e3e3ddc489c67ad8f42e8d924f21b904925e7178b2811d31e71c31500af",
+      "image": "registry.suse.com/caasp/v4/cilium:1.5.3",
+      "image_id": "registry.suse.com/caasp/v4/cilium@sha256:5c8ed0cf209ba1d55173d91306eda6cc59612a91bfa346350271e0c006eceb0d",
+      "pod_name": "cilium-vp85h",
+      "pod_namespace": "kube-system"
+    },
+    {
+      "container_id": "cri-o://5ab4a46fb015bf6f1047df8b5d85ea2407bfcc5169cdbe00a4d793983dc3fc2b",
+      "image": "registry.suse.com/caasp/v4/coredns:1.3.1",
+      "image_id": "registry.suse.com/caasp/v4/coredns@sha256:05e217a54d5225ed20a82414dfb10d14a28e9a9e79c80f40770b871c851b659c",
+      "pod_name": "coredns-69c4947958-pzm4l",
+      "pod_namespace": "kube-system"
+    },
+    {
+      "container_id": "cri-o://7b3e01b86f7f1b73f828f67ca7323db3c131cfbcde977fd415b6904599bd1d55",
+      "image": "registry.suse.com/caasp/v4/coredns:1.3.1",
+      "image_id": "registry.suse.com/caasp/v4/coredns@sha256:05e217a54d5225ed20a82414dfb10d14a28e9a9e79c80f40770b871c851b659c",
+      "pod_name": "coredns-69c4947958-q5rfm",
+      "pod_namespace": "kube-system"
+    },
+    {
+      "container_id": "cri-o://dc3c0b269f76bac21c4f0477e3774164a50c1a55855949feb7ddc5a7f910f2f8",
+      "image": "registry.suse.com/caasp/v4/etcd:3.3.11",
+      "image_id": "registry.suse.com/caasp/v4/etcd@sha256:7a418017ee548f8e1984c5f9b51cc54e047fc8e41909d2aab0ac1c8228df9da9",
+      "pod_name": "etcd-ip-172-27-1-227.eu-central-1.compute.internal",
+      "pod_namespace": "kube-system"
+    },
+    {
+      "container_id": "cri-o://fdaf894ac5d214c8fea57f4906e68540f54c1f2d1541a162a79e77e23af78ecf",
+      "image": "docker.io/bitnami/external-dns:0.5.17-debian-9-r0",
+      "image_id": "docker.io/bitnami/external-dns@sha256:1c683707537311e1a04d6236d522d55292c1b55bcf23a0721b9a2e21544454a3",
+      "pod_name": "external-dns-6c9d75c564-jwmvs",
+      "pod_namespace": "kube-system"
+    },
+    {
+      "container_id": "cri-o://ed04bde8878d474970509e42838a3363dfc8953f03bee2ac767d08cd0b3ddc2f",
+      "image": "registry.suse.com/caasp/v4/hyperkube:v1.15.2",
+      "image_id": "registry.suse.com/caasp/v4/hyperkube@sha256:6a7baa891d90d68bc856d321dcf4cbdd2b86b25204043276f44b4f81a270a515",
+      "pod_name": "kube-apiserver-ip-172-27-1-227.eu-central-1.compute.internal",
+      "pod_namespace": "kube-system"
+    },
+    {
+      "container_id": "cri-o://e330e4dabe2b344ebbf440cc7db08f8b96b3221afc5661302099fe6ec23b0b26",
+      "image": "registry.suse.com/caasp/v4/hyperkube:v1.15.2",
+      "image_id": "registry.suse.com/caasp/v4/hyperkube@sha256:6a7baa891d90d68bc856d321dcf4cbdd2b86b25204043276f44b4f81a270a515",
+      "pod_name": "kube-controller-manager-ip-172-27-1-227.eu-central-1.compute.internal",
+      "pod_namespace": "kube-system"
+    },
+    {
+      "container_id": "cri-o://4832541a77d0f7cf78715b98c502cb497873e6d2ab859d5fe8401349983a29fa",
+      "image": "registry.suse.com/caasp/v4/hyperkube:v1.15.2",
+      "image_id": "registry.suse.com/caasp/v4/hyperkube@sha256:6a7baa891d90d68bc856d321dcf4cbdd2b86b25204043276f44b4f81a270a515",
+      "pod_name": "kube-proxy-fszcn",
+      "pod_namespace": "kube-system"
+    },
+    {
+      "container_id": "cri-o://bb2ef2f9465e00815e0665293ec4fdf86ef9ed4e08540db4ae24a0f7cb00d872",
+      "image": "registry.suse.com/caasp/v4/hyperkube:v1.15.2",
+      "image_id": "registry.suse.com/caasp/v4/hyperkube@sha256:6a7baa891d90d68bc856d321dcf4cbdd2b86b25204043276f44b4f81a270a515",
+      "pod_name": "kube-proxy-pjp2p",
+      "pod_namespace": "kube-system"
+    },
+    {
+      "container_id": "cri-o://24dbd318e298372f4a1836a31ad4ac4e12bbf6afe14b5535ba0228b7ce415085",
+      "image": "registry.suse.com/caasp/v4/hyperkube:v1.15.2",
+      "image_id": "registry.suse.com/caasp/v4/hyperkube@sha256:6a7baa891d90d68bc856d321dcf4cbdd2b86b25204043276f44b4f81a270a515",
+      "pod_name": "kube-proxy-zptm7",
+      "pod_namespace": "kube-system"
+    },
+    {
+      "container_id": "cri-o://1ed94a344f01a155cabf521d267c027915f77f477d7de25095fb3cdc80cff9a4",
+      "image": "registry.suse.com/caasp/v4/hyperkube:v1.15.2",
+      "image_id": "registry.suse.com/caasp/v4/hyperkube@sha256:6a7baa891d90d68bc856d321dcf4cbdd2b86b25204043276f44b4f81a270a515",
+      "pod_name": "kube-scheduler-ip-172-27-1-227.eu-central-1.compute.internal",
+      "pod_namespace": "kube-system"
+    },
+    {
+      "container_id": "cri-o://9fbf97a64a2236e811fc3b13ccb26fd0daca09bb66b179f0d66a9a3ab4e09616",
+      "image": "registry.suse.com/caasp/v4/kured:1.2.0",
+      "image_id": "registry.suse.com/caasp/v4/kured@sha256:52d0bb956a4a012131436263cdc8126f86042af1d6f0c93bd461d229743f5bf3",
+      "pod_name": "kured-bzh5c",
+      "pod_namespace": "kube-system"
+    },
+    {
+      "container_id": "cri-o://779ee08fcf91a472d795459f5e67dfa9dd46df9ebc15478f21147e530da00550",
+      "image": "registry.suse.com/caasp/v4/kured:1.2.0",
+      "image_id": "registry.suse.com/caasp/v4/kured@sha256:52d0bb956a4a012131436263cdc8126f86042af1d6f0c93bd461d229743f5bf3",
+      "pod_name": "kured-rf8v5",
+      "pod_namespace": "kube-system"
+    },
+    {
+      "container_id": "cri-o://6a3bad4b8329e59b85189cef0f3a3f0b0b31f6158904cb4dcde8d0d3e7038810",
+      "image": "registry.suse.com/caasp/v4/kured:1.2.0",
+      "image_id": "registry.suse.com/caasp/v4/kured@sha256:52d0bb956a4a012131436263cdc8126f86042af1d6f0c93bd461d229743f5bf3",
+      "pod_name": "kured-zst7r",
+      "pod_namespace": "kube-system"
+    },
+    {
+      "container_id": "cri-o://854ffbb78f11261aebb49702023638a149547e8b747a292a05347a2f0959ef89",
+      "image": "registry.suse.com/caasp/v4/caasp-dex:2.16.0",
+      "image_id": "registry.suse.com/caasp/v4/caasp-dex@sha256:0542dfb58a97e2de8d25128b673aaa8c1e2dc2680b0db31872eb47b8fe6ce409",
+      "pod_name": "oidc-dex-77bc6b9979-phzlf",
+      "pod_namespace": "kube-system"
+    },
+    {
+      "container_id": "cri-o://9c14e544b51c1053887582b95efd75315573b77b824a9bc731ba93ba5a8fda23",
+      "image": "registry.suse.com/caasp/v4/gangway:3.1.0",
+      "image_id": "registry.suse.com/caasp/v4/gangway@sha256:85922202aaa071e5e13084c58c1375ae7029af77bfe7d99d63e22e98ca574bc3",
+      "pod_name": "oidc-gangway-5855c9bd86-lxx9r",
+      "pod_namespace": "kube-system"
+    },
+    {
+      "container_id": "cri-o://b7378b68a121820bbc116ad74b67f5422f0d606e921ebe627866435d250588bb",
+      "image": "gcr.io/kubernetes-helm/tiller:v2.14.2",
+      "image_id": "gcr.io/kubernetes-helm/tiller@sha256:be79aff05025bd736f027eaf4a1b2716ac1e09b88e0e9493c962642519f19d9c",
+      "pod_name": "tiller-deploy-56c686464b-cfr8b",
+      "pod_namespace": "kube-system"
+    },
+    {
+      "container_id": "cri-o://d83448b94be5074895ba1e34b6821dc8de2a37bfeb32e32550b9c0d2ec4a6d7f",
+      "image": "docker.io/library/traefik:1.7.14",
+      "image_id": "docker.io/library/traefik@sha256:2911f8e1a2d22aeba50126ea6c0883a943cf02912df6c566620ef36fcac3c2a8",
+      "pod_name": "traefik-78ddcc5588-88xtz",
+      "pod_namespace": "kube-system"
+    },
+    {
+      "container_id": "cri-o://e576e944f7c998c2b6e7cd7d28056bad672f76b25402ff3bff41ff8fa5b8047b",
+      "image": "registry.suse.com/cap/stratos-metrics-nginx:1.1.0-39adb67-cap",
+      "image_id": "registry.suse.com/cap/stratos-metrics-nginx@sha256:57e7d461d70416038af36855c641e651a807e8acc17288c0b7be07db6327d9a0",
+      "pod_name": "caasp-metrics-nginx-74755cc75f-6jxnf",
+      "pod_namespace": "metrics"
+    },
+    {
+      "container_id": "cri-o://93ca6a635409df2a889ceb53b1a481982bc53e1e514301c5f27be587981454ac",
+      "image": "registry.suse.com/cap/stratos-metrics-kube-state-metrics:1.1.0-39adb67-cap",
+      "image_id": "registry.suse.com/cap/stratos-metrics-kube-state-metrics@sha256:3c2c0af94f2962a640c9be0942ad8009b80a0ba03b306e6a05b10592dc514cd6",
+      "pod_name": "caasp-metrics-prometheus-kube-state-metrics-9db9cdcc6-4rfth",
+      "pod_namespace": "metrics"
+    },
+    {
+      "container_id": "cri-o://3dd4bf61b78821c9638c185df33a5e89b03d4be71ab5c12ad82f8c31a344a833",
+      "image": "registry.suse.com/cap/stratos-metrics-prometheus:1.1.0-39adb67-cap",
+      "image_id": "registry.suse.com/cap/stratos-metrics-prometheus@sha256:e1713f9630a8ecbb0cdf6c33195579b9ec8719d206e9454485b29370fd4c6b36",
+      "pod_name": "caasp-metrics-prometheus-prometheus-56dc9c568b-rcb2s",
+      "pod_namespace": "metrics"
+    },
+    {
+      "container_id": "cri-o://a65b2ab5a5cfbd62388edd146668f5a411a57e9887cd188c3640955ca710f1e4",
+      "image": "registry.suse.com/cap/stratos-metrics-configmap-reload:1.1.0-39adb67-cap",
+      "image_id": "registry.suse.com/cap/stratos-metrics-configmap-reload@sha256:eaeb62c565bc3b6a2271ffa115757369d3ef09e0cae9b89b94b5e4f60a349ba4",
+      "pod_name": "caasp-metrics-prometheus-prometheus-56dc9c568b-rcb2s",
+      "pod_namespace": "metrics"
+    },
+    {
+      "container_id": "cri-o://02fa82a27186fdb0d2f118dbb1603f585c55baf8d3db583ee9e438de72b74560",
+      "image": "docker.io/grafana/grafana:6.3.5",
+      "image_id": "docker.io/grafana/grafana@sha256:b8875047c89d980b90d478ab0e9726e37c3db97a50eec2399b13dcd1686b2c98",
+      "pod_name": "grafana-66f885c49b-ccqnm",
+      "pod_namespace": "monitoring"
+    }
+  ]
+}

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix: match `image_id` with newer k8s (bsc#1149741)
 - Handle refreshing hardware of VM with changed UUID (bsc#1135380)
 - Bump version to 4.1.0 (bsc#1154940)
 - fix problems with Package Hub repos having multiple rpms with same NEVRA

--- a/susemanager-utils/susemanager-sls/modules/runners/mgrk8s.py
+++ b/susemanager-utils/susemanager-sls/modules/runners/mgrk8s.py
@@ -25,9 +25,9 @@ def get_all_containers(kubeconfig=None, context=None):
        {
             "containers": [
                 {
-                    "image_id": "docker-pullable://some/image@sha256:hash....",
+                    "image_id": "(docker-pullable://)?some/image@sha256:hash....",
                     "image": "myregistry/some/image:v1",
-                    "container_id": "docker://...hash...",
+                    "container_id": "(docker|cri-o)://...hash...",
                     "pod_name": "kubernetes-pod",
                     "pod_namespace": "pod-namespace"
                 }

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Fix: match `image_id` with newer k8s (bsc#1149741)
 - Bump version to 4.1.0 (bsc#1154940)
 - Always install latest available salt during bootstrap
 - Create Kiwi cache dir if not present


### PR DESCRIPTION
## What does this PR change?

Fix: match `image_id` with newer k8s (bsc#1149741)

Salt runner `mgrk8s.get_all_container` returns all the containers
running in the Kubernetes cluster; in the previous versions, the field
`image_id` was using the prefix `docker-pullable`, e.g.:

    docker-pullable://jocatalin/kubernetes-bootcamp@sha256:0d6b8ee63bb57c...

In the newer versions of Kubernetes, the prefix `docker-pullable` has
been omitted and the `image_id` is now returning just the name of
the container, e.g.:

    registry.suse.com/...

With this PR we make the `docker-pullable` prefix optional.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: this is a bugfix

- [X] **DONE**

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/9818
Tracks https://github.com/SUSE/spacewalk/pull/9897

- [X] **DONE**

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
