### PR TITLE
Add missing bsc#1131556 at spacewalk-backend

### DIFF
--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -26,7 +26,7 @@
 - prevent duplicate key violates on repo-sync with long changelog
   entries (bsc#1144889)
 - spacewalk-remove-channel check that channel doesn't have cloned channels before deleting it (bsc#1138454)
-- Fix broken spacewalk-data-fsck utility
+- Fix broken spacewalk-data-fsck utility (bsc#1131556)
 - /etc/rhn also was packaged for spacewalk-backend-tools
 - Add '--latest' support for reposync on DEB based repositories
 - Require uyuni-base-common for /etc/rhn


### PR DESCRIPTION
## What does this PR change?

Add missing bsc#1131556 at spacewalk-backend. Adding now as the bsc was created after the problem was fixed.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Changelog fix.

- [x] **DONE**

## Test coverage
- No tests: Changelog fix.

- [x] **DONE**

## Links

Requires port to Manager 4.0 (link will be added below).

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
