### PR TITLE
Fix: lower the level of k8s logging

### DIFF
--- a/java/code/src/com/suse/manager/kubernetes/KubernetesManager.java
+++ b/java/code/src/com/suse/manager/kubernetes/KubernetesManager.java
@@ -133,7 +133,7 @@ public class KubernetesManager {
                             String[] tokens =
                                     StringUtils.split(container.getImage(), "/", 2);
                             if (tokens.length < 2) {
-                                LOG.warn("No repository available in the image name '" +
+                                LOG.debug("No repository available in the image name '" +
                                         container.getImage() +
                                         "'. Ignoring the image.");
                                 return;
@@ -158,6 +158,7 @@ public class KubernetesManager {
                                                 return usg;
                                             }));
                             if (!usage.isPresent()) {
+                                LOG.debug("Usage of the image not found, exiting");
                                 return;
                             }
                         }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Remove unnecessary WARN log entries from Kubernetes integration
 -------------------------------------------------------------------
 Wed Nov 27 17:01:33 CET 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Add additional logging and lower the level of a message from WARN to DEBUG

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/9960

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
