### PR TITLE
Fake PR to test changelog_test

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,6 @@ Following links might be of value in case you are interested:
   * [Mailing lists](https://www.uyuni-project.org/contact.html#ml)
   * [Bug reports](https://github.com/uyuni-project/uyuni/issues)
   * [SUSE Manager](https://www.suse.com/products/suse-manager/)
+  
+  
+  test

--- a/README.md
+++ b/README.md
@@ -20,5 +20,3 @@ Following links might be of value in case you are interested:
   * [Mailing lists](https://www.uyuni-project.org/contact.html#ml)
   * [Bug reports](https://github.com/uyuni-project/uyuni/issues)
   * [SUSE Manager](https://www.suse.com/products/suse-manager/)
-
-test

--- a/README.md
+++ b/README.md
@@ -20,3 +20,5 @@ Following links might be of value in case you are interested:
   * [Mailing lists](https://www.uyuni-project.org/contact.html#ml)
   * [Bug reports](https://github.com/uyuni-project/uyuni/issues)
   * [SUSE Manager](https://www.suse.com/products/suse-manager/)
+
+test

--- a/README.md
+++ b/README.md
@@ -20,6 +20,3 @@ Following links might be of value in case you are interested:
   * [Mailing lists](https://www.uyuni-project.org/contact.html#ml)
   * [Bug reports](https://github.com/uyuni-project/uyuni/issues)
   * [SUSE Manager](https://www.suse.com/products/suse-manager/)
-  
-  
-  test

--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- test
 - Bump version to 4.1.0 (bsc#1154940)
 - Prevent error when piping stdout in Python 2 (bsc#1153090)
 - Java api expects content as encoded string instead of encoded bytes like before (bsc#1153277)

--- a/spacecmd/spacecmd.spec
+++ b/spacecmd/spacecmd.spec
@@ -1,5 +1,5 @@
 #
-# spec file for package spacecmd
+# spec file for package spacecmd 
 #
 # Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
 # Copyright (c) 2008-2018 Red Hat, Inc.


### PR DESCRIPTION
## What does this PR change?

Changing something to retest

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
