### PR TITLE
Virt tiny UI fixes

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -3774,6 +3774,6 @@ public class SystemManager extends BaseManager {
         Map<String, Object> pillar = new HashMap<>();
         pillar.put("virt_entitled", minion.hasVirtualizationEntitlement());
         saltServiceInstance.callSync(State.apply(Collections.singletonList("virt.engine-events"),
-                                                 Optional.of(pillar)), minion.getName());
+                                                 Optional.of(pillar)), minion.getMinionId());
     }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix minion id when applying engine-events state (bsc#1158181)
 - Prevent ISE and warn disable deletion of a Content Lifecycle channel in use (bsc#1158012)
 - Remove unnecessary WARN log entries from Kubernetes integration
 

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,5 @@
+- Fix rhnActionVirtDelete when migrating from 3.2 to 4.0 (bsc#1158178)
+
 -------------------------------------------------------------------
 Wed Nov 27 17:07:32 CET 2019 - jgonzalez@suse.com
 

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.1-to-susemanager-schema-4.0.2/006-add_rhnVirtActionDelete.sql.postgresql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.1-to-susemanager-schema-4.0.2/006-add_rhnVirtActionDelete.sql.postgresql
@@ -6,7 +6,11 @@ CREATE TABLE IF NOT EXISTS rhnActionVirtDelete
                        REFERENCES rhnAction (id)
                        ON DELETE CASCADE
                     CONSTRAINT rhn_avdl_aid_pk PRIMARY KEY,
-    uuid       VARCHAR(128) NOT NULL
+    uuid       VARCHAR(128) NOT NULL,
+    created    TIMESTAMPTZ
+               DEFAULT (current_timestamp) NOT NULL,
+    modified   TIMESTAMPTZ
+               DEFAULT (current_timestamp) NOT NULL
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS rhn_avdl_aid_uq

--- a/susemanager-utils/susemanager-sls/salt/virt/engine-events.sls
+++ b/susemanager-utils/susemanager-sls/salt/virt/engine-events.sls
@@ -5,6 +5,9 @@
         engines:
           - libvirt_events
 
+/var/cache/virt_state.cache:
+  file.absent
+
 {% else %}
 
 /etc/salt/minion.d/libvirt-events.conf:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Remove the virt-poller cache when applying Virtualization entitlement
 - Force HTTP request timeout on public cloud grain (bsc#1157975)
 
 -------------------------------------------------------------------

--- a/web/html/src/manager/virtualization/guests/console/guests-console.js
+++ b/web/html/src/manager/virtualization/guests/console/guests-console.js
@@ -164,12 +164,14 @@ class GuestsConsole extends React.Component<Props, State> {
           </div>
           <ul className="nav navbar-nav navbar-utility">
             <li>
-              <Button
-                title={t("Toggle full size")}
-                icon={this.state.expanded ? 'fa-compress' : 'fa-expand'}
-                handler={this.toggleScale}
-                disabled={!this.state.connected || !canResize}
-              />
+              {this.props.graphicsType === 'vnc' && (
+                <Button
+                  title={t("Toggle full size")}
+                  icon={this.state.expanded ? 'fa-compress' : 'fa-expand'}
+                  handler={this.toggleScale}
+                  disabled={!this.state.connected || !canResize}
+                />
+              )}
             </li>
           </ul>
         </header>

--- a/web/html/src/manager/virtualization/guests/create/guests-create.js
+++ b/web/html/src/manager/virtualization/guests/create/guests-create.js
@@ -57,7 +57,7 @@ class GuestsCreate extends React.Component<Props, State> {
     disk0_type: 'file',
     disk0_device: 'disk',
     network0_type: 'network',
-    graphicsType: 'spice',
+    graphicsType: 'vnc',
   })
 
   render() {

--- a/web/html/src/manager/virtualization/guests/list/guests-list.js
+++ b/web/html/src/manager/virtualization/guests/list/guests-list.js
@@ -388,7 +388,7 @@ class GuestsList extends React.Component<Props, State> {
                                 {state !== 'stopped' && row.name !== 'Domain-0'
                                  && this.createModalButton('shutdown', modalsData, row) }
                                 {(state === 'paused' || state === 'running') && this.createModalButton('restart', modalsData, row) }
-                                {state === 'running' && (
+                                {this.props.saltEntitled && state === 'running' && (
                                   <LinkButton
                                     title={t('Graphical Console')}
                                     className="btn-default btn-sm"


### PR DESCRIPTION
## What does this PR change?

Fixes minor UI glitches in the VM management.

## GUI diff

Before:

 * The Graphical Console was displayed for both Salt minions and traditional systems, but only supported for salt minions
 * The fullscreen toggle button for Spice even disabled was too misleading: hidding it for spice
 * VM creation dialog defaults to spice

After:

 * The Graphical Console is now hidden for traditional systems
 * The fullscreen toggle button is hidden for Spice
 * Since spice-html5 is not super good, default newly created VMs to VNC

- [X] **DONE**

## Documentation
- No documentation needed: so tiny that there is no doc impact

- [X] **DONE**

## Test coverage
- No tests: not affecting the tests

- [X] **DONE**

## Links

Fixes:
 * SUSE/spacewalk#9343
 * Part of SUSE/spacewalk#9345

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
