### PR TITLE
Making sle_client and sle_minion optionals (Port)

### DIFF
--- a/testsuite/documentation/optional.md
+++ b/testsuite/documentation/optional.md
@@ -32,6 +32,34 @@ Inside of the testsuite, the scenarios that are tagged with
 are executed only if the proxy is available.
 
 
+### Testing with a SLE minion
+
+Using a minion with the testsuite is not mandatory.
+
+If you do not want a SLE minion, do not define `MINION` environment
+variable before you run the testsuite. That's all.
+If you want a SLE minion, make this variable point to the machine that
+will be the minion:
+```bash
+export MINION=myminion.example.com
+```
+and then run the testsuite.
+
+Sumaform can prepare a minion virtual machine and declare the `$MINION`
+variable on the controller (in `/root/.bashrc`).
+To declare a minion in your `main.tf` file, add a line
+to the controller declaration that looks like:
+```
+minion_configuration="${module.min-sles12sp3.configuration}"
+```
+
+Inside of the testsuite, the scenarios that are tagged with
+```
+@sle_minion
+```
+are executed only if the minion is available.
+
+
 ### Testing with a SSH minion
 
 Using a SSH minion with the testsuite is not mandatory.
@@ -50,7 +78,7 @@ variable on the controller (in `/root/.bashrc`).
 To declare a SSH minion in your `main.tf` file, add a line
 to the controller declaration that looks like:
 ```
-centos_configuration="${module.minsles12sp3ssh.configuration}"
+minionssh_configuration="${module.minsles12sp3ssh.configuration}"
 ```
 
 Inside of the testsuite, the scenarios that are tagged with
@@ -58,6 +86,34 @@ Inside of the testsuite, the scenarios that are tagged with
 @ssh_minion
 ```
 are executed only if the SSH minion is available.
+
+
+### Testing with a traditional client
+
+Using a traditional client with the testsuite is not mandatory.
+
+If you do not want a traditional client, do not define `CLIENT` environment
+variable before you run the testsuite. That's all.
+If you want a traditional client, make this variable point to the machine that
+will be the traditional client:
+```bash
+export CLIENT=mytraditionalclient.example.com
+```
+and then run the testsuite.
+
+Sumaform can prepare a traditional client virtual machine and declare the `$CLIENT`
+variable on the controller (in `/root/.bashrc`).
+To declare a traditional client in your `main.tf` file, add a line
+to the controller declaration that looks like:
+```
+client_configuration="${module.cli-sles12sp3.configuration}"
+```
+
+Inside of the testsuite, the scenarios that are tagged with
+```
+@sle_client
+```
+are executed only if the traditional client is available.
 
 
 ### Testing with a CentOS minion

--- a/testsuite/features/core/proxy_branch_network.feature
+++ b/testsuite/features/core/proxy_branch_network.feature
@@ -4,6 +4,8 @@
 # The scenarios in this feature are skipped if there is no proxy
 # ($proxy is nil) or if there is no private network ($private_net is nil)
 
+@sle_minion
+@sle_client
 Feature: Setup SUSE Manager for Retail branch network
   In order to deploy SUSE Manager for Retail solution
   As the system administrator

--- a/testsuite/features/secondary/allcli_software_channels.feature
+++ b/testsuite/features/secondary/allcli_software_channels.feature
@@ -3,35 +3,61 @@
 
 Feature: Chanel subscription via SSM
 
-  Scenario: Change child channels for two systems subscribed to a base channel
+@sle_minion
+  Scenario: Change child channels for SLES Minion subscribed to a base channel
     Given I am authorized as "admin" with password "admin"
     When I am on the System Overview page
     And I follow "Clear"
     And I check the "sle_minion" client
-    And I check the "sle_client" client
-    And I should see "2" systems selected for SSM
+    And I should see "1" systems selected for SSM
     And I am on System Set Manager Overview
     And I follow "channel memberships" in the content area
     Then I should see a "Base Channel" text
     And I should see a "Next" text
-    And I should see a table line with "Test-Channel-x86_64", "2"
     When I select "Test Base Channel" from drop-down in table line with "Test-Channel-x86_64"
     And I click on "Next"
     Then I should see a "Child Channels" text
     And I should see a "Test Base Channel" text
-    And I should see a "2 system(s) to subscribe" text
+    And I should see a "1 system(s) to subscribe" text
     When I choose radio button "Subscribe" for child channel "Test Child Channel"
     And I click on "Next"
     Then I should see a "Channel Changes Overview" text
-    And I should see a "2 system(s) to subscribe" text
+    And I should see a "1 system(s) to subscribe" text
     When I schedule action to 3 minutes from now
     And I click on "Confirm"
     And I remember when I scheduled an action
     Then I wait until I see "Channel Changes Actions" text
-    And I should see a "Items 1 - 2 of 2" text
     And a table line should contain system "sle_minion", "Scheduled"
-    And a table line should contain system "sle_client", "Scheduled"
+    And I follow "Clear"
 
+@sle_client
+  Scenario: Change child channels for SLES Client subscribed to a base channel
+    Given I am authorized as "admin" with password "admin"
+    When I am on the System Overview page
+    And I follow "Clear"
+    And I check the "sle_client" client
+    And I should see "1" systems selected for SSM
+    And I am on System Set Manager Overview
+    And I follow "channel memberships" in the content area
+    Then I should see a "Base Channel" text
+    And I should see a "Next" text
+    When I select "Test Base Channel" from drop-down in table line with "Test-Channel-x86_64"
+    And I click on "Next"
+    Then I should see a "Child Channels" text
+    And I should see a "Test Base Channel" text
+    And I should see a "1 system(s) to subscribe" text
+    When I choose radio button "Subscribe" for child channel "Test Child Channel"
+    And I click on "Next"
+    Then I should see a "Channel Changes Overview" text
+    And I should see a "1 system(s) to subscribe" text
+    When I schedule action to 3 minutes from now
+    And I click on "Confirm"
+    And I remember when I scheduled an action
+    Then I wait until I see "Channel Changes Actions" text
+    And a table line should contain system "sle_client", "Scheduled"
+    And I follow "Clear"
+
+@sle_minion
   Scenario: Check SLES minion is still subscribed to old channels before channel change completes
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area
@@ -41,6 +67,7 @@ Feature: Chanel subscription via SSM
     And I wait until I do not see "Loading..." text
     And I should see "Test-Channel-x86_64 Child Channel" as unchecked
 
+@sle_client
   Scenario: Check SLES client is still subscribed to old channels before channel change completes
     Given I am on the Systems overview page of this "sle_client"
     When I follow "Software" in the content area
@@ -50,26 +77,31 @@ Feature: Chanel subscription via SSM
     And I wait until I do not see "Loading..." text
     And I should see "Test-Channel-x86_64 Child Channel" as unchecked
 
+@sle_minion
   Scenario: Check old channels are still enabled on SLES minion before channel change completes
     When I refresh the metadata for "sle_minion"
     Then "1" channels should be enabled on "sle_minion"
     And channel "Test-Channel-x86_64" should be enabled on "sle_minion"
 
+@sle_client
   Scenario: Check old channels are still enabled on SLES client before channel change completes
     When I refresh the metadata for "sle_client"
     Then "1" channels with prefix "spacewalk:" should be enabled on "sle_client"
     And channel "Test-Channel-x86_64" should be enabled on "sle_client"
 
+@sle_minion
   Scenario: Check channel change has completed for the SLES minion
     Given I am on the Systems overview page of this "sle_minion"
     When I wait until event "Subscribe channels scheduled by admin" is completed
     Then I should see "The client completed this action on" at least 3 minutes after I scheduled an action
 
+@sle_client
   Scenario: Check channel change has completed for the SLES client
     Given I am on the Systems overview page of this "sle_client"
     When I wait until event "Subscribe channels scheduled by admin" is completed
     Then I should see "The client completed this action on" at least 3 minutes after I scheduled an action
 
+@sle_minion
   Scenario: Check the SLES minion is subscribed to the new channels
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area
@@ -79,6 +111,7 @@ Feature: Chanel subscription via SSM
     And I wait until I do not see "Loading..." text
     And I should see "Test Child Channel" as checked
 
+@sle_client
   Scenario: Check the SLES client is subscribed to the new channels
     Given I am on the Systems overview page of this "sle_client"
     When I follow "Software" in the content area
@@ -88,12 +121,14 @@ Feature: Chanel subscription via SSM
     And I wait until I do not see "Loading..." text
     And I should see "Test Child Channel" as checked
 
+@sle_minion
   Scenario: Check the new channels are enabled on the SLES minion
     When I refresh the metadata for "sle_minion"
     Then "2" channels should be enabled on "sle_minion"
     And channel "Test Base Channel" should be enabled on "sle_minion"
     And channel "Test Child Channel" should be enabled on "sle_minion"
 
+@sle_client
   Scenario: Check the new channels are enabled on the SLES client
     When I refresh the metadata for "sle_client"
     Then "2" channels with prefix "spacewalk:" should be enabled on "sle_client"
@@ -104,9 +139,8 @@ Feature: Chanel subscription via SSM
   Scenario: System default channel can't be determined
     Given I am authorized as "admin" with password "admin"
     When I am on the System Overview page
+    And I follow "Clear"
     And I check the "ceos_ssh_minion" client
-    And I uncheck the "sle_minion" client
-    And I uncheck the "sle_client" client
     Then I should see "1" systems selected for SSM
     When I am on System Set Manager Overview
     And I follow "channel memberships" in the content area
@@ -123,6 +157,7 @@ Feature: Chanel subscription via SSM
     Then I should see a "Channel Changes Actions" text
     And I should see a "Items 1 - 1 of 1" text
     And a table line should contain system "ceos_ssh_minion", "Could not determine system default channel"
+    And I follow "Clear"
 
 @centos_minion
   Scenario: Cleanup: make sure the CentOS minion is still unchanged
@@ -131,22 +166,12 @@ Feature: Chanel subscription via SSM
     And I follow "Software Channels" in the content area
     Then radio button "Test Base Channel" is checked
 
-@centos_minion
-  Scenario: Cleanup: remove CentOS systems from SSM
-    Given I am authorized as "admin" with password "admin"
-    And I am on the System Overview page
-    When I uncheck the "ceos_ssh_minion" client
-    And I check the "sle_minion" client
-    And I check the "sle_client" client
-    And I should see "2" systems selected for SSM
-
 @ubuntu_minion
   Scenario: System default channel can't be determined
     Given I am authorized as "admin" with password "admin"
     When I am on the System Overview page
+    And I follow "Clear"
     And I check the "ubuntu_ssh_minion" client
-    And I uncheck the "sle_minion" client
-    And I uncheck the "sle_client" client
     Then I should see "1" systems selected for SSM
     When I am on System Set Manager Overview
     And I follow "channel memberships" in the content area
@@ -163,6 +188,7 @@ Feature: Chanel subscription via SSM
     Then I should see a "Channel Changes Actions" text
     And I should see a "Items 1 - 1 of 1" text
     And a table line should contain system "ubuntu_ssh_minion", "Could not determine system default channel"
+    And I follow "Clear"
 
 @ubuntu_minion
   Scenario: Cleanup: make sure the Ubuntu minion is still unchanged
@@ -171,15 +197,7 @@ Feature: Chanel subscription via SSM
     And I follow "Software Channels" in the content area
     Then radio button "Test-Channel-Deb-AMD64" is checked
 
-@ubuntu_minion
-  Scenario: Cleanup: remove Ubuntu system from SSM
-    Given I am authorized as "admin" with password "admin"
-    And I am on the System Overview page
-    When I uncheck the "ubuntu_ssh_minion" client
-    And I check the "sle_minion" client
-    And I check the "sle_client" client
-    And I should see "2" systems selected for SSM
-
+@sle_minion
   Scenario: Cleanup: subscribe the SLES minion back to previous channels
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area
@@ -197,6 +215,7 @@ Feature: Chanel subscription via SSM
     And I wait until I see "1 system successfully completed this action." text, refreshing the page
     Then channel "Test-Channel-x86_64 Child Channel" should not be enabled on "sle_minion"
 
+@sle_client
   Scenario: Cleanup: subscribe the SLES client back to previous channels
     Given I am on the Systems overview page of this "sle_client"
     When I follow "Software" in the content area

--- a/testsuite/features/secondary/min_action_chain.feature
+++ b/testsuite/features/secondary/min_action_chain.feature
@@ -1,6 +1,7 @@
 # Copyright (c) 2018-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 
+@sle_minion
 Feature: Action chains on Salt minions
 
   Scenario: Pre-requisite: downgrade repositories to lower version on Salt minion

--- a/testsuite/features/secondary/min_bootstrap_script.feature
+++ b/testsuite/features/secondary/min_bootstrap_script.feature
@@ -7,6 +7,7 @@
 # 3) install and remove a package
 # 4) cleanup: re-add build host entitlements
 
+@sle_minion
 Feature: Register a Salt minion via Bootstrap-script
 
   Scenario: Delete SLES minion system profile before script bootstrap test

--- a/testsuite/features/secondary/min_osimage_build_image.feature
+++ b/testsuite/features/secondary/min_osimage_build_image.feature
@@ -9,6 +9,7 @@
 #   java.kiwi_os_image_building_enabled = true
 # which means "Enable Kiwi OS Image building"
 
+@sle_minion
 Feature: Build OS images
 
   Scenario: Login as Kiwi image administrator and build an image

--- a/testsuite/features/secondary/min_salt_install_with_staging.feature
+++ b/testsuite/features/secondary/min_salt_install_with_staging.feature
@@ -10,6 +10,7 @@
 #   java.salt_content_staging_advance = 0.05 (3 minutes)
 # which means "beetwen 3 and 1 minutes before package installation or patching"
 
+@sle_minion
 Feature: Install a package on the minion with staging enabled
 
   Scenario: Pre-requisite: install virgo-dummy-1.0 package, make sure orion-dummy is not present

--- a/testsuite/features/secondary/min_state_config_channel.feature
+++ b/testsuite/features/secondary/min_state_config_channel.feature
@@ -1,6 +1,7 @@
 # Copyright (c) 2018-2019 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
+@sle_minion
 Feature: State Configuration channels
   In order to configure systems through Salt
   I want to be able to use channels from the state tab

--- a/testsuite/features/step_definitions/xmlrpc_common.rb
+++ b/testsuite/features/step_definitions/xmlrpc_common.rb
@@ -59,12 +59,17 @@ When(/^I schedule a highstate for "([^"]*)" via XML\-RPC$/) do |host|
   systest.schedule_apply_highstate(node_id, date_high, false)
 end
 
-When(/^I unsubscribe "([^"]*)" and "([^"]*)" from configuration channel "([^"]*)"$/) do |host1, host2, channel|
+When(/^I unsubscribe "([^"]*)" from configuration channel "([^"]*)"$/) do |host1, channel|
   system_name1 = get_system_name(host1)
   node_id1 = retrieve_server_id(system_name1)
-  system_name2 = get_system_name(host2)
-  node_id2 = retrieve_server_id(system_name2)
-  systest.remove_channels([ node_id1, node_id2 ], [ channel ])
+  systest.remove_channels([ node_id1 ], [ channel ])
+end
+
+When(/^I unsubscribe "([^"]*)" and "([^"]*)" from configuration channel "([^"]*)"$/) do |host1, host2, channel|
+  steps %(
+      When I unsubscribe "#{host1}" from configuration channel "#{channel}"
+      And I unsubscribe "#{host2}" from configuration channel "#{channel}"
+        )
 end
 
 When(/^I create a System Record$/) do

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -6,8 +6,8 @@ require 'twopence'
 # Initialize SSH targets from environment variables
 raise 'Server IP address or domain name variable empty' if ENV['SERVER'].nil?
 warn 'Proxy IP address or domain name variable empty' if ENV['PROXY'].nil?
-raise 'Client IP address or domain name variable empty' if ENV['CLIENT'].nil?
-raise 'Minion IP address or domain name variable empty' if ENV['MINION'].nil?
+warn 'Client IP address or domain name variable empty' if ENV['CLIENT'].nil?
+warn 'Minion IP address or domain name variable empty' if ENV['MINION'].nil?
 warn 'CentOS minion IP address or domain name variable empty' if ENV['CENTOSMINION'].nil?
 warn 'SSH minion IP address or domain name variable empty' if ENV['SSHMINION'].nil?
 warn 'PXE boot MAC address variable empty' if ENV['PXEBOOTMAC'].nil?


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/10341

That PR intends to make all clients optional on the testsuite. So, if a VM is missing, the feature will not run the scenarios depending on that VM.
The VMs which were not optional were SLES Client and SLES Minion


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Documentation added in testsuite/documentation/optional.md

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/pull/10341

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
