### PR TITLE
Avoid traceback error due lazy loading which_bin (bsc#1155794)

### DIFF
--- a/susemanager-utils/susemanager-sls/src/grains/cpuinfo.py
+++ b/susemanager-utils/susemanager-sls/src/grains/cpuinfo.py
@@ -4,9 +4,9 @@ import salt.utils
 import os
 import re
 try:
-    from salt.utils.path import which_bin
+    from salt.utils.path import which_bin as _which_bin
 except ImportError:
-    from salt.utils import which_bin
+    from salt.utils import which_bin as _which_bin
 
 __salt__ = {
     'cmd.run_all': salt.modules.cmdmod.run_all,
@@ -21,7 +21,7 @@ def _lscpu(feedback):
 
     :return:
     '''
-    lscpu = which_bin(['lscpu'])
+    lscpu = _which_bin(['lscpu'])
     if lscpu is not None:
         try:
             log.debug("Trying lscpu to get CPU socket count")
@@ -73,7 +73,7 @@ def _dmidecode(feedback):
 
     :return:
     '''
-    dmidecode = which_bin(['dmidecode'])
+    dmidecode = _which_bin(['dmidecode'])
     if dmidecode is not None:
         try:
             log.debug("Trying dmidecode to get CPU socket count")

--- a/susemanager-utils/susemanager-sls/src/modules/sumautil.py
+++ b/susemanager-utils/susemanager-sls/src/modules/sumautil.py
@@ -141,11 +141,11 @@ def _klp():
     '''
     # get 'kgr' for versions prior to SLE 15
     try:
-        from salt.utils.path import which_bin
+        from salt.utils.path import which_bin as _which_bin
     except:
-        from salt.utils import which_bin
+        from salt.utils import which_bin as _which_bin
 
-    klp = which_bin(['klp', 'kgr'])
+    klp = _which_bin(['klp', 'kgr'])
     patchname = None
     if klp is not None:
         try:

--- a/susemanager-utils/susemanager-sls/src/modules/udevdb.py
+++ b/susemanager-utils/susemanager-sls/src/modules/udevdb.py
@@ -10,9 +10,9 @@ import salt.utils
 import salt.modules.cmdmod
 from salt.exceptions import CommandExecutionError
 try:
-    from salt.utils.path import which_bin
+    from salt.utils.path import which_bin as _which_bin
 except ImportError:
-    from salt.utils import which_bin
+    from salt.utils import which_bin as _which_bin
 
 __salt__ = {
     'cmd.run_all': salt.modules.cmdmod.run_all,
@@ -25,7 +25,7 @@ def __virtual__():
     '''
     Only work when udevadm is installed.
     '''
-    return which_bin(['udevadm']) is not None
+    return _which_bin(['udevadm']) is not None
 
 
 def exportdb():

--- a/susemanager-utils/susemanager-sls/src/tests/test_grains_cpuinfo.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_grains_cpuinfo.py
@@ -36,7 +36,7 @@ def test_cpusockets_dmidecode():
 
     sample = mockery.get_test_data('dmidecode.sample')
     cpuinfo.log = MagicMock()
-    with patch('src.modules.udevdb.which_bin', MagicMock(return_value="/bogus/path")):
+    with patch('src.modules.udevdb._which_bin', MagicMock(return_value="/bogus/path")):
         with patch.dict(cpuinfo.__salt__, {'cmd.run_all': MagicMock(return_value={'retcode': 0, 'stdout': sample})}):
             out = cpuinfo._dmidecode([])
             assert type(out) == dict
@@ -73,7 +73,7 @@ def test_cpusockets_lscpu():
     '''
     for fn_smpl in ['lscpu.ppc64le.sample', 'lscpu.s390.sample', 'lscpu.sample']:
         cpuinfo.log = MagicMock()
-        with patch('src.modules.udevdb.which_bin', MagicMock(return_value="/bogus/path")):
+        with patch('src.modules.udevdb._which_bin', MagicMock(return_value="/bogus/path")):
             with patch.dict(cpuinfo.__salt__,
                             {'cmd.run_all': MagicMock(return_value={'retcode': 0,
                                                                     'stdout': mockery.get_test_data(fn_smpl)})}):

--- a/susemanager-utils/susemanager-sls/src/tests/test_module_sumautil.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_module_sumautil.py
@@ -17,7 +17,7 @@ def test_livepatching_kernelliveversion():
     '''
 
     sumautil.log = MagicMock()
-    with patch('src.modules.udevdb.which_bin', MagicMock(return_value="/bogus/path")):
+    with patch('src.modules.udevdb._which_bin', MagicMock(return_value="/bogus/path")):
         mock = MagicMock(side_effect=[{ 'retcode': 0, 'stdout': 'ready' },
                                     { 'retcode': 0, 'stdout': mockery.get_test_data('livepatching-1.sample')}
                                     ]);
@@ -36,6 +36,6 @@ def test_livepatching_kernelliveversion():
             assert 'mgr_kernel_live_version' in out
             assert out['mgr_kernel_live_version'] == 'kgraft_patch_2_2_1'
 
-    with patch('src.modules.udevdb.which_bin', MagicMock(return_value=None)):
+    with patch('src.modules.udevdb._which_bin', MagicMock(return_value=None)):
         out = sumautil.get_kernel_live_version()
         assert out is None

--- a/susemanager-utils/susemanager-sls/src/tests/test_module_udevdb.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_module_udevdb.py
@@ -15,10 +15,10 @@ def test_virtual():
 
     :return:
     '''
-    with patch('src.modules.udevdb.which_bin', MagicMock(return_value=None)):
+    with patch('src.modules.udevdb._which_bin', MagicMock(return_value=None)):
         assert udevdb.__virtual__() is False
 
-    with patch('src.modules.udevdb.which_bin', MagicMock(return_value="/bogus/path")):
+    with patch('src.modules.udevdb._which_bin', MagicMock(return_value="/bogus/path")):
         assert udevdb.__virtual__() is True
 
 

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Avoid traceback error due lazy loading which_bin (bsc#1155794)
 - Add missing "public_cloud" custom grain (bsc#1155656)
 - Consider timeout value in salt remote script (bsc#1153181)
 - Using new module path for which_bin to get rid of DeprecationWarning


### PR DESCRIPTION
## What does this PR change?

This PR prevents a lazy loading error while loading `which_bin` that causes error messages on the Salt minion logs:

```
# salt-call test.ping
[CRITICAL] Failed to load grains defined in grain file cpuinfo.which_bin in function <function which_bin at 0x7f413864aa28>, error:
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/loader.py", line 811, in grains
    ret = funcs[key](**kwargs)
TypeError: which_bin() takes exactly 1 argument (0 given)
local:
    True
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**
- [x] **DONE**

## Test coverage
- No tests: **bugfix**
- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/9946

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
