### PR TITLE
Force timeout for HTTP requests on public cloud grain (bsc#1157975)

### DIFF
--- a/susemanager-utils/susemanager-sls/src/grains/public_cloud.py
+++ b/susemanager-utils/susemanager-sls/src/grains/public_cloud.py
@@ -54,9 +54,21 @@ def __virtual__():
         return False
 
     def _do_api_request(data):
-        return {
-            data[0]: http.query(data[1], status=True, header_dict=data[2], raise_error=False)
+        opts = {
+            'http_connect_timeout': 0.1,
+            'http_request_timeout': 0.1,
         }
+        try:
+            ret = {
+                data[0]: http.query(data[1],
+                                    status=True,
+                                    header_dict=data[2],
+                                    raise_error=False,
+                                    opts=opts)
+            }
+        except:
+            ret = { data[0]: dict() }
+        return ret
 
     api_check_dict = [
         ('amazon', os.path.join(HOST, AMAZON_URL_PATH), None),
@@ -80,13 +92,13 @@ def __virtual__():
     for i in results:
         api_ret.update(i)
 
-    if api_ret['amazon'].get('status') == 200 and "instance-id" in api_ret['amazon']['body']:
+    if api_ret['amazon'].get('status', 0) == 200 and "instance-id" in api_ret['amazon']['body']:
         INSTANCE_ID = http.query(os.path.join(HOST, AMAZON_URL_PATH, 'instance-id'), raise_error=False)['body']
         return True
-    elif api_ret['azure'].get('status') == 200 and "vmId" in api_ret['azure']['body']:
+    elif api_ret['azure'].get('status', 0) == 200 and "vmId" in api_ret['azure']['body']:
         INSTANCE_ID = http.query(os.path.join(HOST, AZURE_URL_PATH, 'vmId') + AZURE_API_ARGS, header_dict={"Metadata":"true"}, raise_error=False)['body']
         return True
-    elif api_ret['google'].get('status') == 200 and "id" in api_ret['google']['body']:
+    elif api_ret['google'].get('status', 0) == 200 and "id" in api_ret['google']['body']:
         INSTANCE_ID = http.query(os.path.join(HOST, GOOGLE_URL_PATH, 'id'), header_dict={"Metadata-Flavor": "Google"}, raise_error=False)['body']
         return True
 

--- a/susemanager-utils/susemanager-sls/src/grains/public_cloud.py
+++ b/susemanager-utils/susemanager-sls/src/grains/public_cloud.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-                                                                                                                                                      
+# -*- coding: utf-8 -*-
 '''
 Copyright (c) 2019 SUSE LLC
 

--- a/susemanager-utils/susemanager-sls/src/grains/public_cloud.py
+++ b/susemanager-utils/susemanager-sls/src/grains/public_cloud.py
@@ -73,6 +73,8 @@ def __virtual__():
        pool.close()
        pool.join()
     except Exception as exc:
+       import traceback
+       log.error(traceback.format_exc())
        log.error("Exception while creating a ThreadPool for accessing metadata API: %s", exc)
 
     for i in results:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- Force HTTP request timeout on public cloud grain (bsc#1157975)
+
 -------------------------------------------------------------------
 Wed Nov 27 17:08:25 CET 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue that might happen executing `public_cloud.py` grain and the HTTP socket for internal metadata API at `169.254.169.254` is available but there is no actual HTTP response (request timedout)

Without this PR, the minion gets stuck for some seconds until the HTTP requests are timedout and also produces some error messages in the log files:

```console
slepos-virt-18:~ # time salt-call test.ping
[ERROR   ] Exception while creating a ThreadPool for accessing metadata API: object of type 'NoneType' has no len()
[ERROR   ] Exception raised when processing __virtual__ function for salt.loaded.ext.grains.public_cloud. Module will not be loaded: 'amazon'
[WARNING ] salt.loaded.ext.grains.public_cloud.__virtual__() is wrongly returning `None`. It should either return `True`, `False` or a new name. If you're the developer of the module 'public_cloud', please fix this.
local:
    True

real	0m16,791s
user	0m3,884s
sys	0m0,133s
slepos-virt-18:~ #
```

After this PR, the polling HTTP requests are set to be timedout within 0.1 seconds. This way we prevent the minion to stuck for some seconds while waiting those requests to release as timedout. Also makes possible exceptions properly logged:

```console
slepos-virt-18:~ # time salt-call test.ping
local:
    True

real	0m4,526s
user	0m3,797s
sys	0m0,149s
slepos-virt-18:~ # 
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bug fix**

- [x] **DONE**

## Test coverage
- No tests: **bugfix**

- [x] **DONE**

## Links

Tracks: https://github.com/SUSE/spacewalk/issues/10181

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
