### PR TITLE
Testsuite - capybara timeout increased

### DIFF
--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -20,7 +20,7 @@ server = ENV['SERVER']
 # the tests return much before that delay in case of success
 $stdout.sync = true
 STARTTIME = Time.new.to_i
-Capybara.default_max_wait_time = 10
+Capybara.default_max_wait_time = 30
 DEFAULT_TIMEOUT = 250
 
 def enable_assertions


### PR DESCRIPTION
## What does this PR change?

This PR increases value of `Capybara.default_max_wait_time` to 30 seconds. That high value is not necessary every time, so whole execution time still takes around 4-5 hours. Tests without this increased value always fail in core stage, with increased value secondary features are executed. Details [here](https://github.com/SUSE/spacewalk/issues/10199#issuecomment-561527546).

## Links

https://github.com/SUSE/spacewalk/issues/10199

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
