### PR TITLE
Packages with no vendor

### DIFF
--- a/backend/server/importlib/headerSource.py
+++ b/backend/server/importlib/headerSource.py
@@ -92,9 +92,7 @@ class rpmPackage(IncompletePackage):
             del(self['sigmd5'])
 
         # Fix some of the information up
-        vendor = self['vendor']
-        if not vendor:
-            self['vendor'] = 'Not defined'
+        vendor = self['vendor'] or None
         payloadFormat = self['payload_format']
         if payloadFormat is None:
             self['payload_format'] = 'cpio'

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- generate metadata with empty vendor (bsc#1158480)
 - prevent a traceback when reposyncing openSUSE 15.1 (bsc#1158672)
 - close config files after reading them (bsc#1158283)
 - Associate VMs and systems with the same machine ID at bootstrap (bsc#1144176)

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -19540,6 +19540,9 @@ given channel.</source>
       <trans-unit id="package.jsp.vendor">
         <source>Vendor</source>
       </trans-unit>
+      <trans-unit id="package.jsp.vendor.unknown">
+        <source>Not defined</source>
+      </trans-unit>
       <trans-unit id="package.jsp.packagesize">
         <source>Package Size</source>
       </trans-unit>

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriter.java
@@ -22,6 +22,7 @@ import com.redhat.rhn.taskomatic.task.TaskConstants;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 
 import java.io.BufferedWriter;
@@ -85,8 +86,9 @@ public class DebPackageWriter implements Closeable {
         out.write(pkgDto.getArchLabel().replace("-deb", ""));
         out.newLine();
 
+        String vendor = StringUtils.defaultString(pkgDto.getVendor(), "Debian");
         out.write("Maintainer: ");
-        out.write(pkgDto.getVendor());
+        out.write(vendor);
         out.newLine();
 
         Long packagePayloadSize = pkgDto.getPayloadSize();

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/test/DebPackageWriterTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/test/DebPackageWriterTest.java
@@ -55,6 +55,7 @@ public class DebPackageWriterTest extends JMockBaseTestCaseWithUser {
         PackageExtraTagsKeys tag3 = PackageManagerTest.createExtraTagKey("Tag3");
 
         Package pkg1 = PackageManagerTest.addPackageToChannel("pkg_1", channel);
+        pkg1.setVendor(null);
         pkg1.getExtraTags().put(tag1, "value1");
         pkg1.getExtraTags().put(tag2, "value2");
 
@@ -103,7 +104,7 @@ public class DebPackageWriterTest extends JMockBaseTestCaseWithUser {
         assertEquals("Package: pkg_1\n" +
                         "Version: 1:1.0.0-1\n" +
                         "Architecture: noarch\n" +
-                        "Maintainer: Rhn-Java\n" +
+                        "Maintainer: Debian\n" +
                         "Installed-Size: 42\n" +
                         "Depends: python:any (>= 2.4~), python-crypto (>= 2.5.0)\n" +
                         "Filename: channel/getPackage/pkg_1_1:1.0.0-1.noarch.deb\n" +

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/test/RpmRepositoryWriterTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/test/RpmRepositoryWriterTest.java
@@ -77,6 +77,7 @@ public class RpmRepositoryWriterTest extends BaseTestCaseWithUser {
         Channel channel = ChannelFactoryTest.createTestChannel(user);
         channel.setChecksumType(ChannelFactory.findChecksumTypeByLabel("sha256"));
         com.redhat.rhn.domain.rhnpackage.Package pkg1 = PackageManagerTest.addPackageToChannel("pkg1", channel);
+        pkg1.setVendor(null);
 
         PackageProvides prov1 = new PackageProvides();
         PackageCapability provCap = PackageCapabilityTest.createTestCapability("capProv1");
@@ -122,7 +123,7 @@ public class RpmRepositoryWriterTest extends BaseTestCaseWithUser {
                 "<summary>Created by RHN-JAVA unit tests. Please disregard.</summary><description>RHN-JAVA Package Test</description><packager/><url/>" +
                 "<time file=\"1544723761\" build=\"1544723761\"/><size package=\"42\" archive=\"42\" installed=\"42\"/>" +
                 "<location href=\"getPackage/$1$RAiHwOUL$bcHCUHDdGcmVfklrxaRVC1\"/><format><rpm:license>Red Hat - RHN - 2005</rpm:license>" +
-                "<rpm:vendor>Rhn-Java</rpm:vendor><rpm:group>4XwfQEUNzkDr3</rpm:group><rpm:buildhost>foo2</rpm:buildhost>" +
+                "<rpm:vendor/><rpm:group>4XwfQEUNzkDr3</rpm:group><rpm:buildhost>foo2</rpm:buildhost>" +
                 "<rpm:sourcerpm>ZL4ke7jOwX6Tz</rpm:sourcerpm><rpm:header-range start=\"-1\" end=\"-1\"/><rpm:provides>" +
                 "<rpm:entry name=\"capProv1\" flags=\"GE\" epoch=\"0\" ver=\"\" rel=\"1.0\"/></rpm:provides><rpm:requires>" +
                 "<rpm:entry name=\"capReq1\" flags=\"GE\" epoch=\"0\" ver=\"\" rel=\"1.0\"/></rpm:requires><rpm:conflicts/>" +

--- a/java/code/webapp/WEB-INF/pages/rhnpackage/packagedetail.jsp
+++ b/java/code/webapp/WEB-INF/pages/rhnpackage/packagedetail.jsp
@@ -60,7 +60,12 @@
                         <bean:message key="package.jsp.vendor"/>:
                     </label>
                     <div class="col-lg-6">
+                    <c:if test="${pack.vendor != null}">
                         <c:out value="${pack.vendor}" />
+                    </c:if>
+                    <c:if test="${pack.vendor == null}">
+                        <bean:message key="package.jsp.vendor.unkown"/>
+                    </c:if>
                     </div>
                 </div>
                 <div class="form-group">

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- generate metadata with empty vendor (bsc#1158480)
 - Read the subscriptions from the output instead of input (bsc#1140332)
 - remove undefined variable from redhat_register snippet
 - Add a method in API to check if the provided session key is a valid one.

--- a/schema/spacewalk/common/tables/rhnPackage.sql
+++ b/schema/spacewalk/common/tables/rhnPackage.sql
@@ -49,7 +49,7 @@ CREATE TABLE rhnPackage
     checksum_id      NUMBER NOT NULL
                          CONSTRAINT rhn_package_chsum_fk
                              REFERENCES rhnChecksum (id),
-    vendor           VARCHAR2(64) NOT NULL,
+    vendor           VARCHAR2(64),
     payload_format   VARCHAR2(32),
     compat           NUMBER(1)
                          DEFAULT (0)

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- generate metadata with empty vendor (bsc#1158480)
 - Prevent SELECT INSTR error in Postgres logs every minute (bsc#1157034)
 - Fix rhnActionVirtDelete when migrating from 3.2 to 4.0 (bsc#1158178)
 

--- a/schema/spacewalk/upgrade/susemanager-schema-3.2.22-to-susemanager-schema-3.2.23/005-fix-none-vendor.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-3.2.22-to-susemanager-schema-3.2.23/005-fix-none-vendor.sql
@@ -1,0 +1,12 @@
+delete from rhnpackagerepodata where package_id in (select id from rhnpackage where vendor = 'Not defined');
+
+insert into rhnRepoRegenQueue (id, CHANNEL_LABEL, REASON, FORCE)
+(select sequence_nextval('rhn_repo_regen_queue_id_seq'),
+        C.label,
+        'fix empty vendor',
+        'Y'
+   from rhnChannel C
+   where C.id in (select distinct cp.channel_id
+                    from rhnpackage p
+	            join rhnchannelpackage cp on p.id = cp.package_id
+	           where p.vendor = 'Not defined'));

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.17-to-susemanager-schema-4.0.18/005-fix-none-vendor.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.17-to-susemanager-schema-4.0.18/005-fix-none-vendor.sql
@@ -1,0 +1,12 @@
+delete from rhnpackagerepodata where package_id in (select id from rhnpackage where vendor = 'Not defined');
+
+insert into rhnRepoRegenQueue (id, CHANNEL_LABEL, REASON, FORCE)
+(select sequence_nextval('rhn_repo_regen_queue_id_seq'),
+        C.label,
+        'fix empty vendor',
+        'Y'
+   from rhnChannel C
+   where C.id in (select distinct cp.channel_id
+                    from rhnpackage p
+	            join rhnchannelpackage cp on p.id = cp.package_id
+	           where p.vendor = 'Not defined'));

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.1-to-susemanager-schema-4.1.2/005-fix-none-vendor.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.1-to-susemanager-schema-4.1.2/005-fix-none-vendor.sql
@@ -1,0 +1,16 @@
+delete from rhnpackagerepodata where package_id in (select id from rhnpackage where vendor = 'Not defined');
+
+ALTER TABLE rhnpackage ALTER COLUMN vendor DROP NOT NULL;
+
+update rhnpackage set vendor = NULL where vendor = 'Not defined';
+
+insert into rhnRepoRegenQueue (id, CHANNEL_LABEL, REASON, FORCE)
+(select sequence_nextval('rhn_repo_regen_queue_id_seq'),
+        C.label,
+        'fix empty vendor',
+        'Y'
+   from rhnChannel C
+   where C.id in (select distinct cp.channel_id
+                    from rhnpackage p
+	            join rhnchannelpackage cp on p.id = cp.package_id
+	           where p.vendor is NULL));


### PR DESCRIPTION
## What does this PR change?

Rewrite https://github.com/SUSE/spacewalk/pull/10271

Generate an empty vendor tag in the medata when the vendor was not set.

The DB had vendor as NOT NULL column. This PR change this and set vendor to NULL
when the package does not define it.

Earlier it was set to "Not defined" so we need to migrate the existing data.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/10266
Tracks https://github.com/SUSE/spacewalk/pull/10271

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
