### PR TITLE
Dynamic check depending on the product name

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -441,7 +441,9 @@ end
 
 Then(/^I am logged in$/) do
   raise 'User is not logged in' unless find(:xpath, "//a[@href='/rhn/Logout.do']").visible?
-  raise 'The welcome message is not shown' unless has_content?('You have just created your first SUSE Manager user. To finalize your installation please use the Setup Wizard')
+  text = 'You have just created your first $PRODUCT user. To finalize your installation please use the Setup Wizard'
+  text.gsub! '$PRODUCT', $product # TODO: Rid of this substitution, using another step
+  raise 'The welcome message is not shown' unless has_content?(text)
 end
 
 Given(/^I am on the patches page$/) do


### PR DESCRIPTION
## What does this PR change?

Fix test step condition depending on the name of the product

![Screenshot from 2019-12-06 08-44-17](https://user-images.githubusercontent.com/7080830/70305454-b42ceb80-1804-11ea-8061-cdc779806e0e.png)


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
