### PR TITLE
Refine the conditions for cleanup on monitoring entitlement removal

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
@@ -74,7 +74,7 @@ public class FormulaFactory {
     private static final Logger LOG = Logger.getLogger(FormulaFactory.class);
 
     private static String dataDir = "/srv/susemanager/formula_data/";
-    private static final String METADATA_DIR_MANAGER = "/usr/share/susemanager/formulas/metadata/";
+    private static String METADATA_DIR_MANAGER = "/usr/share/susemanager/formulas/metadata/";
     private static final String METADATA_DIR_STANDALONE_SALT = "/usr/share/salt-formulas/metadata/";
     private static final String METADATA_DIR_CUSTOM = "/srv/formula_metadata/";
     private static final String PILLAR_DIR = "pillar/";
@@ -86,7 +86,6 @@ public class FormulaFactory {
     private static final String METADATA_FILE = "metadata.yml";
     private static final String PILLAR_EXAMPLE_FILE = "pillar.example";
     private static final String PILLAR_FILE_EXTENSION = "json";
-    private static String metadataDirOfficial = METADATA_DIR_MANAGER;
     private static final Gson GSON = new GsonBuilder()
             .registerTypeAdapter(Date.class, new ECMAScriptDateAdapter())
             .registerTypeAdapter(Double.class,  new JsonSerializer<Double>() {
@@ -116,7 +115,7 @@ public class FormulaFactory {
     }
 
     public static void setMetadataDirOfficial(String metadataDirPath) {
-        FormulaFactory.metadataDirOfficial = metadataDirPath;
+        FormulaFactory.METADATA_DIR_MANAGER = metadataDirPath;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
@@ -828,6 +828,7 @@ public class FormulaFactory {
     @SuppressWarnings("unchecked")
     public static Map<String, Object> disableMonitoring(Map<String, Object> formData) {
         ((Map<String, Object>) formData.get("node_exporter")).put("enabled", false);
+        ((Map<String, Object>) formData.get("apache_exporter")).put("enabled", false);
         ((Map<String, Object>) formData.get("postgres_exporter")).put("enabled", false);
         return formData;
     }
@@ -857,7 +858,9 @@ public class FormulaFactory {
     @SuppressWarnings("unchecked")
     private static boolean hasMonitoringDataEnabled(Map<String, Object> formData) {
         Map<String, Object> nodeExporter = (Map<String, Object>) formData.get("node_exporter");
+        Map<String, Object> apacheExporter = (Map<String, Object>) formData.get("apache_exporter");
         Map<String, Object> postgresExporter = (Map<String, Object>) formData.get("postgres_exporter");
-        return (boolean) nodeExporter.get("enabled") || (boolean) postgresExporter.get("enabled");
+        return (boolean) nodeExporter.get("enabled") || (boolean) apacheExporter.get("enabled") ||
+                (boolean) postgresExporter.get("enabled");
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
@@ -74,7 +74,7 @@ public class FormulaFactory {
     private static final Logger LOG = Logger.getLogger(FormulaFactory.class);
 
     private static String dataDir = "/srv/susemanager/formula_data/";
-    private static String METADATA_DIR_MANAGER = "/usr/share/susemanager/formulas/metadata/";
+    private static String metadataDirManager = "/usr/share/susemanager/formulas/metadata/";
     private static final String METADATA_DIR_STANDALONE_SALT = "/usr/share/salt-formulas/metadata/";
     private static final String METADATA_DIR_CUSTOM = "/srv/formula_metadata/";
     private static final String PILLAR_DIR = "pillar/";
@@ -107,15 +107,19 @@ public class FormulaFactory {
     private FormulaFactory() { }
 
     /**
-     * Setter for data directory(will be needed for testing)
+     * Setter for data directory, used for testing.
      * @param dataDirPath base path to where store files
      */
     public static void setDataDir(String dataDirPath) {
         FormulaFactory.dataDir = dataDirPath;
     }
 
+    /**
+     * Setter for metadata directory, used for testing.
+     * @param metadataDirPath base path where to read metadata files from
+     */
     public static void setMetadataDirOfficial(String metadataDirPath) {
-        FormulaFactory.METADATA_DIR_MANAGER = metadataDirPath;
+        FormulaFactory.metadataDirManager = metadataDirPath;
     }
 
     /**
@@ -169,8 +173,8 @@ public class FormulaFactory {
             message += (error ? " and '" : " '") + METADATA_DIR_STANDALONE_SALT + "'";
             error = true;
         }
-        if (!new File(METADATA_DIR_MANAGER).canRead()) {
-            message += (error ? " and '" : " '") + METADATA_DIR_MANAGER + "'";
+        if (!new File(metadataDirManager).canRead()) {
+            message += (error ? " and '" : " '") + metadataDirManager + "'";
             error = true;
         }
         if (!new File(METADATA_DIR_CUSTOM).canRead()) {
@@ -186,7 +190,7 @@ public class FormulaFactory {
      */
     public static List<String> listFormulaNames() {
         File standaloneDir = new File(METADATA_DIR_STANDALONE_SALT);
-        File managerDir = new File(METADATA_DIR_MANAGER);
+        File managerDir = new File(metadataDirManager);
         File customDir = new File(METADATA_DIR_CUSTOM);
         List<File> files = new LinkedList<>();
         files.addAll(getFormulasFiles(standaloneDir));
@@ -416,7 +420,7 @@ public class FormulaFactory {
     public static Optional<Map<String, Object>> getFormulaLayoutByName(String name) {
         String layoutFilePath = name + File.separator + LAYOUT_FILE;
         File layoutFileStandalone = new File(METADATA_DIR_STANDALONE_SALT + layoutFilePath);
-        File layoutFileManager = new File(METADATA_DIR_MANAGER + layoutFilePath);
+        File layoutFileManager = new File(metadataDirManager + layoutFilePath);
         File layoutFileCustom = new File(METADATA_DIR_CUSTOM + layoutFilePath);
 
         try {
@@ -754,7 +758,7 @@ public class FormulaFactory {
     public static Map<String, Object> getMetadata(String name) {
         String metadataFilePath = name + File.separator + METADATA_FILE;
         File metadataFileStandalone = new File(METADATA_DIR_STANDALONE_SALT + metadataFilePath);
-        File metadataFileManager = new File(METADATA_DIR_MANAGER + metadataFilePath);
+        File metadataFileManager = new File(metadataDirManager + metadataFilePath);
         File metadataFileCustom = new File(METADATA_DIR_CUSTOM + metadataFilePath);
         try {
             if (metadataFileStandalone.isFile()) {
@@ -796,7 +800,7 @@ public class FormulaFactory {
     public static Map<String, Object> getPillarExample(String name) {
         String pillarExamplePath = name + File.separator + PILLAR_EXAMPLE_FILE;
         File pillarExampleFileStandalone = new File(METADATA_DIR_STANDALONE_SALT + pillarExamplePath);
-        File pillarExampleFileManager = new File(METADATA_DIR_MANAGER + pillarExamplePath);
+        File pillarExampleFileManager = new File(metadataDirManager + pillarExamplePath);
         File pillarExampleFileCustom = new File(METADATA_DIR_CUSTOM + pillarExamplePath);
 
         try {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/formula/FormulaHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/formula/FormulaHandler.java
@@ -237,7 +237,7 @@ public class FormulaHandler extends BaseHandler {
                 Object> content) throws IOFaultException, InvalidParameterException {
         try {
             FormulaManager manager = FormulaManager.getInstance();
-            boolean assigned = manager.hasSystemFormulaAssigned(formulaName, systemId);
+            boolean assigned = manager.hasSystemFormulaAssignedCombined(formulaName, systemId);
             if (assigned) {
                 manager.validateInput(formulaName, content);
                 manager.saveServerFormulaData(loggedInUser, systemId.longValue(), formulaName, content);

--- a/java/code/src/com/redhat/rhn/manager/formula/FormulaManager.java
+++ b/java/code/src/com/redhat/rhn/manager/formula/FormulaManager.java
@@ -14,6 +14,8 @@
  */
 package com.redhat.rhn.manager.formula;
 
+import static com.redhat.rhn.domain.formula.FormulaFactory.PROMETHEUS_EXPORTERS;
+
 import com.redhat.rhn.domain.formula.FormulaFactory;
 import com.redhat.rhn.domain.server.ManagedServerGroup;
 import com.redhat.rhn.domain.server.MinionServer;
@@ -286,15 +288,13 @@ public class FormulaManager {
     }
 
     /**
-     * Check if the given formula is assigned to the specified system
+     * Check if the given formula is assigned to the specified server considering group assignments as well.
      * @param formulaName formulaName
      * @param systemId systemId
      * @return True/False based upon if all of the systems has formulas assigned to them
      */
-    public boolean hasSystemFormulaAssigned(String formulaName, Integer systemId) {
-        return FormulaFactory
-                        .getCombinedFormulasByServerId(systemId.longValue())
-                        .contains(formulaName);
+    public boolean hasSystemFormulaAssignedCombined(String formulaName, Integer systemId) {
+        return FormulaFactory.getCombinedFormulasByServerId(systemId.longValue()).contains(formulaName);
     }
 
     /**
@@ -306,6 +306,16 @@ public class FormulaManager {
     public boolean hasGroupFormulaAssigned(String formulaName, Long groupId) {
         return FormulaFactory.getFormulasByGroupId(groupId).contains(formulaName);
 
+    }
+
+    /**
+     * Check for a given server if cleanup is needed on removal of the monitoring entitlement.
+     * @param server the given server
+     * @return true if cleanup is needed, false otherwise
+     */
+    public boolean isMonitoringCleanupNeeded(MinionServer server) {
+        return FormulaFactory.getFormulasByMinionId(server.getMinionId()).contains(PROMETHEUS_EXPORTERS) ||
+                FormulaFactory.isMemberOfGroupHavingMonitoring(server);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/formula/FormulaManager.java
+++ b/java/code/src/com/redhat/rhn/manager/formula/FormulaManager.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
 /**
  * Singleton class, validates and save formulas' data.
  */
@@ -53,13 +54,13 @@ public class FormulaManager {
      *
      * @return instance
      */
-
     public static synchronized FormulaManager getInstance() {
         if (instance == null) {
             instance = new FormulaManager();
         }
         return instance;
     }
+
     /**
      * This method is only for testing purpose.
      * @param saltServiceIn to set
@@ -305,7 +306,6 @@ public class FormulaManager {
      */
     public boolean hasGroupFormulaAssigned(String formulaName, Long groupId) {
         return FormulaFactory.getFormulasByGroupId(groupId).contains(formulaName);
-
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/formula/test/FormulaManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/formula/test/FormulaManagerTest.java
@@ -14,15 +14,19 @@
  */
 package com.redhat.rhn.manager.formula.test;
 
-import com.redhat.rhn.common.hibernate.LookupException;
+import static com.redhat.rhn.domain.formula.FormulaFactory.PROMETHEUS_EXPORTERS;
+
 import com.redhat.rhn.common.security.PermissionException;
 import com.redhat.rhn.domain.formula.FormulaFactory;
 import com.redhat.rhn.domain.server.ManagedServerGroup;
 import com.redhat.rhn.domain.server.MinionServer;
+import com.redhat.rhn.domain.server.ServerGroup;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
+import com.redhat.rhn.domain.server.test.ServerGroupTest;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.formula.FormulaManager;
 import com.redhat.rhn.manager.formula.InvalidFormulaException;
+import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.testing.ServerGroupTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
@@ -30,11 +34,22 @@ import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.salt.netapi.datatypes.target.MinionList;
 import com.suse.utils.Json;
+
+import org.apache.commons.io.IOUtils;
 import org.cobbler.test.MockConnection;
 import org.jmock.Expectations;
 import org.jmock.lib.legacy.ClassImposteriser;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 
@@ -50,6 +65,12 @@ public class FormulaManagerTest extends JMockBaseTestCaseWithUser {
     static final String formulaName = "dhcpd";
     private SaltService saltServiceMock;
     private FormulaManager manager = FormulaManager.getInstance();
+    private Path metadataDir;
+
+    public FormulaManagerTest() throws Exception {
+        metadataDir = Files.createTempDirectory("metadata");
+        createMetadataFiles();
+    }
 
     @Override
     public void setUp() throws Exception {
@@ -160,6 +181,62 @@ public class FormulaManagerTest extends JMockBaseTestCaseWithUser {
             fail( "Exception expected but didn't throw" );
         } catch (PermissionException ex) {
             //expected exception
+        }
+    }
+
+    /**
+     * Test the conditions in FormulaManager.isMonitoringCleanupNeeded().
+     * @throws Exception
+     */
+    public void testIsMonitoringCleanupNeeded() throws Exception {
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
+        FormulaFactory.setDataDir(tmpSaltRoot.resolve(TEMP_PATH).toString());
+        FormulaFactory.setMetadataDirOfficial(metadataDir.toString() + File.separator);
+
+        // No group or system level assignment of the `prometheus-exporters` Formula
+        assertFalse(manager.isMonitoringCleanupNeeded(minion));
+
+        // Create a group level assignment of the Formula
+        ServerGroup group = ServerGroupTest.createTestServerGroup(user.getOrg(), null);
+        SystemManager.addServerToServerGroup(minion, group);
+        FormulaFactory.saveGroupFormulas(group.getId(), Arrays.asList(PROMETHEUS_EXPORTERS), user.getOrg());
+
+        // Save data that enables monitoring
+        Map<String, Object> formulaData = new HashMap<>();
+        formulaData.put("node_exporter", Collections.singletonMap("enabled", true));
+        formulaData.put("postgres_exporter", Collections.singletonMap("enabled", false));
+        formulaData.put("apache_exporter", Collections.singletonMap("enabled", false));
+        FormulaFactory.saveGroupFormulaData(formulaData, group.getId(), user.getOrg(), PROMETHEUS_EXPORTERS);
+        assertTrue(manager.isMonitoringCleanupNeeded(minion));
+
+        // Save data that disables monitoring
+        formulaData.put("node_exporter", Collections.singletonMap("enabled", false));
+        formulaData.put("postgres_exporter", Collections.singletonMap("enabled", false));
+        formulaData.put("apache_exporter", Collections.singletonMap("enabled", false));
+        FormulaFactory.saveGroupFormulaData(formulaData, group.getId(), user.getOrg(), PROMETHEUS_EXPORTERS);
+        assertFalse(manager.isMonitoringCleanupNeeded(minion));
+
+        // Create a system level assignment of the Formula
+        FormulaFactory.saveServerFormulas(minion.getMinionId(), Arrays.asList(PROMETHEUS_EXPORTERS));
+        FormulaFactory.saveServerFormulaData(formulaData, minion.getMinionId(), PROMETHEUS_EXPORTERS);
+        assertTrue(manager.isMonitoringCleanupNeeded(minion));
+    }
+
+    // Copy the pillar.example file to a temp dir used as metadata directory (in FormulaFactory)
+    private void createMetadataFiles() {
+        try {
+            Path prometheusDir = metadataDir.resolve("prometheus-exporters");
+            Files.createDirectories(prometheusDir);
+            try (
+                InputStream src = this.getClass().getResourceAsStream("prometheus-exporters-pillar.example");
+                OutputStream dst = new FileOutputStream(prometheusDir.resolve("pillar.example").toFile())
+            ) {
+                IOUtils.copy(src, dst);
+            }
+        }
+        catch (IOException e) {
+            e.printStackTrace();
+            fail(e.getMessage());
         }
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/formula/test/prometheus-exporters-pillar.example
+++ b/java/code/src/com/redhat/rhn/manager/formula/test/prometheus-exporters-pillar.example
@@ -1,0 +1,12 @@
+node_exporter:
+  enabled: True
+  args: --web.listen-address=":9100"
+
+apache_exporter:
+  enabled: False
+  args: --telemetry.address=":9117"
+
+postgres_exporter:
+  enabled: False
+  data_source_name: postgresql://user:passwd@localhost:5432/database?sslmode=disable
+  args: --web.listen-address=":9187"

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -2273,10 +2273,9 @@ public class SystemManager extends BaseManager {
         ServerFactory.lookupById(sid).asMinionServer().ifPresent(s -> {
             SystemManager.refreshPillarDataForMinion(s);
 
-            // Configure the monitoring formula for cleanup if still assigned (disable exporters)
+            // Configure prometheus-exporters for cleanup (disable all exporters) if applicable
             if (EntitlementManager.MONITORING.equals(ent)) {
-                FormulaManager formulas = FormulaManager.getInstance();
-                if (formulas.hasSystemFormulaAssigned(PROMETHEUS_EXPORTERS, sid.intValue())) {
+                if (FormulaManager.getInstance().isMonitoringCleanupNeeded(s)) {
                     try {
                         // Get the current data and set all exporters to disabled
                         String minionId = s.getMinionId();

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix a problem with removing the monitoring entitlement from a system
 - Introduce CLM AppStream filters for RHEL 8 support
 - kickstart --nobase option was removed in version F22. Do not use it
   for RHEL8


### PR DESCRIPTION
## What does this PR change?

This patch fixes a problem with removing the monitoring entitlement from a system: server formula data was written for cleanup (disablement) even though group formulas were being used (as described in https://github.com/SUSE/spacewalk/issues/10033).

The new code will trigger a system level cleanup via pillar data only if either:

- The `prometheus-exporters` Formula is still assigned on the system level at the time of entitlement removal.
- There is a group level assignment with monitoring enabled, i.e. at least one exporter is enabled.

## GUI diff

No difference.

- [X] **DONE**

## Documentation

- No documentation needed: internal bugfix.

- [X] **DONE**

## Test coverage

- TODO: Add unit tests.

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/10033.

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"   		 
- [ ] Re-run test "java_pgsql_tests"   		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
