### PR TITLE
Add the system.getMinionIdMap XMLRPC method

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
@@ -415,7 +415,21 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                 AND s.minionId IN (:minionIds)
     ]]>
     </query>
-    
+
+    <sql-query name="Server.listMinionIdMappings">
+        <return-scalar column="minion_id" type="string"/>
+        <return-scalar column="server_id" type="long"/>
+        <![CDATA[
+         SELECT m.minion_id AS minion_id, s.id AS server_id
+             FROM rhnServer s
+                 JOIN suseMinionInfo m ON s.id = m.server_id
+                 WHERE EXISTS (SELECT 1
+                               FROM rhnUserServerPerms USP
+                               WHERE USP.user_id = :user_id AND USP.server_id = s.id)
+        ]]>
+    </sql-query>
+
+
     <sql-query name="Server.lookupAdministrators">
         <![CDATA[select {wc.*}
                                                 from WEB_CONTACT wc

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -14,6 +14,8 @@
  */
 package com.redhat.rhn.frontend.xmlrpc.system;
 
+import static java.util.stream.Collectors.toList;
+
 import com.redhat.rhn.FaultException;
 import com.redhat.rhn.common.client.ClientCertificate;
 import com.redhat.rhn.common.conf.ConfigDefaults;
@@ -152,7 +154,12 @@ import com.redhat.rhn.manager.system.UpdateChildChannelsCommand;
 import com.redhat.rhn.manager.system.VirtualizationActionCommand;
 import com.redhat.rhn.manager.token.ActivationKeyManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
+
 import com.suse.manager.webui.utils.gson.BootstrapHostsJson;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.log4j.Logger;
+import org.cobbler.SystemRecord;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -177,11 +184,6 @@ import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
-import org.cobbler.SystemRecord;
-
-import static java.util.stream.Collectors.toList;
 
 /**
  * SystemHandler
@@ -6996,6 +6998,22 @@ public class SystemHandler extends BaseHandler {
         catch (com.redhat.rhn.taskomatic.TaskomaticApiException e) {
             throw new TaskomaticApiException(e.getMessage());
         }
+    }
+
+    /**
+     * Return a map from Salt minion IDs to System IDs.
+     * Map entries are limited to systems that are visible by the current user.
+     *
+     * @param loggedInUser The current user
+     * @return the minion ID to system ID map
+     *
+     * @xmlrpc.doc Return a map from Salt minion IDs to System IDs.
+     * Map entries are limited to systems that are visible by the current user.
+     * @xmlrpc.param #session_key()
+     * @xmlrpc.returntype  Map from minion IDs to system IDs
+     */
+    public Map<String, Long> getMinionIdMap(User loggedInUser) {
+        return ServerFactory.getMinionIdMap(loggedInUser.getId());
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -14,31 +14,6 @@
  */
 package com.redhat.rhn.frontend.xmlrpc.system.test;
 
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import com.redhat.rhn.domain.server.NetworkInterfaceFactory;
-import com.redhat.rhn.frontend.xmlrpc.InvalidParameterException;
-import com.redhat.rhn.manager.action.ActionChainManager;
-import org.apache.commons.lang3.StringUtils;
-import org.jmock.Expectations;
-import org.jmock.Mockery;
-import org.jmock.integration.junit3.JUnit3Mockery;
-import org.jmock.lib.concurrent.Synchroniser;
-import org.jmock.lib.legacy.ClassImposteriser;
-
 import com.redhat.rhn.FaultException;
 import com.redhat.rhn.common.client.ClientCertificate;
 import com.redhat.rhn.common.db.datasource.DataResult;
@@ -48,9 +23,9 @@ import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
+import com.redhat.rhn.domain.action.channel.SubscribeChannelsAction;
 import com.redhat.rhn.domain.action.salt.ApplyStatesAction;
 import com.redhat.rhn.domain.action.salt.ApplyStatesActionDetails;
-import com.redhat.rhn.domain.action.channel.SubscribeChannelsAction;
 import com.redhat.rhn.domain.action.script.ScriptActionDetails;
 import com.redhat.rhn.domain.action.script.ScriptResult;
 import com.redhat.rhn.domain.action.script.ScriptRunAction;
@@ -87,6 +62,7 @@ import com.redhat.rhn.domain.server.InstalledProduct;
 import com.redhat.rhn.domain.server.ManagedServerGroup;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.NetworkInterface;
+import com.redhat.rhn.domain.server.NetworkInterfaceFactory;
 import com.redhat.rhn.domain.server.Note;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerConstants;
@@ -119,6 +95,7 @@ import com.redhat.rhn.frontend.xmlrpc.InvalidChannelLabelException;
 import com.redhat.rhn.frontend.xmlrpc.InvalidEntitlementException;
 import com.redhat.rhn.frontend.xmlrpc.InvalidErrataException;
 import com.redhat.rhn.frontend.xmlrpc.InvalidPackageException;
+import com.redhat.rhn.frontend.xmlrpc.InvalidParameterException;
 import com.redhat.rhn.frontend.xmlrpc.MissingCapabilityException;
 import com.redhat.rhn.frontend.xmlrpc.NoSuchActionException;
 import com.redhat.rhn.frontend.xmlrpc.NoSuchPackageException;
@@ -129,6 +106,7 @@ import com.redhat.rhn.frontend.xmlrpc.UnsupportedOperationException;
 import com.redhat.rhn.frontend.xmlrpc.system.SUSEInstalledProduct;
 import com.redhat.rhn.frontend.xmlrpc.system.SystemHandler;
 import com.redhat.rhn.frontend.xmlrpc.test.BaseHandlerTestCase;
+import com.redhat.rhn.manager.action.ActionChainManager;
 import com.redhat.rhn.manager.action.ActionManager;
 import com.redhat.rhn.manager.channel.ChannelManager;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
@@ -147,7 +125,28 @@ import com.redhat.rhn.testing.ServerTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
+import org.apache.commons.lang3.StringUtils;
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.integration.junit3.JUnit3Mockery;
+import org.jmock.lib.concurrent.Synchroniser;
+import org.jmock.lib.legacy.ClassImposteriser;
+
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class SystemHandlerTest extends BaseHandlerTestCase {
@@ -2696,6 +2695,16 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         Server server = (Server) getMockedHandler().getDetails(admin, minion.getId().intValue());
 
         assertEquals(minion.getMinionId(), server.getMinionId());
+    }
+
+    public void testGetMinionIdMap() throws Exception {
+        MinionServer m1 = MinionServerFactoryTest.createTestMinionServer(admin);
+        MinionServer m2 = MinionServerFactoryTest.createTestMinionServer(admin);
+
+        var result = handler.getMinionIdMap(admin);
+        assertTrue(result.size() >= 2);
+        assertEquals(m1.getId(), result.get(m1.getMinionId()));
+        assertEquals(m2.getId(), result.get(m2.getMinionId()));
     }
 
     private SystemHandler getMockedHandler() throws Exception {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add the system.getMinionIdMap XMLRPC method
 - remove undefined variable from redhat_register snippet
 - Add a method in API to check if the provided session key is a valid one.
 - Associate VMs and systems with the same machine ID at bootstrap (bsc#1144176)


### PR DESCRIPTION
## What does this PR change?

Adds an endpoint to retrieve a mapping from minion IDs to Uyuni System IDs. This is useful for scripts that combine Salt with the traditional API, original need came in the context of https://github.com/uyuni-project/uyuni/pull/1621 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **API endpoint, self-documented**

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

No relevant link at this time

- [x] **DONE**


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
