### PR TITLE
Refactor changelog github workflow

### DIFF
--- a/.github/workflows/changelog_checker.yml
+++ b/.github/workflows/changelog_checker.yml
@@ -18,3 +18,11 @@ jobs:
       run: |
         files_modified=`git diff --name-only "origin/$GITHUB_BASE_REF..HEAD" | xargs`
         ruby .github/scripts/changelog.rb "$files_modified"
+        
+  changelog_approved:
+    needs: changelog_test
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Changelogs approved
+      run : echo "Changelogs approved"


### PR DESCRIPTION
## What does this PR change?

This PR aims to fix the problem with the duplicated status checks, that issue caused a locked merge button, as github is checking into all the previous status checks.
What refactored the changelog_test workflow, adding a new step. That second step will only run, if the first step pass. So, we can set our project to only block the merge depending on the second step.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: No need

- [x] **DONE**

## Test coverage
- No tests: Tested using a fork PR.

- [x] **DONE**

## Links

After look for a solution into the community, that was the workaround used: https://github.community/t5/GitHub-Actions/duplicate-checks-on-pull-request-event/m-p/33157#M1393

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
