### PR TITLE
argparse is part of python3 base and does not need a special dependency

### DIFF
--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -262,7 +262,6 @@ Summary:        CDN tools
 Group:          System/Management
 Requires:       %{m2crypto}
 Requires:       %{name}-server = %{version}-%{release}
-Requires:       python3-argparse
 Requires:       subscription-manager
 
 %description cdn

--- a/utils/spacewalk-utils.spec
+++ b/utils/spacewalk-utils.spec
@@ -63,7 +63,6 @@ Requires:       perl(:MODULE_COMPAT_%(eval "`%{__perl} -V:version`"; echo $versi
 %endif
 Requires:       python3
 Requires:       python3-rpm
-Requires:       python3-argparse
 Requires:       python3-rhnlib >= 2.5.20
 Requires:       rpm
 Requires:       salt


### PR DESCRIPTION
## What does this PR change?

There is no package python3-argparse as it is part of python base.
Remove the dependency from spec files.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **package dependency**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
