### PR TITLE
Tasks bunch detail show info if start time is null

### DIFF
--- a/java/code/webapp/WEB-INF/pages/admin/bunchDetail.jsp
+++ b/java/code/webapp/WEB-INF/pages/admin/bunchDetail.jsp
@@ -46,9 +46,16 @@
                 <rl:column bound="false"
                            headerkey="task.edit.jsp.stattime"
                            sortattr="start_time" >
-                        <a href="/rhn/admin/ScheduleDetail.do?schid=${current.schedule_id}">
-                          <fmt:formatDate pattern="yyyy-MM-dd HH:mm:ss z" value="${current.start_time}"/>
-                        </a>
+                    <c:choose>
+                        <c:when test="${current.start_time == null && current.status == 'INTERRUPTED'}">
+                            Task never started
+                        </c:when>
+                        <c:otherwise>
+                            <a href="/rhn/admin/ScheduleDetail.do?schid=${current.schedule_id}">
+                               <fmt:formatDate pattern="yyyy-MM-dd HH:mm:ss z" value="${current.start_time}"/>
+                            </a>
+                        </c:otherwise>
+                    </c:choose>
                 </rl:column>
 
                 <rl:column bound="false"

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,5 +1,6 @@
 - Fix WebUI invalidation time by using the package build time instead
   of the WebUI version (bsc#1154868)
+- Tasks bunch detail page displays message "Task never started" in case a task get interrupted before start
 - Create a single action when adding erratas to an action chain via the API (bsc#1148457)
 - Add check for url input when creating/editing repositories
 - Fqdns are coming from salt network module instead of fqdns grain (bsc#1134860)

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -603,7 +603,7 @@ When(/^I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINI
     #  - INTERRUPTED rows with no start time (expected when Taskomatic had been restarted)
     #  - SKIPPED rows (expected when Taskomatic triggers the same task concurrently)
     first_non_skipped = statuses.zip(start_times).drop_while do |status, start_time|
-      (status == 'INTERRUPTED' && start_time.empty?) || status == 'SKIPPED'
+      (status == 'INTERRUPTED' && (start_time.empty? || start_time == 'Task never started')) || status == 'SKIPPED'
     end.first.first
 
     # halt in case we are done, or if an error is detected


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rjmateus@gmail.com>

## What does this PR change?

Tasks bunch detail page displays message "Task never started" in case a task gets interrupted before start
Missing:
- [ ] add before image

## GUI diff


Before:

After:
![Interrupted_solution](https://user-images.githubusercontent.com/2996004/68413674-96795180-0186-11ea-809f-8f52755370d6.png)

- [X] **DONE**

## Documentation
- No documentation needed: Just add an extra label to make it clear to costumers 

- [X] **DONE**

## Test coverage
- No tests: Add one label if a field is empty
- Unit tests were added
- Cucumber tests were adapted to keep the same behavior

- [ ] **DONE**

## Links

Fixes #https://github.com/SUSE/spacewalk/issues/8101
Tracks # **add downstream PR, if any**
Add backport to Manager 4.0

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
