### PR TITLE
Skip dmidecode data on aarch64 to prevent coredump (bsc#1113160)

### DIFF
--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes
@@ -1,3 +1,4 @@
+- Skip dmidecode data on aarch64 to prevent coredump (bsc#1113160)
 - replace spacewalk-usix with uyuni-common-libs
 - return a non-zero exit status on errors in rhn_check
 - Bump version to 4.1.0 (bsc#1154940)

--- a/client/rhel/spacewalk-client-tools/src/up2date_client/hardware.py
+++ b/client/rhel/spacewalk-client-tools/src/up2date_client/hardware.py
@@ -57,7 +57,7 @@ _ = t.ugettext
 import dbus
 import platform
 
-if platform.processor() not in ['s390', 's390x']:
+if platform.processor() not in ['s390', 's390x', 'aarch64']:
     import dmidecode
     _dmi_not_available = 0
 else:


### PR DESCRIPTION
Porting https://github.com/SUSE/spacewalk/pull/9971