### PR TITLE
Fix building for CentOS6/RHEL6/Expanded Support 6

### DIFF
--- a/uyuni/common-libs/uyuni-common-libs.changes
+++ b/uyuni/common-libs/uyuni-common-libs.changes
@@ -1,3 +1,4 @@
+- Fix building for CentOS6/RHEL6/Expanded Support 6
 - add conflicts to spacewalk-backend-libs and spacewalk-usix to
   remove them on update
 

--- a/uyuni/common-libs/uyuni-common-libs.spec
+++ b/uyuni/common-libs/uyuni-common-libs.spec
@@ -22,6 +22,10 @@
 %global build_py3 1
 %endif
 
+%if ( 0%{?rhel} && 0%{?rhel} < 8 ) || 0%{?suse_version}
+%global build_py2   1
+%endif
+
 %define pythonX %{?build_py3:python3}%{!?build_py3:python}
 
 %if 0%{?suse_version} >= 1500
@@ -51,7 +55,7 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 %description
 Uyuni server and client libs
 
-
+%if 0%{?build_py2}
 %package -n python2-%{name}
 Summary:        Uyuni server and client tools libraries for python2
 Group:          Development/Languages/Python
@@ -66,6 +70,7 @@ Conflicts:      spacewalk-usix
 
 %description -n python2-%{name}
 Python 2 libraries required by both Uyuni server and client tools.
+%endif
 
 %if 0%{?build_py3}
 %package -n python3-%{name}
@@ -84,7 +89,6 @@ Conflicts:      python3-spacewalk-usix
 
 %description -n python3-%{name}
 Python 3 libraries required by both Uyuni server and client tools.
-
 %endif
 
 %prep
@@ -108,19 +112,23 @@ cp $RPM_BUILD_ROOT%{python3root}/common/{checksum.py,cli.py,rhn_deb.py,rhn_mpm.p
     $RPM_BUILD_ROOT%{python2root}/common
 %endif
 
+%if 0%{?suse_version}
+%if 0%{?build_py2}
 %py_compile -O %{buildroot}/%{python2root}
 %fdupes %{buildroot}/%{python2root}
-
+%endif
 %if 0%{?build_py3}
 %py3_compile -O %{buildroot}/%{python3root}
 %fdupes %{buildroot}/%{python3root}
 %endif
+%endif
 
-
+%if 0%{?build_py2}
 %files -n python2-%{name}
 %defattr(-,root,root)
 %doc LICENSE
 %{python2root}
+%endif
 
 %if 0%{?build_py3}
 %files -n python3-%{name}


### PR DESCRIPTION
## What does this PR change?

Fix building for CentOS6/RHEL6/Expanded Support 6.

`%py_compile` and `%py3_compile` are SUSE/openSUSE macros.

I tested it and now the package builds for CentOS6/CentOS7/SLE11/SLE12/SLE15

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Fix building.

- [x] **DONE**

## Test coverage
- No tests: Building is tested by OBS.

- [x] **DONE**

## Links

Tracks: https://github.com/SUSE/spacewalk/issues/9475

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
