### PR TITLE
Fix the periodic labeler

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/labeler@v2
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+    - uses: paulfantom/periodic-labeler@v0.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        LABEL_MAPPINGS_FILE: .github/labeler.yml


### PR DESCRIPTION
## What does this PR change?

Due to a limitation in GitHub Action, we can't use the actions/labeler from GitHub Marketplace when you do a PR from a fork. Then we need to work around it using a periodic call to labeler from our master branch. To make it easier, we will just perform another GitHub Action from the Marketplace, supporting exactly that.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: https://github.com/marketplace/actions/periodic-labeler

- [x] **DONE**

## Test coverage
- No tests: CI change

- [x] **DONE**

## Links

https://github.com/marketplace/actions/periodic-labeler

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
