### PR TITLE
Use SCC_CREDENTIALS, PORTUS_URI and PORTUS_CREDENTIALS variables

### DIFF
--- a/testsuite/documentation/optional.md
+++ b/testsuite/documentation/optional.md
@@ -236,16 +236,17 @@ Inside of the testsuite, the scenarios that are tagged with
 ```
 are executed only if you don't use a mirror.
 
-### Testing with a SCC crendentials
+### Testing with SCC credentials
 
-Using the SCC crendentials with the testsuite is not mandatory.
+Using the SCC credentials with the testsuite is not mandatory.
 
-If you do not want to use SCC, do not define `scc_credentials` environment
+If you do not want to use SCC, do not define `SCC_CREDENTIALS` environment
 variable before you run the testsuite. That's all.
+
 If you want to use SCC, let this variable be equal to
 `"username|password"`:
 ```bash
-export scc_credentials="username|password"
+export SCC_CREDENTIALS="username|password"
 ```
 and then run the testsuite.
 

--- a/testsuite/features/secondary/min_docker_auth_registry.feature
+++ b/testsuite/features/secondary/min_docker_auth_registry.feature
@@ -9,7 +9,7 @@ Feature: Build image with authenticated registry
     And I follow "Create"
     And I enter "portus" as "label"
     And I check "useCredentials"
-    And I enter uri, username and password for portus
+    And I enter URI, username and password for portus
     And I click on "create-btn"
 
   Scenario: Create a profile for the authenticated image store as Docker admin

--- a/testsuite/features/secondary/srv_organization_credentials.feature
+++ b/testsuite/features/secondary/srv_organization_credentials.feature
@@ -8,6 +8,7 @@ Feature: Organization credentials in the Setup Wizard
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Organization Credentials"
     And I enter the SCC credentials
+    And I click on "Save"
 
 @no_mirror
   Scenario: Create some organization credentials

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -986,14 +986,13 @@ Then(/^I should see a list item with text "([^"]*)" and bullet with style "([^"]
 end
 
 When(/^I enter the SCC credentials$/) do
-  user = ENV['scc_credentials'].split('|')[0]
-  password = ENV['scc_credentials'].split('|')[1]
+  scc_username = ENV['SCC_CREDENTIALS'].split('|')[0]
+  scc_password = ENV['SCC_CREDENTIALS'].split('|')[1]
   unless has_content?(user)
     steps %(
-      And I want to add a new credential
-      And I enter "#{user}" as "edit-user"
-      And I enter "#{password}" as "edit-password"
-      And I click on "Save"
+      When I want to add a new credential
+      And I enter "#{scc_username}" as "edit-user"
+      And I enter "#{scc_password}" as "edit-password"
     )
   end
 end

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -823,10 +823,15 @@ When(/^I enter "([^"]*)" relative to profiles as "([^"]*)"$/) do |path, field|
   step %(I enter "#{$git_profiles}/#{path}" as "#{field}")
 end
 
-When(/^I enter uri, username and password for portus$/) do
-  step %(I enter "#{ENV['PORTUS_URI']}" as "uri")
-  step %(I enter "#{ENV['PORTUS_USER']}" as "username")
-  step %(I enter "#{ENV['PORTUS_PASS']}" as "password")
+When(/^I enter URI, username and password for portus$/) do
+  portus_uri = ENV['PORTUS_URI']
+  portus_username = ENV['PORTUS_CREDENTIALS'].split('|')[0]
+  portus_password = ENV['PORTUS_CREDENTIALS'].split('|')[1]
+  steps %(
+    When I enter "#{portus_uri}" as "uri"
+    And I enter "#{portus_username}" as "username"
+    And I enter "#{portus_password}" as "password"
+  )
 end
 
 When(/^I scroll to the top of the page$/) do

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -179,7 +179,7 @@ $private_net = ENV['PRIVATENET'] if ENV['PRIVATENET']
 $mirror = ENV['MIRROR']
 $git_profiles = ENV['GITPROFILES']
 $server_http_proxy = ENV['SERVER_HTTP_PROXY'] if ENV['SERVER_HTTP_PROXY']
-$scc_credentials = ENV['scc_credentials'] if ENV['scc_credentials']
+$scc_credentials = ENV['SCC_CREDENTIALS'] if ENV['SCC_CREDENTIALS']
 $node_by_host = { 'server'                => $server,
                   'proxy'                 => $proxy,
                   'ceos_minion'           => $ceos_minion,


### PR DESCRIPTION
## What does this PR change?

This PR uses new variables `SCC_CREDENTIALS`(instead of `scc_credentials`) and `PORTUS_CREDENTIALS`(instead of `PORTUS_USER` and `PORTUS_PASSWORD`)

## Links

Issue:
* https://github.com/SUSE/spacewalk/issues/5665

Runner and Sumaform:
* https://gitlab.suse.de/galaxy/sumaform-test-runner/merge_requests/207
* https://github.com/uyuni-project/sumaform/pull/662

Ports:
* 3.2: https://github.com/SUSE/spacewalk/pull/10433
* 4.0: https://github.com/SUSE/spacewalk/pull/10432

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
