### PR TITLE
internationalization for card #8101

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -20199,6 +20199,12 @@ given channel.</source>
           <context context-type="sourcefile">/rhn/admin/BunchDetail.do</context>
         </context-group>
       </trans-unit>
+        <trans-unit id="bunch.jsp.nullstarttime">
+            <source>Task never started</source>
+            <context-group name="ctx">
+                <context context-type="sourcefile">/rhn/admin/BunchDetail.do</context>
+            </context-group>
+        </trans-unit>
       <trans-unit id="bunch.jsp.description.daily-status-bunch">
         <source>Sends daily report</source>
         <context-group name="ctx">

--- a/java/code/webapp/WEB-INF/pages/admin/bunchDetail.jsp
+++ b/java/code/webapp/WEB-INF/pages/admin/bunchDetail.jsp
@@ -48,7 +48,7 @@
                            sortattr="start_time" >
                     <c:choose>
                         <c:when test="${current.start_time == null && current.status == 'INTERRUPTED'}">
-                            Task never started
+                            <bean:message key="bunch.jsp.nullstarttime"/>
                         </c:when>
                         <c:otherwise>
                             <a href="/rhn/admin/ScheduleDetail.do?schid=${current.schedule_id}">

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,6 +1,6 @@
 - Fix WebUI invalidation time by using the package build time instead
   of the WebUI version (bsc#1154868)
-- Tasks bunch detail page displays message "Task never started" in case a task get interrupted before start
+- Add information message in Tasks bunch detail page if task gets interrupted before start
 - Create a single action when adding erratas to an action chain via the API (bsc#1148457)
 - Add check for url input when creating/editing repositories
 - Fqdns are coming from salt network module instead of fqdns grain (bsc#1134860)


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rjmateus@gmail.com>

## What does this PR change?

This is a follow-up PR for https://github.com/uyuni-project/uyuni/pull/1563 to deal with internationalization.
Moves message to message bundle.
## Links

Fixes # https://github.com/SUSE/spacewalk/issues/8101
Tracks # https://github.com/SUSE/spacewalk/pull/10020

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
