### PR TITLE
Make systemd services and timers enablement really quiet

### DIFF
--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -633,11 +633,11 @@ do_migration() {
     ssh -i $KEYFILE root@$SATELLITE_IP "systemctl is-enabled osa-dispatcher > /dev/null 2>&1"
     if [ $? -eq 0 ]; then
         echo "Enable osa-dispatcher..."
-        systemctl --quiet enable osa-dispatcher
+        systemctl --quiet enable osa-dispatcher 2>&1
     else
         echo "Disable osa-dispatcher..."
-        systemctl --quiet disable osa-dispatcher
-        systemctl --quiet disable jabberd
+        systemctl --quiet disable osa-dispatcher 2>&1
+        systemctl --quiet disable jabberd 2>&1
     fi
 
     cleanup_hostname
@@ -832,12 +832,12 @@ if [ "$DO_SETUP" = "1" -o "$DO_MIGRATION" = "1" ]; then
 
             # explicitly enable OSA dispatcher as it's no longer part of spacewalk.target
             echo "Enable osa-dispatcher..."
-            systemctl --quiet enable jabberd
-            systemctl --quiet enable osa-dispatcher
+            systemctl --quiet enable jabberd 2>&1
+            systemctl --quiet enable osa-dispatcher 2>&1
 
             systemctl restart postgresql
             /usr/sbin/spacewalk-service start
-            systemctl --quiet enable spacewalk-diskcheck.timer
+            systemctl --quiet enable spacewalk-diskcheck.timer 2>&1
             systemctl start spacewalk-diskcheck.timer
         fi
     fi
@@ -856,7 +856,7 @@ if [ "$DO_SETUP" = "1" -o "$DO_MIGRATION" = "1" ]; then
         else
             echo "firewalld not installed" >&2
         fi
-        systemctl --quiet enable slpd
+        systemctl --quiet enable slpd 2>&1
         systemctl start slpd
     fi
 fi

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- Make systemd services and timers enablement really quiet
+
 -------------------------------------------------------------------
 Wed May 20 11:01:49 CEST 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Make systemd services and timers enablement really quiet 

Basically redirect stderr to stdout, as we do already for PostgreSQL service enablement.

We'll still get the message, but not at the error output box, that should be clear unless there are real errors.

## GUI diff

Before:

![image](https://user-images.githubusercontent.com/4226070/71103779-f8cc6580-21ba-11ea-8853-44ab0f49ba4f.png)

After:

![image](https://user-images.githubusercontent.com/4226070/71103833-18638e00-21bb-11ea-8994-d420bc86b514.png)

- [x] **DONE**

## Documentation
- No documentation needed: Bugfix.

- [x] **DONE**

## Test coverage
- No tests: Yast2 setup not covered.

- [x] **DONE**

## Links

Requires backporting to SUSE Manager 4.0

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
