### PR TITLE
Manager configure proxy

### DIFF
--- a/proxy/installer/configure-proxy.sh
+++ b/proxy/installer/configure-proxy.sh
@@ -391,15 +391,6 @@ if [ "$HTTP_PROXY" != "" ]; then
     fi
 fi
 
-VERSION_FROM_PARENT=$(rhn-proxy-activate --server=$RHN_PARENT \
-        --http-proxy="$HTTP_PROXY" \
-        --http-proxy-username="$HTTP_USERNAME" \
-        --http-proxy-password="$HTTP_PASSWORD" \
-        --ca-cert="$CA_CHAIN" \
-        --list-available-versions 2>/dev/null|sort|tail -n1)
-VERSION_FROM_RPM=$(rpm -q --queryformat %{version} spacewalk-proxy-installer|cut -d. -f1-2)
-default_or_input "Proxy version to activate" VERSION ${VERSION_FROM_PARENT:-$VERSION_FROM_RPM}
-
 default_or_input "Traceback email" TRACEBACK_EMAIL ''
 
 default_or_input "Use SSL" USE_SSL 'Y/n'

--- a/proxy/installer/spacewalk-proxy-installer.changes
+++ b/proxy/installer/spacewalk-proxy-installer.changes
@@ -1,3 +1,5 @@
+- do not ask for (unused) version during proxy configuration
+
 -------------------------------------------------------------------
 Wed Nov 27 16:46:47 CET 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

configure-proxy.sh will ask for the proxy version to activate. However, this value is not used anywhere and it some cases the proposed value is even bogus which can confuse admins. So let's simply remove this question.

Closed, but related: https://bugzilla.suse.com/show_bug.cgi?id=1140427

## GUI diff

No difference.

- [X] **DONE**

## Documentation

If documentation is listing all the steps for proxy configuration, this specific question should be removed of course.

- [ ] **DONE**

## Test coverage
- No tests: It gets tested automatically by testsuite. I already manually tested it.

- [X] **DONE**

## Links

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
