### PR TITLE
Adapt our YaST desktop files to https://github.com/yast/yast-control-center/pull/42/

### DIFF
--- a/susemanager/yast/com.suse.yast2.SUSEManager.desktop
+++ b/susemanager/yast/com.suse.yast2.SUSEManager.desktop
@@ -17,7 +17,7 @@ X-SuSE-YaST-SortKey=
 Icon=yast-network_services
 Exec=/sbin/yast2 susemanager_setup
 
-Name=SUSE Manager Setup
-GenericName=Configure SUSE Manager
+Name=YaST SUSE Manager Setup
+GenericName=SUSE Manager Setup
 StartupNotify=true
 

--- a/susemanager/yast/org.uyuni-project.yast2.Uyuni.desktop
+++ b/susemanager/yast/org.uyuni-project.yast2.Uyuni.desktop
@@ -17,7 +17,7 @@ X-SuSE-YaST-SortKey=
 Icon=yast-network_services
 Exec=/sbin/yast2 susemanager_setup
 
-Name=Uyuni Setup
-GenericName=Configure Uyuni Server
+Name=YaST Uyuni Setup
+GenericName=Uyuni Setup
 StartupNotify=true
 


### PR DESCRIPTION
## What does this PR change?

Adapt our YaST desktop files to https://github.com/yast/yast-control-center/pull/42/ (Display GenericName and Comment, not Name)

As recommended by Jiri, I am also adapting the filenames.

## GUI diff

No difference. In fact this restores the old behaviour.

- [ ] **DONE**

## Documentation
- No documentation needed: Not needed, in fact this is to prevents requiring a doc change.

- [ ] **DONE**

## Test coverage
- No tests: Not covered.

- [x] **DONE**

## Links

None.

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
