### PR TITLE
spacewalk-koan: default gfx type to vnc

### DIFF
--- a/client/tools/spacewalk-koan/spacewalk-koan.changes
+++ b/client/tools/spacewalk-koan/spacewalk-koan.changes
@@ -1,3 +1,4 @@
+- gfx_type needs to default to 'vnc' (bsc#1156211)
 - Bump version to 4.1.0 (bsc#1154940)
 - require commands we use in merge-rd.sh
 

--- a/client/tools/spacewalk-koan/spacewalkkoan/spacewalkkoan.py
+++ b/client/tools/spacewalk-koan/spacewalkkoan/spacewalkkoan.py
@@ -169,6 +169,8 @@ def initiate(kickstart_host, base, extra_append, static_device=None, system_reco
         k.virt_type           = None
         k.virt_bridge         = None
         k.no_gfx              = 0
+        if hasattr(k, 'gfx_type'):
+            k.gfx_type        = 'vnc'
         k.add_reinstall_entry = None
         k.kopts_override      = None
         k.use_kexec           = None


### PR DESCRIPTION
## What does this PR change?

Fix this error when autoinstalling a VM on a traditional SLE 15 host:

```
'Koan' object has no attribute 'gfx_type'
  File "/usr/lib/python3.6/site-packages/spacewalkkoan/spacewalkkoan.py", line 269, in initiate_guest
    k.run()
   File "/usr/lib/python3.6/site-packages/koan/app.py", line 516, in run
    self.virt()
   File "/usr/lib/python3.6/site-packages/koan/app.py", line 904, in virt
    return self.net_install(after_download)
   File "/usr/lib/python3.6/site-packages/koan/app.py", line 775, in net_install
    after_download(self, profile_data)
   File "/usr/lib/python3.6/site-packages/koan/app.py", line 902, in after_download
    self.virt_net_install(profile_data)
   File "/usr/lib/python3.6/site-packages/koan/app.py", line 1595, in virt_net_install
    gfx_type=self.gfx_type,
```

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: fixing autoinstallation on SLE 15

- [X] **DONE**

## Test coverage
- No tests: no autoinstallation KVM test, too expensive to create

- [X] **DONE**

## Links

Partly fixes [bsc#1156211](https://bugzilla.suse.com/show_bug.cgi?id=1156211)

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
