### PR TITLE
SLE12 SP5 is not beta anymore

### DIFF
--- a/testsuite/features/reposync/srv_sync_channels.feature
+++ b/testsuite/features/reposync/srv_sync_channels.feature
@@ -46,14 +46,14 @@ Feature: Be able to list available channels and enable them
   Scenario: Enable sles12-sp5-pool-x86_64
     When I execute mgr-sync "add channel sles12-sp5-pool-x86_64"
     And I execute mgr-sync "list channels"
-    Then I should get "[I] SLES12-SP5-Pool for x86_64 SUSE Linux Enterprise Server 12 SP5 x86_64 (BETA) [sles12-sp5-pool-x86_64]"
-    And I should get "    [I] SLES12-SP5-Updates for x86_64 SUSE Linux Enterprise Server 12 SP5 x86_64 (BETA) [sles12-sp5-updates-x86_64]"
+    Then I should get "[I] SLES12-SP5-Pool for x86_64 SUSE Linux Enterprise Server 12 SP5 x86_64 [sles12-sp5-pool-x86_64]"
+    And I should get "    [I] SLES12-SP5-Updates for x86_64 SUSE Linux Enterprise Server 12 SP5 x86_64 [sles12-sp5-updates-x86_64]"
     And I should get "    [ ] SLE-Module-Containers12-Pool for x86_64 Containers Module 12 x86_64 [sle-module-containers12-pool-x86_64-sp5]"
 
   Scenario: Enable sle-module-containers12-pool-x86_64-sp5
     When I execute mgr-sync "add channel sle-module-containers12-pool-x86_64-sp5"
     And I execute mgr-sync "list channels"
-    Then I should get "[I] SLES12-SP5-Pool for x86_64 SUSE Linux Enterprise Server 12 SP5 x86_64 (BETA) [sles12-sp5-pool-x86_64]"
+    Then I should get "[I] SLES12-SP5-Pool for x86_64 SUSE Linux Enterprise Server 12 SP5 x86_64 [sles12-sp5-pool-x86_64]"
     And I should get "    [I] SLE-Module-Containers12-Pool for x86_64 Containers Module 12 x86_64 [sle-module-containers12-pool-x86_64-sp5]"
     And I should get "    [I] SLE-Module-Containers12-Updates for x86_64 Containers Module 12 x86_64 [sle-module-containers12-updates-x86_64-sp5]"
 


### PR DESCRIPTION
## What does this PR change?

This PR removes the `(BETA) ` text from SCC product names in the test suite.

## Links

Ports:
 * 4.0: SUSE/spacewalk#10278
 * 3.2: SUSE/spacewalk#10279

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
