### PR TITLE
Update URLs for Uyuni Master Server and Proxy

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -910,15 +910,15 @@ gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-4.0-POOL-x86_64-Media1/
 
-[uyuni-server-devel-leap-151]
+[uyuni-server-devel]
 name     = Uyuni Server for %(base_channel_name)s (Development)
 archs    = x86_64
 base_channels = opensuse_leap15_1-%(arch)s
 checksum = sha256
-gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_15.1/repo/Uyuni-Server-4.0-POOL-x86_64-Media1/repodata/repomd.xml.key
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Uyuni-Server-POOL-x86_64-Media1/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_15.1/repo/Uyuni-Server-4.0-POOL-x86_64-Media1/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Uyuni-Server-POOL-x86_64-Media1/
 
 [uyuni-proxy-40-leap-151]
 name     = Uyuni Proxy 4.0 for %(base_channel_name)s
@@ -930,15 +930,15 @@ gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Proxy-4.0-POOL-x86_64-Media1/
 
-[uyuni-proxy-devel-leap-151]
+[uyuni-proxy-devel-leap]
 name     = Uyuni Proxy for %(base_channel_name)s (Development)
 archs    = x86_64
 base_channels = opensuse_leap15_1-%(arch)s
 checksum = sha256
-gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_15.1/repo/Uyuni-Proxy-4.0-POOL-x86_64-Media1/repodata/repomd.xml.key
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_15.1/repo/Uyuni-Proxy-4.0-POOL-x86_64-Media1/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/
 
 [ubuntu-1604-pool-amd64]
 label    = ubuntu-16.04-pool-amd64

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,4 @@
+- Update URLs for Uyuni Master Server and Proxy
 - Bump version to 4.1.0 (bsc#1154940)
 - fix hostname-rename script for cobbler files
 - Set openSUSE Leap 15.1 as new Base OS for Uyuni Server and Proxy


### PR DESCRIPTION
## What does this PR change?

Update URLs for Uyuni Master Server and Proxy

As part of the new Uyuni product definitions, we are removing the version from the POOL repositories. And we decided to remove the distribution name from the URL as well (so it's now `images` so we don't need to change it when we change the base OS).

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Devel repositories not mentioned at the doc.

- [x] **DONE**

## Test coverage
- No tests: Not covered.

- [x] **DONE**

## Links

Related: https://github.com/SUSE/spacewalk/issues/9900
Related: https://github.com/uyuni-project/sumaform/pull/632

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
