### PR TITLE
Added sanity checks

### DIFF
--- a/testsuite/features/core/allcli_sanity.feature
+++ b/testsuite/features/core/allcli_sanity.feature
@@ -1,0 +1,54 @@
+# Copyright (c) 2019 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: Sanity checks
+  In order to use the product
+  I want to be sure to use a sane environment
+
+  Scenario: The server is healthy
+    Then "server" should have a FQDN
+
+  Scenario: The traditional client is healthy
+    Then "sle-client" should have a FQDN
+    And "sle-client" should communicate with the server
+
+  Scenario: The minion is healthy
+    Then "sle-minion" should have a FQDN
+    And "sle-minion" should communicate with the server
+
+@ssh_minion
+  Scenario: The SSH minion is healthy
+    Then "ssh-minion" should have a FQDN
+    And "ssh-minion" should communicate with the server
+
+@proxy
+  Scenario: The proxy is healthy
+    Then "proxy" should have a FQDN
+    And "proxy" should communicate with the server
+
+@centos_minion
+  Scenario: The Centos minion is healthy
+    Then "ceos-minion" should have a FQDN
+    And "ceos-minion" should communicate with the server
+
+@ubuntu_minion
+  Scenario: The Ubuntu minion is healthy
+    Then "ubuntu-minion" should have a FQDN
+    And "ubuntu-minion" should communicate with the server
+
+@virthost_kvm
+  Scenario: The KVM host is healthy
+    Then "kvm-server" should have a FQDN
+    And "kvm-server" should communicate with the server
+
+@virthost_xen
+  Scenario: The Xen host is healthy
+    Then "xen-server" should have a FQDN
+    And "xen-server" should communicate with the server
+
+  Scenario: The external resources can be reached
+    Then it should be possible to download the file "http://download.suse.de/ibs/SUSE/Products/SLE-SERVER/12-SP4/x86_64/product/media.1/products.key"
+    And it should be possible to download the file "https://gitlab.suse.de/galaxy/suse-manager-containers/blob/master/test-profile/Dockerfile"
+    And it should be possible to download the file "https://github.com/uyuni-project/uyuni/blob/master/README.md"
+    And it should be possible to reach the portus registry
+    And it should be possible to reach the other registry

--- a/testsuite/features/step_definitions/docker_steps.rb
+++ b/testsuite/features/step_definitions/docker_steps.rb
@@ -121,7 +121,7 @@ end
 When(/^I create and delete an image store via XML-RPC$/) do
   # create and delete a store, even with invalid URI
   cont_op.login('admin', 'admin')
-  cont_op.create_store('fake_store', 'https://github.com/SUSE/spacewalk-testsuite-base', 'registry')
+  cont_op.create_store('fake_store', 'https://github.com/uyuni-project/uyuni', 'registry')
   cont_op.delete_store('fake_store')
 end
 
@@ -141,7 +141,7 @@ When(/^I set and get details of image store via XML-RPC$/) do
   cont_op.login('admin', 'admin')
   # test setDetails call
   # delete if test fail in the middle. delete image doesn't raise an error if image doesn't exists
-  cont_op.create_store('Norimberga', 'https://github.com/SUSE/spacewalk-testsuite-base', 'registry')
+  cont_op.create_store('Norimberga', 'https://github.com/uyuni-project/uyuni', 'registry')
   details_store = {}
   details_store['uri'] = 'Germania'
   details_store['username'] = ''

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -46,7 +46,7 @@ nodes.each do |node|
   raise 'No fully qualified domain name for node' if code.nonzero? || fqdn.empty?
   node.init_full_hostname(fqdn)
 
-  puts "Determined hostname #{hostname.strip} and fqdn #{fqdn.strip}"
+  puts "Determined hostname #{hostname.strip} and FQDN #{fqdn.strip}"
 end
 
 # Initialize IP address or domain name

--- a/testsuite/run_sets/core.yml
+++ b/testsuite/run_sets/core.yml
@@ -8,6 +8,7 @@
 
 # IMMUTABLE ORDER
 
+- features/core/allcli_sanity.feature
 - features/core/first_settings.feature
 
 # initialize SUSE Manager server

--- a/testsuite/run_sets/refhost.yml
+++ b/testsuite/run_sets/refhost.yml
@@ -8,6 +8,7 @@
 
 # IMMUTABLE ORDER
 
+- features/core/allcli_sanity.feature
 - features/core/first_settings.feature
 # initialize SUSE Manager server
 - features/core/srv_channels_add.feature

--- a/testsuite/run_sets/testsuite.yml
+++ b/testsuite/run_sets/testsuite.yml
@@ -8,6 +8,7 @@
 
 # IMMUTABLE ORDER
 
+- features/core/allcli_sanity.feature
 - features/core/first_settings.feature
 # initialize SUSE Manager server
 - features/core/srv_channels_add.feature

--- a/testsuite/run_sets/uyuni.yml
+++ b/testsuite/run_sets/uyuni.yml
@@ -8,6 +8,7 @@
 
 # IMMUTABLE ORDER
 
+- features/core/allcli_sanity.feature
 - features/core/first_settings.feature
 # initialize SUSE Manager server
 - features/core/srv_channels_add.feature

--- a/testsuite/run_sets/virtualization.yml
+++ b/testsuite/run_sets/virtualization.yml
@@ -8,6 +8,7 @@
 
 # IMMUTABLE ORDER
 
+- features/core/allcli_sanity.feature
 - features/core/first_settings.feature
 # initialize SUSE Manager server
 - features/core/srv_channels_add.feature


### PR DESCRIPTION
## What does this PR change?

This PR adds sanity checks at the beginning of test suite.


** DISCLAIMERS **

This is very likely to not catch most of our infra issues, because they are very imaginative in their way of failing, and we simply cannot cover all weird cases. For example, it would not catch our latest DNS issues in provo, where there was a chance out of 3 for resolution to fail, only reverse, and only for a few domains.

Also, this will not catch any infra issue that happens after the start of the test suite. To do that, we would need to check at the beginning of every feature, but Cucumber does not provide hooks at feature level. We could work around this by adding a sanity scenario to each and every feature, and doing some ugly hacks at scenario levels. It would also slow down the test suite significantly.

The real way to watch our infra is to use monitoring.


## Links

Ports:
3.2:
4.0:

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
