### PR TITLE
@@PRODUCT_NAME@@ is not replaced in ReactJS UI

### DIFF
--- a/web/html/src/components/systems.js
+++ b/web/html/src/components/systems.js
@@ -15,7 +15,7 @@ function statusDisplay(system, isAdmin) {
       url: isAdmin && "/rhn/systems/details/Edit.do?sid=" + sid
     },
     "awol": {
-      iconTitle: 'System not checking in with @@PRODUCT_NAME@@',
+      iconTitle: 'System not checking in',
       iconType: 'system-unknown',
       url: null
     },


### PR DESCRIPTION
## What does this PR change?

Fixes a translation issue in the UI

## GUI diff

Before:

Tooltip included `@@PRODUCT_NAME@@`

After:

Tooltip now has no mention of the product

- [X] **DONE**

## Documentation
- No documentation needed: minor string change

- [X] **DONE**

## Test coverage
- No tests: String change

- [X] **DONE**

## Links

Fixes SUSE/spacewalk#9954

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
