### PR TITLE
Master - fix section resize on toggle menu

### DIFF
--- a/branding/css/susemanager-theme.less
+++ b/branding/css/susemanager-theme.less
@@ -191,7 +191,7 @@ section {
 .navbar-collapse.collapse {
   display: none !important;
 }
-.navbar-collapse.collapse + section {
+.navbar-collapse.collapse + div section {
   width: 100%;
 }
 

--- a/web/html/javascript/spacewalk-essentials.js
+++ b/web/html/javascript/spacewalk-essentials.js
@@ -485,10 +485,6 @@ $(document).click(function (e) {
   });
 });
 
-$(document).on('click', '.navbar-toggle', function() {
-  $('aside').toggle();
-});
-
 /* prevent jumping to the top of the page because
 of an <a href> tag that is actually not a link */
 $(document).on('click', 'a', function(e) {


### PR DESCRIPTION
## What does this PR change?

Fix the `section` resize when the `aside` menu is toggled (hidden/shown).

## GUI diff

Before:
![67935374-f772b980-fbc9-11e9-828d-9dc192fd4e39](https://user-images.githubusercontent.com/7080830/68846169-ed25e480-06cc-11ea-91d0-63b964f88298.png)


After:
![Screenshot from 2019-11-14 10-52-21](https://user-images.githubusercontent.com/7080830/68846133-d97a7e00-06cc-11ea-8d04-cd7b22d612e1.png)


- [x] **DONE**

## Documentation
- No documentation needed: style bugfix

- [x] **DONE**

## Test coverage
- No tests: style bugfix

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/9923
Tracks https://github.com/SUSE/spacewalk/pull/10063

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
