### PR TITLE
Fix cleanup and improve performance

### DIFF
--- a/susemanager-utils/testing/automation/clean-objects.sh
+++ b/susemanager-utils/testing/automation/clean-objects.sh
@@ -1,25 +1,15 @@
 #/bin/bash -e
 echo "*************** CLEANING OBJECTS GENERATED INSIDE THE CONTAINER  ***************"
 # Exit if the file does not exist or if it is empty
-if [ ! -f /tmp/objects-init.txt -o -s /tmp/objects-init.txt ]; then
+if [ ! -f /tmp/objects-init.txt -o ! -s /tmp/objects-init.txt ]; then
   echo "No file with the initial list of objects"
   exit 0
 fi
-find /manager > /tmp/objects-end.txt
-while read OBJECTEND; do
-  FOUND=FALSE
-  while read OBJECTINIT; do
-    if [ "${OBJECTINIT}" == "${OBJECTEND}" ]; then
-      FOUND=TRUE
-      break
-    fi
-  done < /tmp/objects-init.txt
-  if [ "${FOUND}" == "FALSE" ]; then
-    echo "${OBJECTEND}"
-    if [ -d ${OBJECTEND} ]; then
-        rm -rf ${OBJECTEND}
-    else
-	rm -f ${OBJECTEND}
-    fi
+find /manager | sort > /tmp/objects-end.txt
+for LINE in $(diff /tmp/objects-init.txt /tmp/objects-end.txt|grep '^> .*$'|sed -e 's/^> //'); do
+  if [ -d ${LINE} ]; then
+    rm -rf ${LINE}
+  else
+    rm -f ${LINE}
   fi
-done < /tmp/objects-end.txt
+done

--- a/susemanager-utils/testing/automation/initial-objects.sh
+++ b/susemanager-utils/testing/automation/initial-objects.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-find /manager > /tmp/objects-init.txt
+find /manager | sort > /tmp/objects-init.txt


### PR DESCRIPTION
## What does this PR change?

Fix cleanup and improve performance.

Comparing the files line by line was just too slow (for the submission container it was running already for one hour).

I tested now, and it takes seconds. I did an e2e test with the submission container, and it worked fine.

## GUI diff

After:

- [X] **DONE**

## Documentation
- No documentation needed: CI change

- [x] **DONE**

## Test coverage
- No tests: CI change

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/9459

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
