### PR TITLE
Uyuni: Enhance product via iss

### DIFF
--- a/backend/satellite_tools/exporter/exportLib.py
+++ b/backend/satellite_tools/exporter/exportLib.py
@@ -760,16 +760,22 @@ class _SuseProductDumper(BaseRowDumper):
             'friendly-name' : self._row['friendly_name'],
             'arch'          : self._row['arch'],
             'release'       : self._row['release'],
-            'product-id'    : self._row['product_id']
-            }
+            'product-id'    : self._row['product_id'],
+            'free'          : self._row['free'],
+            'base'          : self._row['base'],
+            'release-stage' : self._row['release_stage'],
+            'channel-family-label': self._row['channel_family_label']
+        }
 
 class SuseProductDumper(BaseQueryDumper):
     tag_name = 'suse-products'
     iterator_query = """
     SELECT p.name, p.version, p.friendly_name,
-           pa.label AS arch, p.release, p.product_id
+           pa.label AS arch, p.release, p.product_id,
+           p.free, p.base, p.release_stage, cf.label AS channel_family_label
       FROM suseProducts p
  LEFT JOIN rhnPackageArch pa ON p.arch_type_id = pa.id
+ LEFT JOIN rhnChannelFamily cf ON p.channel_family_id = cf.id
     """
 
     def __init__(self, writer, data_iterator=None):

--- a/backend/satellite_tools/satsync.py
+++ b/backend/satellite_tools/satsync.py
@@ -109,7 +109,7 @@ class Runner:
         'arches': [''],  # 5/26/05 wregglej 156079 Added arches to precedence list.
         'orgs': [''],
         'supportinfo': ['channels', 'packages'],
-        'suse-products': ['arches'],
+        'suse-products': ['arches', 'channel-families'],
         'scc-repositories': [''],
         'suse-product-channels': ['suse-products', 'channels'],
         'suse-upgrade-paths': ['suse-products'],

--- a/backend/satellite_tools/xmlSource.py
+++ b/backend/satellite_tools/xmlSource.py
@@ -817,8 +817,10 @@ class SuseProductItem(BaseItem):
     item_name = 'suse-product'
     item_class = importLib.SuseProduct
     tagMap = {
-        'product-id'    : 'product_id',
-        'friendly-name' : 'friendly_name'
+        'product-id'           : 'product_id',
+        'friendly-name'        : 'friendly_name',
+        'release-stage'        : 'release_stage',
+        'channel-family-label' : 'channel_family_label'
     }
 addItem(SuseProductItem)
 

--- a/backend/server/importlib/backend.py
+++ b/backend/server/importlib/backend.py
@@ -1320,8 +1320,8 @@ class Backend:
            If yes, update it, if not add it.
         """
         insert_product = self.dbmodule.prepare("""
-            INSERT INTO suseProducts (id, name, version, friendly_name, arch_type_id, release, product_id)
-            VALUES (:pid, :name, :version, :friendly_name, :arch_type_id, :release, :product_id)
+            INSERT INTO suseProducts (id, name, version, friendly_name, arch_type_id, release, product_id, free, base, release_stage, channel_family_id)
+            VALUES (:pid, :name, :version, :friendly_name, :arch_type_id, :release, :product_id, :free, :base, :release_stage, :channel_family_id)
             """)
         delete_product = self.dbmodule.prepare("""
             DELETE FROM suseProducts WHERE product_id = :product_id
@@ -1332,7 +1332,11 @@ class Backend:
                    version = :version,
                    friendly_name = :friendly_name,
                    arch_type_id = :arch_type_id,
-                   release = :release
+                   release = :release,
+                   free = :free,
+                   base = :base,
+                   release_stage = :release_stage,
+                   channel_family_id = :channel_family_id
              WHERE product_id = :product_id
              """)
         _query_product = self.dbmodule.prepare("""
@@ -1352,7 +1356,11 @@ class Backend:
                 toupdate[2].append(item['friendly_name'])
                 toupdate[3].append(item['arch_type_id'])
                 toupdate[4].append(item['release'])
-                toupdate[5].append(int(item['product_id']))
+                toupdate[5].append(item['free'])
+                toupdate[6].append(item['base'])
+                toupdate[7].append(item['release_stage'])
+                toupdate[8].append(int(item['channel_family_id']))
+                toupdate[9].append(int(item['product_id']))
                 continue
             toinsert[0].append(self.sequences['suseProducts'].next())
             toinsert[1].append(item['name'])
@@ -1360,7 +1368,11 @@ class Backend:
             toinsert[3].append(item['friendly_name'])
             toinsert[4].append(item['arch_type_id'])
             toinsert[5].append(item['release'])
-            toinsert[6].append(int(item['product_id']))
+            toinsert[6].append(item['free'])
+            toinsert[7].append(item['base'])
+            toinsert[8].append(item['release_stage'])
+            toinsert[9].append(int(item['channel_family_id']))
+            toinsert[10].append(int(item['product_id']))
         for ident in existing_data:
             todelete[0].append(int(ident))
         if todelete[0]:
@@ -1368,11 +1380,15 @@ class Backend:
         if toinsert[0]:
             insert_product.executemany(pid=toinsert[0], name=toinsert[1], version=toinsert[2],
                                        friendly_name=toinsert[3], arch_type_id=toinsert[4],
-                                       release=toinsert[5], product_id=toinsert[6])
+                                       release=toinsert[5], free=toinsert[6], base=toinsert[7],
+                                       release_stage=toinsert[8], channel_family_id=toinsert[9],
+                                       product_id=toinsert[10])
         if toupdate[0]:
             update_product.executemany(name=toupdate[0], version=toupdate[1],
                                        friendly_name=toupdate[2], arch_type_id=toupdate[3],
-                                       release=toupdate[4], product_id=toupdate[5])
+                                       release=toupdate[4], free=toupdate[5], base=toupdate[6],
+                                       release_stage=toupdate[7], channel_family_id=toupdate[8],
+                                       product_id=toupdate[9])
 
     def processSuseProductChannels(self, batch):
         """Check if the SUSE ProductChannel is already in DB.

--- a/backend/server/importlib/importLib.py
+++ b/backend/server/importlib/importLib.py
@@ -192,6 +192,10 @@ class SuseProduct(Information):
         'arch'          : StringType,
         'release'       : StringType,
         'product_id'    : IntType,
+        'free'          : StringType,
+        'base'          : StringType,
+        'release_stage' : StringType,
+        'channel_family_label' : StringType,
     }
 
 class SuseProductChannel(Information):

--- a/backend/server/importlib/suseProductsImport.py
+++ b/backend/server/importlib/suseProductsImport.py
@@ -21,6 +21,7 @@ class SuseProductsImport(GenericPackageImport):
 
     def preprocess(self):
         archs = {}
+        families = {}
         for item in self.batch:
             if item['arch'] not in archs:
                 archs[item['arch']] = None
@@ -30,6 +31,12 @@ class SuseProductsImport(GenericPackageImport):
                 item['release'] = None
             if item['version'] == 'None':
                 item['version'] = None
+            if item['channel_family_label'] not in families:
+                fam = {}
+                fam[item['channel_family_label']] = None
+                self.backend.lookupChannelFamilies(fam)
+                families[item['channel_family_label']] = fam[item['channel_family_label']]
+            item['channel_family_id'] = families[item['channel_family_label']]
             self._data.append(item)
 
     def fix(self):

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- enhance suseProducts via ISS to fix SP migration on slave server (bsc#1159184)
 - generate metadata with empty vendor (bsc#1158480)
 - prevent a traceback when reposyncing openSUSE 15.1 (bsc#1158672)
 - close config files after reading them (bsc#1158283)


### PR DESCRIPTION
## What does this PR change?

During ISS we do not transport all values of a suseProduct. This cause troubles during SP migration where the algorithm want to access the channel_family of a product.

This PR enhance the data we transport via ISS.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **manual testing**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/10363

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
