### PR TITLE
Convenient method to split a query to the DB when the parameters count is higher than a certain limit

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
@@ -870,12 +870,11 @@ public class ActionFactory extends HibernateFactory {
         if (log.isDebugEnabled()) {
             log.debug("Action status " + status.getName() + " is going to b set for these servers: " + serverIds);
         }
-        HibernateFactory.getSession()
-                .getNamedQuery("Action.updateServerActions")
-                .setParameter("action_id", actionIn.getId())
-                .setParameter("server_ids", serverIds)
-                .setParameter("status", status.getId())
-                .executeUpdate();
+        Map<String, Object>  parameters = new HashMap<String, Object>();
+        parameters.put("action_id", actionIn.getId());
+        parameters.put("status", status.getId());
+
+        udpateByIds(serverIds, "Action.updateServerActions", "server_ids", parameters);
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Split a query to the database for more reliability in case certain pages are visited and many systems are registered
 - Fix WebUI invalidation time by using the package build time instead
   of the WebUI version (bsc#1154868)
 - Create a single action when adding erratas to an action chain via the API (bsc#1148457)


### PR DESCRIPTION
## What does this PR change?

Convenient method to split a query to the DB when the parameters count is higher than a certain limit.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: technical issue

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
