### PR TITLE
Define specific form for SSM system deletion (bsc#1155800)

### DIFF
--- a/java/code/webapp/WEB-INF/pages/ssm/systems/ssmdeleteconfirm.jsp
+++ b/java/code/webapp/WEB-INF/pages/ssm/systems/ssmdeleteconfirm.jsp
@@ -18,22 +18,24 @@
 <c:set var="noErrata" value="true"/>
 <c:set var="noAddToSsm" value="true"/>
 
-<rl:listset name="systemListSet" legend="system">
-    <rhn:csrf />
-    <rhn:submitted />
+<html:form method="post" action="/systems/ssm/DeleteConfirm.do">
+    <rl:listset name="systemListSet" legend="system">
+        <rhn:csrf />
+        <rhn:submitted />
 
-    <div class="spacewalk-section-toolbar">
-        <div class="action-button-wrapper">
-          <jsp:include page="/WEB-INF/pages/ssm/systems/deleteconfirmdialog.jspf">
-            <jsp:param name="saltMinionsPresent" value="${saltMinionsPresent}"/>
-          </jsp:include>
+        <div class="spacewalk-section-toolbar">
+            <div class="action-button-wrapper">
+              <jsp:include page="/WEB-INF/pages/ssm/systems/deleteconfirmdialog.jspf">
+                <jsp:param name="saltMinionsPresent" value="${saltMinionsPresent}"/>
+              </jsp:include>
+            </div>
         </div>
-    </div>
 
-    <%@ include file="/WEB-INF/pages/common/fragments/systems/system_listdisplay.jspf" %>
+        <%@ include file="/WEB-INF/pages/common/fragments/systems/system_listdisplay.jspf" %>
 
-    </div>
-</rl:listset>
+        </div>
+    </rl:listset>
+</html:form>
 
 </body>
 </html>

--- a/java/code/webapp/WEB-INF/struts-config.xml
+++ b/java/code/webapp/WEB-INF/struts-config.xml
@@ -932,6 +932,12 @@
       <form-property name="submitted" type="java.lang.Boolean"/>
     </form-bean>
 
+    <form-bean name="ssmDeleteConfirmForm"
+                   type="com.redhat.rhn.frontend.struts.ScrubbingDynaActionForm" >
+            <form-property name="saltCleanup" type="java.lang.String" />
+            <form-property name="submitted" type="java.lang.Boolean" />
+    </form-bean>
+
     <form-bean name="ssmPreferencesForm"
                type="com.redhat.rhn.frontend.struts.ScrubbingDynaActionForm" >
       <form-property name="notify" type="java.lang.String"/>
@@ -3385,6 +3391,7 @@
     <!--System Details SSM Configuration -->
         <action path="/systems/ssm/DeleteConfirm"
         scope="request"
+        name="ssmDeleteConfirmForm"
         input="/WEB-INF/pages/ssm/systems/ssmdeleteconfirm.jsp"
         type="com.redhat.rhn.frontend.action.systems.SSMDeleteSystemsConfirm"
         className="com.redhat.rhn.frontend.struts.RhnActionMapping">

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Define specific form for SSM system deletion (bsc#1155800)
 - Consider timeout value in salt remote script (bsc#1153181)
 - rename SUSE Products to just Products in UI
 - Fix: regression with Ubuntu version compare (bsc#1150113)


### PR DESCRIPTION
## What does this PR change?

The missing definition of the `form` tag with proper parameters was causing the *single page application* version to miss the `POST` data parameter. In this specific case the `saltCleanup` parameter was missing from the `context` of the page and it was causing the following stacktrace and failure:

```
2019-11-04 09:50:31,971 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-8] ERROR
com.redhat.rhn.common.errors.BadParameterExceptionHandler - Missing
Parameter Error
com.redhat.rhn.frontend.action.common.BadParameterException: The parameter
saltCleanup is required.
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: functionality bugfix

- [x] **DONE**

## Test coverage
- No tests: SPA regression fix

- [x] **DONE**

## Links

Fixes  https://github.com/SUSE/spacewalk/issues/9949
Tracks # TODO for 4.0

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
