### PR TITLE
Fix console output on the TestSuite Report

### DIFF
--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -243,8 +243,10 @@ end
 
 # have more infos about the errors
 def debug_server_on_realtime_failure
-  puts '#' * 51 + ' /var/log/rhn/rhn_web_ui.log ' + '#' * 51
+  puts '_' * 51 + ' /var/log/rhn/rhn_web_ui.log ' + '_' * 51
   out, _code = $server.run('tail -n35 /var/log/rhn/rhn_web_ui.log')
-  puts out
-  puts '#' * 131
+  out.each_line do |line|
+    puts line.to_s
+  end
+  puts '_' * 131
 end


### PR DESCRIPTION
## What does this PR change?

Fixing the format shown in the test suite report, which printed all the server log output in one line.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

See example here: https://ci.suse.de/view/Manager/view/Uyuni/job/uyuni-master-cucumber-pipeline-NUE/745/TestSuite_20Report/

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
