### PR TITLE
Fix container image import (bsc#1154246)

### DIFF
--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -71,13 +71,6 @@ import com.redhat.rhn.manager.errata.ErrataManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonSyntaxException;
-import com.google.gson.reflect.TypeToken;
 import com.suse.manager.reactor.hardware.CpuArchUtil;
 import com.suse.manager.reactor.hardware.HardwareMapper;
 import com.suse.manager.reactor.messaging.ApplyStatesEventMessage;
@@ -104,8 +97,8 @@ import com.suse.manager.webui.utils.salt.custom.OSImageInspectSlsResult;
 import com.suse.manager.webui.utils.salt.custom.Openscap;
 import com.suse.manager.webui.utils.salt.custom.PkgProfileUpdateSlsResult;
 import com.suse.manager.webui.utils.salt.custom.RetOpt;
-import com.suse.manager.webui.websocket.VirtNotifications;
 import com.suse.manager.webui.utils.salt.custom.SystemInfo;
+import com.suse.manager.webui.websocket.VirtNotifications;
 import com.suse.salt.netapi.calls.modules.Pkg;
 import com.suse.salt.netapi.calls.modules.Pkg.Info;
 import com.suse.salt.netapi.calls.modules.Zypper.ProductInfo;
@@ -121,6 +114,12 @@ import com.suse.salt.netapi.utils.Xor;
 import com.suse.utils.Json;
 import com.suse.utils.Opt;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.reflect.TypeToken;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
@@ -1026,7 +1025,8 @@ public class SaltUtils {
         ActionStatus as = ActionFactory.STATUS_COMPLETED;
         serverAction.setResultMsg("Success");
 
-        if (imageInfo.getProfile().asDockerfileProfile().isPresent()) {
+        if (Optional.ofNullable(imageInfo.getProfile()).isEmpty() ||
+                imageInfo.getProfile().asDockerfileProfile().isPresent()) {
             if (result.getDockerInspect().isResult()) {
                 ImageInspectSlsResult iret = result.getDockerInspect().getChanges().getRet();
                 imageInfo.setChecksum(ImageInfoFactory.convertChecksum(iret.getId()));
@@ -1098,8 +1098,7 @@ public class SaltUtils {
                 serverAction.setResultMsg(result.getDockerSlsBuild().getComment());
             }
         }
-
-        if (imageInfo.getProfile().asKiwiProfile().isPresent()) {
+        else {
             if (result.getKiwiInspect().isResult()) {
                 Long instantNow = new Date().getTime() / 1000L;
                 OSImageInspectSlsResult ret = result.getKiwiInspect().getChanges().getRet();

--- a/java/code/src/com/suse/manager/webui/utils/salt/custom/ImagesProfileUpdateSlsResult.java
+++ b/java/code/src/com/suse/manager/webui/utils/salt/custom/ImagesProfileUpdateSlsResult.java
@@ -14,9 +14,10 @@
  */
 package com.suse.manager.webui.utils.salt.custom;
 
-import com.google.gson.annotations.SerializedName;
 import com.suse.salt.netapi.results.Ret;
 import com.suse.salt.netapi.results.StateApplyResult;
+
+import com.google.gson.annotations.SerializedName;
 
 import java.util.Optional;
 
@@ -68,6 +69,9 @@ public class ImagesProfileUpdateSlsResult {
      * @return getter
      */
     public StateApplyResult<Ret<OSImageInspectSlsResult>> getKiwiInspect() {
+        if (kiwiInspect.isPresent()) {
+            return kiwiInspect.get();
+        }
         return kiwiInspect.get();
     }
 }

--- a/java/code/src/com/suse/manager/webui/utils/salt/custom/ImagesProfileUpdateSlsResult.java
+++ b/java/code/src/com/suse/manager/webui/utils/salt/custom/ImagesProfileUpdateSlsResult.java
@@ -69,9 +69,6 @@ public class ImagesProfileUpdateSlsResult {
      * @return getter
      */
     public StateApplyResult<Ret<OSImageInspectSlsResult>> getKiwiInspect() {
-        if (kiwiInspect.isPresent()) {
-            return kiwiInspect.get();
-        }
         return kiwiInspect.get();
     }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix container image import (bsc#1154246)
 - Add missing permission checks on formula api (bsc#1123274)
 - use channel name from product tree instead of constructing it (bsc#1157317)
 - Add the system.getMinionIdMap XMLRPC method


### PR DESCRIPTION
## What does this PR change?

Fix: container image import (bsc#1154246)
    
When importing a container image, a profile is not associated with the image (because it has been externally built). With this PR we fix the image import feature and we check if the image has associated a profile only for Kiwi images (that do not support importing).

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: bugfix

- [X] **DONE**

## Test coverage

- Unit tests were added

- [X] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/10308

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
