### PR TITLE
Don't kill some of the reposyncs

### DIFF
--- a/testsuite/features/reposync/srv_abort_all_sync.feature
+++ b/testsuite/features/reposync/srv_abort_all_sync.feature
@@ -12,4 +12,4 @@ Feature: Abort all reposync activity
     And I click on "Delete Schedule"
 
   Scenario: Kill running reposyncs
-    When I make sure no spacewalk-repo-sync is executing
+    When I make sure no spacewalk-repo-sync is executing, excepted the ones needed to bootstrap

--- a/testsuite/features/reposync/srv_sync_channels.feature
+++ b/testsuite/features/reposync/srv_sync_channels.feature
@@ -43,21 +43,21 @@ Feature: Be able to list available channels and enable them
     And I should see "Total time:" in the output
     And I should see "Repo URL:" in the output
 
-  Scenario: Enable sles12-sp4-pool-x86_64
+  Scenario: Enable sles12-sp5-pool-x86_64
     # This automaticaly enables all required channels
-    When I execute mgr-sync "add channel sles12-sp4-pool-x86_64"
+    When I execute mgr-sync "add channel sles12-sp5-pool-x86_64"
     And I execute mgr-sync "list channels"
-    Then I should get "[I] SLES12-SP4-Pool for x86_64 SUSE Linux Enterprise Server 12 SP4 x86_64 [sles12-sp4-pool-x86_64]"
-    And I should get "    [I] SLES12-SP4-Updates for x86_64 SUSE Linux Enterprise Server 12 SP4 x86_64 [sles12-sp4-updates-x86_64]"
-    And I should get "    [ ] SLE-Module-Containers12-Pool for x86_64 Containers Module 12 x86_64 [sle-module-containers12-pool-x86_64-sp4]"
+    Then I should get "[I] SLES12-SP5-Pool for x86_64 SUSE Linux Enterprise Server 12 SP5 x86_64 (BETA) [sles12-sp5-pool-x86_64]"
+    And I should get "    [I] SLES12-SP5-Updates for x86_64 SUSE Linux Enterprise Server 12 SP5 x86_64 (BETA) [sles12-sp5-updates-x86_64]"
+    And I should get "    [ ] SLE-Module-Containers12-Pool for x86_64 Containers Module 12 x86_64 [sle-module-containers12-pool-x86_64-sp5]"
 
-  Scenario: Enable sle-module-containers12-pool-x86_64-sp4
+  Scenario: Enable sle-module-containers12-pool-x86_64-sp5
     # This automatically enables all required channels
-    When I execute mgr-sync "add channel sle-module-containers12-pool-x86_64-sp4"
+    When I execute mgr-sync "add channel sle-module-containers12-pool-x86_64-sp5"
     And I execute mgr-sync "list channels"
-    Then I should get "[I] SLES12-SP4-Pool for x86_64 SUSE Linux Enterprise Server 12 SP4 x86_64 [sles12-sp4-pool-x86_64]"
-    And I should get "    [I] SLE-Module-Containers12-Pool for x86_64 Containers Module 12 x86_64 [sle-module-containers12-pool-x86_64-sp4]"
-    And I should get "    [I] SLE-Module-Containers12-Updates for x86_64 Containers Module 12 x86_64 [sle-module-containers12-updates-x86_64-sp4]"
+    Then I should get "[I] SLES12-SP5-Pool for x86_64 SUSE Linux Enterprise Server 12 SP5 x86_64 (BETA) [sles12-sp5-pool-x86_64]"
+    And I should get "    [I] SLE-Module-Containers12-Pool for x86_64 Containers Module 12 x86_64 [sle-module-containers12-pool-x86_64-sp5]"
+    And I should get "    [I] SLE-Module-Containers12-Updates for x86_64 Containers Module 12 x86_64 [sle-module-containers12-updates-x86_64-sp5]"
 
   Scenario: Let mgr-sync time out
     When I remove the mgr-sync cache file

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -150,18 +150,32 @@ When(/^I execute mgr\-sync refresh$/) do
   $command_output = sshcmd('mgr-sync refresh', ignore_err: true)[:stderr]
 end
 
-When(/^I make sure no spacewalk\-repo\-sync is executing$/) do
-  kill_failure_streak = 0
-  while kill_failure_streak <= 120
-    command_output = sshcmd('killall spacewalk-repo-sync', ignore_err: true)
-    kill_failed = !command_output[:stderr].empty?
-
-    if kill_failed
-      kill_failure_streak += 1
+When(/^I make sure no spacewalk\-repo\-sync is executing, excepted the ones needed to bootstrap$/) do
+  reposync_not_running_streak = 0
+  reposync_left_running_streak = 0
+  while reposync_not_running_streak <= 30 && reposync_left_running_streak <= 7200
+    command_output, _code = $server.run('ps -C spacewalk-repo-sync -o pid= -o cmd=', false)
+    if command_output.empty?
+      reposync_not_running_streak += 1
+      reposync_left_running_streak = 0
       sleep 1
-    else
-      kill_failure_streak = 0
+      next
     end
+    reposync_not_running_streak = 0
+    process = command_output.split("\n")[0]
+    pid = process.split(' ')[0]
+    channel = process.split(' ')[5]
+    # The following assumes the clients are SLE 12 SP4
+    if ['sles12-sp4-pool-x86_64', 'sle-manager-tools12-pool-x86_64-sp4', 'sle-module-containers12-pool-x86_64-sp4',
+        'sles12-sp4-updates-x86_64', 'sle-manager-tools12-updates-x86_64-sp4', 'sle-module-containers12-updates-x86_64-sp4'].include? channel
+      STDOUT.puts "Reposync of channel #{channel} left running" if (reposync_left_running_streak % 60).zero?
+      reposync_left_running_streak += 1
+      sleep 1
+      next
+    end
+    reposync_left_running_streak = 0
+    $server.run("kill #{pid}", false)
+    STDOUT.puts "Reposync of channel #{channel} killed"
   end
 end
 


### PR DESCRIPTION
## What does this PR change?

This PR makes it possible to re-enable the reposync tests.

It does two things:
 * it makes sure that no reposync of the repositories that are needed for bootstrapping is killed
    (here, it makes sure that no SLE 12 SP4 reposync is killed, because our minions are SLE 12 SP4)
 * it arranges so that we start reposync for other repositories than those that are needed for bootstrapping
   (here, it starts reposync on SLE 12 SP5, so SLE 12 SP4 is unaffected.

Both measures work hand in hand:
 * The first measure is a safety net that is NOT used when the second measure is in place.
* The second measure is not needed, strictly speaking, thanks to the first measure,
   but it reduces killing time from 1 hour 45 minutes to 10 minutes :smiley_cat: .

**Important notice**: SLE 12 SP5 is beta at this time. We will need to remove `(BETA)` texts when it changes status.

## Links

Ports:
* 3.2: SUSE/spacewalk#10228
* 4.0: SUSE/spacewalk#10229

Fixes: SUSE/spacewalk#9134

Relates to: SUSE/susemanager-ci#67

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
