### PR TITLE
Add missing "public_cloud.py" custom grain file to spec (bsc#1155656)

### DIFF
--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Add missing "public_cloud" custom grain (bsc#1155656)
 - Consider timeout value in salt remote script (bsc#1153181)
 - Using new module path for which_bin to get rid of DeprecationWarning
 - Fix: match `image_id` with newer k8s (bsc#1149741)

--- a/susemanager-utils/susemanager-sls/susemanager-sls.spec
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.spec
@@ -77,6 +77,7 @@ cp -R scap/* %{buildroot}/usr/share/susemanager/scap
 cp src/beacons/pkgset.py %{buildroot}/usr/share/susemanager/salt/_beacons
 cp src/beacons/virtpoller.py %{buildroot}/usr/share/susemanager/salt/_beacons
 cp src/grains/cpuinfo.py %{buildroot}/usr/share/susemanager/salt/_grains/
+cp src/grains/public_cloud.py %{buildroot}/usr/share/susemanager/salt/_grains/
 cp src/modules/sumautil.py %{buildroot}/usr/share/susemanager/salt/_modules
 cp src/modules/mainframesysinfo.py %{buildroot}/usr/share/susemanager/salt/_modules
 cp src/modules/udevdb.py %{buildroot}/usr/share/susemanager/salt/_modules


### PR DESCRIPTION
## What does this PR change?

This PR adds a missing `public_cloud.py` file to the spec file from `susemanager-sls` in order to get that file deployed when installing the package.

Not having that file installed leads into issue when matching Public Cloud instances with registered systems.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **bugfix**

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
