### PR TITLE
Reformar labeler entries

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,12 +1,20 @@
 #Dev Labels
-java: java/**/*
-ui: web/**/*
-webapp: java/code/webapp/**/*
-cobbler: java/code/src/org/cobbler/**/*
-documentation: documentation/**/*
-proxy: proxy/**/*
-API: java/code/src/com/redhat/rhn/frontend/**/*
-Virtualization management: java/code/src/com/suse/manager/virtualization/**/*
+java: 
+- java/**/*
+ui: 
+- web/**/*
+webapp: 
+- java/code/webapp/**/*
+cobbler: 
+- java/code/src/org/cobbler/**/*
+documentation: 
+- documentation/**/*
+proxy: 
+- proxy/**/*
+API: 
+- java/code/src/com/redhat/rhn/frontend/**/*
+Virtualization management: 
+- java/code/src/com/suse/manager/virtualization/**/*
 monitoring: 
 - java/code/src/com/suse/manager/webui/services/impl/test/monitoring/**/*
 - java/code/src/com/redhat/rhn/frontend/xmlrpc/admin/monitoring/**/*
@@ -16,21 +24,35 @@ python3:
 - client/**/*.py
 - susemanager/**/*.py
 - spacecmd/**/*
-database: schema/spacewalk/**/*
-content-management: java/code/src/com/suse/manager/webui/controllers/contentmanagement/**/*
+database: 
+- schema/spacewalk/**/*
+content-management: 
+- java/code/src/com/suse/manager/webui/controllers/contentmanagement/**/*
 
 #QA Labels
-testing: testsuite/**/*
-core-features: testsuite/features/core/**/*
-secondary-features: testsuite/features/secondary/**/*
-ci-pipelines: testsuite/**/*.yml
+testing: 
+- testsuite/**/*
+core-features: 
+- testsuite/features/core/**/*
+secondary-features: 
+- testsuite/features/secondary/**/*
+ci-pipelines: 
+- testsuite/**/*.yml
 
 #Unit tests
-backend_unittests_pgsql: backend/**/*
-javascript_lint: web/**/*
-java_lint_checkstyle: java/**/*
-java_pgsql_tests: java/**/*
-ruby_rubocop: testsuite/**/*
-schema_migration_test_oracle: schema/spacewalk/**/*
-schema_migration_test_pgsql: schema/spacewalk/**/*
-susemanager_unittests: susemanager/**/*
+backend_unittests_pgsql: 
+- backend/**/*
+javascript_lint: 
+- web/**/*
+java_lint_checkstyle: 
+- java/**/*
+java_pgsql_tests: 
+- java/**/*
+ruby_rubocop: 
+- testsuite/**/*
+schema_migration_test_oracle: 
+- schema/spacewalk/**/*
+schema_migration_test_pgsql: 
+- schema/spacewalk/**/*
+susemanager_unittests: 
+- susemanager/**/*

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: paulfantom/periodic-labeler@master
+    - uses: paulfantom/periodic-labeler@v0.0.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_REPOSITORY: ${{ github.repository }}


### PR DESCRIPTION
## What does this PR change?

Our current GitHub action doesn't support the same format that the default labeler does. Re-formatting. Also reverting the version used to v0.0.1

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

https://github.com/paulfantom/periodic-labeler/issues/1

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
