### PR TITLE
fix logging in rhn-search

### DIFF
--- a/search-server/spacewalk-search/build.xml
+++ b/search-server/spacewalk-search/build.xml
@@ -126,7 +126,6 @@
                 <include name="*.xml" />
             </fileset>
         </copy>
-        <copy file="${config.src.dir}/log4j.properties" todir="${build.dir}" />
         <copy file="${config.src.dir}/quartz.properties" todir="${build.dir}" />
     </target>
 

--- a/search-server/spacewalk-search/scripts/build.xml
+++ b/search-server/spacewalk-search/scripts/build.xml
@@ -163,7 +163,6 @@
                deprecation="on"
                excludesfile="buildconf/exclude"
                debug="on" />
-        <copy file="${config.src.dir}/log4j.properties" todir="${build.dir}" />
         <copy file="${config.src.dir}/quartz.properties" todir="${build.dir}" />
     </target>
 

--- a/search-server/spacewalk-search/spacewalk-search.changes
+++ b/search-server/spacewalk-search/spacewalk-search.changes
@@ -1,3 +1,4 @@
+- Make rhn-search log to correct file (bsc#1156751)
 - Enable aarch64 builds
 - Fix rhn-search to read memory variable from rhnconf (bsc#1154586)
 - Bump version to 4.1.0 (bsc#1154940)

--- a/search-server/spacewalk-search/spacewalk-search.spec
+++ b/search-server/spacewalk-search/spacewalk-search.spec
@@ -109,6 +109,7 @@ ant -Djar.version=%{version} install
 install -d -m 755 $RPM_BUILD_ROOT%{_prefix}/share/rhn/config-defaults
 install -d -m 755 $RPM_BUILD_ROOT%{_prefix}/share/rhn/search
 install -d -m 755 $RPM_BUILD_ROOT%{_prefix}/share/rhn/search/lib
+install -d -m 755 $RPM_BUILD_ROOT%{_prefix}/share/rhn/search/classes
 install -d -m 755 $RPM_BUILD_ROOT%{_var}/lib/rhn/search
 install -d -m 755 $RPM_BUILD_ROOT%{_var}/lib/rhn/search/indexes
 ln -s -f %{_prefix}/share/rhn/search/indexes/docs $RPM_BUILD_ROOT%{_var}/lib/rhn/search/indexes/docs
@@ -127,6 +128,7 @@ install -p -m 755 src/config/rhn-search $RPM_BUILD_ROOT%{_sbindir}
 install -p -m 644 src/config/rhn-search.service $RPM_BUILD_ROOT%{_unitdir}
 install -p -m 644 src/config/search/rhn_search.conf $RPM_BUILD_ROOT%{_prefix}/share/rhn/config-defaults/rhn_search.conf
 install -p -m 644 src/config/search/rhn_search_daemon.conf $RPM_BUILD_ROOT%{_prefix}/share/rhn/config-defaults/rhn_search_daemon.conf
+install -p -m 644 src/config/log4j.properties $RPM_BUILD_ROOT%{_prefix}/share/rhn/search/classes/log4j.properties
 ln -s -f %{_prefix}/share/rhn/search/lib/spacewalk-search-%{version}.jar $RPM_BUILD_ROOT%{_prefix}/share/rhn/search/lib/spacewalk-search.jar
 
 # add rc link
@@ -148,11 +150,13 @@ ln -sf service $RPM_BUILD_ROOT/%{_sbindir}/rcrhn-search
 %files
 %defattr(644,root,root,755)
 %attr(755, root, root) %{_var}/log/rhn/search
+%dir /usr/share/rhn/search/classes/
 %{_prefix}/share/rhn/search/lib/*
 %attr(755, root, root) %{_sbindir}/rhn-search
 %attr(644, root, root) %{_unitdir}/rhn-search.service
 %{_prefix}/share/rhn/config-defaults/rhn_search.conf
 %{_prefix}/share/rhn/config-defaults/rhn_search_daemon.conf
+%{_prefix}/share/rhn/search/classes/log4j.properties
 %{_sysconfdir}/logrotate.d/rhn-search
 %dir %attr(755, root, root) %{_var}/lib/rhn/search
 %dir %attr(755, root, root) %{_var}/lib/rhn/search/indexes

--- a/search-server/spacewalk-search/src/config/rhn-search
+++ b/search-server/spacewalk-search/src/config/rhn-search
@@ -13,7 +13,7 @@ SEARCH_PARAMS="-Dfile.encoding=UTF-8 -Xms${SEARCH_INIT_MEMORY}m -Xmx${SEARCH_MAX
 JAVACMD="/usr/bin/java -Djava.library.path=${SEARCH_LIBRARY_PATH} -classpath ${SEARCH_CLASSPATH} ${SEARCH_PARAMS}"
 
 if [[ $# -eq 0 ]]; then
-    $JAVACMD com.redhat.satellite.search.Main
+    $JAVACMD -Dlog4j.configuration=file:"/usr/share/rhn/search/classes/log4j.properties" com.redhat.satellite.search.Main
 else
     case $1 in 
         'cleanindex')


### PR DESCRIPTION
## What does this PR change?

port of 10136
## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
