### PR TITLE
Add QA Squad as PR reviewer, for test framework changes

### DIFF
--- a/.github/scripts/needs_qa_squad_review.rb
+++ b/.github/scripts/needs_qa_squad_review.rb
@@ -1,0 +1,11 @@
+#! /usr/bin/ruby
+require 'json'
+
+# if true we exit with 0, so the PR needs QA Squad as a reviewer
+def needs_qa_squad_review?(files)
+  files.reject! { |f| f.include? '.feature' }
+  files.any? { |f| f.include? 'testsuite' } 
+end
+
+files = ARGV[0].split(' ')
+puts needs_qa_squad_review?(files).to_s.downcase

--- a/.github/workflows/add_pr_reviewer.yml
+++ b/.github/workflows/add_pr_reviewer.yml
@@ -1,0 +1,50 @@
+name: add_pr_reviewer
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  add_pr_reviewer:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+    - uses: actions/setup-ruby@v1
+    - name: "Check if there are test framework changes"
+      id: review_step
+      run: |
+        files_modified=`git diff --name-only "origin/$GITHUB_BASE_REF..HEAD" | xargs`
+        review=`ruby .github/scripts/needs_qa_squad_review.rb "$files_modified"`
+        echo "##[set-output name=review;]$review"
+    - name: "Send Review Request to QA Squad"
+      if: steps.review_step.outputs.review == 'true' && github.actor == 'srbarrios'
+      uses: kunihiko-t/review-request-action@v0.1.3
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        reviewers: "lkotek,ktsamis,Bischoff"
+    - name: "Send Review Request to QA Squad"
+      if: steps.review_step.outputs.review == 'true' && github.actor == 'lkotek'
+      uses: kunihiko-t/review-request-action@v0.1.3
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        reviewers: "srbarrios,ktsamis,Bischoff"
+    - name: "Send Review Request to QA Squad"
+      if: steps.review_step.outputs.review == 'true' && github.actor == 'Bischoff'
+      uses: kunihiko-t/review-request-action@v0.1.3
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        reviewers: "lkotek,ktsamis,srbarrios"
+    - name: "Send Review Request to QA Squad"
+      if: steps.review_step.outputs.review == 'true' && github.actor == 'ktsamis'
+      uses: kunihiko-t/review-request-action@v0.1.3
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        reviewers: "lkotek,srbarrios,Bischoff"
+    - name: "Send Review Request to QA Squad"
+      if: steps.review_step.outputs.review == 'true' && github.actor != 'ktsamis' && github.actor != 'Bischoff' && github.actor != 'lkotek' && github.actor != 'srbarrios'
+      uses: kunihiko-t/review-request-action@v0.1.3
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        reviewers: "lkotek,srbarrios,Bischoff,ktsamis"


### PR DESCRIPTION
## What does this PR change?

A new GitHub Action to add QA Squad as PR reviewer, for test framework changes.
I'm using an existing GitHub Action and wrapping it to implement our desired behavior.
You will notice there is a repeating step which only changes a comparison with the owner, that's a workaround to fix an issue on the GitHub Action which doesn't handle the skip of the owner when it is asked to be added as a reviewer, otherwise, the step fails.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: CI feature, no need doc

- [x] **DONE**

## Test coverage
- No tests: Tested using a PR in my fork

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
