### PR TITLE
Optional py2 for docker buildhost

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/services/docker.sls
+++ b/susemanager-utils/susemanager-sls/salt/services/docker.sls
@@ -14,9 +14,10 @@ mgr_install_docker:
       - python-docker-py: '>=1.6.0'
 {%- endif %}
 {%- if grains['saltversioninfo'][0] >= 2018 %}
-    {%- if grains['osmajorrelease'] == 12 %}
+    {%- if salt['pkg.info_available']('python3', 'python36' 'python3.6') %}
       - python3-salt
-    {%- else %}
+    {%- endif %}
+    {%- if salt['pkg.info_available']('python', 'python2') %}
       - python2-salt
     {%- endif %}
 {%- endif %}

--- a/susemanager-utils/susemanager-sls/salt/services/docker.sls
+++ b/susemanager-utils/susemanager-sls/salt/services/docker.sls
@@ -14,9 +14,7 @@ mgr_install_docker:
       - python-docker-py: '>=1.6.0'
 {%- endif %}
 {%- if grains['saltversioninfo'][0] >= 2018 %}
-    {%- if salt['pkg.info_available']('python3', 'python36' 'python3.6') %}
       - python3-salt
-    {%- endif %}
     {%- if salt['pkg.info_available']('python', 'python2') %}
       - python2-salt
     {%- endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- dockerhost: install python2 and python3 salt packages only when
+  major python version is available (bsc#1129627)
 - Support license entry in kiwi image packages list
 - Install yum plguin for only yum < 4 (bsc#1156173)
 - Add self monitoring to Admin Monitoring UI (bsc#1143638)

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,5 +1,5 @@
-- dockerhost: install python2 and python3 salt packages only when
-  major python version is available (bsc#1129627)
+- dockerhost: install python2 salt packages only when python2
+  is available (bsc#1129627)
 - Support license entry in kiwi image packages list
 - Install yum plguin for only yum < 4 (bsc#1156173)
 - Add self monitoring to Admin Monitoring UI (bsc#1143638)


### PR DESCRIPTION
## What does this PR change?

When applying the highstate for a docker build host we require to have python2 and python3 installed. As there are more system in future without python2, we check now for the avaiability of python2 version package before we require to install the python2-salt package.

python3 is now **required**

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Issue was created (GitHub automatic link expected below)

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/7624
https://bugzilla.suse.com/show_bug.cgi?id=1129627

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test" 
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
