### PR TITLE
jabberd is not longer enabled; so only test whether it is active

### DIFF
--- a/testsuite/features/core/first_settings.feature
+++ b/testsuite/features/core/first_settings.feature
@@ -57,7 +57,8 @@ Feature: Very first settings
     And service "apache2" is active on "server"
     And service "cobblerd" is enabled on "server"
     And service "cobblerd" is active on "server"
-    And service "jabberd" is enabled on "server"
+    # jabberd is not longer enabled; it is tied to osa-dispatcher, so only test that jabberd is active
+    # And service "jabberd" is enabled on "server"
     And service "jabberd" is active on "server"
     And service "osa-dispatcher" is enabled on "server"
     And service "osa-dispatcher" is active on "server"


### PR DESCRIPTION
## What does this PR change?

jabberd is not longer enabled; so only test whether it is active

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: Only affects testsuite

- [X] **DONE**

## Test coverage
- No tests: Only testsuite itself affected

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
