### PR TITLE
before adding channels, check if a refresh is needed (bsc#1153613)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/product/test/SUSEProductTestUtils.java
+++ b/java/code/src/com/redhat/rhn/domain/product/test/SUSEProductTestUtils.java
@@ -22,6 +22,7 @@ import com.redhat.rhn.domain.channel.ChannelFamily;
 import com.redhat.rhn.domain.channel.ChannelFamilyFactory;
 import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
 import com.redhat.rhn.domain.channel.test.ChannelFamilyFactoryTest;
+import com.redhat.rhn.domain.common.ManagerInfoFactory;
 import com.redhat.rhn.domain.credentials.Credentials;
 import com.redhat.rhn.domain.credentials.CredentialsFactory;
 import com.redhat.rhn.domain.product.ReleaseStage;
@@ -316,6 +317,7 @@ public class SUSEProductTestUtils extends HibernateFactory {
             newAuth.setRepository(SCCCachingFactory.lookupRepositoryBySccId(-75L).get());
             SCCCachingFactory.saveRepositoryAuth(newAuth);
         }
+        ManagerInfoFactory.setLastMgrSyncRefresh();
     }
 
     public static void addChannelsForProduct(SUSEProduct product) {

--- a/java/code/src/com/redhat/rhn/frontend/action/satellite/SetupWizardAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/satellite/SetupWizardAction.java
@@ -15,12 +15,12 @@
 package com.redhat.rhn.frontend.action.satellite;
 
 import com.redhat.rhn.domain.iss.IssFactory;
-import com.redhat.rhn.domain.scc.SCCCachingFactory;
 import com.redhat.rhn.frontend.nav.NavCache;
 import com.redhat.rhn.frontend.nav.NavNode;
 import com.redhat.rhn.frontend.nav.NavTree;
 import com.redhat.rhn.frontend.struts.RhnAction;
 import com.redhat.rhn.frontend.struts.RhnHelper;
+import com.redhat.rhn.manager.content.ContentSyncManager;
 import com.redhat.rhn.taskomatic.TaskoFactory;
 import com.redhat.rhn.taskomatic.domain.TaskoRun;
 
@@ -95,7 +95,8 @@ public class SetupWizardAction extends RhnAction {
                         .get(0));
 
         request.setAttribute(ISS_MASTER, IssFactory.getCurrentMaster() == null);
-        request.setAttribute(REFRESH_NEEDED, SCCCachingFactory.refreshNeeded());
+        ContentSyncManager csm = new ContentSyncManager();
+        request.setAttribute(REFRESH_NEEDED, csm.isRefreshNeeded(null));
 
         TaskoRun latestRun = TaskoFactory.getLatestRun("mgr-sync-refresh-bunch");
         request.setAttribute(REFRESH_RUNNING,

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/sync/content/ContentSyncHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/sync/content/ContentSyncHandler.java
@@ -251,6 +251,9 @@ public class ContentSyncHandler extends BaseHandler {
             throws ContentSyncException {
         ensureSatAdmin(loggedInUser);
         ContentSyncManager csm = new ContentSyncManager();
+        if (csm.isRefreshNeeded(mirrorUrl)) {
+            throw new ContentSyncException("Product Data refresh needed. Please call mgr-sync refresh.");
+        }
         csm.addChannel(channelLabel, mirrorUrl);
         return BaseHandler.VALID;
     }
@@ -274,6 +277,9 @@ public class ContentSyncHandler extends BaseHandler {
             throws ContentSyncException {
         ensureSatAdmin(loggedInUser);
         ContentSyncManager csm = new ContentSyncManager();
+        if (csm.isRefreshNeeded(mirrorUrl)) {
+            throw new ContentSyncException("Product Data refresh needed. Please call mgr-sync refresh.");
+        }
 
         List<String> mandatoryChannelLabels =
                 SUSEProductFactory.findNotSyncedMandatoryChannels(channelLabel)

--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -585,6 +585,23 @@ public class ContentSyncManager {
     }
 
     /**
+     * Return true if a refresh of Product Data is needed
+     *
+     * @param mirrorUrl a mirrorURL
+     * @return true if a refresh is needed, otherwise false
+     */
+    public boolean isRefreshNeeded(String mirrorUrl) {
+        for (SCCRepositoryAuth a : SCCCachingFactory.lookupRepositoryAuthWithContentSource()) {
+            ContentSource cs = a.getContentSource();
+            String overwriteUrl = contentSourceUrlOverwrite(a.getRepository(), a.getUrl(), mirrorUrl);
+            if (!cs.getSourceUrl().equals(overwriteUrl)) {
+                return true;
+            }
+        }
+        return SCCCachingFactory.refreshNeeded();
+    }
+
+    /**
      * Update authentication for all repos of the given credential.
      * Removes authentication if they have expired
      *

--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -1955,7 +1955,7 @@ public class ContentSyncManager {
      * @param url the url
      * @return Returns true in case we can access this URL, otherwise false
      */
-    private boolean accessibleUrl(String url) {
+    protected boolean accessibleUrl(String url) {
         try {
             URI uri = new URI(url);
             String username = null;
@@ -1979,7 +1979,7 @@ public class ContentSyncManager {
      * @param password the password
      * @return Returns true in case we can access this URL, otherwise false
      */
-    private boolean accessibleUrl(String url, String user, String password) {
+    protected boolean accessibleUrl(String url, String user, String password) {
         try {
             URI uri = new URI(url);
 

--- a/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
@@ -1054,6 +1054,36 @@ public class ContentSyncManagerTest extends BaseTestCaseWithUser {
     }
 
     /**
+     * Tests {@link ContentSyncManager#isRefreshNeeded}
+     * @throws Exception if anything goes wrong
+     */
+    public void testIsRefreshNeeded() throws Exception {
+        SUSEProductTestUtils.createVendorSUSEProductEnvironment(user, "/com/redhat/rhn/manager/content/test/smallBase", true);
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().clear();
+
+        // SLES12 GA
+        SUSEProductTestUtils.addChannelsForProduct(SUSEProductFactory.lookupByProductId(1117));
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().clear();
+
+        ContentSyncManager csm = new ContentSyncManager() {
+            @Override
+            protected boolean accessibleUrl(String url) {
+                return true;
+            }
+
+            @Override
+            protected boolean accessibleUrl(String url, String user, String password) {
+                return true;
+            }
+        };
+
+        assertFalse(csm.isRefreshNeeded(null));
+        assertTrue(csm.isRefreshNeeded("https://mirror.example.com/"));
+    }
+
+    /**
      * Test for {@link ContentSyncManager#addChannel}.
      * @throws Exception if anything goes wrong
      */

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Check if metadata refresh is needed before adding new channels (bsc#1153613)
 - Fix: match `image_id` with newer k8s (bsc#1149741)
 - Handle refreshing hardware of VM with changed UUID (bsc#1135380)
 - Bump version to 4.1.0 (bsc#1154940)


### PR DESCRIPTION
## What does this PR change?

When changing the mirror values in rhn.conf and do not call refresh after it, we risk ConstraintViolationException when ContentSources are created multiple times.

This PR check if a refresh is needed before adding a channel and raise an exception.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/9786
Tracks 

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"   		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
