### PR TITLE
Fix changelog_test

### DIFF
--- a/.github/workflows/changelog_checker.yml
+++ b/.github/workflows/changelog_checker.yml
@@ -17,4 +17,4 @@ jobs:
     - name: Run a changelog checker
       run: |
         files_modified=`git diff --name-only "origin/$GITHUB_BASE_REF..HEAD" | xargs`
-        ruby .github/scripts/changelog.rb $files_modified
+        ruby .github/scripts/changelog.rb "$files_modified"


### PR DESCRIPTION
## What does this PR change?

This PR fixes the changelog_test GitHub action, it has a mistake passing the list of changed files.
This PR will not fix the issue having duplicated status checks, it will be fixed separately. The workaround is to perform `git commit --amend && git push -f`


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: No need.

- [x] **DONE**

## Test coverage
- No tests:  CI change, no need tests. Tested using that PR.

- [x] **DONE**

## Links

No links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
