### PR TITLE
Upgrade serialize-javascript - CVE-2019-16769

### DIFF
--- a/susemanager-frontend/susemanager-nodejs-sdk-devel/package.json
+++ b/susemanager-frontend/susemanager-nodejs-sdk-devel/package.json
@@ -35,6 +35,7 @@
     "flow-bin": "^0.107.0",
     "jest": "^24.7.1",
     "license-checker-webpack-plugin": "^0.0.9",
+    "serialize-javascript": "^2.1.2",
     "shelljs": "^0.8.3",
     "style-loader": "^0.23.1",
     "terser-webpack-plugin": "^1.2.2",

--- a/susemanager-frontend/susemanager-nodejs-sdk-devel/susemanager-nodejs-sdk-devel.changes
+++ b/susemanager-frontend/susemanager-nodejs-sdk-devel/susemanager-nodejs-sdk-devel.changes
@@ -1,3 +1,5 @@
+- upgrade serialize-javascript - CVE-2019-16769
+
 -------------------------------------------------------------------
 Wed Nov 27 17:05:43 CET 2019 - jgonzalez@suse.com
 

--- a/susemanager-frontend/yarn.lock
+++ b/susemanager-frontend/yarn.lock
@@ -10558,6 +10558,11 @@ serialize-javascript@^1.7.0:
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.9.1.tgz#cfc200aef77b600c47da9bb8149c943e798c2fdb"
   integrity sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==
 
+serialize-javascript@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
+  integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
+
 serve-favicon@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/serve-favicon/-/serve-favicon-2.5.0.tgz#935d240cdfe0f5805307fdfe967d88942a2cbcf0"


### PR DESCRIPTION
## What does this PR change?

Fix https://github.com/advisories/GHSA-h9rv-jmmf-4pgx - CVE-2019-16769

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/1690
Tracks https://github.com/SUSE/spacewalk/pull/10288

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
