### PR TITLE
Manager configure proxy

### DIFF
--- a/proxy/installer/configure-proxy.sh
+++ b/proxy/installer/configure-proxy.sh
@@ -391,14 +391,8 @@ if [ "$HTTP_PROXY" != "" ]; then
     fi
 fi
 
-VERSION_FROM_PARENT=$(rhn-proxy-activate --server=$RHN_PARENT \
-        --http-proxy="$HTTP_PROXY" \
-        --http-proxy-username="$HTTP_USERNAME" \
-        --http-proxy-password="$HTTP_PASSWORD" \
-        --ca-cert="$CA_CHAIN" \
-        --list-available-versions 2>/dev/null|sort|tail -n1)
-VERSION_FROM_RPM=$(rpm -q --queryformat %{version} spacewalk-proxy-installer|cut -d. -f1-2)
-default_or_input "Proxy version to activate" VERSION ${VERSION_FROM_PARENT:-$VERSION_FROM_RPM}
+VERSION=$(rpm -q --queryformat %{version} spacewalk-proxy-installer|cut -d. -f1-2)
+ACCUMULATED_ANSWERS+=$(printf "\n%q=%q" "VERSION" "$VERSION")
 
 default_or_input "Traceback email" TRACEBACK_EMAIL ''
 

--- a/proxy/installer/spacewalk-proxy-installer.changes
+++ b/proxy/installer/spacewalk-proxy-installer.changes
@@ -1,3 +1,5 @@
+- do not ask for version to activate during proxy configuration
+
 -------------------------------------------------------------------
 Wed Nov 27 16:46:47 CET 2019 - jgonzalez@suse.com
 

--- a/proxy/installer/spacewalk-proxy-installer.changes
+++ b/proxy/installer/spacewalk-proxy-installer.changes
@@ -1,4 +1,4 @@
-- do not ask for version to activate during proxy configuration
+- do not ask for version to activate during proxy configuration (bsc#1140427)
 
 -------------------------------------------------------------------
 Wed Nov 27 16:46:47 CET 2019 - jgonzalez@suse.com


### PR DESCRIPTION
## What does this PR change?

configure-proxy.sh will ask for the proxy version to activate. However this value is unused and sometimes the script will even propose bogus values. Using the local proxy version is correct, so we should always use this version and not even bother the admin. Even when using totally random values, things are working, but to be safe let's make sure we still use the right version, but without asking the admin.

The option for giving some specific version seems to be some obsolete compatibility thing from the ancient past and seems not be used any longer. In any case, we never allowed for different versions to choose from.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- If documentation is listing the workflow, this question should be removed.

- [X] **DONE**

## Test coverage
- No tests: Will be tested by testsuite; manual test already was successful.

- [X] **DONE**

## Links

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1140427

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
