### PR TITLE
Be able to determine Ubuntu minion's MAC address

### DIFF
--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -416,12 +416,15 @@ end
 When(/^I enter the MAC address of "([^"]*)" in (.*) field$/) do |host, field|
   if host == 'pxeboot-minion'
     mac = $pxeboot_mac
+  elsif host.include? 'ubuntu'
+    node = get_target(host)
+    output, _code = node.run("ip link show dev ens4")
+    mac = output.split("\n")[1].split[1]
   else
     node = get_target(host)
     output, _code = node.run("ip link show dev eth1")
     mac = output.split("\n")[1].split[1]
   end
-
   fill_in FIELD_IDS[field], with: 'ethernet ' + mac
 end
 


### PR DESCRIPTION
## What does this PR change?

This PR makes it possible to read Ubuntu minion's MAC address.

We currently do not do that in the test suite, but I needed it during private tests. So we will make an exception to YAGNI :-) .

## Links

3.2 branch : SUSE/spacewalk#10072
4.0 branch : SUSE/spacewalk#10073

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
