### PR TITLE
Testsuite - text description changed to singular

### DIFF
--- a/testsuite/features/secondary/min_salt_software_states.feature
+++ b/testsuite/features/secondary/min_salt_software_states.feature
@@ -45,7 +45,7 @@ Feature: Salt package states
     Then I should see a "milkyway-dummy" text
     And "milkyway-dummy" should be installed on "sle_minion"
     And I change the state of "milkyway-dummy" to "Removed" and ""
-    Then I should see a "1 Changes" text
+    Then I should see a "1 Change" text
     And I click save
     Then I wait until I see "Package states have been saved." text
     And I click apply
@@ -60,7 +60,7 @@ Feature: Salt package states
     Then I should see a "milkyway-dummy" text
     And "milkyway-dummy" should not be installed on "sle_minion"
     And I change the state of "milkyway-dummy" to "Installed" and ""
-    Then I should see a "1 Changes" text
+    Then I should see a "1 Change" text
     And I click save
     Then I wait until I see "Package states have been saved." text
     And I click apply
@@ -75,7 +75,7 @@ Feature: Salt package states
     Then I should see a "virgo-dummy" text
     And "virgo-dummy-1.0" should be installed on "sle_minion"
     And I change the state of "virgo-dummy" to "Installed" and "Any"
-    Then I should see a "1 Changes" text
+    Then I should see a "1 Change" text
     And I click save
     Then I wait until I see "Package states have been saved." text
     And I click apply
@@ -90,7 +90,7 @@ Feature: Salt package states
     Then I should see a "andromeda-dummy" text
     And "andromeda-dummy-1.0" should be installed on "sle_minion"
     And I change the state of "andromeda-dummy" to "Installed" and "Latest"
-    Then I should see a "1 Changes" text
+    Then I should see a "1 Change" text
     And I click save
     Then I wait until I see "Package states have been saved." text
     And I click apply


### PR DESCRIPTION
## What does this PR change?

Fix for slightly changed UI.

## Changelogs

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
