### PR TITLE
By default, Ubuntu and CentOS are SSH minions

### DIFF
--- a/testsuite/features/core/allcli_sanity.feature
+++ b/testsuite/features/core/allcli_sanity.feature
@@ -28,13 +28,13 @@ Feature: Sanity checks
 
 @centos_minion
   Scenario: The Centos minion is healthy
-    Then "ceos_minion" should have a FQDN
-    And "ceos_minion" should communicate with the server
+    Then "ceos_ssh_minion" should have a FQDN
+    And "ceos_ssh_minion" should communicate with the server
 
 @ubuntu_minion
   Scenario: The Ubuntu minion is healthy
-    Then "ubuntu_minion" should have a FQDN
-    And "ubuntu_minion" should communicate with the server
+    Then "ubuntu_ssh_minion" should have a FQDN
+    And "ubuntu_ssh_minion" should communicate with the server
 
 @virthost_kvm
   Scenario: The KVM host is healthy

--- a/testsuite/features/core/centos_salt_ssh.feature
+++ b/testsuite/features/core/centos_salt_ssh.feature
@@ -10,7 +10,6 @@ Feature: Bootstrap a SSH-managed CentOS minion and do some basic operations on i
   Scenario: Bootstrap a SSH-managed CentOS minion
     Given I am authorized
     When I go to the bootstrapping page
-    And I wait for "45" seconds
     Then I should see a "Bootstrap Minions" text
     When I check "manageWithSSH"
     And I enter the hostname of "ceos_ssh_minion" as "hostname"
@@ -28,7 +27,7 @@ Feature: Bootstrap a SSH-managed CentOS minion and do some basic operations on i
     Given I am on the Systems overview page of this "ceos_ssh_minion"
     When I follow "Details" in the content area
     And I follow "Connection" in the content area
-    Then I should see "proxy" hostname
+    Then I should see "proxy" short hostname
 
 @proxy
 @centos_minion
@@ -55,11 +54,11 @@ Feature: Bootstrap a SSH-managed CentOS minion and do some basic operations on i
 @centos_minion
   Scenario: Prepare the SSH-managed CentOS minion
     Given I am authorized
-    When I enable SUSE Manager tools repositories on "ceos_client"
-    And  I enable repository "CentOS-Base" on this "ceos_client"
-    And  I install package "hwdata m2crypto wget" on this "ceos_client"
-    And  I install package "spacewalk-client-tools spacewalk-check spacewalk-client-setup mgr-daemon mgr-osad mgr-cfg-actions" on this "ceos_client"
-    And  I install package "spacewalk-oscap scap-security-guide" on this "ceos_client"
+    When I enable SUSE Manager tools repositories on "ceos_ssh_minion"
+    And  I enable repository "CentOS-Base" on this "ceos_ssh_minion"
+    And  I install package "hwdata m2crypto wget" on this "ceos_ssh_minion"
+    And  I install package "spacewalk-client-tools spacewalk-check spacewalk-client-setup mgr-daemon mgr-osad mgr-cfg-actions" on this "ceos_ssh_minion"
+    And  I install package "spacewalk-oscap scap-security-guide" on this "ceos_ssh_minion"
 
 @centos_minion
   Scenario: Check events history for failures on SSH-managed CentOS minion

--- a/testsuite/features/core/ubuntu_salt_ssh.feature
+++ b/testsuite/features/core/ubuntu_salt_ssh.feature
@@ -10,25 +10,24 @@ Feature: Bootstrap a SSH-managed Ubuntu minion and do some basic operations on i
   Scenario: Bootstrap a SSH-managed Ubuntu minion
     Given I am authorized
     When I go to the bootstrapping page
-    And I wait for "60" seconds
     Then I should see a "Bootstrap Minions" text
     When I check "manageWithSSH"
-    And I enter the hostname of "ubuntu_minion" as "hostname"
+    And I enter the hostname of "ubuntu_ssh_minion" as "hostname"
     And I enter "linux" as "password"
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
     And I navigate to "rhn/systems/Overview.do" page
-    And I wait until I see the name of "ubuntu_minion", refreshing the page
-    And I wait until onboarding is completed for "ubuntu_minion"
+    And I wait until I see the name of "ubuntu_ssh_minion", refreshing the page
+    And I wait until onboarding is completed for "ubuntu_ssh_minion"
 
 @proxy
 @ubuntu_minion
   Scenario: Check connection from SSH-managed Ubuntu minion to proxy
-    Given I am on the Systems overview page of this "ubuntu_minion"
+    Given I am on the Systems overview page of this "ubuntu_ssh_minion"
     When I follow "Details" in the content area
     And I follow "Connection" in the content area
-    Then I should see "proxy" hostname
+    Then I should see "proxy" short hostname
 
 @proxy
 @ubuntu_minion
@@ -36,11 +35,11 @@ Feature: Bootstrap a SSH-managed Ubuntu minion and do some basic operations on i
     Given I am on the Systems overview page of this "proxy"
     When I follow "Details" in the content area
     And I follow "Proxy" in the content area
-    Then I should see "ubuntu_minion" hostname
+    Then I should see "ubuntu_ssh_minion" hostname
 
 @ubuntu_minion
   Scenario: Subscribe the SSH-managed Ubuntu minion to a base channel
-    Given I am on the Systems overview page of this "ubuntu_minion"
+    Given I am on the Systems overview page of this "ubuntu_ssh_minion"
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
@@ -54,5 +53,5 @@ Feature: Bootstrap a SSH-managed Ubuntu minion and do some basic operations on i
 
 @ubuntu_minion
   Scenario: Check events history for failures on SSH-managed Ubuntu minion
-    Given I am on the Systems overview page of this "ubuntu_minion"
+    Given I am on the Systems overview page of this "ubuntu_ssh_minion"
     Then I check for failed events on history event page

--- a/testsuite/features/init_clients/centos_minion.feature
+++ b/testsuite/features/init_clients/centos_minion.feature
@@ -54,11 +54,11 @@ Feature: Bootstrap a SSH-managed CentOS minion and do some basic operations on i
 @centos_minion
   Scenario: Prepare the SSH-managed CentOS minion
     Given I am authorized
-    When I enable SUSE Manager tools repositories on "ceos_client"
-    And  I enable repository "CentOS-Base" on this "ceos_client"
-    And  I install package "hwdata m2crypto wget" on this "ceos_client"
-    And  I install package "spacewalk-client-tools spacewalk-check spacewalk-client-setup mgr-daemon mgr-osad mgr-cfg-actions" on this "ceos_client"
-    And  I install package "spacewalk-oscap scap-security-guide" on this "ceos_client"
+    When I enable SUSE Manager tools repositories on "ceos_ssh_minion"
+    And  I enable repository "CentOS-Base" on this "ceos_ssh_minion"
+    And  I install package "hwdata m2crypto wget" on this "ceos_ssh_minion"
+    And  I install package "spacewalk-client-tools spacewalk-check spacewalk-client-setup mgr-daemon mgr-osad mgr-cfg-actions" on this "ceos_ssh_minion"
+    And  I install package "spacewalk-oscap scap-security-guide" on this "ceos_ssh_minion"
 
 @centos_minion
   Scenario: Check events history for failures on SSH-managed CentOS minion

--- a/testsuite/features/init_clients/ubuntu_ssh_minion.feature
+++ b/testsuite/features/init_clients/ubuntu_ssh_minion.feature
@@ -12,19 +12,19 @@ Feature: Bootstrap a SSH-managed Ubuntu minion and do some basic operations on i
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
     When I check "manageWithSSH"
-    And I enter the hostname of "ubuntu_minion" as "hostname"
+    And I enter the hostname of "ubuntu_ssh_minion" as "hostname"
     And I enter "linux" as "password"
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
     And I navigate to "rhn/systems/Overview.do" page
-    And I wait until I see the name of "ubuntu_minion", refreshing the page
-    And I wait until onboarding is completed for "ubuntu_minion"
+    And I wait until I see the name of "ubuntu_ssh_minion", refreshing the page
+    And I wait until onboarding is completed for "ubuntu_ssh_minion"
 
 @proxy
 @ubuntu_minion
   Scenario: Check connection from SSH-managed Ubuntu minion to proxy
-    Given I am on the Systems overview page of this "ubuntu_minion"
+    Given I am on the Systems overview page of this "ubuntu_ssh_minion"
     When I follow "Details" in the content area
     And I follow "Connection" in the content area
     Then I should see "proxy" short hostname
@@ -35,11 +35,11 @@ Feature: Bootstrap a SSH-managed Ubuntu minion and do some basic operations on i
     Given I am on the Systems overview page of this "proxy"
     When I follow "Details" in the content area
     And I follow "Proxy" in the content area
-    Then I should see "ubuntu_minion" hostname
+    Then I should see "ubuntu_ssh_minion" hostname
 
 @ubuntu_minion
   Scenario: Subscribe the SSH-managed Ubuntu minion to a base channel
-    Given I am on the Systems overview page of this "ubuntu_minion"
+    Given I am on the Systems overview page of this "ubuntu_ssh_minion"
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
@@ -53,5 +53,5 @@ Feature: Bootstrap a SSH-managed Ubuntu minion and do some basic operations on i
 
 @ubuntu_minion
   Scenario: Check events history for failures on SSH-managed Ubuntu minion
-    Given I am on the Systems overview page of this "ubuntu_minion"
+    Given I am on the Systems overview page of this "ubuntu_ssh_minion"
     Then I check for failed events on history event page

--- a/testsuite/features/qam/init_clients/ceos7_client.feature
+++ b/testsuite/features/qam/init_clients/ceos7_client.feature
@@ -29,7 +29,7 @@ Feature: Be able to register a CentOS 7 traditional client and do some basic ope
     Then I should see "ceos7_client" hostname
 
   Scenario: Re-subscribe the CentOS 7 traditional client to a base channel
-    Given I am on the Systems overview page of this "ceos_minion"
+    Given I am on the Systems overview page of this "ceos_client"
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text

--- a/testsuite/features/qam/init_clients/disabled/ceos6_client.feature
+++ b/testsuite/features/qam/init_clients/disabled/ceos6_client.feature
@@ -30,7 +30,7 @@ Feature: Be able to register a CentOS 6 traditional client and do some basic ope
     Then I should see "ceos6_client" hostname
     
   Scenario: Re-subscribe the CentOS 6 traditional client to a base channel
-    Given I am on the Systems overview page of this "ceos_minion"
+    Given I am on the Systems overview page of this "ceos_client"
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text

--- a/testsuite/features/secondary/allcli_config_channel.feature
+++ b/testsuite/features/secondary/allcli_config_channel.feature
@@ -47,7 +47,7 @@ Feature: Management of configuration of all types of clients in a single channel
 
 @centos_minion
   Scenario: Subscribe a CentOS minion to the configuration channel
-    When I am on the Systems overview page of this "ceos_minion"
+    When I am on the Systems overview page of this "ceos_ssh_minion"
     And I follow "Configuration" in the content area
     And I follow "Manage Configuration Channels" in the content area
     And I follow first "Subscribe to Channels" in the content area
@@ -58,7 +58,7 @@ Feature: Management of configuration of all types of clients in a single channel
 
 @ubuntu_minion
   Scenario: Subscribe a Ubuntu minion to the configuration channel
-    When I am on the Systems overview page of this "ubuntu_minion"
+    When I am on the Systems overview page of this "ubuntu_ssh_minion"
     And I follow "Configuration" in the content area
     And I follow "Manage Configuration Channels" in the content area
     And I follow first "Subscribe to Channels" in the content area
@@ -101,13 +101,13 @@ Feature: Management of configuration of all types of clients in a single channel
 
 @centos_minion
   Scenario: Check that file has been created on CentOS minion
-    When I wait until file "/etc/s-mgr/config" exists on "ceos_minion"
-    Then file "/etc/s-mgr/config" should contain "COLOR=white" on "ceos_minion"
+    When I wait until file "/etc/s-mgr/config" exists on "ceos_ssh_minion"
+    Then file "/etc/s-mgr/config" should contain "COLOR=white" on "ceos_ssh_minion"
 
 @ubuntu_minion
   Scenario: Check that file has been created on Ubuntu minion
-    When I wait until file "/etc/s-mgr/config" exists on "ubuntu_minion"
-    Then file "/etc/s-mgr/config" should contain "COLOR=white" on "ubuntu_minion"
+    When I wait until file "/etc/s-mgr/config" exists on "ubuntu_ssh_minion"
+    Then file "/etc/s-mgr/config" should contain "COLOR=white" on "ubuntu_ssh_minion"
 
 @ssh_minion
   Scenario: Check that file has been created on SSH minion
@@ -121,15 +121,15 @@ Feature: Management of configuration of all types of clients in a single channel
 
 @centos_minion
   Scenario: Apply highstate to override changed content on CentOS minion
-    When I store "COLOR=blue" into file "/etc/s-mgr/config" on "ceos_minion"
-    And I apply highstate on "ceos_minion"
-    Then file "/etc/s-mgr/config" should contain "COLOR=white" on "ceos_minion"
+    When I store "COLOR=blue" into file "/etc/s-mgr/config" on "ceos_ssh_minion"
+    And I apply highstate on "ceos_ssh_minion"
+    Then file "/etc/s-mgr/config" should contain "COLOR=white" on "ceos_ssh_minion"
 
 @ubuntu_minion
   Scenario: Apply highstate to override changed content on Ubuntu minion
-    When I store "COLOR=blue" into file "/etc/s-mgr/config" on "ubuntu_minion"
-    And I apply highstate on "ubuntu_minion"
-    Then file "/etc/s-mgr/config" should contain "COLOR=white" on "ubuntu_minion"
+    When I store "COLOR=blue" into file "/etc/s-mgr/config" on "ubuntu_ssh_minion"
+    And I apply highstate on "ubuntu_ssh_minion"
+    Then file "/etc/s-mgr/config" should contain "COLOR=white" on "ubuntu_ssh_minion"
 
 @ssh_minion
   Scenario: Apply highstate to override changed content on SSH minion
@@ -143,10 +143,10 @@ Feature: Management of configuration of all types of clients in a single channel
     When I follow the left menu "Configuration > Channels"
     And I follow "Mixed Channel"
     And I follow "Systems" in the content area
-    And I check the "ceos_minion" client
+    And I check the "ceos_ssh_minion" client
     And I click on "Unsubscribe systems"
     Then I should see a "Successfully unsubscribed 1 system(s)." text
-    And I destroy "/etc/s-mgr" directory on "ceos_minion"
+    And I destroy "/etc/s-mgr" directory on "ceos_ssh_minion"
 
 @ubuntu_minion
   Scenario: Unsubscribe Ubuntu minion and delete configuration files
@@ -154,10 +154,10 @@ Feature: Management of configuration of all types of clients in a single channel
     When I follow the left menu "Configuration > Channels"
     And I follow "Mixed Channel"
     And I follow "Systems" in the content area
-    And I check the "ubuntu_minion" client
+    And I check the "ubuntu_ssh_minion" client
     And I click on "Unsubscribe systems"
     Then I should see a "Successfully unsubscribed 1 system(s)." text
-    And I destroy "/etc/s-mgr" directory on "ubuntu_minion"
+    And I destroy "/etc/s-mgr" directory on "ubuntu_ssh_minion"
 
 @ssh_minion
   Scenario: Unsubscribe SSH minion and delete configuration files

--- a/testsuite/features/secondary/allcli_overview_systems_details.feature
+++ b/testsuite/features/secondary/allcli_overview_systems_details.feature
@@ -13,13 +13,13 @@ Feature: The system details of each minion and client provides an overview of th
 
 @centos_minion
   Scenario: CentOS minion grains are displayed correctly on the details page
-    Given I am on the Systems overview page of this "ceos_minion"
-    Then I can see all system information for "ceos_minion"
+    Given I am on the Systems overview page of this "ceos_ssh_minion"
+    Then I can see all system information for "ceos_ssh_minion"
 
 @ubuntu_minion
   Scenario: Ubuntu minion grains are displayed correctly on the details page
-    Given I am on the Systems overview page of this "ubuntu_minion"
-    Then I can see all system information for "ubuntu_minion"
+    Given I am on the Systems overview page of this "ubuntu_ssh_minion"
+    Then I can see all system information for "ubuntu_ssh_minion"
 
 @ssh_minion
   Scenario: SSH-managed minion grains are displayed correctly on the details page

--- a/testsuite/features/secondary/allcli_reboot.feature
+++ b/testsuite/features/secondary/allcli_reboot.feature
@@ -39,7 +39,7 @@ Feature: Reboot systems managed by SUSE Manager
 
 @centos_minion
   Scenario: Reboot the CentOS minion and wait until reboot is completed
-    Given I am on the Systems overview page of this "ceos_minion"
+    Given I am on the Systems overview page of this "ceos_ssh_minion"
     When I follow first "Schedule System Reboot"
     Then I should see a "System Reboot Confirmation" text
     And I should see a "Reboot system" button
@@ -50,7 +50,7 @@ Feature: Reboot systems managed by SUSE Manager
 
 @ubuntu_minion
   Scenario: Reboot the Ubuntu minion and wait until reboot is completed
-    Given I am on the Systems overview page of this "ubuntu_minion"
+    Given I am on the Systems overview page of this "ubuntu_ssh_minion"
     When I follow first "Schedule System Reboot"
     Then I should see a "System Reboot Confirmation" text
     And I should see a "Reboot system" button

--- a/testsuite/features/secondary/allcli_software_channels.feature
+++ b/testsuite/features/secondary/allcli_software_channels.feature
@@ -104,7 +104,7 @@ Feature: Chanel subscription via SSM
   Scenario: System default channel can't be determined
     Given I am authorized as "admin" with password "admin"
     When I am on the System Overview page
-    And I check the "ceos_minion" client
+    And I check the "ceos_ssh_minion" client
     And I uncheck the "sle_minion" client
     And I uncheck the "sle_client" client
     Then I should see "1" systems selected for SSM
@@ -122,11 +122,11 @@ Feature: Chanel subscription via SSM
     When I click on "Confirm"
     Then I should see a "Channel Changes Actions" text
     And I should see a "Items 1 - 1 of 1" text
-    And a table line should contain system "ceos_minion", "Could not determine system default channel"
+    And a table line should contain system "ceos_ssh_minion", "Could not determine system default channel"
 
 @centos_minion
   Scenario: Cleanup: make sure the CentOS minion is still unchanged
-    Given I am on the Systems overview page of this "ceos_minion"
+    Given I am on the Systems overview page of this "ceos_ssh_minion"
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     Then radio button "Test Base Channel" is checked
@@ -135,7 +135,7 @@ Feature: Chanel subscription via SSM
   Scenario: Cleanup: remove CentOS systems from SSM
     Given I am authorized as "admin" with password "admin"
     And I am on the System Overview page
-    When I uncheck the "ceos_minion" client
+    When I uncheck the "ceos_ssh_minion" client
     And I check the "sle_minion" client
     And I check the "sle_client" client
     And I should see "2" systems selected for SSM
@@ -144,7 +144,7 @@ Feature: Chanel subscription via SSM
   Scenario: System default channel can't be determined
     Given I am authorized as "admin" with password "admin"
     When I am on the System Overview page
-    And I check the "ubuntu_minion" client
+    And I check the "ubuntu_ssh_minion" client
     And I uncheck the "sle_minion" client
     And I uncheck the "sle_client" client
     Then I should see "1" systems selected for SSM
@@ -162,11 +162,11 @@ Feature: Chanel subscription via SSM
     When I click on "Confirm"
     Then I should see a "Channel Changes Actions" text
     And I should see a "Items 1 - 1 of 1" text
-    And a table line should contain system "ubuntu_minion", "Could not determine system default channel"
+    And a table line should contain system "ubuntu_ssh_minion", "Could not determine system default channel"
 
 @ubuntu_minion
   Scenario: Cleanup: make sure the Ubuntu minion is still unchanged
-    Given I am on the Systems overview page of this "ubuntu_minion"
+    Given I am on the Systems overview page of this "ubuntu_ssh_minion"
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     Then radio button "Test-Channel-Deb-AMD64" is checked
@@ -175,7 +175,7 @@ Feature: Chanel subscription via SSM
   Scenario: Cleanup: remove Ubuntu system from SSM
     Given I am authorized as "admin" with password "admin"
     And I am on the System Overview page
-    When I uncheck the "ubuntu_minion" client
+    When I uncheck the "ubuntu_ssh_minion" client
     And I check the "sle_minion" client
     And I check the "sle_client" client
     And I should see "2" systems selected for SSM

--- a/testsuite/features/secondary/allcli_system_group.feature
+++ b/testsuite/features/secondary/allcli_system_group.feature
@@ -58,7 +58,7 @@ Feature: Manage a group of systems
     When I follow "new-systems-group"
     And I follow "Target Systems"
     Then I should see a "The following are systems that may be added to this group." text
-    When I check the "ceos_minion" client
+    When I check the "ceos_ssh_minion" client
     And I click on "Add Systems"
     Then I should see a "1 systems were added to new-systems-group server group" text
 

--- a/testsuite/features/secondary/min_ubuntu_salt_install_package.feature
+++ b/testsuite/features/secondary/min_ubuntu_salt_install_package.feature
@@ -5,21 +5,21 @@ Feature: Install and upgrade package on the Ubuntu minion via Salt through the U
 
 @ubuntu_minion
   Scenario: Pre-requisite: install virgo-dummy-1.0 packages on Ubuntu minion
-    When I enable repository "test_repo_deb_pool" on this "ubuntu_minion"
-    And I run "apt update" on "ubuntu_minion" with logging
-    And I remove package "andromeda-dummy" from this "ubuntu_minion"
-    And I install package "virgo-dummy=1.0" on this "ubuntu_minion"
-    And I am on the Systems overview page of this "ubuntu_minion"
+    When I enable repository "test_repo_deb_pool" on this "ubuntu_ssh_minion"
+    And I run "apt update" on "ubuntu_ssh_minion" with logging
+    And I remove package "andromeda-dummy" from this "ubuntu_ssh_minion"
+    And I install package "virgo-dummy=1.0" on this "ubuntu_ssh_minion"
+    And I am on the Systems overview page of this "ubuntu_ssh_minion"
     And I follow "Software" in the content area
     And I click on "Update Package List"
     And I follow "Events" in the content area
     And I wait until I do not see "Package List Refresh scheduled by admin" text, refreshing the page
-    And I wait until package "virgo-dummy" is installed on "ubuntu_minion" via spacecmd
-    And I wait until package "andromeda-dummy" is removed from "ubuntu_minion" via spacecmd
+    And I wait until package "virgo-dummy" is installed on "ubuntu_ssh_minion" via spacecmd
+    And I wait until package "andromeda-dummy" is removed from "ubuntu_ssh_minion" via spacecmd
 
 @ubuntu_minion
   Scenario: Install a package on the minion
-    Given I am on the Systems overview page of this "ubuntu_minion"
+    Given I am on the Systems overview page of this "ubuntu_ssh_minion"
     And I follow "Software" in the content area
     And I follow "Install"
     And I check "andromeda-dummy" in the list
@@ -27,11 +27,11 @@ Feature: Install and upgrade package on the Ubuntu minion via Salt through the U
     And I click on "Confirm"
     And I should see a "1 package install has been scheduled for" text
     When I wait until event "Package Install/Upgrade scheduled by admin" is completed
-    Then Deb package "andromeda-dummy" with version "2.0" should be installed on "ubuntu_minion"
+    Then Deb package "andromeda-dummy" with version "2.0" should be installed on "ubuntu_ssh_minion"
 
 @ubuntu_minion
   Scenario: Update a package on the minion
-    Given I am on the Systems overview page of this "ubuntu_minion"
+    Given I am on the Systems overview page of this "ubuntu_ssh_minion"
     And I follow "Software" in the content area
     And I follow "Upgrade" in the content area
     And I check "virgo-dummy-2.0-X" in the list
@@ -39,14 +39,14 @@ Feature: Install and upgrade package on the Ubuntu minion via Salt through the U
     And I click on "Confirm"
     And I should see a "1 package upgrade has been scheduled for" text
     When I wait until event "Package Install/Upgrade scheduled by admin" is completed
-    Then Deb package "virgo-dummy" with version "2.0" should be installed on "ubuntu_minion"
+    Then Deb package "virgo-dummy" with version "2.0" should be installed on "ubuntu_ssh_minion"
 
 @ubuntu_minion
   Scenario: Cleanup: remove virgo-dummy and andromeda-dummy packages from Ubuntu minion
     Given I am authorized as "admin" with password "admin"
-    And I remove package "andromeda-dummy" from this "ubuntu_minion"
-    And I install package "andromeda-dummy=1.0" on this "ubuntu_minion"
-    And I remove package "virgo-dummy" from this "ubuntu_minion"
-    And I disable repository "test_repo_deb_pool" on this "ubuntu_minion"
-    And I run "apt update" on "ubuntu_minion" with logging
+    And I remove package "andromeda-dummy" from this "ubuntu_ssh_minion"
+    And I install package "andromeda-dummy=1.0" on this "ubuntu_ssh_minion"
+    And I remove package "virgo-dummy" from this "ubuntu_ssh_minion"
+    And I disable repository "test_repo_deb_pool" on this "ubuntu_ssh_minion"
+    And I run "apt update" on "ubuntu_ssh_minion" with logging
 

--- a/testsuite/features/secondary/srv_group_union_intersection.feature
+++ b/testsuite/features/secondary/srv_group_union_intersection.feature
@@ -37,7 +37,7 @@ Feature: Work with Union and Intersection buttons in the group list
     Given I am on the groups page
     When I follow "centos"
     And I follow "Target Systems"
-    And I check the "ceos_minion" client
+    And I check the "ceos_ssh_minion" client
     And I click on "Add Systems"
     Then I should see a "1 systems were added to centos server group." text
 
@@ -55,7 +55,7 @@ Feature: Work with Union and Intersection buttons in the group list
     Given I am on the groups page
     When I follow "ubuntu"
     And I follow "Target Systems"
-    And I check the "ubuntu_minion" client
+    And I check the "ubuntu_ssh_minion" client
     And I click on "Add Systems"
     Then I should see a "1 systems were added to ubuntu server group." text
 
@@ -91,7 +91,7 @@ Feature: Work with Union and Intersection buttons in the group list
     And I click on "Work With Union"
     Then I should see "sle_client" as link
     And I should see "sle_minion" as link
-    And I should see "ceos_minion" as link
+    And I should see "ceos_ssh_minion" as link
 
 @centos_minion
   Scenario: Add an intersection of 2 groups to SSM - CentOS
@@ -101,7 +101,7 @@ Feature: Work with Union and Intersection buttons in the group list
     And I click on "Work With Intersection"
     Then I should see "sle_client" as link
     And I should not see a "sle_minion" link
-    And I should not see a "ceos_minion" link
+    And I should not see a "ceos_ssh_minion" link
 
 @ubuntu_minion
   Scenario: Add a union of 2 groups to SSM - Ubuntu
@@ -111,7 +111,7 @@ Feature: Work with Union and Intersection buttons in the group list
     And I click on "Work With Union"
     Then I should see "sle_client" as link
     And I should see "sle_minion" as link
-    And I should see "ubuntu_minion" as link
+    And I should see "ubuntu_ssh_minion" as link
 
 @ubuntu_minion
   Scenario: Add an intersection of 2 groups to SSM - Ubuntu
@@ -121,7 +121,7 @@ Feature: Work with Union and Intersection buttons in the group list
     And I click on "Work With Intersection"
     Then I should see "sle_client" as link
     And I should not see a "sle_minion" link
-    And I should not see a "ubuntu_minion" link
+    And I should not see a "ubuntu_ssh_minion" link
 
   Scenario: Cleanup: remove the sles group
     Given I am on the groups page

--- a/testsuite/features/secondary/trad_centos_client.feature
+++ b/testsuite/features/secondary/trad_centos_client.feature
@@ -48,7 +48,7 @@ Feature: Be able to register a CentOS 7 traditional client and do some basic ope
 
 @centos_minion
   Scenario: Re-subscribe the CentOS traditional client to a base channel
-    Given I am on the Systems overview page of this "ceos_minion"
+    Given I am on the Systems overview page of this "ceos_client"
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -80,15 +80,13 @@ end
 
 When(/^I apply highstate on "([^"]*)"$/) do |host|
   system_name = get_system_name(host)
-  if host == 'sle_minion'
-    cmd = 'salt'
-    extra_cmd = ''
-  elsif ['ssh_minion', 'ceos_minion', 'ceos_ssh_minion', 'ubuntu_minion', 'ubuntu-ssh_minion'].include?(host)
+  if %w[ssh_minion ceos_ssh_minion ubuntu_ssh_minion].include?(host)
     cmd = 'runuser -u salt -- salt-ssh --priv=/srv/susemanager/salt/salt_ssh/mgr_ssh_id'
     extra_cmd = '-i --roster-file=/tmp/roster_tests -w -W'
     $server.run("printf '#{system_name}:\n  host: #{system_name}\n  user: root\n  passwd: linux\n' > /tmp/roster_tests")
   else
-    raise 'Invalid target'
+    cmd = 'salt'
+    extra_cmd = ''
   end
   $server.run_until_ok("cd /tmp; #{cmd} #{system_name} state.highstate #{extra_cmd}")
 end

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -701,7 +701,7 @@ When(/^I install Salt packages from "(.*?)"$/) do |host|
   target = get_target(host)
   if %w[sle_minion ssh_minion sle_client sle_migrated_minion].include?(host)
     target.run("test -e /usr/bin/zypper && zypper --non-interactive install -y salt salt-minion", false)
-  elsif ['ceos_minion'].include?(host)
+  elsif %w[ceos_minion ceos_ssh_minion].include?(host)
     target.run("test -e /usr/bin/yum && yum -y install salt salt-minion", false)
   elsif %w[ubuntu_minion ubuntu_ssh_minion].include?(host)
     target.run("test -e /usr/bin/apt && apt -y install salt-common salt-minion", false)


### PR DESCRIPTION
## What does this PR change?

We had a bug in 4.0 branch: the highstate was failing because the test steps were referring to `ceos_minion` and `ubuntu_minion`, while the highstate is done differently for normal minions and SSH minions.

This PR makes sure that most of the time we use the version with `_ssh_` in it, because by effect of our idempotency conventions, the CentOS and Ubuntu minions are SSH minions most of the time.

This PR also fixes other problems, for example on branch 4.0 we have `init_clients/centos_minion.feature`, while in uyuni branch  we have `init_clients/centos_ssh_minion.feature`.

## Links

Ports:
* 3.2: TBD
* 4.0: SUSE/spacewalk#10298

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
