### PR TITLE
Manager jabberd disabled

### DIFF
--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -840,6 +840,7 @@ if [ "$DO_SETUP" = "1" -o "$DO_MIGRATION" = "1" ]; then
 
             # explicitly enable OSA dispatcher as it's no longer part of spacewalk.target
             echo "Enable osa-dispatcher..."
+            systemctl --quiet enable jabberd
             systemctl --quiet enable osa-dispatcher
 
             systemctl restart postgresql

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- explicitly enable jabberd during setup
 - separate osa-dispatcher and jabberd so it can be disabled independently
 
 -------------------------------------------------------------------

--- a/testsuite/features/core/first_settings.feature
+++ b/testsuite/features/core/first_settings.feature
@@ -57,7 +57,8 @@ Feature: Very first settings
     And service "apache2" is active on "server"
     And service "cobblerd" is enabled on "server"
     And service "cobblerd" is active on "server"
-    And service "jabberd" is enabled on "server"
+    # jabberd is not longer enabled; it is tied to osa-dispatcher, so only test that jabberd is active
+    # And service "jabberd" is enabled on "server"
     And service "jabberd" is active on "server"
     And service "osa-dispatcher" is enabled on "server"
     And service "osa-dispatcher" is active on "server"

--- a/testsuite/features/core/first_settings.feature
+++ b/testsuite/features/core/first_settings.feature
@@ -57,8 +57,7 @@ Feature: Very first settings
     And service "apache2" is active on "server"
     And service "cobblerd" is enabled on "server"
     And service "cobblerd" is active on "server"
-    # jabberd is not longer enabled; it is tied to osa-dispatcher, so only test that jabberd is active
-    # And service "jabberd" is enabled on "server"
+    And service "jabberd" is enabled on "server"
     And service "jabberd" is active on "server"
     And service "osa-dispatcher" is enabled on "server"
     And service "osa-dispatcher" is active on "server"


### PR DESCRIPTION
## What does this PR change?

explicitly enable jabberd during setup

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: No change in behaviour; admin now just has the option to disable it

- [X] **DONE**

## Test coverage
- No tests: Currently failing test should be fixed again

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
