### PR TITLE
Fix certificate generation during setup

### DIFF
--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,5 @@
+- Fix certificate generation when the serial has leading zeroes to avoid
+  "asn1 encoding routines:a2i_ASN1_INTEGER:odd number of chars" during setup
 - require uyuni-common-libs
 - Bump version to 4.1.0 (bsc#1154940)
 - make traditional bootstrap more robust for unknown hostname (bsc#1152298)

--- a/spacewalk/certs-tools/sslToolLib.py
+++ b/spacewalk/certs-tools/sslToolLib.py
@@ -48,7 +48,7 @@ def fixSerial(serial):
     # make sure the padding is correct
     # if odd number of digits, pad with a 0
     # e.g., '100' --> '0100'
-    if len(serial)/2.0 != len(serial)/2:
+    if len(serial)/2.0 != len(serial)//2:
         serial = '0'+serial
 
     return serial


### PR DESCRIPTION
## What does this PR change?

Fix certificate generation when the serial has leading zeroes to avoid "asn1 encoding routines:a2i_ASN1_INTEGER:odd number of chars" during setup.

It was failing because `/` at python3 is not integer division: https://www.python.org/dev/peps/pep-0238/#how-do-i-write-code-that-works-under-the-classic-rules-as-well-as-under-the-new-rules-without-using-or-a-future-division-statement so the code to add leading zeros (when needed) didn't work.

I didn't see 4.0 failing because of this. Not sure if it's because the serials there are different (at least shorter, maybe because of a different SSL version), or because other reasons. So I'd say we don't require a port.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
- No tests: Covered by cucumber

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/10103

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
