### PR TITLE
SPA: do not early drop modals they can contain inputs (bsc#1155800)

### DIFF
--- a/web/html/src/core/spa/spa-engine.js
+++ b/web/html/src/core/spa/spa-engine.js
@@ -51,8 +51,10 @@ window.pageRenderers.spaengine.init = function init() {
 
     appInstance.on('beforeNavigate', function(navigation) {
       // Integration with bootstrap 3. We need to make sure all the existing modals get fully removed
-      $('.modal').remove();
-      $('.modal-backdrop').remove();
+      // but we have to do it after the navigation ends unless all form inputs contained in the modal will be dropped
+      // before the form serialization happens and they will not submitted because they will not exist anymore
+      $('.modal').addClass('removeWhenNavigationEnds');
+      $('.modal-backdrop').addClass('removeWhenNavigationEnds');
       $('body').removeClass( "modal-open" );
 
       let urlParser = document.createElement('a');
@@ -63,6 +65,10 @@ window.pageRenderers.spaengine.init = function init() {
     })
 
     appInstance.on('endNavigate', function(navigation) {
+      // Drop everything that was marked to be removed
+      $('.modal.removeWhenNavigationEnds').remove();
+      $('.modal-backdrop.removeWhenNavigationEnds').remove();
+
       // If an error happens we make a full refresh to make sure the original request is shown instead of a SPA replacement
       if (
         navigation.error

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- SPA: do not early drop modals they can contain inputs (bsc#1155800)
 - rename SUSE Products to just Products in UI
 - Layout changes in formula forms, validation, deprecate $visibleIf and add new attributes:
   $disabled, $visisble, $required, $match


### PR DESCRIPTION
## What does this PR change?

Due to mimic the SPA behavior for Bootstrap modals, we need to drop them during SPA navigation, but we need to do carefully at the right moment in time, unless modals will be dropped early and, for instance, we could end up missing some input fields during form submissions.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
- No tests: bugfix

- [x] **DONE**

## Links

Fixes  https://github.com/SUSE/spacewalk/issues/9949
Tracks # TODO for 4.0

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
