### PR TITLE
Checksums have changed again

### DIFF
--- a/testsuite/features/secondary/srv_check_channels_page.feature
+++ b/testsuite/features/secondary/srv_check_channels_page.feature
@@ -51,8 +51,7 @@ Feature: The channels page
     And I should see a "Test-Channel-x86_64" link
     And I should see a "build.opensuse.org" text
     And I should see a "SHA256sum:" text
-    And I should see a "11d493dcec20274eb2f312d0b552eaaf3155ee81dd13fe7945cbd7aa44f70761" text
-    And I should see a "packages/1/11d/andromeda-dummy/2.0-1.1/noarch/11d493dcec20274eb2f312d0b552eaaf3155ee81dd13fe7945cbd7aa44f70761/andromeda-dummy-2.0-1.1.noarch.rpm" text
+    And I should see a "packages/1/ba3/andromeda-dummy/2.0-1.1/noarch/ba3f6d939fce43b60f4d20a09887e211f11024b61defb246dd62705bf4f4ced0/andromeda-dummy-2.0-1.1.noarch.rpm" text
 
   Scenario: Check package dependencies page
     Given I am authorized as "admin" with password "admin"

--- a/testsuite/features/secondary/trad_check_patches_install.feature
+++ b/testsuite/features/secondary/trad_check_patches_install.feature
@@ -38,7 +38,7 @@ Feature: Patches display
     And I follow "Packages"
     Then I should see a "Test-Channel-x86_64" link
     And I should see a "Test-Channel-i586" link
-    And I should see a "sha256:11d493dcec20274eb2f312d0b552eaaf3155ee81dd13fe7945cbd7aa44f70761" text
+    And I should see a "sha256:ba3f6d939fce43b60f4d20a09887e211f11024b61defb246dd62705bf4f4ced0" text
     And I should see a "andromeda-dummy-2.0-1.1-noarch" link
 
   Scenario: Check relevant patches for this client


### PR DESCRIPTION
## What does this PR change?

For an unknown reason, our dummy test packages were not built anymore for i586 architecture in OBS.

I re-enabled the build, but this changed all package checksums again. This PR fixes that problem.

This PR also removes a redundant test (if the file path is visible on the package details page, then the checksum is necessarily also visible).

## Links

Ports:
* 4.0: SUSE/spacewalk#10194
* 3.2: SUSE/spacewalk#10195

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
