### PR TITLE
[wip]: Fix the original-clone channel relationship for CLM channels

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Channel_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Channel_queries.xml
@@ -1183,4 +1183,10 @@ ORDER BY CC.modified DESC
   </query>
 </mode>
 
+<write-mode name="add_clone_info">
+    <query params="original_id, channel_id">
+        INSERT INTO rhnChannelCloned(original_id, id)
+        VALUES(:original_id, :channel_id)
+    </query>
+</write-mode>
 </datasource_modes>

--- a/java/code/src/com/redhat/rhn/domain/channel/Channel.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/Channel.java
@@ -955,5 +955,13 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
         return "deb".equalsIgnoreCase(getArchTypeLabel());
     }
 
+    /**
+     * Return the {@link Channel} as {@link ClonedChannel} if it is one
+     *
+     * @return the optional of {@link ClonedChannel}
+     */
+    public Optional<ClonedChannel> asCloned() {
+        return Optional.empty();
+    }
 }
 

--- a/java/code/src/com/redhat/rhn/domain/channel/ClonedChannel.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/ClonedChannel.java
@@ -16,6 +16,8 @@ package com.redhat.rhn.domain.channel;
 
 import com.redhat.rhn.domain.common.ChecksumType;
 
+import java.util.Optional;
+
 /**
  * ClonedChannel
  * @version $Rev$
@@ -46,6 +48,14 @@ public class ClonedChannel extends Channel {
     @Override
     public boolean isCloned() {
         return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Optional<ClonedChannel> asCloned() {
+        return Optional.of(this);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
@@ -40,6 +40,8 @@ import static java.util.Optional.empty;
  */
 public class ContentProjectFactory extends HibernateFactory {
 
+    private static final String DELIMITER = "-";
+
     private static final ContentProjectFactory INSTANCE = new ContentProjectFactory();
     private static Logger log = Logger.getLogger(ContentProjectFactory.class);
 
@@ -562,6 +564,19 @@ public class ContentProjectFactory extends HibernateFactory {
      */
     public static void remove(ContentProjectFilter filter) {
         INSTANCE.removeObject(filter);
+    }
+
+    /**
+     * Create a prefix from given {@link ContentEnvironment}
+     *
+     * e.g. Environment with label "bar" in a Project with label "foo"
+     * will return "foo-bar-".
+     *
+     * @param env the Environment
+     * @return the prefix
+     */
+    public static String prefixString(ContentEnvironment env) {
+        return env.getContentProject().getLabel() + DELIMITER + env.getLabel() + DELIMITER;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
@@ -24,6 +24,7 @@ import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.user.User;
 import org.apache.log4j.Logger;
 
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
@@ -228,10 +229,19 @@ public class ContentProjectFactory extends HibernateFactory {
     }
 
     /**
-     * Remove an environment from the path. It take care that chain stay intact
+     * Remove an environment from the path. Take care that chain stays intact.
+     * Also remove all channels belonging to this environment.
+     *
      * @param toRemove environment to remove.
      */
     public static void removeEnvironment(ContentEnvironment toRemove) {
+        // let's purge all the targets in the environment firstly
+        new ArrayList<>(toRemove.getTargets()).stream()
+                .sorted((t1, t2) -> Boolean.compare(// make sure a parent channel goes first
+                        t1.asSoftwareTarget().map(t -> t.getChannel().isBaseChannel()).orElse(false),
+                        t2.asSoftwareTarget().map(t -> t.getChannel().isBaseChannel()).orElse(false)))
+                .forEach(ContentProjectFactory::purgeTarget);
+
         if (toRemove.getNextEnvironmentOpt().isPresent()) {
             ContentEnvironment next = toRemove.getNextEnvironmentOpt().get();
             if (toRemove.getPrevEnvironmentOpt().isPresent()) {

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
@@ -423,6 +423,24 @@ public class ContentProjectFactory extends HibernateFactory {
     }
 
     /**
+     * Look up a successor (cloned) {@link Channel} of given {@link Channel} in given {@link ContentProject}
+     *
+     * @param channel the channel
+     * @param project the project
+     * @return the successor of the channel in the project
+     */
+    public static Optional<ClonedChannel> lookupSuccessorChannel(Channel channel, ContentProject project) {
+        Optional<Channel> successor = HibernateFactory.getSession()
+                .createQuery("SELECT tgt.channel FROM SoftwareEnvironmentTarget tgt " +
+                        "WHERE tgt.contentEnvironment.contentProject = :project " +
+                        "AND tgt.channel.original = :channel")
+                .setParameter("project", project)
+                .setParameter("channel", channel)
+                .uniqueResultOptional();
+        return successor.flatMap(Channel::asCloned);
+    }
+
+    /**
      * List filters visible to given user
      *
      * @param user the user

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/SoftwareEnvironmentTarget.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/SoftwareEnvironmentTarget.java
@@ -16,6 +16,8 @@
 package com.redhat.rhn.domain.contentmgmt;
 
 import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.channel.ClonedChannel;
+
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
@@ -105,6 +107,24 @@ public class SoftwareEnvironmentTarget extends EnvironmentTarget {
                 .append(channel, that.channel)
                 .append(getContentEnvironment(), that.getContentEnvironment())
                 .isEquals();
+    }
+
+    /**
+     * Find the successor {@link Channel} of the {@link Channel} of this {@link ContentEnvironment}
+     *
+     * @return the optional of the successor {@link Channel}
+     */
+    public Optional<ClonedChannel> findSuccessorChannel() {
+        return ContentProjectFactory.lookupSuccessorChannel(channel, getContentEnvironment().getContentProject());
+    }
+
+    /**
+     * Find the predecessor {@link Channel} of the {@link Channel} of this {@link ContentEnvironment}
+     *
+     * @return the optional of the predecessor {@link Channel}
+     */
+    public Optional<Channel> findPredecessorChannel() {
+        return getChannel().asCloned().map(c -> c.getOriginal());
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/SoftwareEnvironmentTarget.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/SoftwareEnvironmentTarget.java
@@ -119,7 +119,8 @@ public class SoftwareEnvironmentTarget extends EnvironmentTarget {
     }
 
     /**
-     * Find the predecessor {@link Channel} of the {@link Channel} of this {@link ContentEnvironment}
+     * Find the predecessor {@link Channel} of the {@link Channel} of this {@link ContentEnvironment}.
+     * In this case the predecessor is the original channel.
      *
      * @return the optional of the predecessor {@link Channel}
      */

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/test/EnvironmentTargetTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/test/EnvironmentTargetTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.domain.contentmgmt.test;
+
+import static com.redhat.rhn.domain.role.RoleFactory.ORG_ADMIN;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
+import com.redhat.rhn.domain.contentmgmt.SoftwareEnvironmentTarget;
+import com.redhat.rhn.manager.contentmgmt.ContentManager;
+import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
+
+/**
+ * Tests for {@link com.redhat.rhn.domain.contentmgmt.EnvironmentTarget}
+ */
+public class EnvironmentTargetTest extends JMockBaseTestCaseWithUser {
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        user.addPermanentRole(ORG_ADMIN);
+    }
+
+    /**
+     * Tests the links between {@link SoftwareEnvironmentTarget} {@link Channel}s
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testSWEnvironmentTargetLinks() throws Exception {
+        ContentManager.createProject("testproj1", "testproj1", "", user);
+        var devEnv = ContentManager.createEnvironment("testproj1", empty(), "dev", "dev env", "", false, user);
+        var testEnv = ContentManager.createEnvironment("testproj1", of("dev"), "test", "test env", "", false, user);
+
+        Channel srcChannel = ChannelFactoryTest.createTestChannel(user);
+        srcChannel.setLabel("channel123");
+        Channel devChannel = ChannelFactoryTest.createTestClonedChannel(srcChannel, user);
+        devChannel.setLabel("testproj1-dev-channel123");
+        Channel testChannel = ChannelFactoryTest.createTestClonedChannel(devChannel, user);
+        testChannel.setLabel("testproj1-test-channel123");
+
+        var devTgt = new SoftwareEnvironmentTarget(devEnv, devChannel);
+        devEnv.addTarget(devTgt);
+        var testTgt = new SoftwareEnvironmentTarget(testEnv, testChannel);
+        testEnv.addTarget(testTgt);
+
+        // check dev environment
+        assertEquals(srcChannel, devTgt.findPredecessorChannel().get());
+        assertEquals(testChannel, devTgt.findSuccessorChannel().get());
+
+        // check test environment
+        assertEquals(devChannel, testTgt.findPredecessorChannel().get());
+        assertTrue(testTgt.findSuccessorChannel().isEmpty());
+    }
+}

--- a/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
@@ -1319,6 +1319,21 @@ public class ChannelManager extends BaseManager {
     }
 
     /**
+     * Add clone data to the channel (transform regular channel to a cloned one).
+     *
+     * @param originalId the original channel id
+     * @param channelId the channel id
+     * @return the number of rows added
+     */
+    public static int addCloneInfo(long originalId, long channelId) {
+        WriteMode m = ModeFactory.getWriteMode("Channel_queries", "add_clone_info");
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("original_id", originalId);
+        params.put("channel_id", channelId);
+        return m.executeUpdate(params);
+    }
+
+    /**
      * Finds the id of a child channel with the given parent channel id that contains
      * a package with the given name.  Returns all child channel unless expectOne is True
      * @param org Organization of the current user.

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -59,6 +59,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
+import static com.redhat.rhn.domain.contentmgmt.ContentProjectFactory.prefixString;
 import static com.redhat.rhn.domain.contentmgmt.ProjectSource.State.ATTACHED;
 import static com.redhat.rhn.domain.contentmgmt.ProjectSource.State.BUILT;
 import static com.redhat.rhn.domain.contentmgmt.ProjectSource.State.DETACHED;
@@ -79,8 +80,6 @@ import static java.util.stream.Collectors.toSet;
  * Content Management functionality
  */
 public class ContentManager {
-
-    private static final String DELIMITER = "-";
 
     // forbid instantiation
     private ContentManager() { }
@@ -721,19 +720,6 @@ public class ContentManager {
         return env.getPrevEnvironmentOpt()
                 .map(prevEnv -> srcChannelLabel.replaceAll("^" + prefixString(prevEnv), envPrefix))
                 .orElse(envPrefix + srcChannelLabel);
-    }
-
-    /**
-     * Create a prefix from given {@link ContentEnvironment}
-     *
-     * e.g. Environment with label "bar" in a Project with label "foo"
-     * will return "foo-bar-".
-     *
-     * @param env the Environment
-     * @return the prefix
-     */
-    private static String prefixString(ContentEnvironment env) {
-        return env.getContentProject().getLabel() + DELIMITER + env.getLabel() + DELIMITER;
     }
 
     private static ContentProjectHistoryEntry addHistoryEntry(

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
@@ -851,7 +851,7 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
         ContentEnvironment env = ContentManager.createEnvironment(cp.getLabel(), empty(), "fst", "first env", "desc", false, user);
 
         // ... build by another user
-        Channel channel = createPopulatedChannel(user);
+        Channel channel = createPopulatedChannel();
         ContentManager.attachSource("cplabel", SW_CHANNEL, channel.getLabel(), empty(), user);
         ContentManager.buildProject("cplabel", empty(), false, adminSameOrg);
         assertEquals(Long.valueOf(1), env.getVersion());
@@ -878,7 +878,7 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
         ContentProjectFactory.save(cp);
         ContentEnvironment env = ContentManager.createEnvironment(cp.getLabel(), empty(), "fst", "first env", "desc", false, user);
 
-        Channel channel = createPopulatedChannel(user);
+        Channel channel = createPopulatedChannel();
         ContentManager.attachSource("cplabel", SW_CHANNEL, channel.getLabel(), empty(), user);
         ContentManager.buildProject("cplabel", empty(), false, user);
         assertEquals(Long.valueOf(1), env.getVersion());
@@ -1129,10 +1129,6 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
     }
 
     private Channel createPopulatedChannel() throws Exception {
-        return createPopulatedChannel(user);
-    }
-
-    private Channel createPopulatedChannel(User user) throws Exception {
         Channel channel = TestUtils.reload(ChannelFactoryTest.createTestChannel(user, false));
         channel.setChecksumType(ChannelFactory.findChecksumTypeByLabel("sha1"));
         Package pack = PackageTest.createTestPackage(user.getOrg());

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
@@ -52,6 +52,7 @@ import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -62,7 +63,6 @@ import static com.redhat.rhn.domain.contentmgmt.ProjectSource.State.DETACHED;
 import static com.redhat.rhn.domain.contentmgmt.ProjectSource.Type.SW_CHANNEL;
 import static com.redhat.rhn.domain.role.RoleFactory.ORG_ADMIN;
 import static java.util.Arrays.asList;
-import static java.util.Arrays.spliterator;
 import static java.util.Collections.singletonList;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
@@ -730,7 +730,7 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
         ContentEnvironment env = ContentManager.createEnvironment(cp.getLabel(), empty(), "fst", "first env", "desc", false, user);
         assertEquals(Long.valueOf(0), env.getVersion());
 
-        // 1. build a project with a source
+        // 1. build the project with a source
         Channel channel = createPopulatedChannel();
         ContentManager.attachSource("cplabel", SW_CHANNEL, channel.getLabel(), empty(), user);
         assertEquals(channel, cp.lookupSwSourceLeader().get().getChannel());
@@ -748,7 +748,7 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
         assertEquals(channel.getErratas(), tgtChannel.getErratas());
         assertEquals(Long.valueOf(1), env.getVersion());
 
-        // 2. change a project source and rebuild
+        // 2. change the project source and rebuild
         Channel newChannel = createPopulatedChannel();
         ContentManager.attachSource("cplabel", SW_CHANNEL, newChannel.getLabel(), empty(), user);
         assertEquals(channel, cp.lookupSwSourceLeader().get().getChannel()); // leader is the same
@@ -906,7 +906,7 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
         ContentProjectFactory.save(cp);
         ContentEnvironment devEnv = ContentManager.createEnvironment(cp.getLabel(), empty(), "dev", "dev env", "desc", false, user);
 
-        // 1. build a project with a source
+        // 1. build the project with a source
         Channel channel1 = createPopulatedChannel();
         Channel channel2 = createPopulatedChannel();
         ContentManager.attachSource("cplabel", SW_CHANNEL, channel1.getLabel(), empty(), user);
@@ -1126,6 +1126,150 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
         ContentManager.attachFilter("cplabel", filter.getId(), user);
         ContentManager.buildProject("cplabel", empty(), false, user);
         assertEquals(0, env.getTargets().get(0).asSoftwareTarget().get().getChannel().getErrataCount());
+    }
+
+    /**
+     * This scenario tests that the original-clone relation is maintained between CLM channels
+     * during {@link ContentProject} building/promoting
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testClonedChannelLinks() throws Exception {
+        var project = new ContentProject("cplabel", "cpname", "cpdesc", user.getOrg());
+        ContentProjectFactory.save(project);
+        var devEnv = ContentManager.createEnvironment(project.getLabel(), empty(), "dev", "dev env", "desc", false, user);
+        var testEnv = ContentManager.createEnvironment(project.getLabel(), of("dev"), "test", "test env", "desc", false, user);
+
+        // build the project with 2 channels
+        var channel1 = createPopulatedChannel();
+        var channel2 = createPopulatedChannel();
+        ContentManager.attachSource("cplabel", SW_CHANNEL, channel1.getLabel(), empty(), user);
+        ContentManager.attachSource("cplabel", SW_CHANNEL, channel2.getLabel(), empty(), user);
+        ContentManager.buildProject("cplabel", empty(), false, user);
+
+        // check that built channels have the originals set correctly
+        assertEquals(Set.of(channel1, channel2), getOriginalChannels(getEnvChannels(devEnv)));
+
+        // promote project
+        ContentManager.promoteProject("cplabel", "dev", false, user);
+
+        // check the originals of the test environment correspond to channels in the dev environment
+        assertEquals(getEnvChannels(devEnv), getOriginalChannels(getEnvChannels(testEnv)));
+
+        // delete a source && build the project
+        ContentManager.detachSource("cplabel", SW_CHANNEL, channel1.getLabel(), user);
+        ContentManager.buildProject("cplabel", empty(), false, user);
+
+        // check the originals of the "test" channels: one should point to a channel in the "dev" environment,
+        // the other should point to the "source" channel1
+        var expectedTestOriginals = getEnvChannels(devEnv);
+        expectedTestOriginals.add(channel1);
+        assertEquals(expectedTestOriginals, getOriginalChannels(getEnvChannels(testEnv)));
+
+        // add the channel again && build
+        ContentManager.attachSource("cplabel", SW_CHANNEL, channel1.getLabel(), empty(), user);
+        ContentManager.buildProject("cplabel", empty(), false, user);
+
+        // check the originals of the test environment correspond to channels in the dev environment again
+        assertEquals(Set.of(channel1, channel2), getOriginalChannels(getEnvChannels(devEnv)));
+        assertEquals(getEnvChannels(devEnv), getOriginalChannels(getEnvChannels(testEnv)));
+    }
+
+    /**
+     * Similar as testClonedChannelLinks, his scenario tests that the original-clone relation
+     * is maintained between CLM channels during {@link ContentProject} building/promoting.
+     *
+     * The difference is that the original state of the links between channel is broken (existing user data
+     * from previous versions).
+     * The original-clone relation should be fixed by building/promoting the project.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testFixingClonedChannelLinks() throws Exception {
+        var project = new ContentProject("cplabel", "cpname", "cpdesc", user.getOrg());
+        ContentProjectFactory.save(project);
+        var devEnv = ContentManager.createEnvironment(project.getLabel(), empty(), "dev", "dev env", "desc", false, user);
+        var testEnv = ContentManager.createEnvironment(project.getLabel(), of("dev"), "test", "test env", "desc", false, user);
+
+        // build the project
+        var channel1 = createPopulatedChannel();
+        ContentManager.attachSource("cplabel", SW_CHANNEL, channel1.getLabel(), empty(), user);
+        ContentManager.buildProject("cplabel", empty(), false, user);
+
+        // check that built channel has the original set correctly
+        assertEquals(Set.of(channel1), getOriginalChannels(getEnvChannels(devEnv)));
+
+        // promote project
+        ContentManager.promoteProject("cplabel", "dev", false, user);
+
+        // now "break" the testEnv channel
+        getEnvChannels(testEnv).forEach(chan -> chan.asCloned().get().setOriginal(channel1));
+        assertEquals(Set.of(channel1), getOriginalChannels(getEnvChannels(testEnv)));
+
+        // promote project again and check that the original of testEnv channel was fixed
+        ContentManager.promoteProject("cplabel", "dev", false, user);
+
+        assertEquals(getEnvChannels(devEnv), getOriginalChannels(getEnvChannels(testEnv)));
+    }
+
+    /**
+     * Similar as testClonedChannelLinks, but in this case we setup the project targets
+     * with completely crafted (non-clone) channels.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testFixingClonedChannelLinks2() throws Exception {
+        var project = new ContentProject("cplabel", "cpname", "cpdesc", user.getOrg());
+        ContentProjectFactory.save(project);
+        var srcChan = createPopulatedChannel();
+        ContentManager.attachSource("cplabel", SW_CHANNEL, srcChan.getLabel(), empty(), user);
+
+        // 2 environments, 1 channel in each
+        var devEnv = ContentManager.createEnvironment(project.getLabel(), empty(), "dev", "dev env", "desc", false, user);
+        var testEnv = ContentManager.createEnvironment(project.getLabel(), of("dev"), "test", "test env", "desc", false, user);
+
+        var devChan = createChannelInEnvironment(devEnv, of(srcChan.getLabel()));
+        var devTarget = new SoftwareEnvironmentTarget(devEnv, devChan);
+        ContentProjectFactory.save(devTarget);
+        devEnv.addTarget(devTarget);
+
+        var testChan = createChannelInEnvironment(testEnv, of(srcChan.getLabel()));
+        var testTarget = new SoftwareEnvironmentTarget(testEnv, testChan);
+        ContentProjectFactory.save(testTarget);
+        testEnv.addTarget(testTarget);
+
+        // let's just check the env. channels are not cloned
+        assertFalse(devChan.isCloned());
+        assertFalse(testChan.isCloned());
+
+        // let's build the project and check that the procedure fixed the channel in the dev environment
+        ContentManager.buildProject("cplabel", empty(), false, user);
+
+        devChan = ChannelFactory.lookupById(devChan.getId());
+        testChan = ChannelFactory.lookupById(testChan.getId());
+        assertEquals(srcChan, devChan.getOriginal());
+        assertFalse(testChan.isCloned());
+
+        // let's promote the project and check that the procedure fixed the channel in the test environment as well
+        ContentManager.promoteProject("cplabel", "dev", false, user);
+
+        devChan = ChannelFactory.lookupById(devChan.getId());
+        testChan = ChannelFactory.lookupById(testChan.getId());
+        assertEquals(srcChan, devChan.getOriginal());
+        assertEquals(devChan, testChan.getOriginal());
+    }
+
+    // extract original channels from given channels
+    private Set<Channel> getOriginalChannels(Collection<Channel> channels) {
+        return channels.stream().map(Channel::getOriginal).collect(toSet());
+    }
+
+    // get channels of given environment
+    private Set<Channel> getEnvChannels(ContentEnvironment testEnv) {
+        return testEnv.getTargets().stream()
+                .flatMap(tgt -> tgt.asSoftwareTarget().stream())
+                .map(tgt -> tgt.getChannel())
+                .collect(toSet());
     }
 
     private Channel createPopulatedChannel() throws Exception {

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.0-to-susemanager-schema-4.1.1/350-delete-clone-info-in-content-projects.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.0-to-susemanager-schema-4.1.1/350-delete-clone-info-in-content-projects.sql
@@ -1,0 +1,1 @@
+delete from rhnchannelcloned where id in (select c.id from rhnchannel c inner join susecontentenvironmenttarget et on c.id = et.channel_id);


### PR DESCRIPTION
todo
- more tests
- nice PR description (mention the removing environments too!)



## What does this PR change?

**add description**

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links 

Tracks https://github.com/SUSE/spacewalk/issues/9773

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"