### PR TITLE
Manager disable jabberd

### DIFF
--- a/client/tools/mgr-osad/mgr-osad.changes
+++ b/client/tools/mgr-osad/mgr-osad.changes
@@ -1,3 +1,5 @@
+- separate osa-dispatcher and jabberd so it can be disabled independently
+
 -------------------------------------------------------------------
 Wed Nov 27 16:55:56 CET 2019 - jgonzalez@suse.com
 

--- a/client/tools/mgr-osad/osa-dispatcher.service
+++ b/client/tools/mgr-osad/osa-dispatcher.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=OSA Dispatcher daemon
 After=syslog.target network.target jabberd.service
+BindsTo=jabberd.service
+Requires=spacewalk-wait-for-jabberd.service
 
 [Service]
 Type=forking

--- a/spacewalk/admin/spacewalk-admin.changes
+++ b/spacewalk/admin/spacewalk-admin.changes
@@ -1,3 +1,5 @@
+- separate osa-dispatcher and jabberd so it can be disabled independently
+
 -------------------------------------------------------------------
 Wed Nov 27 16:57:56 CET 2019 - jgonzalez@suse.com
 

--- a/spacewalk/admin/spacewalk-service.systemd
+++ b/spacewalk/admin/spacewalk-service.systemd
@@ -68,6 +68,11 @@ start() {
         touch $DISABLE_FILE
     fi
     systemctl start spacewalk.target
+    if systemctl is-enabled osa-dispatcher > /dev/null 2>&1; then
+        systemctl start jabberd
+        /usr/sbin/spacewalk-startup-helper wait-for-jabberd
+        systemctl start osa-dispatcher
+    fi
     rm -f $DISABLE_FILE
     echo "Done."
     return 0
@@ -75,6 +80,9 @@ start() {
 
 stop() {
     echo "Shutting down spacewalk services..."
+    if systemctl is-active osa-dispatcher > /dev/null 2>&1; then
+        systemctl stop jabberd
+    fi
     spacewalk_target_services | xargs systemctl stop
     echo "Done."
     return 0
@@ -83,6 +91,8 @@ stop() {
 status() {
     spacewalk_target_services | xargs systemctl status --no-pager -n0
     systemctl status -n0 spacewalk.target
+    systemctl status -n0 jabberd.service
+    systemctl status -n0 osa-dispatcher.service
     return $?
 }
 

--- a/spacewalk/admin/spacewalk.target.SUSE
+++ b/spacewalk/admin/spacewalk.target.SUSE
@@ -1,15 +1,12 @@
 [Unit]
 Description=Spacewalk
 Wants=auditlog-keeper.service
-Requires=jabberd.service
 Requires=tomcat.service
 Requires=spacewalk-wait-for-tomcat.service
 Requires=salt-master.service
 Requires=salt-api.service
 Requires=spacewalk-wait-for-salt.service
 Requires=apache2.service
-Requires=spacewalk-wait-for-jabberd.service
-Requires=osa-dispatcher.service
 Requires=rhn-search.service
 Requires=cobblerd.service
 Requires=taskomatic.service

--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -838,11 +838,9 @@ if [ "$DO_SETUP" = "1" -o "$DO_MIGRATION" = "1" ]; then
         if [ "$DO_SETUP" = "1" ]; then
             /usr/sbin/spacewalk-service stop
 
-            # disable osa-dispatcher and jabberd by default on new installations
-            echo "Disable osa-dispatcher..."
-            systemctl stop jabberd
-            systemctl disable osa-dispatcher > /dev/null 2>&1
-            systemctl disable jabberd > /dev/null 2>&1
+            # explicitly enable OSA dispatcher as it's no longer part of spacewalk.target
+            echo "Enable osa-dispatcher..."
+            systemctl --quiet enable osa-dispatcher
 
             systemctl restart postgresql
             /usr/sbin/spacewalk-service start

--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -638,6 +638,16 @@ do_migration() {
     copy_remote_files
     wait_step
 
+    ssh -i $KEYFILE root@$SATELLITE_IP "systemctl is-enabled osa-dispatcher > /dev/null 2>&1"
+    if [ $? -eq 0 ]; then
+        echo "Enable osa-dispatcher..."
+        systemctl enable osa-dispatcher > /dev/null 2>&1
+    else
+        echo "Disable osa-dispatcher..."
+        systemctl disable osa-dispatcher > /dev/null 2>&1
+        systemctl disable jabberd > /dev/null 2>&1
+    fi
+
     cleanup_hostname
     remove_ssh_key
     if [ -d /root/.ssh.new ]; then
@@ -827,6 +837,13 @@ if [ "$DO_SETUP" = "1" -o "$DO_MIGRATION" = "1" ]; then
         /usr/bin/smdba system-check autotuning
         if [ "$DO_SETUP" = "1" ]; then
             /usr/sbin/spacewalk-service stop
+
+            # disable osa-dispatcher and jabberd by default on new installations
+            echo "Disable osa-dispatcher..."
+            systemctl stop jabberd
+            systemctl disable osa-dispatcher > /dev/null 2>&1
+            systemctl disable jabberd > /dev/null 2>&1
+
             systemctl restart postgresql
             /usr/sbin/spacewalk-service start
             systemctl --quiet enable spacewalk-diskcheck.timer

--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -641,11 +641,11 @@ do_migration() {
     ssh -i $KEYFILE root@$SATELLITE_IP "systemctl is-enabled osa-dispatcher > /dev/null 2>&1"
     if [ $? -eq 0 ]; then
         echo "Enable osa-dispatcher..."
-        systemctl enable osa-dispatcher > /dev/null 2>&1
+        systemctl --quiet enable osa-dispatcher
     else
         echo "Disable osa-dispatcher..."
-        systemctl disable osa-dispatcher > /dev/null 2>&1
-        systemctl disable jabberd > /dev/null 2>&1
+        systemctl --quiet disable osa-dispatcher
+        systemctl --quiet disable jabberd
     fi
 
     cleanup_hostname

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- separate osa-dispatcher and jabberd so it can be disabled independently
+
 -------------------------------------------------------------------
 Wed Nov 27 17:05:18 CET 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Customers want to be able to disable osa-dispatcher and jabberd. So separate the services to allow for independent disabling of these components.

On new installations, osa-dispatcher and jabberd will be disabled by default. During migrations, we will check whether it was enabled on the source server and also enable it on the target server.

In the longer run this service will become obsolete as it is useful only for traditional clients.

## GUI diff

No difference.

- [X] **DONE**

## Documentation

We should add to the documentation a remark that osa-dispatcher will not be enabled by default, but can be enabled with these commands:

systemctl enable osa-dispatcher
systemctl start osa-dispatcher

Customer does not need to explicitly enable and/or start jabberd as osa-dispatcher has a dependency on it and will take care of that.

- [X] **DONE**

- No tests: 

- [X] **DONE**

## Changelogs
