### PR TITLE
Placeholder for product name in formula forms

### DIFF
--- a/web/html/src/components/FormulaForm.js
+++ b/web/html/src/components/FormulaForm.js
@@ -17,6 +17,8 @@ const defaultMessageTexts = {
     "pillar_only_formula_saved": <p>{t("Formula saved. Applying the highstate is not needed for this formula.")}</p>
 }
 
+const productName = Utils.getProductName();
+
 //props:
 //dataUrl = url to get the server data
 //saveUrl = url to save the data, data is sent as post request
@@ -400,7 +402,7 @@ class FormulaForm extends React.Component {
                             </div>
                             <div className="panel-body">
                                 <div className="formula-content">
-                                <p>{this.state.formulaMetadata.description}</p>
+                                <p>{text(this.state.formulaMetadata.description)}</p>
                                 <hr/>
                                 {this.renderForm()}
                                 </div>
@@ -461,9 +463,9 @@ function adjustElementBasicAttrs([elementName, element], scope) {
     }
 
     element.$id = elementName;
-    element.$name = get(element.$name, capitalize(elementName));
-    element.$help = get(element.$help, element.$name);
-    element.$placeholder = get(element.$placeholder, "");
+    element.$name = text(get(element.$name, capitalize(elementName)));
+    element.$help = text(get(element.$help, element.$name));
+    element.$placeholder = text(get(element.$placeholder, ""));
 
     if (isPrimitiveElement(element)) {
         element.$default = defaultValueForElement(element);
@@ -491,6 +493,12 @@ function isPrimitiveElement(element) {
     return element.$type !== "group" &&
         element.$type !== "namespace" &&
         element.$type !== "edit-group";
+}
+
+function text(txt) {
+    // replace variables
+    txt = txt.replace(/\${productName}/g, productName);
+    return txt;
 }
 
 /*

--- a/web/html/src/components/formulas/EditGroup.js
+++ b/web/html/src/components/formulas/EditGroup.js
@@ -11,6 +11,7 @@ const getEditGroupSubtype = Formulas.getEditGroupSubtype;
 const deepCopy = Utils.deepCopy;
 // circular dependencies are bad
 
+const productName = Utils.getProductName();
 /*
  * Base class for edit-group.
  * Based on the edit-group data, the corresponing shape of component is used.
@@ -271,6 +272,7 @@ class EditDictionaryGroup extends React.Component {
         let name = this.props.element.$itemName;
         name = name.replace(/\${i}/g, parseInt(item_index, 10) + 1);
         name = name.replace(/\${.*}/g, txt => get(this.props.value[item_index][txt.substring(2, txt.length - 1)], txt));
+        name = name.replace(/\${productName}/g, productName);
         return name;
     }
 

--- a/web/html/src/utils/functions.js
+++ b/web/html/src/utils/functions.js
@@ -1,4 +1,5 @@
 /* eslint-disable */
+// @flow
 export type Cancelable = {
   promise: Promise<any>,
   cancel: (any) => void
@@ -195,6 +196,9 @@ function deepCopy(e) {
     return e;
 }
 
+function getProductName() : string {
+    return window._IS_UYUNI ? "Uyuni" : "SUSE Manager"
+}
 
 module.exports = {
     Utils: {
@@ -208,7 +212,8 @@ module.exports = {
         urlBounce: urlBounce,
         capitalize: capitalize,
         generatePassword: generatePassword,
-        deepCopy: deepCopy
+        deepCopy: deepCopy,
+        getProductName: getProductName
     },
     Formats: {
         LocalDateTime: LocalDateTime

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Add placeholder for product name to formula forms
 - Fix ordering by date (bsc#1158818)
 - Add debug packages containing Javascript source map files
 - Don't validate mandatory fields that are not visible (bsc#1158943)


### PR DESCRIPTION
## What does this PR change?

`${productName}` placeholder for usage in `$help`, `$name`, `$placeholder` and formula 
description.

E.g.:
```yaml
minion_blackout_whitelist:  
  $type: edit-group
  $name: Allowed Salt modules
  $help: Removing the default values is not recommended because it may prevent ${productName} from working properly.
```

## GUI diff

On Uyuni:
![Screen Shot 2019-12-18 at 19 03 17](https://user-images.githubusercontent.com/11468018/71111213-3df79400-21c9-11ea-9c43-43ae79d0f8aa.png)

On SUSE Manager:
![Screen Shot 2019-12-18 at 18 56 52](https://user-images.githubusercontent.com/11468018/71111217-3fc15780-21c9-11ea-8098-78fc2f5ee96d.png)



## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: **manual testing**

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
