### PR TITLE
Make jabberd compatible with JeOS (bsc#1148352)

### DIFF
--- a/spacewalk/spacewalk-setup-jabberd/bin/spacewalk-setup-jabberd
+++ b/spacewalk/spacewalk-setup-jabberd/bin/spacewalk-setup-jabberd
@@ -127,7 +127,7 @@ foreach my $basename ('c2s', 's2s', 'sm', 'router', 'router-users') {
 my $definedauthreg = `sqlite3 /var/lib/jabberd/db/sqlite.db ".tables authreg"`;
 chomp $definedauthreg;
 if ($definedauthreg ne 'authreg') {
-        `sqlite3 /var/lib/jabberd/db/sqlite.db < /usr/share/doc/packages/jabberd/db-setup.sqlite`;
+        `sqlite3 /var/lib/jabberd/db/sqlite.db < /etc/jabberd/scripts/db-setup.sqlite`;
         `chown jabber:jabber /var/lib/jabberd/db/sqlite.db`;
 }
 

--- a/spacewalk/spacewalk-setup-jabberd/include/manage_database
+++ b/spacewalk/spacewalk-setup-jabberd/include/manage_database
@@ -2,7 +2,7 @@
 
 XSLPROC="xsltproc"
 SQLITE="sqlite3"
-STP_QUERY="/usr/share/doc/packages/jabberd/db-setup.sqlite"
+STP_QUERY="/etc/jabberd/scripts/db-setup.sqlite"
 
 # How to parse sm.xml config
 read -r -d '' SM_PARSE <<XML

--- a/spacewalk/spacewalk-setup-jabberd/spacewalk-setup-jabberd.changes
+++ b/spacewalk/spacewalk-setup-jabberd/spacewalk-setup-jabberd.changes
@@ -1,3 +1,5 @@
+- SQL scripts are now placed at /etc/jabberd/scripts to make jabberd
+  compatible with JeOS (bsc#1148352)
 - Bump version to 4.1.0 (bsc#1154940)
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

SQL scripts are now placed at /etc/jabberd/scripts to make jabberd compatible with JeOS (bsc#1148352)

Reason: JeOS remove the doc stuff.

**WARNING:** Requires https://build.suse.de/request/show/204645 accepted and copied to Uyuni, and requires back port to 4.0 of both the PR and the SR.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Bugfix

- [x] **DONE**

## Test coverage
- No tests: We don't test JeOS

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/9478

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
