### PR TITLE
Sync changelogs with SUSE Manager 4.0

### DIFF
--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,11 +1,14 @@
+- Revert fixes systems that do not yet use systemd as spacewalk-backend
+  is no more part of client tools (replaced by uyuni-base)
 - convert spacewalk-backend to a python3 only package
 - fix spacewalk-update-signatures for python3 (bsc#1156521)
-- add diskchecker tool to 4.0.3 branch as well (bsc#1156397)
+- port diskcheck utility to 4.0.3 branch (bsc#1156397)
 - add systemd service macros for diskcheck.service
 - removed spacewalk-backend-libs subpackage; replaces by uyuni-common-libs
 - read LOBs explicitly
 - Bump version to 4.1.0 (bsc#1154940)
 - Improve error message when deleting channel that's in a content lifecycle project (bsc#1145769)
+- fix specfile for systems that do not yet use systemd
 - fix problems with Package Hub repos having multiple rpms with same NEVRA
   but different checksums (bsc#1146683)
 - fix re-registration with re-activation key (bsc#1154275)

--- a/branding/spacewalk-branding.changes
+++ b/branding/spacewalk-branding.changes
@@ -4,7 +4,7 @@
 - Improve menu scrollbar style for firefox
 - Migrate login to Spark
 - Add UI message when salt-formulas system folders are unreachable (bsc#1142309)
-- add missing strings for tasks
+- Add missing strings for task status page
 
 -------------------------------------------------------------------
 Wed Jul 31 17:31:26 CEST 2019 - jgonzalez@suse.com

--- a/client/tools/mgr-cfg/mgr-cfg.changes
+++ b/client/tools/mgr-cfg/mgr-cfg.changes
@@ -3,7 +3,7 @@
 - Obsolete all old python2-rhncfg* packages to avoid conflicts (bsc#1152290)
 - Fix data type issue to correctly decode if needed (bsc#1150320)
 - Add mgr manpage links
-- Require mgr-daemon (new name of spacewalksd). So systems with
+- Require mgr-daemon (new name of spacewalksd) so we systems with
   spacewalksd get always the new package installed (bsc#1149353)
 
 -------------------------------------------------------------------

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -26,15 +26,16 @@
 - Fix sorting issues on content filter list page (bsc#1145591)
 - Fix combinatorial explosion when generating migrations (bsc#1151888)
 - Change the default value of taskomatic maxmemory to 4GB
+- Silence cache strategy Hibernate warning
 - Return result in compatible type to what defined in database procedure (bsc#1150729)
 - Allow channels names to start with numbers
 - Fix: handle special deb package names (bsc#1150113)
 - Remove extra spaces in dependencies fields in Debian repo Packages file (bsc#1145551)
 - Improve performance for 'Manage Software Channels' view (bsc#1151399)
 - Allow monitoring for managed systems running Ubuntu 18.04 and RedHat 6/7
-- use default value from systemd unit file if not set in /etc/rhn/rhn.conf
+- use value from systemd unit file if not set in /etc/rhn/rhn.conf
 - implement "keyword" filter for Content Lifecycle Management
-- Add support for Azure, Amazon EC2, and Google Compute Engine as Virtual Host Managers.
+- Add support for Azure, Amazon EC2, and Google Compute Engine as Virtual Host Manager.
 - Import additional fields for Deb packages
 - enable Kiwi NG on SLE15
 - allow ssl connections from Tomcat to Postgres (bsc#1149210)
@@ -47,7 +48,7 @@
 - implement "regular expression" Filter for Content Lifecycle Management
   matching package names, patch name, patch synopsis and package names in patches
 - implement provisioning for salt clients
-- New Single Page Application engine for the UI
+- New Single Page Application engine for the UI. It can be enabled with the config 'web.spa.enable' set to true
 - Check that a channel doesn't have clones before deleting it (bsc#1138454)
 - Fix: initialize the hibernate transaction when merging errata via XMLRPC API (bsc#1145584)
 - Fix documentation of contentmanagement handler (bsc#1145753)
@@ -66,8 +67,8 @@
 - UI render without error if salt-formulas system folders are unreachable (bsc#1142309)
 - Add susemanager as prerequired for spacewalk-java
 - Cloning Errata from a specific channel should not take packages
-- Hide channels managed by Content Lifecycle projects from available sources (bsc#1137965)
   from other channels (bsc#1142764)
+- Hide channels managed by Content Lifecycle projects from available sources (bsc#1137965)
 - add caret sorting for rpm versioning
 - improve performance for retrieving the user permissions on channels (bsc#1140644)
 
@@ -81,7 +82,7 @@ Wed Jul 31 17:34:30 CEST 2019 - jgonzalez@suse.com
 - Align selection column in software channel managers (bsc#1122559)
 - API Documentation: mention the shebang in the system.scheduleScriptRun doc strings (bsc#1138655)
 - Enable product detection for plain rhel systems (bsc#1136301)
-- For orphan contentsources, look also in susesccrepositoryauth to make sure they are not being referenced (bsc#1138275)
+- For orphan contentsources, look also in susesccrepositoryauth to make sure they are not being referenced(bsc#1138275)
 - Fallback to logged-in-user org and then vendor errata when looking up erratum on cloning (bsc#1137308)
 - Add new validation to avoid creating content lifecycle projects starting with a number (bsc#1139493)
 - Improve performance of 'Systems requiring reboot' page (fate#327780)

--- a/spacewalk/config/spacewalk-config.changes
+++ b/spacewalk/config/spacewalk-config.changes
@@ -6,6 +6,7 @@
 - remove superfluous 'apache' entries from sudoers configuration (bsc#1151632)
 - Migrate login to Spark
 - Require uyuni-base-common for /etc/rhn
+- Apache configuration: cache vendors folder
 
 -------------------------------------------------------------------
 Wed Jul 31 17:33:40 CEST 2019 - jgonzalez@suse.com

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,7 +1,7 @@
 - Bump version to 4.1.0 (bsc#1154940)
 - fix cobbler authentication module configuration required for
   new cobbler package
-- prevent CherryPy timeouts (bsc#1118175)
+- prevent CherryPy timeouts (bsc#1118175, bsc#1149343)
 - configure 150 Tomcat workers by default, matching httpds MaxClients
 
 -------------------------------------------------------------------

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -36,6 +36,7 @@ Wed Jul 31 17:42:04 CEST 2019 - jgonzalez@suse.com
   refresh works for all operating systems (bsc#1137952)
 - Prevent stuck Actions when onboarding KVM host minions (bsc#1137888)
 - Fix formula name encoding on Python 3 (bsc#1137533)
+- Adapt tests for SUSE manager 4.0
 - More thorougly disable the Salt mine in util.mgr_mine_config_clean_up (bsc#1135075)
 
 -------------------------------------------------------------------

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -28,7 +28,7 @@
 - implement "regular expression" Filter for Content Lifecycle Management
   matching package names, patch name, patch synopsis and package names in patches
 - Change color of disabled build button on clp page (bsc#1145626)
-- New Single Page Application engine for the UI
+- New Single Page Application engine for the UI. It can be enabled with the config 'web.spa.enable' set to true
 - Fix the 'include recommended' button on channels selection in SSM (bsc#1145086)
 - implement "patch contains package" Filter for Content Lifecycle Management
 - implement Filter Patch "by type" Content Lifecycle Management
@@ -55,6 +55,7 @@ Wed Jul 31 17:38:44 CEST 2019 - jgonzalez@suse.com
 - Fix VM creation dialog with non-default pools and networks (bsc#1138268)
 - Update help URLs in the UI (bsc#1136764)
 - Force python-numpy and python-PyJWT dependencies (bsc#1137357)
+- Display warning if product catalog refresh is already in progress (bsc#1132234)
 - Add state EDITED to filters in the Content Lifecycle
 - Add built time date to the Content Lifecycle Environments
 
@@ -155,6 +156,7 @@ Fri Oct 26 10:46:49 CEST 2018 - jgonzalez@suse.com
 Fri Aug 10 15:40:23 CEST 2018 - jgonzalez@suse.com
 
 - version 4.0.1-1
+- Change WebUI version 4.0.1
 - Bump version to 4.0.0 (bsc#1104034)
 - Fix copyright for the package specfile (bsc#1103696)
 - Allow relative path in visibleIf tag in formulas


### PR DESCRIPTION
## What does this PR change?

In shorts:
- Sync wording for some changelog entries with the wording from SUSE Manager 4.0.
- Add some missing changelog entries (for cases where the code WAS already ported).

This is needed because Uyuni is the direct upstream for SUSE Manager 4.1 Alpha1.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Changelog fixes.

- [x] **DONE**

## Test coverage
- No tests: Changelog fixes.

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/10011

- [x]  **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
