### PR TITLE
Bugfix: attempt to purge SSM when it is empty (bsc#1155372)

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,5 @@
+- Bugfix: attempt to purge SSM when it is empty (bsc#1155372)
+
 -------------------------------------------------------------------
 Wed Nov 27 16:57:34 CET 2019 - jgonzalez@suse.com
 

--- a/spacecmd/src/spacecmd/system.py
+++ b/spacecmd/src/spacecmd/system.py
@@ -1774,16 +1774,23 @@ def do_system_delete(self, args):
     if not self.user_confirm('Delete these systems [y/N]:'):
         return
 
-    self.client.system.deleteSystems(self.session, system_ids, options.cleanuptype)
+    logging.debug("System IDs to remove: %s", system_ids)
+    logging.debug("System names to IDs: %s", systems)
 
+    self.client.system.deleteSystems(self.session, system_ids, options.cleanuptype)
     logging.info('%i system(s) scheduled for removal', len(system_ids))
 
     # regenerate the system name cache
     self.generate_system_cache(True, delay=1)
 
     # remove these systems from the SSM and update the cache
-    all(self.ssm.pop(system_name) for system_name in list(systems))
+    for system_name in list(systems):
+        if system_name in self.ssm:
+            self.ssm.pop(system_name)
+    logging.debug("SSM stack updated")
+
     save_cache(self.ssm_cache_file, self.ssm)
+    logging.debug("SSM cache saved")
 
 
 ####################


### PR DESCRIPTION
## What does this PR change?

Fixes an attempt to purge SSM in the spacecmd when it is empty (bsc#1155372)

## GUI diff

No difference.

Before:

On the attempt to remove a system by FQDN name, `spacecmd` fails to refresh the caches properly, reports an error for the system is unable to be removed, exists with non-zero code. The system is actually removed on the Uyuni side.

After:

On the attempt to remove a system by FQDN name, `spacecmd` removes the system by name properly.

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #9928

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
