### PR TITLE
Add javascript debug packages

### DIFF
--- a/web/html/src/build/webpack.config.js
+++ b/web/html/src/build/webpack.config.js
@@ -43,7 +43,7 @@ module.exports = (env, argv) => {
       publicPath: '/'
     },
     optimization: {
-      minimizer: [new TerserPlugin({extractComments: true})],
+      minimizer: [new TerserPlugin({extractComments: true, sourceMap: true})],
       splitChunks: {
         cacheGroups: {
           vendor: {
@@ -61,6 +61,7 @@ module.exports = (env, argv) => {
         }
       }
     },
+    devtool: isProductionMode ? 'source-map' : 'eval-source-map',
     module: {
       rules: [
         {

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Add debug packages containing Javascript source map files
 - Don't validate mandatory fields that are not visible (bsc#1158943)
 - Show adequate message on saving formulas that change only pillar data
 - Report merge_subscriptions message in a readable way (bsc#1140332)

--- a/web/spacewalk-web.spec
+++ b/web/spacewalk-web.spec
@@ -56,7 +56,7 @@ but it does generate a number of sub-packages.
 
 %package -n susemanager-web-libs
 Summary:        Vendor bundles for spacewalk-web
-License:		0BSD and BSD-3-Clause and LGPL-3.0-or-later and MIT and MPL-2.0
+License:        0BSD and BSD-3-Clause and LGPL-3.0-or-later and MIT and MPL-2.0
 Group:          Applications/Internet
 
 BuildArch:      noarch
@@ -67,6 +67,18 @@ BuildRequires:  nodejs
 
 %description -n susemanager-web-libs
 This package contains Vendor bundles needed for spacewalk-web
+
+%package -n susemanager-web-libs-debug
+Summary:        Vendor bundles for spacewalk-web debug files
+License:        0BSD and BSD-3-Clause and LGPL-3.0-or-later and MIT and MPL-2.0
+Group:          Applications/Internet
+
+BuildArch:      noarch
+BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+Requires:       susemanager-web-libs
+
+%description -n susemanager-web-libs-debug
+This package contains debug files for spacewalk-web-libs
 
 %package -n spacewalk-html
 Summary:        HTML document files for Spacewalk
@@ -86,6 +98,14 @@ Provides:       rhn-html = 5.3.0
 %description -n spacewalk-html
 This package contains the HTML files for the Spacewalk web site.
 
+%package -n spacewalk-html-debug
+Summary:        HTML document debug files for Spacewalk
+License:        GPL-2.0-only AND MIT
+Group:          Applications/Internet
+Requires:       spacewalk-html
+
+%description -n spacewalk-html-debug
+This package contains the debug files for spacewalk-html.
 
 %package -n spacewalk-base
 Summary:        Programs which need to be installed for the Spacewalk Web base classes
@@ -198,12 +218,19 @@ cp -r html/src/dist/javascript/manager %{buildroot}/srv/www/htdocs/javascript
 
 %{__mkdir_p} %{buildroot}/srv/www/htdocs/vendors
 cp html/src/dist/vendors/vendors.bundle.js %{buildroot}/srv/www/htdocs/vendors/vendors.bundle.js
+cp html/src/dist/vendors/vendors.bundle.js.map %{buildroot}/srv/www/htdocs/vendors/vendors.bundle.js.map
 cp html/src/dist/vendors/vendors.bundle.js.LICENSE %{buildroot}/srv/www/htdocs/vendors/vendors.bundle.js.LICENSE
 
 %files -n susemanager-web-libs
 %defattr(644,root,root,755)
 %dir %{www_path}/www/htdocs/vendors
-%{www_path}/www/htdocs/vendors/*
+%{www_path}/www/htdocs/vendors/*.js
+%{www_path}/www/htdocs/vendors/*.js.LICENSE
+
+%files -n susemanager-web-libs-debug
+%defattr(644,root,root,755)
+%dir %{www_path}/www/htdocs/vendors
+%{www_path}/www/htdocs/vendors/*.map
 
 %files -n spacewalk-base
 %defattr(644,root,root,755)
@@ -241,9 +268,17 @@ cp html/src/dist/vendors/vendors.bundle.js.LICENSE %{buildroot}/srv/www/htdocs/v
 %defattr(644,root,root,755)
 %dir %{www_path}/www/htdocs/pub
 %dir %{www_path}/www/htdocs/javascript
+%dir %{www_path}/www/htdocs/javascript/manager
 %{www_path}/www/htdocs/robots.txt
 %{www_path}/www/htdocs/pub
-%{www_path}/www/htdocs/javascript/*
+%{www_path}/www/htdocs/javascript/manager/*.js
+%{www_path}/www/htdocs/javascript/*.js
 %doc LICENSE
+
+%files -n spacewalk-html-debug
+%defattr(644,root,root,755)
+%dir %{www_path}/www/htdocs/javascript
+%dir %{www_path}/www/htdocs/javascript/manager
+%{www_path}/www/htdocs/javascript/manager/*.map
 
 %changelog


### PR DESCRIPTION
## What does this PR change?

Add debug packages containing the webpack source-map files to help debugging the JavaScript of a production setup.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: Only for devs (and support ?)

- [X] **DONE**

## Test coverage
- No tests: no, but needs to play with it a little more to ensure it does the right thing in both production and dev mode.

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
