### PR TITLE
Adapt to new HTML layout in setup wizard

### DIFF
--- a/testsuite/features/core/allcli_sanity.feature
+++ b/testsuite/features/core/allcli_sanity.feature
@@ -48,6 +48,7 @@ Feature: Sanity checks
 
   Scenario: The external resources can be reached
     Then it should be possible to download the file "http://download.suse.de/ibs/SUSE/Products/SLE-SERVER/12-SP4/x86_64/product/media.1/products.key"
+    And it should be possible to download the file "https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Updates/rpm/repodata/repomd.xml"
     And it should be possible to download the file "https://gitlab.suse.de/galaxy/suse-manager-containers/blob/master/test-profile/Dockerfile"
     And it should be possible to download the file "https://github.com/uyuni-project/uyuni/blob/master/README.md"
     And it should be possible to reach the portus registry

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -415,7 +415,7 @@ When(/^I select the addon "(.*?)"$/) do |addon|
 end
 
 And(/^I should see that the "(.*?)" product is "(.*?)"$/) do |product, recommended|
-  xpath = "//span[text()[normalize-space(.) = '#{product}'] and ./span/text() = '#{recommended}']"
+  xpath = "//span[span[1] = '#{product}' and span[3] = '#{recommended}']"
   raise "xpath: #{xpath} not found" unless find(:xpath, xpath)
 end
 


### PR DESCRIPTION
## What does this PR change?

This PR does two things:

* it adds a new sanity check to check connectivity to `download.opensuse.org`
* it adapts the "recommended" product test in setup wizard
   (the product name is now in a `<span>` of its own)

Note: we did not see last problem because reposync stage was disabled. We need this PR before we reenable reposync.

## Links

Ports:
* 3.2: SUSE/spacewalk#10174 
* 4.0: SUSE/spacewalk#10173 

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
