### PR TITLE
Instead of cleanup, adjust permissions when running docker tests

### DIFF
--- a/susemanager-utils/testing/automation/backend-unittest-oracle.sh
+++ b/susemanager-utils/testing/automation/backend-unittest-oracle.sh
@@ -14,10 +14,10 @@ EXIT=0
 
 INITIAL_CMD="/manager/susemanager-utils/testing/automation/initial-objects.sh"
 CMD="/manager/backend/test/docker-backend-oracle-tests.sh"
-CLEAN_CMD="/manager/susemanager-utils/testing/automation/clean-objects.sh"
+CHOWN_CMD="/manager/susemanager-utils/testing/automation/chown-objects.sh $(id -u) $(id -g)""
 
 docker pull $REGISTRY/$ORACLE_CONTAINER
-docker run --privileged --rm=true -e $DOCKER_RUN_EXPORT -v "$GITROOT:/manager" $REGISTRY/$ORACLE_CONTAINER /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CLEAN_CMD} && exit \${RET}"
+docker run --privileged --rm=true -e $DOCKER_RUN_EXPORT -v "$GITROOT:/manager" $REGISTRY/$ORACLE_CONTAINER /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CHOWN_CMD} && exit \${RET}"
 if [ $? -ne 0 ]; then
     EXIT=3
 fi

--- a/susemanager-utils/testing/automation/backend-unittest-pgsql.sh
+++ b/susemanager-utils/testing/automation/backend-unittest-pgsql.sh
@@ -13,21 +13,21 @@ DOCKER_RUN_EXPORT="PYTHONPATH=/manager/client/rhel/rhnlib/:/manager/client/rhel/
 EXIT=0
 
 INITIAL_CMD="/manager/susemanager-utils/testing/automation/initial-objects.sh"
-CLEAN_CMD="/manager/susemanager-utils/testing/automation/clean-objects.sh"
+CHOWN_CMD="/manager/susemanager-utils/testing/automation/chown-objects.sh $(id -u) $(id -g)""
 
 docker pull $REGISTRY/$PGSQL_CONTAINER
 CMD="/manager/backend/test/docker-backend-common-tests.sh"
-docker run --rm=true -e $DOCKER_RUN_EXPORT -v "$GITROOT:/manager" $REGISTRY/$PGSQL_CONTAINER /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CLEAN_CMD} && exit \${RET}"
+docker run --rm=true -e $DOCKER_RUN_EXPORT -v "$GITROOT:/manager" $REGISTRY/$PGSQL_CONTAINER /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CHOWN_CMD} && exit \${RET}"
 if [ $? -ne 0 ]; then
     EXIT=1
 fi
 CMD="/manager/backend/test/docker-backend-tools-tests.sh"
-docker run --rm=true -e $DOCKER_RUN_EXPORT -v "$GITROOT:/manager" $REGISTRY/$PGSQL_CONTAINER /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CLEAN_CMD} && exit \${RET}"
+docker run --rm=true -e $DOCKER_RUN_EXPORT -v "$GITROOT:/manager" $REGISTRY/$PGSQL_CONTAINER /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CHOWN_CMD} && exit \${RET}"
 if [ $? -ne 0 ]; then
     EXIT=2
 fi
 CMD="/manager/backend/test/docker-backend-pgsql-tests.sh"
-docker run --privileged --rm=true -e $DOCKER_RUN_EXPORT -v "$GITROOT:/manager" $REGISTRY/$PGSQL_CONTAINER /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CLEAN_CMD} && exit \${RET}"
+docker run --privileged --rm=true -e $DOCKER_RUN_EXPORT -v "$GITROOT:/manager" $REGISTRY/$PGSQL_CONTAINER /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CHOWN_CMD} && exit \${RET}"
 if [ $? -ne 0 ]; then
     EXIT=3
 fi

--- a/susemanager-utils/testing/automation/chown-objects.sh
+++ b/susemanager-utils/testing/automation/chown-objects.sh
@@ -1,5 +1,11 @@
 #/bin/bash -e
-echo "*************** CLEANING OBJECTS GENERATED INSIDE THE CONTAINER  ***************"
+if [ -z ${1} -o -z ${2} ]; then
+  echo "This scripts needs two parameters: the first one for the UID, the second one for the GID"
+  exit 1
+fi
+NEWUID=${1}
+NEWGID=${2}
+echo "*********** ADJUSTING PERMISSIONS FOR OBJECTS GENERATED INSIDE THE CONTAINER TO ${NEWUID}:${NEWGID} ***********"
 # Exit if the file does not exist or if it is empty
 if [ ! -f /tmp/objects-init.txt -o ! -s /tmp/objects-init.txt ]; then
   echo "No file with the initial list of objects"
@@ -7,9 +13,5 @@ if [ ! -f /tmp/objects-init.txt -o ! -s /tmp/objects-init.txt ]; then
 fi
 find /manager | sort > /tmp/objects-end.txt
 for LINE in $(diff /tmp/objects-init.txt /tmp/objects-end.txt|grep '^> .*$'|sed -e 's/^> //'); do
-  if [ -d ${LINE} ]; then
-    rm -rf ${LINE}
-  else
-    rm -f ${LINE}
-  fi
+  chown ${NEWUID}:${NEWGID} ${LINE}
 done

--- a/susemanager-utils/testing/automation/java-checkstyle.sh
+++ b/susemanager-utils/testing/automation/java-checkstyle.sh
@@ -42,10 +42,10 @@ fi
 
 INITIAL_CMD="/manager/susemanager-utils/testing/automation/initial-objects.sh"
 CMD="/manager/java/scripts/docker-checkstyle.sh"
-CLEAN_CMD="/manager/susemanager-utils/testing/automation/clean-objects.sh"
+CHOWN_CMD="/manager/susemanager-utils/testing/automation/chown-objects.sh $(id -u) $(id -g)""
 
 docker pull $REGISTRY/$PGSQL_CONTAINER
 docker run --privileged --rm=true -v "$GITROOT:/manager" \
     --mount type=bind,source=${CREDENTIALS},target=/root/.oscrc \
     $REGISTRY/$PGSQL_CONTAINER \
-    /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CLEAN_CMD} && exit \${RET}"
+    /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CHOWN_CMD} && exit \${RET}"

--- a/susemanager-utils/testing/automation/java-unittests-oracle.sh
+++ b/susemanager-utils/testing/automation/java-unittests-oracle.sh
@@ -11,7 +11,7 @@ GITROOT=`readlink -f $HERE/../../../`
 
 INITIAL_CMD="/manager/susemanager-utils/testing/automation/initial-objects.sh"
 CMD="/manager/java/scripts/docker-testing-oracle.sh $TARGET"
-CLEAN_CMD="/manager/susemanager-utils/testing/automation/clean-objects.sh"
+CHOWN_CMD="/manager/susemanager-utils/testing/automation/chown-objects.sh $(id -u) $(id -g)""
 
 docker pull $REGISTRY/$ORACLE_CONTAINER
-docker run --privileged --rm=true -v "$GITROOT:/manager" $REGISTRY/$ORACLE_CONTAINER /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CLEAN_CMD} && exit \${RET}"
+docker run --privileged --rm=true -v "$GITROOT:/manager" $REGISTRY/$ORACLE_CONTAINER /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CHOWN_CMD} && exit \${RET}"

--- a/susemanager-utils/testing/automation/java-unittests-pgsql.sh
+++ b/susemanager-utils/testing/automation/java-unittests-pgsql.sh
@@ -46,10 +46,10 @@ fi
 
 INITIAL_CMD="/manager/susemanager-utils/testing/automation/initial-objects.sh"
 CMD="/manager/java/scripts/docker-testing-pgsql.sh ${TARGET}"
-CLEAN_CMD="/manager/susemanager-utils/testing/automation/clean-objects.sh"
+CHOWN_CMD="/manager/susemanager-utils/testing/automation/chown-objects.sh $(id -u) $(id -g)"
 
 docker pull $REGISTRY/$PGSQL_CONTAINER
 docker run --privileged --rm=true -v "$GITROOT:/manager" \
     --mount type=bind,source=${CREDENTIALS},target=/root/.oscrc \
     $REGISTRY/$PGSQL_CONTAINER \
-    /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CLEAN_CMD} && exit \${RET}"
+    /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CHOWN_CMD} && exit \${RET}"

--- a/susemanager-utils/testing/automation/javascript-lint.sh
+++ b/susemanager-utils/testing/automation/javascript-lint.sh
@@ -8,7 +8,7 @@ echo $GITROOT
 
 INITIAL_CMD="/manager/susemanager-utils/testing/automation/initial-objects.sh"
 CMD="/manager/web/html/src/scripts/docker-javascript-lint.sh"
-CLEAN_CMD="/manager/susemanager-utils/testing/automation/clean-objects.sh"
+CHOWN_CMD="/manager/susemanager-utils/testing/automation/chown-objects.sh $(id -u) $(id -g)""
 
 docker pull $REGISTRY/$NODEJS_CONTAINER
-docker run --privileged --rm=true -v "$GITROOT:/manager" $REGISTRY/$NODEJS_CONTAINER /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CLEAN_CMD} && exit \${RET}"
+docker run --privileged --rm=true -v "$GITROOT:/manager" $REGISTRY/$NODEJS_CONTAINER /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CHOWN_CMD} && exit \${RET}"

--- a/susemanager-utils/testing/automation/push-to-obs.sh
+++ b/susemanager-utils/testing/automation/push-to-obs.sh
@@ -52,7 +52,7 @@ fi
 
 INITIAL_CMD="/manager/susemanager-utils/testing/automation/initial-objects.sh"
 CMD="/manager/susemanager-utils/testing/docker/scripts/push-to-obs.sh -d '${DESTINATIONS}' -c /tmp/.oscrc ${VERBOSE} ${TEST}"
-CLEAN_CMD="/manager/susemanager-utils/testing/automation/clean-objects.sh"
+CHOWN_CMD="/manager/susemanager-utils/testing/automation/chown-objects.sh $(id -u) $(id -g)""
 
 docker pull $REGISTRY/$PUSH2OBS_CONTAINER
-docker run --rm=true -v "$GITROOT:/manager" -v "/srv/mirror:/srv/mirror" --mount type=bind,source=${CREDENTIALS},target=/tmp/.oscrc $REGISTRY/$PUSH2OBS_CONTAINER /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CLEAN_CMD} && exit \${RET}"
+docker run --rm=true -v "$GITROOT:/manager" -v "/srv/mirror:/srv/mirror" --mount type=bind,source=${CREDENTIALS},target=/tmp/.oscrc $REGISTRY/$PUSH2OBS_CONTAINER /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CHOWN_CMD} && exit \${RET}"

--- a/susemanager-utils/testing/automation/schema-migration-test-oracle.sh
+++ b/susemanager-utils/testing/automation/schema-migration-test-oracle.sh
@@ -6,7 +6,7 @@ GITROOT=`readlink -f $HERE/../../../`
 
 INITIAL_CMD="/manager/susemanager-utils/testing/automation/initial-objects.sh"
 CMD="/manager/susemanager-utils/testing/docker/scripts/schema_migration_test_oracle-31to41.sh"
-CLEAN_CMD="/manager/susemanager-utils/testing/automation/clean-objects.sh"
+CHOWN_CMD="/manager/susemanager-utils/testing/automation/chown-objects.sh $(id -u) $(id -g)""
 
 docker pull $REGISTRY/$ORACLE_CONTAINER
-docker run --privileged --rm=true -v "$GITROOT:/manager" $REGISTRY/$ORACLE_CONTAINER /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CLEAN_CMD} && exit \${RET}"
+docker run --privileged --rm=true -v "$GITROOT:/manager" $REGISTRY/$ORACLE_CONTAINER /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CHOWN_CMD} && exit \${RET}"

--- a/susemanager-utils/testing/automation/schema-migration-test-pgsql.sh
+++ b/susemanager-utils/testing/automation/schema-migration-test-pgsql.sh
@@ -26,6 +26,6 @@ fi
 INITIAL_CMD="/manager/susemanager-utils/testing/automation/initial-objects.sh"
 MIGRATION_TEST='/manager/susemanager-utils/testing/docker/scripts/schema_migration_test_pgsql-31to41.sh'
 IDEMPOTENCY_TEST="/manager/susemanager-utils/testing/docker/scripts/schema_idempotency_test_pgsql.py ${IDEMPOTENCY_PARAMS}"
-CLEAN_CMD="/manager/susemanager-utils/testing/automation/clean-objects.sh"
+CHOWN_CMD="/manager/susemanager-utils/testing/automation/chown-objects.sh $(id -u) $(id -g)""
 
-docker run --privileged --rm=true -v "$GITROOT:/manager" $REGISTRY/$PGSQL_CONTAINER /bin/bash -c "${INITIAL_CMD}; ${MIGRATION_TEST} && ${IDEMPOTENCY_TEST}; RET=\${?}; ${CLEAN_CMD} && exit \${RET}"
+docker run --privileged --rm=true -v "$GITROOT:/manager" $REGISTRY/$PGSQL_CONTAINER /bin/bash -c "${INITIAL_CMD}; ${MIGRATION_TEST} && ${IDEMPOTENCY_TEST}; RET=\${?}; ${CHOWN_CMD} && exit \${RET}"

--- a/susemanager-utils/testing/automation/spacewalk-pylint.sh
+++ b/susemanager-utils/testing/automation/spacewalk-pylint.sh
@@ -156,10 +156,10 @@ susemanager-utils/susemanager-sls/src/
 
 INITIAL_CMD="/manager/susemanager-utils/testing/automation/initial-objects.sh"
 PYLINT_CMD="mkdir -p /manager/reports; cd /manager/; pylint --disable=E0203,E0611,E1101,E1102,C0111,I0011,R0801 --ignore=test --output-format=parseable --rcfile /manager/spacewalk/pylint/spacewalk-pylint.rc --reports=y --msg-template=\"{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}\""
-CLEAN_CMD="/manager/susemanager-utils/testing/automation/clean-objects.sh"
+CHOWN_CMD="/manager/susemanager-utils/testing/automation/chown-objects.sh $(id -u) $(id -g)""
 
 docker pull $REGISTRY/$PYLINT_CONTAINER
-docker run --rm=true -e $DOCKER_RUN_EXPORT -v "$GITROOT:/manager" $REGISTRY/$PGSQL_CONTAINER /bin/sh -c "${INITIAL_CMD}; $PYLINT_CMD `echo $SPACEWALK_FILES` > reports/pylint.log || :; RET=\${?}; ${CLEAN_CMD} && exit \${RET}"
+docker run --rm=true -e $DOCKER_RUN_EXPORT -v "$GITROOT:/manager" $REGISTRY/$PGSQL_CONTAINER /bin/sh -c "${INITIAL_CMD}; $PYLINT_CMD `echo $SPACEWALK_FILES` > reports/pylint.log || :; RET=\${?}; ${CHOWN_CMD} && exit \${RET}"
 
 if [ $? -ne 0 ]; then
    EXIT=1

--- a/susemanager-utils/testing/automation/susemanager-unittest.sh
+++ b/susemanager-utils/testing/automation/susemanager-unittest.sh
@@ -13,10 +13,10 @@ DOCKER_RUN_EXPORT="PYTHONPATH=/manager/client/rhel/rhnlib/:/manager/client/rhel/
 
 INITIAL_CMD="/manager/susemanager-utils/testing/automation/initial-objects.sh"
 CMD="cd /manager/susemanager; make -f Makefile.susemanager unittest_inside_docker pylint_inside_docker"
-CLEAN_CMD="/manager/susemanager-utils/testing/automation/clean-objects.sh"
+CHOWN_CMD="/manager/susemanager-utils/testing/automation/chown-objects.sh $(id -u) $(id -g)""
 
 docker pull $REGISTRY/$PGSQL_CONTAINER
-docker run --rm=true -e $DOCKER_RUN_EXPORT -v "$GITROOT:/manager" $REGISTRY/$PGSQL_CONTAINER /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CLEAN_CMD} && exit \${RET}"
+docker run --rm=true -e $DOCKER_RUN_EXPORT -v "$GITROOT:/manager" $REGISTRY/$PGSQL_CONTAINER /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CHOWN_CMD} && exit \${RET}"
 if [ $? -ne 0 ]; then
    EXIT=1
 fi


### PR DESCRIPTION
## What does this PR change?

The cleanup worked fine, but there's a small problem: we use reports generated inside the container.

Long term we should think about rewriting the CI to use less hacks:
- We should start the container with `docker run`, run whatever we have in one or several `docker exec` calls, then copy whatever we want with `docker copy` and finally kill the container with `docker rm`. 
- If we really want to use bind mounting, we should NOT create stuff inside the directory that we mounted, but outside (otherwise any unexpected crash will leave stuff that can't be removed by the Jenkins user)
-And we should consider a common library for stuff, to clean up the scripts.

But for now, this new hack will do it. As far as I know we always run things inside the container as root.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: CI fix.

- [x] **DONE**

## Test coverage
- No tests: CI fix

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

Tested with `java-unittests-pgsql.sh`

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
