### PR TITLE
wait a bit until page is really loaded

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -436,7 +436,9 @@ Then(/^I should not be authorized$/) do
 end
 
 Then(/^I should be logged in$/) do
-  raise 'User is not logged in' unless all(:xpath, "//a[@href='/rhn/Logout.do']").any?
+  repeat_until_timeout(message: 'User is not logged in') do
+    break if all(:xpath, "//a[@href='/rhn/Logout.do']").any?
+  end
 end
 
 Then(/^I am logged in$/) do

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -331,6 +331,7 @@ Given(/^I am on the Systems overview page of this "([^"]*)"$/) do |host|
   steps %(
     Given I am on the Systems page
     When I follow "#{system_name}"
+    I wait until I see "#{system_name}" text
   )
 end
 

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -172,6 +172,7 @@ def file_inject(node, local_file, remote_file)
 end
 
 # Other global variables
+$product = product
 $sle15_minion = sle15family?($minion)
 $pxeboot_mac = ENV['PXEBOOTMAC']
 $private_net = ENV['PRIVATENET'] if ENV['PRIVATENET']


### PR DESCRIPTION
## What does this PR change?

The new login page take a while and we need to wait a bit until we are really logged-in.
Especially after new setup of the machine or a tomcat restart.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **already covered**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/10199

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
