### PR TITLE
Uyuni testsuite logging

### DIFF
--- a/testsuite/features/secondary/min_ubuntu_salt_install_package.feature
+++ b/testsuite/features/secondary/min_ubuntu_salt_install_package.feature
@@ -6,7 +6,7 @@ Feature: Install and upgrade package on the Ubuntu minion via Salt through the U
 @ubuntu_minion
   Scenario: Pre-requisite: install virgo-dummy-1.0 packages on Ubuntu minion
     When I enable repository "test_repo_deb_pool" on this "ubuntu-minion"
-    And I run "apt update" on "ubuntu-minion"
+    And I run "apt update" on "ubuntu-minion" with logging
     And I remove package "andromeda-dummy" from this "ubuntu-minion"
     And I install package "virgo-dummy=1.0" on this "ubuntu-minion"
     And I am on the Systems overview page of this "ubuntu-minion"
@@ -48,5 +48,5 @@ Feature: Install and upgrade package on the Ubuntu minion via Salt through the U
     And I install package "andromeda-dummy=1.0" on this "ubuntu-minion"
     And I remove package "virgo-dummy" from this "ubuntu-minion"
     And I disable repository "test_repo_deb_pool" on this "ubuntu-minion"
-    And I run "apt update" on "ubuntu-minion"
+    And I run "apt update" on "ubuntu-minion" with logging
 

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -425,6 +425,12 @@ When(/^I run "([^"]*)" on "([^"]*)"$/) do |cmd, host|
   node.run(cmd)
 end
 
+When(/^I run "([^"]*)" on "([^"]*)" with logging$/) do |cmd, host|
+  node = get_target(host)
+  output, _code = node.run(cmd)
+  puts "OUT: #{output}"
+end
+
 When(/^I run "([^"]*)" on "([^"]*)" without error control$/) do |cmd, host|
   node = get_target(host)
   _out, $fail_code = node.run(cmd, false)


### PR DESCRIPTION
## What does this PR change?

To debug problems with packages not found on Ubuntu added a logging call which print also the command output if there was no error.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **change test steps**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/9959

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
