### PR TITLE
Guard FormContext uses in components

### DIFF
--- a/web/html/src/components/input/Check.js
+++ b/web/html/src/components/input/Check.js
@@ -25,7 +25,7 @@ export function Check(props: Props) {
           const setChecked = (event: Object) => {
             setValue(event.target.name, event.target.checked);
           };
-          const fieldValue = formContext.model[props.name] || props.defaultValue || '';
+          const fieldValue = (formContext.model || {})[props.name] || props.defaultValue || '';
           return (
             <div className="checkbox">
               <label htmlFor={props.name}>

--- a/web/html/src/components/input/DateTime.js
+++ b/web/html/src/components/input/DateTime.js
@@ -24,7 +24,7 @@ export function DateTime(props: Props) {
           const onChange = (value) => {
             setValue(props.name, value);
           };
-          const fieldValue = formContext.model[props.name] || props.defaultValue || '';
+          const fieldValue = (formContext.model || {})[props.name] || props.defaultValue || '';
           if(fieldValue instanceof Date) {
             return (
               <DateTimePicker

--- a/web/html/src/components/input/InputBase.js
+++ b/web/html/src/components/input/InputBase.js
@@ -51,10 +51,12 @@ export class InputBase extends React.Component<Props, State> {
 
   componentDidMount() {
     if (this.props && this.props.name) {
-      this.context.registerInput(this);
+      if (this.context.registerInput != null) {
+        this.context.registerInput(this);
+      }
 
-      const { model } = this.context;
-      const value = this.context.model[this.props.name] || this.props.defaultValue || '';
+      const model = this.context.model || {};
+      const value = model[this.props.name] || this.props.defaultValue || '';
       const valueChanged =
         (value instanceof Date && model[this.props.name] instanceof Date
           && value.getTime() !== model[this.props.name].getTime())
@@ -62,14 +64,18 @@ export class InputBase extends React.Component<Props, State> {
 
       if (valueChanged) {
         model[this.props.name] = value;
-        this.context.setModelValue(this.props.name, value);
+        if (this.context.setModelValue != null) {
+          this.context.setModelValue(this.props.name, value);
+        }
       }
     }
   }
 
   componentWillUnmount() {
-    this.context.unregisterInput(this);
-    this.context.setModelValue(this.props.name, undefined);
+    if (Object.keys(this.context).length > 0) {
+      this.context.unregisterInput(this);
+      this.context.setModelValue(this.props.name, undefined);
+    }
   }
 
   onBlur() {
@@ -99,7 +105,9 @@ export class InputBase extends React.Component<Props, State> {
         isValid = isValid && r;
       });
       this.setState({isValid});
-      this.context.onFieldValidation(name, isValid);
+      if (this.context.onFieldValidation != null) {
+        this.context.onFieldValidation(name, isValid);
+      }
     });
 
     this.setState({
@@ -109,7 +117,9 @@ export class InputBase extends React.Component<Props, State> {
   }
 
   setValue(name: string, value: string) {
-    this.context.setModelValue(name, value);
+    if (this.context.setModelValue != null) {
+      this.context.setModelValue(name, value);
+    }
 
     if (this.props.onChange) this.props.onChange(name, value);
   }

--- a/web/html/src/components/input/Radio.js
+++ b/web/html/src/components/input/Radio.js
@@ -36,7 +36,7 @@ export function Radio(props: Props) {
             setIsPristine(false);
           };
 
-          const fieldValue = formContext.model[props.name] || props.defaultValue || '';
+          const fieldValue = (formContext.model || {})[props.name] || props.defaultValue || '';
           const isOpenOption = props.openOption
             && !props.items.some(item => item.value === fieldValue)
             && (fieldValue || !isPristine);

--- a/web/html/src/components/input/Select.js
+++ b/web/html/src/components/input/Select.js
@@ -26,7 +26,7 @@ export function Select(props: Props) {
           const onChange = (event: Object) => {
             setValue(event.target.name, event.target.value);
           };
-          const fieldValue = formContext.model[props.name] || props.defaultValue || '';
+          const fieldValue = (formContext.model || {})[props.name] || props.defaultValue || '';
           return (
             <select
               className={`form-control${inputClass ? ` ${inputClass}` : ''}`}

--- a/web/html/src/components/input/Text.js
+++ b/web/html/src/components/input/Text.js
@@ -27,7 +27,7 @@ export const Text = (props: Props) => {
           const onChange = (event: Object) => {
             setValue(event.target.name, event.target.value);
           };
-          const fieldValue = formContext.model[props.name] || props.defaultValue || '';
+          const fieldValue = (formContext.model || {})[props.name] || props.defaultValue || '';
           return (
             <input
               className={`form-control${inputClass ? ` ${inputClass}` : ''}`}


### PR DESCRIPTION
## What does this PR change?

Some form fields are used outside of Forms and thus have an empty
context. Add guards against this.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: refactoring fix

- [X] **DONE**

## Test coverage
- No tests: should be covered by cucumber tests

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
