### PR TITLE
Manager 1154599

### DIFF
--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- update requirements to match documented values (bsc#1154599)
 - add bootstrap repo for RHEL 8 and ES 8
 - Show help message when missing sub-command in  mgr-sync call (bsc#1134708)
 - Use python2-uyuni-common-libs and python3-uyuni-common-libs for

--- a/susemanager/yast/susemanager_reqs.rb
+++ b/susemanager/yast/susemanager_reqs.rb
@@ -15,8 +15,8 @@ module Yast
       @args = GetInstArgs.argmap
       @product_name = SCR.Read(path(".usr_share_rhn_config_defaults_rhn.product_name")) || "SUSE Manager"
 
-      # 4GB
-      @enough_memory = 4000000
+      # 8GB
+      @enough_memory = 8000000
 
       @free_disk_space = 0
       @message = ""
@@ -85,7 +85,7 @@ module Yast
         if !Popup.AnyQuestionRichText(
             _("Not enough memory"),
             _(
-              "#{@product_name} requires 4G of memory to be installed and 16G for good perfomance. If you continue the product will not function correctly."
+              "#{@product_name} requires 8G of memory to be installed and 16G for good perfomance. If you continue the product will not function correctly."
             ),
             40,
             10,
@@ -131,7 +131,7 @@ module Yast
       )
       Builtins.y2milestone("check_disk_space.sh call: %1", @m)
       @free_disk_space = Builtins.tointeger(Ops.get_string(@m, "stdout", "0"))
-      if Ops.less_than(@free_disk_space, 30 * 1024 * 1024)
+      if Ops.less_than(@free_disk_space, 50 * 1024 * 1024)
         @message = Builtins.sformat(
           _("    Not enough disk space (only %1G free)"),
           Ops.divide(@free_disk_space, 1024 * 1024)
@@ -139,7 +139,7 @@ module Yast
         if !Popup.AnyQuestionRichText(
             @message,
             _(
-              "#{@product_name} requires 30G of free disk space in /var/lib/pgsql to be installed. If you continue the product will not function correctly."
+              "#{@product_name} requires 50G of free disk space in /var/lib/pgsql to be installed. If you continue the product will not function correctly."
             ),
             46,
             10,


### PR DESCRIPTION
## What does this PR change?

According to documentation SUSE Manager requires at least 8 GB of RAM and at least 50 GB of disk space for /var/lib/pgsql; the yast setup code has been checking for outdated values. This PR fixes this.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**

- [X] **DONE**

## Test coverage
- No tests: Can only be seen with an interactive setup using yast. Documentation is already correct and issue probably is mostly academic for customers anyway.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)