### PR TITLE
Various test suite fixes

### DIFF
--- a/testsuite/features/core/proxy_register_as_minion_with_gui.feature
+++ b/testsuite/features/core/proxy_register_as_minion_with_gui.feature
@@ -32,7 +32,6 @@ Feature: Setup SUSE Manager proxy
 @proxy
   Scenario: Copy the keys and configure the proxy
     When I copy server's keys to the proxy
-    And I remove package "zypp-plugin-spacewalk" from this "proxy"
     And I configure the proxy
     Then I should see "proxy" in spacewalk
 

--- a/testsuite/features/secondary/min_osimage_build_image.feature
+++ b/testsuite/features/secondary/min_osimage_build_image.feature
@@ -18,10 +18,11 @@ Feature: Build OS images
     And I select "suse_os_image" from "profileId"
     And I select the hostname of "sle_minion" from "buildHostId"
     And I click on "submit-btn"
-    # Check the OS image built as Kiwi image administrator
+
+  Scenario: Check the OS image built as Kiwi image administrator
     Given I am on the Systems overview page of this "sle_minion"
-    When I should see a "[OS Image Build Host]" text
-    And I wait at most 3300 seconds until event "Image Build suse_os_image scheduled by kiwikiwi" is completed
+    Then I should see a "[OS Image Build Host]" text
+    When I wait at most 3300 seconds until event "Image Build suse_os_image scheduled by kiwikiwi" is completed
     And I wait at most 300 seconds until event "Image Inspect 1//suse_os_image:latest scheduled by kiwikiwi" is completed
     And I navigate to "os-images/1/" page
     Then I should see a "POS_Image_JeOS6" text


### PR DESCRIPTION
## What does this PR change?

Various fixes to test suite:
* split image creation scenario into two, the reason for them
   to be merged apparently does not exist anymore
* when preparing the proxy, don't remove `zypp-plugin-spacewalk`
  package any more, it not needed now the traditional stack is cleaned up

## Links

Ports:
 * 3.2: SUSE/spacewalk#10417
 * 4.0: SUSE/spacewalk#10418

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
