### PR TITLE
Use uyuni version

### DIFF
--- a/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -83,6 +83,8 @@ public class ConfigDefaults {
 
     public static final String PRODUCT_NAME = "web.product_name";
     public static final String VENDOR_NAME = "java.vendor_name";
+    public static final String PRODUCT_VERSION_MGR = "web.version";
+    public static final String PRODUCT_VERSION_UYUNI = "web.version.uyuni";
     public static final String ENTERPRISE_LINUX_NAME = "java.enterprise_linux_name";
     public static final String VENDOR_SERVICE_NAME = "java.vendor_service_name";
 
@@ -623,6 +625,19 @@ public class ConfigDefaults {
      */
     public boolean isUyuni() {
         return isSpacewalk();
+    }
+
+    /**
+     * Return the product version string depending on the product.
+     * Either web.version or web.version.uyuni
+     *
+     * @return the product version
+     */
+    public String getProductVersion() {
+        if (isUyuni()) {
+            return Config.get().getString(PRODUCT_VERSION_UYUNI);
+        }
+        return Config.get().getString(PRODUCT_VERSION_MGR);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/RhnTagFunctions.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/RhnTagFunctions.java
@@ -18,6 +18,7 @@ import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import com.redhat.rhn.common.conf.Config;
+import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.common.util.StringUtil;
 
@@ -74,6 +75,16 @@ public class RhnTagFunctions {
      */
     public static String getConfig(String confIn) {
         return Config.get().getString(confIn);
+    }
+
+    /**
+     * Fetch the Version from the Configuration system.
+     * Makes a call into com.redhat.rhn.common.config.Config.get()
+     *
+     * @return Product Version String
+     */
+    public static String getProductVersion() {
+        return ConfigDefaults.get().getProductVersion();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/rhn-taglib.tld
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/rhn-taglib.tld
@@ -798,6 +798,11 @@
         <function-signature>java.lang.String getConfig(java.lang.String)</function-signature>
     </function>
     <function>
+        <name>getProductVersion</name>
+        <function-class>com.redhat.rhn.frontend.taglibs.RhnTagFunctions</function-class>
+        <function-signature>java.lang.String getProductVersion()</function-signature>
+    </function>
+    <function>
         <name>urlEncode</name>
         <function-class>com.redhat.rhn.frontend.taglibs.RhnTagFunctions</function-class>
         <function-signature>java.lang.String urlEncode(java.lang.String)</function-signature>

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/api/ApiHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/api/ApiHandler.java
@@ -15,6 +15,7 @@
 package com.redhat.rhn.frontend.xmlrpc.api;
 
 import com.redhat.rhn.common.conf.Config;
+import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.util.StringUtil;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.xmlrpc.BaseHandler;
@@ -51,7 +52,7 @@ public class ApiHandler extends BaseHandler {
      * @xmlrpc.returntype string
      */
     public String systemVersion() {
-        return Config.get().getString("web.version");
+        return ConfigDefaults.get().getProductVersion();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/api/test/ApiHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/api/test/ApiHandlerTest.java
@@ -15,6 +15,7 @@
 package com.redhat.rhn.frontend.xmlrpc.api.test;
 
 import com.redhat.rhn.common.conf.Config;
+import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.frontend.xmlrpc.api.ApiHandler;
 import com.redhat.rhn.testing.RhnBaseTestCase;
 
@@ -27,7 +28,7 @@ public class ApiHandlerTest extends RhnBaseTestCase {
          * get *something*.
          */
 
-        String version = Config.get().getString("web.version");
+        String version = ConfigDefaults.get().getProductVersion();
         assertEquals(version, handler.systemVersion());
     }
 

--- a/java/code/src/com/suse/manager/webui/controllers/login/LoginController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/login/LoginController.java
@@ -105,7 +105,7 @@ public class LoginController {
             model.put("request_method", reqMethod);
             model.put("validationErrors", Json.GSON.toJson(LoginHelper.validateDBVersion()));
             model.put("schemaUpgradeRequired", Json.GSON.toJson(LoginHelper.isSchemaUpgradeRequired()));
-            model.put("webVersion", Config.get().getString("web.version"));
+            model.put("webVersion", ConfigDefaults.get().getProductVersion());
             model.put("productName", Config.get().getString(ConfigDefaults.PRODUCT_NAME));
             model.put("customHeader", Config.get().getString("java.custom_header"));
             model.put("customFooter", Config.get().getString("java.custom_footer"));

--- a/java/code/src/com/suse/manager/webui/menu/MenuTree.java
+++ b/java/code/src/com/suse/manager/webui/menu/MenuTree.java
@@ -18,6 +18,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.jsp.PageContext;
 
 import com.redhat.rhn.common.conf.Config;
+import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.security.acl.Access;
 import com.redhat.rhn.common.security.acl.Acl;
 import com.redhat.rhn.common.security.acl.AclFactory;
@@ -369,7 +370,7 @@ public class MenuTree {
 
             // Help
             nodes.add(new MenuItem("Help").withIcon("fa-book").withTarget("_blank")
-                .addChild(new MenuItem("Documentation_version", Config.get().getString("web.version"))
+                .addChild(new MenuItem("Documentation_version", ConfigDefaults.get().getProductVersion())
                     .withPrimaryUrl("/docs/index.html").withTarget("_blank"))
                 .addChild(new MenuItem("Release Notes").withTarget("_blank")
                         .addChild(new MenuItem("product_server")
@@ -408,7 +409,7 @@ public class MenuTree {
             nodes.add(new MenuItem("About Spacewalk").withIcon("fa-question-circle")
                 .addChild(new MenuItem("Overview").withPrimaryUrl("/rhn/help/about.do"))
                 .addChild(new MenuItem("Sign In").withPrimaryUrl("/rhn/manager/login"))
-                .addChild(new MenuItem("Documentation_version", Config.get().getString("web.version"))
+                .addChild(new MenuItem("Documentation_version", ConfigDefaults.get().getProductVersion())
                     .withPrimaryUrl("/docs/index.html").withTarget("_blank"))
                 .addChild(new MenuItem("Lookup Login/Password").withPrimaryUrl("/rhn/help/ForgotCredentials.do"))
                 .addChild(new MenuItem("Release Notes").withTarget("_blank")

--- a/java/code/src/com/suse/manager/webui/utils/SparkApplicationHelper.java
+++ b/java/code/src/com/suse/manager/webui/utils/SparkApplicationHelper.java
@@ -15,6 +15,7 @@
 package com.suse.manager.webui.utils;
 
 import com.redhat.rhn.common.conf.Config;
+import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.security.CSRFTokenValidator;
 import com.redhat.rhn.common.security.PermissionException;
 import com.redhat.rhn.domain.role.Role;
@@ -285,7 +286,7 @@ public class SparkApplicationHelper {
         sharedVariables.put("h", ViewHelper.getInstance());
         sharedVariables.put("isDevMode",
                 Config.get().getBoolean("java.development_environment"));
-        sharedVariables.put("webVersion", Config.get().getString("web.version"));
+        sharedVariables.put("webVersion", ConfigDefaults.get().getProductVersion());
         sharedVariables.put("webBuildtimestamp", Config.get().getString("web.buildtimestamp"));
         JadeConfiguration config = jade.configuration();
         config.setSharedVariables(sharedVariables);

--- a/java/code/webapp/WEB-INF/includes/footer.jsp
+++ b/java/code/webapp/WEB-INF/includes/footer.jsp
@@ -7,7 +7,7 @@
     <bean:message key="footer.jsp.copyright" />
   </div>
   <div class="footer-release">
-    <bean:message key="footer.jsp.release" arg0="/docs/release-notes/release-notes-server.html" arg1="${rhn:getConfig('web.version')}" />
+    <bean:message key="footer.jsp.release" arg0="/docs/release-notes/release-notes-server.html" arg1="${rhn:getProductVersion()}" />
   </div>
   <%@ include file="/WEB-INF/pages/common/fragments/bugzilla.jspf" %>
   <c:set var="custom_footer" scope="page" value="${rhn:getConfig('java.custom_footer')}" />

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- show version depending on the product
 - Fix loading proper activation key details on SPA enabled (bsc#1157141)
 - Add 'license' entry to the kiwi image inspection test data
 - Enable aarch64 builds


### PR DESCRIPTION
## What does this PR change?

Uyuni gets an own versioning scheme. Show the uyuni version in the footer and return it from the API if the product name is set to Uyuni.

## GUI diff

No difference.

![Screenshot_20191125_163456](https://user-images.githubusercontent.com/1038917/69554094-901a1080-0fa1-11ea-81df-abeb5cdcd60e.png)

- [x] **DONE**

## Documentation
- https://github.com/SUSE/spacewalk/issues/9562

- [x] **DONE**

## Test coverage
- No tests: **already covered**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/9559

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test" 
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
