### PR TITLE
Remove page element call from the testsuite (Port)

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -85,7 +85,7 @@ When(/^I wait until I see the event "([^"]*)" completed during last minute, refr
     current_minute = now.strftime('%H:%M')
     previous_minute = (now - 60).strftime('%H:%M')
     break if find(:xpath, "//a[contains(text(),'#{event}')]/../..//td[4][contains(text(),'#{current_minute}') or contains(text(),'#{previous_minute}')]/../td[3]/a[1]", wait: 1)
-    page.evaluate_script 'window.location.reload()'
+    evaluate_script 'window.location.reload()'
   end
 end
 
@@ -703,7 +703,7 @@ end
 
 Then(/^I should see "([^"]*)" at least (\d+) minutes after I scheduled an action$/) do |text, minutes|
   # TODO is there a better way then page.all ?
-  elements = page.all('div', text: text)
+  elements = all('div', text: text)
   raise "Text #{text} not found in the page" if elements.nil?
   match = elements[0].text.match(/#{text}\s*(\d+\/\d+\/\d+ \d+:\d+:\d+ (AM|PM)+ [^\s]+)/)
   raise "No element found matching text '#{text}'" if match.nil?
@@ -865,7 +865,7 @@ end
 And(/^I wait until radio button "([^"]*)" is checked, refreshing the page$/) do |arg1|
   repeat_until_timeout(message: "Couldn't find checked radio button #{arg1}") do
     break if has_checked_field?(arg1)
-    page.evaluate_script 'window.location.reload()'
+    evaluate_script 'window.location.reload()'
   end
 end
 
@@ -910,7 +910,7 @@ And(/^I remove package "([^"]*)" from highstate$/) do |package|
     next unless tr.text.include?(package)
     puts tr.text
     tr.find("##{package}-pkg-state").select('Removed')
-    next if page.has_css?('#save[disabled]')
+    next if has_css?('#save[disabled]')
     steps %(
       Then I click on "Save"
       And I click on "Apply"
@@ -965,7 +965,7 @@ end
 When(/^I enter the SCC credentials$/) do
   user = ENV['scc_credentials'].split('|')[0]
   password = ENV['scc_credentials'].split('|')[1]
-  unless page.has_content?(user)
+  unless has_content?(user)
     steps %(
       And I want to add a new credential
       And I enter "#{user}" as "edit-user"

--- a/testsuite/features/step_definitions/content_lifecycle_steps.rb
+++ b/testsuite/features/step_definitions/content_lifecycle_steps.rb
@@ -12,7 +12,7 @@ end
 
 When(/^I should see a "([^"]*)" text in the environment "([^"]*)"$/) do |text, env|
   within(:xpath, "//h3[text()='#{env}']/../..") do
-    page.has_content?(text)
+    has_content?(text)
   end
 end
 
@@ -24,6 +24,6 @@ end
 
 Then(/^I wait until I see "([^"]*)" text in the environment "([^"]*)"$/) do |text, env|
   within(:xpath, "//h3[text()='#{env}']/../..") do
-    raise "Text #{text} not found" unless page.has_text?(text, wait: DEFAULT_TIMEOUT)
+    raise "Text #{text} not found" unless has_text?(text, wait: DEFAULT_TIMEOUT)
   end
 end

--- a/testsuite/features/step_definitions/datepicker_steps.rb
+++ b/testsuite/features/step_definitions/datepicker_steps.rb
@@ -69,7 +69,7 @@ Given(/^I open the date picker$/) do
 end
 
 Then(/^the date picker is closed$/) do
-  raise unless page.has_no_css?('.datepicker')
+  raise unless has_no_css?('.datepicker')
 end
 
 Then(/^the date picker title should be the current month and year$/) do
@@ -78,7 +78,7 @@ Then(/^the date picker title should be the current month and year$/) do
 end
 
 Then(/^the date picker title should be "([^"]*)"$/) do |arg1|
-  step %(I open the date picker) if page.has_no_css?('.datepicker')
+  step %(I open the date picker) if has_no_css?('.datepicker')
   switch = find('.datepicker .datepicker-days th.datepicker-switch')
   raise unless switch.has_content?(arg1)
 end
@@ -92,13 +92,13 @@ end
 
 When(/^I pick (\d+) minutes from now as schedule time$/) do |arg1|
   action_time = get_future_time(arg1)
-  page.execute_script("$('#date_timepicker_widget_input')
+  execute_script("$('#date_timepicker_widget_input')
     .timepicker('setTime', '#{action_time}').trigger('changeTime');")
 end
 
 When(/^I schedule action to (\d+) minutes from now$/) do |minutes|
   action_time = (DateTime.now + Rational(1,1440) * minutes.to_i + Rational(59,86400)).strftime("%Y-%m-%dT%H:%M%:z")
-  page.execute_script("window.schedulePage.setScheduleTime('#{action_time}')")
+  execute_script("window.schedulePage.setScheduleTime('#{action_time}')")
 end
 
 Then(/^the time field is set to "([^"]*)"$/) do |arg1|

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -12,13 +12,13 @@ end
 
 Then(/^I should see a "(.*)" text in the content area$/) do |txt|
   within('#spacewalk-content') do
-    raise "Text #{txt} not found" unless page.has_content?(txt)
+    raise "Text #{txt} not found" unless has_content?(txt)
   end
 end
 
 Then(/^I should not see a "(.*)" text in the content area$/) do |txt|
   within('#spacewalk-content') do
-    raise "Text #{txt} found" unless page.has_no_content?(txt)
+    raise "Text #{txt} found" unless has_no_content?(txt)
   end
 end
 
@@ -33,34 +33,34 @@ Then(/^the current path is "([^"]*)"$/) do |arg1|
 end
 
 When(/^I wait until I see "([^"]*)" text$/) do |text|
-  raise "Text #{text} not found" unless page.has_text?(text, wait: DEFAULT_TIMEOUT)
+  raise "Text #{text} not found" unless has_text?(text, wait: DEFAULT_TIMEOUT)
 end
 
 When(/^I wait until I do not see "([^"]*)" text$/) do |text|
-  raise "Text #{text} found" unless page.has_no_text?(text, wait: DEFAULT_TIMEOUT)
+  raise "Text #{text} found" unless has_no_text?(text, wait: DEFAULT_TIMEOUT)
 end
 
 When(/^I wait at most (\d+) seconds until I see "([^"]*)" text$/) do |seconds, text|
-  raise "Text #{text} not found" unless page.has_content?(text, wait: seconds.to_i)
+  raise "Text #{text} not found" unless has_content?(text, wait: seconds.to_i)
 end
 
 When(/^I wait until I see "([^"]*)" text or "([^"]*)" text$/) do |text1, text2|
-  raise "Text #{text1} or #{text2} not found" unless page.has_content?(text1, wait: DEFAULT_TIMEOUT) || page.has_content?(text2, wait: DEFAULT_TIMEOUT)
+  raise "Text #{text1} or #{text2} not found" unless has_content?(text1, wait: DEFAULT_TIMEOUT) || has_content?(text2, wait: DEFAULT_TIMEOUT)
 end
 
 When(/^I wait until I see "([^"]*)" text, refreshing the page$/) do |text|
   text.gsub! '$PRODUCT', $product # TODO: Rid of this substitution, using another step
   repeat_until_timeout(message: "Couldn't find text '#{text}'") do
-    break if page.has_content?(text)
-    page.evaluate_script 'window.location.reload()'
+    break if has_content?(text)
+    evaluate_script 'window.location.reload()'
   end
 end
 
 When(/^I wait at most (\d+) seconds until the event is completed, refreshing the page$/) do |timeout|
   repeat_until_timeout(timeout: timeout.to_i, message: 'Event not yet completed') do
-    break if page.has_content?("This action's status is: Completed.")
-    raise 'Event failed' if page.has_content?("This action's status is: Failed.")
-    page.evaluate_script 'window.location.reload()'
+    break if has_content?("This action's status is: Completed.")
+    raise 'Event failed' if has_content?("This action's status is: Failed.")
+    evaluate_script 'window.location.reload()'
   end
 end
 
@@ -71,8 +71,8 @@ end
 
 When(/^I wait until I do not see "([^"]*)" text, refreshing the page$/) do |text|
   repeat_until_timeout(message: "Text '#{text}' is still visible") do
-    break unless page.has_content?(text)
-    page.evaluate_script 'window.location.reload()'
+    break unless has_content?(text)
+    evaluate_script 'window.location.reload()'
   end
 end
 
@@ -83,12 +83,12 @@ end
 
 Then(/^I wait until I see the (VNC|spice) graphical console$/) do |type|
   repeat_until_timeout(message: "The #{type} graphical console didn't load") do
-    break unless page.has_xpath?('.//canvas')
+    break unless has_xpath?('.//canvas')
   end
 end
 
 When(/^I close the window$/) do
-  page.evaluate_script 'window.close();'
+  evaluate_script 'window.close();'
 end
 
 #
@@ -239,7 +239,7 @@ When(/^I follow "([^"]*)" on "(.*?)" row$/) do |text, host|
 end
 
 When(/^I enter "(.*?)" in the editor$/) do |arg1|
-  page.execute_script("ace.edit('contents-editor').insert('#{arg1}')")
+  execute_script("ace.edit('contents-editor').insert('#{arg1}')")
 end
 
 #
@@ -291,7 +291,7 @@ end
 
 Given(/^I access the host the first time$/) do
   visit Capybara.app_host
-  raise "Text 'Create #{product} Administrator' not found" unless page.has_content?("Create #{product} Administrator")
+  raise "Text 'Create #{product} Administrator' not found" unless has_content?("Create #{product} Administrator")
 end
 
 # Menu permission check
@@ -396,9 +396,9 @@ end
 
 Given(/^I am authorized as "([^"]*)" with password "([^"]*)"$/) do |user, passwd|
   visit Capybara.app_host
-  next if page.all(:xpath, "//header//span[text()='#{user}']").any?
+  next if all(:xpath, "//header//span[text()='#{user}']").any?
 
-  find(:xpath, "//header//i[@class='fa fa-sign-out']").click if page.all(:xpath, "//header//i[@class='fa fa-sign-out']").any?
+  find(:xpath, "//header//i[@class='fa fa-sign-out']").click if all(:xpath, "//header//i[@class='fa fa-sign-out']").any?
 
   fill_in 'username', with: user
   fill_in 'password', with: passwd
@@ -425,7 +425,7 @@ end
 
 Then(/^I am logged in$/) do
   raise 'User is not logged in' unless find(:xpath, "//a[@href='/rhn/Logout.do']").visible?
-  raise 'The welcome meesage is not shown' unless page.has_content?("You have just created your first #{product} user. To finalize your installation please use the Setup Wizard")
+  raise 'The welcome message is not shown' unless has_content?('You have just created your first SUSE Manager user. To finalize your installation please use the Setup Wizard')
 end
 
 Given(/^I am on the patches page$/) do
@@ -488,11 +488,11 @@ end
 #
 Then(/^I should see a "([^"]*)" text$/) do |text|
   text.gsub! '$PRODUCT', $product # TODO: Rid of this substitution, using another step
-  raise "Text #{text} not found" unless page.has_content?(text)
+  raise "Text #{text} not found" unless has_content?(text)
 end
 
 Then(/^I should see a "([^"]*)" text or "([^"]*)" text$/) do |text1, text2|
-  raise "Text #{text1} and #{text2} are not found" unless page.has_content?(text1) || page.has_content?(text2)
+  raise "Text #{text1} and #{text2} are not found" unless has_content?(text1) || has_content?(text2)
 end
 
 #
@@ -500,7 +500,7 @@ end
 #
 Then(/^I should see "([^"]*)" in the textarea$/) do |arg1|
   within('textarea') do
-    raise "Text #{arg1} not found" unless page.has_content?(arg1)
+    raise "Text #{arg1} not found" unless has_content?(arg1)
   end
 end
 
@@ -508,14 +508,14 @@ end
 # Test for a text in the whole page using regexp
 #
 Then(/^I should see a text like "([^"]*)"$/) do |title|
-  raise "Text #{title} not found" unless page.has_content?(Regexp.new(title))
+  raise "Text #{title} not found" unless has_content?(Regexp.new(title))
 end
 
 #
 # Test for a text not allowed in the whole page
 #
 Then(/^I should not see a "([^"]*)" text$/) do |text|
-  raise "#{text} found on the page! FAIL" unless page.has_no_content?(text)
+  raise "#{text} found on the page! FAIL" unless has_no_content?(text)
 end
 
 #
@@ -582,7 +582,7 @@ Then(/^I should see a "([^"]*)" link in the table (.*) column$/) do |link, colum
     # try column by name
     # unquote if neeeded
     colname = column.gsub(/\A['"]+|['"]+\Z/, '')
-    cols = page.all(:xpath, '//table//thead/tr[1]/th').map(&:text)
+    cols = all(:xpath, '//table//thead/tr[1]/th').map(&:text)
     idx = cols.index(colname)
   end
   raise("Unknown column '#{column}'") unless idx
@@ -597,11 +597,11 @@ When(/^I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINI
     visit current_url
     # get all texts in the table column under the "Status" header
     status_tds = "//tr/td[count(//th[contains(*/text(), 'Status')]/preceding-sibling::*) + 1]"
-    statuses = page.all(:xpath, status_tds).map(&:text)
+    statuses = all(:xpath, status_tds).map(&:text)
 
     # get all texts in the table column under the "Start time" header
     start_time_tds = "//tr/td[count(//th[contains(*/text(), 'Start Time')]/preceding-sibling::*) + 1]"
-    start_times = page.all(:xpath, start_time_tds).map(&:text)
+    start_times = all(:xpath, start_time_tds).map(&:text)
 
     # disregard any number of initial unimportant rows, that is:
     #  - INTERRUPTED rows with no start time (expected when Taskomatic had been restarted)
@@ -729,15 +729,15 @@ end
 # Test if a checkbox is disabled
 #
 Then(/^the "([^\"]*)" checkbox should be disabled$/) do |arg1|
-  page.has_css?("##{arg1}[disabled]")
+  has_css?("##{arg1}[disabled]")
 end
 
 Then(/^the "([^\"]*)" field should be disabled$/) do |arg1|
-  page.has_css?("##{arg1}[disabled]")
+  has_css?("##{arg1}[disabled]")
 end
 
 Then(/^I should see "([^"]*)" in field "([^"]*)"$/) do |arg1, arg2|
-  raise "Field #{arg2} with #{arg1} value not found" unless page.has_field?(arg2, with: arg1)
+  raise "Field #{arg2} with #{arg1} value not found" unless has_field?(arg2, with: arg1)
 end
 
 Then(/^I should see a "([^"]*)" element in "([^"]*)" form$/) do |arg1, arg2|
@@ -749,7 +749,7 @@ end
 Then(/^I should see a "([^"]*)" editor in "([^"]*)" form$/) do |arg1, arg2|
   within(:xpath, "//form[@id=\"#{arg2}\"] | //form[@name=\"#{arg2}\"]") do
     raise "xpath: textarea##{arg1} not found" unless find("textarea##{arg1}", visible: false)
-    raise "css: ##{arg1}-editor not found" unless page.has_css?("##{arg1}-editor")
+    raise "css: ##{arg1}-editor not found" unless has_css?("##{arg1}-editor")
   end
 end
 

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -181,12 +181,12 @@ end
 
 Then(/^I should see "([^"]*)" hostname$/) do |host|
   system_name = get_system_name(host)
-  raise "Hostname #{system_name} is not present" unless page.has_content?(system_name)
+  raise "Hostname #{system_name} is not present" unless has_content?(system_name)
 end
 
 Then(/^I should not see "([^"]*)" hostname$/) do |host|
   system_name = get_system_name(host)
-  raise "Hostname #{system_name} is present" if page.has_content?(system_name)
+  raise "Hostname #{system_name} is present" if has_content?(system_name)
 end
 
 When(/^I expand the results for "([^"]*)"$/) do |host|
@@ -205,20 +205,20 @@ end
 Then(/^I should see "([^"]*)" in the command output for "([^"]*)"$/) do |text, host|
   system_name = get_system_name(host)
   within("pre[id='#{system_name}-results']") do
-    raise "Text '#{text}' not found in the results of #{system_name}" unless page.has_content?(text)
+    raise "Text '#{text}' not found in the results of #{system_name}" unless has_content?(text)
   end
 end
 
 Then(/^I click on the css "(.*)" until page does not contain "([^"]*)" text$/) do |css, text|
   repeat_until_timeout(message: "'#{text}' still found") do
-    break unless page.has_content?(text)
+    break unless has_content?(text)
     find(css).click
   end
 end
 
 Then(/^I click on the css "(.*)" until page does contain "([^"]*)" text$/) do |css, text|
   repeat_until_timeout(message: "'#{text}' was not found") do
-    break if page.has_content?(text)
+    break if has_content?(text)
     find(css).click
   end
 end
@@ -570,7 +570,7 @@ When(/^I see "([^"]*)" fingerprint$/) do |host|
   node = get_target(host)
   output, _code = node.run('salt-call --local key.finger')
   fing = output.split("\n")[1].strip!
-  raise "Text: #{fing} not found" unless page.has_content?(fing)
+  raise "Text: #{fing} not found" unless has_content?(fing)
 end
 
 When(/^I accept "([^"]*)" key$/) do |host|

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -112,27 +112,27 @@ def format_detail(message, last_result, report_result)
 end
 
 def click_button_and_wait(locator = nil, **options)
-  page.click_button(locator, options)
+  click_button(locator, options)
   begin
-    raise 'Timeout: Waiting AJAX transition (click link)' unless page.has_no_css?('.senna-loading', wait: 1)
+    raise 'Timeout: Waiting AJAX transition (click link)' unless has_no_css?('.senna-loading', wait: 1)
   rescue StandardError => e
     puts e.message # Skip errors related to .senna-loading element
   end
 end
 
 def click_link_and_wait(locator = nil, **options)
-  page.click_link(locator, options)
+  click_link(locator, options)
   begin
-    raise 'Timeout: Waiting AJAX transition (click link)' unless page.has_no_css?('.senna-loading', wait: 1)
+    raise 'Timeout: Waiting AJAX transition (click link)' unless has_no_css?('.senna-loading', wait: 1)
   rescue StandardError => e
     puts e.message # Skip errors related to .senna-loading element
   end
 end
 
 def click_link_or_button_and_wait(locator = nil, **options)
-  page.click_link_or_button(locator, options)
+  click_link_or_button(locator, options)
   begin
-    raise 'Timeout: Waiting AJAX transition (click link)' unless page.has_no_css?('.senna-loading', wait: 1)
+    raise 'Timeout: Waiting AJAX transition (click link)' unless has_no_css?('.senna-loading', wait: 1)
   rescue StandardError => e
     puts e.message # Skip errors related to .senna-loading element
   end
@@ -143,7 +143,7 @@ module CapybaraNodeElementExtension
   def click
     super
     begin
-      raise 'Timeout: Waiting AJAX transition (click link)' unless page.has_no_css?('.senna-loading', wait: 1)
+      raise 'Timeout: Waiting AJAX transition (click link)' unless has_no_css?('.senna-loading', wait: 1)
     rescue StandardError => e
       puts e.message # Skip errors related to .senna-loading element
     end
@@ -151,6 +151,6 @@ module CapybaraNodeElementExtension
 end
 
 def find_and_wait_click(*args, **options, &optional_filter_block)
-  element = page.find(*args, options, &optional_filter_block)
+  element = find(*args, options, &optional_filter_block)
   element.extend(CapybaraNodeElementExtension)
 end


### PR DESCRIPTION
## What does this PR change?

Removing all "page." calls, as we don't need them.

Port of https://github.com/SUSE/spacewalk/pull/9753

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
