### PR TITLE
Testsuite - fix for moved search input

### DIFF
--- a/testsuite/features/secondary/min_salt_software_states.feature
+++ b/testsuite/features/secondary/min_salt_software_states.feature
@@ -40,6 +40,7 @@ Feature: Salt package states
     Given I am on the Systems overview page of this "sle_minion"
     Then I follow "States" in the content area
     And I follow "Packages"
+    And I follow "Search"
     And I should see a "Package States" text
     And I list packages with "dummy"
     Then I should see a "milkyway-dummy" text
@@ -70,6 +71,7 @@ Feature: Salt package states
     Given I am on the Systems overview page of this "sle_minion"
     Then I follow "States" in the content area
     And I follow "Packages"
+    And I follow "Search"
     And I should see a "Package States" text
     And I list packages with "dummy"
     Then I should see a "virgo-dummy" text
@@ -85,6 +87,7 @@ Feature: Salt package states
     Given I am on the Systems overview page of this "sle_minion"
     Then I follow "States" in the content area
     And I follow "Packages"
+    And I follow "Search"
     And I should see a "Package States" text
     And I list packages with "dummy"
     Then I should see a "andromeda-dummy" text


### PR DESCRIPTION
## What does this PR change?

Search input field is moved under "Search" menu. PR adapts testsuite for it.

## Links

https://github.com/SUSE/spacewalk/issues/10199

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
