### PR TITLE
Fix onboarding of ES6, CentOS6 and Red Hat 6 salt-ssh minions (bsc#1155295)

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -246,6 +246,8 @@ RES6 = [
     "python2-suseRegisterInfo",
     "python2-hwdata",
     "dmidecode",
+    "openssh-clients",
+    "libedit",
 ]
 
 RES7 = [

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- Allow bootstraping of Expanded Support 6, CentOS6 and Red Hat 6
+  salt-ssh minions when using the "Minimal" software set (bsc#1155295)
 - Bump version to 4.1.0 (bsc#1154940)
 - prepare bootstrap data for upcoming openSUSE 15.2
 - add bootstrap data for openSUSE 15.1 when mirrored as


### PR DESCRIPTION
## What does this PR change?

Allow bootstraping of Expanded Support 6, CentOS6 and Red Hat 6 salt-ssh minions when using the "Minimal" software set (bsc#1155295)

Right now such software set does not contain `openssh-clients` or `libedit` packages that are required to have `scp` available.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Bugfix

- [x] **DONE**

## Test coverage
- No tests: We don't cover such variant with automated tests. I already told QA we should always us the most restricted installation we could possibly find, for all OS.

- [x] **DONE**

## Links

Related: https://github.com/SUSE/spacewalk/issues/9906

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
