### PR TITLE
Support for CentOS8 at spacewalk-common-channels and bootstrap repos (bsc#1159206)

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -854,6 +854,10 @@ DATA = {
         'BASECHANNEL' : 'centos7-x86_64', 'PKGLIST' : RES7,
         'DEST' : '/srv/www/htdocs/pub/repositories/centos/7/bootstrap/'
     },
+    'centos-8-x86_64' : {
+        'BASECHANNEL' : 'centos8-x86_64', 'PKGLIST' : RES8,
+        'DEST' : '/srv/www/htdocs/pub/repositories/centos/8/bootstrap/'
+    },
     'RHEL6-x86_64' : {
         'PDID' : [-5, 1682], 'PKGLIST' : RES6,
         'DEST' : '/srv/www/htdocs/pub/repositories/res/6/bootstrap/'

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- Allow creating bootstrap repositories for CentoS8 (bsc#1159206)
 - add bootstrap-repo data for SLE12 SP5 Family (bsc#1158963)
 - explicitly enable jabberd during setup
 - separate osa-dispatcher and jabberd so it can be disabled independently

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -150,6 +150,85 @@ checksum = sha256
 base_channels = fedora30-%(arch)s
 yumrepo_url = https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f30&arch=%(arch)s
 
+[centos8]
+archs    = x86_64
+name     = CentOS 8 (%(arch)s)
+gpgkey_url = http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-Official
+gpgkey_id = 8483C65D
+gpgkey_fingerprint = 99DB 70FA E1D7 CE22 7FB6 4882 05B5 55B3 8483 C65D
+repo_url = http://mirrorlist.centos.org/?release=8&arch=%(arch)s&repo=BaseOS&infra=stock
+dist_map_release = 8
+
+[centos8-appstream]
+label    = %(base_channel)s-appstream
+archs    = x86_64
+name     = CentOS 8 AppStream (%(arch)s)
+base_channels = centos8-%(arch)s
+repo_url = http://mirrorlist.centos.org/?release=8&arch=%(arch)s&repo=AppStream&infra=stock
+
+[centos8-centosplus]
+label    = %(base_channel)s-centosplus
+archs    = x86_64
+name     = CentOS 8 Plus (%(arch)s)
+base_channels = centos8-%(arch)s
+repo_url = http://mirrorlist.centos.org/?release=8&arch=%(arch)s&repo=centosplus&infra=stock
+
+[centos8-cr]
+label    = %(base_channel)s-cr
+archs    = x86_64
+name     = CentOS 8 CR (%(arch)s)
+base_channels = centos8-%(arch)s
+repo_url = http://mirrorlist.centos.org/?release=8&arch=%(arch)s&repo=cr&infra=stock
+
+[centos8-extras]
+label    = %(base_channel)s-extras
+archs    = x86_64
+name     = CentOS 8 Extras (%(arch)s)
+base_channels = centos8-%(arch)s
+repo_url = http://mirrorlist.centos.org/?release=8&arch=%(arch)s&repo=extras&infra=stock
+
+[centos8-fasttrack]
+label    = %(base_channel)s-fasttrack
+archs    = x86_64
+name     = CentOS 8 FastTrack (%(arch)s)
+base_channels = centos8-%(arch)s
+repo_url = http://mirrorlist.centos.org/?release=8&arch=%(arch)s&repo=fasttrack&infra=stock
+
+[centos8-powertools]
+label    = %(base_channel)s-powertools
+archs    = x86_64
+name     = CentOS 8 PowerTools (%(arch)s)
+base_channels = centos8-%(arch)s
+repo_url = http://mirrorlist.centos.org/?release=8&arch=%(arch)s&repo=PowerTools&infra=stock
+
+[centos8-uyuni-client]
+name     = Uyuni Client Tools for %(base_channel_name)s
+archs    = %(_x86_archs)s
+base_channels = centos8-%(arch)s
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8/
+
+[centos8-uyuni-client-devel]
+name     = Uyuni Client Tools for %(base_channel_name)s (Development)
+archs    = %(_x86_archs)s
+base_channels = centos8-%(arch)s
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS8-Uyuni-Client-Tools/CentOS_8/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS8-Uyuni-Client-Tools/CentOS_8/
+
+[epel8]
+label    = epel8-%(base_channel)s
+name     = EPEL 8 for %(base_channel_name)s
+archs    = x86_64
+base_channels = centos8-%(arch)s
+gpgkey_url = http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8
+gpgkey_id = 2F86D6A1
+gpgkey_fingerprint = 94E2 79EB 8D8F 25B2 1810 ADF1 21EA 45AB 2F86 D6A1
+repo_url = http://mirrors.fedoraproject.org/mirrorlist?repo=epel-8&arch=%(arch)s
+
 [centos7]
 archs    = x86_64
 name     = CentOS 7 (%(arch)s)

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,5 @@
+- Enable CentOS8 at spacewalk-common-channels (bsc#1159206)
+
 -------------------------------------------------------------------
 Wed Nov 27 17:04:04 CET 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Support for CentOS8  at spacewalk-common-channels and bootstrap repos (bsc#1159206)

CentOS8 Stream support should come later.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: https://github.com/uyuni-project/uyuni-docs/pull/27#issuecomment-565302435

- [x] **DONE**

## Test coverage
- No tests: spacewalk-common-channels doesn't have testing (and is an unsupported tool for now)

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/10338

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
