### PR TITLE
Get fqdns information using salt module instead of from grains

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -672,6 +672,20 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         });
     }
 
+    public void testHardwareProfileUpdateGrainsFqdns() throws Exception {
+        testHardwareProfileUpdate("hardware.profileupdate.ppc64.json", (server) -> {
+            assertNotNull(server);
+            assertEquals(2, server.getFqdns().size());
+        });
+    }
+
+    public void testHardwareProfileUpdateNetworkModuleFqdns() throws Exception {
+        testHardwareProfileUpdate("hardware.profileupdate.x86.json", (server) -> {
+            assertNotNull(server);
+            assertEquals(2, server.getFqdns().size());
+        });
+    }
+
     public void testHardwareProfileUpdateX86LongCPUValues()  throws Exception {
         testHardwareProfileUpdate("hardware.profileupdate.cpulongval.x86.json", (server) -> {
             assertNotNull(server);

--- a/java/code/src/com/suse/manager/reactor/messaging/test/hardware.profileupdate.cpulongval.x86.json
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/hardware.profileupdate.cpulongval.x86.json
@@ -3456,6 +3456,23 @@
                     }]
                 }
             },
+            "module_|-fqdns_|-network.fqdns_|-run": {
+                "__id__": "fqdns",
+                "__run_num__": 13,
+                "__sls__": "hardware.profileupdate",
+                "changes": {
+                    "ret": {
+                        "fqdns": [
+                            "minionsles12-suma3pg.vagrant.local"
+                        ]
+                    }
+                },
+                "comment": "Module function network.fqdns executed",
+                "duration": 105.654,
+                "name": "network.fqdns",
+                "result": true,
+                "start_time": "13:58:24.817053"
+            },
             "module_|-network-ips_|-sumautil.primary_ips_|-run": {
                 "comment": "Module function sumautil.primary_ips executed",
                 "name": "sumautil.primary_ips",

--- a/java/code/src/com/suse/manager/reactor/messaging/test/hardware.profileupdate.docker.json
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/hardware.profileupdate.docker.json
@@ -221,6 +221,23 @@
         "changes": {},
         "__id__": "smbios-records-system"
       },
+      "module_|-fqdns_|-network.fqdns_|-run": {
+        "__id__": "fqdns",
+        "__run_num__": 13,
+        "__sls__": "hardware.profileupdate",
+        "changes": {
+          "ret": {
+            "fqdns": [
+              "minionsles12-suma3pg.vagrant.local"
+            ]
+          }
+        },
+        "comment": "Module function network.fqdns executed",
+        "duration": 105.654,
+        "name": "network.fqdns",
+        "result": true,
+        "start_time": "13:58:24.817053"
+      },
       "module_|-network-ips_|-sumautil.primary_ips_|-run": {
         "comment": "Module function sumautil.primary_ips executed",
         "name": "sumautil.primary_ips",

--- a/java/code/src/com/suse/manager/reactor/messaging/test/hardware.profileupdate.infiniband.json
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/hardware.profileupdate.infiniband.json
@@ -698,6 +698,23 @@
                 "result": true,
                 "start_time": "13:58:24.817053"
             },
+            "module_|-fqdns_|-network.fqdns_|-run": {
+                "__id__": "fqdns",
+                "__run_num__": 13,
+                "__sls__": "hardware.profileupdate",
+                "changes": {
+                    "ret": {
+                        "fqdns": [
+                            "minionsles12-suma3pg.vagrant.local"
+                        ]
+                    }
+                },
+                "comment": "Module function network.fqdns executed",
+                "duration": 105.654,
+                "name": "network.fqdns",
+                "result": true,
+                "start_time": "13:58:24.817053"
+            },
             "module_|-sync_beacons_|-saltutil.sync_beacons_|-run": {
                 "__id__": "sync_beacons",
                 "__run_num__": 2,

--- a/java/code/src/com/suse/manager/reactor/messaging/test/hardware.profileupdate.ip_change_ipv4ipv6.x86.json
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/hardware.profileupdate.ip_change_ipv4ipv6.x86.json
@@ -3509,6 +3509,23 @@
                     }]
                 }
             },
+            "module_|-fqdns_|-network.fqdns_|-run": {
+                "__id__": "fqdns",
+                "__run_num__": 13,
+                "__sls__": "hardware.profileupdate",
+                "changes": {
+                    "ret": {
+                        "fqdns": [
+                            "minionsles12-suma3pg.vagrant.local"
+                        ]
+                    }
+                },
+                "comment": "Module function network.fqdns executed",
+                "duration": 105.654,
+                "name": "network.fqdns",
+                "result": true,
+                "start_time": "12:58:12.430383"
+            },
             "module_|-network-ips_|-sumautil.primary_ips_|-run": {
                 "comment": "Module function sumautil.primary_ips executed",
                 "name": "sumautil.primary_ips",

--- a/java/code/src/com/suse/manager/reactor/messaging/test/hardware.profileupdate.nodmi.x86.json
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/hardware.profileupdate.nodmi.x86.json
@@ -3462,6 +3462,23 @@
                 "changes": {
                 }
             },
+            "module_|-fqdns_|-network.fqdns_|-run": {
+                "__id__": "fqdns",
+                "__run_num__": 13,
+                "__sls__": "hardware.profileupdate",
+                "changes": {
+                    "ret": {
+                        "fqdns": [
+                            "minionsles12-suma3pg.vagrant.local"
+                        ]
+                    }
+                },
+                "comment": "Module function network.fqdns executed",
+                "duration": 105.654,
+                "name": "network.fqdns",
+                "result": true,
+                "start_time": "13:58:24.817053"
+            },
             "module_|-network-ips_|-sumautil.primary_ips_|-run": {
                 "comment": "Module function sumautil.primary_ips executed",
                 "name": "sumautil.primary_ips",

--- a/java/code/src/com/suse/manager/reactor/messaging/test/hardware.profileupdate.ppc64.json
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/hardware.profileupdate.ppc64.json
@@ -3190,6 +3190,10 @@
                         "fqdn_ip6": [
                             "2620:113:80c0:8000:10:161:25:49"
                         ],
+                        "fqdns": [
+                            "minionsles12-suma3pg.vagrant.local",
+                            "minionsles12-suma3pg.dummy.vagrant.local"
+                        ],
                         "gpus": [],
                         "host": "pinotage-1",
                         "hwaddr_interfaces": {

--- a/java/code/src/com/suse/manager/reactor/messaging/test/hardware.profileupdate.primary_ips_ipv4ipv6.x86.json
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/hardware.profileupdate.primary_ips_ipv4ipv6.x86.json
@@ -3509,6 +3509,23 @@
                     }]
                 }
             },
+            "module_|-fqdns_|-network.fqdns_|-run": {
+                "__id__": "fqdns",
+                "__run_num__": 13,
+                "__sls__": "hardware.profileupdate",
+                "changes": {
+                    "ret": {
+                        "fqdns": [
+                            "minionsles12-suma3pg.vagrant.local"
+                        ]
+                    }
+                },
+                "comment": "Module function network.fqdns executed",
+                "duration": 105.654,
+                "name": "network.fqdns",
+                "result": true,
+                "start_time": "12:58:12.430383"
+            },
             "module_|-network-ips_|-sumautil.primary_ips_|-run": {
                 "comment": "Module function sumautil.primary_ips executed",
                 "name": "sumautil.primary_ips",

--- a/java/code/src/com/suse/manager/reactor/messaging/test/hardware.profileupdate.primary_ips_ipv4only.x86.json
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/hardware.profileupdate.primary_ips_ipv4only.x86.json
@@ -3509,6 +3509,23 @@
                     }]
                 }
             },
+            "module_|-fqdns_|-network.fqdns_|-run": {
+                "__id__": "fqdns",
+                "__run_num__": 13,
+                "__sls__": "hardware.profileupdate",
+                "changes": {
+                    "ret": {
+                        "fqdns": [
+                            "minionsles12-suma3pg.vagrant.local"
+                        ]
+                    }
+                },
+                "comment": "Module function network.fqdns executed",
+                "duration": 105.654,
+                "name": "network.fqdns",
+                "result": true,
+                "start_time": "12:58:12.430383"
+            },
             "module_|-network-ips_|-sumautil.primary_ips_|-run": {
                 "comment": "Module function sumautil.primary_ips executed",
                 "name": "sumautil.primary_ips",

--- a/java/code/src/com/suse/manager/reactor/messaging/test/hardware.profileupdate.primary_ips_ipv4onlylocalhost.x86.json
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/hardware.profileupdate.primary_ips_ipv4onlylocalhost.x86.json
@@ -3509,6 +3509,23 @@
                     }]
                 }
             },
+            "module_|-fqdns_|-network.fqdns_|-run": {
+                "__id__": "fqdns",
+                "__run_num__": 13,
+                "__sls__": "hardware.profileupdate",
+                "changes": {
+                    "ret": {
+                        "fqdns": [
+                            "minionsles12-suma3pg.vagrant.local"
+                        ]
+                    }
+                },
+                "comment": "Module function network.fqdns executed",
+                "duration": 105.654,
+                "name": "network.fqdns",
+                "result": true,
+                "start_time": "12:58:12.430383"
+            },
             "module_|-network-ips_|-sumautil.primary_ips_|-run": {
                 "comment": "Module function sumautil.primary_ips executed",
                 "name": "sumautil.primary_ips",

--- a/java/code/src/com/suse/manager/reactor/messaging/test/hardware.profileupdate.primary_ips_ipv6only.x86.json
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/hardware.profileupdate.primary_ips_ipv6only.x86.json
@@ -3509,6 +3509,23 @@
                     }]
                 }
             },
+            "module_|-fqdns_|-network.fqdns_|-run": {
+                "__id__": "fqdns",
+                "__run_num__": 13,
+                "__sls__": "hardware.profileupdate",
+                "changes": {
+                    "ret": {
+                        "fqdns": [
+                            "minionsles12-suma3pg.vagrant.local"
+                        ]
+                    }
+                },
+                "comment": "Module function network.fqdns executed",
+                "duration": 105.654,
+                "name": "network.fqdns",
+                "result": true,
+                "start_time": "12:58:12.430383"
+            },
             "module_|-network-ips_|-sumautil.primary_ips_|-run": {
                 "comment": "Module function sumautil.primary_ips executed",
                 "name": "sumautil.primary_ips",

--- a/java/code/src/com/suse/manager/reactor/messaging/test/hardware.profileupdate.public_cloud.json
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/hardware.profileupdate.public_cloud.json
@@ -3509,6 +3509,23 @@
                     }]
                 }
             },
+            "module_|-fqdns_|-network.fqdns_|-run": {
+                "__id__": "fqdns",
+                "__run_num__": 13,
+                "__sls__": "hardware.profileupdate",
+                "changes": {
+                    "ret": {
+                        "fqdns": [
+                            "minionsles12-suma3pg.vagrant.local"
+                        ]
+                    }
+                },
+                "comment": "Module function network.fqdns executed",
+                "duration": 105.654,
+                "name": "network.fqdns",
+                "result": true,
+                "start_time": "12:58:12.430383"
+            },
             "module_|-network-ips_|-sumautil.primary_ips_|-run": {
                 "comment": "Module function sumautil.primary_ips executed",
                 "name": "sumautil.primary_ips",

--- a/java/code/src/com/suse/manager/reactor/messaging/test/hardware.profileupdate.s390.json
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/hardware.profileupdate.s390.json
@@ -2071,6 +2071,23 @@
                 "changes": {
                 }
             },
+            "module_|-fqdns_|-network.fqdns_|-run": {
+                "__id__": "fqdns",
+                "__run_num__": 13,
+                "__sls__": "hardware.profileupdate",
+                "changes": {
+                    "ret": {
+                        "fqdns": [
+                            "minionsles12-suma3pg.vagrant.local"
+                        ]
+                    }
+                },
+                "comment": "Module function network.fqdns executed",
+                "duration": 105.654,
+                "name": "network.fqdns",
+                "result": true,
+                "start_time": "12:58:12.430383"
+            },
             "module_|-network-ips_|-sumautil.primary_ips_|-run": {
                 "comment": "Module function sumautil.primary_ips executed",
                 "name": "sumautil.primary_ips",

--- a/java/code/src/com/suse/manager/reactor/messaging/test/hardware.profileupdate.scsi.x86.json
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/hardware.profileupdate.scsi.x86.json
@@ -4364,6 +4364,23 @@
                     }]
                 }
             },
+            "module_|-fqdns_|-network.fqdns_|-run": {
+                "__id__": "fqdns",
+                "__run_num__": 13,
+                "__sls__": "hardware.profileupdate",
+                "changes": {
+                    "ret": {
+                        "fqdns": [
+                            "minionsles12-suma3pg.vagrant.local"
+                        ]
+                    }
+                },
+                "comment": "Module function network.fqdns executed",
+                "duration": 105.654,
+                "name": "network.fqdns",
+                "result": true,
+                "start_time": "12:58:12.430383"
+            },
             "module_|-network-ips_|-sumautil.primary_ips_|-run": {
                 "comment": "Module function sumautil.primary_ips executed",
                 "name": "sumautil.primary_ips",

--- a/java/code/src/com/suse/manager/reactor/messaging/test/hardware.profileupdate.x86.json
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/hardware.profileupdate.x86.json
@@ -3509,6 +3509,24 @@
                     }]
                 }
             },
+            "module_|-fqdns_|-network.fqdns_|-run": {
+                "__id__": "fqdns",
+                "__run_num__": 13,
+                "__sls__": "hardware.profileupdate",
+                "changes": {
+                    "ret": {
+                        "fqdns": [
+                            "minionsles12-suma3pg.vagrant.local",
+                            "minionsles12-suma3pg.dummy.vagrant.local"
+                        ]
+                    }
+                },
+                "comment": "Module function network.fqdns executed",
+                "duration": 105.654,
+                "name": "network.fqdns",
+                "result": true,
+                "start_time": "13:58:24.817053"
+            },
             "module_|-network-ips_|-sumautil.primary_ips_|-run": {
                 "comment": "Module function sumautil.primary_ips executed",
                 "name": "sumautil.primary_ips",

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -1347,10 +1347,8 @@ public class SaltUtils {
             hwMapper.mapSysinfo(result.getMainframeSysinfo());
         }
         hwMapper.mapVirtualizationInfo(result.getSmbiosRecordsSystem());
-        hwMapper.mapNetworkInfo(
-                result.getNetworkInterfaces(),
-                Optional.of(result.getNetworkIPs()),
-                result.getNetworkModules());
+        hwMapper.mapNetworkInfo(result.getNetworkInterfaces(), Optional.of(result.getNetworkIPs()),
+                result.getNetworkModules(), result.getFqdns());
 
         // Let the action fail in case there is error messages
         if (!hwMapper.getErrors().isEmpty()) {

--- a/java/code/src/com/suse/manager/webui/utils/salt/custom/HwProfileUpdateSlsResult.java
+++ b/java/code/src/com/suse/manager/webui/utils/salt/custom/HwProfileUpdateSlsResult.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+
 /**
  * Object representation of the results of a call to state.apply hardware.profileupdate.
  */
@@ -49,6 +50,10 @@ public class HwProfileUpdateSlsResult {
 
     @SerializedName("module_|-network-modules_|-sumautil.get_net_modules_|-run")
     private StateApplyResult<Ret<Map<String, Optional<String>>>> networkModules;
+
+    @SerializedName("module_|-fqdns_|-network.fqdns_|-run")
+    private Optional<StateApplyResult<Ret<Map<String, List<String>>>>> fqdnsFromNetworkModule =
+            Optional.empty();
 
     @SerializedName("module_|-smbios-records-bios_|-smbios.records_|-run")
     private Optional<StateApplyResult<Ret<List<Smbios.Record>>>> smbiosRecordsBios =
@@ -148,6 +153,16 @@ public class HwProfileUpdateSlsResult {
         }
         return "";
     }
+
+    /**
+     * Get the fqdns from network.fqdns module
+     * and if module is not available then fall back to 'fqdns' grain.
+     * @return fqdns of the system
+     */
+    public List<String> getFqdns() {
+       return fqdnsFromNetworkModule.map(s->s.getChanges().getRet().get("fqdns"))
+               .orElseGet(()-> (List<String>)this.getGrains().get("fqdns"));
+     }
 
     private Optional<Map<String, Object>> getSmbiosRecords(
             Optional<StateApplyResult<Ret<List<Smbios.Record>>>> smbiosRecords) {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fqdns are coming from salt network module instead of fqdns grain (bsc#1134860)
 - Consider timeout value in salt remote script (bsc#1153181)
 - rename SUSE Products to just Products in UI
 - Fix: regression with Ubuntu version compare (bsc#1150113)

--- a/susemanager-utils/susemanager-sls/salt/bootstrap/susemanager.conf
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/susemanager.conf
@@ -2,6 +2,7 @@
 master: {{ pillar['mgr_server'] }}
 server_id_use_crc: adler32
 enable_legacy_startup_events: False
+enable_fqdns_grains: False
 {% if pillar['activation_key'] is defined %}
 grains:
   susemanager:

--- a/susemanager-utils/susemanager-sls/salt/hardware/profileupdate.sls
+++ b/susemanager-utils/susemanager-sls/salt/hardware/profileupdate.sls
@@ -43,6 +43,8 @@ mainframe-sysinfo:
   module.run:
     - name: mainframesysinfo.read_values
 {% endif %}
+{% if 'network.fqdns' in salt %}
 fqdns:
   module.run:
     - name: network.fqdns
+{% endif%}

--- a/susemanager-utils/susemanager-sls/salt/hardware/profileupdate.sls
+++ b/susemanager-utils/susemanager-sls/salt/hardware/profileupdate.sls
@@ -43,4 +43,6 @@ mainframe-sysinfo:
   module.run:
     - name: mainframesysinfo.read_values
 {% endif %}
-
+fqdns:
+  module.run:
+    - name: network.fqdns

--- a/susemanager-utils/susemanager-sls/salt/util/mgr_disable_fqdns_grain.sls
+++ b/susemanager-utils/susemanager-sls/salt/util/mgr_disable_fqdns_grain.sls
@@ -1,0 +1,12 @@
+mgr_disable_fqdns_grains:
+  file.append:
+    - name: /etc/salt/minion.d/susemanager.conf
+    - text: "enable_fqdns_grains: False"
+
+mgr_salt_minion:
+  service.running:
+   - name: salt-minion
+   - enable: True
+   - order: last
+   - watch:
+     - file: mgr_disable_fqdns_grains


### PR DESCRIPTION
## What does this PR change?

port of https://github.com/SUSE/spacewalk/pull/9888


- [x] No changelog needed