### PR TITLE
Execute config_channels states of the activation key when minion bootstraps 

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/ApplyStatesEventMessage.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/ApplyStatesEventMessage.java
@@ -34,6 +34,7 @@ public class ApplyStatesEventMessage implements EventDatabaseMessage {
     public static final String PACKAGES_PROFILE_UPDATE = "packages.profileupdate";
     public static final String HARDWARE_PROFILE_UPDATE = "hardware.profileupdate";
     public static final String CHANNELS = "channels";
+    public static final String CONFIG_CHANNELS = "custom";
     public static final String CHANNELS_DISABLE_LOCAL_REPOS = "channels.disablelocalrepos";
     public static final String SALT_MINION_SERVICE = "services.salt-minion";
     public static final String SYNC_CUSTOM_ALL = "util.synccustomall";

--- a/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
@@ -134,6 +134,7 @@ public class RegistrationUtils {
         statesToApply.add(ApplyStatesEventMessage.CERTIFICATE);
         statesToApply.add(ApplyStatesEventMessage.CHANNELS);
         statesToApply.add(ApplyStatesEventMessage.CHANNELS_DISABLE_LOCAL_REPOS);
+        statesToApply.add(ApplyStatesEventMessage.CONFIG_CHANNELS);
         statesToApply.add(ApplyStatesEventMessage.PACKAGES);
         if (enableMinionService) {
             statesToApply.add(ApplyStatesEventMessage.SALT_MINION_SERVICE);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Execute config_channels states of the activation key when minion bootstraps (bsc#1158260)
 - remove undefined variable from redhat_register snippet
 - Add a method in API to check if the provided session key is a valid one.
 - Associate VMs and systems with the same machine ID at bootstrap (bsc#1144176)


### PR DESCRIPTION
## What does this PR change?
States for config/states channels were not being applied if they were part of an activation key and a minion was bootstrapped using that activation key.

This PR fixes this issue and now states are being applied

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **Bug Fix**

- [ ] **DONE**

## Test coverage
- No tests:
- [ ] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/10232
Tracks # **add downstream PR, if any**

- [ ] **DONE**

