### PR TITLE
Fix Add check for url input when creating/editing repositories

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/channel/repo/BaseRepoCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/repo/BaseRepoCommand.java
@@ -17,8 +17,6 @@
  */
 package com.redhat.rhn.manager.channel.repo;
 
-import org.apache.commons.validator.UrlValidator;
-
 import com.redhat.rhn.common.client.InvalidCertificateException;
 import com.redhat.rhn.domain.channel.ChannelFactory;
 import com.redhat.rhn.domain.channel.ContentSource;
@@ -32,6 +30,7 @@ import com.redhat.rhn.frontend.xmlrpc.channel.repo.InvalidRepoTypeException;
 import com.redhat.rhn.frontend.xmlrpc.channel.repo.InvalidRepoUrlException;
 import com.redhat.rhn.frontend.xmlrpc.channel.repo.InvalidRepoUrlInputException;
 
+import java.net.URL;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
@@ -220,8 +219,10 @@ public abstract class BaseRepoCommand {
         }
 
         if (this.url != null && this.type != null) {
-            UrlValidator urlValidator = new UrlValidator();
-            if (!urlValidator.isValid(this.url)) {
+            final URL u;
+            try {
+                u = new URL(this.url);
+            } catch (Exception e) {
                 throw new InvalidRepoUrlInputException(url);
             }
             ContentSourceType cst = ChannelFactory.lookupContentSourceType(this.type);

--- a/java/code/src/com/redhat/rhn/manager/channel/test/BaseRepoCommandTest.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/test/BaseRepoCommandTest.java
@@ -48,22 +48,13 @@ public class BaseRepoCommandTest extends RhnBaseTestCase {
         invalidUrlInput("example.com");
         invalidUrlInput("htp://some_test_url.com");
         invalidUrlInput("www.example.com");
-        invalidUrlInput("http://test123/example.net");
-        invalidUrlInput("ftp://example@test123.com");
-        invalidUrlInput("http://example_1.com");
-        invalidUrlInput("http://example#2.com");
-        invalidUrlInput("http://example;3.com");
-        invalidUrlInput("http://example:4.com");
-        invalidUrlInput("http://example=5.com");
-        invalidUrlInput("http://example,6.com");
-        invalidUrlInput("http://example$7.com");
-        invalidUrlInput("http://example$8.com");
-        invalidUrlInput("http://example(9).com");
-        invalidUrlInput("http://example[0].com");
-        invalidUrlInput("http://example.123");
-
 
         // V A L I D
+        validUrlInput("file:///srv/mirror");
+        validUrlInput("http://localhost");
+        validUrlInput("http://localhost:8080");
+        validUrlInput("http://localhost/pub");
+        validUrlInput("http://localhost.com.x/pub");
         validUrlInput("http://www.example.com");
         validUrlInput("http://www.example.co.uk");
         validUrlInput("https://www3.example.com");


### PR DESCRIPTION


Signed-off-by: Pascal Arlt <parlt@suse.com>

## What does this PR change?

PR #1399 introduced a bug that would not allow 'http://localhost'
or 'file:///srv/mirror' as a valid repository url.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: **This is a bug fix for a previous commit.**

- [x] **DONE**

## Test coverage
- No tests: **Just a bug fix**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
