### PR TITLE
CLM: show channels filters in history

### DIFF
--- a/web/html/src/manager/content-management/project/project.js
+++ b/web/html/src/manager/content-management/project/project.js
@@ -56,17 +56,22 @@ const Project = (props: Props) => {
   const projectId = project.properties.label;
   const currentHistoryEntry = _last(project.properties.historyEntries);
 
-  let changesToBuild = project.softwareSources
-    .filter(source => statesEnum.isEdited(source.state))
-    .map(source => `Source: ${source.type} ${source.name} ${statesEnum.findByKey(source.state).description}`);
+  let changesToBuild = ["Software Channels:\n"];
   changesToBuild = changesToBuild.concat(
-    project
-      .filters
-      .filter(filter => statesEnum.isEdited(filter.state))
-      .map(filter =>
-        `${getClmFilterDescription(filter)} ${statesEnum.findByKey(filter.state).description}`
-      )
+     project.softwareSources
+      .map(source => `\n ${statesEnum.findByKey(source.state).sign} ${source.name}`)
   );
+  if (project.filters.length > 0) {
+    changesToBuild = changesToBuild.concat("\n\nSoftware Filter:\n");
+    changesToBuild = changesToBuild.concat(
+      project
+        .filters
+        .map(filter =>
+          `\n ${statesEnum.findByKey(filter.state).sign} ${getClmFilterDescription(filter)}`
+        )
+    );
+  }
+
   const isProjectEdited = changesToBuild.length > 0;
   const isBuildDisabled = !hasEditingPermissions || _isEmpty(project.environments) || _isEmpty(project.softwareSources);
 

--- a/web/html/src/manager/content-management/project/project.js
+++ b/web/html/src/manager/content-management/project/project.js
@@ -50,7 +50,7 @@ const Project = (props: Props) => {
   }, []);
 
   if(!props.project) {
-    return (<div className="alert alert-danger"><span>The project you are looking for does not exist or has been deleted.</span></div>);
+    return (<div className="alert alert-danger"><span>{t('The project you are looking for does not exist or has been deleted')}.</span></div>);
   }
 
   const projectId = project.properties.label;

--- a/web/html/src/manager/content-management/shared/business/states.enum.js
+++ b/web/html/src/manager/content-management/shared/business/states.enum.js
@@ -4,7 +4,8 @@ import _find from "lodash/find";
 
 type stateType = {
   key: string,
-    description: string
+  description: string,
+  sign: string
 }
 
 type statesEnumType = {
@@ -14,10 +15,10 @@ type statesEnumType = {
 const defaultState = {};
 
 const statesEnum: statesEnumType = new Proxy({
-    ATTACHED: {key: "ATTACHED", description: "added", deletion: false, edited: true},
-    DETACHED: {key: "DETACHED", description: "deleted", deletion: true, edited: true},
-    EDITED: {key: "EDITED", description: "edited", deletion: false, edited: true},
-    BUILT: {key: "BUILT", description: "built", deletion: false, edited: false},
+    ATTACHED: {key: "ATTACHED", description: "added", deletion: false, edited: true, sign: "+"},
+    DETACHED: {key: "DETACHED", description: "deleted", deletion: true, edited: true, sign: "-"},
+    EDITED: {key: "EDITED", description: "edited", deletion: false, edited: true, sign: " "},
+    BUILT: {key: "BUILT", description: "built", deletion: false, edited: false, sign: " "},
   },
   objectDefaultValueHandler(defaultState)
 );

--- a/web/html/src/manager/content-management/shared/components/panels/build/build.js
+++ b/web/html/src/manager/content-management/shared/components/panels/build/build.js
@@ -49,7 +49,7 @@ const Build = ({projectId, onBuild, currentHistoryEntry = {}, changesToBuild, di
         <ModalButton
           id={`build-contentmngt-modal-link`}
           className={ disabled ? `btn-secondary` : `btn-success` }
-          text={changesToBuild.length > 0 ? `Build (${changesToBuild.length})` : `Build`}
+          text={changesToBuild.length > 0 ? t('Build ({0})', changesToBuild.length) : t('Build')}
           disabled={disabled}
           target={modalNameId}
           onClick={() => {
@@ -89,9 +89,9 @@ const Build = ({projectId, onBuild, currentHistoryEntry = {}, changesToBuild, di
                         divClass="col-md-9"/>
                     </div>
                     <dl className="row">
-                      <dt className="col-md-3 control-label">Version {buildVersionForm.version} history:</dt>
+                      <dt className="col-md-3 control-label">{t('Version {0} history', buildVersionForm.version)}:</dt>
                       <dd className="col-md-9">
-		        <pre>{changesToBuild}</pre>
+                        <pre>{changesToBuild}</pre>
                       </dd>
                     </dl>
                   </Form>
@@ -117,7 +117,7 @@ const Build = ({projectId, onBuild, currentHistoryEntry = {}, changesToBuild, di
                           }, "action", projectId)
                             .then((projectWithUpdatedSources) => {
                               closeDialog(modalNameId);
-                              showSuccessToastr(`Version ${buildVersionForm.version} successfully built into ${projectWithUpdatedSources.environments[0].name}`)
+                              showSuccessToastr(t('Version {0} succesfully built into {1}', buildVersionForm.version, projectWithUpdatedSources.environments[0].name))
                               onBuild(projectWithUpdatedSources)
                             })
                             .catch((error) => {

--- a/web/html/src/manager/content-management/shared/components/panels/build/build.js
+++ b/web/html/src/manager/content-management/shared/components/panels/build/build.js
@@ -91,17 +91,7 @@ const Build = ({projectId, onBuild, currentHistoryEntry = {}, changesToBuild, di
                     <dl className="row">
                       <dt className="col-md-3 control-label">Version {buildVersionForm.version} history:</dt>
                       <dd className="col-md-9">
-                        <ul className="list-unstyled">
-                          {
-                            changesToBuild.map((change, index) => {
-                              return (
-                                <li key={index}>
-                                  {change}
-                                </li>
-                              )
-                            })
-                          }
-                        </ul>
+		        <pre>{changesToBuild}</pre>
                       </dd>
                     </dl>
                   </Form>
@@ -123,7 +113,7 @@ const Build = ({projectId, onBuild, currentHistoryEntry = {}, changesToBuild, di
                         handler={() => {
                           onAction({
                             projectLabel: projectId,
-                            message: buildVersionForm.message,
+                            message: buildVersionForm.message.concat('\n\n').concat(changesToBuild.join('')),
                           }, "action", projectId)
                             .then((projectWithUpdatedSources) => {
                               closeDialog(modalNameId);

--- a/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-view.js
+++ b/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-view.js
@@ -21,23 +21,23 @@ type EnvironmentStatusEnumType = {
 }
 
 const environmentStatusEnum: EnvironmentStatusEnumType = new Proxy({
-    new: {key: "new", text: "New", isBuilding: false},
-    building: {key: "building", text: "Cloning channels", isBuilding: true},
-    generating_repodata: {key: "generating_repodata", text: "Generating repositories data", isBuilding: true},
-    built: {key: "built", text: "Built", isBuilding: false},
-    failed: {key: "failed", text: "Failed", isBuilding: false},
+    new: {key: "new", text: t("New"), isBuilding: false},
+    building: {key: "building", text: t("Cloning channels"), isBuilding: true},
+    generating_repodata: {key: "generating_repodata", text: t("Generating repositories data"), isBuilding: true},
+    built: {key: "built", text: t("Built"), isBuilding: false},
+    failed: {key: "failed", text: t("Failed"), isBuilding: false},
   },
   objectDefaultValueHandler({text: '', isBuilding: false})
 );
 
 // $FlowFixMe  // upgrade flow
 const EnvironmentView = React.memo((props: Props) => {
-  let  versionMessage = getVersionMessageByNumber(props.environment.version, props.historyEntries) || "not built";
+  let  versionMessage = getVersionMessageByNumber(props.environment.version, props.historyEntries) || t("not built");
 
   return (
     <React.Fragment>
       <dl className="row">
-        <dt className="col-xs-3">Description:</dt>
+        <dt className="col-xs-3">{t('Description')}:</dt>
         <dd className="col-xs-9">{props.environment.description}</dd>
       </dl>
       {/*<dl className="row">*/}
@@ -45,13 +45,13 @@ const EnvironmentView = React.memo((props: Props) => {
       {/*<dd className="col-xs-9">{0}</dd>*/}
       {/*</dl>*/}
       <dl className="row">
-        <dt className="col-xs-3">Version:</dt>
+        <dt className="col-xs-3">{t('Version')}:</dt>
         <dd className="col-xs-9"><pre>{versionMessage}</pre></dd>
       </dl>
       {
         props.environment.version > 0 ?
           <dl className="row">
-            <dt className="col-xs-3">Status:</dt>
+            <dt className="col-xs-3">{t('Status')}:</dt>
             <dd className="col-xs-9">
               {environmentStatusEnum[props.environment.status].text}
               &nbsp;
@@ -66,7 +66,7 @@ const EnvironmentView = React.memo((props: Props) => {
       {
         props.environment.status === environmentStatusEnum.built.key && !_isEmpty(props.environment.builtTime) ?
           <dl className="row">
-            <dt className="col-xs-3">Built time:</dt>
+            <dt className="col-xs-3">{t('Built time')}:</dt>
             <dd className="col-xs-9">
               {props.environment.builtTime}
             </dd>

--- a/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-view.js
+++ b/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-view.js
@@ -46,7 +46,7 @@ const EnvironmentView = React.memo((props: Props) => {
       {/*</dl>*/}
       <dl className="row">
         <dt className="col-xs-3">Version:</dt>
-        <dd className="col-xs-9">{versionMessage}</dd>
+        <dd className="col-xs-9"><pre>{versionMessage}</pre></dd>
       </dl>
       {
         props.environment.version > 0 ?

--- a/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-view.js
+++ b/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-view.js
@@ -6,6 +6,7 @@ import type {ProjectEnvironmentType} from '../../../type/project.type.js';
 import type {ProjectHistoryEntry} from "../../../type/project.type";
 import {getVersionMessageByNumber} from "../properties/properties.utils";
 import {objectDefaultValueHandler} from "core/utils/objects";
+import propertiesStyles from "../properties/properties.css";
 
 type Props = {
   environment: ProjectEnvironmentType,
@@ -46,7 +47,16 @@ const EnvironmentView = React.memo((props: Props) => {
       {/*</dl>*/}
       <dl className="row">
         <dt className="col-xs-3">{t('Version')}:</dt>
-        <dd className="col-xs-9"><pre>{versionMessage}</pre></dd>
+        <dd className="col-xs-9">
+          <div className={`${propertiesStyles.version_collapse_line} pointer`} data-toggle="collapse"
+              data-target={`#historyentry_${props.environment.label}_${props.environment.version}`} role="button"
+              aria-expanded="false" aria-controls="collapseExample">
+            {versionMessage.split('\n')[0]}
+          </div>
+          <div class="collapse" id={`historyentry_${props.environment.label}_${props.environment.version}`}>
+            <pre>{versionMessage}</pre>
+          </div>
+        </dd>
       </dl>
       {
         props.environment.version > 0 ?

--- a/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project.js
+++ b/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project.js
@@ -26,7 +26,7 @@ const renderFilterEntry = (filter, projectId, symbol, last) => {
       <LinkButton
         id={`edit-filter-${filter.id}`}
         icon='fa-edit'
-        title={t(`Edit Filter ${filter.name}`)}
+        title={t('Edit Filter {0}', filter.name)}
         className='pull-right js-spa'
         href={`/rhn/manager/contentmanagement/filters?openFilterId=${filter.id}&projectLabel=${projectId}`}
       />
@@ -84,7 +84,7 @@ const FiltersProject = (props:  FiltersProps) => {
     <CreatorPanel
       id="filters"
       title={t('Filters')}
-      creatingText="Attach/Detach Filters"
+      creatingText={t("Attach/Detach Filters")}
       panelLevel="2"
       collapsible
       customIconClass="fa-small"
@@ -100,7 +100,7 @@ const FiltersProject = (props:  FiltersProps) => {
         onAction(requestParam, "update", props.projectId)
           .then((projectWithUpdatedSources) => {
             closeDialog();
-            showSuccessToastr(t("Filters edited successfully"));
+            showSuccessToastr(t("Filter edited successfully"));
             props.onChange(projectWithUpdatedSources)
           })
           .catch((error) => {

--- a/web/html/src/manager/content-management/shared/components/panels/promote/promote.js
+++ b/web/html/src/manager/content-management/shared/components/panels/promote/promote.js
@@ -36,7 +36,7 @@ const Promote = (props: Props) => {
     }
   }, [open]);
 
-  const versionMessage = getVersionMessageByNumber(props.environmentPromote.version, props.historyEntries) || "not built";
+  const versionMessage = getVersionMessageByNumber(props.environmentPromote.version, props.historyEntries) || t("not built");
   const modalNameId = `${props.environmentPromote.label}-cm-promote-env-modal`;
   const disabled =
     !hasEditingPermissions
@@ -44,14 +44,14 @@ const Promote = (props: Props) => {
     || props.environmentPromote.version <= props.environmentTarget.version;
   return (
     <div
-      {...(disabled ? {title: "No version to promote"} : {})}
+      {...(disabled ? {title: t("No version to promote")} : {})}
     >
       <DownArrow/>
       <div className="text-center">
         <ModalButton
           id={`${props.environmentPromote.label}-promote-modal-link`}
           className="btn-default"
-          text="Promote"
+          text={t("Promote")}
           disabled={disabled}
           target={modalNameId}
           onClick={() => {
@@ -69,20 +69,20 @@ const Promote = (props: Props) => {
         }
         content={
           isLoading
-            ? <Loading text='Promoting project..'/>
+            ? <Loading text={t('Promoting project..')}/>
             :
             <React.Fragment>
               <dl className="row">
-                <dt className="col-xs-4">Version:</dt>
+                <dt className="col-xs-4">{t('Version')}:</dt>
                 <dd className="col-xs-8">{versionMessage}</dd>
               </dl>
               <dl className="row">
-                <dt className="col-xs-4">Target environment:</dt>
+                <dt className="col-xs-4">{t('Target environment')}:</dt>
                 <dd className="col-xs-8">{props.environmentTarget.name}</dd>
               </dl>
             </React.Fragment>
         }
-        title={`Promote version ${props.environmentPromote.version} into ${props.environmentTarget.name}`}
+        title={t('Promote version {0} into {1}', props.environmentPromote.version, props.environmentTarget.name)}
         buttons={
           <div className="col-lg-12">
             <div className="pull-right btn-group">
@@ -105,7 +105,7 @@ const Promote = (props: Props) => {
                   }, "action", props.projectId)
                     .then((projectWithUpdatedSources) => {
                       closeDialog(modalNameId);
-                      showSuccessToastr(`Version ${props.versionToPromote} successfully promoted into ${props.environmentTarget.name}`)
+                      showSuccessToastr(t('Version {0} successfully promoted into {1}', props.versionToPromote, props.environmentTarget.name))
                       props.onChange(projectWithUpdatedSources)
                     })
                     .catch((error) => {

--- a/web/html/src/manager/content-management/shared/components/panels/promote/promote.js
+++ b/web/html/src/manager/content-management/shared/components/panels/promote/promote.js
@@ -74,7 +74,9 @@ const Promote = (props: Props) => {
             <React.Fragment>
               <dl className="row">
                 <dt className="col-xs-4">{t('Version')}:</dt>
-                <dd className="col-xs-8">{versionMessage}</dd>
+                <dd className="col-xs-8">
+                  <pre>{versionMessage}</pre>
+              </dd>
               </dl>
               <dl className="row">
                 <dt className="col-xs-4">{t('Target environment')}:</dt>

--- a/web/html/src/manager/content-management/shared/components/panels/properties/properties-edit.js
+++ b/web/html/src/manager/content-management/shared/components/panels/properties/properties-edit.js
@@ -29,7 +29,7 @@ const PropertiesEdit = (props: Props) => {
 
   const defaultDraftHistory = {
     version: props.currentHistoryEntry ? props.currentHistoryEntry.version + 1 : 1 ,
-    message:'(draft - not built) - Check the changes below'
+    message:t('(draft - not built) - Check the changes below')
   };
 
   let propertiesToShow = produce(props.properties, draftProperties => {
@@ -41,7 +41,7 @@ const PropertiesEdit = (props: Props) => {
   return (
       <CreatorPanel
         id="properties"
-        creatingText="Edit Properties"
+        creatingText={t("Edit Properties")}
         panelLevel="2"
         disableEditing={!hasEditingPermissions}
         title={t('Project Properties')}
@@ -66,7 +66,7 @@ const PropertiesEdit = (props: Props) => {
 
           if (isLoading) {
             return (
-              <Loading text='Editing properties..'/>
+              <Loading text={t('Editing properties..')}/>
             )
           }
 

--- a/web/html/src/manager/content-management/shared/components/panels/properties/properties-view.js
+++ b/web/html/src/manager/content-management/shared/components/panels/properties/properties-view.js
@@ -6,6 +6,8 @@ import type {ProjectPropertiesType} from '../../../type/project.type.js';
 import {getVersionMessage} from "./properties.utils";
 import {ModalLink} from "components/dialog/ModalLink";
 import {Dialog} from "components/dialog/Dialog";
+import {Panel} from "../../../../../../components/panels/Panel";
+import styles from "./properties.css";
 
 type Props = {
   properties: ProjectPropertiesType,
@@ -19,13 +21,28 @@ const PropertiesHistoryEntries = (props) =>
       props.entries.map((history, index) => {
         const versionMessage = getVersionMessage(history)
         return (
-          <li key={`historyentries_${props.id}_${index}`}><pre>
+          <li key={`historyentries_${props.id}_${index}`}>
             {
               index === 0
-                ? <strong>{versionMessage}</strong>
-                : versionMessage
+                ? versionMessage
+                : <div>
+                    <div className={`${styles.version_collapse_line} pointer`} data-toggle="collapse"
+                        data-target={`#historyentries_${props.id}_${index}`} role="button"
+                        aria-expanded="false" aria-controls="collapseExample">
+                      {t('Version {0}: {1}', history.version, history.message.split('\n')[0])}
+                    </div>
+                    <div class="collapse" id={`historyentries_${props.id}_${index}`}>
+                      <pre>
+                        {
+                          index === 0
+                            ? <strong>{versionMessage}</strong>
+                            : versionMessage
+                        }
+                      </pre>
+                    </div>
+                  </div>
             }
-          </pre></li>
+          </li>
         )
       })
     }

--- a/web/html/src/manager/content-management/shared/components/panels/properties/properties-view.js
+++ b/web/html/src/manager/content-management/shared/components/panels/properties/properties-view.js
@@ -64,7 +64,7 @@ const PropertiesView = (props: Props) => {
               <>
                 <ModalLink
                   id={`properties-longlist-modal-button`}
-                  text="show more"
+                  text={t("show more")}
                   target="properties-longlist-modal-content"
                 />
                 <Dialog

--- a/web/html/src/manager/content-management/shared/components/panels/properties/properties-view.js
+++ b/web/html/src/manager/content-management/shared/components/panels/properties/properties-view.js
@@ -19,13 +19,13 @@ const PropertiesHistoryEntries = (props) =>
       props.entries.map((history, index) => {
         const versionMessage = getVersionMessage(history)
         return (
-          <li key={`historyentries_${props.id}_${index}`}>
+          <li key={`historyentries_${props.id}_${index}`}><pre>
             {
               index === 0
                 ? <strong>{versionMessage}</strong>
                 : versionMessage
             }
-          </li>
+          </pre></li>
         )
       })
     }

--- a/web/html/src/manager/content-management/shared/components/panels/properties/properties.css
+++ b/web/html/src/manager/content-management/shared/components/panels/properties/properties.css
@@ -1,0 +1,7 @@
+.version_collapse_line {
+  margin-bottom: .3em;
+}
+
+.version_collapse_line:hover {
+  text-decoration: underline;
+}

--- a/web/html/src/manager/content-management/shared/components/panels/properties/properties.utils.js
+++ b/web/html/src/manager/content-management/shared/components/panels/properties/properties.utils.js
@@ -2,7 +2,7 @@
 import type {ProjectHistoryEntry} from "../../../type/project.type";
 
 export function getVersionMessage(historyEntry: ProjectHistoryEntry): string {
-  return `Version ${historyEntry.version}: ${historyEntry.message || ""}`
+  return `${t('Version')} ${historyEntry.version}: ${historyEntry.message || ""}`
 }
 
 

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- show channels and filters in CLM history
 - SPA: do not early drop modals they can contain inputs (bsc#1155800)
 - rename SUSE Products to just Products in UI
 - Layout changes in formula forms, validation, deprecate $visibleIf and add new attributes:


### PR DESCRIPTION
## What does this PR change?

Show Channels and Filters with its changes in the history

## GUI diff

![Screenshot_20191109_131929](https://user-images.githubusercontent.com/1038917/68528485-9480d100-02f3-11ea-8aa9-d6fb782dcb26.png)

- [x] **DONE**

## Documentation
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/9898

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
