### PR TITLE
Metadata for formulas that change only pillar data

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/FormulaController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/FormulaController.java
@@ -229,6 +229,10 @@ public class FormulaController {
                     Arrays.asList("Error while saving formula data: " +
                             e.getMessage()));
         }
+        Map<String, Object> metadata = FormulaFactory.getMetadata(formulaName);
+        if (Boolean.TRUE.equals(metadata.get("pillar_only"))) {
+            return GSON.toJson(Arrays.asList("pillar_only_formula_saved"));
+        }
         return GSON.toJson(Arrays.asList("formula_saved")); // Formula saved!
     }
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Show adequate message on saving formulas that change only pillar data
 - Fix container image import (bsc#1154246)
 - Add missing permission checks on formula api (bsc#1123274)
 - use channel name from product tree instead of constructing it (bsc#1157317)

--- a/web/html/src/components/FormulaForm.js
+++ b/web/html/src/components/FormulaForm.js
@@ -13,6 +13,10 @@ const EditGroupSubtype = Formulas.EditGroupSubtype;
 const deepCopy = Utils.deepCopy;
 const capitalize = Utils.capitalize;
 
+const defaultMessageTexts = {
+    "pillar_only_formula_saved": <p>{t("Formula saved. Applying the highstate is not needed for this formula.")}</p>
+}
+
 //props:
 //dataUrl = url to get the server data
 //saveUrl = url to save the data, data is sent as post request
@@ -317,6 +321,9 @@ class FormulaForm extends React.Component {
     }
 
     getMessageText(msg) {
+      if (!this.props.messageTexts[msg] && defaultMessageTexts[msg]) {
+          return t(defaultMessageTexts[msg]);
+      }
       return this.props.messageTexts[msg] ? t(this.props.messageTexts[msg]) : msg;
     }
 

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Show adequate message on saving formulas that change only pillar data
 - Report merge_subscriptions message in a readable way (bsc#1140332)
 - Use ReactJS Context in Form components
 


### PR DESCRIPTION
## What does this PR change?

Some formulas can change only pillar data without providing a state. 
This PR adds a the `pillar_only` flag to the form metadata.
E.g.
```yaml
description:
  Change minion blackout mode...
group: general_system_configuration
pillar_only: True

```

## GUI diff

Before:
![Screenshot_2019-12-10 SUSE Manager - Systems(1)](https://user-images.githubusercontent.com/11468018/70540650-e83a4080-1b65-11ea-9571-24d0ab0c6e9d.png)

After:

![Screenshot_2019-12-10 SUSE Manager - Systems](https://user-images.githubusercontent.com/11468018/70540597-d6589d80-1b65-11ea-8472-762658a1427c.png)

- [x] **DONE**

## Documentation
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: simple change

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/10104

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
