### PR TITLE
Always run Kiwi with empty cache (bsc#1155899)

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/services/kiwi-image-server.sls
+++ b/susemanager-utils/susemanager-sls/salt/services/kiwi-image-server.sls
@@ -66,12 +66,6 @@ mgr_osimage_cert_deployed:
     - source: salt://images/rhn-org-trusted-ssl-cert-osimage-1.0-1.noarch.rpm
 {%- endif %}
 
-mgr_kiwi_clear_cache:
-  file.directory:
-    - name: /var/cache/kiwi/zypper/
-    - makedirs: True
-    - clean: True
-
 mgr_sshd_installed_enabled:
   pkg.installed:
     - name: openssh

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Always run Kiwi with empty cache (bsc#1155899)
 - Do not show errors when polling internal metadata API (bsc#1155794)
 - Avoid traceback error due lazy loading which_bin (bsc#1155794)
 - Add missing "public_cloud" custom grain (bsc#1155656)


### PR DESCRIPTION
## What does this PR change?

Make sure that Kiwi is started with empty cache. Without this fix, Kiwi can use wrong packages from previous builds.

With legacy Kiwi it clears shared cache, with Kiwi-ng it uses independent cache for each build and deletes it after build.

## GUI diff

No difference.


## Documentation
- No documentation needed: expected behavior

## Test coverage

- covered by openQA tests

- [X] **DONE**

## Links

Fixes http://bugzilla.suse.com/show_bug.cgi?id=1155899

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
