### PR TITLE
Manager bsc1137248

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_bn_IN.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_bn_IN.xml
@@ -9150,8 +9150,8 @@ the &lt;strong&gt;Red Hat Enterprise Linux System Administration Guide.&lt;/stro
         <target>rhncfg প্যাকেজ ইনস্টল কর্মের সময় নির্ধারণ করুন</target>
       </trans-unit>
       <trans-unit id="targetsystems.jsp.installcfgactions">
-        <source>Schedule rhncfg-actions package install</source>
-        <target>rhncfg-actions প্যাকেজ ইনস্টল কর্মের সময় নির্ধারণ করুন</target>
+        <source>Schedule mgr-cfg-actions package install</source>
+        <target>mgr-cfg-actions প্যাকেজ ইনস্টল কর্মের সময় নির্ধারণ করুন</target>
       </trans-unit>
       <trans-unit id="targetsystems.jsp.installcfgclient">
         <source>Schedule rhncfg-client package install</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ca.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ca.xml
@@ -11815,7 +11815,7 @@ the &lt;strong&gt;Red Hat Enterprise Linux System Administration Guide.&lt;/stro
           <source>Schedule rhncfg package install</source>
         </trans-unit>
         <trans-unit id="targetsystems.jsp.installcfgactions">
-          <source>Schedule rhncfg-actions package install</source>
+          <source>Schedule mgr-cfg-actions package install</source>
         </trans-unit>
         <trans-unit id="targetsystems.jsp.installcfgclient">
           <source>Schedule rhncfg-client package install</source>
@@ -15117,7 +15117,7 @@ any of these revisions.  Are you sure you want to do this?</source>
           <source>No systems within this set are available to run remote commands.</source>
         </trans-unit>
         <trans-unit id="ssm.operations.provisioning.remotecommand.no_script_run">
-          <source>You must enable Remote Command execution on the target system by installing the &lt;code&gt;rhncfg-actions&lt;/code&gt; RPM.</source>
+          <source>You must enable Remote Command execution on the target system by installing the &lt;code&gt;mgr-cfg-actions&lt;/code&gt; RPM.</source>
         </trans-unit>
         <trans-unit id="stringutil.scriptcheck.error.noshelldefined">
           <source>Script does not contain shell definition.</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_de.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_de.xml
@@ -13832,8 +13832,8 @@ Anschließend wird das nicht-chroot Post-Skript ausgeführt, und zuletzt das Pos
           <target>rhncfg Paket-Installation planen</target>
         </trans-unit>
         <trans-unit id="targetsystems.jsp.installcfgactions">
-          <source>Schedule rhncfg-actions package install</source>
-          <target>rhncfg-actions Paket-Installation planen</target>
+          <source>Schedule mgr-cfg-actions package install</source>
+          <target>mgr-cfg-actions Paket-Installation planen</target>
         </trans-unit>
         <trans-unit id="targetsystems.jsp.installcfgclient">
           <source>Schedule rhncfg-client package install</source>
@@ -17808,8 +17808,8 @@ dieser Revisionen.  Möchten Sie dies wirklich tun?</target>
           <target>Keine Systeme innerhalb dieses Satzes sind zur Ausführung von Remote-Befehlen verfügbar.</target>
         </trans-unit>
         <trans-unit id="ssm.operations.provisioning.remotecommand.no_script_run">
-          <source>You must enable Remote Command execution on the target system by installing the &lt;code&gt;rhncfg-actions&lt;/code&gt; RPM.</source>
-          <target>Sie müssen die Ausführung von Remote-Befehlen am Zielsystem durch Installation des &lt;code&gt;rhncfg-actions&lt;/code&gt; RPM aktivieren.</target>
+          <source>You must enable Remote Command execution on the target system by installing the &lt;code&gt;mgr-cfg-actions&lt;/code&gt; RPM.</source>
+          <target>Sie müssen die Ausführung von Remote-Befehlen am Zielsystem durch Installation des &lt;code&gt;mgr-cfg-actions&lt;/code&gt; RPM aktivieren.</target>
         </trans-unit>
         <trans-unit id="stringutil.scriptcheck.error.noshelldefined">
           <source>Script does not contain shell definition.</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -11907,7 +11907,7 @@ the &lt;strong&gt;Red Hat Enterprise Linux System Administration Guide.&lt;/stro
           <source>Schedule rhncfg package install</source>
         </trans-unit>
         <trans-unit id="targetsystems.jsp.installcfgactions">
-          <source>Schedule rhncfg-actions package install</source>
+          <source>Schedule mgr-cfg-actions package install</source>
         </trans-unit>
         <trans-unit id="targetsystems.jsp.installcfgclient">
           <source>Schedule rhncfg-client package install</source>
@@ -15255,7 +15255,7 @@ any of these revisions.  Are you sure you want to do this?</source>
           <source>No systems within this set are available to run remote commands.</source>
         </trans-unit>
         <trans-unit id="ssm.operations.provisioning.remotecommand.no_script_run">
-          <source>You must enable Remote Command execution on the target system by installing the &lt;code&gt;rhncfg-actions&lt;/code&gt; RPM.</source>
+          <source>You must enable Remote Command execution on the target system by installing the &lt;code&gt;mgr-cfg-actions&lt;/code&gt; RPM.</source>
         </trans-unit>
         <trans-unit id="stringutil.scriptcheck.error.noshelldefined">
           <source>Script does not contain shell definition.</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_es.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_es.xml
@@ -13840,8 +13840,8 @@ Esto puede tener algún efecto en los archivos de configuración que se implemen
           <target>Programar instalación de paquete rhncfg</target>
         </trans-unit>
         <trans-unit id="targetsystems.jsp.installcfgactions">
-          <source>Schedule rhncfg-actions package install</source>
-          <target>Programar instalación de paquete rhncfg-actions</target>
+          <source>Schedule mgr-cfg-actions package install</source>
+          <target>Programar instalación de paquete mgr-cfg-actions</target>
         </trans-unit>
         <trans-unit id="targetsystems.jsp.installcfgclient">
           <source>Schedule rhncfg-client package install</source>
@@ -17817,8 +17817,8 @@ concerniente con esas revisiones. ¿Está seguro que es ésto lo que desea hacer
           <target>No hay sistemas disponibles dentro de este conjunto para ejecutar los comandos remotos.</target>
         </trans-unit>
         <trans-unit id="ssm.operations.provisioning.remotecommand.no_script_run">
-          <source>You must enable Remote Command execution on the target system by installing the &lt;code&gt;rhncfg-actions&lt;/code&gt; RPM.</source>
-          <target>Debe habilitar la ejecución de comandos remotos en el sistema de destino al instalar el RPM &lt;code&gt;rhncfg-actions&lt;/code&gt; . </target>
+          <source>You must enable Remote Command execution on the target system by installing the &lt;code&gt;mgr-cfg-actions&lt;/code&gt; RPM.</source>
+          <target>Debe habilitar la ejecución de comandos remotos en el sistema de destino al instalar el RPM &lt;code&gt;mgr-cfg-actions&lt;/code&gt; . </target>
         </trans-unit>
         <trans-unit id="stringutil.scriptcheck.error.noshelldefined">
           <source>Script does not contain shell definition.</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_fr.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_fr.xml
@@ -13836,8 +13836,8 @@ Le script post non-chroot sera ensuite exécuté et le script post sera enfin ex
           <target>Programmer l'installation des paquetages rhncfg</target>
         </trans-unit>
         <trans-unit id="targetsystems.jsp.installcfgactions">
-          <source>Schedule rhncfg-actions package install</source>
-          <target>Programmer l'installation des paquetages rhncfg-actions</target>
+          <source>Schedule mgr-cfg-actions package install</source>
+          <target>Programmer l'installation des paquetages mgr-cfg-actions</target>
         </trans-unit>
         <trans-unit id="targetsystems.jsp.installcfgclient">
           <source>Schedule rhncfg-client package install</source>
@@ -17812,8 +17812,8 @@ pour ces versions seront également supprimées, ainsi que tous les historiques 
           <target>Aucun système dans cet ensemble n'est disponible pour exécuter des commandes à distance.</target>
         </trans-unit>
         <trans-unit id="ssm.operations.provisioning.remotecommand.no_script_run">
-          <source>You must enable Remote Command execution on the target system by installing the &lt;code&gt;rhncfg-actions&lt;/code&gt; RPM.</source>
-          <target>Vous devez activer l'exécution de commandes à distance sur le système cible en installant le RPM &lt;code&gt;rhncfg-actions&lt;/code&gt;.</target>
+          <source>You must enable Remote Command execution on the target system by installing the &lt;code&gt;mgr-cfg-actions&lt;/code&gt; RPM.</source>
+          <target>Vous devez activer l'exécution de commandes à distance sur le système cible en installant le RPM &lt;code&gt;mgr-cfg-actions&lt;/code&gt;.</target>
         </trans-unit>
         <trans-unit id="stringutil.scriptcheck.error.noshelldefined">
           <source>Script does not contain shell definition.</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_gu.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_gu.xml
@@ -13037,8 +13037,8 @@ the &lt;strong&gt;Red Hat Enterprise Linux System Administration Guide.&lt;/stro
           <target>rhncfg પેકેજ સ્થાપન સુનિશ્ચિત કરો</target>
         </trans-unit>
         <trans-unit id="targetsystems.jsp.installcfgactions">
-          <source>Schedule rhncfg-actions package install</source>
-          <target>rhncfg-actions પેકેજ સ્થાપન સુનિશ્ચિત કરો</target>
+          <source>Schedule mgr-cfg-actions package install</source>
+          <target>mgr-cfg-actions પેકેજ સ્થાપન સુનિશ્ચિત કરો</target>
         </trans-unit>
         <trans-unit id="targetsystems.jsp.installcfgclient">
           <source>Schedule rhncfg-client package install</source>
@@ -16927,7 +16927,7 @@ any of these revisions.  Are you sure you want to do this?</source>
           <source>No systems within this set are available to run remote commands.</source>
         </trans-unit>
         <trans-unit id="ssm.operations.provisioning.remotecommand.no_script_run">
-          <source>You must enable Remote Command execution on the target system by installing the &lt;code&gt;rhncfg-actions&lt;/code&gt; RPM.</source>
+          <source>You must enable Remote Command execution on the target system by installing the &lt;code&gt;mgr-cfg-actions&lt;/code&gt; RPM.</source>
         </trans-unit>
         <trans-unit id="stringutil.scriptcheck.error.noshelldefined">
           <source>Script does not contain shell definition.</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_hi.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_hi.xml
@@ -13037,7 +13037,7 @@ the &lt;strong&gt;Red Hat Enterprise Linux System Administration Guide.&lt;/stro
           <target>rhncfg संकुल अधिष्ठापन नियोजित करें</target>
         </trans-unit>
         <trans-unit id="targetsystems.jsp.installcfgactions">
-          <source>Schedule rhncfg-actions package install</source>
+          <source>Schedule mgr-cfg-actions package install</source>
           <target>rhncfg-क्रिया संकुल अधिष्ठापन को अनुसूचित करें</target>
         </trans-unit>
         <trans-unit id="targetsystems.jsp.installcfgclient">
@@ -16927,7 +16927,7 @@ any of these revisions.  Are you sure you want to do this?</source>
           <source>No systems within this set are available to run remote commands.</source>
         </trans-unit>
         <trans-unit id="ssm.operations.provisioning.remotecommand.no_script_run">
-          <source>You must enable Remote Command execution on the target system by installing the &lt;code&gt;rhncfg-actions&lt;/code&gt; RPM.</source>
+          <source>You must enable Remote Command execution on the target system by installing the &lt;code&gt;mgr-cfg-actions&lt;/code&gt; RPM.</source>
         </trans-unit>
         <trans-unit id="stringutil.scriptcheck.error.noshelldefined">
           <source>Script does not contain shell definition.</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_it.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_it.xml
@@ -13823,8 +13823,8 @@ cancellati.{0}
           <target>Programma l'installazione del pacchetto rhncfg</target>
         </trans-unit>
         <trans-unit id="targetsystems.jsp.installcfgactions">
-          <source>Schedule rhncfg-actions package install</source>
-          <target>Programma l'installazione del pacchetto rhncfg-actions</target>
+          <source>Schedule mgr-cfg-actions package install</source>
+          <target>Programma l'installazione del pacchetto mgr-cfg-actions</target>
         </trans-unit>
         <trans-unit id="targetsystems.jsp.installcfgclient">
           <source>Schedule rhncfg-client package install</source>
@@ -17793,8 +17793,8 @@ Siete sicuri di voler fare questo?</target>
           <target>Nessun sistema di questo insieme può eseguire comandi remoti.</target>
         </trans-unit>
         <trans-unit id="ssm.operations.provisioning.remotecommand.no_script_run">
-          <source>You must enable Remote Command execution on the target system by installing the &lt;code&gt;rhncfg-actions&lt;/code&gt; RPM.</source>
-          <target>Abilitare l'esecuzione dei Comandi remoti sul sistema target installando l'RPM &lt;code&gt;rhncfg-actions&lt;/code&gt;.</target>
+          <source>You must enable Remote Command execution on the target system by installing the &lt;code&gt;mgr-cfg-actions&lt;/code&gt; RPM.</source>
+          <target>Abilitare l'esecuzione dei Comandi remoti sul sistema target installando l'RPM &lt;code&gt;mgr-cfg-actions&lt;/code&gt;.</target>
         </trans-unit>
         <trans-unit id="stringutil.scriptcheck.error.noshelldefined">
           <source>Script does not contain shell definition.</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ja.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ja.xml
@@ -13838,8 +13838,8 @@ the &lt;strong&gt;Red Hat Enterprise Linux System Administration Guide.&lt;/stro
           <target>rhncfg パッケージインストールのスケジュール</target>
         </trans-unit>
         <trans-unit id="targetsystems.jsp.installcfgactions">
-          <source>Schedule rhncfg-actions package install</source>
-          <target>rhncfg-actions パッケージインストールのスケジュール</target>
+          <source>Schedule mgr-cfg-actions package install</source>
+          <target>mgr-cfg-actions パッケージインストールのスケジュール</target>
         </trans-unit>
         <trans-unit id="targetsystems.jsp.installcfgclient">
           <source>Schedule rhncfg-client package install</source>
@@ -17814,8 +17814,8 @@ any of these revisions.  Are you sure you want to do this?</source>
           <target>このセット内のシステムにリモートコマンドを実行できるシステムはありません。</target>
         </trans-unit>
         <trans-unit id="ssm.operations.provisioning.remotecommand.no_script_run">
-          <source>You must enable Remote Command execution on the target system by installing the &lt;code&gt;rhncfg-actions&lt;/code&gt; RPM.</source>
-          <target>&lt;code&gt;rhncfg-actions&lt;/code&gt; RPM をインストールして対象システムでリモートコマンドを実行できるようにする必要があります。</target>
+          <source>You must enable Remote Command execution on the target system by installing the &lt;code&gt;mgr-cfg-actions&lt;/code&gt; RPM.</source>
+          <target>&lt;code&gt;mgr-cfg-actions&lt;/code&gt; RPM をインストールして対象システムでリモートコマンドを実行できるようにする必要があります。</target>
         </trans-unit>
         <trans-unit id="stringutil.scriptcheck.error.noshelldefined">
           <source>Script does not contain shell definition.</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ko.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ko.xml
@@ -13479,8 +13479,8 @@ the &lt;strong&gt;Red Hat Enterprise Linux System Administration Guide.&lt;/stro
           <target>rhncfg 패키지 설치 스케줄하기</target>
         </trans-unit>
         <trans-unit id="targetsystems.jsp.installcfgactions">
-          <source>Schedule rhncfg-actions package install</source>
-          <target>rhncfg-actions 패키지 설치 스케줄하기</target>
+          <source>Schedule mgr-cfg-actions package install</source>
+          <target>mgr-cfg-actions 패키지 설치 스케줄하기</target>
         </trans-unit>
         <trans-unit id="targetsystems.jsp.installcfgclient">
           <source>Schedule rhncfg-client package install</source>
@@ -17412,7 +17412,7 @@ any of these revisions.  Are you sure you want to do this?</source>
           <source>No systems within this set are available to run remote commands.</source>
         </trans-unit>
         <trans-unit id="ssm.operations.provisioning.remotecommand.no_script_run">
-          <source>You must enable Remote Command execution on the target system by installing the &lt;code&gt;rhncfg-actions&lt;/code&gt; RPM.</source>
+          <source>You must enable Remote Command execution on the target system by installing the &lt;code&gt;mgr-cfg-actions&lt;/code&gt; RPM.</source>
         </trans-unit>
         <trans-unit id="stringutil.scriptcheck.error.noshelldefined">
           <source>Script does not contain shell definition.</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_pa.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_pa.xml
@@ -13036,8 +13036,8 @@ the &lt;strong&gt;Red Hat Enterprise Linux System Administration Guide.&lt;/stro
           <target>rhncfg ਪੈਕੇਜ ਇੰਸਟਾਲ ਕਰਨ ਲਈ ਤਹਿ ਕਰੋ</target>
         </trans-unit>
         <trans-unit id="targetsystems.jsp.installcfgactions">
-          <source>Schedule rhncfg-actions package install</source>
-          <target>rhncfg-actions ਪੈਕੇਜ ਇੰਸਟਾਲ ਕਰਨ ਲਈ ਤਹਿ ਕਰੋ</target>
+          <source>Schedule mgr-cfg-actions package install</source>
+          <target>mgr-cfg-actions ਪੈਕੇਜ ਇੰਸਟਾਲ ਕਰਨ ਲਈ ਤਹਿ ਕਰੋ</target>
         </trans-unit>
         <trans-unit id="targetsystems.jsp.installcfgclient">
           <source>Schedule rhncfg-client package install</source>
@@ -16926,7 +16926,7 @@ any of these revisions.  Are you sure you want to do this?</source>
           <source>No systems within this set are available to run remote commands.</source>
         </trans-unit>
         <trans-unit id="ssm.operations.provisioning.remotecommand.no_script_run">
-          <source>You must enable Remote Command execution on the target system by installing the &lt;code&gt;rhncfg-actions&lt;/code&gt; RPM.</source>
+          <source>You must enable Remote Command execution on the target system by installing the &lt;code&gt;mgr-cfg-actions&lt;/code&gt; RPM.</source>
         </trans-unit>
         <trans-unit id="stringutil.scriptcheck.error.noshelldefined">
           <source>Script does not contain shell definition.</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_pt_BR.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_pt_BR.xml
@@ -13837,7 +13837,7 @@ o &lt;strong&gt;Guia de Administração de Sistemas Red Hat Enterprise Li
           <target>Agendar Instalação de Pacotes rhncfg</target>
         </trans-unit>
         <trans-unit id="targetsystems.jsp.installcfgactions">
-          <source>Schedule rhncfg-actions package install</source>
+          <source>Schedule mgr-cfg-actions package install</source>
           <target>Agendar Instalação de Pacotes de ações rhncfg</target>
         </trans-unit>
         <trans-unit id="targetsystems.jsp.installcfgclient">
@@ -17812,8 +17812,8 @@ para qualquer uma das revisões, assim como todo o histórico de implementação
           <target>Nenhum sistema dentro deste conjunto está disponível para executar comandos remotos.</target>
         </trans-unit>
         <trans-unit id="ssm.operations.provisioning.remotecommand.no_script_run">
-          <source>You must enable Remote Command execution on the target system by installing the &lt;code&gt;rhncfg-actions&lt;/code&gt; RPM.</source>
-          <target>Você deve ativar a execução do Comando Remoto no sistema alvo, instalando o RPM &lt;code&gt;rhncfg-actions&lt;/code&gt;.</target>
+          <source>You must enable Remote Command execution on the target system by installing the &lt;code&gt;mgr-cfg-actions&lt;/code&gt; RPM.</source>
+          <target>Você deve ativar a execução do Comando Remoto no sistema alvo, instalando o RPM &lt;code&gt;mgr-cfg-actions&lt;/code&gt;.</target>
         </trans-unit>
         <trans-unit id="stringutil.scriptcheck.error.noshelldefined">
           <source>Script does not contain shell definition.</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ru.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ru.xml
@@ -13821,8 +13821,8 @@ the &lt;strong&gt;Red Hat Enterprise Linux System Administration Guide.&lt;/stro
           <target>Назначить установку пакета rhncfg</target>
         </trans-unit>
         <trans-unit id="targetsystems.jsp.installcfgactions">
-          <source>Schedule rhncfg-actions package install</source>
-          <target>Назначить установку пакета rhncfg-actions</target>
+          <source>Schedule mgr-cfg-actions package install</source>
+          <target>Назначить установку пакета mgr-cfg-actions</target>
         </trans-unit>
         <trans-unit id="targetsystems.jsp.installcfgclient">
           <source>Schedule rhncfg-client package install</source>
@@ -17797,8 +17797,8 @@ any of these revisions.  Are you sure you want to do this?</source>
           <target>Нет систем, где можно выполнять удаленные команды.</target>
         </trans-unit>
         <trans-unit id="ssm.operations.provisioning.remotecommand.no_script_run">
-          <source>You must enable Remote Command execution on the target system by installing the &lt;code&gt;rhncfg-actions&lt;/code&gt; RPM.</source>
-          <target>Чтобы разрешить выполнение удаленных команд, установите &lt;code&gt;rhncfg-actions&lt;/code&gt;.</target>
+          <source>You must enable Remote Command execution on the target system by installing the &lt;code&gt;mgr-cfg-actions&lt;/code&gt; RPM.</source>
+          <target>Чтобы разрешить выполнение удаленных команд, установите &lt;code&gt;mgr-cfg-actions&lt;/code&gt;.</target>
         </trans-unit>
         <trans-unit id="stringutil.scriptcheck.error.noshelldefined">
           <source>Script does not contain shell definition.</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ta.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ta.xml
@@ -13037,8 +13037,8 @@ the &lt;strong&gt;Red Hat Enterprise Linux System Administration Guide.&lt;/stro
           <target>rhncfg தொகுப்பை நிறுவ திட்டமிடவும்</target>
         </trans-unit>
         <trans-unit id="targetsystems.jsp.installcfgactions">
-          <source>Schedule rhncfg-actions package install</source>
-          <target>rhncfg-actions தொகுப்பை நிறுவ திட்டமிடவும்</target>
+          <source>Schedule mgr-cfg-actions package install</source>
+          <target>mgr-cfg-actions தொகுப்பை நிறுவ திட்டமிடவும்</target>
         </trans-unit>
         <trans-unit id="targetsystems.jsp.installcfgclient">
           <source>Schedule rhncfg-client package install</source>
@@ -16927,7 +16927,7 @@ any of these revisions.  Are you sure you want to do this?</source>
           <source>No systems within this set are available to run remote commands.</source>
         </trans-unit>
         <trans-unit id="ssm.operations.provisioning.remotecommand.no_script_run">
-          <source>You must enable Remote Command execution on the target system by installing the &lt;code&gt;rhncfg-actions&lt;/code&gt; RPM.</source>
+          <source>You must enable Remote Command execution on the target system by installing the &lt;code&gt;mgr-cfg-actions&lt;/code&gt; RPM.</source>
         </trans-unit>
         <trans-unit id="stringutil.scriptcheck.error.noshelldefined">
           <source>Script does not contain shell definition.</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_uk.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_uk.xml
@@ -13825,7 +13825,7 @@ the &lt;strong&gt;Red Hat Enterprise Linux System Administration Guide.&lt;/stro
           
         </trans-unit>
         <trans-unit id="targetsystems.jsp.installcfgactions">
-          <source>Schedule rhncfg-actions package install</source>
+          <source>Schedule mgr-cfg-actions package install</source>
           
         </trans-unit>
         <trans-unit id="targetsystems.jsp.installcfgclient">
@@ -17774,7 +17774,7 @@ any of these revisions.  Are you sure you want to do this?</source>
           
         </trans-unit>
         <trans-unit id="ssm.operations.provisioning.remotecommand.no_script_run">
-          <source>You must enable Remote Command execution on the target system by installing the &lt;code&gt;rhncfg-actions&lt;/code&gt; RPM.</source>
+          <source>You must enable Remote Command execution on the target system by installing the &lt;code&gt;mgr-cfg-actions&lt;/code&gt; RPM.</source>
           
         </trans-unit>
         <trans-unit id="stringutil.scriptcheck.error.noshelldefined">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_zh_CN.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_zh_CN.xml
@@ -13841,8 +13841,8 @@ kickstart 前脚本的内容可以在 &lt;strong&gt;《红帽企业版 Linux 系
           <target>调度 rhncfg 软件包安装</target>
         </trans-unit>
         <trans-unit id="targetsystems.jsp.installcfgactions">
-          <source>Schedule rhncfg-actions package install</source>
-          <target>调度 rhncfg-actions 软件包安装</target>
+          <source>Schedule mgr-cfg-actions package install</source>
+          <target>调度 mgr-cfg-actions 软件包安装</target>
         </trans-unit>
         <trans-unit id="targetsystems.jsp.installcfgclient">
           <source>Schedule rhncfg-client package install</source>
@@ -17817,8 +17817,8 @@ any of these revisions.  Are you sure you want to do this?</source>
           <target>这个集合中的系统均无法运行远程命令。</target>
         </trans-unit>
         <trans-unit id="ssm.operations.provisioning.remotecommand.no_script_run">
-          <source>You must enable Remote Command execution on the target system by installing the &lt;code&gt;rhncfg-actions&lt;/code&gt; RPM.</source>
-          <target>您必须安装 &lt;code&gt;rhncfg-actions&lt;/code&gt; RPM 启用在目标系统中执行远程命令。</target>
+          <source>You must enable Remote Command execution on the target system by installing the &lt;code&gt;mgr-cfg-actions&lt;/code&gt; RPM.</source>
+          <target>您必须安装 &lt;code&gt;mgr-cfg-actions&lt;/code&gt; RPM 启用在目标系统中执行远程命令。</target>
         </trans-unit>
         <trans-unit id="stringutil.scriptcheck.error.noshelldefined">
           <source>Script does not contain shell definition.</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_zh_TW.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_zh_TW.xml
@@ -13833,7 +13833,7 @@ the &lt;strong&gt;Red Hat Enterprise Linux System Administration Guide.&lt;/stro
           <target>排程 rhncfg 的套件安裝</target>
         </trans-unit>
         <trans-unit id="targetsystems.jsp.installcfgactions">
-          <source>Schedule rhncfg-actions package install</source>
+          <source>Schedule mgr-cfg-actions package install</source>
           <target>排程 rhncfg 動作的套件安裝</target>
         </trans-unit>
         <trans-unit id="targetsystems.jsp.installcfgclient">
@@ -17809,8 +17809,8 @@ any of these revisions.  Are you sure you want to do this?</source>
           <target>此系統集裡沒有能夠執行遠端指令的系統。</target>
         </trans-unit>
         <trans-unit id="ssm.operations.provisioning.remotecommand.no_script_run">
-          <source>You must enable Remote Command execution on the target system by installing the &lt;code&gt;rhncfg-actions&lt;/code&gt; RPM.</source>
-          <target>您必須透過安裝 &lt;code&gt;rhncfg-actions&lt;/code&gt; RPM 來在目標系統上啟用遠端指令執行。</target>
+          <source>You must enable Remote Command execution on the target system by installing the &lt;code&gt;mgr-cfg-actions&lt;/code&gt; RPM.</source>
+          <target>您必須透過安裝 &lt;code&gt;mgr-cfg-actions&lt;/code&gt; RPM 來在目標系統上啟用遠端指令執行。</target>
         </trans-unit>
         <trans-unit id="stringutil.scriptcheck.error.noshelldefined">
           <source>Script does not contain shell definition.</source>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- rename rhncfg-actions to mgr-cfg-actions in UI advice (bsc#1137248)
 - Show additional headers and dependencies for deb packages
 - Show adequate message on saving formulas that change only pillar data
 - Fix container image import (bsc#1154246)


### PR DESCRIPTION
## What does this PR change?

Package rhncfg-actions has been renamed to mgr-cfg-actions. This should be reflected in the UI when the user is asked to install this package in order to allow remote commands and similar things.

## GUI diff

Before:
You will have this message: 
"You must enable Remote Command execution on the target system by installing the rhncfg-actions RPM."

After:
You will have this message: 
"You must enable Remote Command execution on the target system by installing the mgr-cfg-actions RPM."

- [X] **DONE**

## Documentation
- No documentation needed:

- [X] **DONE**

## Test coverage
- No tests: 

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
