### PR TITLE
Uyuni fix pkg rename without service

### DIFF
--- a/client/tools/mgr-osad/mgr-osad.changes
+++ b/client/tools/mgr-osad/mgr-osad.changes
@@ -1,4 +1,7 @@
+- take care that osad is not disabled nor deactivated during update
+  (bsc#1157700, bsc#1158697)
 - separate osa-dispatcher and jabberd so it can be disabled independently
+
 
 -------------------------------------------------------------------
 Wed Nov 27 16:55:56 CET 2019 - jgonzalez@suse.com

--- a/client/tools/mgr-osad/mgr-osad.spec
+++ b/client/tools/mgr-osad/mgr-osad.spec
@@ -451,6 +451,10 @@ fi
 if [ -x /usr/bin/systemctl ]; then
     (
         test "$YAST_IS_RUNNING" = instsys && exit 0
+        test -e /var/lib/systemd/migrated/enable-osad && /usr/bin/systemctl enable osad.service >/dev/null 2>&1
+        rm -f /var/lib/systemd/migrated/enable-osad 2> /dev/null
+        test -e /var/lib/systemd/migrated/activate-osad && /usr/bin/systemctl start osad.service >/dev/null 2>&1
+        rm -f /var/lib/systemd/migrated/activate-osad 2> /dev/null
         test -f /etc/sysconfig/services -a \
              -z "$DISABLE_RESTART_ON_UPDATE" && . /etc/sysconfig/services
         test "$DISABLE_RESTART_ON_UPDATE" = yes -o \
@@ -459,10 +463,19 @@ if [ -x /usr/bin/systemctl ]; then
     ) || :
 fi
 
-%if 0%{?suse_version} >= 1210
 %pre
+%if 0%{?suse_version} >= 1210
 %service_add_pre osad.service
+%endif
+if [ -x /usr/bin/systemctl ]; then
+  (
+    [ -d /var/lib/systemd/migrated ] || mkdir -p /var/lib/systemd/migrated || :
+    /usr/bin/systemctl is-enabled osad.service >/dev/null 2>&1 && touch /var/lib/systemd/migrated/enable-osad
+    /usr/bin/systemctl is-active osad.service >/dev/null 2>&1 && touch /var/lib/systemd/migrated/activate-osad
+  ) ||:
+fi
 
+%if 0%{?suse_version} >= 1210
 %pre -n mgr-osa-dispatcher
 %service_add_pre osa-dispatcher.service
 


### PR DESCRIPTION
## What does this PR change?

Take care that osad service stays enabled and active even after a package rename.

IMPORTANT: this will not enable or activate the service when it was already disabled during the update.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/10297

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
