### PR TITLE
Uyuni fix product ids sle12sp5

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -763,10 +763,6 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/5/bootstrap/'
     },
     'SLE-12-SP5-x86_64' : {
-        'PDID' : 1625, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
-        'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/5/bootstrap/'
-    },
-    'SLED-12-SP5-x86_64' : {
         'PDID' : 1878, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/5/bootstrap/'
     },

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- fix product id of SLES12 SP5 x86_64 and remove never released
+  SLED product (bsc#1158963)
 - Allow creating bootstrap repositories for CentoS8 (bsc#1159206)
 - add bootstrap-repo data for SLE12 SP5 Family (bsc#1158963)
 - explicitly enable jabberd during setup


### PR DESCRIPTION
## What does this PR change?

SLED 12 SP5 was never released and the product id for SLE-12-SP5-x86_64 was pointing to SP4 product.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **manual test needed**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/10374

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint" (Test skipped, there are no changes to test)		 
- [ ] Re-run test "spacecmd_unittests"
