### PR TITLE
Fix spacewalk-setup-httpd for future FIPS support at SLE and openSUSE

### DIFF
--- a/spacewalk/setup/bin/spacewalk-setup-httpd
+++ b/spacewalk/setup/bin/spacewalk-setup-httpd
@@ -23,7 +23,30 @@ use warnings;
 use Getopt::Long;
 use Spacewalk::Setup;
 
-my $isSUSE = 0;
+sub id_like_match {
+  $what = shift;
+  my $filename = '/etc/os-release';
+  if(! -e $filename) {
+    return 0;
+  }
+  open my $fh, "<", $filename or die "Could not open '$filename': $!\n";
+  while( my $line = <$fh> ) {
+    if ($line =~ m/ID_LIKE="$what"/) {
+      close $fh;
+      return 1;
+    }
+  }
+  close $fh;
+  return 0;
+}
+
+sub is_suse_like {
+   return id_like_match(".*suse.*");
+}
+
+sub is_opensuse {
+   return id_like_match(".*opensuse.*");
+}
 
 sub os_fips_mode_on {
         # For kernels without CONFIG_CRYPTO_FIPS enabled
@@ -37,29 +60,25 @@ sub os_fips_mode_on {
 }
 
 sub mod_ssl_fipsmode_option {
-	# FIXME: have a look if we can support fips mode
-	return 0 if($isSUSE);
+        # Remove this IF as soon as we have FIPS support enabled at openSUSE Leap 15.2.
+        if (is_opensuse()) {
+                return 0;
+        }
+        if(is_suse_like()) {
+                # Remove this return as soon as we have FIPS support enabled at SLE15SP2.
+                return 0;
 
-	my $mod_ssl_version = `rpm -q --qf='%{VERSION}' mod_ssl`;
-	my $mod_ssl_release = `rpm -q --qf='%{RELEASE}' mod_ssl`;
-
-	# RHEL-5 / CentOS-5 mod_ssl build 2.2.3-66 and above support SSLFIPS directive
-	if ($mod_ssl_version eq '2.2.3' and $mod_ssl_release ge '66') {
-		return 1;
-	}
-
-	# RHEL-6 / CentOS-6 mod_ssl builds do support FIPS, but do not have
-	# the SSLFIPS configuration option implemented
-	if ($mod_ssl_version eq '2.2.15' and $mod_ssl_release ge '5') {
-		return 0;
-	}
-
-	# mod_ssl > 2.4 supports SSLFIPS directive (Fedora 19, 20, ...)
-	if ($mod_ssl_version gt '2.4.0') {
-		return 1;
-	}
-
-	return 0;
+                $mod_ssl_version = `rpm -q --qf='%{VERSION}' apache2-prefork`;
+        }
+        else {
+                $mod_ssl_version = `rpm -q --qf='%{VERSION}' mod_ssl`;
+        }
+        # mod_ssl > 2.4 supports SSLFIPS directive (Fedora 19, 20, ...)
+        # apache2-prefork > 2.4 supports SSLFIPS directive (SLE15, openSUSE Leap 15.0, ...)
+        if ($mod_ssl_version gt '2.4.0') {
+                return 1;
+        }
+        return 0;
 }
 
 sub modify_conf_content {
@@ -89,13 +108,13 @@ sub setup_mod_ssl {
 
         my ($sslconf_content, $original_sslconf_content, $pre, $vhost, $post);
         my $sslconf_dir = '/etc/httpd/conf.d';
-        $sslconf_dir = '/etc/apache2/vhosts.d' if($isSUSE);
+        $sslconf_dir = '/etc/apache2/vhosts.d' if(is_suse_like());
         my $sslconf     = 'ssl.conf';
-        $sslconf = 'vhost-ssl.conf' if($isSUSE);
+        $sslconf = 'vhost-ssl.conf' if(is_suse_like());
 
 	my $sslconf_path = "$sslconf_dir/$sslconf";
 	local *FILE;
-        if($isSUSE && ! -f $sslconf_path)
+        if(is_suse_like() && ! -f $sslconf_path)
 	{
 		`cp "$sslconf_dir/vhost-ssl.template" "$sslconf_path"`;
 	}
@@ -141,22 +160,6 @@ sub setup_mod_ssl {
         return;
 }
 
-sub is_suse_like {
-  my $filename = '/etc/os-release';
-  if(! -e $filename) {
-    return;
-  }
-  open my $fh, "<", $filename or die "Could not open '$filename': $!\n";
-  while( my $line = <$fh> ) {
-    if ($line =~ m/ID_LIKE=".*suse.*"/) {
-      close $fh;
-      return 1;
-    }
-  }
-  close $fh;
-  return;
-}
-
 # main
 
 my $help;
@@ -179,16 +182,12 @@ if ($help) {
         exit 0;
 }
 
-if(is_suse_like) {
-  $isSUSE = 1;
-}
-
 setup_mod_ssl($fips_mode_on);
 
 =head1 NAME
 
 spacewalk-setup-httpd - utility for configuring httpd service to work with
-Spacewalk / Red Hat Satellite
+Uyuni / SUSE Manager
 
 =head1 SYNOPSIS
 
@@ -214,11 +213,11 @@ Print help message.
 =head1 DESCRIPTION
 
 B<spacewalk-setup-httpd> is a utility for configuring httpd service to work
-with Spacewalk / Red Hat Satellite. The script uses configuration templates
+with Uyuni / SUSE Manager. The script uses configuration templates
 to modify existing httpd configuration files.
 
 Ordinarily, spacewalk-setup-httpd is called by spacewalk-setup(1) during
-initial Spacewalk / Red Hat Satellite configuration or upgrade.
+initial Uyuni / SUSE Manager configuration or upgrade.
 
 =head1 FILES
 

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,6 @@
+- Fix spacewalk-setup-httpd for future FIPS support at SLE and
+  openSUSE
+
 -------------------------------------------------------------------
 Wed Nov 27 17:03:14 CET 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Fix spacewalk-setup-httpd for future FIPS support at SLE and openSUSE

Also remove code for old RHEL versions.

WARNING: Having this doesn't mean we are FIPS compliant. Neither SLE15SP2 or openSUSE 15.X are FIPS compliant right now.

Tested locally. With the script as it is, FIPS for Apache is never enabled, even when forced with `--fips-mode-on`.

I also tested commenting the `return 0` at line 69 and in that case FIPS for Apache gets enabled (but apache doesn't start as openSSL at SLE15SP2 still doesn't have FIPS enabled):
```
suma:/etc/apache2 # perl /usr/bin/spacewalk-setup-httpd --fips-mode-on
** /etc/apache2/vhosts.d/vhost-ssl.conf has been backed up to vhost-ssl.conf-swsave

suma:/etc/apache2 # grep -ir 'fips' *      
vhosts.d/vhost-ssl.conf:SSLFIPS on

suma:/etc/apache2 # service apache2 restart
Job for apache2.service failed because the control process exited with error code.
See "systemctl  status apache2.service" and "journalctl  -xe" for details.
suma:/etc/apache2 # journalctl -xe
-- 
-- Unit taskomatic.service has begun shutting down.
dic 11 20:53:49 suma systemd[1]: Stopped Taskomatic.
-- Subject: Unit taskomatic.service has finished shutting down
-- Defined-By: systemd
-- Support: https://lists.freedesktop.org/mailman/listinfo/systemd-devel
-- 
-- Unit taskomatic.service has finished shutting down.
dic 11 20:53:49 suma systemd[1]: Stopping The Apache Webserver...
-- Subject: Unit apache2.service has begun shutting down
-- Defined-By: systemd
-- Support: https://lists.freedesktop.org/mailman/listinfo/systemd-devel
-- 
-- Unit apache2.service has begun shutting down.
dic 11 20:53:50 suma start_apache2[21491]: AH00526: Syntax error on line 63 of /etc/apache2/vhosts.d/vhost-ssl.conf:
dic 11 20:53:50 suma start_apache2[21491]: SSLFIPS invalid, rebuild httpd and openssl compiled for FIPS
dic 11 20:53:50 suma systemd[1]: apache2.service: Control process exited, code=exited status=1
dic 11 20:53:50 suma systemd[1]: Stopped The Apache Webserver.
```
NOTE: Ignore date and time, it's in correct at the instance (not sure why, maybe because I am playing with snapshots).

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Not yet. Should be done when we can test FIPS.

- [x] **DONE**

## Test coverage
- No tests: We should probably cover it with sumaform, so we can run the testsuite with and without FIPS enabled.

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/3617

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
