### PR TITLE
Trigger the labeler periodically

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,5 +1,7 @@
 name: Labeler
-on: [pull_request]
+on:
+  schedule:
+  - cron: "0 0 * * *"
 
 jobs:
   label:


### PR DESCRIPTION
## What does this PR change?

Trigger the labeler periodically instead of by PR event.
Due to a constraint on GitHub Actions API, we don't have to write access to forks, for some reason if we trigger by pull-request we are requesting access to it.
The solution is to trigger it every midnight.

See:
https://github.com/actions/labeler/issues/12#issuecomment-525762657
https://github.com/actions/starter-workflows/pull/78/files

## GUI diff

Before:
```
on: [pull_request]
```

After:
```
on:
  schedule:
  - cron: "0 0 * * *"
```

- [x] **DONE**

## Documentation
- No documentation needed:  CI change

- [x] **DONE**

## Test coverage
- No tests: CI Change

- [x] **DONE**

## Links

https://github.com/actions/labeler/issues/12#issuecomment-525762657
https://github.com/actions/starter-workflows/pull/78/files

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
