### PR TITLE
Do not hardcode image name in features

### DIFF
--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -27,7 +27,7 @@
 ### Basic notions
 
 We use "targets" in the Ruby code to encapsulate the notion of testing hosts.
-The corresponding notion in cucumber steps is "step host names".
+The corresponding notion in Cucumber steps is "step host names".
 
 Possible values are currently:
 
@@ -40,7 +40,7 @@ Possible values are currently:
 | SLES Salt SSH minion | ```$ssh_minion``` | ```$SSHMINION``` | ```"ssh_minion"``` | ```"minion"``` |
 | Cent OS Salt minion or traditional client | ```$ceos_minion``` | ```$CENTOSMINION``` | ```"ceos_minion"```, ```"ceos_traditional_client"```, or ``"ceos_ssh_minion"``` | ```"minion"``` |
 | Ubuntu minion | ```$ubuntu_minion``` | ```$UBUNTUMINION``` | ```"ubuntu_minion"``` or ```"ubuntu_ssh_minion"``` | ```"minion"``` |
-| PXE-Boot minion |  None | ```$PXEBOOTMAC``` | ```"pxeboot_minion"``` | ```"pxeboot"``` |
+| PXE-Boot minion |  None | ```$PXEBOOT_MAC``` | ```"pxeboot_minion"``` | ```"pxeboot"``` |
 
 These names are such for historical reasons and might be made better in the future.
 

--- a/testsuite/documentation/optional.md
+++ b/testsuite/documentation/optional.md
@@ -302,13 +302,16 @@ via the private network. The proxy reboots this minion
 through SSH and then triggers a complete reinstallation
 with the help of PXE.
 
-If you do not want a PXE boot minion, do not define `PXEBOOTMAC`
-environment variable before you run the testsuite. That's all.
+If you do not want a PXE boot minion, do not define `PXEBOOT_MAC` nor
+`PXEBOOT_IMAGE` environment variables before you run the testsuite.
+That's all.
 
-If you want a PXE boot minion, make this variable contain
-the MAC address of the PXE boot minion:
+If you want a PXE boot minion, make these variables contain
+the MAC address of the PXE boot minion and the name of
+the desired image you want it reformatted with:
 ```bash
-export PXEBOOTMAC=52:54:00:01:02:03
+export PXEBOOT_MAC=52:54:00:01:02:03
+export PXEBOOT_IMAGE=sles12sp4
 ```
 and then run the testsuite.
 

--- a/testsuite/features/core/srv_osimage_profiles.feature
+++ b/testsuite/features/core/srv_osimage_profiles.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 SUSE LLC
+# Copyright (c) 2018-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Prepare server for using Kiwi
@@ -39,5 +39,5 @@ Feature: Prepare server for using Kiwi
     And I enter "suse_os_image" as "label"
     And I select "Kiwi" from "imageType"
     And I select "1-KIWI-TEST" from "activationKey"
-    And I enter "Kiwi/POS_Image-JeOS6_head" relative to profiles as "path"
+    And I enter the image filename relative to profiles as "path"
     And I click on "create-btn"

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_32/config.sh
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_32/config.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# Copyright (c) 2019-2020 SUSE LLC
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#======================================
+# Functions...
+#--------------------------------------
+test -f /.kconfig && . /.kconfig
+test -f /.profile && . /.profile
+
+mkdir /var/lib/misc/reconfig_system
+
+#======================================
+# Greeting...
+#--------------------------------------
+echo "Configure image: [$name]..."
+
+#======================================
+# add missing fonts
+#--------------------------------------
+CONSOLE_FONT="eurlatgr.psfu"
+
+#======================================
+# prepare for setting root pw, timezone
+#--------------------------------------
+echo ** "reset machine settings"
+
+# FIXME:
+#sed -i 's/^root:[^:]*:/root:*:/' /etc/shadow
+rm -f /etc/machine-id \
+      /var/lib/zypp/AnonymousUniqueId \
+      /var/lib/systemd/random-seed \
+      /var/lib/dbus/machine-id
+
+#======================================
+# SuSEconfig
+#--------------------------------------
+echo "** Running suseConfig..."
+suseConfig
+
+echo "** Running ldconfig..."
+/sbin/ldconfig
+
+#======================================
+# Setup baseproduct link
+#--------------------------------------
+suseSetupProduct
+
+#======================================
+# Specify default runlevel
+#--------------------------------------
+baseSetRunlevel 3
+
+#======================================
+# Add missing gpg keys to rpm
+#--------------------------------------
+suseImportBuildKey
+
+#======================================
+# Enable DHCP on eth0
+#--------------------------------------
+cat >/etc/sysconfig/network/ifcfg-eth0 <<EOF
+BOOTPROTO='dhcp'
+MTU=''
+REMOTE_IPADDR=''
+STARTMODE='auto'
+ETHTOOL_OPTIONS=''
+USERCONTROL='no'
+EOF
+
+#======================================
+# Enable sshd
+#--------------------------------------
+chkconfig sshd on
+
+#======================================
+# Remove doc files
+#--------------------------------------
+baseStripDocs
+
+#======================================
+# Sysconfig Update
+#--------------------------------------
+echo '** Update sysconfig entries...'
+
+baseUpdateSysConfig /etc/sysconfig/network/dhcp DHCLIENT_SET_HOSTNAME yes
+
+# Enable firewalld
+chkconfig firewalld on
+
+# Set GRUB2 to boot graphically (bsc#1097428)
+sed -Ei"" "s/#?GRUB_TERMINAL=.+$/GRUB_TERMINAL=gfxterm/g" /etc/default/grub
+sed -Ei"" "s/#?GRUB_GFXMODE=.+$/GRUB_GFXMODE=auto/g" /etc/default/grub
+
+# Systemd controls the console font now
+echo FONT="$CONSOLE_FONT" >> /etc/vconsole.conf
+
+#======================================
+# SSL Certificates Configuration
+#--------------------------------------
+echo '** Rehashing SSL Certificates...'
+update-ca-certificates
+
+if [ ! -s /var/log/zypper.log ]; then
+	> /var/log/zypper.log
+fi
+
+# only for debugging
+#systemctl enable debug-shell.service
+
+baseCleanMount
+
+exit 0

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_32/config.xml
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_32/config.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="6.1" name="POS_Image_JeOS7_32">
+    <description type="system">
+        <author>Admin User</author>
+        <contact>noemail@example.com</contact>
+        <specification>SUSE Linux Enterprise 15 SP1 JeOS</specification>
+    </description>
+    <preferences>
+        <version>7.0.0</version>
+        <packagemanager>zypper</packagemanager>
+        <bootsplash-theme>SLE</bootsplash-theme>
+        <bootloader-theme>SLE</bootloader-theme>
+
+        <locale>en_US</locale>
+        <keytable>us.map.gz</keytable>
+        <timezone>Europe/Berlin</timezone>
+        <hwclock>utc</hwclock>
+
+        <rpm-excludedocs>true</rpm-excludedocs>
+        <type filesystem="ext3" image="pxe" initrd_system="dracut"/>
+    </preferences>
+    <users group="root">
+      <user home="/root" name="root" password="linux" pwdformat="plain" shell="/bin/bash"/>
+    </users>
+
+    <drivers>
+      <file name="drivers/block/virtio_blk.ko" />
+    </drivers>
+
+    <!-- remove all the following repositories if you want to get their packages through SUSE Manager;
+         in that case, sync those repos in SUSE Manager, and add them to the activation key;
+         finally, re-enable option  '- -ignore-repos-used-for-build' in file 'kiwi-image-build.sls' -->
+    <repository type="rpm-md">  <!-- product -->
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP1/x86_64/product/"/>
+    </repository>
+    <repository type="rpm-md">
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP1/x86_64/update/"/>
+    </repository>
+    <repository type="rpm-md">  <!-- base system -->
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/"/>
+    </repository>
+    <repository type="rpm-md">
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP1/x86_64/update/"/>
+    </repository>
+    <repository type="rpm-md">  <!-- desktop applications -->
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Desktop-Applications/15-SP1/x86_64/product/"/>
+    </repository>
+    <repository type="rpm-md">
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Desktop-Applications/15-SP1/x86_64/update/"/>
+    </repository>
+    <repository type="rpm-md">  <!-- development tools -->
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Development-Tools/15-SP1/x86_64/product/"/>
+    </repository>
+    <repository type="rpm-md">
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Development-Tools/15-SP1/x86_64/update/"/>
+    </repository>
+    <repository type="rpm-md">  <!-- manager tools -->
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Manager-Tools/15/x86_64/product/"/>
+    </repository>
+    <repository type="rpm-md">
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update/"/>
+    </repository>
+    <repository type="rpm-md">  <!-- 3.2 development client tools -->
+        <source path="http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/3.2:/SLE15-SUSE-Manager-Tools/SLE_15/"/>
+    </repository>
+
+    <packages type="image">
+        <package name="patterns-base-minimal_base"/>
+        <package name="aaa_base-extras"/>
+        <package name="acl"/>
+        <package name="chrony"/>
+        <package name="curl"/>
+        <package name="dracut"/>
+        <package name="fipscheck"/>
+        <package name="group(mail)"/>
+        <package name="group(wheel)"/>
+        <package name="grub2-branding-SLE" bootinclude="true"/>
+        <package name="iputils"/>
+        <package name="issue-generator"/>
+        <package name="zypper-lifecycle-plugin"/>
+        <package name="vim"/>
+        <package name="shim" arch="x86_64"/>
+        <package name="grub2"/>
+        <package name="grub2-x86_64-efi" arch="x86_64"/>
+        <package name="haveged"/>
+        <package name="less" />
+        <package name="tar"/>
+        <package name="parted"/>
+        <package name="SUSEConnect"/>
+        <package name="suse-build-key"/>
+        <package name="systemd"/>
+        <package name="systemd-sysvinit"/>
+        <package name="timezone"/>
+        <package name="wicked"/>
+        <package name="iproute2"/>
+        <package name="openssh"/>
+        <package name="rsync"/>
+
+        <package name="kernel-default"/>
+	<package name="salt-minion"/>
+
+	<package name="dracut-saltboot"/>
+        <package name="mdadm"/>
+        <package name="cryptsetup"/>
+        <package name="kernel-firmware"/>
+        <package name="kexec-tools"/>
+        <package name="plymouth"/>
+        <package name="plymouth-dracut"/>
+        <package name="plymouth-branding-SLE"/>
+        <package name="fontconfig"/>
+        <package name="fonts-config"/>
+        <package name="noto-sans-fonts"/>
+        <package name="wpa_supplicant"/>
+        <package name="busybox"/>
+        <package name="bind-utils"/>
+        <package name="kiwi-tools"/>
+        <package name="dosfstools"/>
+        <package name="xfsprogs"/>
+    </packages>
+
+    <packages type="bootstrap">
+        <package name="udev"/>
+        <package name="filesystem"/>
+        <package name="glibc-locale-base"/>
+        <package name="ca-certificates-mozilla"/>
+        <package name="sles-release"/>
+        <package name="rhn-org-trusted-ssl-cert-osimage"/>
+    </packages>
+</image>

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_32/images.sh
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_32/images.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright (c) 2019-2020 SUSE LLC
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+test -f /.kconfig && . /.kconfig
+test -f /.profile && . /.profile
+
+systemctl enable salt-minion.service
+
+# notify SUSE Manager about newly deployed image
+systemctl enable image-deployed.service
+
+# install bootloader and generate boot menu
+systemctl enable install-local-bootloader.service

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_32/root/etc/multipath.conf
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_32/root/etc/multipath.conf
@@ -1,0 +1,4 @@
+# workaround for bsc#1069169
+defaults {
+  find_multipaths smart
+}

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_32/root/etc/sysconfig/bootloader
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_32/root/etc/sysconfig/bootloader
@@ -1,0 +1,34 @@
+
+## Path:	System/Bootloader
+## Description:	Bootloader configuration
+## Type:	list(grub,grub2,grub2-efi,none)
+## Default:	grub2
+#
+# Type of bootloader in use.
+# For making the change effect run bootloader configuration tool
+# and configure newly selected bootloader
+#
+#
+LOADER_TYPE="grub2"
+
+## Path:	System/Bootloader
+## Description:	Bootloader configuration
+## Type:	yesno
+## Default:	"no"
+#
+# Enable UEFI Secure Boot support
+# This setting is only relevant to UEFI which supports Secure Boot. It won't
+# take effect on any other firmware type.
+#
+#
+SECURE_BOOT="no"
+
+## Path:	System/Bootloader
+## Description:	Bootloader configuration
+## Type:	yesno
+## Default:	"no"
+#
+# Enable Trusted Boot support
+# Only available for legacy (non-UEFI) boot.
+#
+TRUSTED_BOOT="no"

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_32/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_32/root/etc/systemd/system/image-deployed.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Notify SUSE Manager about newly deployed image
+Requires=salt-minion.service
+After=salt-minion.service
+
+# only if there are no susemanager channels configured
+ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/salt-call event.send suse/manager/image_deployed with_grains=True
+
+[Install]
+WantedBy=multi-user.target

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_32/root/etc/systemd/system/install-local-bootloader.service
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_32/root/etc/systemd/system/install-local-bootloader.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Install bootloader for local boot
+
+# only if not configured yet
+ConditionPathExists=!/boot/grub2/grub.cfg
+
+[Service]
+Type=oneshot
+ExecStartPre=/bin/bash -c 'if [ -e /sys/firmware/efi ]; then sed -i -e "s|^LOADER_TYPE=.*|LOADER_TYPE=\\"grub2-efi\\"|" /etc/sysconfig/bootloader; fi'
+ExecStartPre=/bin/bash -c 'if [ ! -e /sys/firmware/efi ]; then sed -i -e "s|^LOADER_TYPE=.*|LOADER_TYPE=\\"grub2\\"|" /etc/sysconfig/bootloader; fi'
+ExecStart=/bin/bash -c 'pbl --install ; dracut -f ; pbl --config '
+
+[Install]
+WantedBy=multi-user.target

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_40/config.sh
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_40/config.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# Copyright (c) 2019-2020 SUSE LLC
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#======================================
+# Functions...
+#--------------------------------------
+test -f /.kconfig && . /.kconfig
+test -f /.profile && . /.profile
+
+mkdir /var/lib/misc/reconfig_system
+
+#======================================
+# Greeting...
+#--------------------------------------
+echo "Configure image: [$name]..."
+
+#======================================
+# add missing fonts
+#--------------------------------------
+CONSOLE_FONT="eurlatgr.psfu"
+
+#======================================
+# prepare for setting root pw, timezone
+#--------------------------------------
+echo ** "reset machine settings"
+
+# FIXME:
+#sed -i 's/^root:[^:]*:/root:*:/' /etc/shadow
+rm -f /etc/machine-id \
+      /var/lib/zypp/AnonymousUniqueId \
+      /var/lib/systemd/random-seed \
+      /var/lib/dbus/machine-id
+
+#======================================
+# SuSEconfig
+#--------------------------------------
+echo "** Running suseConfig..."
+suseConfig
+
+echo "** Running ldconfig..."
+/sbin/ldconfig
+
+#======================================
+# Setup baseproduct link
+#--------------------------------------
+suseSetupProduct
+
+#======================================
+# Specify default runlevel
+#--------------------------------------
+baseSetRunlevel 3
+
+#======================================
+# Add missing gpg keys to rpm
+#--------------------------------------
+suseImportBuildKey
+
+#======================================
+# Enable DHCP on eth0
+#--------------------------------------
+cat >/etc/sysconfig/network/ifcfg-eth0 <<EOF
+BOOTPROTO='dhcp'
+MTU=''
+REMOTE_IPADDR=''
+STARTMODE='auto'
+ETHTOOL_OPTIONS=''
+USERCONTROL='no'
+EOF
+
+#======================================
+# Enable sshd
+#--------------------------------------
+chkconfig sshd on
+
+#======================================
+# Remove doc files
+#--------------------------------------
+baseStripDocs
+
+#======================================
+# Sysconfig Update
+#--------------------------------------
+echo '** Update sysconfig entries...'
+
+baseUpdateSysConfig /etc/sysconfig/network/dhcp DHCLIENT_SET_HOSTNAME yes
+
+# Enable firewalld
+chkconfig firewalld on
+
+# Set GRUB2 to boot graphically (bsc#1097428)
+sed -Ei"" "s/#?GRUB_TERMINAL=.+$/GRUB_TERMINAL=gfxterm/g" /etc/default/grub
+sed -Ei"" "s/#?GRUB_GFXMODE=.+$/GRUB_GFXMODE=auto/g" /etc/default/grub
+
+# Systemd controls the console font now
+echo FONT="$CONSOLE_FONT" >> /etc/vconsole.conf
+
+#======================================
+# SSL Certificates Configuration
+#--------------------------------------
+echo '** Rehashing SSL Certificates...'
+update-ca-certificates
+
+if [ ! -s /var/log/zypper.log ]; then
+	> /var/log/zypper.log
+fi
+
+# only for debugging
+#systemctl enable debug-shell.service
+
+baseCleanMount
+
+exit 0

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_40/config.xml
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_40/config.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="6.1" name="POS_Image_JeOS7_40">
+    <description type="system">
+        <author>Admin User</author>
+        <contact>noemail@example.com</contact>
+        <specification>SUSE Linux Enterprise 15 SP1 JeOS</specification>
+    </description>
+    <preferences>
+        <version>7.0.0</version>
+        <packagemanager>zypper</packagemanager>
+        <bootsplash-theme>SLE</bootsplash-theme>
+        <bootloader-theme>SLE</bootloader-theme>
+
+        <locale>en_US</locale>
+        <keytable>us.map.gz</keytable>
+        <timezone>Europe/Berlin</timezone>
+        <hwclock>utc</hwclock>
+
+        <rpm-excludedocs>true</rpm-excludedocs>
+        <type filesystem="ext3" image="pxe" initrd_system="dracut"/>
+    </preferences>
+    <users group="root">
+      <user home="/root" name="root" password="linux" pwdformat="plain" shell="/bin/bash"/>
+    </users>
+
+    <drivers>
+      <file name="drivers/block/virtio_blk.ko" />
+    </drivers>
+
+    <!-- remove all the following repositories if you want to get their packages through SUSE Manager;
+         in that case, sync those repos in SUSE Manager, and add them to the activation key;
+         finally, re-enable option  '- -ignore-repos-used-for-build' in file 'kiwi-image-build.sls' -->
+    <repository type="rpm-md">  <!-- product -->
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP1/x86_64/product/"/>
+    </repository>
+    <repository type="rpm-md">
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP1/x86_64/update/"/>
+    </repository>
+    <repository type="rpm-md">  <!-- base system -->
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/"/>
+    </repository>
+    <repository type="rpm-md">
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP1/x86_64/update/"/>
+    </repository>
+    <repository type="rpm-md">  <!-- desktop applications -->
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Desktop-Applications/15-SP1/x86_64/product/"/>
+    </repository>
+    <repository type="rpm-md">
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Desktop-Applications/15-SP1/x86_64/update/"/>
+    </repository>
+    <repository type="rpm-md">  <!-- development tools -->
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Development-Tools/15-SP1/x86_64/product/"/>
+    </repository>
+    <repository type="rpm-md">
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Development-Tools/15-SP1/x86_64/update/"/>
+    </repository>
+    <repository type="rpm-md">  <!-- manager tools -->
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Manager-Tools/15/x86_64/product/"/>
+    </repository>
+    <repository type="rpm-md">
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update/"/>
+    </repository>
+    <repository type="rpm-md">  <!-- 4.0 development client toools -->
+        <source path="http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.0:/SLE15-SUSE-Manager-Tools/SLE_15/"/>
+    </repository>
+
+    <packages type="image">
+        <package name="patterns-base-minimal_base"/>
+        <package name="aaa_base-extras"/>
+        <package name="acl"/>
+        <package name="chrony"/>
+        <package name="curl"/>
+        <package name="dracut"/>
+        <package name="fipscheck"/>
+        <package name="group(mail)"/>
+        <package name="group(wheel)"/>
+        <package name="grub2-branding-SLE" bootinclude="true"/>
+        <package name="iputils"/>
+        <package name="issue-generator"/>
+        <package name="zypper-lifecycle-plugin"/>
+        <package name="vim"/>
+        <package name="shim" arch="x86_64"/>
+        <package name="grub2"/>
+        <package name="grub2-x86_64-efi" arch="x86_64"/>
+        <package name="haveged"/>
+        <package name="less" />
+        <package name="tar"/>
+        <package name="parted"/>
+        <package name="SUSEConnect"/>
+        <package name="suse-build-key"/>
+        <package name="systemd"/>
+        <package name="systemd-sysvinit"/>
+        <package name="timezone"/>
+        <package name="wicked"/>
+        <package name="iproute2"/>
+        <package name="openssh"/>
+        <package name="rsync"/>
+
+        <package name="kernel-default"/>
+	<package name="salt-minion"/>
+
+	<package name="dracut-saltboot"/>
+        <package name="mdadm"/>
+        <package name="cryptsetup"/>
+        <package name="kernel-firmware"/>
+        <package name="kexec-tools"/>
+        <package name="plymouth"/>
+        <package name="plymouth-dracut"/>
+        <package name="plymouth-branding-SLE"/>
+        <package name="fontconfig"/>
+        <package name="fonts-config"/>
+        <package name="noto-sans-fonts"/>
+        <package name="wpa_supplicant"/>
+        <package name="busybox"/>
+        <package name="bind-utils"/>
+        <package name="kiwi-tools"/>
+        <package name="dosfstools"/>
+        <package name="xfsprogs"/>
+    </packages>
+
+    <packages type="bootstrap">
+        <package name="udev"/>
+        <package name="filesystem"/>
+        <package name="glibc-locale-base"/>
+        <package name="ca-certificates-mozilla"/>
+        <package name="sles-release"/>
+        <package name="rhn-org-trusted-ssl-cert-osimage"/>
+    </packages>
+</image>

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_40/images.sh
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_40/images.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright (c) 2019-2020 SUSE LLC
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+test -f /.kconfig && . /.kconfig
+test -f /.profile && . /.profile
+
+systemctl enable salt-minion.service
+
+# notify SUSE Manager about newly deployed image
+systemctl enable image-deployed.service
+
+# install bootloader and generate boot menu
+systemctl enable install-local-bootloader.service

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_40/root/etc/multipath.conf
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_40/root/etc/multipath.conf
@@ -1,0 +1,4 @@
+# workaround for bsc#1069169
+defaults {
+  find_multipaths smart
+}

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_40/root/etc/sysconfig/bootloader
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_40/root/etc/sysconfig/bootloader
@@ -1,0 +1,34 @@
+
+## Path:	System/Bootloader
+## Description:	Bootloader configuration
+## Type:	list(grub,grub2,grub2-efi,none)
+## Default:	grub2
+#
+# Type of bootloader in use.
+# For making the change effect run bootloader configuration tool
+# and configure newly selected bootloader
+#
+#
+LOADER_TYPE="grub2"
+
+## Path:	System/Bootloader
+## Description:	Bootloader configuration
+## Type:	yesno
+## Default:	"no"
+#
+# Enable UEFI Secure Boot support
+# This setting is only relevant to UEFI which supports Secure Boot. It won't
+# take effect on any other firmware type.
+#
+#
+SECURE_BOOT="no"
+
+## Path:	System/Bootloader
+## Description:	Bootloader configuration
+## Type:	yesno
+## Default:	"no"
+#
+# Enable Trusted Boot support
+# Only available for legacy (non-UEFI) boot.
+#
+TRUSTED_BOOT="no"

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_40/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_40/root/etc/systemd/system/image-deployed.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Notify SUSE Manager about newly deployed image
+Requires=salt-minion.service
+After=salt-minion.service
+
+# only if there are no susemanager channels configured
+ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/salt-call event.send suse/manager/image_deployed with_grains=True
+
+[Install]
+WantedBy=multi-user.target

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_40/root/etc/systemd/system/install-local-bootloader.service
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_40/root/etc/systemd/system/install-local-bootloader.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Install bootloader for local boot
+
+# only if not configured yet
+ConditionPathExists=!/boot/grub2/grub.cfg
+
+[Service]
+Type=oneshot
+ExecStartPre=/bin/bash -c 'if [ -e /sys/firmware/efi ]; then sed -i -e "s|^LOADER_TYPE=.*|LOADER_TYPE=\\"grub2-efi\\"|" /etc/sysconfig/bootloader; fi'
+ExecStartPre=/bin/bash -c 'if [ ! -e /sys/firmware/efi ]; then sed -i -e "s|^LOADER_TYPE=.*|LOADER_TYPE=\\"grub2\\"|" /etc/sysconfig/bootloader; fi'
+ExecStart=/bin/bash -c 'pbl --install ; dracut -f ; pbl --config '
+
+[Install]
+WantedBy=multi-user.target

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/config.sh
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/config.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# Copyright (c) 2019-2020 SUSE LLC
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#======================================
+# Functions...
+#--------------------------------------
+test -f /.kconfig && . /.kconfig
+test -f /.profile && . /.profile
+
+mkdir /var/lib/misc/reconfig_system
+
+#======================================
+# Greeting...
+#--------------------------------------
+echo "Configure image: [$name]..."
+
+#======================================
+# add missing fonts
+#--------------------------------------
+CONSOLE_FONT="eurlatgr.psfu"
+
+#======================================
+# prepare for setting root pw, timezone
+#--------------------------------------
+echo ** "reset machine settings"
+
+# FIXME:
+#sed -i 's/^root:[^:]*:/root:*:/' /etc/shadow
+rm -f /etc/machine-id \
+      /var/lib/zypp/AnonymousUniqueId \
+      /var/lib/systemd/random-seed \
+      /var/lib/dbus/machine-id
+
+#======================================
+# SuSEconfig
+#--------------------------------------
+echo "** Running suseConfig..."
+suseConfig
+
+echo "** Running ldconfig..."
+/sbin/ldconfig
+
+#======================================
+# Setup baseproduct link
+#--------------------------------------
+suseSetupProduct
+
+#======================================
+# Specify default runlevel
+#--------------------------------------
+baseSetRunlevel 3
+
+#======================================
+# Add missing gpg keys to rpm
+#--------------------------------------
+suseImportBuildKey
+
+#======================================
+# Enable DHCP on eth0
+#--------------------------------------
+cat >/etc/sysconfig/network/ifcfg-eth0 <<EOF
+BOOTPROTO='dhcp'
+MTU=''
+REMOTE_IPADDR=''
+STARTMODE='auto'
+ETHTOOL_OPTIONS=''
+USERCONTROL='no'
+EOF
+
+#======================================
+# Enable sshd
+#--------------------------------------
+chkconfig sshd on
+
+#======================================
+# Remove doc files
+#--------------------------------------
+baseStripDocs
+
+#======================================
+# Sysconfig Update
+#--------------------------------------
+echo '** Update sysconfig entries...'
+
+baseUpdateSysConfig /etc/sysconfig/network/dhcp DHCLIENT_SET_HOSTNAME yes
+
+# Enable firewalld
+chkconfig firewalld on
+
+# Set GRUB2 to boot graphically (bsc#1097428)
+sed -Ei"" "s/#?GRUB_TERMINAL=.+$/GRUB_TERMINAL=gfxterm/g" /etc/default/grub
+sed -Ei"" "s/#?GRUB_GFXMODE=.+$/GRUB_GFXMODE=auto/g" /etc/default/grub
+
+# Systemd controls the console font now
+echo FONT="$CONSOLE_FONT" >> /etc/vconsole.conf
+
+#======================================
+# SSL Certificates Configuration
+#--------------------------------------
+echo '** Rehashing SSL Certificates...'
+update-ca-certificates
+
+if [ ! -s /var/log/zypper.log ]; then
+	> /var/log/zypper.log
+fi
+
+# only for debugging
+#systemctl enable debug-shell.service
+
+baseCleanMount
+
+exit 0

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/config.xml
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/config.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="6.1" name="POS_Image_JeOS7_head">
+    <description type="system">
+        <author>Admin User</author>
+        <contact>noemail@example.com</contact>
+        <specification>SUSE Linux Enterprise 15 SP1 JeOS</specification>
+    </description>
+    <preferences>
+        <version>7.0.0</version>
+        <packagemanager>zypper</packagemanager>
+        <bootsplash-theme>SLE</bootsplash-theme>
+        <bootloader-theme>SLE</bootloader-theme>
+
+        <locale>en_US</locale>
+        <keytable>us.map.gz</keytable>
+        <timezone>Europe/Berlin</timezone>
+        <hwclock>utc</hwclock>
+
+        <rpm-excludedocs>true</rpm-excludedocs>
+        <type filesystem="ext3" image="pxe" initrd_system="dracut"/>
+    </preferences>
+
+    <drivers>
+      <file name="drivers/block/virtio_blk.ko" />
+    </drivers>
+
+    <!-- remove all the following repositories if you want to get their packages through SUSE Manager;
+         in that case, sync those repos in SUSE Manager, and add them to the activation key;
+         finally, re-enable option  '- -ignore-repos-used-for-build' in file 'kiwi-image-build.sls' -->
+    <repository type="rpm-md">  <!-- product -->
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP1/x86_64/product/"/>
+    </repository>
+    <repository type="rpm-md">
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP1/x86_64/update/"/>
+    </repository>
+    <repository type="rpm-md">  <!-- base system -->
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/"/>
+    </repository>
+    <repository type="rpm-md">
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP1/x86_64/update/"/>
+    </repository>
+    <repository type="rpm-md">  <!-- desktop applications -->
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Desktop-Applications/15-SP1/x86_64/product/"/>
+    </repository>
+    <repository type="rpm-md">
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Desktop-Applications/15-SP1/x86_64/update/"/>
+    </repository>
+    <repository type="rpm-md">  <!-- development tools -->
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Development-Tools/15-SP1/x86_64/product/"/>
+    </repository>
+    <repository type="rpm-md">
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Development-Tools/15-SP1/x86_64/update/"/>
+    </repository>
+    <repository type="rpm-md">  <!-- manager tools -->
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Manager-Tools/15/x86_64/product/"/>
+    </repository>
+    <repository type="rpm-md">
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update/"/>
+    </repository>
+    <repository type="rpm-md">  <!-- head development client toools -->
+        <source path="http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/SLE15-SUSE-Manager-Tools/SLE_15/"/>
+    </repository>
+
+    <packages type="image">
+        <package name="patterns-base-minimal_base"/>
+        <package name="aaa_base-extras"/>
+        <package name="acl"/>
+        <package name="chrony"/>
+        <package name="curl"/>
+        <package name="dracut"/>
+        <package name="fipscheck"/>
+        <package name="group(mail)"/>
+        <package name="group(wheel)"/>
+        <package name="grub2-branding-SLE" bootinclude="true"/>
+        <package name="iputils"/>
+        <package name="issue-generator"/>
+        <package name="zypper-lifecycle-plugin"/>
+        <package name="vim"/>
+        <package name="shim" arch="x86_64"/>
+        <package name="grub2"/>
+        <package name="grub2-x86_64-efi" arch="x86_64"/>
+        <package name="haveged"/>
+        <package name="less" />
+        <package name="tar"/>
+        <package name="parted"/>
+        <package name="SUSEConnect"/>
+        <package name="suse-build-key"/>
+        <package name="systemd"/>
+        <package name="systemd-sysvinit"/>
+        <package name="timezone"/>
+        <package name="wicked"/>
+        <package name="iproute2"/>
+        <package name="openssh"/>
+        <package name="rsync"/>
+
+        <package name="kernel-default"/>
+	<package name="salt-minion"/>
+
+	<package name="dracut-saltboot"/>
+        <package name="mdadm"/>
+        <package name="cryptsetup"/>
+        <package name="kernel-firmware"/>
+        <package name="kexec-tools"/>
+        <package name="plymouth"/>
+        <package name="plymouth-dracut"/>
+        <package name="plymouth-branding-SLE"/>
+        <package name="fontconfig"/>
+        <package name="fonts-config"/>
+        <package name="noto-sans-fonts"/>
+        <package name="wpa_supplicant"/>
+        <package name="busybox"/>
+        <package name="bind-utils"/>
+        <package name="kiwi-tools"/>
+        <package name="dosfstools"/>
+        <package name="xfsprogs"/>
+    </packages>
+    <users group="root">
+      <user home="/root" name="root" password="linux" pwdformat="plain" shell="/bin/bash"/>
+    </users>
+
+    <packages type="bootstrap">
+        <package name="udev"/>
+        <package name="filesystem"/>
+        <package name="glibc-locale-base"/>
+        <package name="ca-certificates-mozilla"/>
+        <package name="sles-release"/>
+        <package name="rhn-org-trusted-ssl-cert-osimage"/>
+    </packages>
+</image>

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/images.sh
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/images.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright (c) 2019-2020 SUSE LLC
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+test -f /.kconfig && . /.kconfig
+test -f /.profile && . /.profile
+
+systemctl enable salt-minion.service
+
+# notify SUSE Manager about newly deployed image
+systemctl enable image-deployed.service
+
+# install bootloader and generate boot menu
+systemctl enable install-local-bootloader.service

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/root/etc/multipath.conf
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/root/etc/multipath.conf
@@ -1,0 +1,4 @@
+# workaround for bsc#1069169
+defaults {
+  find_multipaths smart
+}

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/root/etc/sysconfig/bootloader
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/root/etc/sysconfig/bootloader
@@ -1,0 +1,34 @@
+
+## Path:	System/Bootloader
+## Description:	Bootloader configuration
+## Type:	list(grub,grub2,grub2-efi,none)
+## Default:	grub2
+#
+# Type of bootloader in use.
+# For making the change effect run bootloader configuration tool
+# and configure newly selected bootloader
+#
+#
+LOADER_TYPE="grub2"
+
+## Path:	System/Bootloader
+## Description:	Bootloader configuration
+## Type:	yesno
+## Default:	"no"
+#
+# Enable UEFI Secure Boot support
+# This setting is only relevant to UEFI which supports Secure Boot. It won't
+# take effect on any other firmware type.
+#
+#
+SECURE_BOOT="no"
+
+## Path:	System/Bootloader
+## Description:	Bootloader configuration
+## Type:	yesno
+## Default:	"no"
+#
+# Enable Trusted Boot support
+# Only available for legacy (non-UEFI) boot.
+#
+TRUSTED_BOOT="no"

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/root/etc/systemd/system/image-deployed.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Notify SUSE Manager about newly deployed image
+Requires=salt-minion.service
+After=salt-minion.service
+
+# only if there are no susemanager channels configured
+ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/salt-call event.send suse/manager/image_deployed with_grains=True
+
+[Install]
+WantedBy=multi-user.target

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/root/etc/systemd/system/install-local-bootloader.service
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/root/etc/systemd/system/install-local-bootloader.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Install bootloader for local boot
+
+# only if not configured yet
+ConditionPathExists=!/boot/grub2/grub.cfg
+
+[Service]
+Type=oneshot
+ExecStartPre=/bin/bash -c 'if [ -e /sys/firmware/efi ]; then sed -i -e "s|^LOADER_TYPE=.*|LOADER_TYPE=\\"grub2-efi\\"|" /etc/sysconfig/bootloader; fi'
+ExecStartPre=/bin/bash -c 'if [ ! -e /sys/firmware/efi ]; then sed -i -e "s|^LOADER_TYPE=.*|LOADER_TYPE=\\"grub2\\"|" /etc/sysconfig/bootloader; fi'
+ExecStart=/bin/bash -c 'pbl --install ; dracut -f ; pbl --config '
+
+[Install]
+WantedBy=multi-user.target

--- a/testsuite/features/secondary/min_osimage_build_image.feature
+++ b/testsuite/features/secondary/min_osimage_build_image.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2019 SUSE LLC
+# Copyright (c) 2018-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # This feature relies on having properly configured
@@ -25,7 +25,7 @@ Feature: Build OS images
     When I wait at most 3300 seconds until event "Image Build suse_os_image scheduled by kiwikiwi" is completed
     And I wait at most 300 seconds until event "Image Inspect 1//suse_os_image:latest scheduled by kiwikiwi" is completed
     And I navigate to "os-images/1/" page
-    Then I should see a "POS_Image_JeOS6_head" text
+    Then I should see the name of the image
 
 @proxy
 @private_net
@@ -34,7 +34,7 @@ Feature: Build OS images
     And I enable repositories before installing branch server
     And I synchronize all Salt dynamic modules on "proxy"
     And I apply state "image-sync" to "proxy"
-    Then the image "POS_Image_JeOS6_head" should exist on "proxy"
+    Then the image should exist on "proxy"
 
   Scenario: Cleanup: remove the image from SUSE Manager server
     Given I am authorized as "admin" with password "admin"

--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2019 SUSE LLC
+# Copyright (c) 2018-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # This feature depends on a JeOS image present on the proxy
@@ -214,7 +214,7 @@ Feature: PXE boot a Retail terminal
     And I press "Add Item" in partitions section
     And I enter "p2" in second partition id field
     And I enter "/" in second mount point field
-    And I enter "POS_Image_JeOS6_head" in second OS image field
+    And I enter the image name in second OS image field
     And I press "Add Item" in partitions section
     And I enter "p3" in third partition id field
     And I enter "/data" in third mount point field

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2019 SUSE LLC.
+# Copyright (c) 2014-2020 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'xmlrpc/client'
@@ -1160,7 +1160,8 @@ When(/^I prepare the retail configuration file on server$/) do
   sed_values << "s/<MINION>/#{ADDRESSES['minion']}/; "
   sed_values << "s/<MINION_MAC>/#{get_mac_address('sle_minion')}/; "
   sed_values << "s/<CLIENT>/#{ADDRESSES['client']}/; "
-  sed_values << "s/<CLIENT_MAC>/#{get_mac_address('sle_client')}/"
+  sed_values << "s/<CLIENT_MAC>/#{get_mac_address('sle_client')}/; "
+  sed_values << "s/<IMAGE>/#{compute_image_name}/"
   $server.run("sed -i '#{sed_values}' #{dest}")
 end
 

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2019 SUSE LLC.
+# Copyright (c) 2010-2020 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'jwt'
@@ -38,6 +38,10 @@ Then(/^I can see all system information for "([^"]*)"$/) do |host|
   # skip this test for centos and ubuntu systems
   puts 'i should see os version: ' + os_pretty if os_pretty.include? 'SUSE Linux'
   step %(I should see a "#{os_pretty}" text) if os_pretty.include? 'SUSE Linux'
+end
+
+Then(/^I should see the name of the image$/) do
+  step %(I should see a "#{compute_image_name}" text)
 end
 
 Then(/^I should see the terminals imported from the configuration file/) do
@@ -567,10 +571,10 @@ Then(/^I remove server hostname from hosts file on "([^"]*)"$/) do |host|
   node.run("sed -i \'s/#{$server.full_hostname}//\' /etc/hosts")
 end
 
-Then(/^the image "([^"]*)" should exist on "([^"]*)"$/) do |image, host|
+Then(/^the image should exist on "([^"]*)"$/) do |host|
   node = get_target(host)
   images, _code = node.run("ls /srv/saltboot/image/")
-  raise "Image #{image} does not exist on #{host}" unless images.include? image
+  raise "Image #{image} does not exist on #{host}" unless images.include? compute_image_name
 end
 
 # Repository steps

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2019 SUSE LLC.
+# Copyright (c) 2010-2020 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 #
@@ -820,6 +820,11 @@ end
 
 # Image-specific steps
 When(/^I enter "([^"]*)" relative to profiles as "([^"]*)"$/) do |path, field|
+  step %(I enter "#{$git_profiles}/#{path}" as "#{field}")
+end
+
+When(/^I enter the image filename relative to profiles as "([^"]*)"$/) do |field|
+  path = compute_image_filename
   step %(I enter "#{$git_profiles}/#{path}" as "#{field}")
 end
 

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -1,4 +1,4 @@
-# Copyright 2015-2019 SUSE LLC
+# Copyright 2015-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 require 'timeout'
@@ -469,6 +469,11 @@ end
 
 When(/^I enter the local network in (.*) field$/) do |field|
   fill_in FIELD_IDS[field], with: $private_net
+end
+
+When(/^I enter the image name in (.*) field$/) do |field|
+  name = compute_image_name
+  fill_in FIELD_IDS[field], with: name
 end
 
 When(/^I press "Add Item" in (.*) section$/) do |section|

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013-2019 SUSE LLC.
+# Copyright (c) 2013-2020 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'tempfile'
@@ -34,6 +34,29 @@ def read_server_domain_from_yaml
   name = File.dirname(__FILE__) + '/../upload_files/massive-import-terminals.yml'
   tree = YAML.load_file(name)
   tree['branches'].values[0]['server_domain']
+end
+
+# determine image for PXE boot tests
+def compute_image_filename
+  case ENV['PXEBOOT_IMAGE']
+  when nil
+    'Kiwi/POS_Image-JeOS6_head'
+  when 'sles15sp1'
+    'Kiwi/POS_Image-JeOS7_head'
+  else
+    'Kiwi/POS_Image-JeOS6_head'
+  end
+end
+
+def compute_image_name
+  case ENV['PXEBOOT_IMAGE']
+  when nil
+    'POS_Image_JeOS6_head'
+  when 'sles15sp1'
+    'POS_Image_JeOS7_head'
+  else
+    'POS_Image_JeOS6_head'
+  end
 end
 
 # get registration URL

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2019 SUSE LLC.
+# Copyright (c) 2016-2020 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'twopence'
@@ -10,7 +10,7 @@ warn 'Client IP address or domain name variable empty' if ENV['CLIENT'].nil?
 warn 'Minion IP address or domain name variable empty' if ENV['MINION'].nil?
 warn 'CentOS minion IP address or domain name variable empty' if ENV['CENTOSMINION'].nil?
 warn 'SSH minion IP address or domain name variable empty' if ENV['SSHMINION'].nil?
-warn 'PXE boot MAC address variable empty' if ENV['PXEBOOTMAC'].nil?
+warn 'PXE boot MAC address variable empty' if ENV['PXEBOOT_MAC'].nil?
 warn 'KVM server minion IP address or domain name variable empty' if ENV['VIRTHOST_KVM_URL'].nil?
 warn 'XEN server minion IP address or domain name variable empty' if ENV['VIRTHOST_XEN_URL'].nil?
 
@@ -132,7 +132,7 @@ end
 # Get MAC address of system
 def get_mac_address(host)
   if host == 'pxeboot_minion'
-    mac = ENV['PXEBOOTMAC']
+    mac = ENV['PXEBOOT_MAC']
   else
     node = get_target(host)
     output, _code = node.run('ip link show dev eth1')
@@ -174,7 +174,7 @@ end
 # Other global variables
 $product = product
 $sle15_minion = sle15family?($minion)
-$pxeboot_mac = ENV['PXEBOOTMAC']
+$pxeboot_mac = ENV['PXEBOOT_MAC']
 $private_net = ENV['PRIVATENET'] if ENV['PRIVATENET']
 $mirror = ENV['MIRROR']
 $git_profiles = ENV['GITPROFILES']

--- a/testsuite/features/upload_files/massive-import-terminals.yml
+++ b/testsuite/features/upload_files/massive-import-terminals.yml
@@ -70,7 +70,7 @@ hwtypes:
           disklabel: msdos
           partitions:
             p1:
-              image: POS_Image-JeOS6_head
+              image: <IMAGE>
               mountpoint: /
               size_MiB: 14000
             p2:


### PR DESCRIPTION
## What does this PR change?

This PR:
* renames environment variable `PXEBOOTMAC` to `PXEBOOT_MAC`
* does not mention anymore explicitely in the feature tests
   which OS image to build
* uses new variable `PXEBOOT_IMAGE` in implementation steps
   to decide which OS image to build 
* (uyuni branch only) adds Kiwi-NG files for SLE 15 SP1 client

## Links

Sumaform: uyuni-project/sumaform#669

Ports:
* 3.2: SUSE/spacewalk#10449
* 4.0: SUSE/spacewalk#10450

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
