### PR TITLE
Bug 1163121: Fix the original-clone channel relationship for CLM channels

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Channel_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Channel_queries.xml
@@ -1183,4 +1183,10 @@ ORDER BY CC.modified DESC
   </query>
 </mode>
 
+<write-mode name="add_clone_info">
+    <query params="original_id, channel_id">
+        INSERT INTO rhnChannelCloned(original_id, id)
+        VALUES(:original_id, :channel_id)
+    </query>
+</write-mode>
 </datasource_modes>

--- a/java/code/src/com/redhat/rhn/domain/channel/Channel.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/Channel.java
@@ -959,5 +959,13 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
         return "deb".equalsIgnoreCase(getArchTypeLabel());
     }
 
+    /**
+     * Return the {@link Channel} as {@link ClonedChannel} if it is one
+     *
+     * @return the optional of {@link ClonedChannel}
+     */
+    public Optional<ClonedChannel> asCloned() {
+        return Optional.empty();
+    }
 }
 

--- a/java/code/src/com/redhat/rhn/domain/channel/ClonedChannel.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/ClonedChannel.java
@@ -16,6 +16,8 @@ package com.redhat.rhn.domain.channel;
 
 import com.redhat.rhn.domain.common.ChecksumType;
 
+import java.util.Optional;
+
 /**
  * ClonedChannel
  * @version $Rev$
@@ -46,6 +48,14 @@ public class ClonedChannel extends Channel {
     @Override
     public boolean isCloned() {
         return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Optional<ClonedChannel> asCloned() {
+        return Optional.of(this);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
@@ -231,10 +231,19 @@ public class ContentProjectFactory extends HibernateFactory {
     }
 
     /**
-     * Remove an environment from the path. It take care that chain stay intact
+     * Remove an environment from the path. Take care that chain stays intact.
+     * Also remove all channels belonging to this environment.
+     *
      * @param toRemove environment to remove.
      */
     public static void removeEnvironment(ContentEnvironment toRemove) {
+        // let's purge all the targets in the environment firstly
+        new ArrayList<>(toRemove.getTargets()).stream()
+                .sorted((t1, t2) -> Boolean.compare(// make sure a parent channel goes first
+                        t1.asSoftwareTarget().map(t -> t.getChannel().isBaseChannel()).orElse(false),
+                        t2.asSoftwareTarget().map(t -> t.getChannel().isBaseChannel()).orElse(false)))
+                .forEach(ContentProjectFactory::purgeTarget);
+
         if (toRemove.getNextEnvironmentOpt().isPresent()) {
             ContentEnvironment next = toRemove.getNextEnvironmentOpt().get();
             if (toRemove.getPrevEnvironmentOpt().isPresent()) {

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentProjectFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentProjectFactoryTest.java
@@ -19,6 +19,7 @@ package com.redhat.rhn.domain.contentmgmt.test;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.ChannelFactory;
+import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
 import com.redhat.rhn.domain.contentmgmt.ContentEnvironment;
 import com.redhat.rhn.domain.contentmgmt.ContentFilter;
 import com.redhat.rhn.domain.contentmgmt.ContentProject;
@@ -607,5 +608,45 @@ public class ContentProjectFactoryTest extends BaseTestCaseWithUser {
                 assertEquals(oldStatus, tgt.getStatus());
             }
         });
+    }
+
+    /**
+     * Test the lookup method for cloned channels within content project
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testLookupClonesInProject() throws Exception {
+        // create CLM objects
+        ContentProject cp = new ContentProject("project1", "Project 1", "This is project 1", user.getOrg());
+        ContentProjectFactory.save(cp);
+
+        var devEnv = new ContentEnvironment("dev", "dev", null, cp);
+        cp.setFirstEnvironment(devEnv);
+        ContentProjectFactory.save(devEnv);
+        var testEnv = new ContentEnvironment("test", "test", null, cp);
+        ContentProjectFactory.save(testEnv);
+        ContentProjectFactory.insertEnvironment(testEnv, of(devEnv));
+
+        // create channels and corresponding targets
+        Channel srcChannel = ChannelFactoryTest.createTestChannel(user);
+        srcChannel.setLabel("channel123");
+        Channel devChannel = ChannelFactoryTest.createTestClonedChannel(srcChannel, user);
+        devChannel.setLabel("testproj1-dev-channel123");
+        Channel testChannel = ChannelFactoryTest.createTestClonedChannel(devChannel, user);
+        testChannel.setLabel("testproj1-test-channel123");
+
+        var devTgt = new SoftwareEnvironmentTarget(devEnv, devChannel);
+        devEnv.addTarget(devTgt);
+        var testTgt = new SoftwareEnvironmentTarget(testEnv, testChannel);
+        testEnv.addTarget(testTgt);
+
+        // check dev environment
+        assertEquals(srcChannel, devTgt.getChannel().asCloned().map(c1 -> c1.getOriginal()).get());
+        assertEquals(1, ContentProjectFactory.lookupClonesInProject(devTgt.getChannel(), devTgt.getContentEnvironment().getContentProject()).size());
+        assertEquals(testChannel, ContentProjectFactory.lookupClonesInProject(devTgt.getChannel(), devTgt.getContentEnvironment().getContentProject()).iterator().next());
+
+        // check test environment
+        assertEquals(devChannel, testTgt.getChannel().asCloned().map(c -> c.getOriginal()).get());
+        assertTrue(ContentProjectFactory.lookupClonesInProject(testTgt.getChannel(), testTgt.getContentEnvironment().getContentProject()).isEmpty());
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
@@ -1320,6 +1320,21 @@ public class ChannelManager extends BaseManager {
     }
 
     /**
+     * Add clone data to the channel (transform regular channel to a cloned one).
+     *
+     * @param originalId the original channel id
+     * @param channelId the channel id
+     * @return the number of rows added
+     */
+    public static int addCloneInfo(long originalId, long channelId) {
+        WriteMode m = ModeFactory.getWriteMode("Channel_queries", "add_clone_info");
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("original_id", originalId);
+        params.put("channel_id", channelId);
+        return m.executeUpdate(params);
+    }
+
+    /**
      * Finds the id of a child channel with the given parent channel id that contains
      * a package with the given name.  Returns all child channel unless expectOne is True
      * @param org Organization of the current user.

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
@@ -1245,15 +1245,15 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
     public void testClonedChannelLinks() throws Exception {
         var project = new ContentProject("cplabel", "cpname", "cpdesc", user.getOrg());
         ContentProjectFactory.save(project);
-        var devEnv = ContentManager.createEnvironment(project.getLabel(), empty(), "dev", "dev env", "desc", false, user);
-        var testEnv = ContentManager.createEnvironment(project.getLabel(), of("dev"), "test", "test env", "desc", false, user);
+        var devEnv = contentManager.createEnvironment(project.getLabel(), empty(), "dev", "dev env", "desc", false, user);
+        var testEnv = contentManager.createEnvironment(project.getLabel(), of("dev"), "test", "test env", "desc", false, user);
 
         // build the project with 2 channels
         var channel1 = createPopulatedChannel();
         var channel2 = createPopulatedChannel();
-        ContentManager.attachSource("cplabel", SW_CHANNEL, channel1.getLabel(), empty(), user);
-        ContentManager.attachSource("cplabel", SW_CHANNEL, channel2.getLabel(), empty(), user);
-        ContentManager.buildProject("cplabel", empty(), false, user);
+        contentManager.attachSource("cplabel", SW_CHANNEL, channel1.getLabel(), empty(), user);
+        contentManager.attachSource("cplabel", SW_CHANNEL, channel2.getLabel(), empty(), user);
+        contentManager.buildProject("cplabel", empty(), false, user);
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().clear();
 
@@ -1261,7 +1261,7 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
         assertEquals(Set.of(channel1, channel2), getOriginalChannels(getEnvChannels(devEnv)));
 
         // promote project
-        ContentManager.promoteProject("cplabel", "dev", false, user);
+        contentManager.promoteProject("cplabel", "dev", false, user);
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().clear();
 
@@ -1271,8 +1271,8 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
         assertEquals(getEnvChannels(devEnv), getOriginalChannels(getEnvChannels(testEnv)));
 
         // delete a source && build the project
-        ContentManager.detachSource("cplabel", SW_CHANNEL, channel1.getLabel(), user);
-        ContentManager.buildProject("cplabel", empty(), false, user);
+        contentManager.detachSource("cplabel", SW_CHANNEL, channel1.getLabel(), user);
+        contentManager.buildProject("cplabel", empty(), false, user);
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().clear();
 
@@ -1283,8 +1283,8 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
         assertEquals(expectedTestOriginals, getOriginalChannels(getEnvChannels(testEnv)));
 
         // add the channel again && build
-        ContentManager.attachSource("cplabel", SW_CHANNEL, channel1.getLabel(), empty(), user);
-        ContentManager.buildProject("cplabel", empty(), false, user);
+        contentManager.attachSource("cplabel", SW_CHANNEL, channel1.getLabel(), empty(), user);
+        contentManager.buildProject("cplabel", empty(), false, user);
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().clear();
 
@@ -1304,18 +1304,18 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
     public void testClonedChannelLinksInEnvPath() throws Exception {
         var project = new ContentProject("cplabel", "cpname", "cpdesc", user.getOrg());
         ContentProjectFactory.save(project);
-        var devEnv = ContentManager.createEnvironment(project.getLabel(), empty(), "dev", "dev env", "desc", false, user);
-        var testEnv = ContentManager.createEnvironment(project.getLabel(), of("dev"), "test", "test env", "desc", false, user);
+        var devEnv = contentManager.createEnvironment(project.getLabel(), empty(), "dev", "dev env", "desc", false, user);
+        var testEnv = contentManager.createEnvironment(project.getLabel(), of("dev"), "test", "test env", "desc", false, user);
 
         // build the project with 1 channel
         var channel1 = createPopulatedChannel();
-        ContentManager.attachSource("cplabel", SW_CHANNEL, channel1.getLabel(), empty(), user);
-        ContentManager.buildProject("cplabel", empty(), false, user);
+        contentManager.attachSource("cplabel", SW_CHANNEL, channel1.getLabel(), empty(), user);
+        contentManager.buildProject("cplabel", empty(), false, user);
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().clear();
 
         // promote project
-        ContentManager.promoteProject("cplabel", "dev", false, user);
+        contentManager.promoteProject("cplabel", "dev", false, user);
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().clear();
 
@@ -1325,7 +1325,7 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
         assertEquals(getEnvChannels(devEnv), getOriginalChannels(getEnvChannels(testEnv)));
 
         // create a new environment "in the middle"
-        var middleEnv = ContentManager.createEnvironment(project.getLabel(), of("dev"), "mid", "mid env", "desc", false, user);
+        var middleEnv = contentManager.createEnvironment(project.getLabel(), of("dev"), "mid", "mid env", "desc", false, user);
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().clear();
         devEnv = ContentManager.lookupEnvironment(devEnv.getLabel(), "cplabel", user).get();
@@ -1337,7 +1337,7 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
         assertEquals(getEnvChannels(middleEnv), getOriginalChannels(getEnvChannels(testEnv)));
 
         // check that after removing the middle env, the originals of the test point to dev channels again
-        ContentManager.removeEnvironment("mid", "cplabel", user);
+        contentManager.removeEnvironment("mid", "cplabel", user);
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().clear();
         devEnv = ContentManager.lookupEnvironment(devEnv.getLabel(), "cplabel", user).get();
@@ -1359,26 +1359,26 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
     public void testFixingClonedChannelLinks() throws Exception {
         var project = new ContentProject("cplabel", "cpname", "cpdesc", user.getOrg());
         ContentProjectFactory.save(project);
-        var devEnv = ContentManager.createEnvironment(project.getLabel(), empty(), "dev", "dev env", "desc", false, user);
-        var testEnv = ContentManager.createEnvironment(project.getLabel(), of("dev"), "test", "test env", "desc", false, user);
+        var devEnv = contentManager.createEnvironment(project.getLabel(), empty(), "dev", "dev env", "desc", false, user);
+        var testEnv = contentManager.createEnvironment(project.getLabel(), of("dev"), "test", "test env", "desc", false, user);
 
         // build the project
         var channel1 = createPopulatedChannel();
-        ContentManager.attachSource("cplabel", SW_CHANNEL, channel1.getLabel(), empty(), user);
-        ContentManager.buildProject("cplabel", empty(), false, user);
+        contentManager.attachSource("cplabel", SW_CHANNEL, channel1.getLabel(), empty(), user);
+        contentManager.buildProject("cplabel", empty(), false, user);
 
         // check that built channel has the original set correctly
         assertEquals(Set.of(channel1), getOriginalChannels(getEnvChannels(devEnv)));
 
         // promote project
-        ContentManager.promoteProject("cplabel", "dev", false, user);
+        contentManager.promoteProject("cplabel", "dev", false, user);
 
         // now "break" the testEnv channel
         getEnvChannels(testEnv).forEach(chan -> chan.asCloned().get().setOriginal(channel1));
         assertEquals(Set.of(channel1), getOriginalChannels(getEnvChannels(testEnv)));
 
         // promote project again and check that the original of testEnv channel was fixed
-        ContentManager.promoteProject("cplabel", "dev", false, user);
+        contentManager.promoteProject("cplabel", "dev", false, user);
 
         assertEquals(getEnvChannels(devEnv), getOriginalChannels(getEnvChannels(testEnv)));
     }
@@ -1393,11 +1393,11 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
         var project = new ContentProject("cplabel", "cpname", "cpdesc", user.getOrg());
         ContentProjectFactory.save(project);
         var srcChan = createPopulatedChannel();
-        ContentManager.attachSource("cplabel", SW_CHANNEL, srcChan.getLabel(), empty(), user);
+        contentManager.attachSource("cplabel", SW_CHANNEL, srcChan.getLabel(), empty(), user);
 
         // 2 environments, 1 channel in each
-        var devEnv = ContentManager.createEnvironment(project.getLabel(), empty(), "dev", "dev env", "desc", false, user);
-        var testEnv = ContentManager.createEnvironment(project.getLabel(), of("dev"), "test", "test env", "desc", false, user);
+        var devEnv = contentManager.createEnvironment(project.getLabel(), empty(), "dev", "dev env", "desc", false, user);
+        var testEnv = contentManager.createEnvironment(project.getLabel(), of("dev"), "test", "test env", "desc", false, user);
 
         var devChan = createChannelInEnvironment(devEnv, of(srcChan.getLabel()));
         var devTarget = new SoftwareEnvironmentTarget(devEnv, devChan);
@@ -1414,7 +1414,7 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
         assertFalse(testChan.isCloned());
 
         // let's build the project and check that the procedure fixed the channel in the dev environment
-        ContentManager.buildProject("cplabel", empty(), false, user);
+        contentManager.buildProject("cplabel", empty(), false, user);
 
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().clear();
@@ -1425,7 +1425,7 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
         assertFalse(testChan.isCloned());
 
         // let's promote the project and check that the procedure fixed the channel in the test environment as well
-        ContentManager.promoteProject("cplabel", "dev", false, user);
+        contentManager.promoteProject("cplabel", "dev", false, user);
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().clear();
 

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
@@ -52,6 +52,7 @@ import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -239,7 +240,6 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
 
     /**
      * Test that removing a Environment also removes its targets
-     * to the first environment of the project is updated
      *
      * @throws Exception if anything goes wrong
      */
@@ -259,8 +259,9 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
                 .setParameter("channel", channel)
                 .uniqueResultOptional()
                 .isPresent());
-        // but the channel stays
-        assertNotNull(ChannelFactory.lookupById(channel.getId()));
+
+        // channel is also removed
+        assertNull(ChannelFactory.lookupById(channel.getId()));
     }
 
     /**
@@ -734,7 +735,7 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
         ContentEnvironment env = contentManager.createEnvironment(cp.getLabel(), empty(), "fst", "first env", "desc", false, user);
         assertEquals(Long.valueOf(0), env.getVersion());
 
-        // 1. build a project with a source
+        // 1. build the project with a source
         Channel channel = createPopulatedChannel();
         contentManager.attachSource("cplabel", SW_CHANNEL, channel.getLabel(), empty(), user);
         assertEquals(channel, cp.lookupSwSourceLeader().get().getChannel());
@@ -752,7 +753,7 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
         assertEquals(channel.getErratas(), tgtChannel.getErratas());
         assertEquals(Long.valueOf(1), env.getVersion());
 
-        // 2. change a project source and rebuild
+        // 2. change the project source and rebuild
         Channel newChannel = createPopulatedChannel();
         contentManager.attachSource("cplabel", SW_CHANNEL, newChannel.getLabel(), empty(), user);
         assertEquals(channel, cp.lookupSwSourceLeader().get().getChannel()); // leader is the same
@@ -932,7 +933,7 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
         ContentProjectFactory.save(cp);
         ContentEnvironment devEnv = contentManager.createEnvironment(cp.getLabel(), empty(), "dev", "dev env", "desc", false, user);
 
-        // 1. build a project with a source
+        // 1. build the project with a source
         Channel channel1 = createPopulatedChannel();
         Channel channel2 = createPopulatedChannel();
         contentManager.attachSource("cplabel", SW_CHANNEL, channel1.getLabel(), empty(), user);
@@ -1230,10 +1231,221 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
         try {
             contentManager.buildProject("cplabel", empty(), false, user);
             fail("An exception should have been thrown");
-        }
-        catch (ContentManagementException e) {
+        } catch (ContentManagementException e) {
             // should happen
         }
+    }
+
+    /**
+     * This scenario tests that the original-clone relation is maintained between CLM channels
+     * during {@link ContentProject} building/promoting
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testClonedChannelLinks() throws Exception {
+        var project = new ContentProject("cplabel", "cpname", "cpdesc", user.getOrg());
+        ContentProjectFactory.save(project);
+        var devEnv = ContentManager.createEnvironment(project.getLabel(), empty(), "dev", "dev env", "desc", false, user);
+        var testEnv = ContentManager.createEnvironment(project.getLabel(), of("dev"), "test", "test env", "desc", false, user);
+
+        // build the project with 2 channels
+        var channel1 = createPopulatedChannel();
+        var channel2 = createPopulatedChannel();
+        ContentManager.attachSource("cplabel", SW_CHANNEL, channel1.getLabel(), empty(), user);
+        ContentManager.attachSource("cplabel", SW_CHANNEL, channel2.getLabel(), empty(), user);
+        ContentManager.buildProject("cplabel", empty(), false, user);
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().clear();
+
+        // check that built channels have the originals set correctly
+        assertEquals(Set.of(channel1, channel2), getOriginalChannels(getEnvChannels(devEnv)));
+
+        // promote project
+        ContentManager.promoteProject("cplabel", "dev", false, user);
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().clear();
+
+        // check the originals of the test environment correspond to channels in the dev environment
+        devEnv = ContentManager.lookupEnvironment(devEnv.getLabel(), "cplabel", user).get();
+        testEnv = ContentManager.lookupEnvironment(testEnv.getLabel(), "cplabel", user).get();
+        assertEquals(getEnvChannels(devEnv), getOriginalChannels(getEnvChannels(testEnv)));
+
+        // delete a source && build the project
+        ContentManager.detachSource("cplabel", SW_CHANNEL, channel1.getLabel(), user);
+        ContentManager.buildProject("cplabel", empty(), false, user);
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().clear();
+
+        // check the originals of the "test" channels: one should point to a channel in the "dev" environment,
+        // the other should point to the "source" channel1
+        var expectedTestOriginals = getEnvChannels(devEnv);
+        expectedTestOriginals.add(channel1);
+        assertEquals(expectedTestOriginals, getOriginalChannels(getEnvChannels(testEnv)));
+
+        // add the channel again && build
+        ContentManager.attachSource("cplabel", SW_CHANNEL, channel1.getLabel(), empty(), user);
+        ContentManager.buildProject("cplabel", empty(), false, user);
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().clear();
+
+        // check the originals of the test environment correspond to channels in the dev environment again
+        devEnv = ContentManager.lookupEnvironment(devEnv.getLabel(), "cplabel", user).get();
+        testEnv = ContentManager.lookupEnvironment(testEnv.getLabel(), "cplabel", user).get();
+        assertEquals(Set.of(channel1, channel2), getOriginalChannels(getEnvChannels(devEnv)));
+        assertEquals(getEnvChannels(devEnv), getOriginalChannels(getEnvChannels(testEnv)));
+    }
+
+    /**
+     * This scenario tests that the original-clone relation is maintained between CLM channels even after inserting
+     * a new Environment in the middle and then removing it
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testClonedChannelLinksInEnvPath() throws Exception {
+        var project = new ContentProject("cplabel", "cpname", "cpdesc", user.getOrg());
+        ContentProjectFactory.save(project);
+        var devEnv = ContentManager.createEnvironment(project.getLabel(), empty(), "dev", "dev env", "desc", false, user);
+        var testEnv = ContentManager.createEnvironment(project.getLabel(), of("dev"), "test", "test env", "desc", false, user);
+
+        // build the project with 1 channel
+        var channel1 = createPopulatedChannel();
+        ContentManager.attachSource("cplabel", SW_CHANNEL, channel1.getLabel(), empty(), user);
+        ContentManager.buildProject("cplabel", empty(), false, user);
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().clear();
+
+        // promote project
+        ContentManager.promoteProject("cplabel", "dev", false, user);
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().clear();
+
+        // check the originals of the test environment correspond to channels in the dev environment
+        devEnv = ContentManager.lookupEnvironment(devEnv.getLabel(), "cplabel", user).get();
+        testEnv = ContentManager.lookupEnvironment(testEnv.getLabel(), "cplabel", user).get();
+        assertEquals(getEnvChannels(devEnv), getOriginalChannels(getEnvChannels(testEnv)));
+
+        // create a new environment "in the middle"
+        var middleEnv = ContentManager.createEnvironment(project.getLabel(), of("dev"), "mid", "mid env", "desc", false, user);
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().clear();
+        devEnv = ContentManager.lookupEnvironment(devEnv.getLabel(), "cplabel", user).get();
+        testEnv = ContentManager.lookupEnvironment(testEnv.getLabel(), "cplabel", user).get();
+
+        // check the originals of the mid environment correspond to channels in the dev environment
+        assertEquals(getEnvChannels(devEnv), getOriginalChannels(getEnvChannels(middleEnv)));
+        // check the originals of the test environment correspond to channels in the mid environment
+        assertEquals(getEnvChannels(middleEnv), getOriginalChannels(getEnvChannels(testEnv)));
+
+        // check that after removing the middle env, the originals of the test point to dev channels again
+        ContentManager.removeEnvironment("mid", "cplabel", user);
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().clear();
+        devEnv = ContentManager.lookupEnvironment(devEnv.getLabel(), "cplabel", user).get();
+        testEnv = ContentManager.lookupEnvironment(testEnv.getLabel(), "cplabel", user).get();
+        // check the originals of the mid environment correspond to channels in the dev environment
+        assertEquals(getEnvChannels(devEnv), getOriginalChannels(getEnvChannels(testEnv)));
+    }
+
+    /**
+     * Similar as testClonedChannelLinks, this scenario tests that the original-clone relation
+     * is maintained between CLM channels during {@link ContentProject} building/promoting.
+     *
+     * The difference is that the original state of the links between channel is broken (existing user data
+     * from previous versions).
+     * The original-clone relation should be fixed by building/promoting the project.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testFixingClonedChannelLinks() throws Exception {
+        var project = new ContentProject("cplabel", "cpname", "cpdesc", user.getOrg());
+        ContentProjectFactory.save(project);
+        var devEnv = ContentManager.createEnvironment(project.getLabel(), empty(), "dev", "dev env", "desc", false, user);
+        var testEnv = ContentManager.createEnvironment(project.getLabel(), of("dev"), "test", "test env", "desc", false, user);
+
+        // build the project
+        var channel1 = createPopulatedChannel();
+        ContentManager.attachSource("cplabel", SW_CHANNEL, channel1.getLabel(), empty(), user);
+        ContentManager.buildProject("cplabel", empty(), false, user);
+
+        // check that built channel has the original set correctly
+        assertEquals(Set.of(channel1), getOriginalChannels(getEnvChannels(devEnv)));
+
+        // promote project
+        ContentManager.promoteProject("cplabel", "dev", false, user);
+
+        // now "break" the testEnv channel
+        getEnvChannels(testEnv).forEach(chan -> chan.asCloned().get().setOriginal(channel1));
+        assertEquals(Set.of(channel1), getOriginalChannels(getEnvChannels(testEnv)));
+
+        // promote project again and check that the original of testEnv channel was fixed
+        ContentManager.promoteProject("cplabel", "dev", false, user);
+
+        assertEquals(getEnvChannels(devEnv), getOriginalChannels(getEnvChannels(testEnv)));
+    }
+
+    /**
+     * Similar as testClonedChannelLinks, but in this case we setup the project targets
+     * with completely crafted (non-clone) channels.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testFixingClonedChannelLinks2() throws Exception {
+        var project = new ContentProject("cplabel", "cpname", "cpdesc", user.getOrg());
+        ContentProjectFactory.save(project);
+        var srcChan = createPopulatedChannel();
+        ContentManager.attachSource("cplabel", SW_CHANNEL, srcChan.getLabel(), empty(), user);
+
+        // 2 environments, 1 channel in each
+        var devEnv = ContentManager.createEnvironment(project.getLabel(), empty(), "dev", "dev env", "desc", false, user);
+        var testEnv = ContentManager.createEnvironment(project.getLabel(), of("dev"), "test", "test env", "desc", false, user);
+
+        var devChan = createChannelInEnvironment(devEnv, of(srcChan.getLabel()));
+        var devTarget = new SoftwareEnvironmentTarget(devEnv, devChan);
+        ContentProjectFactory.save(devTarget);
+        devEnv.addTarget(devTarget);
+
+        var testChan = createChannelInEnvironment(testEnv, of(srcChan.getLabel()));
+        var testTarget = new SoftwareEnvironmentTarget(testEnv, testChan);
+        ContentProjectFactory.save(testTarget);
+        testEnv.addTarget(testTarget);
+
+        // let's just check the env. channels are not cloned
+        assertFalse(devChan.isCloned());
+        assertFalse(testChan.isCloned());
+
+        // let's build the project and check that the procedure fixed the channel in the dev environment
+        ContentManager.buildProject("cplabel", empty(), false, user);
+
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().clear();
+
+        devChan = ChannelFactory.lookupById(devChan.getId());
+        testChan = ChannelFactory.lookupById(testChan.getId());
+        assertEquals(srcChan, devChan.getOriginal());
+        assertFalse(testChan.isCloned());
+
+        // let's promote the project and check that the procedure fixed the channel in the test environment as well
+        ContentManager.promoteProject("cplabel", "dev", false, user);
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().clear();
+
+        devChan = ChannelFactory.lookupById(devChan.getId());
+        testChan = ChannelFactory.lookupById(testChan.getId());
+        assertEquals(srcChan, devChan.getOriginal());
+        assertEquals(devChan, testChan.getOriginal());
+    }
+
+    // extract original channels from given channels
+    private Set<Channel> getOriginalChannels(Collection<Channel> channels) {
+        return channels.stream().map(Channel::getOriginal).collect(toSet());
+    }
+
+    // get channels of given environment
+    private Set<Channel> getEnvChannels(ContentEnvironment testEnv) {
+        return testEnv.getTargets().stream()
+                .flatMap(tgt -> tgt.asSoftwareTarget().stream())
+                .map(tgt -> tgt.getChannel())
+                .collect(toSet());
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
@@ -855,7 +855,7 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
         ContentEnvironment env = contentManager.createEnvironment(cp.getLabel(), empty(), "fst", "first env", "desc", false, user);
 
         // ... build by another user
-        Channel channel = createPopulatedChannel(user);
+        Channel channel = createPopulatedChannel();
         contentManager.attachSource("cplabel", SW_CHANNEL, channel.getLabel(), empty(), user);
         contentManager.buildProject("cplabel", empty(), false, adminSameOrg);
         assertEquals(Long.valueOf(1), env.getVersion());
@@ -882,7 +882,7 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
         ContentProjectFactory.save(cp);
         ContentEnvironment env = contentManager.createEnvironment(cp.getLabel(), empty(), "fst", "first env", "desc", false, user);
 
-        Channel channel = createPopulatedChannel(user);
+        Channel channel = createPopulatedChannel();
         contentManager.attachSource("cplabel", SW_CHANNEL, channel.getLabel(), empty(), user);
         contentManager.buildProject("cplabel", empty(), false, user);
         assertEquals(Long.valueOf(1), env.getVersion());
@@ -1400,10 +1400,6 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
     }
 
     private Channel createPopulatedChannel() throws Exception {
-        return createPopulatedChannel(user);
-    }
-
-    private Channel createPopulatedChannel(User user) throws Exception {
         Channel channel = TestUtils.reload(ChannelFactoryTest.createTestChannel(user, false));
         channel.setChecksumType(ChannelFactory.findChecksumTypeByLabel("sha1"));
         Package pack = PackageTest.createTestPackage(user.getOrg());

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix the original-clone channel relationship for CLM channels (bsc#1163121)
 - fix serializer and documentation for system.listSystems (bsc#1168083)
 - skip and show migration targets which do not have a successor
   for all installed extension products (bsc#1168227)


### PR DESCRIPTION
## Structure
Commit-by-commit review is recommended.

## What does this PR change?

For the security audit of the channels to work properly, the channels need to
maintain original-clone relationship. This was not necesarilly the case for
the content management channels.

This PR fixes the logic so that the original-clone is set correctly on every
desctructive operation (project build/promote, environment deletion).

Example 1: Removing an environment
3 environments: `dev` -> `test` -> `prod`
1 channel in each environment, with original-clone relation: `dev-chan` -> `test-chan` -> `prod-chan`
Deleting the test environment now deletes the `test-chan` and restores the original-channel relation so that `dev-chan` is original channel of `prod-chan`

Example : Removing a source
2 environments: `dev` -> `prod`
2 source channels in the project: `c1`, `c2`
2 channels in each environment: `dev-c1`, `dev-c2`, `prod-c1`, `prod-c2`
Original-clone relation looks as follows:
```
c1 -> dev-c1 -> prod-c1
c2 -> dev-c2 -> prod-c2
```
Now we detach `c2` from the project and build it (this deletes the `dev-c2`
channel), the original-clone relation looks like this now:
```
c1 -> dev-c1 -> prod-c1
c2 -> prod-c2
```

When we re-attach `c2` to the project and build it, the schema will looks like in the original scenario above.

### Other important changes
Environment deletion also deletes corresponding channel

#### Existing data
Users who already use CLM likely got to inconsistent state. The code in this PR will heal the broken original-channel relationship continually as the users build/promote their content projects.

## GUI diff

No difference.


## Documentation
- No documentation needed: the only likely enhancement would be to mention the
  channel removing behavior on environment deletion, but the docs don't contain
  a section about enviroment removal.

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/9773

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"