### PR TITLE
Refactor Form component to use ReactJS Context

### DIFF
--- a/web/html/src/components/datetimepicker.js
+++ b/web/html/src/components/datetimepicker.js
@@ -1,7 +1,7 @@
 /* eslint-disable */
 'use strict';
 
-const React = require("react");
+import React from "react";
 
 $.fn.datepicker.dates['en_US'] = {
     days:      [ 'Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday',],
@@ -131,7 +131,7 @@ class TimePicker extends React.Component {
     }
 }
 
-class DateTimePicker extends React.Component {
+export class DateTimePicker extends React.Component {
 
     constructor(props) {
         super();
@@ -197,8 +197,4 @@ class DateTimePicker extends React.Component {
             </div>
         );
     }
-}
-
-module.exports = {
-    DateTimePicker : DateTimePicker
 }

--- a/web/html/src/components/input/Check.js
+++ b/web/html/src/components/input/Check.js
@@ -1,14 +1,14 @@
 // @flow
 
-const React = require('react');
-const { InputBase } = require('./InputBase');
-const { FormContext } = require('./Form');
+import React from 'react';
+import { InputBase } from './InputBase';
+import { FormContext } from './Form';
 
 type Props = {
   inputClass?: string,
 } & InputBase.Props;
 
-function Check(props: Props) {
+export function Check(props: Props) {
   const {
     label,
     inputClass,
@@ -52,7 +52,3 @@ function Check(props: Props) {
 Check.defaultProps = Object.assign({
   inputClass: undefined,
 }, InputBase.defaultProps);
-
-module.exports = {
-  Check,
-};

--- a/web/html/src/components/input/Check.js
+++ b/web/html/src/components/input/Check.js
@@ -2,6 +2,7 @@
 
 const React = require('react');
 const { InputBase } = require('./InputBase');
+const { FormContext } = require('./Form');
 
 type Props = {
   inputClass?: string,
@@ -13,6 +14,7 @@ function Check(props: Props) {
     inputClass,
     ...propsToPass
   } = props;
+  const formContext = React.useContext(FormContext);
   return (
     <InputBase {...propsToPass}>
       {
@@ -23,6 +25,7 @@ function Check(props: Props) {
           const setChecked = (event: Object) => {
             setValue(event.target.name, event.target.checked);
           };
+          const fieldValue = formContext.model[props.name] || props.defaultValue || '';
           return (
             <div className="checkbox">
               <label htmlFor={props.name}>
@@ -31,7 +34,7 @@ function Check(props: Props) {
                   className={inputClass}
                   name={props.name}
                   type="checkbox"
-                  checked={props.value}
+                  checked={fieldValue}
                   onChange={setChecked}
                   onBlur={onBlur}
                   disabled={props.disabled}

--- a/web/html/src/components/input/DateTime.js
+++ b/web/html/src/components/input/DateTime.js
@@ -3,6 +3,7 @@
 const React = require('react');
 const { DateTimePicker } = require('../datetimepicker');
 const { InputBase } = require('./InputBase');
+const { FormContext } = require('./Form');
 
 type Props = {
   timezone?: string,
@@ -13,6 +14,7 @@ function DateTime(props: Props) {
     timezone,
     ...propsToPass
   } = props;
+  const formContext = React.useContext(FormContext);
   return (
     <InputBase {...propsToPass}>
       {
@@ -22,11 +24,12 @@ function DateTime(props: Props) {
           const onChange = (value) => {
             setValue(props.name, value);
           };
-          if(props.value instanceof Date) {
+          const fieldValue = formContext.model[props.name] || props.defaultValue || '';
+          if(fieldValue instanceof Date) {
             return (
               <DateTimePicker
                 onChange={onChange}
-                value={props.value}
+                value={fieldValue}
                 timezone={timezone}
               />
             );

--- a/web/html/src/components/input/DateTime.js
+++ b/web/html/src/components/input/DateTime.js
@@ -1,15 +1,15 @@
 // @flow
 
-const React = require('react');
-const { DateTimePicker } = require('../datetimepicker');
-const { InputBase } = require('./InputBase');
-const { FormContext } = require('./Form');
+import React from 'react';
+import { DateTimePicker } from '../datetimepicker';
+import { InputBase } from './InputBase';
+import { FormContext } from './Form';
 
 type Props = {
   timezone?: string,
 } & InputBase.Props;
 
-function DateTime(props: Props) {
+export function DateTime(props: Props) {
   const {
     timezone,
     ...propsToPass
@@ -45,8 +45,3 @@ function DateTime(props: Props) {
 DateTime.defaultProps = Object.assign({
   timezone: undefined,
 }, InputBase.defaultProps);
-
-
-module.exports = {
-  DateTime,
-};

--- a/web/html/src/components/input/Form.js
+++ b/web/html/src/components/input/Form.js
@@ -1,6 +1,6 @@
 // @flow
 
-const React = require('react');
+import * as React from 'react';
 
 type Props = {
   model: Object,
@@ -27,9 +27,9 @@ type FormContextType = {
   unregisterInput: Function,
 };
 
-const FormContext = React.createContext<FormContextType>({});
+export const FormContext = React.createContext<FormContextType>({});
 
-class Form extends React.Component<Props, State> {
+export class Form extends React.Component<Props, State> {
   static defaultProps = {
     onSubmit: undefined,
     onSubmitInvalid: undefined,
@@ -144,8 +144,3 @@ class Form extends React.Component<Props, State> {
     );
   }
 }
-
-module.exports = {
-  Form,
-  FormContext,
-};

--- a/web/html/src/components/input/FormGroup.js
+++ b/web/html/src/components/input/FormGroup.js
@@ -1,20 +1,16 @@
 // @flow
 
-const React = require('react');
+import * as React from 'react';
 
 type Props = {
   isError: boolean,
   children: React.Node,
 };
 
-function FormGroup(props: Props) {
+export function FormGroup(props: Props) {
   return (
     <div className={`form-group${props.isError ? ' has-error' : ''}`}>
       {props.children}
     </div>
   );
 }
-
-module.exports = {
-  FormGroup,
-};

--- a/web/html/src/components/input/InputBase.js
+++ b/web/html/src/components/input/InputBase.js
@@ -2,6 +2,7 @@ const React = require('react');
 
 const { Label } = require('./Label');
 const { FormGroup } = require('./FormGroup');
+const { FormContext } = require('./Form');
 
 export type Props = {
   name: string,
@@ -20,10 +21,6 @@ export type Props = {
   disabled?: boolean,
   invalidHint?: string,
   onChange?: (name: string, value: string) => void,
-  onFormChange?: Function,
-  registerInput?: Function,
-  unregisterInput?: Function,
-  validate?: Function,
 };
 
 type State = {
@@ -42,10 +39,6 @@ class InputBase extends React.Component<Props, State> {
     disabled: false,
     invalidHint: undefined,
     onChange: undefined,
-    onFormChange: undefined,
-    registerInput: undefined,
-    unregisterInput: undefined,
-    validate: undefined,
   };
 
   constructor(props: Props) {
@@ -56,17 +49,27 @@ class InputBase extends React.Component<Props, State> {
     };
   }
 
-  // eslint-disable-next-line
-  UNSAFE_componentWillMount() {
-    if (this.props.registerInput) {
-      this.props.registerInput(this);
+  componentDidMount() {
+    if (this.props && this.props.name) {
+      this.context.registerInput(this);
+
+      const { model } = this.context;
+      const value = this.context.model[this.props.name] || this.props.defaultValue || '';
+      const valueChanged =
+        (value instanceof Date && model[this.props.name] instanceof Date
+          && value.getTime() !== model[this.props.name].getTime())
+        || value !== model[this.props.name];
+
+      if (valueChanged) {
+        model[this.props.name] = value;
+        this.context.setModelValue(this.props.name, value);
+      }
     }
   }
 
   componentWillUnmount() {
-    if (this.props.unregisterInput) {
-      this.props.unregisterInput(this);
-    }
+    this.context.unregisterInput(this);
+    this.context.setModelValue(this.props.name, undefined);
   }
 
   onBlur() {
@@ -75,20 +78,47 @@ class InputBase extends React.Component<Props, State> {
     });
   }
 
-  setValue(name: string, value: string) {
-    if (this.props.onFormChange) {
-      this.props.onFormChange({
-        name,
-        value,
-      });
+  validate(model: Object): boolean {
+    const { name } = this.props;
+    const results = [];
+    let isValid = true;
+
+    if (!this.props.disabled && (model[name] || this.props.required)) {
+      if (this.props.required && !model[name]) {
+        isValid = false;
+      } else if (this.props.validators) {
+        const validators = Array.isArray(this.props.validators) ? this.props.validators : [this.props.validators];
+        validators.forEach((v) => {
+          results.push(Promise.resolve(v(`${model[name] || ''}`)));
+        });
+      }
     }
+
+    Promise.all(results).then((result) => {
+      result.forEach((r) => {
+        isValid = isValid && r;
+      });
+      this.setState({isValid});
+      this.context.onFieldValidation(name, isValid);
+    });
+
+    this.setState({
+      isValid,
+    });
+    return isValid;
+  }
+
+  setValue(name: string, value: string) {
+    this.context.setModelValue(name, value);
 
     if (this.props.onChange) this.props.onChange(name, value);
   }
 
   render() {
     const isError = this.state.showErrors && !this.state.isValid;
-    const invalidHint = isError && this.props.invalidHint;
+    const invalidHint = isError && (
+      this.props.invalidHint || (this.props.required && (`${this.props.label} is required.`))
+    );
     const hint = [this.props.hint, (invalidHint && this.props.hint && <br />), invalidHint];
     return (
       <FormGroup isError={isError}>
@@ -121,6 +151,7 @@ class InputBase extends React.Component<Props, State> {
     );
   }
 }
+InputBase.contextType = FormContext;
 
 module.exports = {
   InputBase,

--- a/web/html/src/components/input/InputBase.js
+++ b/web/html/src/components/input/InputBase.js
@@ -63,21 +63,6 @@ class InputBase extends React.Component<Props, State> {
     }
   }
 
-  // eslint-disable-next-line
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    const valueNotChanged =
-      (nextProps.value instanceof Date && this.props.value instanceof Date
-        && nextProps.value.getTime() === this.props.value.getTime())
-      || nextProps.value === this.props.value;
-    if (!(valueNotChanged && nextProps.disabled === this.props.disabled
-              && nextProps.required === this.props.required)) {
-      if (this.props.validate) this.props.validate(this, nextProps);
-      this.setState({
-        showErrors: false,
-      });
-    }
-  }
-
   componentWillUnmount() {
     if (this.props.unregisterInput) {
       this.props.unregisterInput(this);

--- a/web/html/src/components/input/InputBase.js
+++ b/web/html/src/components/input/InputBase.js
@@ -1,8 +1,8 @@
-const React = require('react');
+import * as React from 'react';
 
-const { Label } = require('./Label');
-const { FormGroup } = require('./FormGroup');
-const { FormContext } = require('./Form');
+import { Label } from './Label';
+import { FormGroup } from './FormGroup';
+import { FormContext } from './Form';
 
 export type Props = {
   name: string,
@@ -28,7 +28,7 @@ type State = {
   showErrors: boolean,
 };
 
-class InputBase extends React.Component<Props, State> {
+export class InputBase extends React.Component<Props, State> {
   static defaultProps = {
     defaultValue: undefined,
     label: undefined,
@@ -152,7 +152,3 @@ class InputBase extends React.Component<Props, State> {
   }
 }
 InputBase.contextType = FormContext;
-
-module.exports = {
-  InputBase,
-};

--- a/web/html/src/components/input/Label.js
+++ b/web/html/src/components/input/Label.js
@@ -1,6 +1,6 @@
 // @flow
 
-const React = require('react');
+import React from 'react';
 
 type Props = {
   name: string,
@@ -9,7 +9,7 @@ type Props = {
   required?: boolean,
 };
 
-function Label(props: Props) {
+export function Label(props: Props) {
   return (
     <label
       className={`control-label${props.className ? ` ${props.className}` : ''}`}
@@ -25,8 +25,4 @@ function Label(props: Props) {
 Label.defaultProps = {
   className: undefined,
   required: false,
-};
-
-module.exports = {
-  Label,
 };

--- a/web/html/src/components/input/Password.js
+++ b/web/html/src/components/input/Password.js
@@ -1,15 +1,15 @@
 // @flow
 
-const React = require('react');
-const { Text } = require('./Text');
-const { InputBase } = require('./InputBase');
+import React from 'react';
+import { Text } from './Text';
+import { InputBase } from './InputBase';
 
 type Props = {
   placeholder?: string,
   inputClass?: string,
 } & InputBase.Props;
 
-function Password(props: Props) {
+export function Password(props: Props) {
   return (<Text type="password" {...props} />);
 }
 
@@ -17,7 +17,3 @@ Password.defaultProps = Object.assign({
   placeholder: undefined,
   inputClass: undefined,
 }, InputBase.defaultProps);
-
-module.exports = {
-  Password,
-};

--- a/web/html/src/components/input/Radio.js
+++ b/web/html/src/components/input/Radio.js
@@ -3,6 +3,7 @@
 const React = require('react');
 const { useState } = require('react');
 const { InputBase } = require('./InputBase');
+const { FormContext } = require('./Form');
 
 const styles = require('./Radio.css');
 
@@ -21,6 +22,7 @@ function Radio(props: Props) {
     inputClass,
     ...propsToPass
   } = props;
+  const formContext = React.useContext(FormContext);
   return (
     <InputBase {...propsToPass}>
       {
@@ -34,9 +36,10 @@ function Radio(props: Props) {
             setIsPristine(false);
           };
 
+          const fieldValue = formContext.model[props.name] || props.defaultValue || '';
           const isOpenOption = props.openOption
-            && !props.items.some(item => item.value === props.value)
-            && (props.value || !isPristine);
+            && !props.items.some(item => item.value === fieldValue)
+            && (fieldValue || !isPristine);
 
           const radioClass = props.inline ? "radio-inline" : "radio";
           return (
@@ -48,7 +51,7 @@ function Radio(props: Props) {
                       type="radio"
                       name={props.name}
                       value={value}
-                      checked={props.value === value}
+                      checked={fieldValue === value}
                       className={inputClass}
                       onBlur={onBlur}
                       onChange={event => onChange(event.target.name, event.target.value)} />
@@ -74,7 +77,7 @@ function Radio(props: Props) {
                     name={props.name}
                     type="text"
                     disabled={!isOpenOption}
-                    value={isOpenOption ? props.value : ''}
+                    value={isOpenOption ? fieldValue : ''}
                     onChange={event => onChange(event.target.name, event.target.value)}
                   />
                 </div>

--- a/web/html/src/components/input/Radio.js
+++ b/web/html/src/components/input/Radio.js
@@ -1,11 +1,11 @@
 // @flow
 
-const React = require('react');
-const { useState } = require('react');
-const { InputBase } = require('./InputBase');
-const { FormContext } = require('./Form');
+import React from 'react';
+import { useState } from 'react';
+import { InputBase } from './InputBase';
+import { FormContext } from './Form';
 
-const styles = require('./Radio.css');
+import styles from './Radio.css';
 
 type Props = {
   items: Array<{label: string, value: string}>,
@@ -14,7 +14,7 @@ type Props = {
   inputClass?: string,
 } & InputBase.Props;
 
-function Radio(props: Props) {
+export function Radio(props: Props) {
   const [isPristine, setIsPristine] = useState(true);
 
   const {
@@ -93,7 +93,3 @@ function Radio(props: Props) {
 Radio.defaultProps = Object.assign({
   inputClass: undefined,
 }, InputBase.defaultProps);
-
-module.exports = {
-  Radio,
-};

--- a/web/html/src/components/input/Select.js
+++ b/web/html/src/components/input/Select.js
@@ -2,6 +2,7 @@
 
 const React = require('react');
 const { InputBase } = require('./InputBase');
+const { FormContext } = require('./Form');
 
 type Props = {
   children: React.Node,
@@ -14,6 +15,7 @@ function Select(props: Props) {
     children,
     ...propsToPass
   } = props;
+  const formContext = React.useContext(FormContext);
   return (
     <InputBase {...propsToPass}>
       {
@@ -24,12 +26,13 @@ function Select(props: Props) {
           const onChange = (event: Object) => {
             setValue(event.target.name, event.target.value);
           };
+          const fieldValue = formContext.model[props.name] || props.defaultValue || '';
           return (
             <select
               className={`form-control${inputClass ? ` ${inputClass}` : ''}`}
               name={props.name}
               disabled={props.disabled}
-              value={props.value}
+              value={fieldValue}
               onBlur={onBlur}
               onChange={onChange}
             >

--- a/web/html/src/components/input/Select.js
+++ b/web/html/src/components/input/Select.js
@@ -1,15 +1,15 @@
 // @flow
 
-const React = require('react');
-const { InputBase } = require('./InputBase');
-const { FormContext } = require('./Form');
+import * as React from 'react';
+import { InputBase } from './InputBase';
+import { FormContext } from './Form';
 
 type Props = {
   children: React.Node,
   inputClass?: string,
 } & InputBase.Props;
 
-function Select(props: Props) {
+export function Select(props: Props) {
   const {
     inputClass,
     children,
@@ -48,7 +48,3 @@ function Select(props: Props) {
 Select.defaultProps = Object.assign({
   inputClass: undefined,
 }, InputBase.defaultProps);
-
-module.exports = {
-  Select,
-};

--- a/web/html/src/components/input/Text.js
+++ b/web/html/src/components/input/Text.js
@@ -1,7 +1,7 @@
 // @flow
-const React = require('react');
-const { InputBase } = require('./InputBase');
-const { FormContext } = require('./Form');
+import * as React from 'react';
+import { InputBase } from './InputBase';
+import { FormContext } from './Form';
 
 type Props = {
   type: string,
@@ -9,7 +9,7 @@ type Props = {
   inputClass?: string,
 } & InputBase.Props;
 
-const Text = (props: Props) => {
+export const Text = (props: Props) => {
   const {
     type,
     placeholder,
@@ -50,7 +50,3 @@ Text.defaultProps = Object.assign({
   placeholder: undefined,
   inputClass: undefined,
 }, InputBase.defaultProps);
-
-module.exports = {
-  Text,
-};

--- a/web/html/src/components/input/Text.js
+++ b/web/html/src/components/input/Text.js
@@ -1,6 +1,7 @@
 // @flow
 const React = require('react');
 const { InputBase } = require('./InputBase');
+const { FormContext } = require('./Form');
 
 type Props = {
   type: string,
@@ -15,6 +16,7 @@ const Text = (props: Props) => {
     inputClass,
     ...propsToPass
   } = props;
+  const formContext = React.useContext(FormContext);
   return (
     <InputBase {...propsToPass}>
       {
@@ -25,12 +27,13 @@ const Text = (props: Props) => {
           const onChange = (event: Object) => {
             setValue(event.target.name, event.target.value);
           };
+          const fieldValue = formContext.model[props.name] || props.defaultValue || '';
           return (
             <input
               className={`form-control${inputClass ? ` ${inputClass}` : ''}`}
               type={type || 'text'}
               name={props.name}
-              value={props.value}
+              value={fieldValue}
               onChange={onChange}
               disabled={props.disabled}
               onBlur={onBlur}

--- a/web/html/src/components/input/form.stories.js
+++ b/web/html/src/components/input/form.stories.js
@@ -1,0 +1,199 @@
+import * as React from 'react';
+import { storiesOf } from '@storybook/react';
+import { Form } from './Form';
+import { Text } from './Text';
+import { Password } from './Password';
+import { Check } from './Check';
+import { DateTime } from './DateTime';
+import { Radio } from './Radio';
+import { Select } from './Select';
+import { SubmitButton } from 'components/buttons';
+
+
+storiesOf('Forms', module)
+  .add('text input', () => {
+    let model = {
+      firstname: 'John',
+    };
+
+    return (
+      <Form
+        model={model}
+        onChange={newModel => {model['firstname'] = newModel['firstname']}}
+        onSubmit={() => alert(`Hello ${model['firstname']}`)}
+        onSubmitInvalid={(data, evt) => alert("Submit clicked, but form invalid")}
+        divClass="col-md-12"
+        formDirection="form-horizontal"
+      >
+        <Text
+          name="firstname"
+          label={t('First Name')}
+          required
+          invalidHint={t('Minimum 2 characters')}
+          labelClass="col-md-3"
+          divClass="col-md-6"
+          validators={[(value => (value.length > 2))]}
+        />
+        <SubmitButton
+          id="submit-btn"
+          className="btn-success"
+          text={t("Submit")}
+        />
+      </Form>
+    );
+  })
+  .add('password input', () => {
+    let model = {
+      password: 'secret',
+    };
+
+    return (
+      <Form
+        model={model}
+        onChange={newModel => {model['password'] = newModel['password']}}
+        onSubmit={() => alert(`Secret revealed: ${model['password']}`)}
+        onSubmitInvalid={(data, evt) => alert("Submit clicked, but form invalid")}
+        divClass="col-md-12"
+        formDirection="form-horizontal"
+      >
+        <Password
+          name="password"
+          label={t('Password')}
+          required
+          invalidHint={t('Minimum 4 characters')}
+          labelClass="col-md-3"
+          divClass="col-md-6"
+          validators={[(value => (value.length > 4))]}
+        />
+        <SubmitButton
+          id="submit-btn"
+          className="btn-success"
+          text={t("Submit")}
+        />
+      </Form>
+    );
+  })
+  .add('check box', () => {
+    let model = {
+      force: false,
+    };
+
+    return (
+      <Form
+        model={model}
+        onSubmit={() => alert(`May${model['force'] ? '' : ' NOT'} the force be with you`)}
+        divClass="col-md-12"
+        formDirection="form-horizontal"
+        onChange={newModel => {model['force'] = newModel['force']}}
+      >
+        <Check
+          name="force"
+          label="Force action"
+          divClass="col-md-6 col-md-offset-3"
+        />
+        <SubmitButton
+          id="submit-btn"
+          className="btn-success"
+          text={t("Submit")}
+        />
+      </Form>
+    )
+  })
+  .add('date time input', () => {
+    let model = {
+      time: new Date(),
+    };
+
+    return (
+      <Form
+        model={model}
+        onChange={newModel => {model['time'] = newModel['time']}}
+        onSubmit={() => alert(`Set time: ${model['time'].toISOString()}`)}
+        onSubmitInvalid={(data, evt) => alert("Submit clicked, but form invalid")}
+        divClass="col-md-12"
+        formDirection="form-horizontal"
+      >
+        <DateTime
+          name="time"
+          timezone="CEST"
+          label={t('Time')}
+          required
+          labelClass="col-md-3"
+          divClass="col-md-6"
+        />
+        <SubmitButton
+          id="submit-btn"
+          className="btn-success"
+          text={t("Submit")}
+        />
+      </Form>
+    );
+  })
+  .add('radio button input', () => {
+    let model = {
+      level: 'beginner',
+    };
+
+    return (
+      <Form
+        model={model}
+        onChange={newModel => {model['level'] = newModel['level']}}
+        onSubmit={() => alert(`Level: ${model['level']}`)}
+        onSubmitInvalid={(data, evt) => alert("Submit clicked, but form invalid")}
+        divClass="col-md-12"
+        formDirection="form-horizontal"
+      >
+        <Radio
+          name="level"
+          label={t('Level')}
+          required
+          openOption={true}
+          labelClass="col-md-3"
+          divClass="col-md-6"
+          items={[
+            {label: t('Beginner'), value: 'beginner'},
+            {label: t('Normal'), value: 'normal'},
+            {label: t('Expert'), value: 'expert'}
+          ]}
+        />
+        <SubmitButton
+          id="submit-btn"
+          className="btn-success"
+          text={t("Submit")}
+        />
+      </Form>
+    );
+  })
+  .add('drop down list input', () => {
+    let model = {
+      level: 'beginner',
+    };
+
+    return (
+      <Form
+        model={model}
+        onChange={newModel => {model['level'] = newModel['level']}}
+        onSubmit={() => alert(`Level: ${model['level']}`)}
+        onSubmitInvalid={(data, evt) => alert("Submit clicked, but form invalid")}
+        divClass="col-md-12"
+        formDirection="form-horizontal"
+      >
+        <Select
+          name="level"
+          label={t('Level')}
+          required
+          labelClass="col-md-3"
+          divClass="col-md-6"
+        >
+          <option key="beginner" value="beginner">Beginner</option>
+          <option key="normal" value="normal">Normal</option>
+          <option key="expert" value="expert">Expert</option>
+        </Select>
+        <SubmitButton
+          id="submit-btn"
+          className="btn-success"
+          text={t("Submit")}
+        />
+      </Form>
+    );
+  })

--- a/web/html/src/manager/virtualization/guests/console/guests-console.js
+++ b/web/html/src/manager/virtualization/guests/console/guests-console.js
@@ -126,6 +126,10 @@ class GuestsConsole extends React.Component<Props, State> {
     this.setState({ popupState: 'askPassword' }, this.showPopup);
   });
 
+  onPasswordChange = (model: Object) => {
+    this.setState({ password: model.password });
+  }
+
   render() {
     const buttonValues = {
       askPassword: {
@@ -142,7 +146,7 @@ class GuestsConsole extends React.Component<Props, State> {
       }
       if (this.state.popupState === 'askPassword') {
         return (
-          <Form model={this.state} className="form-horizontal">
+          <Form model={this.state} className="form-horizontal" onChange={this.onPasswordChange}>
             <Password
               name="password"
               label={t('Password')}

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- Use ReactJS Context in Form components
+
 -------------------------------------------------------------------
 Wed Nov 27 17:04:54 CET 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

The `Form` component is fairly complex with the children cloning at render time. This complexity also limits the possibilities of the component user to generate components at render time too.

This rework passes down the needed data and functions down from the `Form` to the `InputBase` and other inputs using the new [Context](https://reactjs.org/docs/context.html) feature.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal refactoring

- [X] **DONE**

## Test coverage
- No tests: tests already existing, but may not be covering the whole feature surface

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test" 
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
