### PR TITLE
Associate VMs with Systems with the same machine ID at bootstrap

### DIFF
--- a/backend/server/rhnVirtualization.py
+++ b/backend/server/rhnVirtualization.py
@@ -532,14 +532,27 @@ class VirtualizationEventHandler:
             raise VirtualizationEventError('unable to get virt instance id')
         id = row['id']
 
+        # Do we have a system with a machine id matching the uuid?
+        get_system_id_sql = """
+            SELECT s.id
+            FROM rhnServer s
+            LEFT JOIN rhnVirtualInstance vi on vi.virtual_system_id = s.id
+            WHERE s.machine_id = ':uuid' and vi.virtual_system_id IS NULL
+        """
+        query = rhnSQL.prepare(get_system_id_sql)
+        query.execute(uuid=uuid)
+        row = query.fetchone_dict() or {}
+
+        guest_id = row['id'] if row and 'id' in row else None 
+
         insert_sql = """
             INSERT INTO rhnVirtualInstance
                 (id, host_system_id, virtual_system_id, uuid, confirmed)
             VALUES
-                (:id, :host_id, null, :uuid, 1)
+                (:id, :host_id, :guest_id, :uuid, 1)
         """
         query = rhnSQL.prepare(insert_sql)
-        query.execute(id=id, host_id=host_id, uuid=uuid)
+        query.execute(id=id, host_id=host_id, guest_id=guest_id, uuid=uuid)
 
         # Now we'll insert into the rhnVirtualInstanceInfo table.
 

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- Associate VMs and systems with the same machine ID at bootstrap (bsc#1144176)
+
 -------------------------------------------------------------------
 Wed Nov 27 16:58:20 CET 2019 - jgonzalez@suse.com
 

--- a/java/code/src/com/redhat/rhn/manager/system/VirtualInstanceManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/VirtualInstanceManager.java
@@ -15,6 +15,7 @@
 package com.redhat.rhn.manager.system;
 
 import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.server.VirtualInstance;
 import com.redhat.rhn.domain.server.VirtualInstanceFactory;
 import com.redhat.rhn.domain.server.VirtualInstanceState;
@@ -240,7 +241,21 @@ public class VirtualInstanceManager extends BaseManager {
             VirtualInstance virtualInstance = new VirtualInstance();
             virtualInstance.setUuid(vmGuid);
             virtualInstance.setConfirmed(1L);
-            virtualInstance.setGuestSystem(guest);
+
+            // Do we have a System with machineid matching the GUID that has no
+            // virtual instance?
+            if (guest == null) {
+                ServerFactory.findByMachineId(vmGuid)
+                    .ifPresent(system -> {
+                        if (system.getVirtualInstance() == null) {
+                            virtualInstance.setGuestSystem(system);
+                        }
+                    });
+            }
+            else {
+                virtualInstance.setGuestSystem(guest);
+            }
+
             virtualInstance.setState(state);
             virtualInstance.setName(name);
             virtualInstance.setType(type);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Associate VMs and systems with the same machine ID at bootstrap (bsc#1144176)
 - Prevent Package List Refresh actions to stay pending forever (bsc#1157034)
 - Fix minion id when applying engine-events state (bsc#1158181)
 - Prevent ISE and warn disable deletion of a Content Lifecycle channel in use (bsc#1158012)


### PR DESCRIPTION
## What does this PR change?

In both traditional and Salt bootstraps, when reporting the existing
VMs, check if we have a system with a machine ID matching the VM UUID
that is not already a Virtual System. If such a system is found
associate it with the VM.

This use case is typically encountered when deleting a system and
bootstrapping it again.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: internal fix

- [X] **DONE**

## Test coverage
- No tests: would need more heavy cucumber tests

- [X] **DONE**

## Links

Fixes SUSE/spacewalk#8974 and [bsc#1144176](https://bugzilla.suse.com/show_bug.cgi?id=1144176)

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
