### PR TITLE
Implement autobuild suggestions for spacewalk-backend and susemanager

### DIFF
--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -16,6 +16,7 @@
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
+
 %{!?_unitdir: %global _unitdir /lib/systemd/system}
 
 %global rhnroot %{_prefix}/share/rhn
@@ -84,9 +85,9 @@ Requires:       %{pythonX}
 Requires(pre):  uyuni-base-common
 BuildRequires:  uyuni-base-common
 %if 0%{?build_py3}
-Requires:       python3-uyuni-common-libs
 Requires:       python3-rhnlib >= 2.5.74
 Requires:       python3-rpm
+Requires:       python3-uyuni-common-libs
 %else
 Requires:       python2-rhnlib >= 2.5.74
 Requires:       python2-uyuni-common-libs
@@ -118,16 +119,16 @@ BuildRequires:  docbook-utils
 BuildRequires:  fdupes
 %if 0%{?fedora} || 0%{?rhel} || 0%{?suse_version} > 1310
 %if 0%{?build_py3}
-BuildRequires:  python3-uyuni-common-libs
 BuildRequires:  python3-gzipstream
 BuildRequires:  python3-rhn-client-tools
 BuildRequires:  python3-rhnlib >= 2.5.74
 BuildRequires:  python3-rpm
+BuildRequires:  python3-uyuni-common-libs
 %else
-BuildRequires:  python2-uyuni-common-libs
 BuildRequires:  python2-gzipstream
 BuildRequires:  python2-rhn-client-tools
 BuildRequires:  python2-rhnlib >= 2.5.74
+BuildRequires:  python2-uyuni-common-libs
 %if 0%{?suse_version} >= 1500
 Requires:       python2-rpm
 %else
@@ -372,17 +373,17 @@ BuildRequires:  systemd
 %endif
 
 %if 0%{?build_py3}
-Requires:       python3-python-dateutil
 Requires:       python3-gzipstream
+Requires:       python3-python-dateutil
 Requires:       python3-rhn-client-tools
 Requires:       python3-solv
 Requires:       python3-urlgrabber
 %else
+Requires:       python-configparser
 Requires:       python-dateutil
+Requires:       python-solv
 Requires:       python2-gzipstream
 Requires:       python2-rhn-client-tools
-Requires:       python-solv
-Requires:       python-configparser
 Requires:       python2-urlgrabber
 %if 0%{?suse_version}
 Requires:       python-pyliblzma
@@ -534,7 +535,6 @@ spacewalk-%{pythonX} $RPM_BUILD_ROOT%{pythonrhnroot}/common \
 
 %endif
 
-
 %pre server
 OLD_SECRET_FILE=%{_var}/www/rhns/server/secret/rhnSecret.py
 if [ -f $OLD_SECRET_FILE ]; then
@@ -551,20 +551,16 @@ if [ ! -e %{rhnconf}/rhn.conf ]; then
 fi
 
 %pre tools
-%service_add_pre spacewalk-diskcheck.service
-%service_add_pre spacewalk-diskcheck.timer
+%service_add_pre spacewalk-diskcheck.service spacewalk-diskcheck.timer
 
 %post tools
-%service_add_post spacewalk-diskcheck.service
-%service_add_post spacewalk-diskcheck.timer
+%service_add_post spacewalk-diskcheck.service spacewalk-diskcheck.timer
 
 %preun tools
-%service_del_preun spacewalk-diskcheck.service
-%service_del_preun spacewalk-diskcheck.timer
+%service_del_preun spacewalk-diskcheck.service spacewalk-diskcheck.timer
 
 %postun tools
-%service_del_postun spacewalk-diskcheck.service
-%service_del_postun spacewalk-diskcheck.timer
+%service_del_postun spacewalk-diskcheck.service spacewalk-diskcheck.timer
 
 # Is secret key in our config file?
 regex="^[[:space:]]*(server\.|)secret_key[[:space:]]*=.*$"

--- a/susemanager/susemanager.spec
+++ b/susemanager/susemanager.spec
@@ -15,6 +15,7 @@
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
+
 %if 0%{?suse_version} > 1320
 # SLE15 builds on Python 3
 %global build_py3   1
@@ -82,8 +83,8 @@ Requires:       SuSEfirewall2
 Requires:       postfix
 Requires:       yast2-users
 # mgr-setup want to call mksubvolume
-Requires:       snapper
 Requires:       reprepro
+Requires:       snapper
 %define python_sitelib %(%{pythonX} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
 %global pythonsmroot %{python_sitelib}/spacewalk
 
@@ -97,16 +98,16 @@ Group:          Productivity/Other
 
 %if 0%{?build_py3}
 Requires:       createrepo_c
-Requires:       python3-uyuni-common-libs
 Requires:       python3
 Requires:       python3-configobj
+Requires:       python3-uyuni-common-libs
 BuildRequires:  python3-configobj
 %else
 Requires:       createrepo
-Requires:       python2-uyuni-common-libs
 Requires:       python
 Requires:       python-argparse
 Requires:       python-configobj
+Requires:       python2-uyuni-common-libs
 BuildRequires:  python-configobj
 Requires:       python-enum34
 BuildRequires:  python-enum34
@@ -117,7 +118,6 @@ Requires:       suseRegisterInfo
 Requires:       susemanager-build-keys
 Requires:       susemanager-sync-data
 BuildRequires:  docbook-utils
-
 
 %description tools
 This package contains SUSE Manager tools
@@ -305,4 +305,5 @@ fi
 /srv/www/htdocs/pub/repositories/empty/repodata/*.xml*
 /srv/www/htdocs/pub/repositories/empty-deb/Packages
 /srv/www/htdocs/pub/repositories/empty-deb/Release
+
 %changelog


### PR DESCRIPTION
## What does this PR change?

Implement autobuild suggestions for spacewalk-backend and susemanager.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: SPEC fixes

- [x] **DONE**

## Test coverage
- No tests: SPEC fixes

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
