### PR TITLE
Temporarily disable SLE12 SP5 tests

### DIFF
--- a/testsuite/features/reposync/srv_sync_channels.feature
+++ b/testsuite/features/reposync/srv_sync_channels.feature
@@ -43,21 +43,21 @@ Feature: Be able to list available channels and enable them
     And I should see "Total time:" in the output
     And I should see "Repo URL:" in the output
 
-  Scenario: Enable sles12-sp5-pool-x86_64
-    # This automaticaly enables all required channels
-    When I execute mgr-sync "add channel sles12-sp5-pool-x86_64"
-    And I execute mgr-sync "list channels"
-    Then I should get "[I] SLES12-SP5-Pool for x86_64 SUSE Linux Enterprise Server 12 SP5 x86_64 (BETA) [sles12-sp5-pool-x86_64]"
-    And I should get "    [I] SLES12-SP5-Updates for x86_64 SUSE Linux Enterprise Server 12 SP5 x86_64 (BETA) [sles12-sp5-updates-x86_64]"
-    And I should get "    [ ] SLE-Module-Containers12-Pool for x86_64 Containers Module 12 x86_64 [sle-module-containers12-pool-x86_64-sp5]"
+  # TODO: re-enable this on Monday
+  # Scenario: Enable sles12-sp5-pool-x86_64
+  #   When I execute mgr-sync "add channel sles12-sp5-pool-x86_64"
+  #   And I execute mgr-sync "list channels"
+  #   Then I should get "[I] SLES12-SP5-Pool for x86_64 SUSE Linux Enterprise Server 12 SP5 x86_64 (BETA) [sles12-sp5-pool-x86_64]"
+  #   And I should get "    [I] SLES12-SP5-Updates for x86_64 SUSE Linux Enterprise Server 12 SP5 x86_64 (BETA) [sles12-sp5-updates-x86_64]"
+  #   And I should get "    [ ] SLE-Module-Containers12-Pool for x86_64 Containers Module 12 x86_64 [sle-module-containers12-pool-x86_64-sp5]"
 
-  Scenario: Enable sle-module-containers12-pool-x86_64-sp5
-    # This automatically enables all required channels
-    When I execute mgr-sync "add channel sle-module-containers12-pool-x86_64-sp5"
-    And I execute mgr-sync "list channels"
-    Then I should get "[I] SLES12-SP5-Pool for x86_64 SUSE Linux Enterprise Server 12 SP5 x86_64 (BETA) [sles12-sp5-pool-x86_64]"
-    And I should get "    [I] SLE-Module-Containers12-Pool for x86_64 Containers Module 12 x86_64 [sle-module-containers12-pool-x86_64-sp5]"
-    And I should get "    [I] SLE-Module-Containers12-Updates for x86_64 Containers Module 12 x86_64 [sle-module-containers12-updates-x86_64-sp5]"
+  # TODO: re-enable this on Monday
+  # Scenario: Enable sle-module-containers12-pool-x86_64-sp5
+  #   When I execute mgr-sync "add channel sle-module-containers12-pool-x86_64-sp5"
+  #   And I execute mgr-sync "list channels"
+  #   Then I should get "[I] SLES12-SP5-Pool for x86_64 SUSE Linux Enterprise Server 12 SP5 x86_64 (BETA) [sles12-sp5-pool-x86_64]"
+  #   And I should get "    [I] SLE-Module-Containers12-Pool for x86_64 Containers Module 12 x86_64 [sle-module-containers12-pool-x86_64-sp5]"
+  #   And I should get "    [I] SLE-Module-Containers12-Updates for x86_64 Containers Module 12 x86_64 [sle-module-containers12-updates-x86_64-sp5]"
 
   Scenario: Let mgr-sync time out
     When I remove the mgr-sync cache file


### PR DESCRIPTION
## What does this PR change?

Until missing channels
```
sles12-sp5-pool-x86_64
sles12-sp5-updates-x86_64
sle-module-containers12-pool-x86_64-sp5
sle-module-containers12-updates-x86_64-sp5
```

are mirrored in Provo, disable corresponding tests. I will re-enable them when mirroring is complete.

This PR also removes accidentally duplicated features:
```
core/srv_abort_all_sync.feature 
core/srv_mgr_sync_products.feature 
core/srv_sync_channels.feature
```

## Links

Ports:
 * 4.0: SUSE/spacewalk#10255
 * 3.2: SUSE/spacewalk#10256

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
