### PR TITLE
Create a single action when adding erratas to an action chain via the API (bsc#1148457)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/chain/test/ActionChainHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/chain/test/ActionChainHandlerTest.java
@@ -47,6 +47,7 @@ import com.redhat.rhn.frontend.xmlrpc.NoSuchActionChainException;
 import com.redhat.rhn.frontend.xmlrpc.NoSuchActionException;
 import com.redhat.rhn.frontend.xmlrpc.chain.ActionChainHandler;
 import com.redhat.rhn.frontend.xmlrpc.test.BaseHandlerTestCase;
+import com.redhat.rhn.manager.errata.cache.ErrataCacheManager;
 import com.redhat.rhn.manager.errata.cache.test.ErrataCacheManagerTest;
 import com.redhat.rhn.manager.rhnpackage.PackageManager;
 import com.redhat.rhn.manager.system.SystemManager;
@@ -78,6 +79,7 @@ public class ActionChainHandlerTest extends BaseHandlerTestCase {
     private Package pkg;
     private Package channelPackage;
     private Errata errata;
+    private Errata errata2;
     private ActionChain actionChain;
     private static final String UNAUTHORIZED_EXCEPTION_EXPECTED =
             "Expected an exception of type " +
@@ -110,6 +112,8 @@ public class ActionChainHandlerTest extends BaseHandlerTestCase {
         // Add errata available to the installation
         this.errata = ErrataFactoryTest.createTestPublishedErrata(
                 this.admin.getOrg().getId());
+        this.errata2 = ErrataFactoryTest.createTestPublishedErrata(
+                this.admin.getOrg().getId());
 
         // Install one package on the server
         InstalledPackage ipkg = new InstalledPackage();
@@ -121,6 +125,10 @@ public class ActionChainHandlerTest extends BaseHandlerTestCase {
         serverPkgs.add(ipkg);
 
         ServerFactory.save(this.server);
+
+        ErrataCacheManager.insertNeededErrataCache(
+                this.server.getId(), this.errata.getId(), this.pkg.getId());
+
         this.server = ActionChainHandlerTest.reload(this.server);
         ach = new ActionChainHandler();
         actionChain = ActionChainFactory.createActionChain(CHAIN_LABEL, admin);
@@ -175,6 +183,7 @@ public class ActionChainHandlerTest extends BaseHandlerTestCase {
     public void testAcAddErrataUpdate() throws Exception {
         List<Integer> errataIds = new ArrayList<Integer>();
         errataIds.add(this.errata.getId().intValue());
+        errataIds.add(this.errata2.getId().intValue());
         assertEquals(true, this.ach.addErrataUpdate(this.admin,
                                                     this.server.getId().intValue(),
                                                     errataIds,

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -2010,7 +2010,8 @@ public class ErrataManager extends BaseManager {
            actionIds.add(action.getId());
         });
         //Taskomatic part is needed only for minionActions
-        if (!minionTaskoActions.isEmpty()) {
+        //and only if actions are not added to an action chain
+        if (actionChain == null && !minionTaskoActions.isEmpty()) {
             taskomaticApi.scheduleMinionActionExecutions(minionTaskoActions, false);
             MinionActionManager.scheduleStagingJobsForMinions(minionTaskoActions, user);
         }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Create a single action when adding erratas to an action chain via the API (bsc#1148457)
 - Add check for url input when creating/editing repositories
 - Fqdns are coming from salt network module instead of fqdns grain (bsc#1134860)
 - Consider timeout value in salt remote script (bsc#1153181)


### PR DESCRIPTION
## What does this PR change?

Currently when using `actionchain.addErrata` API with multiple erratas an action is created for each errata.
This patch changes this behavior to create a single action for all errata.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/9777

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
