### PR TITLE
Don't output tabs in the spacewalk-web.spec

### DIFF
--- a/web/html/src/build/fill-spec-file.js
+++ b/web/html/src/build/fill-spec-file.js
@@ -14,7 +14,7 @@ function fillSpecFile() {
             if (err) {
                 throw err;
             }
-            var specFileEdited = specFile.replace(/(?<=%package -n susemanager-web-libs[\s\S]*?)License:.*/m, `License:\t\t${mappedProcessedLicenses}`);
+            var specFileEdited = specFile.replace(/(?<=%package -n susemanager-web-libs[\s\S]*?)License:.*/m, `License:        ${mappedProcessedLicenses}`);
 
             fs.writeFile(specFileLocation, specFileEdited, 'utf8', function (err) {
                 if (err) {


### PR DESCRIPTION
## What does this PR change?

Output spaces rather than tabs to avoid editors to automatically
convert them to spaces again and get build failures.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: tooling change

- [X] **DONE**

## Test coverage
- No tests: tooling change

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
