### PR TITLE
Remove trad from salt proxy

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/bootstrap/remove_traditional_stack.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/remove_traditional_stack.sls
@@ -27,8 +27,6 @@ remove_traditional_stack_all:
       - mgr-osad
       - spacewalksd
       - mgr-daemon
-      - rhncfg
-      - mgr-cfg
       - rhnlib
       - rhnmd
 {%- if grains['os_family'] == 'Suse' %}
@@ -52,6 +50,8 @@ remove_traditional_stack:
   pkg.removed:
     - pkgs:
       - spacewalk-client-tools
+      - rhncfg
+      - mgr-cfg
 {%- if repos_disabled.count > 0 %}
     - require:
       - module: disable_repo*

--- a/susemanager-utils/susemanager-sls/salt/bootstrap/remove_traditional_stack.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/remove_traditional_stack.sls
@@ -17,12 +17,20 @@ disable_osad:
     - name: osad
     - enable: False
 
-remove_traditional_stack:
+remove_traditional_stack_all:
   pkg.removed:
     - pkgs:
       - spacewalk-check
       - spacewalk-client-setup
-      - spacewalk-client-tools
+      - osad
+      - osa-common
+      - mgr-osad
+      - spacewalksd
+      - mgr-daemon
+      - rhncfg
+      - mgr-cfg
+      - rhnlib
+      - rhnmd
 {%- if grains['os_family'] == 'Suse' %}
       - zypp-plugin-spacewalk
       - suseRegisterInfo
@@ -35,12 +43,15 @@ remove_traditional_stack:
 {%- elif grains['os_family'] == 'Debian' %}
       - apt-transport-spacewalk
 {%- endif %}
-      - osad
-      - osa-common
-      - spacewalksd
-      - rhncfg
-      - rhnlib
-      - rhnmd
+{%- if repos_disabled.count > 0 %}
+    - require:
+      - module: disable_repo*
+{%- endif %}
+
+remove_traditional_stack:
+  pkg.removed:
+    - pkgs:
+      - spacewalk-client-tools
 {%- if repos_disabled.count > 0 %}
     - require:
       - module: disable_repo*

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- split remove_traditional_stack into two parts. One for all systems and
+  another for clients not beeing a Uyuni Server or Proxy (bsc#1121640)
 - Change the order to check the version correctly for RES (bsc#1152795)
 - Remove the virt-poller cache when applying Virtualization entitlement
 - Force HTTP request timeout on public cloud grain (bsc#1157975)

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,5 +1,5 @@
 - split remove_traditional_stack into two parts. One for all systems and
-  another for clients not beeing a Uyuni Server or Proxy (bsc#1121640)
+  another for clients not being a Uyuni Server or Proxy (bsc#1121640)
 - Change the order to check the version correctly for RES (bsc#1152795)
 - Remove the virt-poller cache when applying Virtualization entitlement
 - Force HTTP request timeout on public cloud grain (bsc#1157975)


### PR DESCRIPTION
## What does this PR change?

Remove traditional stack state is skipped when it run on a Uyuni Server or Proxy.
There are some packages (currently 1 only) which is required on them as well.

But this leave a lot of traditional client tools on Server and Proxy which create warnings.

So this PR sprit the package remove state into 2 parts. One for all systems and another for clients not beeing a Uyuni Server or Proxy .

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/6767
Tracks https://github.com/SUSE/spacewalk/pull/10354 https://github.com/SUSE/spacewalk/pull/10355

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
