### PR TITLE
Clean files after running containers

### DIFF
--- a/susemanager-utils/testing/automation/backend-unittest-oracle.sh
+++ b/susemanager-utils/testing/automation/backend-unittest-oracle.sh
@@ -11,8 +11,13 @@ fi
 
 DOCKER_RUN_EXPORT="PYTHONPATH=/manager/client/rhel/rhnlib/:/manager/client/rhel/rhn-client-tools/src"
 EXIT=0
+
+INITIAL_CMD="/manager/susemanager-utils/testing/automation/initial-objects.sh"
+CMD="/manager/backend/test/docker-backend-oracle-tests.sh"
+CLEAN_CMD="/manager/susemanager-utils/testing/automation/clean-objects.sh"
+
 docker pull $REGISTRY/$ORACLE_CONTAINER
-docker run --privileged --rm=true -e $DOCKER_RUN_EXPORT -v "$GITROOT:/manager" $REGISTRY/$ORACLE_CONTAINER /manager/backend/test/docker-backend-oracle-tests.sh
+docker run --privileged --rm=true -e $DOCKER_RUN_EXPORT -v "$GITROOT:/manager" $REGISTRY/$ORACLE_CONTAINER /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CLEAN_CMD} && exit \${RET}"
 if [ $? -ne 0 ]; then
     EXIT=3
 fi

--- a/susemanager-utils/testing/automation/backend-unittest-pgsql.sh
+++ b/susemanager-utils/testing/automation/backend-unittest-pgsql.sh
@@ -11,16 +11,23 @@ fi
 
 DOCKER_RUN_EXPORT="PYTHONPATH=/manager/client/rhel/rhnlib/:/manager/client/rhel/spacewalk-client-tools/src"
 EXIT=0
+
+INITIAL_CMD="/manager/susemanager-utils/testing/automation/initial-objects.sh"
+CLEAN_CMD="/manager/susemanager-utils/testing/automation/clean-objects.sh"
+
 docker pull $REGISTRY/$PGSQL_CONTAINER
-docker run --rm=true -e $DOCKER_RUN_EXPORT -v "$GITROOT:/manager" $REGISTRY/$PGSQL_CONTAINER /manager/backend/test/docker-backend-common-tests.sh
+CMD="/manager/backend/test/docker-backend-common-tests.sh"
+docker run --rm=true -e $DOCKER_RUN_EXPORT -v "$GITROOT:/manager" $REGISTRY/$PGSQL_CONTAINER /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CLEAN_CMD} && exit \${RET}"
 if [ $? -ne 0 ]; then
     EXIT=1
 fi
-docker run --rm=true -e $DOCKER_RUN_EXPORT -v "$GITROOT:/manager" $REGISTRY/$PGSQL_CONTAINER /manager/backend/test/docker-backend-tools-tests.sh
+CMD="/manager/backend/test/docker-backend-tools-tests.sh"
+docker run --rm=true -e $DOCKER_RUN_EXPORT -v "$GITROOT:/manager" $REGISTRY/$PGSQL_CONTAINER /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CLEAN_CMD} && exit \${RET}"
 if [ $? -ne 0 ]; then
     EXIT=2
 fi
-docker run --privileged --rm=true -e $DOCKER_RUN_EXPORT -v "$GITROOT:/manager" $REGISTRY/$PGSQL_CONTAINER /manager/backend/test/docker-backend-pgsql-tests.sh
+CMD="/manager/backend/test/docker-backend-pgsql-tests.sh"
+docker run --privileged --rm=true -e $DOCKER_RUN_EXPORT -v "$GITROOT:/manager" $REGISTRY/$PGSQL_CONTAINER /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CLEAN_CMD} && exit \${RET}"
 if [ $? -ne 0 ]; then
     EXIT=3
 fi

--- a/susemanager-utils/testing/automation/clean-objects.sh
+++ b/susemanager-utils/testing/automation/clean-objects.sh
@@ -1,0 +1,25 @@
+#/bin/bash -e
+echo "*************** CLEANING OBJECTS GENERATED INSIDE THE CONTAINER  ***************"
+# Exit if the file does not exist or if it is empty
+if [ ! -f /tmp/objects-init.txt -o -s /tmp/objects-init.txt ]; then
+  echo "No file with the initial list of objects"
+  exit 0
+fi
+find /manager > /tmp/objects-end.txt
+while read OBJECTEND; do
+  FOUND=FALSE
+  while read OBJECTINIT; do
+    if [ "${OBJECTINIT}" == "${OBJECTEND}" ]; then
+      FOUND=TRUE
+      break
+    fi
+  done < /tmp/objects-init.txt
+  if [ "${FOUND}" == "FALSE" ]; then
+    echo "${OBJECTEND}"
+    if [ -d ${OBJECTEND} ]; then
+        rm -rf ${OBJECTEND}
+    else
+	rm -f ${OBJECTEND}
+    fi
+  fi
+done < /tmp/objects-end.txt

--- a/susemanager-utils/testing/automation/initial-objects.sh
+++ b/susemanager-utils/testing/automation/initial-objects.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+find /manager > /tmp/objects-init.txt

--- a/susemanager-utils/testing/automation/java-checkstyle.sh
+++ b/susemanager-utils/testing/automation/java-checkstyle.sh
@@ -40,8 +40,12 @@ if [ ! -f ${CREDENTIALS} ]; then
   exit 1
 fi
 
+INITIAL_CMD="/manager/susemanager-utils/testing/automation/initial-objects.sh"
+CMD="/manager/java/scripts/docker-checkstyle.sh"
+CLEAN_CMD="/manager/susemanager-utils/testing/automation/clean-objects.sh"
+
 docker pull $REGISTRY/$PGSQL_CONTAINER
 docker run --privileged --rm=true -v "$GITROOT:/manager" \
     --mount type=bind,source=${CREDENTIALS},target=/root/.oscrc \
     $REGISTRY/$PGSQL_CONTAINER \
-    /manager/java/scripts/docker-checkstyle.sh
+    /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CLEAN_CMD} && exit \${RET}"

--- a/susemanager-utils/testing/automation/java-unittests-oracle.sh
+++ b/susemanager-utils/testing/automation/java-unittests-oracle.sh
@@ -9,5 +9,9 @@ HERE=`dirname $0`
 . $HERE/VERSION
 GITROOT=`readlink -f $HERE/../../../`
 
+INITIAL_CMD="/manager/susemanager-utils/testing/automation/initial-objects.sh"
+CMD="/manager/java/scripts/docker-testing-oracle.sh $TARGET"
+CLEAN_CMD="/manager/susemanager-utils/testing/automation/clean-objects.sh"
+
 docker pull $REGISTRY/$ORACLE_CONTAINER
-docker run --privileged --rm=true -v "$GITROOT:/manager" $REGISTRY/$ORACLE_CONTAINER /manager/java/scripts/docker-testing-oracle.sh $TARGET
+docker run --privileged --rm=true -v "$GITROOT:/manager" $REGISTRY/$ORACLE_CONTAINER /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CLEAN_CMD} && exit \${RET}"

--- a/susemanager-utils/testing/automation/java-unittests-pgsql.sh
+++ b/susemanager-utils/testing/automation/java-unittests-pgsql.sh
@@ -44,8 +44,12 @@ if [ ! -f ${CREDENTIALS} ]; then
   exit 1
 fi
 
+INITIAL_CMD="/manager/susemanager-utils/testing/automation/initial-objects.sh"
+CMD="/manager/java/scripts/docker-testing-pgsql.sh ${TARGET}"
+CLEAN_CMD="/manager/susemanager-utils/testing/automation/clean-objects.sh"
+
 docker pull $REGISTRY/$PGSQL_CONTAINER
 docker run --privileged --rm=true -v "$GITROOT:/manager" \
     --mount type=bind,source=${CREDENTIALS},target=/root/.oscrc \
     $REGISTRY/$PGSQL_CONTAINER \
-    /manager/java/scripts/docker-testing-pgsql.sh ${TARGET}
+    /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CLEAN_CMD} && exit \${RET}"

--- a/susemanager-utils/testing/automation/javascript-lint.sh
+++ b/susemanager-utils/testing/automation/javascript-lint.sh
@@ -5,5 +5,10 @@ HERE=`dirname $0`
 GITROOT=`readlink -f $HERE/../../../`
 echo $HERE
 echo $GITROOT
+
+INITIAL_CMD="/manager/susemanager-utils/testing/automation/initial-objects.sh"
+CMD="/manager/web/html/src/scripts/docker-javascript-lint.sh"
+CLEAN_CMD="/manager/susemanager-utils/testing/automation/clean-objects.sh"
+
 docker pull $REGISTRY/$NODEJS_CONTAINER
-docker run --privileged --rm=true -v "$GITROOT:/manager" $REGISTRY/$NODEJS_CONTAINER /manager/web/html/src/scripts/docker-javascript-lint.sh
+docker run --privileged --rm=true -v "$GITROOT:/manager" $REGISTRY/$NODEJS_CONTAINER /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CLEAN_CMD} && exit \${RET}"

--- a/susemanager-utils/testing/automation/push-to-obs.sh
+++ b/susemanager-utils/testing/automation/push-to-obs.sh
@@ -50,8 +50,9 @@ if [ ! -f ${CREDENTIALS} ]; then
   exit 1
 fi
 
-PUSH_CMD="/manager/susemanager-utils/testing/docker/scripts/push-to-obs.sh -d '${DESTINATIONS}' -c /tmp/.oscrc ${VERBOSE} ${TEST}"
-CLEAN_CMD="cd /manager; /manager/susemanager-utils/testing/docker/scripts/clean-push-to-obs.sh"
+INITIAL_CMD="/manager/susemanager-utils/testing/automation/initial-objects.sh"
+CMD="/manager/susemanager-utils/testing/docker/scripts/push-to-obs.sh -d '${DESTINATIONS}' -c /tmp/.oscrc ${VERBOSE} ${TEST}"
+CLEAN_CMD="/manager/susemanager-utils/testing/automation/clean-objects.sh"
 
 docker pull $REGISTRY/$PUSH2OBS_CONTAINER
-docker run --rm=true -v "$GITROOT:/manager" -v "/srv/mirror:/srv/mirror" --mount type=bind,source=${CREDENTIALS},target=/tmp/.oscrc $REGISTRY/$PUSH2OBS_CONTAINER /bin/bash -c "${PUSH_CMD}; RET=\${?}; ${CLEAN_CMD} && exit \${RET}"
+docker run --rm=true -v "$GITROOT:/manager" -v "/srv/mirror:/srv/mirror" --mount type=bind,source=${CREDENTIALS},target=/tmp/.oscrc $REGISTRY/$PUSH2OBS_CONTAINER /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CLEAN_CMD} && exit \${RET}"

--- a/susemanager-utils/testing/automation/schema-migration-test-oracle.sh
+++ b/susemanager-utils/testing/automation/schema-migration-test-oracle.sh
@@ -4,5 +4,9 @@ HERE=`dirname $0`
 . $HERE/VERSION
 GITROOT=`readlink -f $HERE/../../../`
 
+INITIAL_CMD="/manager/susemanager-utils/testing/automation/initial-objects.sh"
+CMD="/manager/susemanager-utils/testing/docker/scripts/schema_migration_test_oracle-31to41.sh"
+CLEAN_CMD="/manager/susemanager-utils/testing/automation/clean-objects.sh"
+
 docker pull $REGISTRY/$ORACLE_CONTAINER
-docker run --privileged --rm=true -v "$GITROOT:/manager" $REGISTRY/$ORACLE_CONTAINER /manager/susemanager-utils/testing/docker/scripts/schema_migration_test_oracle-31to41.sh
+docker run --privileged --rm=true -v "$GITROOT:/manager" $REGISTRY/$ORACLE_CONTAINER /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CLEAN_CMD} && exit \${RET}"

--- a/susemanager-utils/testing/automation/schema-migration-test-pgsql.sh
+++ b/susemanager-utils/testing/automation/schema-migration-test-pgsql.sh
@@ -23,7 +23,9 @@ else
   IDEMPOTENCY_PARAMS=" -v ${IDEMPOTENCY_SCHEMA_BASE_VERSION}"  
 fi
 
+INITIAL_CMD="/manager/susemanager-utils/testing/automation/initial-objects.sh"
 MIGRATION_TEST='/manager/susemanager-utils/testing/docker/scripts/schema_migration_test_pgsql-31to41.sh'
 IDEMPOTENCY_TEST="/manager/susemanager-utils/testing/docker/scripts/schema_idempotency_test_pgsql.py ${IDEMPOTENCY_PARAMS}"
+CLEAN_CMD="/manager/susemanager-utils/testing/automation/clean-objects.sh"
 
-docker run --privileged --rm=true -v "$GITROOT:/manager" $REGISTRY/$PGSQL_CONTAINER /bin/bash -c "${MIGRATION_TEST} && ${IDEMPOTENCY_TEST}"
+docker run --privileged --rm=true -v "$GITROOT:/manager" $REGISTRY/$PGSQL_CONTAINER /bin/bash -c "${INITIAL_CMD}; ${MIGRATION_TEST} && ${IDEMPOTENCY_TEST}; RET=\${?}; ${CLEAN_CMD} && exit \${RET}"

--- a/susemanager-utils/testing/automation/spacewalk-pylint.sh
+++ b/susemanager-utils/testing/automation/spacewalk-pylint.sh
@@ -154,10 +154,12 @@ susemanager-utils/susemanager-sls/salt/channels/yum-susemanager-plugin/susemanag
 susemanager-utils/susemanager-sls/src/
 "
 
-PYLINT_CMD="pylint --disable=E0203,E0611,E1101,E1102,C0111,I0011,R0801 --ignore=test --output-format=parseable --rcfile /manager/spacewalk/pylint/spacewalk-pylint.rc --reports=y --msg-template=\"{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}\""
+INITIAL_CMD="/manager/susemanager-utils/testing/automation/initial-objects.sh"
+PYLINT_CMD="mkdir -p /manager/reports; cd /manager/; pylint --disable=E0203,E0611,E1101,E1102,C0111,I0011,R0801 --ignore=test --output-format=parseable --rcfile /manager/spacewalk/pylint/spacewalk-pylint.rc --reports=y --msg-template=\"{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}\""
+CLEAN_CMD="/manager/susemanager-utils/testing/automation/clean-objects.sh"
 
 docker pull $REGISTRY/$PYLINT_CONTAINER
-docker run --rm=true -e $DOCKER_RUN_EXPORT -v "$GITROOT:/manager" $REGISTRY/$PGSQL_CONTAINER /bin/sh -c "mkdir -p /manager/reports; cd /manager/; $PYLINT_CMD `echo $SPACEWALK_FILES` > reports/pylint.log || :"
+docker run --rm=true -e $DOCKER_RUN_EXPORT -v "$GITROOT:/manager" $REGISTRY/$PGSQL_CONTAINER /bin/sh -c "${INITIAL_CMD}; $PYLINT_CMD `echo $SPACEWALK_FILES` > reports/pylint.log || :; RET=\${?}; ${CLEAN_CMD} && exit \${RET}"
 
 if [ $? -ne 0 ]; then
    EXIT=1

--- a/susemanager-utils/testing/automation/susemanager-unittest.sh
+++ b/susemanager-utils/testing/automation/susemanager-unittest.sh
@@ -11,8 +11,12 @@ fi
 
 DOCKER_RUN_EXPORT="PYTHONPATH=/manager/client/rhel/rhnlib/:/manager/client/rhel/rhn-client-tools/src"
 
+INITIAL_CMD="/manager/susemanager-utils/testing/automation/initial-objects.sh"
+CMD="cd /manager/susemanager; make -f Makefile.susemanager unittest_inside_docker pylint_inside_docker"
+CLEAN_CMD="/manager/susemanager-utils/testing/automation/clean-objects.sh"
+
 docker pull $REGISTRY/$PGSQL_CONTAINER
-docker run --rm=true -e $DOCKER_RUN_EXPORT -v "$GITROOT:/manager" $REGISTRY/$PGSQL_CONTAINER /bin/sh -c "cd /manager/susemanager; make -f Makefile.susemanager unittest_inside_docker pylint_inside_docker"
+docker run --rm=true -e $DOCKER_RUN_EXPORT -v "$GITROOT:/manager" $REGISTRY/$PGSQL_CONTAINER /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CLEAN_CMD} && exit \${RET}"
 if [ $? -ne 0 ]; then
    EXIT=1
 fi


### PR DESCRIPTION
## What does this PR change?

Clean files after running containers.

When we share the Git repository with the container as a volume, and then new stuff is created inside, Jenkins can't clean the workspace anymore (such new objects are exposed as owned by root user from the docker host perspective).

This PR modifies all the tests to get a list of objects from the `/manager` volume when the container stats, run the tests, then looks for new objects and removes them.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Testing stuff.

- [x] **DONE**

## Test coverage
- No tests: Testing fix.

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/9908

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test" 
- [ ] Re-run test "backend_unittests_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "java_lint_checkstyle" (Test skipped, there are no changes to test)		 
- [ ] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)		 
- [ ] Re-run test "ruby_rubocop" (Test skipped, there are no changes to test)
- [x] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql" (Test skipped, there are no changes to test)		 
- [ ] Re-run test "susemanager_unittests" (Test skipped, there are no changes to test)
- [ ] Re-run test "javascript_lint" (Test skipped, there are no changes to test)		 
- [ ] Re-run test "spacecmd_unittests" (Test skipped, there are no changes to test)
