### PR TITLE
Install yum plugin for only yum < 4

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/channels/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/init.sls
@@ -1,6 +1,9 @@
-{%- set is_yum = salt['cmd.which']("yum") %}
-{%- set is_dnf = salt['cmd.which']("dnf") %}
 {%- if grains['os_family'] == 'RedHat' %}
+
+{%- set yum_version = salt['pkg.version']("yum") %}
+{%- set is_yum = yum_version and salt['pkg.version_cmp'](yum_version, "4") < 0 %}
+{%- set is_dnf = salt['pkg.version']("dnf") %}
+
 {%- if is_dnf %}
 mgrchannels_susemanagerplugin_dnf:
   file.managed:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Install yum plguin for only yum < 4 (bsc#1156173)
 - Add self monitoring to Admin Monitoring UI (bsc#1143638)
 - configure GPG keys and SSL Certificates for RHEL8 and ES8
 - Always run Kiwi with empty cache (bsc#1155899)


### PR DESCRIPTION
To install the yum plugin, the `channels` state checks if the `yum` is installed in the client. Since version 4, `yum` is just a wrapper around `dnf`, therefore the yum plugin is not supported with it anymore. The plugin directory for yum is not available with the new version and trying to deploy a file causes the state to fail.

This change adds a yum version check to the state to deploy the plugin only for versions older than 4.

https://bugzilla.suse.com/1156173

## GUI diff
No difference.

## Documentation
- No documentation needed: bugfix

## Test coverage
- No tests: will be covered with CentOS 8 bootstrap tests

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test" 
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
