### PR TITLE
sle_minion test support for ipv4 error message

### DIFF
--- a/testsuite/features/init_clients/sle_minion.feature
+++ b/testsuite/features/init_clients/sle_minion.feature
@@ -42,7 +42,7 @@ Feature: Be able to bootstrap a Salt minion via the GUI
      And I click on "Bootstrap"
      And I wait until I see "ssh: connect to host" text
      Then I should not see a "GenericSaltError" text
-     And I should see a "port 11: Connection refused" text
+     And I should see a "port 11: Connection refused" text or "port 11: Invalid argument"
 
   Scenario: Bootstrap a SLES minion
      Given I am authorized


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

## What does this PR change?

Correct the test `features/init_clients/sle_minion.feature` scenario `Bootstrap a SLES minion with wrong SSH port number` to work with error message from ipv6 and ipv4 configurations.


## Links

Fixes https://github.com/SUSE/spacewalk/issues/10422
Tracks

Manager 4.0: https://github.com/SUSE/spacewalk/pull/10424
Manager 3.2: https://github.com/SUSE/spacewalk/pull/10425


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
