### PR TITLE
Master testsuite spa adjustmentents

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -418,7 +418,7 @@ Given(/^I am authorized as "([^"]*)" with password "([^"]*)"$/) do |user, passwd
 
   fill_in 'username', with: user
   fill_in 'password', with: passwd
-  click_button('Sign In')
+  click_button_and_wait('Sign In', match: :first)
 
   step %(I should be logged in)
 end

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -114,7 +114,7 @@ end
 def click_button_and_wait(locator = nil, **options)
   click_button(locator, options)
   begin
-    raise 'Timeout: Waiting AJAX transition (click link)' unless has_no_css?('.senna-loading', wait: 1)
+    raise 'Timeout: Waiting AJAX transition (click link)' unless has_no_css?('.senna-loading', wait: 5)
   rescue StandardError => e
     puts e.message # Skip errors related to .senna-loading element
   end
@@ -123,7 +123,7 @@ end
 def click_link_and_wait(locator = nil, **options)
   click_link(locator, options)
   begin
-    raise 'Timeout: Waiting AJAX transition (click link)' unless has_no_css?('.senna-loading', wait: 1)
+    raise 'Timeout: Waiting AJAX transition (click link)' unless has_no_css?('.senna-loading', wait: 5)
   rescue StandardError => e
     puts e.message # Skip errors related to .senna-loading element
   end
@@ -132,7 +132,7 @@ end
 def click_link_or_button_and_wait(locator = nil, **options)
   click_link_or_button(locator, options)
   begin
-    raise 'Timeout: Waiting AJAX transition (click link)' unless has_no_css?('.senna-loading', wait: 1)
+    raise 'Timeout: Waiting AJAX transition (click link)' unless has_no_css?('.senna-loading', wait: 5)
   rescue StandardError => e
     puts e.message # Skip errors related to .senna-loading element
   end
@@ -143,7 +143,7 @@ module CapybaraNodeElementExtension
   def click
     super
     begin
-      raise 'Timeout: Waiting AJAX transition (click link)' unless has_no_css?('.senna-loading', wait: 1)
+      raise 'Timeout: Waiting AJAX transition (click link)' unless has_no_css?('.senna-loading', wait: 5)
     rescue StandardError => e
       puts e.message # Skip errors related to .senna-loading element
     end


### PR DESCRIPTION
## What does this PR change?

Prevent false negative test outputs: we fail too fast by checking the content of a page, and the test fails but it is not a real failure, it is just a not-waiting issue. Of course we don't want to wait too much, but giving a buffer margin reflects better the real life. Moreover, the parameter `wait:` stands for a `default_max_wait_time`, and it means we will not really wait always for that amount of time, but we will only in case the server response is slow. On the other hand we all agree that if a click navigation takes longer than a certain amount of time, we can say it is an issue and we fail.

This PR increases the `default_max_wait_time` from 1s to 5s, according to the above statements.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: testsuite changes

- [x] **DONE**

## Test coverage
- No tests: testsuite changes

- [x] **DONE**

## Links

Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
