### PR TITLE
renaming cucumber tests for clarify

### DIFF
--- a/testsuite/features/secondary/srv_delete_channel_from_ui.feature
+++ b/testsuite/features/secondary/srv_delete_channel_from_ui.feature
@@ -2,8 +2,8 @@
 # Licensed under the terms of the MIT License.
 
 Feature: Delete channels with child or clone is not allowed
-  we cannot delete a channel if it has a child
-  or have a clone from it
+  Using the UI, we cannot delete a channel if it has a child
+  or a clone created from it
 
   Scenario: Clone the first channel before deletion from UI test
     Given I am on the manage software channels page

--- a/testsuite/features/secondary/srv_delete_channel_with_tool.feature
+++ b/testsuite/features/secondary/srv_delete_channel_with_tool.feature
@@ -2,7 +2,8 @@
 # Licensed under the terms of the MIT License.
 
 Feature: Deleting channels with children or clones is not allowed
-  We cannot delete a channel if it has a clone
+  Using the tool spacewalk-remove-channel, we cannot delete a channel if it has a child
+  or a clone created from it
 
   Scenario: Clone the first channel before deletion from tool test
     Given I am on the manage software channels page

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -31,8 +31,8 @@
 - features/secondary/trad_action_chain.feature
 - features/secondary/min_action_chain.feature
 - features/secondary/minssh_action_chain.feature
-- features/secondary/srv_delete_channel.feature
-- features/secondary/srv_spacewalk_remove_channel_tool.feature
+- features/secondary/srv_delete_channel_from_ui.feature
+- features/secondary/srv_delete_channel_with_tool.feature
 - features/secondary/min_docker_build_image.feature
 - features/secondary/min_docker_auth_registry.feature
 - features/secondary/min_docker_xmlrpc.feature

--- a/testsuite/run_sets/testsuite.yml
+++ b/testsuite/run_sets/testsuite.yml
@@ -66,8 +66,8 @@
 - features/secondary/min_docker_build_image.feature
 - features/secondary/trad_metadata_check.feature
 - features/secondary/srv_clone_channel_npn.feature
-- features/secondary/srv_delete_channel.feature
-- features/secondary/srv_spacewalk_remove_channel_tool.feature
+- features/secondary/srv_delete_channel_from_ui.feature
+- features/secondary/srv_delete_channel_with_tool.feature
 - features/secondary/trad_cve_id_new_syntax.feature
 - features/secondary/trad_weak_deps.feature
 - features/secondary/srv_cve_audit.feature


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rjmateus@gmail.com>

## What does this PR change?

Rename cucumber tests to clarify is goal.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: rename cucumber tests

- [X] **DONE**

## Test coverage
- Cucumber tests were changed

- [X] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/9990
Tracks
Manager 4.0:  https://github.com/SUSE/spacewalk/pull/10027
Manager 3.2: https://github.com/SUSE/spacewalk/pull/10028

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

