### PR TITLE
Do not conflict uyuni-common-libs with spacewalk-backend-libs

### DIFF
--- a/uyuni/common-libs/uyuni-common-libs.changes
+++ b/uyuni/common-libs/uyuni-common-libs.changes
@@ -1,3 +1,5 @@
+- remove conflicts to spacewalk-backend-libs packages
+
 -------------------------------------------------------------------
 Wed Nov 27 17:12:01 CET 2019 - jgonzalez@suse.com
 

--- a/uyuni/common-libs/uyuni-common-libs.spec
+++ b/uyuni/common-libs/uyuni-common-libs.spec
@@ -65,8 +65,6 @@ BuildRequires:  python-devel
 %else
 BuildRequires:  python2-devel
 %endif
-Conflicts:      spacewalk-backend-libs
-Conflicts:      spacewalk-usix
 
 %description -n python2-%{name}
 Python 2 libraries required by both Uyuni server and client tools.
@@ -83,8 +81,6 @@ Requires:       python3-base
 %else
 Requires:       python3-libs
 %endif
-Conflicts:      python3-spacewalk-backend-libs
-Conflicts:      python3-spacewalk-usix
 
 
 %description -n python3-%{name}


### PR DESCRIPTION
## What does this PR change?

Even if uyuni-common-libs is the successor of spacewalk-backend-libs, it is not a 1:1 replacement.
So we cannot just obsolete it as the tool which should use it must change at least the imports.

So we accept, that the ols spacewalk-backend-libs packages stay installed, even when they are unused. 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Release Notes: https://github.com/SUSE/spacewalk/issues/10285

- [x] **DONE**

## Test coverage
- No tests: **rpm dependencies**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
