### PR TITLE
New config style for Cobbler's modules.conf

### DIFF
--- a/susemanager-utils/testing/docker/master/uyuni-master-cobbler/modules.conf
+++ b/susemanager-utils/testing/docker/master/uyuni-master-cobbler/modules.conf
@@ -4,13 +4,13 @@
 # authentication: 
 # what users can log into the WebUI and Read-Write XMLRPC?
 # choices:
-#    authn_denyall    -- no one (default)
-#    authn_configfile -- use /etc/cobbler/users.digest (for basic setups)
-#    authn_passthru   -- ask Apache to handle it (used for kerberos)
-#    authn_ldap       -- authenticate against LDAP
-#    authn_spacewalk  -- ask Spacewalk/Satellite (experimental)
-#    authn_pam        -- use PAM facilities
-#    authn_testing    -- username/password is always testing/testing (debug)
+#    authentication.denyall    -- no one (default)
+#    authentication.configfile -- use /etc/cobbler/users.digest (for basic setups)
+#    authentication.passthru   -- ask Apache to handle it (used for kerberos)
+#    authentication.ldap       -- authenticate against LDAP
+#    authentication.spacewalk  -- ask Spacewalk/Satellite (experimental)
+#    authentication.pam        -- use PAM facilities
+#    authentication.testing    -- username/password is always testing/testing (debug)
 #    (user supplied)  -- you may write your own module
 # WARNING: this is a security setting, do not choose an option blindly.
 # for more information:
@@ -20,17 +20,18 @@
 # https://github.com/cobbler/cobbler/wiki/Ldap
 
 [authentication]
-module = authn_testing
+## disabled by spacewalk-setup-cobbler ## module = authentication.configfile
+module = authentication.spacewalk
 
 # authorization: 
 # once a user has been cleared by the WebUI/XMLRPC, what can they do?
 # choices:
-#    authz_allowall   -- full access for all authneticated users (default)
-#    authz_ownership  -- use users.conf, but add object ownership semantics
+#    authorization.allowall   -- full access for all authneticated users (default)
+#    authorization.ownership  -- use users.conf, but add object ownership semantics
 #    (user supplied)  -- you may write your own module
 # WARNING: this is a security setting, do not choose an option blindly.
 # If you want to further restrict cobbler with ACLs for various groups,
-# pick authz_ownership.  authz_allowall does not support ACLs.  configfile
+# pick authorization.ownership. authorization.ownership does not support ACLs.  configfile
 # does but does not support object ownership which is useful as an additional
 # layer of control.
 
@@ -40,44 +41,45 @@ module = authn_testing
 # https://github.com/cobbler/cobbler/wiki/Web-authorization
 
 [authorization]
-module = authz_allowall
+module = authorization.allowall
 
 # dns:
 # chooses the DNS management engine if manage_dns is enabled
 # in /etc/cobbler/settings, which is off by default.
 # choices:
-#    manage_bind    -- default, uses BIND/named
-#    manage_dnsmasq -- uses dnsmasq, also must select dnsmasq for dhcp below
+#    managers.bind    -- default, uses BIND/named
+#    managers.dnsmasq -- uses dnsmasq, also must select dnsmasq for dhcp below
+#    managers.ndjbdns -- uses ndjbdns
 # NOTE: more configuration is still required in /etc/cobbler
 # for more information:
 # https://github.com/cobbler/cobbler/wiki/Dns-management
 
 [dns]
-module = manage_bind
+module = managers.bind
 
 # dhcp:
 # chooses the DHCP management engine if manage_dhcp is enabled
 # in /etc/cobbler/settings, which is off by default.
 # choices:
-#    manage_isc     -- default, uses ISC dhcpd
-#    manage_dnsmasq -- uses dnsmasq, also must select dnsmasq for dns above
+#    managers.isc     -- default, uses ISC dhcpd
+#    managers.dnsmasq -- uses dnsmasq, also must select dnsmasq for dns above
 # NOTE: more configuration is still required in /etc/cobbler
 # for more information:
 # https://github.com/cobbler/cobbler/wiki/Dhcp-management
   
 [dhcp]
-module = manage_isc
+module = managers.isc
 
 # tftpd:
 # chooses the TFTP management engine if manage_tftp is enabled
 # in /etc/cobbler/settings, which is ON by default.
 #
 # choices:
-#    manage_in_tftpd -- default, uses the system's tftp server
-#    manage_tftpd_py -- uses cobbler's tftp server
+#    managers.in_tftpd -- default, uses the system's tftp server
+#    managers.tftpd_py -- uses cobbler's tftp server
 #
   
 [tftpd]
-module = manage_in_tftpd
+module = managers.in_tftpd
 
 #--------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Update for the Cobbler `modules.conf`. With the latest version ob Cobbler, we have an other module structure, which needs to be reflected in the `modules.conf`.


## Documentation
- No documentation needed: It's just about the testsuite. The user won't see this.

## Test coverage
- No tests: This is about our testsuite.

## Changelogs

I think we need no changelog entry of this. 

- [x] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
