### PR TITLE
use channel name instead of constructing it

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -376,9 +376,7 @@ public class ContentSyncManager {
             List<Tuple2<SUSEProductSCCRepository, MgrSyncStatus>> childRepos = partitionBaseRepo.get(false);
 
             Set<MgrSyncChannelDto> allChannels = childRepos.stream().map(c -> new MgrSyncChannelDto(
-                    c.getA().getRepository().getName() +
-                    (c.getA().getRootProduct().getArch() != null ?
-                            " for " + c.getA().getRootProduct().getArch().getLabel() : ""),
+                    c.getA().getChannelName(),
                     c.getA().getChannelLabel(),
                     c.getA().getProduct().getFriendlyName(),
                     c.getA().getRepository().getDescription(),
@@ -395,9 +393,7 @@ public class ContentSyncManager {
             )).collect(Collectors.toSet());
 
             List<MgrSyncChannelDto> baseChannels = baseRepos.stream().map(baseRepo -> new MgrSyncChannelDto(
-                    baseRepo.getA().getRepository().getName() +
-                    (baseRepo.getA().getRootProduct().getArch() != null ?
-                            " for " + baseRepo.getA().getRootProduct().getArch().getLabel() : ""),
+                    baseRepo.getA().getChannelName(),
                     baseRepo.getA().getChannelLabel(),
                     baseRepo.getA().getProduct().getFriendlyName(),
                     baseRepo.getA().getRepository().getDescription(),

--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -324,16 +324,16 @@ public class ContentSyncManager {
      */
     private static List<SCCProductJson> getAdditionalProducts() {
         Gson gson = new GsonBuilder().create();
-        List<SCCProductJson> oes = new ArrayList<>();
+        List<SCCProductJson> additionalProducts = new ArrayList<>();
         try {
-            oes = gson.fromJson(new BufferedReader(new InputStreamReader(
+            additionalProducts = gson.fromJson(new BufferedReader(new InputStreamReader(
                             new FileInputStream(additionalProductsJson))),
                     SCCClientUtils.toListType(SCCProductJson.class));
         }
         catch (IOException e) {
             log.error(e);
         }
-        return fixAdditionalProducts(oes);
+        return fixAdditionalProducts(additionalProducts);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/content/ProductTreeEntry.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ProductTreeEntry.java
@@ -69,6 +69,52 @@ public class ProductTreeEntry {
     private List<String> tags = Collections.emptyList();
 
     /**
+     * Here only for gson
+     */
+    public ProductTreeEntry() {
+    }
+
+    /**
+     *
+     * @param channelLabelIn channel label
+     * @param parentChannelLabelIn parent channel label
+     * @param channelNameIn channel name
+     * @param productIdIn product id
+     * @param repositoryIdIn repository id
+     * @param parentProductIdIn parent product id
+     * @param rootProductIdIn root product id
+     * @param updateTagIn update tag
+     * @param signedIn signed flag
+     * @param mandatoryIn mandatory flag
+     * @param recommendedIn recommended flag
+     * @param urlIn repo url
+     * @param releaseStageIn release stage
+     * @param productTypeIn product type
+     * @param tagsIn tags
+     */
+    public ProductTreeEntry(String channelLabelIn, Optional<String> parentChannelLabelIn, String channelNameIn,
+                            long productIdIn, long repositoryIdIn, Optional<Long> parentProductIdIn,
+                            long rootProductIdIn, Optional<String> updateTagIn, boolean signedIn, boolean mandatoryIn,
+                            boolean recommendedIn, String urlIn, ReleaseStage releaseStageIn,
+                            Optional<ProductType> productTypeIn, List<String> tagsIn) {
+        this.channelLabel = channelLabelIn;
+        this.parentChannelLabel = parentChannelLabelIn;
+        this.channelName = channelNameIn;
+        this.productId = productIdIn;
+        this.repositoryId = repositoryIdIn;
+        this.parentProductId = parentProductIdIn;
+        this.rootProductId = rootProductIdIn;
+        this.updateTag = updateTagIn;
+        this.signed = signedIn;
+        this.mandatory = mandatoryIn;
+        this.recommended = recommendedIn;
+        this.url = urlIn;
+        this.releaseStage = releaseStageIn;
+        this.productType = productTypeIn;
+        this.tags = tagsIn;
+    }
+
+    /**
      * @return the tags
      */
     public List<String> getTags() {

--- a/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
@@ -22,6 +22,7 @@ import com.redhat.rhn.domain.channel.ChannelFamily;
 import com.redhat.rhn.domain.channel.ChannelFamilyFactory;
 import com.redhat.rhn.domain.channel.ContentSource;
 import com.redhat.rhn.domain.channel.test.ChannelFamilyFactoryTest;
+import com.redhat.rhn.domain.common.ManagerInfoFactory;
 import com.redhat.rhn.domain.credentials.Credentials;
 import com.redhat.rhn.domain.credentials.CredentialsFactory;
 import com.redhat.rhn.domain.product.MgrSyncChannelDto;
@@ -71,6 +72,7 @@ import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -305,6 +307,202 @@ public class ContentSyncManagerTest extends BaseTestCaseWithUser {
         upRepo = upRepoOpt.get();
         assertTrue("Best Auth is not token auth", upRepo.getBestAuth().get() instanceof SCCRepositoryTokenAuth);
     }
+
+    public void dupIdSzenario(boolean rhel6sync, boolean rhel7sync, boolean rhel6first) throws Exception {
+        Gson gson = new GsonBuilder()
+                .setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX")
+                .create();
+        String testDataPath = "/com/redhat/rhn/manager/content/test/dupidfix/";
+        InputStreamReader inputStreamReader = new InputStreamReader(ContentSyncManager.class.getResourceAsStream(
+                testDataPath + (rhel6first ? "products_6_first.json" : "products_7_first.json")
+        ));
+        List<SCCProductJson> products = gson.fromJson(inputStreamReader, new TypeToken<List<SCCProductJson>>() {}.getType());
+        InputStreamReader inputStreamReader3 = new InputStreamReader(ContentSyncManager.class.getResourceAsStream(
+                "/com/redhat/rhn/manager/content/test/smallBase/channel_families.json"
+        ));
+        List<ChannelFamilyJson> channelFamilies = gson.fromJson(inputStreamReader3, new TypeToken<List<ChannelFamilyJson>>() {}.getType());
+        InputStreamReader inputStreamReader4 = new InputStreamReader(ContentSyncManager.class.getResourceAsStream(
+                testDataPath + "product_tree.json"
+        ));
+        List<ProductTreeEntry> staticTree = JsonParser.GSON.fromJson(inputStreamReader4, new TypeToken<List<ProductTreeEntry>>() {}.getType());
+
+        List<SCCRepositoryJson> additionalRepos = ContentSyncManager.collectRepos(products);
+
+        Credentials credentials = CredentialsFactory.createSCCCredentials();
+        credentials.setPassword("dummy");
+        credentials.setUrl("dummy");
+        credentials.setUsername("dummy");
+        credentials.setUser(user);
+        CredentialsFactory.storeCredentials(credentials);
+
+        ContentSyncManager csm = new ContentSyncManager() {
+            @Override
+            protected boolean accessibleUrl(String url) {
+                return true;
+            }
+        };
+        csm.updateChannelFamilies(channelFamilies);
+        csm.updateSUSEProducts(products, Collections.emptyList(), staticTree, additionalRepos);
+        csm.refreshRepositoriesAuthentication(additionalRepos, credentials, null, false);
+
+        ManagerInfoFactory.setLastMgrSyncRefresh();
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().clear();
+        if (rhel6sync) {
+            SUSEProductTestUtils.addChannelsForProduct(SUSEProductFactory.lookupByProductId(-6));
+        }
+        if (rhel7sync) {
+            SUSEProductTestUtils.addChannelsForProduct(SUSEProductFactory.lookupByProductId(-7));
+        }
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().clear();
+
+        List<SCCProductJson> fixedAdditionalProducts = ContentSyncManager.fixAdditionalProducts(products);
+        List<SCCRepositoryJson> fixedAdditionalRepos = ContentSyncManager.collectRepos(fixedAdditionalProducts);
+
+        csm.updateChannelFamilies(channelFamilies);
+        csm.updateSUSEProducts(fixedAdditionalProducts, Collections.emptyList(),
+                csm.productTreeFix(staticTree), fixedAdditionalRepos);
+        csm.refreshRepositoriesAuthentication(fixedAdditionalRepos, credentials, null);
+
+        ManagerInfoFactory.setLastMgrSyncRefresh();
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().clear();
+
+
+        SUSEProductSCCRepository rhel7 = SUSEProductFactory.lookupPSRByChannelLabel("rhel7-pool-x86_64").get(0);
+        //check if rhel7-pool-x86_64 has fixed id -83
+        assertEquals(-83L, rhel7.getRepository().getSccId().longValue());
+
+
+        SUSEProductSCCRepository rhel6 = SUSEProductFactory.lookupPSRByChannelLabel("rhel6-pool-i386").get(0);
+        //check if rhel6-pool-i386 still has id -81 and fixed dist target
+        assertEquals(-81, rhel6.getRepository().getSccId().longValue());
+        assertEquals("i386", rhel6.getRepository().getDistroTarget());
+
+        //check if both repos are unsigned
+        assertFalse(rhel6.getRepository().isSigned());
+        assertFalse(rhel7.getRepository().isSigned());
+
+        //check repoauth from repo with scc_id -83 has same content source as from scc_id -81
+        List<ContentSource> rhel7csIds = rhel7.getRepository().getRepositoryAuth()
+                .stream().map(s -> s.getContentSource()).collect(Collectors.toList());
+        List<ContentSource> rhel6csIds = rhel6.getRepository().getRepositoryAuth()
+                .stream().map(s -> s.getContentSource()).collect(Collectors.toList());
+        assertNotEmpty(rhel7.getRepository().getRepositoryAuth());
+        assertNotEmpty(rhel6.getRepository().getRepositoryAuth());
+        if (rhel6sync == rhel7sync) {
+            assertEquals(rhel6csIds, rhel7csIds);
+        }
+        else {
+            if (rhel6sync) {
+               assertTrue(rhel6csIds.stream().allMatch(Objects::nonNull));
+               assertTrue(rhel7csIds.stream().allMatch(Objects::isNull));
+            }
+            else {
+                assertTrue(rhel7csIds.stream().allMatch(Objects::nonNull));
+                assertTrue(rhel6csIds.stream().allMatch(Objects::isNull));
+            }
+        }
+    }
+
+    public void testDupIdSzenario9() throws Exception {
+        Gson gson = new GsonBuilder()
+                .setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX")
+                .create();
+        String testDataPath = "/com/redhat/rhn/manager/content/test/dupidfix/";
+        InputStreamReader inputStreamReader = new InputStreamReader(ContentSyncManager.class.getResourceAsStream(
+                testDataPath + "products_7_first.json"));
+        List<SCCProductJson> products = gson.fromJson(inputStreamReader, new TypeToken<List<SCCProductJson>>() {}.getType());
+        InputStreamReader inputStreamReader3 = new InputStreamReader(ContentSyncManager.class.getResourceAsStream(
+                "/com/redhat/rhn/manager/content/test/smallBase/channel_families.json"
+        ));
+        List<ChannelFamilyJson> channelFamilies = gson.fromJson(inputStreamReader3, new TypeToken<List<ChannelFamilyJson>>() {}.getType());
+        InputStreamReader inputStreamReader4 = new InputStreamReader(ContentSyncManager.class.getResourceAsStream(
+                testDataPath + "product_tree.json"
+        ));
+        List<ProductTreeEntry> staticTree = JsonParser.GSON.fromJson(inputStreamReader4, new TypeToken<List<ProductTreeEntry>>() {}.getType());
+
+        List<SCCProductJson> fixedAdditionalProducts = ContentSyncManager.fixAdditionalProducts(products);
+        List<SCCRepositoryJson> fixedAdditionalRepos = ContentSyncManager.collectRepos(fixedAdditionalProducts);
+
+        Credentials credentials = CredentialsFactory.createSCCCredentials();
+        credentials.setPassword("dummy");
+        credentials.setUrl("dummy");
+        credentials.setUsername("dummy");
+        credentials.setUser(user);
+        CredentialsFactory.storeCredentials(credentials);
+
+        ContentSyncManager csm = new ContentSyncManager() {
+            @Override
+            protected boolean accessibleUrl(String url) {
+                return true;
+            }
+        };
+        csm.updateChannelFamilies(channelFamilies);
+        csm.updateSUSEProducts(fixedAdditionalProducts, Collections.emptyList(), csm.productTreeFix(staticTree), fixedAdditionalRepos);
+        csm.refreshRepositoriesAuthentication(fixedAdditionalRepos, credentials, null);
+
+        ManagerInfoFactory.setLastMgrSyncRefresh();
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().clear();
+
+
+        SUSEProductSCCRepository rhel7 = SUSEProductFactory.lookupPSRByChannelLabel("rhel7-pool-x86_64").get(0);
+        //check if rhel7-pool-x86_64 has fixed id -83
+        assertEquals(-83L, rhel7.getRepository().getSccId().longValue());
+
+
+        SUSEProductSCCRepository rhel6 = SUSEProductFactory.lookupPSRByChannelLabel("rhel6-pool-i386").get(0);
+        //check if rhel6-pool-i386 still has id -81 and fixed dist target
+        assertEquals(-81, rhel6.getRepository().getSccId().longValue());
+        assertEquals("i386", rhel6.getRepository().getDistroTarget());
+
+        //check if both repos are unsigned
+        assertFalse(rhel6.getRepository().isSigned());
+        assertFalse(rhel7.getRepository().isSigned());
+
+        //check repoauth from repo with scc_id -83 has same content source as from scc_id -81
+        List<ContentSource> rhel7csIds = rhel7.getRepository().getRepositoryAuth()
+                .stream().map(s -> s.getContentSource()).collect(Collectors.toList());
+        List<ContentSource> rhel6csIds = rhel6.getRepository().getRepositoryAuth()
+                .stream().map(s -> s.getContentSource()).collect(Collectors.toList());
+        assertEquals(rhel6csIds, rhel7csIds);
+    }
+
+    public void testDupIdSzenario1() throws Exception {
+        dupIdSzenario(false, true, false);
+    }
+
+    public void testDupIdSzenario2() throws Exception {
+        dupIdSzenario(false, false, false);
+    }
+
+    public void testDupIdSzenario3() throws Exception {
+        dupIdSzenario(true, true, false);
+    }
+
+    public void testDupIdSzenario4() throws Exception {
+        dupIdSzenario(true, false, false);
+    }
+
+    public void testDupIdSzenario5() throws Exception {
+        dupIdSzenario(false, true, true);
+    }
+
+    public void testDupIdSzenario6() throws Exception {
+        dupIdSzenario(false, false, true);
+    }
+
+    public void testDupIdSzenario7() throws Exception {
+        dupIdSzenario(true, true, true);
+    }
+
+    public void testDupIdSzenario8() throws Exception {
+        dupIdSzenario(true, false, true);
+    }
+
+
     /**
      * Test if changes in SCC data result in updates of the channel data in the DB
      * @throws Exception if anything goes wrong

--- a/java/code/src/com/redhat/rhn/manager/content/test/dupidfix/product_tree.json
+++ b/java/code/src/com/redhat/rhn/manager/content/test/dupidfix/product_tree.json
@@ -1,0 +1,36 @@
+[
+  {
+    "channel_label": "rhel7-pool-x86_64",
+    "parent_channel_label": null,
+    "product_id": -7,
+    "repository_id": -81,
+    "parent_product_id": null,
+    "root_product_id": -7,
+    "update_tag": null,
+    "url": "http://localhost/pub/repositories/empty/",
+    "release_stage": "released",
+    "mandatory": true,
+    "signed": false,
+    "recommended": false,
+    "channel_name": "RHEL7-Pool for x86_64",
+    "product_type": "base",
+    "tags": []
+  },
+  {
+    "channel_label": "rhel6-pool-i386",
+    "parent_channel_label": null,
+    "product_id": -6,
+    "repository_id": -81,
+    "parent_product_id": null,
+    "root_product_id": -6,
+    "update_tag": null,
+    "url": "http://localhost/pub/repositories/empty/",
+    "release_stage": "released",
+    "mandatory": true,
+    "signed": false,
+    "recommended": false,
+    "channel_name": "RHEL6-Pool for i386",
+    "product_type": "base",
+    "tags": []
+  }
+]

--- a/java/code/src/com/redhat/rhn/manager/content/test/dupidfix/products_6_first.json
+++ b/java/code/src/com/redhat/rhn/manager/content/test/dupidfix/products_6_first.json
@@ -1,0 +1,76 @@
+[
+  {
+    "id" : -6,
+    "name" : "RHEL6 Base",
+    "identifier" : "rhel-base",
+    "former_identifier" : "",
+    "version" : "6",
+    "release_type" : null,
+    "arch" : "i386",
+    "friendly_name" : "RHEL6 Base i386",
+    "product_class" : "SLE-M-T",
+    "cpe" : null,
+    "free" : false,
+    "description" : null,
+    "release_stage" : "released",
+    "eula_url" : "",
+    "product_type" : "base",
+    "offline_predecessor_ids" : [
+    ],
+    "online_predecessor_ids" : [
+    ],
+    "shortname" : null,
+    "recommended" : false,
+    "extensions" : [
+    ],
+    "repositories" : [
+      {
+        "id" : -81,
+        "url" : "http://localhost/pub/repositories/empty/",
+        "name" : "RHEL6-Pool",
+        "distro_target" : "i386",
+        "description" : "RHEL6-Pool",
+        "enabled" : true,
+        "autorefresh" : false,
+        "installer_updates" : false
+      }
+    ]
+  },
+  {
+    "id" : -7,
+    "name" : "RHEL7 Base",
+    "identifier" : "rhel-base",
+    "former_identifier" : "",
+    "version" : "7",
+    "release_type" : null,
+    "arch" : "x86_64",
+    "friendly_name" : "RHEL7 Base x86_64",
+    "product_class" : "SLE-M-T",
+    "cpe" : null,
+    "free" : false,
+    "description" : null,
+    "release_stage" : "released",
+    "eula_url" : "",
+    "product_type" : "base",
+    "offline_predecessor_ids" : [
+    ],
+    "online_predecessor_ids" : [
+    ],
+    "shortname" : null,
+    "recommended" : false,
+    "extensions" : [
+    ],
+    "repositories" : [
+      {
+        "id" : -81,
+        "url" : "http://localhost/pub/repositories/empty/",
+        "name" : "RHEL7-Pool",
+        "distro_target" : "x86_64",
+        "description" : "RHEL7-Pool",
+        "enabled" : true,
+        "autorefresh" : false,
+        "installer_updates" : false
+      }
+    ]
+  }
+]

--- a/java/code/src/com/redhat/rhn/manager/content/test/dupidfix/products_7_first.json
+++ b/java/code/src/com/redhat/rhn/manager/content/test/dupidfix/products_7_first.json
@@ -1,0 +1,76 @@
+[
+  {
+    "id" : -7,
+    "name" : "RHEL7 Base",
+    "identifier" : "rhel-base",
+    "former_identifier" : "",
+    "version" : "7",
+    "release_type" : null,
+    "arch" : "x86_64",
+    "friendly_name" : "RHEL7 Base x86_64",
+    "product_class" : "SLE-M-T",
+    "cpe" : null,
+    "free" : false,
+    "description" : null,
+    "release_stage" : "released",
+    "eula_url" : "",
+    "product_type" : "base",
+    "offline_predecessor_ids" : [
+    ],
+    "online_predecessor_ids" : [
+    ],
+    "shortname" : null,
+    "recommended" : false,
+    "extensions" : [
+    ],
+    "repositories" : [
+      {
+        "id" : -81,
+        "url" : "http://localhost/pub/repositories/empty/",
+        "name" : "RHEL7-Pool",
+        "distro_target" : "x86_64",
+        "description" : "RHEL7-Pool",
+        "enabled" : true,
+        "autorefresh" : false,
+        "installer_updates" : false
+      }
+    ]
+  },
+  {
+    "id" : -6,
+    "name" : "RHEL6 Base",
+    "identifier" : "rhel-base",
+    "former_identifier" : "",
+    "version" : "6",
+    "release_type" : null,
+    "arch" : "i386",
+    "friendly_name" : "RHEL6 Base i386",
+    "product_class" : "SLE-M-T",
+    "cpe" : null,
+    "free" : false,
+    "description" : null,
+    "release_stage" : "released",
+    "eula_url" : "",
+    "product_type" : "base",
+    "offline_predecessor_ids" : [
+    ],
+    "online_predecessor_ids" : [
+    ],
+    "shortname" : null,
+    "recommended" : false,
+    "extensions" : [
+    ],
+    "repositories" : [
+      {
+        "id" : -81,
+        "url" : "http://localhost/pub/repositories/empty/",
+        "name" : "RHEL6-Pool",
+        "distro_target" : "i386",
+        "description" : "RHEL6-Pool",
+        "enabled" : true,
+        "autorefresh" : false,
+        "installer_updates" : false
+      }
+    ]
+  }
+]

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- use channel name from product tree instead of constructing it (bsc#1157317)
 - Add the system.getMinionIdMap XMLRPC method
 - generate metadata with empty vendor (bsc#1158480)
 - Read the subscriptions from the output instead of input (bsc#1140332)


### PR DESCRIPTION
## What does this PR change?

When listing channels we construct the channel name even if we have the final channel name available.
This fixes also the display error of [Bug 1157317](http://bugzilla.suse.com/show_bug.cgi?id=1157317).

## GUI diff

```diff
-[I] RHEL6-Pool for x86_64 RHEL7 Base x86_64 [rhel7-pool-x86_64]
+[I] RHEL7-Pool for x86_64 RHEL7 Base x86_64 [rhel7-pool-x86_64]
```

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **already covered**

- [x] **DONE**

## Links

Fixes http://bugzilla.suse.com/show_bug.cgi?id=1157317
Tracks https://github.com/SUSE/spacewalk/issues/10166

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
