### PR TITLE
Revised the documentation for optional components

### DIFF
--- a/testsuite/documentation/optional.md
+++ b/testsuite/documentation/optional.md
@@ -1,29 +1,32 @@
 ## Optional components
 
+The test suite can be parametrized to accomodate various test situations.
+
+The parameters are stored in `/root/.bashrc`.
+
+sumaform can prepare those parameters in `.bashrc` for you. For information
+about the syntax in your sumaform's `main.tf` file that allows to do this,
+please refer to sumaform's documentation:
+* [basic instructions](https://github.com/uyuni-project/sumaform/blob/master/README.md)
+* [test suite instructions](https://github.com/uyuni-project/sumaform/blob/master/README_TESTING.md)
+* [advanced instructions](https://github.com/uyuni-project/sumaform/blob/master/README_ADVANCED.md)
+
+This document here focuses on he test suite side.
+
+
 ### Testing with a proxy
 
 Using a SUSE Manager proxy with the testsuite is not mandatory.
 
 If you do not want a proxy, do not define `$PROXY` environment variable
 before you run the testsuite. That's all.
+
 If you want a proxy, make this variable point to the machine that will be
 the proxy:
 ```bash
 export PROXY=myproxy.example.com
 ```
 and then run the testsuite.
-
-Sumaform can prepare a proxy virtual machine and declare the `$PROXY`
-variable on the controller (in `/root/.bashrc`).
-To declare a proxy in your `main.tf` file, add a line to the controller
-declaration that looks like:
-```
-proxy_configuration = "${module.proxy.configuration}"
-```
-The module defining the proxy is declared accordingly to the "Proxies"
-chapter of the
-[advanced instructions](https://github.com/moio/sumaform/blob/master/README_ADVANCED.md)
-for sumaform.
 
 Inside of the testsuite, the scenarios that are tagged with
 ```
@@ -38,20 +41,13 @@ Using a minion with the testsuite is not mandatory.
 
 If you do not want a SLE minion, do not define `MINION` environment
 variable before you run the testsuite. That's all.
+
 If you want a SLE minion, make this variable point to the machine that
 will be the minion:
 ```bash
 export MINION=myminion.example.com
 ```
 and then run the testsuite.
-
-Sumaform can prepare a minion virtual machine and declare the `$MINION`
-variable on the controller (in `/root/.bashrc`).
-To declare a minion in your `main.tf` file, add a line
-to the controller declaration that looks like:
-```
-minion_configuration="${module.min-sles12sp3.configuration}"
-```
 
 Inside of the testsuite, the scenarios that are tagged with
 ```
@@ -66,20 +62,13 @@ Using a SSH minion with the testsuite is not mandatory.
 
 If you do not want a SSH minion, do not define `SSHMINION` environment
 variable before you run the testsuite. That's all.
+
 If you want a SSH minion, make this variable point to the machine that
 will be the SSH minion:
 ```bash
 export SSHMINION=myssh.example.com
 ```
 and then run the testsuite.
-
-Sumaform can prepare a SSH minion virtual machine and declare the `$SSHMINION`
-variable on the controller (in `/root/.bashrc`).
-To declare a SSH minion in your `main.tf` file, add a line
-to the controller declaration that looks like:
-```
-minionssh_configuration="${module.minsles12sp3ssh.configuration}"
-```
 
 Inside of the testsuite, the scenarios that are tagged with
 ```
@@ -94,20 +83,13 @@ Using a traditional client with the testsuite is not mandatory.
 
 If you do not want a traditional client, do not define `CLIENT` environment
 variable before you run the testsuite. That's all.
+
 If you want a traditional client, make this variable point to the machine that
 will be the traditional client:
 ```bash
 export CLIENT=mytraditionalclient.example.com
 ```
 and then run the testsuite.
-
-Sumaform can prepare a traditional client virtual machine and declare the `$CLIENT`
-variable on the controller (in `/root/.bashrc`).
-To declare a traditional client in your `main.tf` file, add a line
-to the controller declaration that looks like:
-```
-client_configuration="${module.cli-sles12sp3.configuration}"
-```
 
 Inside of the testsuite, the scenarios that are tagged with
 ```
@@ -122,24 +104,13 @@ Using a CentOS minion with the testsuite is not mandatory.
 
 If you do not want a CentOS minion, do not define `CENTOSMINION` environment
 variable before you run the testsuite. That's all.
+
 If you want a CentOS minion, make this variable point to the machine that
 will be the CentOS minion:
 ```bash
 export CENTOSMINION=myceos.example.com
 ```
 and then run the testsuite.
-
-Sumaform can prepare a CentOS virtual machine and declare the `$CENTOSMINION`
-variable on the controller (in `/root/.bashrc`).
-To declare a CentOS minion in your `main.tf` file, add a line
-to the controller declaration that looks like:
-```
-centos_configuration="${module.mincentos7.configuration}"
-```
-The module defining the CentOS minion will use a CentOS image:
-```
-image = "centos7"
-```
 
 Inside of the testsuite, the scenarios that are tagged with
 ```
@@ -148,30 +119,19 @@ Inside of the testsuite, the scenarios that are tagged with
 are executed only if the CentOS minion is available.
 
 
-### Testing with a Ubuntu minion
+### Testing with an Ubuntu minion
 
 Using an Ubuntu minion with the testsuite is not mandatory.
 
 If you do not want an Ubuntu minion, do not define `UBUNTUMINION` environment
 variable before you run the testsuite. That's all.
+
 If you want an Ubuntu minion, make this variable point to the machine that
 will be the Ubuntu minion:
 ```bash
 export UBUNTUMINION=ubuntu.example.com
 ```
 and then run the testsuite.
-
-Sumaform can prepare an Ubuntu virtual machine and declare the `$UBUNTUMINION`
-variable on the controller (in `/root/.bashrc`).
-To declare an Ubuntu minion in your `main.tf` file, add a line
-to the controller declaration that looks like:
-```
-ubuntu_configuration="${module.min-ubuntu.configuration}"
-```
-The module defining the Ubuntu minion will use a Ubuntu image:
-```
-image = "ubuntu1804"
-```
 
 Inside of the testsuite, the scenarios that are tagged with
 ```
@@ -212,12 +172,14 @@ Inside the testsuite, the scenarios that are tagged with
 are executed only if the server has Uyuni installed and will
 not run if SUSE Manager is detected.
 
+
 ### Testing with a mirror
 
 Using a mirror with the testsuite is not mandatory.
 
 If you do not want a mirror, do not define `MIRROR` environment
 variable before you run the testsuite. That's all.
+
 If you want a mirror, let this variable be equal to
 `yes` or `true`:
 ```bash
@@ -225,16 +187,12 @@ export MIRROR=yes
 ```
 and then run the testsuite.
 
-Sumaform can prepare a mirror and declare the `$MIRROR`
-variable on the controller (in `/root/.bashrc`).
-To declare a mirror in your `main.tf` file, follow the
-instructions in sumaform documentation.
-
 Inside of the testsuite, the scenarios that are tagged with
 ```
 @no_mirror
 ```
 are executed only if you don't use a mirror.
+
 
 ### Testing with SCC credentials
 
@@ -250,10 +208,11 @@ export SCC_CREDENTIALS="username|password"
 ```
 and then run the testsuite.
 
+
 ### Testing with external Docker or Kiwi profiles
 
-Normally, the profiles are stored within the testsuite itself, but
-you can also use another git repository for that.
+Normally, the profiles are stored within the testsuite itself (on the uyuni branch only),
+but you can also use another git repository for that.
 
 If you want to use external profiles, declare:
 ```bash
@@ -261,24 +220,17 @@ export GITPROFILES="https://github.com#mybranch:myprofiles"
 ```
 and then run the testsuite.
 
-This variable needs to be set even if you don't use external
-profiles.
-
-Sumaform declares the `$GITPROFILES`
-variable on the controller (in `/root/.bashrc`).
-To declare your own external profiles in your `main.tf` file, add a line
-to the controller declaration that looks like:
-```
-git_profiles_repo="https://github.com#mybranch:myprofiles"
-```
+This variable needs to be set even if you don't use external profiles (to the normal
+place `https://github.com/uyuni-project/uyuni/tree/master/testsuite/features/profiles`).
 
 
 ### Testing virtualization features
 
 Using a virtualization host with the testsuite is not mandatory.
 
-If you do not want a virtualization host minion, do not define `VIRTHOST_KVM_URL` and
+If you do not want a virtualization host minion, do not define `VIRTHOST_KVM_URL` or
 `VIRTHOST_XEN_URL` environment variables before you run the testsuite. That's all.
+
 If you want virtualization minions, make these variables point to the machines that
 will be the virtualization KVM or Xen host minions and define the `VIRTHOST_KVM_PASSWORD`
 and `VIRTHOST_XEN_PASSWORD` variables:
@@ -288,13 +240,11 @@ export VIRTHOST_KVM_URL=myvirthost.example.com
 export VIRTHOST_KVM_PASSWORD=therootpwd
 ```
 
-One of the virtualization servers can be disabled by not providing the corresponding
-environment variables.
-
 Make sure the image to use for the test virtual machines is located in
 `/var/testsuite-data/disk-image-template.qcow2` on the virtual hosts.
 A `/var/testsuite-data/disk-image-template-xenpv.qcow2` disk image to use for Xen ParaVirtualized
 guests is needed on the machine pointed by `VIRTHOST_XEN_URL`.
+
 In order for the virtual hosts to be able to report to the test server,
 use a bridge virtual network for the test machines.
 
@@ -315,6 +265,7 @@ Inside of the testsuite, the scenarios that are tagged with one of:
 ```
 are executed only if the corresponding virtualization host minion is available.
 
+
 ### Testing SUSE Manager for Retail
 
 Testing SUSE Manager for Retail is optional. To test it, you need:
@@ -322,28 +273,20 @@ Testing SUSE Manager for Retail is optional. To test it, you need:
 * a PXE boot minion.
 
 The PXE boot minion will reside in the private network only.
-The proxy will route between the private network and the
-outer world.
+The proxy will route between the private network and the outer world.
 
 
 #### Private network
 
 If you do not want a private network, do not define `PRIVATENET`
 environment variable before you run the testsuite. That's all.
+
 If you want that optional network, make this variable contain
 `yes` or `true`:
 ```bash
 export PRIVATENET=yes
 ```
 and then run the testsuite.
-
-Sumaform declares the `$PRIVATENET`
-variable on the controller (in `/root/.bashrc`).
-To create the private network in your `main.tf` file, add a line
-to the base declaration that looks like:
-```
-additional_network=true
-```
 
 Inside of the testsuite, the scenarios that are tagged with
 ```
@@ -361,24 +304,13 @@ with the help of PXE.
 
 If you do not want a PXE boot minion, do not define `PXEBOOTMAC`
 environment variable before you run the testsuite. That's all.
+
 If you want a PXE boot minion, make this variable contain
 the MAC address of the PXE boot minion:
 ```bash
 export PXEBOOTMAC=52:54:00:01:02:03
 ```
 and then run the testsuite.
-
-Sumaform declares the `$PXEBOOTMAC`
-variable on the controller (in `/root/.bashrc`).
-To create the PXE boot minion in your `main.tf` file, add a line
-to the controller declaration that looks like:
-```
-pxeboot_configuration = "${module.pxeboot.configuration}
-```
-The module defining the PXE boot minion is declared accordingly to the
-"PXE boot hosts" chapter of the
-[advanced instructions](https://github.com/moio/sumaform/blob/master/README_ADVANCED.md)
-for sumaform.
 
 Inside of the testsuite, the scenarios that are tagged with
 ```
@@ -387,17 +319,38 @@ Inside of the testsuite, the scenarios that are tagged with
 are executed only if the PXE boot minion is available.
 
 
-## HTTP Proxy setting
+## HTTP Proxy for the SUSE Manager server
 
-If you need to specify HTTP proxy on SUSE Manager "Setup Wizard" page, you can use 
-variable `server_http_proxy` from `controller` module in your `main.tf` file with following syntax:
-```
-server_http_proxy = "hostname:port"
-```
-It is set to `galaxy-proxy.mgr.suse.de:3128` by default.
+Using an HTTP proxy for the SUSE Manager server when testing is not mandatory.
 
-Sumaform creates `$SERVER_HTTP_PROXY` variable with corresponding settings in `/root/.bashrc` file
-on the controller. It is also possible to tag the scenarios with:
+If you do not want an HTTP proxy, do not define `SERVER_HTTP_PROXY`
+environment variable before you run the testsuite. That's all.
+
+If you want to specify an HTTP proxy on SUSE Manager's "Setup Wizard" page,
+make this variable contain the hostname and port of the proxy:
+```bash
+export SERVER_HTTP_PROXY = "hostname:port"
+```
+
+Inside the testsuite, the scenarios that are tagged with
 ```
 @server_http_proxy
+```
+are executed only if the HTTP proxy is available.
+
+
+## Portus server
+
+Using a Portus Docker access server when testing is not mandatory.
+
+If you do not want a Portus server, do not define `PORTUS_URI` nor `PORTUS_CREDENTIALS`
+environment variables before you run the testsuite. That's all.
+
+If you want to specify a Portus server to be used when testing Docker, make the
+`PORTUS_URI` variable contain the URI of the Portus server,
+and place the credentials on that server in the `PORTUS_CREDENTIALS` separated
+by a vertical bar:
+```bash
+export PORTUS_URI = "hostname:port/path"
+export PORTUS_CREDENTIALS = "user|password"
 ```


### PR DESCRIPTION
## What does this PR change?

This PR restructures the documentation for optional components

* it moves sumaform's documentation of optional components to sumaform itself
* it adds new Portus options

## Links

Ports:
* 3.2:
* 4.0:

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
