### PR TITLE
For file diff, use return result's  'changes' field if 'pchanges' field doesn't exist

### DIFF
--- a/java/code/src/com/suse/manager/webui/utils/salt/custom/FilesDiffResult.java
+++ b/java/code/src/com/suse/manager/webui/utils/salt/custom/FilesDiffResult.java
@@ -30,14 +30,15 @@ import java.util.Optional;
  */
 public class FilesDiffResult extends StateApplyResult<JsonElement> {
 
-    protected JsonElement pchanges;
+    protected Optional<JsonElement> pchanges = Optional.empty();
 
     /**
      * Return the pchanges
      * @return a map with all the changes
      */
     public Map getPChanges() {
-        return JsonParser.GSON.fromJson(this.pchanges, Map.class);
+
+        return JsonParser.GSON.fromJson(pchanges.orElse(getChanges()), Map.class);
     }
 
     /**
@@ -47,7 +48,7 @@ public class FilesDiffResult extends StateApplyResult<JsonElement> {
      * @return Object dataType's class
      */
     public <R> R getPChanges(Class<R> dataType) {
-        return JsonParser.GSON.fromJson(this.pchanges, dataType);
+        return JsonParser.GSON.fromJson(pchanges.orElse(getChanges()), dataType);
     }
 
     /**
@@ -57,7 +58,7 @@ public class FilesDiffResult extends StateApplyResult<JsonElement> {
      * @return Object of dataType.getType
      */
     public <R> R getPChanges(TypeToken<R> dataType) {
-        return JsonParser.GSON.fromJson(this.pchanges, dataType.getType());
+        return JsonParser.GSON.fromJson(pchanges.orElse(getChanges()), dataType.getType());
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/utils/salt/test/dummy_files_diff_res.json
+++ b/java/code/src/com/suse/manager/webui/utils/salt/test/dummy_files_diff_res.json
@@ -31,16 +31,14 @@
   },
   "file_|-file_deploy_6_|-/tmp/gitrec_|-managed":{
     "comment":"The file /tmp/gitrec is set to be changed",
-    "pchanges":{
-      "newfile":"/tmp/gitrec"
-    },
+
     "name":"/tmp/gitrec",
     "start_time":"10:29:04.062771",
     "result":null,
     "duration":2.835,
     "__run_num__":5,
     "changes":{
-
+      "newfile":"/tmp/gitrec"
     },
     "__id__":"file_deploy_6"
   },

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Use 'changes' field if 'pchanges' field doesn't exist (bsc#1159202)
 - Show additional headers and dependencies for deb packages
 - Show adequate message on saving formulas that change only pillar data
 - Fix container image import (bsc#1154246)


### PR DESCRIPTION
## What does this PR change?

In the newer version, upstream salt has removed the `pchanges` in favor of `changes` field.
Problem is that apparently salt has removed a field(`pchanges`) which we were using so it just breaks now while looking for that fied.


Before:

<pre>
"return": {
        "file_|-file_deploy_1_|-/tmp/deleteme_|-managed": {
            "__id__": "file_deploy_1", 
            "__run_num__": 0, 
            "__sls__": "configuration.diff_files", 
             <b>"changes" </b>: {}, 
            "comment": "The file /tmp/deleteme is set to be changed", 
            "duration": 172.27, 
            "name": "/tmp/deleteme", 
            <b>"pchanges"</b>: {
                "diff": "--- \n+++ \n@@ -1,3 +1 @@\n-delete me!\n-.....\n-dele\n+delete me!"
            }, 
            "result": null, 
            "start_time": "11:33:46.914513"
        }
    }, 
</pre>


Now:
<pre>
"return": {
        "file_|-file_deploy_1_|-/etc/s-mgr/config_|-managed": {
            "__id__": "file_deploy_1",
            "__run_num__": 0,
            "__sls__": "configuration.diff_files",
            <b>"changes"** </b>: {
                "diff": "--- \n+++ \n@@ -1 +1 @@\n-COLOR=red\n+COLOR=white"
            },
            "comment": "The file /etc/s-mgr/config is set to be changed\nNote: No changes made, actual changes may\nbe different due to other states.",
            "duration": 82.164,
            "name": "/etc/s-mgr/config",
            "result": null,
            "start_time": "13:29:33.693568"
        }
    },
</pre>

This PR takes care of both, `pchanges` takes the precedence and if `pchanges` doesn't exist, code uses the `changes` field to get the needed data

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **Bug fix**


- [x] **DONE**

## Test coverage
- Unit tests: **existing has been modified to cater this change**

- [x] **DONE**

## Links

Fixes #https://github.com/SUSE/spacewalk/issues/10339
Tracks # **add downstream PR, if any**

- [ ] **DONE**

