### PR TITLE
Simplify massive import test

### DIFF
--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -366,8 +366,7 @@ Feature: PXE boot a Retail terminal
 @proxy
 @private_net
   Scenario: Mass import of terminals
-    Given the retail configuration file name is "massive-import-terminals.yml"
-    When I copy the retail configuration file "massive-import-terminals.yml" on server
+    When I prepare the retail configuration file on server
     And I import the retail configuration using retail_yaml command
     And I am on the Systems page
     Then I should see the terminals imported from the configuration file
@@ -380,10 +379,12 @@ Feature: PXE boot a Retail terminal
     Given I am on the Systems overview page of this "proxy"
     When I follow "Formulas" in the content area
     And I follow first "Bind" in the content area
-    # Temporary fix as "empty-zones-enable" option is rewritten by retail_yaml command
+    # WORKAROUND to be removed when bsc#1150657 is fixed
+    # "empty-zones-enable" option is rewritten by retail_yaml command
     And I press "Add Item" in config options section
     And I enter "empty-zones-enable" in first option field
     And I enter "no" in first value field
+    # end of WORKAROUND
     And I press "Add Item" in configured zones section
     And I enter "tf.local" in third configured zone name field
     And I press "Add Item" in available zones section
@@ -414,9 +415,8 @@ Feature: PXE boot a Retail terminal
 @private_net
 @pxeboot_minion
   Scenario: Bootstrap the PXE boot minion
-    Given the retail configuration file name is "massive-import-terminals.yml"
-    And I am authorized
-    And I stop and disable avahi on the PXE boot minion
+    Given I am authorized
+    When I stop and disable avahi on the PXE boot minion
     And I create bootstrap script and set the activation key "1-SUSE-DEV-x86_64" in the bootstrap script on the proxy
     And I bootstrap pxeboot minion via bootstrap script on the proxy
     And I wait at most 180 seconds until Salt master sees "pxeboot_minion" as "unaccepted"
@@ -428,10 +428,9 @@ Feature: PXE boot a Retail terminal
 @private_net
 @pxeboot_minion
   Scenario: Check connection from bootstrapped terminal to proxy
-    Given the retail configuration file name is "massive-import-terminals.yml"
-    When I am on the Systems page
-    And I follow "pxeboot" terminal
-    When I follow "Details" in the content area
+    Given I am on the Systems page
+    When I follow "pxeboot" terminal
+    And I follow "Details" in the content area
     And I follow "Connection" in the content area
     Then I should see "proxy" short hostname
 
@@ -439,9 +438,8 @@ Feature: PXE boot a Retail terminal
 @private_net
 @pxeboot_minion
   Scenario: Install a package on the bootstrapped terminal
-    Given the retail configuration file name is "massive-import-terminals.yml"
-    When I am on the Systems page
-    And I follow "pxeboot" terminal
+    Given I am on the Systems page
+    When I follow "pxeboot" terminal
     And I follow "Software" in the content area
     And I follow "Install"
     And I check "virgo-dummy-2.0-1.1" in the list
@@ -454,9 +452,8 @@ Feature: PXE boot a Retail terminal
 @private_net
 @pxeboot_minion
   Scenario: Cleanup: remove a package on the bootstrapped terminal
-    Given the retail configuration file name is "massive-import-terminals.yml"
-    When I am on the Systems page
-    And I follow "pxeboot" terminal
+    Given I am on the Systems page
+    When I follow "pxeboot" terminal
     And I follow "Software" in the content area
     And I follow "List / Remove"
     And I enter "virgo" as the filtered package name
@@ -470,9 +467,8 @@ Feature: PXE boot a Retail terminal
 @proxy
 @private_net
   Scenario: Cleanup: delete all imported Retail terminals
-    Given the retail configuration file name is "massive-import-terminals.yml"
-    When I am on the Systems page
-    And I delete all the terminals imported
+    Given I am on the Systems page
+    When I delete all the imported terminals
     Then I should not see any terminals imported from the configuration file
 
 @proxy
@@ -527,5 +523,5 @@ Feature: PXE boot a Retail terminal
 @proxy
 @private_net
   Scenario: Cleanup: remove remaining systems from SSM after PXE boot tests
-  When I am authorized as "admin" with password "admin"
-  And I follow "Clear"
+    Given I am authorized as "admin" with password "admin"
+    When I follow "Clear"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1144,12 +1144,12 @@ When(/^I wait until package "([^"]*)" is removed from "([^"]*)" via spacecmd$/) 
   end
 end
 
-When(/^I copy the retail configuration file "([^"]*)" on server$/) do |file|
-  # Reuse the value during scenario (it will be automatically cleaned after it)
-  @retail_config = File.dirname(__FILE__) + '/../upload_files/' + file
-  dest = "/tmp/" + file
-  return_code = file_inject($server, @retail_config, dest)
+When(/^I prepare the retail configuration file on server$/) do
+  source = File.dirname(__FILE__) + '/../upload_files/massive-import-terminals.yml'
+  dest = '/tmp/massive-import-terminals.yml'
+  return_code = file_inject($server, source, dest)
   raise "File #{file} couldn't be copied to server" unless return_code.zero?
+
   sed_values = "s/<PROXY_HOSTNAME>/#{$proxy.full_hostname}/; "
   sed_values << "s/<NET_PREFIX>/#{net_prefix}/; "
   sed_values << "s/<PROXY>/#{ADDRESSES['proxy']}/; "
@@ -1160,22 +1160,17 @@ When(/^I copy the retail configuration file "([^"]*)" on server$/) do |file|
   sed_values << "s/<MINION>/#{ADDRESSES['minion']}/; "
   sed_values << "s/<MINION_MAC>/#{get_mac_address('sle_minion')}/; "
   sed_values << "s/<CLIENT>/#{ADDRESSES['client']}/; "
-  sed_values << "s/<CLIENT_MAC>/#{get_mac_address('sle_client')}/; "
-  # Retail DNS fix for client and minion
+  sed_values << "s/<CLIENT_MAC>/#{get_mac_address('sle_client')}/"
   $server.run("sed -i '#{sed_values}' #{dest}")
 end
 
-Given(/^the retail configuration file name is "([^"]*)"$/) do |file|
-  @retail_config = File.dirname(__FILE__) + '/../upload_files/' + file
-end
-
 When(/^I import the retail configuration using retail_yaml command/) do
-  filepath = "/tmp/" + File.basename(@retail_config)
+  filepath = '/tmp/massive-import-terminals.yml'
   $server.run("retail_yaml --api-user admin --api-pass admin --from-yaml #{filepath}")
 end
 
-When(/^I delete all the terminals imported$/) do
-  terminals = get_terminals_from_yaml(@retail_config)
+When(/^I delete all the imported terminals$/) do
+  terminals = read_terminals_from_yaml
   terminals.each do |terminal|
     next if (terminal.include? 'minion') || (terminal.include? 'client')
     puts "Deleting terminal with name: #{terminal}"
@@ -1190,14 +1185,14 @@ When(/^I delete all the terminals imported$/) do
 end
 
 When(/^I remove all the DHCP hosts created by retail_yaml$/) do
-  terminals = get_terminals_from_yaml(@retail_config)
+  terminals = read_terminals_from_yaml
   terminals.each do |terminal|
     raise unless find(:xpath, "//*[@value='#{terminal}']/../../../..//*[@title='Remove item']").click
   end
 end
 
 When(/^I remove the bind zones created by retail_yaml$/) do
-  domain = get_branch_prefix_from_yaml(@retail_config)
+  domain = read_branch_prefix_from_yaml
   raise unless find(:xpath, "//*[text()='Configured Zones']/../..//*[@value='#{domain}']/../../../..//*[@title='Remove item']").click
   raise unless find(:xpath, "//*[text()='Available Zones']/../..//*[@value='#{domain}' and @name='Name']/../../../..//i[@title='Remove item']").click
 end

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -41,12 +41,12 @@ Then(/^I can see all system information for "([^"]*)"$/) do |host|
 end
 
 Then(/^I should see the terminals imported from the configuration file/) do
-  terminals = get_terminals_from_yaml(@retail_config)
+  terminals = read_terminals_from_yaml
   terminals.each { |terminal| step %(I should see a "#{terminal}" text) }
 end
 
 Then(/^I should not see any terminals imported from the configuration file/) do
-  terminals = get_terminals_from_yaml(@retail_config)
+  terminals = read_terminals_from_yaml
   terminals.each do |terminal|
     next if (terminal.include? 'minion') || (terminal.include? 'client')
     step %(I should not see a "#{terminal}" text)
@@ -54,7 +54,7 @@ Then(/^I should not see any terminals imported from the configuration file/) do
 end
 
 When(/^I enter the hostname of "([^"]*)" terminal as "([^"]*)"$/) do |host, hostname|
-  domain = get_branch_prefix_from_yaml(@retail_config)
+  domain = read_branch_prefix_from_yaml
   puts "The hostname of #{host} terminal is #{host}.#{domain}"
   step %(I enter "#{host}.#{domain}" as "#{hostname}")
 end

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -195,7 +195,7 @@ end
 # Click on the terminal
 #
 When(/^I follow "([^"]*)" terminal$/) do |host|
-  domain = get_branch_prefix_from_yaml(@retail_config)
+  domain = read_branch_prefix_from_yaml
   if !host.include? 'pxeboot'
     step %(I follow "#{domain}.#{host}")
   else

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -17,18 +17,21 @@ def generate_temp_file(name, content)
   end
 end
 
-# extract terminals from a retail yaml configuration
-def get_terminals_from_yaml(name)
+# extract various data from Retail yaml configuration
+def read_terminals_from_yaml
+  name = File.dirname(__FILE__) + '/../upload_files/massive-import-terminals.yml'
   tree = YAML.load_file(name)
   tree['branches'].values[0]['terminals'].keys
 end
 
-def get_branch_prefix_from_yaml(name)
+def read_branch_prefix_from_yaml
+  name = File.dirname(__FILE__) + '/../upload_files/massive-import-terminals.yml'
   tree = YAML.load_file(name)
   tree['branches'].values[0]['branch_prefix']
 end
 
-def get_server_domain_from_yaml(name)
+def read_server_domain_from_yaml
+  name = File.dirname(__FILE__) + '/../upload_files/massive-import-terminals.yml'
   tree = YAML.load_file(name)
   tree['branches'].values[0]['server_domain']
 end


### PR DESCRIPTION
## What does this PR change?

Simplify the testing of massive import feature:
* remove useless global variable
* remove useless parameters passing

Plus various nitpicks:
* mark existing workaround as such
* English grammar
* `Given`, `When`, `And` sequence


## Links

Ports:
* 3.2: SUSE/spacewalk#10446
* 4.0: SUSE/spacewalk#10445


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
