### PR TITLE
Move some channel tests to a secondary feature

### DIFF
--- a/testsuite/features/core/srv_channels_add.feature
+++ b/testsuite/features/core/srv_channels_add.feature
@@ -2,14 +2,12 @@
 # Licensed under the terms of the MIT license.
 
 Feature: Adding channels
-  In Order distribute software to the clients
+  In Order to distribute software to the clients
   As an authorized user
   I want to add channels
 
-  Background:
-    Given I am authorized as "admin" with password "admin"
-
   Scenario: Add a base channel
+    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Create Channel"
     And I enter "Test Base Channel" as "Channel Name"
@@ -17,11 +15,12 @@ Feature: Adding channels
     And I select "None" from "Parent Channel"
     And I select "x86_64" from "Architecture:"
     And I enter "Base channel for testing" as "Channel Summary"
-    And I enter "No more desdcription for base channel." as "Channel Description"
+    And I enter "No more description for base channel." as "Channel Description"
     And I click on "Create Channel"
     Then I should see a "Channel Test Base Channel created." text
 
   Scenario: Add a child channel
+    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Create Channel"
     When I enter "Test Child Channel" as "Channel Name"
@@ -34,6 +33,7 @@ Feature: Adding channels
     Then I should see a "Channel Test Child Channel created." text
 
   Scenario: Add a base test channel for i586
+    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Create Channel"
     And I enter "Test-Channel-i586" as "Channel Name"
@@ -41,11 +41,12 @@ Feature: Adding channels
     And I select "None" from "Parent Channel"
     And I select "IA-32" from "Architecture:"
     And I enter "Test-Channel-i586 channel for testing" as "Channel Summary"
-    And I enter "No more desdcription for base channel." as "Channel Description"
+    And I enter "No more description for base channel." as "Channel Description"
     And I click on "Create Channel"
     Then I should see a "Channel Test-Channel-i586 created." text
 
   Scenario: Add a child channel to the i586 test channel
+    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Create Channel"
     And I enter "Test-Channel-i586 Child Channel" as "Channel Name"
@@ -58,6 +59,7 @@ Feature: Adding channels
     Then I should see a "Channel Test-Channel-i586 Child Channel created." text
 
   Scenario: Add a test base channel for x86_64
+    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Create Channel"
     And I enter "Test-Channel-x86_64" as "Channel Name"
@@ -65,11 +67,12 @@ Feature: Adding channels
     And I select "None" from "Parent Channel"
     And I select "x86_64" from "Architecture:"
     And I enter "Test-Channel-x86_64 channel for testing" as "Channel Summary"
-    And I enter "No more desdcription for base channel." as "Channel Description"
+    And I enter "No more description for base channel." as "Channel Description"
     And I click on "Create Channel"
     Then I should see a "Channel Test-Channel-x86_64 created." text
 
   Scenario: Add a child channel to the x86_64 test channel
+    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Create Channel"
     And I enter "Test-Channel-x86_64 Child Channel" as "Channel Name"
@@ -81,19 +84,8 @@ Feature: Adding channels
     And I click on "Create Channel"
     Then I should see a "Channel Test-Channel-x86_64 Child Channel created." text
 
-  Scenario: Add Fedora x86_64 base channel
-    When I follow the left menu "Software > Manage > Channels"
-    And I follow "Create Channel"
-    And I enter "Fedora x86_64 Channel" as "Channel Name"
-    And I enter "fedora-x86_64-channel" as "Channel Label"
-    And I select "None" from "Parent Channel"
-    And I select "x86_64" from "Architecture:"
-    And I enter "Fedora x86_64 channel for testing" as "Channel Summary"
-    And I enter "No more description for base channel." as "Channel Description"
-    And I click on "Create Channel"
-    Then I should see a "Channel Fedora x86_64 Channel created." text
-
   Scenario: Add Ubuntu AMD64 base channel
+    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Create Channel"
     And I enter "Test-Channel-Deb-AMD64" as "Channel Name"
@@ -104,67 +96,3 @@ Feature: Adding channels
     And I enter "No more description for base channel." as "Channel Description"
     And I click on "Create Channel"
     Then I should see a "Channel Test-Channel-Deb-AMD64 created." text
-
-  Scenario: Fail when trying to add a duplicate channel
-     When I follow the left menu "Software > Manage > Channels"
-     And I follow "Create Channel"
-     And I enter "Test Base Channel" as "Channel Name"
-     And I enter "test_base_channel" as "Channel Label"
-     And I select "None" from "Parent Channel"
-     And I select "x86_64" from "Architecture:"
-     And I enter "Base channel for testing" as "Channel Summary"
-     And I enter "No more desdcription for base channel." as "Channel Description"
-     And I click on "Create Channel"
-     Then I should see a "The channel name 'Test Base Channel' is already in use, please enter a different name" text
-
-  Scenario: Fail when trying to use invalid characters in the channel label
-      When I follow the left menu "Software > Manage > Channels"
-      And I follow "Create Channel"
-      And I enter "test123" as "Channel Name"
-      And I enter "tesT123" as "Channel Label"
-      And I enter "test123" as "Channel Summary"
-      And I click on "Create Channel"
-      Then I should see a "Invalid channel label, please see the format described below" text
-
-  Scenario: Fail when trying to use invalid characters in the channel name
-      When I follow the left menu "Software > Manage > Channels"
-      And I follow "Create Channel"
-      And I enter "!test123" as "Channel Name"
-      And I enter "test123" as "Channel Label"
-      And I enter "test123" as "Channel Summary"
-      And I click on "Create Channel"
-      Then I should see a "Invalid channel name, please see the format described below" text
-
-  Scenario: Fail when trying to use reserved names for channels
-    When I follow the left menu "Software > Manage > Channels"
-     And I follow "Create Channel"
-     And I enter "SLE-12-Cloud-Compute5-Pool for x86_64" as "Channel Name"
-     And I enter "test123" as "Channel Label"
-     And I enter "test123" as "Channel Summary"
-     And I click on "Create Channel"
-    Then I should see a "The channel name 'SLE-12-Cloud-Compute5-Pool for x86_64' is reserved, please enter a different name" text
-
-  Scenario: Fail when trying to use reserved labels for channels
-    When I follow the left menu "Software > Manage > Channels"
-     And I follow "Create Channel"
-     And I enter "test123" as "Channel Name"
-     And I enter "sle-we12-pool-x86_64-sap" as "Channel Label"
-     And I enter "test123" as "Channel Summary"
-     And I click on "Create Channel"
-    Then I should see a "The channel label 'sle-we12-pool-x86_64-sap' is reserved, please enter a different name" text
-
-  Scenario: Create a channel that will be changed
-    When I follow the left menu "Software > Manage > Channels"
-     And I follow "Create Channel"
-     And I enter "aaaSLE-12-Cloud-Compute5-Pool for x86_64" as "Channel Name"
-     And I enter "sle-we12aaa-pool-x86_64-sap" as "Channel Label"
-     And I enter "test123" as "Channel Summary"
-     And I click on "Create Channel"
-    Then I should see a "Channel aaaSLE-12-Cloud-Compute5-Pool for x86_64 created." text
-
-  Scenario: Fail when trying to change the channel name to a reserved name
-    When I follow the left menu "Software > Manage > Channels"
-     And I follow "aaaSLE-12-Cloud-Compute5-Pool for x86_64"
-     And I enter "SLE-12-Cloud-Compute5-Pool for x86_64" as "Channel Name"
-     And I click on "Update Channel"
-    Then I should see a "The channel name 'SLE-12-Cloud-Compute5-Pool for x86_64' is reserved, please enter a different name" text

--- a/testsuite/features/secondary/srv_manage_channels_page.feature
+++ b/testsuite/features/secondary/srv_manage_channels_page.feature
@@ -1,0 +1,78 @@
+# Copyright (c) 2019 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: Managing channels
+  In Order to distribute software to the clients
+  As an authorized user
+  I want to manage channels
+
+  Scenario: Fail when trying to add a duplicate channel
+    Given I am authorized as "admin" with password "admin"
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Create Channel"
+    And I enter "Test Base Channel" as "Channel Name"
+    And I enter "test_base_channel" as "Channel Label"
+    And I select "None" from "Parent Channel"
+    And I select "x86_64" from "Architecture:"
+    And I enter "Base channel for testing" as "Channel Summary"
+    And I enter "No more desdcription for base channel." as "Channel Description"
+    And I click on "Create Channel"
+    Then I should see a "The channel name 'Test Base Channel' is already in use, please enter a different name" text
+
+  Scenario: Fail when trying to use invalid characters in the channel label
+    Given I am authorized as "admin" with password "admin"
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Create Channel"
+    And I enter "test123" as "Channel Name"
+    And I enter "tesT123" as "Channel Label"
+    And I enter "test123" as "Channel Summary"
+    And I click on "Create Channel"
+    Then I should see a "Invalid channel label, please see the format described below" text
+
+  Scenario: Fail when trying to use invalid characters in the channel name
+    Given I am authorized as "admin" with password "admin"
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Create Channel"
+    And I enter "!test123" as "Channel Name"
+    And I enter "test123" as "Channel Label"
+    And I enter "test123" as "Channel Summary"
+    And I click on "Create Channel"
+    Then I should see a "Invalid channel name, please see the format described below" text
+
+  Scenario: Fail when trying to use reserved names for channels
+    Given I am authorized as "admin" with password "admin"
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Create Channel"
+    And I enter "SLE-12-Cloud-Compute5-Pool for x86_64" as "Channel Name"
+    And I enter "test123" as "Channel Label"
+    And I enter "test123" as "Channel Summary"
+    And I click on "Create Channel"
+    Then I should see a "The channel name 'SLE-12-Cloud-Compute5-Pool for x86_64' is reserved, please enter a different name" text
+
+  Scenario: Fail when trying to use reserved labels for channels
+    Given I am authorized as "admin" with password "admin"
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Create Channel"
+    And I enter "test123" as "Channel Name"
+    And I enter "sle-we12-pool-x86_64-sap" as "Channel Label"
+    And I enter "test123" as "Channel Summary"
+    And I click on "Create Channel"
+    Then I should see a "The channel label 'sle-we12-pool-x86_64-sap' is reserved, please enter a different name" text
+
+  Scenario: Create a channel that will be changed
+    Given I am authorized as "admin" with password "admin"
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Create Channel"
+    And I enter "aaaSLE-12-Cloud-Compute5-Pool for x86_64" as "Channel Name"
+    And I enter "sle-we12aaa-pool-x86_64-sap" as "Channel Label"
+    And I enter "test123" as "Channel Summary"
+    And I click on "Create Channel"
+    Then I should see a "Channel aaaSLE-12-Cloud-Compute5-Pool for x86_64 created." text
+
+  Scenario: Fail when trying to change the channel name to a reserved name
+    Given I am authorized as "admin" with password "admin"
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "aaaSLE-12-Cloud-Compute5-Pool for x86_64"
+    And I enter "SLE-12-Cloud-Compute5-Pool for x86_64" as "Channel Name"
+    And I click on "Update Channel"
+    Then I should see a "The channel name 'SLE-12-Cloud-Compute5-Pool for x86_64' is reserved, please enter a different name" text

--- a/testsuite/run_sets/secondary_parallelizable.yml
+++ b/testsuite/run_sets/secondary_parallelizable.yml
@@ -25,6 +25,7 @@
 - features/secondary/srv_security.feature
 - features/secondary/srv_salt.feature
 - features/secondary/srv_check_channels_page.feature
+- features/secondary/srv_manage_channels_page.feature
 - features/secondary/srv_xmlrpc_channel.feature
 - features/secondary/srv_patches_page.feature
 - features/secondary/srv_spacewalk_channel.feature

--- a/testsuite/run_sets/testsuite.yml
+++ b/testsuite/run_sets/testsuite.yml
@@ -107,6 +107,7 @@
 - features/secondary/srv_salt.feature
 - features/secondary/min_salt_user_states.feature
 - features/secondary/srv_check_channels_page.feature
+- features/secondary/srv_manage_channels_page.feature
 - features/secondary/min_salt_minion_details.feature
 - features/secondary/trad_check_registration.feature
 - features/secondary/min_salt_minions_page.feature

--- a/testsuite/run_sets/uyuni.yml
+++ b/testsuite/run_sets/uyuni.yml
@@ -63,6 +63,7 @@
 - features/secondary/srv_organization_credentials.feature
 - features/secondary/srv_change_password.feature
 - features/secondary/srv_check_sync_source_packages.feature
+- features/secondary/srv_manage_channels_page.feature
 - features/secondary/min_salt_software_states.feature
 - features/secondary/min_docker_xmlrpc.feature
 - features/secondary/min_docker_build_image.feature


### PR DESCRIPTION
## What does this PR change?

This PR makes one more core feature lighter by moving some tests to secondary.

It also removes the scenario named "Add Fedora x86_64 base channel", which was useless.

Finally, it fixes a few mistakes in English language.


## Links

Part of SUSE/spacewalk#4965

Ports:
 * 3.2: SUSE/spacewalk#10368
 * 4.0: SUSE/spacewalk#10367


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
