### PR TITLE
Add updates for universe to Ubuntu common channels

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -1034,13 +1034,22 @@ base_channels = ubuntu-16.04-pool-amd64
 repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial-security/main/binary-amd64/
 
 [ubuntu-1604-amd64-universe]
-label    = ubuntu-1604-amd64-main-universe
+label    = ubuntu-1604-amd64-universe
 name     = Ubuntu 16.04 LTS AMD64 Universe
 archs    = amd64-deb
 repo_type = deb
 checksum = sha256
 base_channels = ubuntu-16.04-pool-amd64
 repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial/universe/binary-amd64/
+
+[ubuntu-1604-amd64-universe-updates]
+label    = ubuntu-1604-amd64-universe-updates
+name     = Ubuntu 16.04 LTS AMD64 Universe Updates
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = ubuntu-16.04-pool-amd64
+repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial-updates/universe/binary-amd64/
 
 [ubuntu-1604-pool-amd64-uyuni]
 label    = ubuntu-16.04-pool-amd64-uyuni
@@ -1081,13 +1090,22 @@ base_channels = ubuntu-16.04-pool-amd64-uyuni
 repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial-security/main/binary-amd64/
 
 [ubuntu-1604-amd64-universe-uyuni]
-label    = ubuntu-1604-amd64-main-universe-uyuni
+label    = ubuntu-1604-amd64-universe-uyuni
 name     = Ubuntu 16.04 LTS AMD64 Universe for Uyuni
 archs    = amd64-deb
 repo_type = deb
 checksum = sha256
 base_channels = ubuntu-16.04-pool-amd64-uyuni
 repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial/universe/binary-amd64/
+
+[ubuntu-1604-amd64-universe-updates-uyuni]
+label    = ubuntu-1604-amd64-universe-updates-uyuni
+name     = Ubuntu 16.04 LTS AMD64 Universe Updates for Uyuni
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = ubuntu-16.04-pool-amd64-uyuni
+repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial-updates/universe/binary-amd64/
 
 [ubuntu-1604-amd64-uyuni-client]
 label    = ubuntu-1604-amd64-uyuni-client
@@ -1146,13 +1164,22 @@ base_channels = ubuntu-18.04-pool-amd64
 repo_url = http://archive.ubuntu.com/ubuntu/dists/bionic-security/main/binary-amd64/
 
 [ubuntu-1804-amd64-universe]
-label    = ubuntu-1804-amd64-main-universe
+label    = ubuntu-1804-amd64-universe
 name     = Ubuntu 18.04 LTS AMD64 Universe
 archs    = amd64-deb
 repo_type = deb
 checksum = sha256
 base_channels = ubuntu-18.04-pool-amd64
 repo_url = http://archive.ubuntu.com/ubuntu/dists/bionic/universe/binary-amd64/
+
+[ubuntu-1804-amd64-universe-updates]
+label    = ubuntu-1804-amd64-universe-updates
+name     = Ubuntu 18.04 LTS AMD64 Universe Updates
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = ubuntu-18.04-pool-amd64
+repo_url = http://archive.ubuntu.com/ubuntu/dists/bionic-updates/universe/binary-amd64/
 
 [ubuntu-1804-pool-amd64-uyuni]
 label    = ubuntu-18.04-pool-amd64-uyuni
@@ -1193,13 +1220,22 @@ base_channels = ubuntu-18.04-pool-amd64-uyuni
 repo_url = http://archive.ubuntu.com/ubuntu/dists/bionic-security/main/binary-amd64/
 
 [ubuntu-1804-amd64-universe-uyuni]
-label    = ubuntu-1804-amd64-main-universe-uyuni
+label    = ubuntu-1804-amd64-universe-uyuni
 name     = Ubuntu 18.04 LTS AMD64 Universe for Uyuni
 archs    = amd64-deb
 repo_type = deb
 checksum = sha256
 base_channels = ubuntu-18.04-pool-amd64-uyuni
 repo_url = http://archive.ubuntu.com/ubuntu/dists/bionic/universe/binary-amd64/
+
+[ubuntu-1804-amd64-universe-updates-uyuni]
+label    = ubuntu-1804-amd64-universe-updates-uyuni
+name     = Ubuntu 18.04 LTS AMD64 Universe Updates for Uyuni
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = ubuntu-18.04-pool-amd64-uyuni
+repo_url = http://archive.ubuntu.com/ubuntu/dists/bionic-updates/universe/binary-amd64/
 
 [ubuntu-1804-amd64-uyuni-client]
 label    = ubuntu-1804-amd64-uyuni-client

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,7 @@
+- Add universe updates to Ubuntu common channels
+- Rename ubuntu-XXXX-amd64-main-universe to ubuntu-XXXX-amd64-universe and
+  ubuntu-XXXX-amd64-main-universe-uyuni to ubuntu-XXXX-amd64-universe-uyuni
+  in common channels
 - Enable CentOS8 at spacewalk-common-channels (bsc#1159206)
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

- Add updates for universe to Ubuntu common channels
- Rename ubuntu-XXXX-amd64-main-universe to ubuntu-XXXX-amd64-universe

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: trivial change

- [x] **DONE**

## Test coverage
- No tests: trivial change

- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/10129

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
