### PR TITLE
Rescue Capybara::ExpectationNotMet in our SPA wrappers (Port)

### DIFF
--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -115,7 +115,7 @@ def click_button_and_wait(locator = nil, **options)
   click_button(locator, options)
   begin
     raise 'Timeout: Waiting AJAX transition (click link)' unless has_no_css?('.senna-loading', wait: 5)
-  rescue StandardError => e
+  rescue StandardError, Capybara::ExpectationNotMet => e
     puts e.message # Skip errors related to .senna-loading element
   end
 end
@@ -124,7 +124,7 @@ def click_link_and_wait(locator = nil, **options)
   click_link(locator, options)
   begin
     raise 'Timeout: Waiting AJAX transition (click link)' unless has_no_css?('.senna-loading', wait: 5)
-  rescue StandardError => e
+  rescue StandardError, Capybara::ExpectationNotMet => e
     puts e.message # Skip errors related to .senna-loading element
   end
 end
@@ -133,7 +133,7 @@ def click_link_or_button_and_wait(locator = nil, **options)
   click_link_or_button(locator, options)
   begin
     raise 'Timeout: Waiting AJAX transition (click link)' unless has_no_css?('.senna-loading', wait: 5)
-  rescue StandardError => e
+  rescue StandardError, Capybara::ExpectationNotMet => e
     puts e.message # Skip errors related to .senna-loading element
   end
 end
@@ -144,7 +144,7 @@ module CapybaraNodeElementExtension
     super
     begin
       raise 'Timeout: Waiting AJAX transition (click link)' unless has_no_css?('.senna-loading', wait: 5)
-    rescue StandardError => e
+    rescue StandardError, Capybara::ExpectationNotMet => e
       puts e.message # Skip errors related to .senna-loading element
     end
   end


### PR DESCRIPTION
## What does this PR change?

Sometimes the wrapper of click_button capybara method is raising the error Capybara::ExpectationNotMet, we want to prevent that error to fail our testsuite by rescuing that exception in our wrappers made to support SPA.

Port of https://github.com/SUSE/spacewalk/pull/10326

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests: Part of Test Framework

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
