### PR TITLE
Change the order of checks to identify the RES version correctly

### DIFF
--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -358,12 +358,12 @@ if [ "$INSTALLER" == yum ]; then
     function getY_CLIENT_CODE_BASE() {{
         local BASE=""
         local VERSION=""
-        if [ -f /etc/centos-release ]; then
-            grep -v '^#' /etc/centos-release | grep -q '\(CentOS\)' && BASE="centos"
-            VERSION=`grep -v '^#' /etc/centos-release | grep -Po '(?<=release )\d+'`
-        elif [ -f /etc/redhat-release ]; then
+        if [ -f /etc/redhat-release ]; then
             grep -v '^#' /etc/redhat-release | grep -q '\(Red Hat\)' && BASE="res"
             VERSION=`grep -v '^#' /etc/redhat-release | grep -Po '(?<=release )\d+'`
+        elif [ -f /etc/centos-release ]; then
+            grep -v '^#' /etc/centos-release | grep -q '\(CentOS\)' && BASE="centos"
+            VERSION=`grep -v '^#' /etc/centos-release | grep -Po '(?<=release )\d+'`
         fi
         Y_CLIENT_CODE_BASE="${{BASE:-unknown}}"
         Y_CLIENT_CODE_VERSION="${{VERSION:-unknown}}"

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,5 @@
+- Change the order to check the version correctly for RES (bsc#1152795)
+
 -------------------------------------------------------------------
 Thu Nov 28 17:54:02 CET 2019 - jgonzalez@suse.com
 

--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -27,10 +27,10 @@ mgr_server_localhost_alias_absent:
 {% set bootstrap_repo_url = 'https://' ~ salt['pillar.get']('mgr_server') ~ '/pub/repositories/' ~ os_base ~ '/' ~ grains['osrelease'] ~ '/0/bootstrap/' %}
 {%- endif %}
 {%- elif grains['os_family'] == 'RedHat' %}
-{% if salt['file.file_exists' ]('/etc/centos-release') %}
-{% set bootstrap_repo_url = 'https://' ~ salt['pillar.get']('mgr_server') ~ '/pub/repositories/' ~ os_base ~ '/' ~ grains['osmajorrelease'] ~ '/bootstrap/' %}
-{%- else %}
+{% if salt['file.file_exists' ]('/etc/redhat-release') %}
 {% set bootstrap_repo_url = 'https://' ~ salt['pillar.get']('mgr_server') ~ '/pub/repositories/res/' ~ grains['osmajorrelease'] ~ '/bootstrap/' %}
+{%- else %}
+{% set bootstrap_repo_url = 'https://' ~ salt['pillar.get']('mgr_server') ~ '/pub/repositories/' ~ os_base ~ '/' ~ grains['osmajorrelease'] ~ '/bootstrap/' %}
 {% endif %}
 {%- elif grains['os_family'] == 'Debian' %}
 {%- set osrelease = grains['osrelease'].split('.') %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Change the order to check the version correctly for RES (bsc#1152795)
 - Remove the virt-poller cache when applying Virtualization entitlement
 - Force HTTP request timeout on public cloud grain (bsc#1157975)
 


### PR DESCRIPTION
## What does this PR change?

port of https://github.com/SUSE/spacewalk/pull/10233