### PR TITLE
Fix checkstyle in BaseRepoCommand

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/channel/repo/BaseRepoCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/repo/BaseRepoCommand.java
@@ -222,7 +222,8 @@ public abstract class BaseRepoCommand {
             final URL u;
             try {
                 u = new URL(this.url);
-            } catch (Exception e) {
+            }
+            catch (Exception e) {
                 throw new InvalidRepoUrlInputException(url);
             }
             ContentSourceType cst = ChannelFactory.lookupContentSourceType(this.type);


### PR DESCRIPTION
## What does this PR change?

Just a checkstyle fix.

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation

- No documentation needed:


- [x] **DONE**

## Test coverage

- No tests:

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
