### PR TITLE
Enhance mgr-sync

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,6 @@
+- disable globbing for api subcommand to allow wildcards in filter
+  settings
+
 -------------------------------------------------------------------
 Thu Jan 30 14:47:39 CET 2020 - jgonzalez@suse.com
 

--- a/spacecmd/src/spacecmd/api.py
+++ b/spacecmd/src/spacecmd/api.py
@@ -58,7 +58,8 @@ def do_api(self, args):
     arg_parser.add_argument('-F', '--format', default='')
     arg_parser.add_argument('-o', '--output', default='')
 
-    (args, options) = parse_command_arguments(args, arg_parser)
+    # set glob = False otherwise repo filters cannot set wildcard characters
+    args, options = parse_command_arguments(args, arg_parser, glob=False)
 
     if not args:
         self.help_api()

--- a/susemanager/src/mgr_sync/cli.py
+++ b/susemanager/src/mgr_sync/cli.py
@@ -52,8 +52,26 @@ def _create_parser():
     _create_add_subparser(subparsers)
     _create_refresh_subparser(subparsers)
     _create_delete_subparser(subparsers)
+    _create_sync_subparser(subparsers)
 
     return parser
+
+
+def _create_sync_subparser(subparsers):
+    """ Create the parser for the "sync" command. """
+
+    sync_parser = subparsers.add_parser('sync',
+                                       help='sync channels')
+    sync_parser.add_argument(
+        'sync_target',
+        choices=['channel', 'channels'])
+    sync_parser.add_argument(
+        'target',
+        nargs='*',
+        help='element to sync')
+    sync_parser.add_argument(
+        '--with-children', action='store_true', dest='with_children',
+        help='Sync all child channels as well')
 
 
 def _create_add_subparser(subparsers):

--- a/susemanager/src/mgr_sync/cli.py
+++ b/susemanager/src/mgr_sync/cli.py
@@ -88,6 +88,13 @@ def _create_add_subparser(subparsers):
         dest='no_recommends',
         default=False,
         help='do not enable recommended products automatically')
+    add_parser.add_argument(
+        '--no-sync',
+        action='store_true',
+        dest='no_sync',
+        default=False,
+        help='do not syncronize product channels automatically after adding')
+
 
 
 def _create_list_subparser(subparsers):

--- a/susemanager/src/mgr_sync/mgr_sync.py
+++ b/susemanager/src/mgr_sync/mgr_sync.py
@@ -138,11 +138,13 @@ class MgrSync(object):  # pylint: disable=too-few-public-methods
             if 'channel' in options.add_target:
                 self._add_channels(channels=options.target,
                                    mirror=options.mirror,
-                                   no_optionals=options.no_optionals)
+                                   no_optionals=options.no_optionals,
+                                   no_sync=options.no_sync)
             elif 'credentials' in options.add_target:
                 self._add_credentials(options.primary, options.target)
             elif 'product' in options.add_target:
-                self._add_products(mirror="", no_recommends=options.no_recommends)
+                self._add_products(mirror="", no_recommends=options.no_recommends,
+                                   no_sync=options.no_sync)
         elif 'refresh' in vars(options):
             self.exit_with_error = not self._refresh(
                 enable_reposync=options.refresh_channels,
@@ -236,7 +238,7 @@ class MgrSync(object):  # pylint: disable=too-few-public-methods
             self._execute_xmlrpc_method(self.conn.sync.content,
                                         "listChannels", self.auth.token()), self.log)
 
-    def _add_channels(self, channels, mirror="", no_optionals=False):
+    def _add_channels(self, channels, mirror="", no_optionals=False, no_sync=False):
         """ Add a list of channels.
 
         If the channel list is empty the interactive mode is started.
@@ -318,7 +320,8 @@ class MgrSync(object):  # pylint: disable=too-few-public-methods
             if channel not in channels_to_sync:
                 channels_to_sync.append(channel)
 
-        self._schedule_channel_reposync(channels_to_sync)
+        if not no_sync:
+            self._schedule_channel_reposync(channels_to_sync)
 
     def _schedule_channel_reposync(self, channels):
         """ Schedules a reposync for a set of channels.
@@ -410,7 +413,7 @@ class MgrSync(object):  # pylint: disable=too-few-public-methods
 
         return interactive_data
 
-    def _add_products(self, mirror="", no_recommends=False):
+    def _add_products(self, mirror="", no_recommends=False, no_sync=False):
         """ Add a list of products.
 
         If the products list is empty the interactive mode is started.
@@ -433,7 +436,7 @@ class MgrSync(object):  # pylint: disable=too-few-public-methods
             product.friendly_name))
         print("Adding channels required by '{0}' product".format(
             product.friendly_name))
-        self._add_channels(channels=mandatory_channels, mirror=mirror)
+        self._add_channels(channels=mandatory_channels, mirror=mirror, no_sync=no_sync)
         self.log.info("Product successfully added")
         print("Product successfully added")
 

--- a/susemanager/src/test/test_mgr_sync/test_channel_operations.py
+++ b/susemanager/src/test/test_mgr_sync/test_channel_operations.py
@@ -266,6 +266,42 @@ Status:
         self.assertEqual(['rhel-i386-as-4', 'rhel-x86_64-as-4', 'sle10-sdk-sp4-pool-x86_64'],
                          available_channels)
 
+    def test_list_installed_only_channels_interactive(self):
+        """ Test listing channels when interactive more is set """
+        stubbed_xmlrpm_call = MagicMock(
+            return_value=read_data_from_fixture(
+                'list_channels_simplified.data'))
+        self.mgr_sync._execute_xmlrpc_method = stubbed_xmlrpm_call
+        available_channels = []
+        with ConsoleRecorder() as recorder:
+            available_channels = self.mgr_sync._list_channels(
+                expand=False,
+                filter=None,
+                no_optionals=True,
+                show_interactive_numbers=True,
+                only_installed=True)
+        expected_output = """Available Channels:
+
+
+Status:
+  - [I] - channel is installed
+  - [ ] - channel is not installed, but is available
+  - [U] - channel is unavailable
+
+  1) [I] SLES10-SP4-Pool for x86_64 SUSE Linux Enterprise Server 10 SP4 x86_64 [sles10-sp4-pool-x86_64]
+      2) [I] SLE10-SDK-SP4-Updates for x86_64 SUSE Linux Enterprise Software Development Kit 10 SP4 Software Development Kit [sle10-sdk-sp4-updates-x86_64]"""
+
+        self.assertEqual(expected_output.split("\n"), recorder.stdout)
+
+        stubbed_xmlrpm_call.assert_called_once_with(
+            self.mgr_sync.conn.sync.content,
+            "listChannels",
+            self.fake_auth_token)
+
+        self.assertEqual(['sles10-sp4-pool-x86_64', 'sle10-sdk-sp4-updates-x86_64'],
+                         available_channels)
+
+
     def test_add_available_base_channel_with_mirror(self):
         """ Test adding an available base channel"""
         mirror_url = "http://smt.suse.de"

--- a/susemanager/src/test/test_mgr_sync/test_channel_operations.py
+++ b/susemanager/src/test/test_mgr_sync/test_channel_operations.py
@@ -240,7 +240,8 @@ Status:
                 expand=False,
                 filter=None,
                 no_optionals=True,
-                show_interactive_numbers=True)
+                show_interactive_numbers=True,
+                only_installed=False)
         expected_output = """Available Channels:
 
 
@@ -249,11 +250,11 @@ Status:
   - [ ] - channel is not installed, but is available
   - [U] - channel is unavailable
 
-01) [ ] RHEL i386 AS 4 RES 4 [rhel-i386-as-4]
-02) [ ] RHEL x86_64 AS 4 RES 4 [rhel-x86_64-as-4]
-    [I] SLES10-SP4-Pool for x86_64 SUSE Linux Enterprise Server 10 SP4 x86_64 [sles10-sp4-pool-x86_64]
-    03) [ ] SLE10-SDK-SP4-Pool for x86_64 SUSE Linux Enterprise Software Development Kit 10 SP4 Software Development Kit [sle10-sdk-sp4-pool-x86_64]
-        [I] SLE10-SDK-SP4-Updates for x86_64 SUSE Linux Enterprise Software Development Kit 10 SP4 Software Development Kit [sle10-sdk-sp4-updates-x86_64]"""
+  1) [ ] RHEL i386 AS 4 RES 4 [rhel-i386-as-4]
+  2) [ ] RHEL x86_64 AS 4 RES 4 [rhel-x86_64-as-4]
+     [I] SLES10-SP4-Pool for x86_64 SUSE Linux Enterprise Server 10 SP4 x86_64 [sles10-sp4-pool-x86_64]
+      3) [ ] SLE10-SDK-SP4-Pool for x86_64 SUSE Linux Enterprise Software Development Kit 10 SP4 Software Development Kit [sle10-sdk-sp4-pool-x86_64]
+         [I] SLE10-SDK-SP4-Updates for x86_64 SUSE Linux Enterprise Software Development Kit 10 SP4 Software Development Kit [sle10-sdk-sp4-updates-x86_64]"""
 
         self.assertEqual(expected_output.split("\n"), recorder.stdout)
 
@@ -515,7 +516,8 @@ Scheduling reposync for following channels:
 
             self.mgr_sync._list_channels.assert_called_once_with(
                 expand=False, filter=None, no_optionals=False,
-                show_interactive_numbers=True, compact=False)
+                show_interactive_numbers=True, compact=False,
+                only_installed=False)
 
             expected_xmlrpc_calls = [
                 call._execute_xmlrpc_method(self.mgr_sync.conn.sync.content,
@@ -556,7 +558,8 @@ Scheduling reposync for following channels:
 
             self.mgr_sync._list_channels.assert_called_once_with(
                 expand=False, filter=None, no_optionals=True,
-                show_interactive_numbers=True, compact=False)
+                show_interactive_numbers=True, compact=False,
+                only_installed=False)
 
             expected_xmlrpc_calls = [
                 call._execute_xmlrpc_method(self.mgr_sync.conn.sync.content,

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- mgr-sync: add option '--no-sync' to add commands and implement new
+  'sync' sub command
 - remove support for SuSEfirewall2
 - remove outdated yast2 firstboot file
 


### PR DESCRIPTION
## What does this PR change?

Adding the following features to mgr-sync:

- option --no-sync to `add` target. This allow to only add products and channels without starting the sync directly.
- add `sync` target for channels. This allow to trigger a channel sync at any time

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- https://github.com/SUSE/spacewalk/issues/10704

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
