### PR TITLE
Rename suse products

### DIFF
--- a/branding/java/code/src/com/redhat/rhn/branding/strings/StringResource_en_US.xml
+++ b/branding/java/code/src/com/redhat/rhn/branding/strings/StringResource_en_US.xml
@@ -2223,7 +2223,7 @@ tree will not be usable for autoinstalling.
         <source>What are Organization Credentials?</source>
       </trans-unit>
       <trans-unit id="mirror-credentials.jsp.info.p1">
-        <source>Organization credentials (Mirror credentials) are your access to SUSE product downloads.</source>
+        <source>Organization credentials (Mirror credentials) are your access to product downloads.</source>
       </trans-unit>
       <trans-unit id="mirror-credentials.jsp.info.h2">
         <source>Where do I find my Organization Credentials?</source>

--- a/branding/java/code/src/com/redhat/rhn/branding/strings/StringResource_en_US.xml
+++ b/branding/java/code/src/com/redhat/rhn/branding/strings/StringResource_en_US.xml
@@ -2139,8 +2139,8 @@ tree will not be usable for autoinstalling.
       <trans-unit id="Mirror Credentials">
         <source>Organization Credentials</source>
       </trans-unit>
-      <trans-unit id="SUSE Products">
-        <source>SUSE Products</source>
+      <trans-unit id="Products">
+        <source>Products</source>
       </trans-unit>
       <trans-unit id="Sync Schedule">
         <source>Sync Schedule</source>

--- a/branding/spacewalk-branding.changes
+++ b/branding/spacewalk-branding.changes
@@ -1,3 +1,4 @@
+- rename SUSE Products to just Products in UI
 - Move formula form styles to spacewalk-web
 - Bump version to 4.1.0 (bsc#1154940)
 - Improve menu scrollbar style for firefox

--- a/java/code/src/com/suse/manager/webui/Router.java
+++ b/java/code/src/com/suse/manager/webui/Router.java
@@ -300,7 +300,7 @@ public class Router implements SparkApplication {
         post("/manager/notification-messages/retry-reposync/:channelId",
                 withUser(NotificationMessageController::retryReposync));
 
-        // SUSE Products
+        // Products
         get("/manager/admin/setup/products",
                 withUserPreferences(withCsrfToken(withOrgAdmin(ProductsController::show))), jade);
         get("/manager/api/admin/products", withUser(ProductsController::data));

--- a/java/code/src/com/suse/manager/webui/menu/MenuTree.java
+++ b/java/code/src/com/suse/manager/webui/menu/MenuTree.java
@@ -315,7 +315,7 @@ public class MenuTree {
                                 .withPrimaryUrl("/rhn/admin/setup/ProxySettings.do"))
                         .addChild(new MenuItem("Mirror Credentials")
                                 .withPrimaryUrl("/rhn/admin/setup/MirrorCredentials.do"))
-                        .addChild(new MenuItem("SUSE Products")
+                        .addChild(new MenuItem("Products")
                                 .withPrimaryUrl("/rhn/manager/admin/setup/products")))
                 .addChild(new MenuItem("Organizations")
                     .withPrimaryUrl("/rhn/admin/multiorg/Organizations.do")

--- a/java/code/webapp/WEB-INF/nav/setup_wizard.xml
+++ b/java/code/webapp/WEB-INF/nav/setup_wizard.xml
@@ -6,7 +6,7 @@
   <rhn-tab name="Mirror Credentials" acl="user_role(satellite_admin)">
     <rhn-tab-url>/rhn/admin/setup/MirrorCredentials.do</rhn-tab-url>
   </rhn-tab>
-  <rhn-tab name="SUSE Products" acl="user_role(satellite_admin)">
+  <rhn-tab name="Products" acl="user_role(satellite_admin)">
     <rhn-tab-url>/rhn/manager/admin/setup/products</rhn-tab-url>
   </rhn-tab>
 </rhn-navi-tree>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- rename SUSE Products to just Products in UI
 - Fix: regression with Ubuntu version compare (bsc#1150113)
 - Add formula metadata to form data response
 - ignore kickstarttrees for child channels and prevent

--- a/testsuite/features/core/srv_products_page.feature
+++ b/testsuite/features/core/srv_products_page.feature
@@ -8,7 +8,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     Given I am authorized for the "Admin" section
     # Order matters here, refresh first
     When I refresh SCC
-    And I follow the left menu "Admin > Setup Wizard > SUSE Products"
+    And I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I see "Product Description" text
     Then I should see a "Arch" text
     And I should see a "Channels" text
@@ -17,7 +17,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
 @scc_credentials
   Scenario: Use the products filter
     Given I am authorized for the "Admin" section
-    When I follow the left menu "Admin > Setup Wizard > SUSE Products"
+    When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I see "Product Description" text
     And I enter "RHEL Expanded Support 7" in the css "input[name='product-description-filter']"
     Then I should see a "RHEL Expanded Support 7" text
@@ -25,7 +25,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
 @scc_credentials
   Scenario: View the channels list in the products page
     Given I am authorized for the "Admin" section
-    When I follow the left menu "Admin > Setup Wizard > SUSE Products"
+    When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I see "Product Description" text
     And I enter "SUSE Linux Enterprise Server for SAP All-in-One 11 SP2" in the css "input[name='product-description-filter']"
     And I click the channel list of product "SUSE Linux Enterprise Server for SAP All-in-One 11 SP2"
@@ -36,7 +36,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
 @scc_credentials
   Scenario: Add a product and one of its modules
     Given I am authorized for the "Admin" section
-    When I follow the left menu "Admin > Setup Wizard > SUSE Products"
+    When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I see "Product Description" text
     And I enter "SUSE Linux Enterprise Server 12 SP2" in the css "input[name='product-description-filter']"
     And I select "x86_64" in the dropdown list of the architecture filter
@@ -54,7 +54,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
 @scc_credentials
   Scenario: Add a product with recommended enabled
     Given I am authorized for the "Admin" section
-    When I follow the left menu "Admin > Setup Wizard > SUSE Products"
+    When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I see "Product Description" text
     And I enter "SUSE Linux Enterprise Server 15" in the css "input[name='product-description-filter']"
     And I select "x86_64" in the dropdown list of the architecture filter

--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -7,7 +7,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     Given I am authorized for the "Admin" section
     # Order matters here, refresh first
     When I refresh SCC
-    And I follow the left menu "Admin > Setup Wizard > SUSE Products"
+    And I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I see "Product Description" text
     Then I should see a "Arch" text
     And I should see a "Channels" text
@@ -15,14 +15,14 @@ Feature: Synchronize products in the products page of the Setup Wizard
 
   Scenario: Use the products filter
     Given I am authorized for the "Admin" section
-    When I follow the left menu "Admin > Setup Wizard > SUSE Products"
+    When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I see "Product Description" text
     And I enter "RHEL Expanded Support 7" in the css "input[name='product-description-filter']"
     Then I should see a "RHEL Expanded Support 7" text
 
   Scenario: View the channels list in the products page
     Given I am authorized for the "Admin" section
-    When I follow the left menu "Admin > Setup Wizard > SUSE Products"
+    When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I see "Product Description" text
     And I enter "SUSE Linux Enterprise Server for SAP All-in-One 11 SP2" in the css "input[name='product-description-filter']"
     And I click the channel list of product "SUSE Linux Enterprise Server for SAP All-in-One 11 SP2"
@@ -32,7 +32,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
 
   Scenario: Add a product and one of its modules
     Given I am authorized for the "Admin" section
-    When I follow the left menu "Admin > Setup Wizard > SUSE Products"
+    When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I see "Product Description" text
     And I enter "SUSE Linux Enterprise Server 12 SP2" in the css "input[name='product-description-filter']"
     And I select "x86_64" in the dropdown list of the architecture filter
@@ -48,7 +48,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     Then the SLE12 products should be added
 
   Scenario: Add a product with recommended enabled
-    When I follow the left menu "Admin > Setup Wizard > SUSE Products"
+    When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I see "Product Description" text
     And I enter "SUSE Linux Enterprise Server 15" in the css "input[name='product-description-filter']"
     And I select "x86_64" in the dropdown list of the architecture filter

--- a/testsuite/features/secondary/srv_menu.feature
+++ b/testsuite/features/secondary/srv_menu.feature
@@ -118,7 +118,7 @@ Feature: Web UI - Main landing page menu, texts and links
     When I follow the left menu "Admin > Setup Wizard"
     Then I should see a "HTTP Proxy" link in the left menu
     And I should see a "Organization Credentials" link in the left menu
-    And I should see a "SUSE Products" link in the left menu
+    And I should see a "Products" link in the left menu
 
   Scenario: The manager configuration submenu of the admin menu
     When I follow the left menu "Admin > Manager Configuration"

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -298,7 +298,7 @@ end
 Given(/^I am authorized for the "([^"]*)" section$/) do |section|
   case section
   when 'Admin'
-    step %(When I am authorized as "admin" with password "admin")
+    step %(I am authorized as "admin" with password "admin")
   end
 end
 

--- a/web/html/src/manager/admin/setup/products/products.js
+++ b/web/html/src/manager/admin/setup/products/products.js
@@ -317,7 +317,7 @@ class ProductsPageWrapper extends React.Component {
                 : null
             }
             <hr/>
-              <h4>{t("Why aren't all SUSE products displayed in the list?")}</h4>
+              <h4>{t("Why aren't all products displayed in the list?")}</h4>
               <p>{t('The products displayed on this list are directly linked to your \
                   Organization credentials (Mirror credentials) as well as your SUSE subscriptions.')}</p>
               <p>{t('If you believe there are products missing, make sure you have added the correct \

--- a/web/html/src/manager/admin/setup/products/products.js
+++ b/web/html/src/manager/admin/setup/products/products.js
@@ -39,7 +39,7 @@ const _SETUP_WIZARD_STEPS = [
   },
   {
     id: 'wizard-step-suse-products',
-    label: 'SUSE Products',
+    label: 'Products',
     url: location.href.split(/\?|#/)[0],
     active: true
   }
@@ -329,7 +329,7 @@ class ProductsPageWrapper extends React.Component {
     else {
       pageContent = (
         <div className='alert alert-warning' role='alert'>
-          {t('This server is configured as an Inter-Server Synchronisation (ISS) slave. SUSE Products can only be managed on the ISS master.')}
+          {t('This server is configured as an Inter-Server Synchronisation (ISS) slave. Products can only be managed on the ISS master.')}
         </div>
       );
     }

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- rename SUSE Products to just Products in UI
 - Layout changes in formula forms, validation, deprecate $visibleIf and add new attributes:
   $disabled, $visisble, $required, $match
 - Fix WebUI invalidation time by using the package build time instead


### PR DESCRIPTION
## What does this PR change?

Rename "SUSE Products" to just "Products" in Web UI.

Requires: ncounter:master-add-missing-third-level-menu-entries to be merged before

## GUI diff

Screenshots see below:

- [x] **DONE**

## Documentation
- https://github.com/SUSE/spacewalk/issues/9924

- [x] **DONE**

## Test coverage
- Cucumber tests were adapted

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/9530

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
