### PR TITLE
Prevent traceback when reposyncing openSUSE 15.1 (bsc#1158672)

### DIFF
--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -1152,8 +1152,14 @@ class RepoSync(object):
                     if os.path.exists(stage_path):
                         os.remove(stage_path)
                     if os.path.exists(os.path.dirname(stage_path)):
-                        # remove the checksum directory
-                        os.rmdir(os.path.dirname(stage_path))
+                        # remove the checksum directory if empty
+                        try:
+                            os.rmdir(os.path.dirname(stage_path))
+                        except OSError as exc:
+                            if exc.errno == errno.ENOTEMPTY:
+                                pass
+                            else:
+                                raise exc
             pack.clear_header()
         if affected_channels:
             errataCache.schedule_errata_cache_update(affected_channels)

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- prevent a traceback when reposyncing openSUSE 15.1 (bsc#1158672)
 - close config files after reading them (bsc#1158283)
 - Associate VMs and systems with the same machine ID at bootstrap (bsc#1144176)
 


### PR DESCRIPTION
## What does this PR change?

It makes `spacewalk-repo-sync` robust to a format change in the repository metadata of openSUSE 15.1.

The following stack trace is prevented:
```
2019/12/05 17:53:01 +02:00   Importing packages to DB:
2019/12/05 17:54:59 +02:00 0.37 %
2019/12/05 17:55:54 +02:00 Unexpected error: <class 'OSError'>
2019/12/05 17:55:54 +02:00 Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/spacewalk/satellite_tools/reposync.py", line 577, in sync
    ret = self.import_packages(plugin, data['id'], url, is_non_local_repo)
  File "/usr/lib/python3.6/site-packages/spacewalk/satellite_tools/reposync.py", line 1156, in import_packages
    os.rmdir(os.path.dirname(stage_path))
OSError: [Errno 39] Directory not empty: '/var/spacewalk/packages/1/stage/7ed08f423996c92cfdf84aaa2f87aef55a26c95ee64f0a92a24d87d87d9be1e5'
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **not coverable at this time**

- [x] **DONE**

## Links

Tracks # **add downstream PR, if any**

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1158672

- [ ] **DONE**


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
