### PR TITLE
Let the ActivationKeyId be re-read from the server side (bsc#1157141)

### DIFF
--- a/java/code/webapp/WEB-INF/pages/common/fragments/activationkeys/details.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/activationkeys/details.jspf
@@ -71,17 +71,11 @@
         <div id="activation-key-channels"></div>
         <script type="text/javascript">
             window.csrfToken = '<c:out value="${csrf_token}" />';
-            window.pageRenderers = window.pageRenderers || {};
-            window.pageRenderers.customValues = { DOMid: 'activation-key-channels' }
-
-            function getActivationKeyId(){
-                return ${param.tid};
-            }
-        </script>
-
-        <script>
             spaImportReactPage('systems/activation-key/activation-key-channels')
-                .then(function(module) { module.renderer('activation-key-channels') });
+                .then(function(module) {
+                    module.renderer('activation-key-channels', {activationKeyId: '${param.tid}'})
+                }
+            );
         </script>
 
         <div class="form-group">

--- a/java/code/webapp/WEB-INF/pages/common/fragments/activationkeys/details.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/activationkeys/details.jspf
@@ -72,15 +72,16 @@
         <script type="text/javascript">
             window.csrfToken = '<c:out value="${csrf_token}" />';
             window.pageRenderers = window.pageRenderers || {};
-            window.pageRenderers.customValues = {
-                DOMid: 'activation-key-channels',
-                    activationKeyId: '<c:out value="${param.tid}" />'
-                }
+            window.pageRenderers.customValues = { DOMid: 'activation-key-channels' }
+
+            function getActivationKeyId(){
+                return ${param.tid};
+            }
         </script>
 
         <script>
             spaImportReactPage('systems/activation-key/activation-key-channels')
-                .then(function(module) { module.renderer() });
+                .then(function(module) { module.renderer('activation-key-channels') });
         </script>
 
         <div class="form-group">

--- a/java/code/webapp/WEB-INF/pages/systems/sdc/channels.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/sdc/channels.jsp
@@ -12,20 +12,14 @@
   </div>
 
     <div id="subscribe-channels-div"></div>
-    <script>
+    <script type="text/javascript">
         var csrfToken="<%= com.redhat.rhn.common.security.CSRFTokenValidator.getToken(session) %>";
         var timezone = "<%= com.suse.manager.webui.utils.ViewHelper.getInstance().renderTimezone() %>";
         var localTime = "<%= com.suse.manager.webui.utils.ViewHelper.getInstance().renderLocalTime() %>";
         var actionChains = ${actionChainsJson};
 
-        function getServerId(){
-            return ${system.id};
-        }
-    </script>
-
-    <script>
       spaImportReactPage('systems/subscribe-channels/subscribe-channels')
-        .then(function(module) { module.renderer('subscribe-channels-div') });
+        .then(function(module) { module.renderer('subscribe-channels-div', {systemId: '${system.id}'}) });
     </script>
 
 </body>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix loading proper activation key details on SPA enabled (bsc#1157141)
 - Add 'license' entry to the kiwi image inspection test data
 - Enable aarch64 builds
 - Add self monitoring to Admin Monitoring UI (bsc#1143638)

--- a/web/html/src/manager/systems/activation-key/activation-key-channels.renderer.js
+++ b/web/html/src/manager/systems/activation-key/activation-key-channels.renderer.js
@@ -1,4 +1,5 @@
 /* eslint-disable */
+/* global getActivationKeyId */
 import ActivationKeyChannels from './activation-key-channels';
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -10,6 +11,6 @@ window.pageRenderers = window.pageRenderers || {};
 const customValues = window.pageRenderers.customValues || {DOMid: 'activation-key-channels'};
 
 export const renderer = () => SpaRenderer.renderNavigationReact(
-    <ActivationKeyChannels activationKeyId={customValues.activationKeyId ? customValues.activationKeyId : -1} />,
+    <ActivationKeyChannels activationKeyId={getActivationKeyId() ? getActivationKeyId() : -1} />,
     document.getElementById(customValues.DOMid)
 );

--- a/web/html/src/manager/systems/activation-key/activation-key-channels.renderer.js
+++ b/web/html/src/manager/systems/activation-key/activation-key-channels.renderer.js
@@ -1,16 +1,10 @@
 /* eslint-disable */
-/* global getActivationKeyId */
 import ActivationKeyChannels from './activation-key-channels';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import SpaRenderer from "core/spa/spa-renderer";
 
-// receive parameters from the backend
-// if nothing from the backend, fallback on defaults
-window.pageRenderers = window.pageRenderers || {};
-const customValues = window.pageRenderers.customValues || {DOMid: 'activation-key-channels'};
-
-export const renderer = () => SpaRenderer.renderNavigationReact(
-    <ActivationKeyChannels activationKeyId={getActivationKeyId() ? getActivationKeyId() : -1} />,
-    document.getElementById(customValues.DOMid)
+export const renderer = (id, {activationKeyId}) => SpaRenderer.renderNavigationReact(
+    <ActivationKeyChannels activationKeyId={activationKeyId} />,
+    document.getElementById(id)
 );

--- a/web/html/src/manager/systems/ssm/ssm-subscribe-channels.js
+++ b/web/html/src/manager/systems/ssm/ssm-subscribe-channels.js
@@ -21,7 +21,6 @@ const SpaRenderer  = require("core/spa/spa-renderer").default;
 import type JsonResult from "utils/network";
 import type {ActionChain} from "components/action-schedule";
 
-declare function getServerId(): number;
 declare var localTime: string;
 declare var timezone: string;
 declare var userPrefPageSize: string;

--- a/web/html/src/manager/systems/subscribe-channels/subscribe-channels.js
+++ b/web/html/src/manager/systems/subscribe-channels/subscribe-channels.js
@@ -18,7 +18,6 @@ const ChannelUtils = require("core/channels/utils/channels-dependencies.utils");
 import type JsonResult from "utils/network";
 import type {ActionChain} from "components/action-schedule";
 
-declare function getServerId(): number;
 declare var localTime: string;
 declare var timezone: string;
 declare var actionChains: Array<ActionChain>;

--- a/web/html/src/manager/systems/subscribe-channels/subscribe-channels.renderer.js
+++ b/web/html/src/manager/systems/subscribe-channels/subscribe-channels.renderer.js
@@ -1,11 +1,8 @@
-/* global getServerId */
 const React = require('react');
 const { SubscribeChannels } = require('./subscribe-channels');
 const SpaRenderer  = require("core/spa/spa-renderer").default;
 
-export const renderer = (id) => SpaRenderer.renderNavigationReact(
-  <SubscribeChannels
-    serverId={getServerId()}
-  />,
+export const renderer = (id, {systemId}) => SpaRenderer.renderNavigationReact(
+  <SubscribeChannels serverId={systemId} />,
   document.getElementById(id),
 );

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fix loading proper activation key details on SPA enabled (bsc#1157141)
 - Add self monitoring to Admin Monitoring UI (bsc#1143638)
 - Fix create VM dialog when there is no virtual storage pool or network
 - show channels and filters in CLM history


### PR DESCRIPTION
On SPA enabled the window.pageRenderers.customValues are not reloaded,
so we need to re-read the value from the one provided by the server.

## What does this PR change?

On SPA enabled the window.pageRenderers.customValues are not reloaded,
so we need to re-read the value from the one provided by the server.

@mateiw - hint for the review: same pattern used [here](https://github.com/uyuni-project/uyuni/blob/master/java/code/webapp/WEB-INF/pages/systems/sdc/channels.jsp#L21)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
- No tests: bugfix

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/10095
Tracks https://github.com/SUSE/spacewalk/pull/10133

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"  
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
