### PR TITLE
Do not show errors when polling internal metadata API (bsc#1155794)

### DIFF
--- a/susemanager-utils/susemanager-sls/src/grains/public_cloud.py
+++ b/susemanager-utils/susemanager-sls/src/grains/public_cloud.py
@@ -55,7 +55,7 @@ def __virtual__():
 
     def _do_api_request(data):
         return {
-            data[0]: http.query(data[1], status=True, header_dict=data[2])
+            data[0]: http.query(data[1], status=True, header_dict=data[2], raise_error=False)
         }
 
     api_check_dict = [
@@ -79,13 +79,13 @@ def __virtual__():
         api_ret.update(i)
 
     if api_ret['amazon'].get('status') == 200 and "instance-id" in api_ret['amazon']['body']:
-        INSTANCE_ID = http.query(os.path.join(HOST, AMAZON_URL_PATH, 'instance-id'))['body']
+        INSTANCE_ID = http.query(os.path.join(HOST, AMAZON_URL_PATH, 'instance-id'), raise_error=False)['body']
         return True
     elif api_ret['azure'].get('status') == 200 and "vmId" in api_ret['azure']['body']:
-        INSTANCE_ID = http.query(os.path.join(HOST, AZURE_URL_PATH, 'vmId') + AZURE_API_ARGS, header_dict={"Metadata":"true"})['body']
+        INSTANCE_ID = http.query(os.path.join(HOST, AZURE_URL_PATH, 'vmId') + AZURE_API_ARGS, header_dict={"Metadata":"true"}, raise_error=False)['body']
         return True
     elif api_ret['google'].get('status') == 200 and "id" in api_ret['google']['body']:
-        INSTANCE_ID = http.query(os.path.join(HOST, GOOGLE_URL_PATH, 'id'), header_dict={"Metadata-Flavor": "Google"})['body']
+        INSTANCE_ID = http.query(os.path.join(HOST, GOOGLE_URL_PATH, 'id'), header_dict={"Metadata-Flavor": "Google"}, raise_error=False)['body']
         return True
 
     return False

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Do not show errors when polling internal metadata API (bsc#1155794)
 - Avoid traceback error due lazy loading which_bin (bsc#1155794)
 - Add missing "public_cloud" custom grain (bsc#1155656)
 - Consider timeout value in salt remote script (bsc#1153181)


### PR DESCRIPTION
## What does this PR change?

This PR prevents some unwanted ERROR messages to be shown in the Salt logs when the `public_cloud` custom grains is executed:

```
[ERROR   ] Cannot perform 'http.query': http://169.254.169.254/latest/meta-data/ - HTTP 404: Not Found
[ERROR   ] Cannot perform 'http.query': http://169.254.169.254/metadata/instance/compute/?api-version=2017-08-01&format=text - HTTP 404: Not Found
[ERROR   ] Cannot perform 'http.query': http://169.254.169.254/computeMetadata/v1/instance/ - HTTP 404: Not Found
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **bugfix**
- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/9946

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
