### PR TITLE
SPA does not reload <head> content

### DIFF
--- a/java/code/webapp/WEB-INF/pages/kickstart/cobbler/snippetdetails.jsp
+++ b/java/code/webapp/WEB-INF/pages/kickstart/cobbler/snippetdetails.jsp
@@ -3,12 +3,10 @@
 <%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean" %>
 <%@ taglib uri="http://struts.apache.org/tags-html" prefix="html" %>
 
-<head>
-    <%@ include file="/WEB-INF/pages/common/fragments/editarea.jspf" %>
-</head>
-
 <html:html>
     <body>
+        <%@ include file="/WEB-INF/pages/common/fragments/editarea.jspf" %>
+
         <%@ include file="/WEB-INF/pages/common/fragments/kickstart/kickstart-rules.jspf" %>
         <c:choose>
             <c:when test = "${not empty requestScope.create_mode}">

--- a/java/code/webapp/WEB-INF/pages/kickstart/scriptcreate.jsp
+++ b/java/code/webapp/WEB-INF/pages/kickstart/scriptcreate.jsp
@@ -3,12 +3,9 @@
 <%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean" %>
 <%@ taglib uri="http://struts.apache.org/tags-html" prefix="html" %>
 
-<head>
-<%@ include file="/WEB-INF/pages/common/fragments/editarea.jspf" %>
-</head>
-
 <html:html >
 <body>
+<%@ include file="/WEB-INF/pages/common/fragments/editarea.jspf" %>
 <%@ include file="/WEB-INF/pages/common/fragments/kickstart/kickstart-toolbar.jspf" %>
 
 <rhn:dialogmenu mindepth="0" maxdepth="1"

--- a/java/code/webapp/WEB-INF/pages/kickstart/scriptedit.jsp
+++ b/java/code/webapp/WEB-INF/pages/kickstart/scriptedit.jsp
@@ -4,13 +4,9 @@
 <%@ taglib uri="http://struts.apache.org/tags-html" prefix="html" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
 
-<head>
-<%@ include file="/WEB-INF/pages/common/fragments/editarea.jspf" %>
-</head>
-
-
 <html>
 <body>
+<%@ include file="/WEB-INF/pages/common/fragments/editarea.jspf" %>
 <rhn:toolbar base="h1" icon="header-kickstart"
            deletionUrl="/rhn/kickstart/KickstartScriptDelete.do?kssid=${kssid}&ksid=${ksdata.id}"
            deletionType="kickstartscript" >


### PR DESCRIPTION
## What does this PR change?

Load `ace-editor` properly within SPA behavior.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
- No tests: 

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/10041
Tracks # https://github.com/SUSE/spacewalk/pull/10060

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
