### PR TITLE
Fixing the product name when loggin

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -425,7 +425,7 @@ end
 
 Then(/^I am logged in$/) do
   raise 'User is not logged in' unless find(:xpath, "//a[@href='/rhn/Logout.do']").visible?
-  raise 'The welcome message is not shown' unless has_content?('You have just created your first SUSE Manager user. To finalize your installation please use the Setup Wizard')
+  raise 'The welcome message is not shown' unless has_content?('You have just created your first #{product} user. To finalize your installation please use the Setup Wizard')
 end
 
 Given(/^I am on the patches page$/) do


### PR DESCRIPTION
## What does this PR change?

Fix a mistake during a port, where we mention SUSE Manager instead of using the product variable.

## Documentation
- No documentation needed: TestSuite fix

- [x] **DONE**

## Test coverage
- No tests: Test step

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
