### PR TITLE
Fix ordering by date (bsc#1158818)

### DIFF
--- a/web/html/src/utils/functions.js
+++ b/web/html/src/utils/functions.js
@@ -88,8 +88,37 @@ function sortByNumber(aRaw: Object, bRaw: Object, columnKey: string, sortDirecti
 }
 
 function sortByDate(aRaw: Object, bRaw: Object, columnKey: string, sortDirection: number): number {
-    const aDate = aRaw[columnKey] instanceof Date ? aRaw[columnKey] : new Date(aRaw[columnKey]);
-    const bDate = bRaw[columnKey] instanceof Date ? bRaw[columnKey] : new Date(bRaw[columnKey]);
+    /**
+     *  HACK
+     *
+     * Expected input String format: "YYYY-MM-DD HH:mm:ss z" where "z" is the timezone
+     * This is an 'unparsable' format for a javascript Date
+     *
+     * Assuming both dates are on the same timezone, we need to drop the timezone information in order to
+     * convert the String into a javascript Date and compare which one is before the other. In the end,
+     * if the initial assumption is true, the offset is the same.
+     * The troubles could start if the String format is not as expected or if the two timezones to compare are not the same.
+     *
+     * Expected output String format to convert to a javascript Date "YYYY-MM-DD HH:mm:ss"
+     *
+     * Explaining the regex:
+     *   "d{2,4}" => DD or YYYY
+     *   "." => anyseparator
+     *   "d{2}" => MM
+     *   "." => anyseparator
+     *   "d{2,4}" => DD or YYYY
+     *   "." => anyseparator
+     *   "d{1,2}" => h or HH
+     *   "." => anyseparator
+     *   "d{2}" => mm
+     *   "." => anyseparator
+     *   "d{2}" => ss
+     *   " \w+" => any timezone letters with a 'space' as a prefix separator from seconds; the timezone catching group is optionable
+     */
+    const unparsableDateRegex = /(\d{2,4}.\d{2}.\d{2,4}.\d{1,2}.\d{2}.\d{2})( \w+)*/g;
+
+    const aDate = aRaw[columnKey] instanceof Date ? aRaw[columnKey] : new Date(aRaw[columnKey].replace(unparsableDateRegex, "$1"));
+    const bDate = bRaw[columnKey] instanceof Date ? bRaw[columnKey] : new Date(bRaw[columnKey].replace(unparsableDateRegex, "$1"));
 
     const result = aDate > bDate ? 1 : (aDate < bDate ? -1 : 0);
     return result * sortDirection;

--- a/web/html/src/utils/functions.test.js
+++ b/web/html/src/utils/functions.test.js
@@ -1,0 +1,29 @@
+import {Utils} from "./functions";
+
+test("check order by date function'", () => {
+  const eRaw = { id: "e", date: "11/11/1983 23:59:59"};
+  const aRaw = { id: "a", date: "11/11/1983 1:10:10 CEST"};
+  const bRaw = { id: "b", date: "1983/11/11 11:11:11 CEST"};
+  const dRaw = { id: "d", date: "1983/11/11 23:23:23"};
+  const cRaw = { id: "c", date: "11/11/1983 16:16:16 CEST"};
+
+  let arr = [eRaw, aRaw, bRaw, dRaw, cRaw];
+  const sortColumnKey = "date";
+  const sortDirection = 1;
+
+  // sort ASC
+  arr = arr.sort((a, b) => Utils.sortByDate(a, b, sortColumnKey, sortDirection));
+  expect(arr[0]).toEqual(aRaw);
+  expect(arr[1]).toEqual(bRaw);
+  expect(arr[2]).toEqual(cRaw);
+  expect(arr[3]).toEqual(dRaw);
+  expect(arr[4]).toEqual(eRaw);
+
+  // sort DESC
+  arr = arr.sort((a, b) => Utils.sortByDate(a, b, sortColumnKey, -sortDirection));
+  expect(arr[4]).toEqual(aRaw);
+  expect(arr[3]).toEqual(bRaw);
+  expect(arr[2]).toEqual(cRaw);
+  expect(arr[1]).toEqual(dRaw);
+  expect(arr[0]).toEqual(eRaw);
+})

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fix ordering by date (bsc#1158818)
 - Add debug packages containing Javascript source map files
 - Don't validate mandatory fields that are not visible (bsc#1158943)
 - Show adequate message on saving formulas that change only pillar data


### PR DESCRIPTION
## What does this PR change?

Bug fix: ordering by date

## Documentation
- No documentation needed: bug fix

- [x] **DONE**

## Test coverage
- Tests added: see commit "Add test for sortByDate function"

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/10303
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
