### PR TITLE
Parse license in kiwi image packages list

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/test/image.inspect.kiwi.json
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/image.inspect.kiwi.json
@@ -58,7 +58,8 @@
                                 "epoch": "",
                                 "version": "13.1",
                                 "release": "14.15",
-                                "arch": "x86_64"
+                                "arch": "x86_64",
+                                "license": "MIT"
                             },
                             {
                                 "name": "kernel-firmware",
@@ -66,7 +67,8 @@
                                 "epoch": "",
                                 "version": "20170530",
                                 "release": "21.19.1",
-                                "arch": "noarch"
+                                "arch": "noarch",
+                                "license": "SUSE-Firmware AND GPL-2.0-only AND GPL-2.0-or-later AND MIT"
                             },
                             {
                                 "name": "file-magic",

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add 'license' entry to the kiwi image inspection test data
 - Enable aarch64 builds
 - Add self monitoring to Admin Monitoring UI (bsc#1143638)
 - Use apache proxy of websockify (bsc#1155455)

--- a/susemanager-utils/susemanager-sls/src/modules/kiwi_info.py
+++ b/susemanager-utils/susemanager-sls/src/modules/kiwi_info.py
@@ -95,7 +95,7 @@ def parse_packages(path):
     ret = []
     if __salt__['file.file_exists'](path):
         packages = __salt__['cp.get_file_str'](path)
-        pattern = re.compile(r"^(?P<name>.*)\|(?P<epoch>.*)\|(?P<version>.*)\|(?P<release>.*)\|(?P<arch>.*)\|(?P<disturl>.*)$")
+        pattern = re.compile(r"^(?P<name>.*?)\|(?P<epoch>.*?)\|(?P<version>.*?)\|(?P<release>.*?)\|(?P<arch>.*?)\|(?P<disturl>.*?)(\|(?P<license>.*))?$")
         for line in packages.splitlines():
             match = pattern.match(line)
             if match:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Support license entry in kiwi image packages list
 - Install yum plguin for only yum < 4 (bsc#1156173)
 - Add self monitoring to Admin Monitoring UI (bsc#1143638)
 - configure GPG keys and SSL Certificates for RHEL8 and ES8


### PR DESCRIPTION
## What does this PR change?
Kiwi-NG in upcomming update added package license text at the end of image package list.
For backward compatibility the license match is optional, but the rest patterns were modified to be non-greedy.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: internal data parsing

- [X] **DONE**

## Test coverage
- Unit tests were updated
- Already part of the cucumber SLE15 image building test scenario

- [X] **DONE**

## Links

Backport https://github.com/SUSE/spacewalk/pull/10118

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"   
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
