### PR TITLE
Adapt format to a github action limitation

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,58 +1,58 @@
 #Dev Labels
 java: 
-- java/**/*
+- java/*
 ui: 
-- web/**/*
+- web/*
 webapp: 
-- java/code/webapp/**/*
+- java/code/webapp/*
 cobbler: 
-- java/code/src/org/cobbler/**/*
+- java/code/src/org/cobbler/*
 documentation: 
-- documentation/**/*
+- documentation/*
 proxy: 
-- proxy/**/*
+- proxy/*
 API: 
-- java/code/src/com/redhat/rhn/frontend/**/*
+- java/code/src/com/redhat/rhn/frontend/*
 Virtualization management: 
-- java/code/src/com/suse/manager/virtualization/**/*
+- java/code/src/com/suse/manager/virtualization/*
 monitoring: 
-- java/code/src/com/suse/manager/webui/services/impl/test/monitoring/**/*
-- java/code/src/com/redhat/rhn/frontend/xmlrpc/admin/monitoring/**/*
+- java/code/src/com/suse/manager/webui/services/impl/test/monitoring/*
+- java/code/src/com/redhat/rhn/frontend/xmlrpc/admin/monitoring/*
 python3: 
 - java/**/*.py
 - backend/**/*.py
 - client/**/*.py
 - susemanager/**/*.py
-- spacecmd/**/*
+- spacecmd/*
 database: 
-- schema/spacewalk/**/*
+- schema/spacewalk/*
 content-management: 
-- java/code/src/com/suse/manager/webui/controllers/contentmanagement/**/*
+- java/code/src/com/suse/manager/webui/controllers/contentmanagement/*
 
 #QA Labels
 testing: 
-- testsuite/**/*
+- testsuite/*
 core-features: 
-- testsuite/features/core/**/*
+- testsuite/features/core/*
 secondary-features: 
-- testsuite/features/secondary/**/*
+- testsuite/features/secondary/*
 ci-pipelines: 
 - testsuite/**/*.yml
 
 #Unit tests
 backend_unittests_pgsql: 
-- backend/**/*
+- backend/*
 javascript_lint: 
-- web/**/*
+- web/*
 java_lint_checkstyle: 
-- java/**/*
+- java/*
 java_pgsql_tests: 
-- java/**/*
+- java/*
 ruby_rubocop: 
-- testsuite/**/*
+- testsuite/*
 schema_migration_test_oracle: 
-- schema/spacewalk/**/*
+- schema/spacewalk/*
 schema_migration_test_pgsql: 
-- schema/spacewalk/**/*
+- schema/spacewalk/*
 susemanager_unittests: 
-- susemanager/**/*
+- susemanager/*

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,7 +1,7 @@
 name: Labeler
 on:
   schedule:
-  - cron: "0 0 * * *"
+  - cron: "0 * * * *"
 
 jobs:
   label:


### PR DESCRIPTION
## What does this PR change?

Our current GitHub action doesn't support the same format that the default labeler does. Re-formatting.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

The solution was obtained from here:
https://github.com/paulfantom/periodic-labeler/issues/1#issuecomment-559827533

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
