### PR TITLE
Use apache-proxied websockify

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/VirtualGuestsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/VirtualGuestsController.java
@@ -471,7 +471,8 @@ public class VirtualGuestsController {
             try {
                 WebSockifyTokenBuilder tokenBuilder = new WebSockifyTokenBuilder(hostname, port);
                 tokenBuilder.useServerSecret();
-                url = "wss://" + ConfigDefaults.get().getHostname() + ":8050/?token=" + tokenBuilder.getToken();
+                url = "wss://" + ConfigDefaults.get().getHostname() +
+                        "/rhn/websockify/?token=" + tokenBuilder.getToken();
             }
             catch (JoseException e) {
                 LOG.error(e);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Use apache proxy of websockify (bsc#1155455)
 - Split a query to the database for more reliability in case certain pages are visited and many systems are registered
 - Fix WebUI invalidation time by using the package build time instead
   of the WebUI version (bsc#1154868)

--- a/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-www.conf
+++ b/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-www.conf
@@ -65,11 +65,13 @@ ProxyTimeout 600
 </Proxy>
 RewriteRule ^/rhn/Login2\.do ajp://localhost:8009/rhn/manager/login [P]
 RewriteCond %{REQUEST_URI} !^/rhn/websocket
+RewriteCond %{REQUEST_URI} !^/rhn/websockify
 RewriteRule ^/rhn(.*) ajp://localhost:8009/rhn$1 [P]
 </IfModule>
 
 <IfModule proxy_wstunnel_module>
 ProxyPass "/rhn/websocket" "ws://localhost:8080/rhn/websocket"
+ProxyPass "/rhn/websockify" "wss://localhost:8050/"
 </IfModule>
 
 # mod_xsendfile configuration

--- a/spacewalk/config/spacewalk-config.changes
+++ b/spacewalk/config/spacewalk-config.changes
@@ -1,3 +1,4 @@
+- Proxy websockify through Apache (bsc#1155455)
 - Bump version to 4.1.0 (bsc#1154940)
 - Change the default value of taskomatic maxmemory to 4GB
 - Resolve modules.yaml file for modular repositories


### PR DESCRIPTION
## What does this PR change?

The biggest usability issue of the Spice / VNC Graphical console is that
the websockify process is served over SSL on 8050 port. This port needs to be
opened and the browser don't ask to accept the invalid certificates for
websockets.

By using a proxy, there is now no need to open port 8050 on firewalls
and to handle invalid or self-signed certificates for that port.

## GUI diff

No difference.

- [X] **DONE**

## Documentation

- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue needed: this will alter the ports needed to be opened

- [X] **DONE**

## Test coverage
- No tests: existing tests are covering this already

- [X] **DONE**

## Links

Fixes bsc#1155455

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
