### PR TITLE
Separate component for build version details

### DIFF
--- a/branding/css/susemanager-theme.less
+++ b/branding/css/susemanager-theme.less
@@ -1241,7 +1241,7 @@ select.small-select {
 
 /*Colapsed pannels*/
 
-.panel-heading {
+.panel-heading, .collapsible-content {
 
   .collapsed {
     .hide-on-collapsed {

--- a/web/html/src/manager/content-management/shared/components/panels/build/build-version.js
+++ b/web/html/src/manager/content-management/shared/components/panels/build/build-version.js
@@ -1,0 +1,36 @@
+//@flow
+
+import React from 'react';
+import styles from "./build.css";
+
+type Props = {
+  id: string,
+  text: string,
+  collapsed?: boolean
+}
+
+const BuildVersion = ({id, text, collapsed} : Props) => {
+  return (
+    <div>
+      <dd className="collapsible-content">
+        <div data-toggle="collapse" href={`#historyentry_${id}`}
+            className={`${styles.version_collapse_line} pointer accordion-toggle collapsed`}>
+          <i className="fa fa-chevron-down show-on-collapsed fa-small" />
+          <i className="fa fa-chevron-right hide-on-collapsed fa-small" />
+          <span>{text.split('\n')[0]}</span>
+        </div>
+        <div className="collapse" id={`historyentry_${id}`}>
+          <pre>{text}</pre>
+        </div>
+      </dd>
+    </div>
+  );
+};
+
+BuildVersion.defaultProps = {
+  id: undefined,
+  text: undefined,
+  collapsed: true
+};
+
+export default BuildVersion;

--- a/web/html/src/manager/content-management/shared/components/panels/build/build.css
+++ b/web/html/src/manager/content-management/shared/components/panels/build/build.css
@@ -1,0 +1,8 @@
+.version_collapse_line {
+  padding-top: .3em;
+  padding-bottom: .3em;
+}
+
+.version_collapse_line:hover > span{
+  text-decoration: underline;
+}

--- a/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-view.js
+++ b/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-view.js
@@ -6,7 +6,7 @@ import type {ProjectEnvironmentType} from '../../../type/project.type.js';
 import type {ProjectHistoryEntry} from "../../../type/project.type";
 import {getVersionMessageByNumber} from "../properties/properties.utils";
 import {objectDefaultValueHandler} from "core/utils/objects";
-import propertiesStyles from "../properties/properties.css";
+import BuildVersion from "../build/build-version";
 
 type Props = {
   environment: ProjectEnvironmentType,
@@ -33,8 +33,6 @@ const environmentStatusEnum: EnvironmentStatusEnumType = new Proxy({
 
 // $FlowFixMe  // upgrade flow
 const EnvironmentView = React.memo((props: Props) => {
-  let  versionMessage = getVersionMessageByNumber(props.environment.version, props.historyEntries) || t("not built");
-
   return (
     <React.Fragment>
       <dl className="row">
@@ -48,14 +46,10 @@ const EnvironmentView = React.memo((props: Props) => {
       <dl className="row">
         <dt className="col-xs-3">{t('Version')}:</dt>
         <dd className="col-xs-9">
-          <div className={`${propertiesStyles.version_collapse_line} pointer`} data-toggle="collapse"
-              data-target={`#historyentry_${props.environment.label}_${props.environment.version}`} role="button"
-              aria-expanded="false" aria-controls="collapseExample">
-            {versionMessage.split('\n')[0]}
-          </div>
-          <div class="collapse" id={`historyentry_${props.environment.label}_${props.environment.version}`}>
-            <pre>{versionMessage}</pre>
-          </div>
+          <BuildVersion
+              id={`${props.environment.version}_${props.environment.label}`}
+              text={getVersionMessageByNumber(props.environment.version, props.historyEntries) || t("not built")}
+              collapsed={true} />
         </dd>
       </dl>
       {

--- a/web/html/src/manager/content-management/shared/components/panels/promote/promote.js
+++ b/web/html/src/manager/content-management/shared/components/panels/promote/promote.js
@@ -11,7 +11,7 @@ import {Loading} from "components/loading/loading";
 import useRoles from "core/auth/use-roles";
 import {isOrgAdmin} from "core/auth/auth.utils";
 import useLifecycleActionsApi from "../../../api/use-lifecycle-actions-api";
-
+import BuildVersion from "../build/build-version";
 
 type Props = {
   projectId: string,
@@ -36,7 +36,6 @@ const Promote = (props: Props) => {
     }
   }, [open]);
 
-  const versionMessage = getVersionMessageByNumber(props.environmentPromote.version, props.historyEntries) || t("not built");
   const modalNameId = `${props.environmentPromote.label}-cm-promote-env-modal`;
   const disabled =
     !hasEditingPermissions
@@ -75,7 +74,11 @@ const Promote = (props: Props) => {
               <dl className="row">
                 <dt className="col-xs-4">{t('Version')}:</dt>
                 <dd className="col-xs-8">
-                  <pre>{versionMessage}</pre>
+                  <BuildVersion
+                      id={`${props.environmentPromote.version}_promote_${props.environmentTarget.label}`}
+                      text={getVersionMessageByNumber(props.environmentPromote.version, props.historyEntries) || t("not built")}
+                      collapsed={true}
+                  />
               </dd>
               </dl>
               <dl className="row">

--- a/web/html/src/manager/content-management/shared/components/panels/properties/properties-view.js
+++ b/web/html/src/manager/content-management/shared/components/panels/properties/properties-view.js
@@ -6,7 +6,7 @@ import type {ProjectPropertiesType} from '../../../type/project.type.js';
 import {getVersionMessage} from "./properties.utils";
 import {ModalLink} from "components/dialog/ModalLink";
 import {Dialog} from "components/dialog/Dialog";
-import styles from "./properties.css";
+import BuildVersion from "../build/build-version";
 
 type Props = {
   properties: ProjectPropertiesType,
@@ -24,22 +24,7 @@ const PropertiesHistoryEntries = (props) =>
             {
               index === 0
                 ? versionMessage
-                : <div>
-                    <div className={`${styles.version_collapse_line} pointer`} data-toggle="collapse"
-                        data-target={`#historyentries_${props.id}_${index}`} role="button"
-                        aria-expanded="false" aria-controls="collapseExample">
-                      {t('Version {0}: {1}', history.version, history.message.split('\n')[0])}
-                    </div>
-                    <div class="collapse" id={`historyentries_${props.id}_${index}`}>
-                      <pre>
-                        {
-                          index === 0
-                            ? <strong>{versionMessage}</strong>
-                            : versionMessage
-                        }
-                      </pre>
-                    </div>
-                  </div>
+                : <BuildVersion id={`${history.version}_historyentry`} text={versionMessage} collapsed={true} />
             }
           </li>
         )

--- a/web/html/src/manager/content-management/shared/components/panels/properties/properties.css
+++ b/web/html/src/manager/content-management/shared/components/panels/properties/properties.css
@@ -1,7 +1,0 @@
-.version_collapse_line {
-  margin-bottom: .3em;
-}
-
-.version_collapse_line:hover {
-  text-decoration: underline;
-}


### PR DESCRIPTION
## What does this PR change?

Refactoring to create a new standalone component to create the `Build Version` details box and the show/hide behavior to be reuse everywhere. Add an icon to properly give the hint of a clickable text to hide/show the `Build Version` details.

## GUI diff

Before:
![Screenshot from 2019-11-14 15-25-12](https://user-images.githubusercontent.com/7080830/68865402-0fcaf400-06f3-11ea-9684-2738f07e906c.png)


After:

![Screenshot from 2019-11-14 15-21-02](https://user-images.githubusercontent.com/7080830/68865411-135e7b00-06f3-11ea-92f9-aca4063e6d08.png)

- [x] **DONE**

## Documentation
- No documentation needed: refactoring and one icon added

- [x] **DONE**

## Test coverage
- No tests: nothing to test

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/10071
Tracks https://github.com/SUSE/spacewalk/pull/10070

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
