### PR TITLE
add permission checks for formula api

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -8287,12 +8287,18 @@ tree will not be usable for kickstarting.
         <context-group name="ctx">
           <context context-type="sourcefile">Navigation Menu</context>
         </context-group>
+     <trans-unit id="formula.accessdenied">
+        <source>You do not have access.</source>
       </trans-unit>
+     </trans-unit>
       <trans-unit id="Home">
         <source>Home</source>
         <context-group name="ctx">
           <context context-type="sourcefile">Navigation Menu</context>
         </context-group>
+       <trans-unit id="help.credentials.nologins">
+        <source>There are no registered accounts with that email address.</source>
+      </trans-unit>
       </trans-unit>
     </body>
   </file>

--- a/java/code/src/com/redhat/rhn/manager/formula/FormulaUtil.java
+++ b/java/code/src/com/redhat/rhn/manager/formula/FormulaUtil.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.manager.formula;
+
+import com.redhat.rhn.common.hibernate.LookupException;
+import com.redhat.rhn.common.localization.LocalizationService;
+import com.redhat.rhn.common.security.PermissionException;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerGroup;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.manager.system.ServerGroupManager;
+import com.redhat.rhn.manager.system.SystemManager;
+
+
+/**
+ * Util class for checking permissions on for formulas.
+ */
+public class FormulaUtil {
+
+    private FormulaUtil() { }
+
+    /**
+     * Verify user has access to system group
+     * @param user Logged in user
+     * @param group Target group to check for permissions
+     */
+    public static void ensureUserHasPermissionsOnServerGroup(User user, ServerGroup group) {
+        try {
+            ServerGroupManager.getInstance().validateAccessCredentials(user, group, group.getName());
+            ServerGroupManager.getInstance().validateAdminCredentials(user);
+        }
+        catch (NullPointerException | LookupException e) {
+            throw new LookupException("Unable to find user or group");
+        }
+        catch (PermissionException e) {
+            throw new PermissionException(LocalizationService.getInstance().getMessage("formula.accessdenied"));
+        }
+    }
+
+
+    /**
+     * Verify user has access to server
+     * @param user Logged in user
+     * @param server Targer server to check for permissions
+     */
+    public static void ensureUserHasPermissionsOnServer(User user, Server server) {
+        if (!SystemManager.isAvailableToUser(user, server.getId())) {
+            throw new PermissionException(LocalizationService.getInstance().getMessage("formula.accessdenied"));
+        }
+    }
+}

--- a/java/code/src/com/redhat/rhn/manager/formula/test/FormulaManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/formula/test/FormulaManagerTest.java
@@ -15,6 +15,7 @@
 package com.redhat.rhn.manager.formula.test;
 
 import com.redhat.rhn.common.hibernate.LookupException;
+import com.redhat.rhn.common.security.PermissionException;
 import com.redhat.rhn.domain.formula.FormulaFactory;
 import com.redhat.rhn.domain.server.ManagedServerGroup;
 import com.redhat.rhn.domain.server.MinionServer;
@@ -157,7 +158,7 @@ public class FormulaManagerTest extends JMockBaseTestCaseWithUser {
         try {
             manager.saveServerFormulaData(testUser,minion.getId(), formulaName, contents);
             fail( "Exception expected but didn't throw" );
-        } catch (LookupException ex) {
+        } catch (PermissionException ex) {
             //expected exception
         }
     }

--- a/java/code/src/com/suse/manager/webui/controllers/FormulaController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/FormulaController.java
@@ -20,13 +20,11 @@ import com.redhat.rhn.domain.formula.FormulaFactory;
 import com.redhat.rhn.domain.server.ManagedServerGroup;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.MinionServerFactory;
-import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerFactory;
-import com.redhat.rhn.domain.server.ServerGroup;
 import com.redhat.rhn.domain.server.ServerGroupFactory;
 import com.redhat.rhn.domain.user.User;
-import com.redhat.rhn.manager.system.ServerGroupManager;
-import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.manager.formula.FormulaUtil;
+
 
 import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.utils.gson.StateTargetType;
@@ -118,16 +116,20 @@ public class FormulaController {
         List<String> formulas;
         switch (type) {
             case SERVER:
-                if (!checkUserHasPermissionsOnServer(user,
-                        ServerFactory.lookupById(id))) {
+                try {
+                    FormulaUtil.ensureUserHasPermissionsOnServer(user, ServerFactory.lookupById(id));
+                }
+                catch (PermissionException e) {
                     return deniedResponse(response);
                 }
-                formulas = new LinkedList<>(
-                        FormulaFactory.getCombinedFormulasByServerId(id));
+                formulas = new LinkedList<>(FormulaFactory.getCombinedFormulasByServerId(id));
                 break;
             case GROUP:
-                if (!checkUserHasPermissionsOnServerGroup(user,
-                            ServerGroupFactory.lookupByIdAndOrg(id, user.getOrg()))) {
+                try {
+                    FormulaUtil.ensureUserHasPermissionsOnServerGroup(user,
+                            ServerGroupFactory.lookupByIdAndOrg(id, user.getOrg()));
+                }
+                catch (PermissionException | LookupException e) {
                     return deniedResponse(response);
                 }
                 formulas = FormulaFactory.getFormulasByGroupId(id);
@@ -195,7 +197,10 @@ public class FormulaController {
             switch (type) {
                 case SERVER:
                     Optional<MinionServer> minion = MinionServerFactory.lookupById(id);
-                    if (!checkUserHasPermissionsOnServer(user, minion.get())) {
+                    try {
+                        FormulaUtil.ensureUserHasPermissionsOnServer(user, minion.get());
+                    }
+                    catch (PermissionException e) {
                         return deniedResponse(response);
                     }
                     FormulaFactory.saveServerFormulaData(formData, MinionServerFactory.getMinionId(id), formulaName);
@@ -203,7 +208,10 @@ public class FormulaController {
                     break;
                 case GROUP:
                     ManagedServerGroup group = ServerGroupFactory.lookupByIdAndOrg(id, user.getOrg());
-                    if (!checkUserHasPermissionsOnServerGroup(user, group)) {
+                    try {
+                        FormulaUtil.ensureUserHasPermissionsOnServerGroup(user, group);
+                    }
+                    catch (PermissionException | LookupException e) {
                         return deniedResponse(response);
                     }
                     FormulaFactory.saveGroupFormulaData(formData, id, user.getOrg(), formulaName);
@@ -260,17 +268,23 @@ public class FormulaController {
         Map<String, Object> data = new HashMap<>();
         switch (type) {
             case SERVER:
-                if (!checkUserHasPermissionsOnServer(user, ServerFactory.lookupById(id))) {
+                try {
+                    FormulaUtil.ensureUserHasPermissionsOnServer(user, ServerFactory.lookupById(id));
+                }
+                catch (PermissionException e) {
                     return deniedResponse(response);
                 }
                 data.put("selected", FormulaFactory.getFormulasByMinionId(MinionServerFactory.getMinionId(id)));
                 data.put("active", FormulaFactory.getCombinedFormulasByServerId(id));
                 break;
             case GROUP:
-                if (!checkUserHasPermissionsOnServerGroup(user,
-                        ServerGroupFactory.lookupByIdAndOrg(id, user.getOrg()))) {
-                    return deniedResponse(response);
+                try {
+                    FormulaUtil.ensureUserHasPermissionsOnServerGroup(user,
+                            ServerGroupFactory.lookupByIdAndOrg(id, user.getOrg()));
                 }
+               catch (PermissionException | LookupException e) {
+                    return deniedResponse(response);
+               }
                 data.put("selected", FormulaFactory.getFormulasByGroupId(id));
                 break;
             default:
@@ -300,15 +314,21 @@ public class FormulaController {
         try {
             switch (type) {
                 case SERVER:
-                    if (!checkUserHasPermissionsOnServer(user,
-                            ServerFactory.lookupById(id))) {
+                    try {
+                        FormulaUtil.ensureUserHasPermissionsOnServer(user,
+                                ServerFactory.lookupById(id));
+                    }
+                    catch (PermissionException e) {
                         return deniedResponse(response);
                     }
                     FormulaFactory.saveServerFormulas(MinionServerFactory.getMinionId(id), selectedFormulas);
                     break;
                 case GROUP:
-                    if (!checkUserHasPermissionsOnServerGroup(user,
-                            ServerGroupFactory.lookupByIdAndOrg(id, user.getOrg()))) {
+                    try {
+                        FormulaUtil.ensureUserHasPermissionsOnServerGroup(user,
+                                ServerGroupFactory.lookupByIdAndOrg(id, user.getOrg()));
+                    }
+                    catch (PermissionException | LookupException e) {
                         return deniedResponse(response);
                     }
                     FormulaFactory.saveGroupFormulas(id, selectedFormulas, user.getOrg());
@@ -364,22 +384,5 @@ public class FormulaController {
         response.type("application/json");
         response.status(HttpStatus.SC_FORBIDDEN);
         return GSON.toJson("['Permission denied!']");
-    }
-
-    private static boolean checkUserHasPermissionsOnServerGroup(User user,
-            ServerGroup group) {
-        try {
-            ServerGroupManager.getInstance().validateAccessCredentials(user, group,
-                    group.getName());
-            ServerGroupManager.getInstance().validateAdminCredentials(user);
-            return true;
-        }
-        catch (NullPointerException | PermissionException | LookupException e) {
-            return false;
-        }
-    }
-
-    private static boolean checkUserHasPermissionsOnServer(User user, Server server) {
-        return SystemManager.isAvailableToUser(user, server.getId());
     }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add missing permission checks on formula api (bsc#1123274)
 - use channel name from product tree instead of constructing it (bsc#1157317)
 - Add the system.getMinionIdMap XMLRPC method
 - generate metadata with empty vendor (bsc#1158480)


### PR DESCRIPTION
## What does this PR change?

port of 8596
## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
