### PR TITLE
Make scenario names unique

### DIFF
--- a/testsuite/features/secondary/allcli_config_channel.feature
+++ b/testsuite/features/secondary/allcli_config_channel.feature
@@ -252,6 +252,6 @@ Feature: Management of configuration of all types of clients in a single channel
     When I destroy "/etc/s-mgr" directory on "sle-client"
     And I destroy "/etc/s-mgr" directory on "sle-minion"
 
-  Scenario: Cleanup: remove remaining systems from SSM
+  Scenario: Cleanup: remove remaining systems from SSM after tests of configuration channel on all clients
     When I am authorized as "admin" with password "admin"
     And I follow "Clear"

--- a/testsuite/features/secondary/allcli_software_channels.feature
+++ b/testsuite/features/secondary/allcli_software_channels.feature
@@ -214,6 +214,6 @@ Feature: Chanel subscription via SSM
     And I wait until I see "1 system successfully completed this action." text, refreshing the page
     Then channel "Test-Channel-x86_64 Child Channel" should not be enabled on "sle-client"
 
-  Scenario: Cleanup: remove remaining systems from SSM
+  Scenario: Cleanup: remove remaining systems from SSM after channel subscription tests
     When I am authorized as "admin" with password "admin"
     And I follow "Clear"

--- a/testsuite/features/secondary/allcli_software_channels_dependencies.feature
+++ b/testsuite/features/secondary/allcli_software_channels_dependencies.feature
@@ -46,6 +46,6 @@ Feature: Chanel subscription with recommended/required dependencies
     Then I should see "Subscribe" "selected" for the "SLE-Module-Basesystem15-Pool for x86_64" channel
     And I should see "No change" "unselected" for the "SLE-Module-Basesystem15-Pool for x86_64" channel
 
-  Scenario: Cleanup: remove remaining systems from SSM
+  Scenario: Cleanup: remove remaining systems from SSM after software channel tests
     When I am authorized as "admin" with password "admin"
     And I follow "Clear"

--- a/testsuite/features/secondary/min_action_chain.feature
+++ b/testsuite/features/secondary/min_action_chain.feature
@@ -18,7 +18,7 @@ Feature: Action chain on salt minions
     And I wait until refresh package list on "sle-minion" is finished
     Then spacecmd should show packages "milkyway-dummy andromeda-dummy-1.0" installed on "sle-minion"
 
-  Scenario: Pre-requisite: wait until downgrade is finished
+  Scenario: Pre-requisite: wait until downgrade is finished on SLE minion
     Given I am on the Systems overview page of this "sle-minion"
     When I follow "Software" in the content area
     And I follow "List / Remove" in the content area
@@ -238,7 +238,7 @@ Feature: Action chain on salt minions
     Then "andromeda-dummy" should be installed on "sle-client"
     And "andromeda-dummy" should be installed on "sle-minion"
 
-  Scenario: Cleanup: roll back action chain effects
+  Scenario: Cleanup: roll back action chain effects on Salt minion
     Given I am on the Systems overview page of this "sle-minion"
     When I run "rm /tmp/action_chain_done" on "sle-minion" without error control
     And I run "zypper -n rm andromeda-dummy" on "sle-minion" without error control
@@ -286,7 +286,7 @@ Feature: Action chain on salt minions
     Then file "/tmp/action_chain.log" should contain "123" on "sle-minion"
     And I wait until there are no more scheduled actions
 
-  Scenario: Cleanup: remove Salt client from configuration channel
+  Scenario: Cleanup: remove Salt minion from configuration channel
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Configuration > Channels"
     And I follow "Action Chain Channel"
@@ -314,6 +314,6 @@ Feature: Action chain on salt minions
     And I run "rm -f /etc/action-chain.cnf" on "sle-minion" without error control
     And I run "rm -f /tmp/action_chain_one_system_done" on "sle-minion" without error control
 
-  Scenario: Cleanup: remove remaining systems from SSM
+  Scenario: Cleanup: remove remaining systems from SSM after action chain tests on normal minion
     When I am authorized as "admin" with password "admin"
     And I follow "Clear"

--- a/testsuite/features/secondary/min_centos_salt.feature
+++ b/testsuite/features/secondary/min_centos_salt.feature
@@ -9,7 +9,7 @@
 Feature: Be able to bootstrap a CentOS minion and do some basic operations on it
 
 @centos_minion
-  Scenario: Delete the CentOS SSH minion
+  Scenario: Delete the CentOS SSH minion before normal minion tests
     When I am on the Systems overview page of this "ceos-ssh-minion"
     And I follow "Delete System"
     Then I should see a "Confirm System Profile Deletion" text
@@ -120,7 +120,7 @@ Feature: Be able to bootstrap a CentOS minion and do some basic operations on it
     Then "ceos-minion" should not be registered
 
 @centos_minion
-  Scenario: Cleanup: bootstrap a SSH-managed CentOS minion
+  Scenario: Cleanup: bootstrap a SSH-managed CentOS minion after normal minion tests
     Given I am authorized
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text

--- a/testsuite/features/secondary/min_osimage_build_image.feature
+++ b/testsuite/features/secondary/min_osimage_build_image.feature
@@ -46,6 +46,6 @@ Feature: Build OS images
   Scenario: Cleanup: Disable the repositories on branch server
     When I disable repositories after installing branch server
 
-  Scenario: Cleanup: remove remaining systems from SSM
+  Scenario: Cleanup: remove remaining systems from SSM after OS image tests
     When I am authorized as "admin" with password "admin"
     And I follow "Clear"

--- a/testsuite/features/secondary/min_salt_formulas.feature
+++ b/testsuite/features/secondary/min_salt_formulas.feature
@@ -6,7 +6,7 @@ Feature: Use salt formulas
   As an authorized user
   I want to be able to install and use salt formulas
 
-  Scenario: Install a formula package on the server
+  Scenario: Install the locale formula package on the server
      Given I am authorized
      When I manually install the "locale" formula on the server
      And I synchronize all Salt dynamic modules on "sle-minion"
@@ -109,7 +109,7 @@ Feature: Use salt formulas
      And the pillar data for "timezone" should be empty on "sle-minion"
      And the pillar data for "keyboard_and_language" should be empty on "sle-minion"
 
-  Scenario: Assign formula to minion via group formula
+  Scenario: Assign locale formula to minion via group formula
      Given I am on the groups page
      When I follow "Create Group"
      And I enter "locale-formula-group" as "name"
@@ -163,6 +163,6 @@ Feature: Use salt formulas
      Given I am authorized
      And I manually uninstall the "locale" formula from the server
 
-  Scenario: Cleanup: remove remaining systems from SSM
+  Scenario: Cleanup: remove remaining systems from SSM after formula tests
      When I am authorized as "admin" with password "admin"
      And I follow "Clear"

--- a/testsuite/features/secondary/min_salt_formulas_advanced.feature
+++ b/testsuite/features/secondary/min_salt_formulas_advanced.feature
@@ -6,14 +6,14 @@ Feature: Use advanced features of Salt formulas
   As an authorized user
   I want to be able to install and use Salt formulas
 
-  Scenario: Install a formula package on the server
+  Scenario: Install a test formula package on the server
      Given I am authorized
      When I install "form.yml" to custom formula metadata directory "testform"
      And I install "metadata.yml" to custom formula metadata directory "testform"
      When I follow the left menu "Salt > Formula Catalog"
      Then I should see a "testform" text
 
-  Scenario: Assign formula to minion via group formula
+  Scenario: Assign test formula to minion via group formula
      Given I am on the groups page
      When I follow "Create Group"
      And I enter "test-formula-group" as "name"

--- a/testsuite/features/secondary/min_salt_install_package.feature
+++ b/testsuite/features/secondary/min_salt_install_package.feature
@@ -3,17 +3,17 @@
 
 Feature: Install a patch on the client via Salt through the UI
 
-  Scenario: Pre-requisite: install virgo-dummy-1.0 packages
+  Scenario: Pre-requisite: install virgo-dummy-1.0 packages on SLE minion
     When I enable repository "test_repo_rpm_pool" on this "sle-minion"
     And I run "zypper -n ref" on "sle-minion"
     And I run "zypper -n in --oldpackage virgo-dummy-1.0" on "sle-minion" without error control
 
-  Scenario: Pre-requisite: refresh package list and check old packages installed on SLE minion client
+  Scenario: Pre-requisite: refresh package list and check old packages installed on SLE minion
     When I refresh packages list via spacecmd on "sle-minion"
     And I wait until refresh package list on "sle-minion" is finished
     Then spacecmd should show packages "virgo-dummy-1.0" installed on "sle-minion"
 
-  Scenario: Pre-requisite: ensure the errata cache is computed before patchin Salt minion
+  Scenario: Pre-requisite: ensure the errata cache is computed before patching Salt minion
     Given I am on the Systems overview page of this "sle-minion"
     When I follow "Software" in the content area
     And I follow "List / Remove" in the content area

--- a/testsuite/features/secondary/min_salt_install_with_staging.feature
+++ b/testsuite/features/secondary/min_salt_install_with_staging.feature
@@ -22,7 +22,7 @@ Feature: Install a package on the minion with staging enabled
     And I wait until refresh package list on "sle-minion" is finished
     Then spacecmd should show packages "virgo-dummy-1.0" installed on "sle-minion"
 
-  Scenario: Pre-requisite: ensure the errata cache is computed
+  Scenario: Pre-requisite: ensure the errata cache is computed before staging tests
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Admin > Task Schedules"
     And I follow "errata-cache-default"

--- a/testsuite/features/secondary/min_salt_pkgset_beacon.feature
+++ b/testsuite/features/secondary/min_salt_pkgset_beacon.feature
@@ -14,7 +14,7 @@ Feature: System package list is updated if packages are manually installed or re
     And I wait until refresh package list on "sle-minion" is finished
     Then spacecmd should show packages "milkyway-dummy-1.0" installed on "sle-minion"
 
-  Scenario: Pre-requisite: ensure the errata cache is computed
+  Scenario: Pre-requisite: ensure the errata cache is computed before package list tests
     Given I am on the Systems overview page of this "sle-minion"
     When I follow "Software" in the content area
     And I follow "List / Remove" in the content area

--- a/testsuite/features/secondary/min_salt_software_states.feature
+++ b/testsuite/features/secondary/min_salt_software_states.feature
@@ -17,7 +17,7 @@ Feature: Salt package states
     And I wait until refresh package list on "sle-minion" is finished
     Then spacecmd should show packages "milkyway-dummy-1.0 virgo-dummy-1.0 andromeda-dummy-1.0" installed on "sle-minion"
 
-  Scenario: Pre-requisite: ensure the errata cache is computed
+  Scenario: Pre-requisite: ensure the errata cache is computed before software states tests
     Given I am on the Systems overview page of this "sle-minion"
     When I follow "Software" in the content area
     And I follow "List / Remove" in the content area

--- a/testsuite/features/secondary/min_ubuntu_salt_install_package.feature
+++ b/testsuite/features/secondary/min_ubuntu_salt_install_package.feature
@@ -4,7 +4,7 @@
 Feature: Install and upgrade package on the Ubuntu minion via Salt through the UI
 
 @ubuntu_minion
-  Scenario: Pre-requisite: install virgo-dummy-1.0 packages
+  Scenario: Pre-requisite: install virgo-dummy-1.0 packages on Ubuntu minion
     When I enable repository "test_repo_deb_pool" on this "ubuntu-minion"
     And I run "apt update" on "ubuntu-minion"
     And I remove package "andromeda-dummy" from this "ubuntu-minion"

--- a/testsuite/features/secondary/minssh_action_chain.feature
+++ b/testsuite/features/secondary/minssh_action_chain.feature
@@ -22,7 +22,7 @@ Feature: Salt SSH action chain
     Then spacecmd should show packages "milkyway-dummy andromeda-dummy-1.0" installed on "ssh-minion"
 
 @ssh_minion
-  Scenario: Pre-requisite: wait until downgrade is finished
+  Scenario: Pre-requisite: wait until downgrade is finished on SSH minion
     Given I am on the Systems overview page of this "ssh-minion"
     When I follow "Software" in the content area
     And I follow "List / Remove" in the content area
@@ -209,7 +209,7 @@ Feature: Salt SSH action chain
     Then I click on "Delete"
 
 @ssh_minion
-  Scenario: Cleanup: roll back action chain effects
+  Scenario: Cleanup: roll back action chain effects on SSH minion
     Given I am on the Systems overview page of this "ssh-minion"
     When I run "rm /tmp/action_chain_done" on "ssh-minion" without error control
     And I run "zypper -n rm andromeda-dummy" on "ssh-minion" without error control
@@ -263,7 +263,7 @@ Feature: Salt SSH action chain
     And I wait until there are no more scheduled actions
 
 @ssh_minion
-  Scenario: Cleanup: remove Salt client from configuration channel
+  Scenario: Cleanup: remove SSH minion from configuration channel
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Configuration > Channels"
     And I follow "Action Chain Channel"
@@ -294,6 +294,6 @@ Feature: Salt SSH action chain
     And I run "rm -f /etc/action-chain.cnf" on "ssh-minion" without error control
     And I run "rm -f /tmp/action_chain_one_system_done" on "ssh-minion" without error control
 
-  Scenario: Cleanup: remove remaining systems from SSM
+  Scenario: Cleanup: remove remaining systems from SSM after action chain tests on SSH minion
     When I am authorized as "admin" with password "admin"
     And I follow "Clear"

--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -521,6 +521,6 @@ Feature: PXE boot a Retail terminal
 
 @proxy
 @private_net
-  Scenario: Cleanup: remove remaining systems from SSM
+  Scenario: Cleanup: remove remaining systems from SSM after PXE boot tests
   When I am authorized as "admin" with password "admin"
   And I follow "Clear"

--- a/testsuite/features/secondary/srv_check_sync_source_packages.feature
+++ b/testsuite/features/secondary/srv_check_sync_source_packages.feature
@@ -16,7 +16,7 @@ Feature: Check if source packages were successfully synced
     And I follow "virgo-dummy-2.0-1.1.noarch"
     Then I should see a "virgo-dummy-2.0-1.1.src.rpm" text
 
-  Scenario: Check sources for noarch package
+  Scenario: Check sources for x86_64 package
     When I follow "Test-Channel-x86_64"
     And I follow "Packages"
     And I follow "blackhole-dummy-1.0-1.1.x86_64"

--- a/testsuite/features/secondary/srv_clone_channel_npn.feature
+++ b/testsuite/features/secondary/srv_clone_channel_npn.feature
@@ -123,6 +123,6 @@ Feature: Clone a channel
     Then I should see a "Clone 3 of Test-Channel-x86_64" text
     And I should see a "has been deleted." text
 
-  Scenario: Cleanup: remove remaining systems from SSM
+  Scenario: Cleanup: remove remaining systems from SSM after channel cloning tests
     When I am authorized as "admin" with password "admin"
     And I follow "Clear"

--- a/testsuite/features/secondary/srv_cve_audit.feature
+++ b/testsuite/features/secondary/srv_cve_audit.feature
@@ -111,6 +111,6 @@ Feature: CVE Audit
     And I run "zypper -n rm milkyway-dummy" on "sle-client" without error control
     And I run "rhn_check -vvv" on "sle-client" without error control
 
-  Scenario: Cleanup: remove remaining systems from SSM
+  Scenario: Cleanup: remove remaining systems from SSM after CVE audit tests
     When I am authorized as "admin" with password "admin"
     And I follow "Clear"

--- a/testsuite/features/secondary/srv_delete_channel.feature
+++ b/testsuite/features/secondary/srv_delete_channel.feature
@@ -5,7 +5,7 @@ Feature: Delete channels with child or clone is not allowed
   we cannot delete a channel if it has a child
   or have a clone from it
 
-  Scenario: Clone the first channel
+  Scenario: Clone the first channel before deletion from UI test
     Given I am on the manage software channels page
     When I follow "Clone Channel"
     And I select "Test-Channel-x86_64" as the origin channel

--- a/testsuite/features/secondary/srv_group_union_intersection.feature
+++ b/testsuite/features/secondary/srv_group_union_intersection.feature
@@ -75,7 +75,7 @@ Feature: Work with Union and Intersection buttons in the group list
     And I click on "Add Systems"
     Then I should see a "1 systems were added to traditional server group." text
 
-  Scenario: Add the new group to SSM
+  Scenario: Add the sles group to SSM
     Given I am on the groups page
     When I click on "Use in SSM" in row "sles"
     And I should see a "systems selected" text
@@ -153,6 +153,6 @@ Feature: Work with Union and Intersection buttons in the group list
     And I click on "Confirm Deletion"
     Then I should see a "deleted" text
 
-  Scenario: Cleanup: remove remaining systems from SSM
+  Scenario: Cleanup: remove remaining systems from SSM after group union and intersection tests
     When I am authorized as "admin" with password "admin"
     And I follow "Clear"

--- a/testsuite/features/secondary/srv_power_management.feature
+++ b/testsuite/features/secondary/srv_power_management.feature
@@ -85,6 +85,6 @@ Feature: Power management
   Scenario: Cleanup: don't fake an IPMI host
     Given the server stops mocking an IPMI host
 
-  Scenario: Cleanup: remove remaining systems from SSM
+  Scenario: Cleanup: remove remaining systems from SSM after power management tests
     When I am authorized as "admin" with password "admin"
     And I follow "Clear"

--- a/testsuite/features/secondary/srv_spacewalk_remove_channel_tool.feature
+++ b/testsuite/features/secondary/srv_spacewalk_remove_channel_tool.feature
@@ -4,7 +4,7 @@
 Feature: Deleting channels with children or clones is not allowed
   We cannot delete a channel if it has a clone
 
-  Scenario: Clone the first channel
+  Scenario: Clone the first channel before deletion from tool test
     Given I am on the manage software channels page
     When I follow "Clone Channel"
     And I select "Test-Channel-x86_64" as the origin channel

--- a/testsuite/features/secondary/trad_action_chain.feature
+++ b/testsuite/features/secondary/trad_action_chain.feature
@@ -257,6 +257,6 @@ Feature: Action chain on traditional clients
   Scenario: Cleanup: remove temporary files for testing action chains on traditional client
     When I run "rm -f /tmp/action_chain.log" on "sle-client" without error control
 
-  Scenario: Cleanup: remove remaining systems from SSM
+  Scenario: Cleanup: remove remaining systems from SSM after action chain tests on traditional client
     When I am authorized as "admin" with password "admin"
     And I follow "Clear"

--- a/testsuite/features/secondary/trad_baremetal_discovery.feature
+++ b/testsuite/features/secondary/trad_baremetal_discovery.feature
@@ -120,6 +120,6 @@ Feature: Bare metal discovery
     When I register using "1-SUSE-DEV-x86_64" key
     Then I should see "sle-client" in spacewalk
 
-  Scenario: Cleanup: remove remaining systems from SSM
+  Scenario: Cleanup: remove remaining systems from SSM after bare metal tests
     When I am authorized as "admin" with password "admin"
     And I follow "Clear"

--- a/testsuite/features/secondary/trad_centos_client.feature
+++ b/testsuite/features/secondary/trad_centos_client.feature
@@ -11,7 +11,7 @@
 Feature: Be able to register a CentOS 7 traditional client and do some basic operations on it
 
 @centos_minion
-  Scenario: Delete the CentOS SSH minion
+  Scenario: Delete the CentOS SSH minion before traditional client tests
     When I am on the Systems overview page of this "ceos-ssh-minion"
     And I follow "Delete System"
     Then I should see a "Confirm System Profile Deletion" text
@@ -102,7 +102,7 @@ Feature: Be able to register a CentOS 7 traditional client and do some basic ope
     Then "ceos-client" should not be registered
 
 @centos_minion
-  Scenario: Cleanup: bootstrap a SSH-managed CentOS minion
+  Scenario: Cleanup: bootstrap a SSH-managed CentOS minion after traditional client tests
     Given I am authorized
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text

--- a/testsuite/features/secondary/trad_config_channel.feature
+++ b/testsuite/features/secondary/trad_config_channel.feature
@@ -286,6 +286,6 @@ Feature: Configuration management of traditional clients
   Scenario: Cleanup: delete configuration file on client
     When I remove "/etc/mgr-test-file.cnf" from "sle-client"
 
-  Scenario: Cleanup: remove remaining systems from SSM
+  Scenario: Cleanup: remove remaining systems from SSM after tests of configuration channel on traditional client
     When I am authorized as "admin" with password "admin"
     And I follow "Clear"

--- a/testsuite/features/secondary/trad_migrate_to_sshminion.feature
+++ b/testsuite/features/secondary/trad_migrate_to_sshminion.feature
@@ -39,33 +39,33 @@ Feature: Migrate a traditional client into a Salt SSH minion
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
 
-  Scenario: Check that the migrated system is now a ssh-minion
+  Scenario: Check that the migrated system is now a SSH minion
     Given I am on the Systems overview page of this "sle-migrated-minion"
     When I wait until I see the name of "sle-migrated-minion", refreshing the page
     And I follow "Properties" in the content area
     Then I wait until I see "Base System Type:     Salt" text, refreshing the page
 
 @proxy
-  Scenario: Check connection from migrated ssh-minion to proxy
+  Scenario: Check connection from migrated SSH minion to proxy
     Given I am on the Systems overview page of this "sle-migrated-minion"
     When I follow "Details" in the content area
     And I follow "Connection" in the content area
     Then I should see "proxy" hostname
 
 @proxy
-  Scenario: Check registration on proxy of migrated ssh-minion
+  Scenario: Check registration on proxy of migrated SSH minion
     Given I am on the Systems overview page of this "proxy"
     When I follow "Details" in the content area
     And I follow "Proxy" in the content area
     Then I should see "sle-migrated-minion" hostname
 
   # bsc#1020902 - moving from traditional to Salt with bootstrap is not disabling rhnsd
-  Scenario: Check that service nhsd has been stopped on migrated ssh-minion
+  Scenario: Check that service nhsd has been stopped on migrated SSH minion
     When I run "systemctl status nhsd" on "sle-migrated-minion" without error control
     Then the command should fail
 
   # bsc#1031081 - old and new activation keys shown for the migrated client
-  Scenario: Check that ssh-minion only has the new activation key
+  Scenario: Check that SSH minion only has the new activation key
     Given I am on the Systems overview page of this "sle-migrated-minion"
     Then I should see a "Activation Key:	1-SUSE-PKG-x86_64" text
     And I should not see a "1-SUSE-DEV-x86_64" text
@@ -80,7 +80,7 @@ Feature: Migrate a traditional client into a Salt SSH minion
     And I follow "History" in the content area
     Then I should see a "subscribed to channel test-channel-x86_64" text
 
-  Scenario: Install a package to the migrated ssh-minion
+  Scenario: Install a package to the migrated SSH minion
     Given I am on the Systems overview page of this "sle-migrated-minion"
     When I follow "Software" in the content area
     And I follow "Install"
@@ -90,7 +90,7 @@ Feature: Migrate a traditional client into a Salt SSH minion
     Then I should see a "1 package install has been scheduled for" text
     And I wait for "perseus-dummy-1.1-1.1" to be installed on this "sle-migrated-minion"
 
-  Scenario: Run a remote script on the migrated ssh-minion
+  Scenario: Run a remote script on the migrated SSH minion
     Given I am on the Systems overview page of this "sle-migrated-minion"
     When I follow "Remote Command" in the content area
     And I enter as remote command this script in
@@ -103,7 +103,7 @@ Feature: Migrate a traditional client into a Salt SSH minion
     When I wait until file "/tmp/remote-command-on-migrated-test" exists on "sle-migrated-minion"
     And I remove "/tmp/remote-command-on-migrated-test" from "sle-migrated-minion"
 
-  Scenario: Cleanup: remove package from the migrated ssh-minion
+  Scenario: Cleanup: remove package from the migrated SSH minion
     When I remove package "perseus-dummy-1.1-1.1" from this "sle-migrated-minion"
     And I remove package "orion-dummy-1.1-1.1" from this "sle-migrated-minion"
 


### PR DESCRIPTION
## What does this PR change?

This PR changes scenario names so they are unique testsuite-wide.

Reasons:
 * needed to run without ambiguity scenarios from command line
 * makes reading results more informative

Scenario names change only: cannot break anything.

## Links

Ports
* 4.0: SUSE/spacewalk#9991
* 3.2: SUSE/spacewalk#9992 

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
