### PR TITLE
redhat_management_type is undefined - do not use it in snippets

### DIFF
--- a/java/conf/cobbler/snippets/redhat_register
+++ b/java/conf/cobbler/snippets/redhat_register
@@ -1,18 +1,13 @@
 # begin Red Hat management server registration
-#if $redhat_management_type != "off" and $redhat_management_key != ""
+#if $redhat_management_key != ""
 mkdir -p /usr/share/rhn/
-   #if $redhat_management_type == "site"
-      #set $mycert_file = "RHN-ORG-TRUSTED-SSL-CERT"
-      #set $mycert = "/usr/share/rhn/" + $mycert_file
+   #set $mycert_file = "RHN-ORG-TRUSTED-SSL-CERT"
+   #set $mycert = "/usr/share/rhn/" + $mycert_file
 wget http://$redhat_management_server/pub/RHN-ORG-TRUSTED-SSL-CERT -O $mycert   
 perl -Xnpe 's/RHNS-CA-CERT/$mycert_file/g' -i /etc/sysconfig/rhn/*  
 if [ -f /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release ]; then
     rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 fi
-   #end if
-   #if $redhat_management_type == "hosted"
-      #set $mycert = "/usr/share/rhn/RHNS-CA-CERT"
-   #end if 
    #set $endpoint = "https://%s/XMLRPC" % $redhat_management_server
 key=$redhat_management_key
 if [ -f /tmp/key ]; then

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- remove undefined variable from redhat_register snippet
 - Add a method in API to check if the provided session key is a valid one.
 - Associate VMs and systems with the same machine ID at bootstrap (bsc#1144176)
 - Prevent Package List Refresh actions to stay pending forever (bsc#1157034)


### PR DESCRIPTION
## What does this PR change?

`redhat_management_type` is nowhere defined. Not in cobbler nor in uyuni code.
As we do not support "hosted" variant this variable is obsolete.

Change the snippet and remove the use of this variable.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/1656
Tracks https://github.com/SUSE/spacewalk/pull/10264

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
