### PR TITLE
Rename the changelog_test action

### DIFF
--- a/.github/workflows/changelog_checker.yml
+++ b/.github/workflows/changelog_checker.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, edited, synchronize, reopened]
 
 jobs:
-  test:
+  changelog_test:
 
     runs-on: ubuntu-latest
     


### PR DESCRIPTION
## What does this PR change?

That PR will rename the status check of the changelog_test with currently is "test" and we want "changelog_test"

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests: CI Change

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
