### PR TITLE
Do not use buildtimestamp for WebUI, and generate correct buildtimestamp

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/login/LoginController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/login/LoginController.java
@@ -105,7 +105,7 @@ public class LoginController {
             model.put("request_method", reqMethod);
             model.put("validationErrors", Json.GSON.toJson(LoginHelper.validateDBVersion()));
             model.put("schemaUpgradeRequired", Json.GSON.toJson(LoginHelper.isSchemaUpgradeRequired()));
-            model.put("webVersion", Config.get().getString("web.buildtimestamp"));
+            model.put("webVersion", Config.get().getString("web.version"));
             model.put("productName", Config.get().getString(ConfigDefaults.PRODUCT_NAME));
             model.put("customHeader", Config.get().getString("java.custom_header"));
             model.put("customFooter", Config.get().getString("java.custom_footer"));

--- a/java/code/src/com/suse/manager/webui/controllers/login/templates/login.jade
+++ b/java/code/src/com/suse/manager/webui/controllers/login/templates/login.jade
@@ -11,9 +11,9 @@ html
         link(rel='shortcut icon', href='/img/favicon.ico')
         meta(name='viewport', content='width=device-width, initial-scale=1.0')
         // import default fonts/icons styles
-        link(rel='stylesheet', href='/fonts/font-awesome/css/font-awesome.css?cb=#{webVersion}')
+        link(rel='stylesheet', href='/fonts/font-awesome/css/font-awesome.css?cb=#{webBuildtimestamp}')
         // import custom fonts/icons styles
-        link(rel='stylesheet', href='/fonts/font-spacewalk/css/spacewalk-font.css?cb=#{webVersion}')
+        link(rel='stylesheet', href='/fonts/font-spacewalk/css/spacewalk-font.css?cb=#{webBuildtimestamp}')
         // import spacewalk styles
         if isDevMode
             link(rel='stylesheet/less', href='/css/spacewalk.less')
@@ -21,15 +21,15 @@ html
                 less = {env: 'development'};
             script(src='/javascript/less.js')
         else
-            link(rel='stylesheet', href='/css/spacewalk.css?cb=#{webVersion}')
-        script(src='/javascript/loggerhead.js?cb=#{webVersion}')
-        script(src='/javascript/frontend-log.js?cb=#{webVersion}')
-        script(src='/javascript/jquery.js?cb=#{webVersion}')
-        script(src='/javascript/bootstrap.js?cb=#{webVersion}')
-        script(src='/javascript/susemanager-translate.js?cb=#{webVersion}')
-        script(src='/vendors/vendors.bundle.js?cb=#{webVersion}')
-        script(src='/javascript/manager/core.bundle.js?cb=#{webVersion}')
-        script(src='/javascript/manager/main.bundle.js?cb=#{webVersion}')
+            link(rel='stylesheet', href='/css/spacewalk.css?cb=#{webBuildtimestamp}')
+        script(src='/javascript/loggerhead.js?cb=#{webBuildtimestamp}')
+        script(src='/javascript/frontend-log.js?cb=#{webBuildtimestamp}')
+        script(src='/javascript/jquery.js?cb=#{webBuildtimestamp}')
+        script(src='/javascript/bootstrap.js?cb=#{webBuildtimestamp}')
+        script(src='/javascript/susemanager-translate.js?cb=#{webBuildtimestamp}')
+        script(src='/vendors/vendors.bundle.js?cb=#{webBuildtimestamp}')
+        script(src='/javascript/manager/core.bundle.js?cb=#{webBuildtimestamp}')
+        script(src='/javascript/manager/main.bundle.js?cb=#{webBuildtimestamp}')
         noscript
             .alert.alert-danger
                 | Some features require JavaScript in order to work properly. Make sure you enable JavaScript in your browser.

--- a/java/code/src/com/suse/manager/webui/templates/content_management/edit-profile.jade
+++ b/java/code/src/com/suse/manager/webui/templates/content_management/edit-profile.jade
@@ -2,7 +2,7 @@ include ../common.jade
 
 #image-profile-edit
 
-script(src='/javascript/validator/validator.min.js?cb=#{webVersion}', type='text/javascript')
+script(src='/javascript/validator/validator.min.js?cb=#{webBuildtimestamp}', type='text/javascript')
 
 script(type='text/javascript').
     window.csrfToken = "#{csrf_token}";

--- a/java/code/src/com/suse/manager/webui/templates/errors/404.jade
+++ b/java/code/src/com/suse/manager/webui/templates/errors/404.jade
@@ -2,7 +2,7 @@ include ../common.jade
 
 #notfoundpage
 
-script(src='/javascript/manager/errors/not-found.bundle.js?cb=#{webVersion}', type='text/javascript')
+script(src='/javascript/manager/errors/not-found.bundle.js?cb=#{webBuildtimestamp}', type='text/javascript')
 
 script(type='text/javascript').
     spaImportReactPage('errors/not-found')

--- a/java/code/src/com/suse/manager/webui/templates/groups/custom.jade
+++ b/java/code/src/com/suse/manager/webui/templates/groups/custom.jade
@@ -18,9 +18,9 @@ script(type='text/javascript').
     window.csrfToken = "#{csrf_token}";
     window.groupId = "#{groupId}";
 
-script(src='/javascript/ace-editor/src-min-noconflict/ace.js?cb=#{webVersion}')
-script(src='/javascript/ace-editor/src-min-noconflict/ext-modelist.js?cb=#{webVersion}')
-script(src='/javascript/jquery-ui.js?cb=#{webVersion}')
+script(src='/javascript/ace-editor/src-min-noconflict/ace.js?cb=#{webBuildtimestamp}')
+script(src='/javascript/ace-editor/src-min-noconflict/ext-modelist.js?cb=#{webBuildtimestamp}')
+script(src='/javascript/jquery-ui.js?cb=#{webBuildtimestamp}')
 
 script(type='text/javascript').
     spaImportReactPage('groups/config-channels/group-config-channels')

--- a/java/code/src/com/suse/manager/webui/templates/minion/custom.jade
+++ b/java/code/src/com/suse/manager/webui/templates/minion/custom.jade
@@ -6,9 +6,9 @@ script(type='text/javascript').
     window.csrfToken = "#{csrf_token}";
     window.serverId = "#{server.id}";
 
-script(src='/javascript/ace-editor/src-min-noconflict/ace.js?cb=#{webVersion}')
-script(src='/javascript/ace-editor/src-min-noconflict/ext-modelist.js?cb=#{webVersion}')
-script(src='/javascript/jquery-ui.js?cb=#{webVersion}')
+script(src='/javascript/ace-editor/src-min-noconflict/ace.js?cb=#{webBuildtimestamp}')
+script(src='/javascript/ace-editor/src-min-noconflict/ext-modelist.js?cb=#{webBuildtimestamp}')
+script(src='/javascript/jquery-ui.js?cb=#{webBuildtimestamp}')
 
 script(type='text/javascript').
     spaImportReactPage('minion/config-channels/minion-config-channels')

--- a/java/code/src/com/suse/manager/webui/templates/notification-messages/list.jade
+++ b/java/code/src/com/suse/manager/webui/templates/notification-messages/list.jade
@@ -2,7 +2,7 @@ include ../common.jade
 
 #notification-messages
 
-script(src='/javascript/momentjs/moment-with-langs.min.js?cb=#{webVersion}', type='text/javascript')
+script(src='/javascript/momentjs/moment-with-langs.min.js?cb=#{webBuildtimestamp}', type='text/javascript')
 
 script(type='text/javascript').
     window.csrfToken = "#{csrf_token}";

--- a/java/code/src/com/suse/manager/webui/templates/org/custom.jade
+++ b/java/code/src/com/suse/manager/webui/templates/org/custom.jade
@@ -14,9 +14,9 @@ script(type='text/javascript').
     window.csrfToken = "#{csrf_token}";
     window.orgId = "#{orgId}";
 
-script(src='/javascript/ace-editor/src-min-noconflict/ace.js?cb=#{webVersion}')
-script(src='/javascript/ace-editor/src-min-noconflict/ext-modelist.js?cb=#{webVersion}')
-script(src='/javascript/jquery-ui.js?cb=#{webVersion}')
+script(src='/javascript/ace-editor/src-min-noconflict/ace.js?cb=#{webBuildtimestamp}')
+script(src='/javascript/ace-editor/src-min-noconflict/ext-modelist.js?cb=#{webBuildtimestamp}')
+script(src='/javascript/jquery-ui.js?cb=#{webBuildtimestamp}')
 
 script(type='text/javascript').
     spaImportReactPage('organizations/config-channels/org-config-channels')

--- a/java/code/src/com/suse/manager/webui/templates/virtualization/guests/create.jade
+++ b/java/code/src/com/suse/manager/webui/templates/virtualization/guests/create.jade
@@ -1,8 +1,8 @@
 include ../../system-common.jade
 #virtualguests-create
 
-script(src='/javascript/momentjs/moment-with-langs.min.js?cb=#{webVersion}', type='text/javascript')
-script(src='/javascript/validator/validator.min.js?cb=#{webVersion}', type='text/javascript')
+script(src='/javascript/momentjs/moment-with-langs.min.js?cb=#{webBuildtimestamp}', type='text/javascript')
+script(src='/javascript/validator/validator.min.js?cb=#{webBuildtimestamp}', type='text/javascript')
 
 script(type='text/javascript').
     window.csrfToken = "#{csrf_token}";

--- a/java/code/src/com/suse/manager/webui/templates/virtualization/guests/edit.jade
+++ b/java/code/src/com/suse/manager/webui/templates/virtualization/guests/edit.jade
@@ -1,8 +1,8 @@
 include ../../system-common.jade
 #virtualguests-edit
 
-script(src='/javascript/momentjs/moment-with-langs.min.js?cb=#{webVersion}', type='text/javascript')
-script(src='/javascript/validator/validator.min.js?cb=#{webVersion}', type='text/javascript')
+script(src='/javascript/momentjs/moment-with-langs.min.js?cb=#{webBuildtimestamp}', type='text/javascript')
+script(src='/javascript/validator/validator.min.js?cb=#{webBuildtimestamp}', type='text/javascript')
 
 script(type='text/javascript').
     window.csrfToken = "#{csrf_token}";

--- a/java/code/src/com/suse/manager/webui/templates/virtualization/guests/show.jade
+++ b/java/code/src/com/suse/manager/webui/templates/virtualization/guests/show.jade
@@ -1,7 +1,7 @@
 include ../../system-common.jade
 #virtualguests
 
-script(src='/javascript/momentjs/moment-with-langs.min.js?cb=#{webVersion}', type='text/javascript')
+script(src='/javascript/momentjs/moment-with-langs.min.js?cb=#{webBuildtimestamp}', type='text/javascript')
 
 script(type='text/javascript').
     window.csrfToken = "#{csrf_token}";

--- a/java/code/src/com/suse/manager/webui/templates/visualization/hierarchy.jade
+++ b/java/code/src/com/suse/manager/webui/templates/visualization/hierarchy.jade
@@ -1,6 +1,6 @@
 include ../common.jade
 
-script(src='/javascript/d3.js?cb=#{webVersion}', type='text/javascript')
+script(src='/javascript/d3.js?cb=#{webBuildtimestamp}', type='text/javascript')
 
 #hierarchy
 

--- a/java/code/src/com/suse/manager/webui/templates/yourorg/custom.jade
+++ b/java/code/src/com/suse/manager/webui/templates/yourorg/custom.jade
@@ -12,9 +12,9 @@ script(type='text/javascript').
     window.csrfToken = "#{csrf_token}";
     window.orgId = "#{orgId}";
 
-script(src='/javascript/ace-editor/src-min-noconflict/ace.js?cb=#{webVersion}')
-script(src='/javascript/ace-editor/src-min-noconflict/ext-modelist.js?cb=#{webVersion}')
-script(src='/javascript/jquery-ui.js?cb=#{webVersion}')
+script(src='/javascript/ace-editor/src-min-noconflict/ace.js?cb=#{webBuildtimestamp}')
+script(src='/javascript/ace-editor/src-min-noconflict/ext-modelist.js?cb=#{webBuildtimestamp}')
+script(src='/javascript/jquery-ui.js?cb=#{webBuildtimestamp}')
 
 script(type='text/javascript').
     spaImportReactPage('organizations/config-channels/org-config-channels')

--- a/java/code/src/com/suse/manager/webui/utils/SparkApplicationHelper.java
+++ b/java/code/src/com/suse/manager/webui/utils/SparkApplicationHelper.java
@@ -286,6 +286,7 @@ public class SparkApplicationHelper {
         sharedVariables.put("isDevMode",
                 Config.get().getBoolean("java.development_environment"));
         sharedVariables.put("webVersion", Config.get().getString("web.version"));
+        sharedVariables.put("webBuildtimestamp", Config.get().getString("web.buildtimestamp"));
         JadeConfiguration config = jade.configuration();
         config.setSharedVariables(sharedVariables);
 

--- a/java/code/src/com/suse/manager/webui/utils/SparkApplicationHelper.java
+++ b/java/code/src/com/suse/manager/webui/utils/SparkApplicationHelper.java
@@ -285,7 +285,7 @@ public class SparkApplicationHelper {
         sharedVariables.put("h", ViewHelper.getInstance());
         sharedVariables.put("isDevMode",
                 Config.get().getBoolean("java.development_environment"));
-        sharedVariables.put("webVersion", Config.get().getString("web.buildtimestamp"));
+        sharedVariables.put("webVersion", Config.get().getString("web.version"));
         JadeConfiguration config = jade.configuration();
         config.setSharedVariables(sharedVariables);
 

--- a/web/spacewalk-web.spec
+++ b/web/spacewalk-web.spec
@@ -172,7 +172,7 @@ ln -sf %{nodejs_sitelib} .
 BUILD_VALIDATION=false node build.js
 popd
 %endif
-sed -i -r "s/^(web.buildtimestamp *= *)_OBS_BUILD_TIMESTAMP_$/\1$(date +"%Y%m%d%H%M%S")/" conf/rhn_web.conf
+sed -i -r "s/^(web.buildtimestamp *= *)_OBS_BUILD_TIMESTAMP_$/\1$(date +'%%Y%%m%%d%%H%%M%%S')/" conf/rhn_web.conf
 
 %install
 make -C modules install DESTDIR=$RPM_BUILD_ROOT PERLARGS="INSTALLDIRS=vendor" %{?_smp_mflags}


### PR DESCRIPTION
## What does this PR change?

Do not use buildtimestamp for WebUI, and generate correct buildtimestamp

Basically some bugfixing for https://github.com/uyuni-project/uyuni/pull/1529

## GUI diff

Before:

![image](https://user-images.githubusercontent.com/4226070/68128558-3c735480-ff18-11e9-9e06-9ca40a57b8ad.png)

After:

![Screenshot from 2019-11-06 12-02-45](https://user-images.githubusercontent.com/7080830/68293116-977a8800-008d-11ea-9f54-1376525ff4b8.png)


- [x] **DONE**

## Documentation
- No documentation needed: Bugfix.

- [x] **DONE**

## Test coverage
- No tests: Not covered

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
