### PR TITLE
Hide CSS details in step definitions

### DIFF
--- a/testsuite/features/core/srv_products_page.feature
+++ b/testsuite/features/core/srv_products_page.feature
@@ -19,7 +19,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I see "Product Description" text
-    And I enter "RHEL Expanded Support 7" in the css "input[name='product-description-filter']"
+    And I enter "RHEL Expanded Support 7" as the filtered product description
     Then I should see a "RHEL Expanded Support 7" text
 
 @scc_credentials
@@ -27,7 +27,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I see "Product Description" text
-    And I enter "SUSE Linux Enterprise Server for SAP All-in-One 11 SP2" in the css "input[name='product-description-filter']"
+    And I enter "SUSE Linux Enterprise Server for SAP All-in-One 11 SP2" as the filtered product description
     And I click the channel list of product "SUSE Linux Enterprise Server for SAP All-in-One 11 SP2"
     Then I should see a "Product Channels" text
     And I should see a "Mandatory Channels" text
@@ -38,7 +38,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I see "Product Description" text
-    And I enter "SUSE Linux Enterprise Server 12 SP2" in the css "input[name='product-description-filter']"
+    And I enter "SUSE Linux Enterprise Server 12 SP2" as the filtered product description
     And I select "x86_64" in the dropdown list of the architecture filter
     And I select "SUSE Linux Enterprise Server 12 SP2 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Server 12 SP2 x86_64" selected
@@ -56,7 +56,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I see "Product Description" text
-    And I enter "SUSE Linux Enterprise Server 15" in the css "input[name='product-description-filter']"
+    And I enter "SUSE Linux Enterprise Server 15" as the filtered product description
     And I select "x86_64" in the dropdown list of the architecture filter
     And I open the sub-list of the product "SUSE Linux Enterprise Server 15 x86_64"
     Then I should see a "Basesystem Module 15 x86_64" text

--- a/testsuite/features/core/trad_register_client.feature
+++ b/testsuite/features/core/trad_register_client.feature
@@ -13,7 +13,7 @@ Feature: Register a traditional client
   Scenario: Check registration values
     Given I update the profile of this client
     When I am on the Systems overview page of this "sle-client"
-    And I click on the css "a#clear-ssm"
+    And I click on the clear SSM button
     And I wait until I see "Software Updates Available" text, refreshing the page
     Then I should see a "System Status" text
     And I should see a "Software Updates Available" text

--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -17,14 +17,14 @@ Feature: Synchronize products in the products page of the Setup Wizard
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I see "Product Description" text
-    And I enter "RHEL Expanded Support 7" in the css "input[name='product-description-filter']"
+    And I enter "RHEL Expanded Support 7" as the filtered product description
     Then I should see a "RHEL Expanded Support 7" text
 
   Scenario: View the channels list in the products page
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I see "Product Description" text
-    And I enter "SUSE Linux Enterprise Server for SAP All-in-One 11 SP2" in the css "input[name='product-description-filter']"
+    And I enter "SUSE Linux Enterprise Server for SAP All-in-One 11 SP2" as the filtered product description
     And I click the channel list of product "SUSE Linux Enterprise Server for SAP All-in-One 11 SP2"
     Then I should see a "Product Channels" text
     And I should see a "Mandatory Channels" text
@@ -34,7 +34,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I see "Product Description" text
-    And I enter "SUSE Linux Enterprise Server 12 SP2" in the css "input[name='product-description-filter']"
+    And I enter "SUSE Linux Enterprise Server 12 SP2" as the filtered product description
     And I select "x86_64" in the dropdown list of the architecture filter
     And I select "SUSE Linux Enterprise Server 12 SP2 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Server 12 SP2 x86_64" selected
@@ -50,7 +50,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
   Scenario: Add a product with recommended enabled
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I see "Product Description" text
-    And I enter "SUSE Linux Enterprise Server 15" in the css "input[name='product-description-filter']"
+    And I enter "SUSE Linux Enterprise Server 15" as the filtered product description
     And I select "x86_64" in the dropdown list of the architecture filter
     And I open the sub-list of the product "SUSE Linux Enterprise Server 15 x86_64"
     Then I should see a "Basesystem Module 15 x86_64" text

--- a/testsuite/features/secondary/min_action_chain.feature
+++ b/testsuite/features/secondary/min_action_chain.feature
@@ -21,8 +21,8 @@ Feature: Action chains on Salt minions
     Given I am on the Systems overview page of this "sle-minion"
     When I follow "Software" in the content area
     And I follow "List / Remove" in the content area
-    And I enter "andromeda-dummy" in the css "input[placeholder='Filter by Package Name: ']"
-    And I click on the css "button.spacewalk-button-filter" until page does contain "andromeda-dummy-1.0" text
+    And I enter "andromeda-dummy" as the filtered package name
+    And I click on the filter button until page does contain "andromeda-dummy-1.0" text
 
   Scenario: Pre-requisite: ensure the errata cache is computed before testing on Salt minion
     Given I am authorized as "admin" with password "admin"
@@ -52,8 +52,8 @@ Feature: Action chains on Salt minions
     Given I am on the Systems overview page of this "sle-minion"
     When I follow "Software" in the content area
     And I follow "List / Remove" in the content area
-    And I enter "milkyway-dummy" in the css "input[placeholder='Filter by Package Name: ']"
-    And I click on the css "button.spacewalk-button-filter"
+    And I enter "milkyway-dummy" as the filtered package name
+    And I click on the filter button
     And I check "milkyway-dummy" in the list
     And I click on "Remove Packages"
     And I check radio button "schedule-by-action-chain"
@@ -197,8 +197,8 @@ Feature: Action chains on Salt minions
     And I am on System Set Manager Overview
     And I follow "Install" in the content area
     And I follow "Test-Channel-x86_64" in the content area
-    And I enter "andromeda-dummy" in the css "input[placeholder='Filter by Package Name: ']"
-    And I click on the css "button.spacewalk-button-filter"
+    And I enter "andromeda-dummy" as the filtered package name
+    And I click on the filter button
     And I check "andromeda-dummy" in the list
     And I click on "Install Selected Packages"
     Then I should see "sle-minion" hostname

--- a/testsuite/features/secondary/min_docker_auth_registry.feature
+++ b/testsuite/features/secondary/min_docker_auth_registry.feature
@@ -38,7 +38,7 @@ Feature: Build image with authenticated registry
     When I follow the left menu "Images > Profiles"
     And I check the row with the "portus_profile" text
     And I click on "Delete"
-    And I click on the css "button.btn-danger"
+    And I click on the red confirmation button
     And I should see a "Image profile has been deleted." text
 
   Scenario: Cleanup: remove authenticated image store
@@ -46,7 +46,7 @@ Feature: Build image with authenticated registry
     When I follow the left menu "Images > Stores"
     And I check the row with the "portus" text
     And I click on "Delete"
-    And I click on the css "button.btn-danger"
+    And I click on the red confirmation button
     And I should see a "Image store has been deleted." text
 
   Scenario: Cleanup: delete portus image

--- a/testsuite/features/secondary/min_salt_install_package.feature
+++ b/testsuite/features/secondary/min_salt_install_package.feature
@@ -17,8 +17,8 @@ Feature: Install a patch on the client via Salt through the UI
     Given I am on the Systems overview page of this "sle-minion"
     When I follow "Software" in the content area
     And I follow "List / Remove" in the content area
-    And I enter "virgo-dummy" in the css "input[placeholder='Filter by Package Name: ']"
-    And I click on the css "button.spacewalk-button-filter" until page does contain "virgo-dummy" text
+    And I enter "virgo-dummy" as the filtered package name
+    And I click on the filter button until page does contain "virgo-dummy" text
     When I follow the left menu "Admin > Task Schedules"
     And I follow "errata-cache-default"
     And I follow "errata-cache-bunch"

--- a/testsuite/features/secondary/min_salt_install_with_staging.feature
+++ b/testsuite/features/secondary/min_salt_install_with_staging.feature
@@ -69,11 +69,11 @@ Feature: Install a package on the minion with staging enabled
     Given I am on the Systems overview page of this "sle-minion"
     When I follow "Software" in the content area
     And I follow "List / Remove"
-    And I enter "orion-dummy" in the css "input[placeholder='Filter by Package Name: ']"
-    And I click on the css "button.spacewalk-button-filter"
+    And I enter "orion-dummy" as the filtered package name
+    And I click on the filter button
     And I check "orion-dummy" in the list
-    And I enter "virgo-dummy" in the css "input[placeholder='Filter by Package Name: ']"
-    And I click on the css "button.spacewalk-button-filter"
+    And I enter "virgo-dummy" as the filtered package name
+    And I click on the filter button
     And I check "virgo-dummy" in the list
     And I click on "Remove Packages"
     And I click on "Confirm"

--- a/testsuite/features/secondary/min_salt_pkgset_beacon.feature
+++ b/testsuite/features/secondary/min_salt_pkgset_beacon.feature
@@ -18,34 +18,34 @@ Feature: System package list is updated if packages are manually installed or re
     Given I am on the Systems overview page of this "sle-minion"
     When I follow "Software" in the content area
     And I follow "List / Remove" in the content area
-    And I enter "milkyway-dummy" in the css "input[placeholder='Filter by Package Name: ']"
-    And I click on the css "button.spacewalk-button-filter" until page does contain "milkyway-dummy-1.0" text
-    When I follow the left menu "Admin > Task Schedules"
+    And I enter "milkyway-dummy" as the filtered package name
+    And I click on the filter button until page does contain "milkyway-dummy-1.0" text
+    And I follow the left menu "Admin > Task Schedules"
     And I follow "errata-cache-default"
     And I follow "errata-cache-bunch"
-    Then I click on "Single Run Schedule"
-    And I should see a "bunch was scheduled" text
-    Then I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows
+    And I click on "Single Run Schedule"
+    Then I should see a "bunch was scheduled" text
+    When I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows
 
   Scenario: Remove manually a package on a minion
     Given I am on the Systems overview page of this "sle-minion"
-    And I follow "Software" in the content area
+    When I follow "Software" in the content area
     And I follow "List / Remove"
-    And I enter "milkyway-dummy" in the css "input[placeholder='Filter by Package Name: ']"
-    And I click on the css "button.spacewalk-button-filter"
-    And I should see a "milkyway-dummy" text
-    Then I remove package "milkyway-dummy" from this "sle-minion"
-    And I click on the css "button.spacewalk-button-filter" until page does not contain "milkyway-dummy" text
+    And I enter "milkyway-dummy" as the filtered package name
+    And I click on the filter button
+    Then I should see a "milkyway-dummy" text
+    When I remove package "milkyway-dummy" from this "sle-minion"
+    And I click on the filter button until page does not contain "milkyway-dummy" text
 
   Scenario: Install manually a package on a minion
     Given I am on the Systems overview page of this "sle-minion"
-    And I follow "Software" in the content area
+    When I follow "Software" in the content area
     And I follow "List / Remove"
-    And I enter "milkyway-dummy" in the css "input[placeholder='Filter by Package Name: ']"
-    And I click on the css "button.spacewalk-button-filter"
-    And I should not see a "milkyway-dummy" text
-    Then I install package "milkyway-dummy" on this "sle-minion"
-    And I click on the css "button.spacewalk-button-filter" until page does not contain "milkyway-dummy" text
+    And I enter "milkyway-dummy" as the filtered package name
+    And I click on the filter button
+    Then I should not see a "milkyway-dummy" text
+    When I install package "milkyway-dummy" on this "sle-minion"
+    And I click on the filter button until page does not contain "milkyway-dummy" text
 
   Scenario: Cleanup: remove milkyway-dummy packages from SLES minion
     When I disable repository "test_repo_rpm_pool" on this "sle-minion"

--- a/testsuite/features/secondary/min_salt_software_states.feature
+++ b/testsuite/features/secondary/min_salt_software_states.feature
@@ -21,8 +21,8 @@ Feature: Salt package states
     Given I am on the Systems overview page of this "sle-minion"
     When I follow "Software" in the content area
     And I follow "List / Remove" in the content area
-    And I enter "andromeda-dummy" in the css "input[placeholder='Filter by Package Name: ']"
-    And I click on the css "button.spacewalk-button-filter" until page does contain "andromeda-dummy-1.0" text
+    And I enter "andromeda-dummy" as the filtered package name
+    And I click on the filter button until page does contain "andromeda-dummy-1.0" text
     When I follow the left menu "Admin > Task Schedules"
     And I follow "errata-cache-default"
     And I follow "errata-cache-bunch"

--- a/testsuite/features/secondary/minssh_action_chain.feature
+++ b/testsuite/features/secondary/minssh_action_chain.feature
@@ -26,8 +26,8 @@ Feature: Salt SSH action chain
     Given I am on the Systems overview page of this "ssh-minion"
     When I follow "Software" in the content area
     And I follow "List / Remove" in the content area
-    And I enter "andromeda-dummy" in the css "input[placeholder='Filter by Package Name: ']"
-    And I click on the css "button.spacewalk-button-filter" until page does contain "andromeda-dummy-1.0" text
+    And I enter "andromeda-dummy" as the filtered package name
+    And I click on the filter button until page does contain "andromeda-dummy-1.0" text
 
 @ssh_minion
   Scenario: Pre-requisite: ensure the errata cache is computed before testing on SSH minion
@@ -61,8 +61,8 @@ Feature: Salt SSH action chain
     Given I am on the Systems overview page of this "ssh-minion"
     When I follow "Software" in the content area
     And I follow "List / Remove" in the content area
-    And I enter "milkyway-dummy" in the css "input[placeholder='Filter by Package Name: ']"
-    And I click on the css "button.spacewalk-button-filter"
+    And I enter "milkyway-dummy" as the filtered package name
+    And I click on the filter button
     And I check "milkyway-dummy" in the list
     And I click on "Remove Packages"
     And I check radio button "schedule-by-action-chain"
@@ -222,8 +222,8 @@ Feature: Salt SSH action chain
     And I wait until I do not see "Package List Refresh scheduled by admin" text, refreshing the page
     And I follow "Software" in the content area
     And I follow "List / Remove" in the content area
-    And I enter "andromeda-dummy" in the css "input[placeholder='Filter by Package Name: ']"
-    And I click on the css "button.spacewalk-button-filter" until page does contain "andromeda-dummy-1.0" text
+    And I enter "andromeda-dummy" as the filtered package name
+    And I click on the filter button until page does contain "andromeda-dummy-1.0" text
     When I follow the left menu "Admin > Task Schedules"
     And I follow "errata-cache-default"
     And I follow "errata-cache-bunch"

--- a/testsuite/features/secondary/minssh_centos_salt_install_package_and_patch.feature
+++ b/testsuite/features/secondary/minssh_centos_salt_install_package_and_patch.feature
@@ -34,8 +34,8 @@ Feature: Install a patch on the CentOS SSH minion via Salt through the UI
     Given I am on the Systems overview page of this "ceos-ssh-minion"
     When I follow "Software" in the content area
     And I follow "List / Remove" in the content area
-    And I enter "virgo-dummy" in the css "input[placeholder='Filter by Package Name: ']"
-    And I click on the css "button.spacewalk-button-filter" until page does contain "virgo-dummy" text
+    And I enter "virgo-dummy" as the filtered package name
+    And I click on the filter button until page does contain "virgo-dummy" text
     When I follow the left menu "Admin > Task Schedules"
     And I follow "errata-cache-default"
     And I follow "errata-cache-bunch"
@@ -46,7 +46,7 @@ Feature: Install a patch on the CentOS SSH minion via Salt through the UI
 @centos_minion
   Scenario: Install a patch on the Centos SSH minion
     Given I am on the Systems overview page of this "ceos-ssh-minion"
-    And I follow "Software" in the content area
+    When I follow "Software" in the content area
     And I follow "Patches" in the content area
     When I check "virgo-dummy-3456" in the list
     And I click on "Apply Patches"
@@ -58,7 +58,7 @@ Feature: Install a patch on the CentOS SSH minion via Salt through the UI
 @centos_minion
   Scenario: Install a package on the Centos SSH minion
     Given I am on the Systems overview page of this "ceos-ssh-minion"
-    And I follow "Software" in the content area
+    When I follow "Software" in the content area
     And I follow "Install"
     And I check "andromeda-dummy" in the list
     And I click on "Install Selected Packages"
@@ -69,13 +69,13 @@ Feature: Install a patch on the CentOS SSH minion via Salt through the UI
 @centos_minion
   Scenario: Cleanup: remove virgo-dummy and andromeda-dummy packages from Centos SSH minion
     Given I am on the Systems overview page of this "ceos-ssh-minion"
-    And I follow "Software" in the content area
+    When I follow "Software" in the content area
     And I follow "List / Remove"
-    And I enter "andromeda" in the css "input[placeholder='Filter by Package Name: ']"
-    And I click on the css "button.spacewalk-button-filter"
+    And I enter "andromeda" as the filtered package name
+    And I click on the filter button
     And I check "andromeda-dummy" in the list
-    And I enter "virgo-dummy" in the css "input[placeholder='Filter by Package Name: ']"
-    And I click on the css "button.spacewalk-button-filter"
+    And I enter "virgo-dummy" as the filtered package name
+    And I click on the filter button
     And I check "virgo-dummy" in the list
     And I click on "Remove Packages"
     And I click on "Confirm"

--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -271,8 +271,8 @@ Feature: PXE boot a Retail terminal
     Given I am on the Systems overview page of this "pxeboot-minion"
     And I follow "Software" in the content area
     And I follow "List / Remove"
-    And I enter "virgo" in the css "input[placeholder='Filter by Package Name: ']"
-    And I click on the css "button.spacewalk-button-filter"
+    And I enter "virgo" as the filtered package name
+    And I click on the filter button
     And I check "virgo-dummy-2.0-1.1" in the list
     And I click on "Remove Packages"
     And I click on "Confirm"
@@ -456,8 +456,8 @@ Feature: PXE boot a Retail terminal
     And I follow "pxeboot" terminal
     And I follow "Software" in the content area
     And I follow "List / Remove"
-    And I enter "virgo" in the css "input[placeholder='Filter by Package Name: ']"
-    And I click on the css "button.spacewalk-button-filter"
+    And I enter "virgo" as the filtered package name
+    And I click on the filter button
     And I check "virgo-dummy-2.0-1.1" in the list
     And I click on "Remove Packages"
     And I click on "Confirm"

--- a/testsuite/features/secondary/srv_docker_advanced_content_management.feature
+++ b/testsuite/features/secondary/srv_docker_advanced_content_management.feature
@@ -41,7 +41,7 @@ Feature: Advanced content management
     When I follow the left menu "Images > Profiles"
     And I check the row with the "suse_docker_admin" text
     And I click on "Delete"
-    And I click on the css "button.btn-danger"
+    And I click on the red confirmation button
     And I should see a "Image profile has been deleted." text
 
   Scenario: Cleanup: remove image store
@@ -49,7 +49,7 @@ Feature: Advanced content management
     When I follow the left menu "Images > Stores"
     And I check the row with the "docker_admin" text
     And I click on "Delete"
-    And I click on the css "button.btn-danger"
+    And I click on the red confirmation button
     And I should see a "Image store has been deleted." text
 
   Scenario: Cleanup: delete no role user

--- a/testsuite/features/secondary/srv_patches_page.feature
+++ b/testsuite/features/secondary/srv_patches_page.feature
@@ -79,8 +79,8 @@ Feature: Patches page
     Given I am on the patches page
     When I follow the left menu "Patches > Patch List > All"
     And I follow "Bugfix Patches" in the content area
-    And I enter "Test Patch" in the css "input[placeholder='Filter by Synopsis: ']"
-    And I click on the css "button.spacewalk-button-filter"
+    And I enter "Test Patch" as the filtered synopsis
+    And I click on the filter button
     And I follow "Test Advisory"
     Then I should see a "Test Patch" text
     And I should see a "test@test.org" text

--- a/testsuite/features/secondary/trad_action_chain.feature
+++ b/testsuite/features/secondary/trad_action_chain.feature
@@ -63,8 +63,8 @@ Feature: Action chain on traditional clients
     Given I am on the Systems overview page of this "sle-client"
     When I follow "Software" in the content area
     And I follow "List / Remove" in the content area
-    And I enter "milkyway-dummy" in the css "input[placeholder='Filter by Package Name: ']"
-    And I click on the css "button.spacewalk-button-filter"
+    And I enter "milkyway-dummy" as the filtered package name
+    And I click on the filter button
     And I check "milkyway-dummy" in the list
     And I click on "Remove Packages"
     And I check radio button "schedule-by-action-chain"

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -209,29 +209,45 @@ Then(/^I should see "([^"]*)" in the command output for "([^"]*)"$/) do |text, h
   end
 end
 
-Then(/^I click on the css "(.*)" until page does not contain "([^"]*)" text$/) do |css, text|
+Then(/^I click on the filter button until page does not contain "([^"]*)" text$/) do |text|
   repeat_until_timeout(message: "'#{text}' still found") do
     break unless has_content?(text)
-    find(css).click
+    find("button.spacewalk-button-filter").click
   end
 end
 
-Then(/^I click on the css "(.*)" until page does contain "([^"]*)" text$/) do |css, text|
+Then(/^I click on the filter button until page does contain "([^"]*)" text$/) do |text|
   repeat_until_timeout(message: "'#{text}' was not found") do
     break if has_content?(text)
-    find(css).click
+    find("button.spacewalk-button-filter").click
   end
 end
 
-When(/^I click on the css "(.*)"$/) do |css|
-  find_and_wait_click(css).click
+When(/^I click on the filter button$/) do
+  find_and_wait_click("button.spacewalk-button-filter").click
 end
 
-When(/^I enter "(.*)" in the css "(.*)"$/) do |input, css|
-  find(css).set(input)
+When(/^I click on the red confirmation button$/) do
+  find_and_wait_click("button.btn-danger").click
 end
 
-# salt formulas
+When(/^I click on the clear SSM button$/) do
+  find_and_wait_click("a#clear-ssm").click
+end
+
+When(/^I enter "([^"]*)" as the filtered package name$/) do |input|
+  find("input[placeholder='Filter by Package Name: ']").set(input)
+end
+
+When(/^I enter "([^"]*)" as the filtered synopsis$/) do |input|
+  find("input[placeholder='Filter by Synopsis: ']").set(input)
+end
+
+When(/^I enter "([^"]*)" as the filtered product description$/) do |input|
+  find("input[name='product-description-filter']").set(input)
+end
+
+# Salt formulas
 When(/^I manually install the "([^"]*)" formula on the server$/) do |package|
   $server.run("zypper --non-interactive install --force #{package}-formula")
 end


### PR DESCRIPTION
## What does this PR change?

This PR moves all the gory details about CSS elements from the test suite features to the step definitions.

Rationale:
* Maintenability: things like `input[placeholder='Filter by Package Name: ']` were repeated many times; now, if those details change, there's only one place to fix
* Conciseness: new steps are shorter
* Readability: Gherkin text should be high level English, not a reinvented programming language

## Links

Ports:
* 3.2: SUSE/spacewalk#10183
* 4.0: SUSE/spacewalk#10184

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
