### PR TITLE
Testsuite - fix of bind config after mass import

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1112,6 +1112,11 @@ When(/^I copy the retail configuration file "([^"]*)" on server$/) do |file|
   sed_values << "s/<RANGE_END>/#{ADDRESSES['range end']}/; "
   sed_values << "s/<PXEBOOT>/#{ADDRESSES['pxeboot']}/; "
   sed_values << "s/<PXEBOOT_MAC>/#{$pxeboot_mac}/; "
+  sed_values << "s/<MINION>/#{ADDRESSES['minion']}/; "
+  sed_values << "s/<MINION_MAC>/#{get_mac_address('sle-minion')}/; "
+  sed_values << "s/<CLIENT>/#{ADDRESSES['client']}/; "
+  sed_values << "s/<CLIENT_MAC>/#{get_mac_address('sle-client')}/; "
+  # Retail DNS fix for client and minion
   $server.run("sed -i '#{sed_values}' #{dest}")
 end
 
@@ -1127,6 +1132,7 @@ end
 When(/^I delete all the terminals imported$/) do
   terminals = get_terminals_from_yaml(@retail_config)
   terminals.each do |terminal|
+    next if (terminal.include? 'minion') || (terminal.include? 'client')
     puts "Deleting terminal with name: #{terminal}"
     steps %(
       When I follow "#{terminal}" terminal

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -47,7 +47,10 @@ end
 
 Then(/^I should not see any terminals imported from the configuration file/) do
   terminals = get_terminals_from_yaml(@retail_config)
-  terminals.each { |terminal| step %(I should not see a "#{terminal}" text) }
+  terminals.each do |terminal|
+    next if (terminal.include? 'minion') || (terminal.include? 'client')
+    step %(I should not see a "#{terminal}" text)
+  end
 end
 
 When(/^I enter the hostname of "([^"]*)" terminal as "([^"]*)"$/) do |host, hostname|

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -98,6 +98,17 @@ def get_system_name(host)
   system_name
 end
 
+def get_mac_address(host)
+  if host == 'pxeboot-minion'
+    mac = ENV['PXEBOOTMAC']
+  else
+    node = get_target(host)
+    output, _code = node.run('ip link show dev eth1')
+    mac = output.split("\n")[1].split[1]
+  end
+  mac
+end
+
 # This function returns the net prefix, caching it
 def net_prefix
   $net_prefix = $private_net.sub(%r{\.0+/24$}, '.') if $net_prefix.nil?

--- a/testsuite/features/upload_files/massive-import-terminals.yml
+++ b/testsuite/features/upload_files/massive-import-terminals.yml
@@ -54,6 +54,12 @@ branches:
         IP: <NET_PREFIX><PXEBOOT>
         hwAddress: <PXEBOOT_MAC>
         hwtype: Intel-Genuine
+      client:
+        IP: <NET_PREFIX><CLIENT>
+        hwAddress: <CLIENT_MAC>
+      minion:
+        IP: <NET_PREFIX><MINION>
+        hwAddress: <MINION_MAC>        
 
 hwtypes:
   Intel-Genuine:


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/10074

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
