### PR TITLE
VM properties dialog fixes

### DIFF
--- a/web/html/src/manager/virtualization/guests/properties/guest-disks-panel.js
+++ b/web/html/src/manager/virtualization/guests/properties/guest-disks-panel.js
@@ -15,6 +15,7 @@ function getFileSourceFields(model: Object, index: number, pools: Array<Object>,
     if (model[`disk${index}_device`] === 'cdrom') {
       return [];
     }
+    const first_pool = pools.length > 0 ? pools[0].name : '';
     return [
       <Select
         key={`disk${index}_source_pool`}
@@ -24,7 +25,7 @@ function getFileSourceFields(model: Object, index: number, pools: Array<Object>,
         divClass="col-md-6"
         disabled={!onlyHandledDisks}
         required
-        defaultValue={pools.find(pool => pool.name === 'default') ? 'default' : pools[0].name}
+        defaultValue={pools.find(pool => pool.name === 'default') ? 'default' : first_pool}
       >
         {
           pools.map(k => <option key={k.name} value={k.name}>{k.name}</option>)
@@ -84,13 +85,14 @@ function addDisk(model: Object, changeModel: Function, domainCaps: Object, pools
   const allDisks = GuestPropertiesUtils.getOrderedDevicesFromModel(model, 'disk');
   const index = Number.parseInt(allDisks[allDisks.length - 1].substring('disk'.length), 10) + 1;
   const preferredBusses = ['virtio', 'xen'].filter(type => busTypes.includes(type));
+  const first_pool = pools.length > 0 ? pools[0].name : '';
 
   changeModel(Object.assign(model, {
     [`disk${index}_editable`]: true,
     [`disk${index}_type`]: 'file',
     [`disk${index}_device`]: 'disk',
     [`disk${index}_bus`]: preferredBusses.length > 0 ? preferredBusses[0] : busTypes[0],
-    [`disk${index}_source_pool`]: pools.find(item => item.name === 'default') ? 'default' : pools[0].name,
+    [`disk${index}_source_pool`]: pools.find(item => item.name === 'default') ? 'default' : first_pool,
     [`disk${index}_source_template`]: undefined,
     [`disk${index}_source_size`]: 10,
   }));

--- a/web/html/src/manager/virtualization/guests/properties/guest-nics-panel.js
+++ b/web/html/src/manager/virtualization/guests/properties/guest-nics-panel.js
@@ -12,10 +12,11 @@ const GuestPropertiesUtils = require('./guest-properties-utils');
 function addNic(model: Object, changeModel: Function, networks: Array<Object>) {
   const allNics = GuestPropertiesUtils.getOrderedDevicesFromModel(model, 'network');
   const index = Number.parseInt(allNics[allNics.length - 1].substring('network'.length), 10) + 1;
+  const first_nic = networks.length > 0 ? networks[0].name : '';
 
   changeModel(Object.assign(model, {
     [`network${index}_type`]: 'network',
-    [`network${index}_source`]: networks.find(item => item.name === 'default') ? 'default' : networks[0].name,
+    [`network${index}_source`]: networks.find(item => item.name === 'default') ? 'default' : first_nic,
     [`network${index}_mac`]: '',
   }));
 }
@@ -28,6 +29,7 @@ function guestNicFields(model: Object, index: number, networks: Array<Object>,
       return Object.assign(res, property);
     }, {}));
   };
+  const first_nic = networks.length > 0 ? networks[0].name : '';
 
   return (
     <Panel
@@ -60,7 +62,7 @@ function guestNicFields(model: Object, index: number, networks: Array<Object>,
             key={`network${index}_source`}
             disabled={!onlyHandledNics}
             required
-            defaultValue={networks.find(net => net.name === 'default') ? 'default' : networks[0].name}
+            defaultValue={networks.find(net => net.name === 'default') ? 'default' : first_nic}
           >
             {
               networks.map(k => <option key={k.name} value={k.name}>{k.name}</option>)

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fix create VM dialog when there is no virtual storage pool or network
 - show channels and filters in CLM history
 - SPA: do not early drop modals they can contain inputs (bsc#1155800)
 - rename SUSE Products to just Products in UI


### PR DESCRIPTION
## What does this PR change?

When there is no virtual storage pool or virtual network the VM creation
or editing dialog would show a blank page. These cases are now handled.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: Fixes a bug

- [X] **DONE**

## Test coverage
- No tests: painful to test in the cucumber testsuite

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
