### PR TITLE
Manager fast migration

### DIFF
--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -546,6 +546,7 @@ check_remote_type() {
 postgres_fast() {
     cp -a /var/lib/pgsql/data/postgresql.conf /var/lib/pgsql/data/postgresql.conf.migrate
     echo "fsync = off" >> /var/lib/pgsql/data/postgresql.conf
+    echo "full_page_writes = off" >> /var/lib/pgsql/data/postgresql.conf
     echo "checkpoint_completion_target = 0.9" >> /var/lib/pgsql/data/postgresql.conf
     systemctl restart postgresql
 }

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- add 'full_page_writes = off' during migration for fast database import
 - update requirements to match documented values (bsc#1154599)
 - add bootstrap repo for RHEL 8 and ES 8
 - Show help message when missing sub-command in  mgr-sync call (bsc#1134708)


### PR DESCRIPTION
## What does this PR change?

During SUSE Manager migrations, we are using a postgresql configuration that is optimized for speed instead of safety in order to minimize downtime; a crash during migration cannot be recovered anyway. Adding this new parameter can speed things up even more.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed; this is an implementation detail the user does not need to know about.
- [X] **DONE**

## Test coverage
- No tests: We do not test migrations

- [X] **DONE**