### PR TITLE
Uyuni fix bootstrap script for sle ex8

### DIFF
--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -199,7 +199,10 @@ if [ $USING_SSL -eq 0 ] ; then
 fi
 
 INSTALLER=up2date
-if [ -x /usr/bin/zypper ] ; then
+
+if [ -x /usr/bin/dnf ] ; then
+    INSTALLER=yum
+elif [ -x /usr/bin/zypper ] ; then
     INSTALLER=zypper
 elif [ -x /usr/bin/yum ] ; then
     INSTALLER=yum

--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -403,8 +403,8 @@ if [ "$INSTALLER" == yum ]; then
     # try update main packages for registration from any repo which is available
     get_rhnlib_pkgs
     yum -y upgrade {PKG_NAME_UPDATE_YUM} $RHNLIB_PKG ||:
-fi
-if [ "$INSTALLER" == zypper ]; then
+
+elif [ "$INSTALLER" == zypper ]; then
   function getZ_CLIENT_CODE_BASE() {{
     local BASE=""
     local VERSION=""
@@ -551,9 +551,8 @@ if [ "$INSTALLER" == zypper ]; then
   get_rhnlib_pkgs
   # try update main packages for registration from any repo which is available
   zypper --non-interactive up {PKG_NAME_UPDATE} $RHNLIB_PKG ||:
-fi
 
-if [ "$INSTALLER" == apt ]; then
+elif [ "$INSTALLER" == apt ]; then
     function check_deb_pkg_installed {{
         dpkg-query -W -f='${{Status}}' $1 2>/dev/null | grep -q "ok installed"
     }}

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,6 @@
+- fix bootstrap script generator to work with Expanded Support 8
+  product (bsc#1158002)
+
 -------------------------------------------------------------------
 Wed Nov 27 17:00:05 CET 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

SUSE Linux Expanded Support 8 has yum and zypper. This cause the bootstrap script to generate
a wrong URL to the bootstrap repo with /sle/8/0/bootstrap instead of /res/8/bootstrap/

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/10187
Tracks https://github.com/SUSE/spacewalk/pull/10185

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
