### PR TITLE
Adaptations for SLE 15 SP1 clients - batch 1

### DIFF
--- a/testsuite/features/init_clients/sle_minion.feature
+++ b/testsuite/features/init_clients/sle_minion.feature
@@ -57,13 +57,13 @@ Feature: Be able to bootstrap a Salt minion via the GUI
      And I wait until I see "Successfully bootstrapped host!" text
 
   Scenario: Check the new bootstrapped minion in System Overview page
-     Given I am authorized
-     And I go to the minion onboarding page
-     Then I should see a "accepted" text
-     And the Salt master can reach "sle_minion"
-     When I navigate to "rhn/systems/Overview.do" page
-     And I wait until I see the name of "sle_minion", refreshing the page
-     And I wait until onboarding is completed for "sle_minion"
+    Given I am authorized
+    When I go to the minion onboarding page
+    Then I should see a "accepted" text
+    When I navigate to "rhn/systems/Overview.do" page
+    And I wait until I see the name of "sle_minion", refreshing the page
+    And I wait until onboarding is completed for "sle_minion"
+    Then the Salt master can reach "sle_minion"
 
 @proxy
   Scenario: Check connection from minion to proxy

--- a/testsuite/features/secondary/min_activationkey.feature
+++ b/testsuite/features/secondary/min_activationkey.feature
@@ -70,7 +70,7 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
     When I go to the minion onboarding page
     Then I should see a "accepted" text
     And the Salt master can reach "sle_minion"
-    And I wait for "orion-dummy" to be installed on this "sle_minion"
+    When I wait for "orion-dummy" to be installed on this "sle_minion"
     And I wait for "perseus-dummy" to be installed on this "sle_minion"
 
   Scenario: Check system ID of bootstrapped minion

--- a/testsuite/features/secondary/min_bootstrap_xmlrpc.feature
+++ b/testsuite/features/secondary/min_bootstrap_xmlrpc.feature
@@ -18,13 +18,13 @@ Feature: Register a Salt minion via XML-RPC API
     And I logout from XML-RPC system namespace
 
   Scenario: Check new minion bootstrapped via XML-RPC in System Overview page
-     Given I am authorized
-     And I go to the minion onboarding page
-     Then I should see a "accepted" text
-     And the Salt master can reach "sle_minion"
-     And I navigate to "rhn/systems/Overview.do" page
-     And I wait until I see the name of "sle_minion", refreshing the page
-     And I wait until onboarding is completed for "sle_minion"
+    Given I am authorized
+    When I go to the minion onboarding page
+    Then I should see a "accepted" text
+    When I navigate to "rhn/systems/Overview.do" page
+    And I wait until I see the name of "sle_minion", refreshing the page
+    And I wait until onboarding is completed for "sle_minion"
+    Then the Salt master can reach "sle_minion"
 
   Scenario: Check contact method of this minion
     Given I am on the Systems overview page of this "sle_minion"

--- a/testsuite/features/secondary/min_salt_minions_page.feature
+++ b/testsuite/features/secondary/min_salt_minions_page.feature
@@ -54,7 +54,7 @@ Feature: Management of minion keys
 
   Scenario: The minion communicates with the Salt master
     Given I am authorized as "testing" with password "testing"
-    And the Salt master can reach "sle_minion"
+    Then the Salt master can reach "sle_minion"
     When I get OS information of "sle_minion" from the Master
     Then it should contain the OS of "sle_minion"
 

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -593,7 +593,7 @@ end
 When(/^I enable repositories before installing Docker$/) do
   os_version, os_family = get_os_version($minion)
 
-  # Distribution Pool and Update
+  # Distribution
   repos = "os_pool_repo os_update_repo"
   puts $minion.run("zypper mr --enable #{repos}")
 
@@ -601,13 +601,15 @@ When(/^I enable repositories before installing Docker$/) do
   repos, _code = $minion.run('zypper lr | grep "tools" | cut -d"|" -f2')
   puts $minion.run("zypper mr --enable #{repos.gsub(/\s/, ' ')}")
 
-  # Development repositories
+  # Development
+  # (we do not install Python 2 repositories in this branch
+  #  because they are not needed anymore starting with version 4.1)
   if os_family =~ /^sles/ && os_version =~ /^15/
     repos = "devel_pool_repo devel_updates_repo"
     puts $minion.run("zypper mr --enable #{repos}")
   end
 
-  # Container repositories
+  # Containers
   unless os_family =~ /^opensuse/ || os_version =~ /^11/
     repos = "containers_pool_repo containers_updates_repo"
     puts $minion.run("zypper mr --enable #{repos}")
@@ -619,7 +621,7 @@ end
 When(/^I disable repositories after installing Docker$/) do
   os_version, os_family = get_os_version($minion)
 
-  # Distribution Pool and Update
+  # Distribution
   repos = "os_pool_repo os_update_repo"
   puts $minion.run("zypper mr --disable #{repos}")
 
@@ -627,13 +629,15 @@ When(/^I disable repositories after installing Docker$/) do
   repos, _code = $minion.run('zypper lr | grep "tools" | cut -d"|" -f2')
   puts $minion.run("zypper mr --disable #{repos.gsub(/\s/, ' ')}")
 
-  # Development repositories
+  # Development
+  # (we do not install Python 2 repositories in this branch
+  #  because they are not needed anymore starting with version 4.1)
   if os_family =~ /^sles/ && os_version =~ /^15/
     repos = "devel_pool_repo devel_updates_repo"
     puts $minion.run("zypper mr --disable #{repos}")
   end
 
-  # Container repositories
+  # Containers
   unless os_family =~ /^opensuse/ || os_version =~ /^11/
     repos = "containers_pool_repo containers_updates_repo"
     puts $minion.run("zypper mr --disable #{repos}")
@@ -645,11 +649,11 @@ end
 When(/^I enable repositories before installing branch server$/) do
   os_version, os_family = get_os_version($proxy)
 
-  # Distribution Pool and Update
+  # Distribution
   repos = "os_pool_repo os_update_repo"
   puts $proxy.run("zypper mr --enable #{repos}")
 
-  # Server Applications Pool and Update
+  # Server Applications
   if os_family =~ /^sles/ && os_version =~ /^15/
     repos = "module_server_applications_pool_repo module_server_applications_update_repo"
     puts $proxy.run("zypper mr --enable #{repos}")
@@ -659,11 +663,11 @@ end
 When(/^I disable repositories after installing branch server$/) do
   os_version, os_family = get_os_version($proxy)
 
-  # Distribution Pool and Update
+  # Distribution
   repos = "os_pool_repo os_update_repo"
   puts $proxy.run("zypper mr --disable #{repos}")
 
-  # Server Applications Pool and Update
+  # Server Applications
   if os_family =~ /^sles/ && os_version =~ /^15/
     repos = "module_server_applications_pool_repo module_server_applications_update_repo"
     puts $proxy.run("zypper mr --disable #{repos}")

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -601,6 +601,12 @@ When(/^I enable repositories before installing Docker$/) do
   repos, _code = $minion.run('zypper lr | grep "tools" | cut -d"|" -f2')
   puts $minion.run("zypper mr --enable #{repos.gsub(/\s/, ' ')}")
 
+  # Development repositories
+  if os_family =~ /^sles/ && os_version =~ /^15/
+    repos = "devel_pool_repo devel_updates_repo"
+    puts $minion.run("zypper mr --enable #{repos}")
+  end
+
   # Container repositories
   unless os_family =~ /^opensuse/ || os_version =~ /^11/
     repos = "containers_pool_repo containers_updates_repo"
@@ -620,6 +626,12 @@ When(/^I disable repositories after installing Docker$/) do
   # Tools
   repos, _code = $minion.run('zypper lr | grep "tools" | cut -d"|" -f2')
   puts $minion.run("zypper mr --disable #{repos.gsub(/\s/, ' ')}")
+
+  # Development repositories
+  if os_family =~ /^sles/ && os_version =~ /^15/
+    repos = "devel_pool_repo devel_updates_repo"
+    puts $minion.run("zypper mr --disable #{repos}")
+  end
 
   # Container repositories
   unless os_family =~ /^opensuse/ || os_version =~ /^11/


### PR DESCRIPTION
## What does this PR change?

First batch of changes needed to test SLE 15 SP1 clients

* Master-minion communication can take time
* SLE 15 development tools repos are needed for Kiwi
* SLE 15 SP1 Python 2 repos are needed for Docker

## Links

Partly solves SUSE/spacewalk#7575

Ports:
* 4.0: SUSE/spacewalk#10329
* 3.2: SUSE/spacewalk#10336

See also uyuni-project/sumaform#655 for the sumaform side

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
