### PR TITLE
Sle 15 ltss product classes

### DIFF
--- a/susemanager-sync-data/additional_products.json
+++ b/susemanager-sync-data/additional_products.json
@@ -8,11 +8,11 @@
         "release_type" : null,
         "arch" : "x86_64",
         "friendly_name" : "RHEL8 Base x86_64",
-        "product_class" : "SLE-M-T-BETA",
+        "product_class" : "SLE-M-T",
         "cpe" : null,
         "free" : false,
         "description" : null,
-        "release_stage" : "beta",
+        "release_stage" : "released",
         "eula_url" : "",
         "product_type" : "base",
         "offline_predecessor_ids" : [

--- a/susemanager-sync-data/channel_families.json
+++ b/susemanager-sync-data/channel_families.json
@@ -8,24 +8,12 @@
     "name" : "SUSE Linux Enterprise Real Time"
   },
   {
-    "label" : "18962",
-    "name" : "Novell ZENworks Configuration Management"
-  },
-  {
-    "label" : "20082",
-    "name" : "Novell Open Workgroup Suite - Small Business Edition"
-  },
-  {
     "label" : "7260",
     "name" : "SUSE Linux Enterprise Desktop"
   },
   {
     "label" : "7261",
     "name" : "SUSE Linux Enterprise Server"
-  },
-  {
-    "label" : "ATI",
-    "name" : "ATI"
   },
   {
     "label" : "AiO",
@@ -40,14 +28,6 @@
     "name" : "SUSE Container as a Service Platform x86_64"
   },
   {
-    "label" : "DSMP",
-    "name" : "Data Synchronizer Mobility Pack"
-  },
-  {
-    "label" : "HP-HWREF",
-    "name" : "SUSE Linux Enterprise Desktop HW Refresh 2011A"
-  },
-  {
     "label" : "HPC-ARM64",
     "name" : "SUSE Linux Enterprise High Performance Computing (ARM64)"
   },
@@ -56,32 +36,8 @@
     "name" : "SUSE Linux Enterprise High Performance Computing (x86)"
   },
   {
-    "label" : "JBEAP",
-    "name" : "Novell Support for JBoss"
-  },
-  {
-    "label" : "MEEGO-1",
-    "name" : "MEEGO"
-  },
-  {
     "label" : "MODULE",
     "name" : "SUSE Linux Enterprise Modules"
-  },
-  {
-    "label" : "MONO",
-    "name" : "SUSE Linux Enterprise Mono Extension"
-  },
-  {
-    "label" : "Moblin-2-Samsung",
-    "name" : "Moblin for Samsung"
-  },
-  {
-    "label" : "Moblin-2.1-MSI",
-    "name" : "Moblin for MSI"
-  },
-  {
-    "label" : "NAM-AGA",
-    "name" : "Novell Access Manager"
   },
   {
     "label" : "OES2",
@@ -128,10 +84,6 @@
     "name" : "SUSE Linux Enterprise High Availability Extension (Z-Series)"
   },
   {
-    "label" : "SLE-HAS",
-    "name" : "SUSE Linux Enterprise HA Server"
-  },
-  {
     "label" : "SLE-LP",
     "name" : "SUSE Linux Enterprise Live Patching"
   },
@@ -152,20 +104,12 @@
     "name" : "SUSE Linux Enterprise Software Development Kit"
   },
   {
-    "label" : "SLE-TC",
-    "name" : "SUSE Linux Enterprise Thin Client"
-  },
-  {
     "label" : "SLE-WE",
     "name" : "SUSE Linux Enterprise Workstation Extension"
   },
   {
     "label" : "SLES-ARM64",
     "name" : "SUSE Linux Enterprise Server (ARM64)"
-  },
-  {
-    "label" : "SLES-EC2",
-    "name" : "SUSE Linux Enterprise Server for Amazon EC2"
   },
   {
     "label" : "SLES-IA",
@@ -228,10 +172,6 @@
     "name" : "SUSE Linux Enterprise Subscription Management Tool"
   },
   {
-    "label" : "SLM",
-    "name" : "Novell Sentinel Log Manager"
-  },
-  {
     "label" : "SLMS",
     "name" : "SUSE Lifecycle Management Server"
   },
@@ -260,43 +200,11 @@
     "name" : "SUSE Studio Onsite"
   },
   {
-    "label" : "STUDIOONSITERUNNER",
-    "name" : "SUSE Studio OnSite Runner"
-  },
-  {
-    "label" : "SUSE",
-    "name" : "openSUSE"
-  },
-  {
     "label" : "SUSE_CLOUD",
     "name" : "SUSE Cloud"
   },
   {
-    "label" : "VMDP",
-    "name" : "SUSE Linux Enterprise Virtual Machine Driver Pack"
-  },
-  {
     "label" : "WEBYAST",
     "name" : "WebYaST for SUSE Linux Enterprise"
-  },
-  {
-    "label" : "WebYast-SLMS",
-    "name" : "WebYaST for SUSE Appliance Toolkit"
-  },
-  {
-    "label" : "ZLM7",
-    "name" : "ZENworks Linux Management"
-  },
-  {
-    "label" : "ZOS",
-    "name" : "ZENworks Orchestrator"
-  },
-  {
-    "label" : "jeos",
-    "name" : "Just enough OS"
-  },
-  {
-    "label" : "nVidia",
-    "name" : "nVidia"
   }
 ]

--- a/susemanager-sync-data/channel_families.json
+++ b/susemanager-sync-data/channel_families.json
@@ -60,8 +60,8 @@
     "name" : "SUSE Enterprise Storage"
   },
   {
-    "label" : "SES-ARM",
-    "name" : "SUSE Enterprise Storage (ARM64)"
+    "label" : "SES-ARM64",
+    "name" : "SUSE Enterprise Storage ARM64"
   },
   {
     "label" : "SLE-HAE-GEO",

--- a/susemanager-sync-data/channel_families.json
+++ b/susemanager-sync-data/channel_families.json
@@ -36,6 +36,10 @@
     "name" : "SUSE Linux Enterprise High Performance Computing (x86)"
   },
   {
+    "label" : "HPE-HELION-OPENSTACK-X86",
+    "name" : "HPE Helion Openstack (x86)"
+  },
+  {
     "label" : "MODULE",
     "name" : "SUSE Linux Enterprise Modules"
   },
@@ -62,6 +66,10 @@
   {
     "label" : "SES-ARM64",
     "name" : "SUSE Enterprise Storage ARM64"
+  },
+  {
+    "label" : "SLE-HAE-ARM64",
+    "name" : "SUSE Linux Enterprise High Availability Extension (ARM64)"
   },
   {
     "label" : "SLE-HAE-GEO",
@@ -148,6 +156,10 @@
     "name" : "SUSE Linux Enterprise Server LTSS 12 SP1 Z-Series"
   },
   {
+    "label" : "SLES12-SP2-LTSS-PPC",
+    "name" : "SUSE Linux Enterprise Server LTSS 12 SP2 PPC"
+  },
+  {
     "label" : "SLES12-SP2-LTSS-X86",
     "name" : "SUSE Linux Enterprise Server LTSS 12 SP2 x86_64"
   },
@@ -202,6 +214,14 @@
   {
     "label" : "SUSE_CLOUD",
     "name" : "SUSE Cloud"
+  },
+  {
+    "label" : "SUSE_CLOUD_CD",
+    "name" : "SUSE Cloud CD"
+  },
+  {
+    "label" : "SUSE_RT",
+    "name" : "SUSE Realtime"
   },
   {
     "label" : "WEBYAST",

--- a/susemanager-sync-data/channel_families.json
+++ b/susemanager-sync-data/channel_families.json
@@ -36,6 +36,14 @@
     "name" : "SUSE Linux Enterprise High Performance Computing (x86)"
   },
   {
+    "label" : "HPC15-LTSS-ARM64",
+    "name" : "SUSE Linux Enterprise High Performance Computing LTSS 15 ARM64"
+  },
+  {
+    "label" : "HPC15-LTSS-X86",
+    "name" : "SUSE Linux Enterprise High Performance Computing LTSS 15 x86_64"
+  },
+  {
     "label" : "HPE-HELION-OPENSTACK-X86",
     "name" : "HPE Helion Openstack (x86)"
   },
@@ -66,6 +74,14 @@
   {
     "label" : "SES-ARM64",
     "name" : "SUSE Enterprise Storage ARM64"
+  },
+  {
+    "label" : "SLE-ESPOS-ARM64",
+    "name" : "SUSE Linux Enterprise Extended Service Pack Overlap Support (ARM64)"
+  },
+  {
+    "label" : "SLE-ESPOS-X86",
+    "name" : "SUSE Linux Enterprise Extended Service Pack Overlap Support (x86)"
   },
   {
     "label" : "SLE-HAE-ARM64",
@@ -178,6 +194,22 @@
   {
     "label" : "SLES12-SP3-LTSS-Z",
     "name" : "SUSE Linux Enterprise Server LTSS 12 SP3 Z-Series"
+  },
+  {
+    "label" : "SLES15-LTSS-ARM64",
+    "name" : "SUSE Linux Enterprise Server LTSS 15 ARM64"
+  },
+  {
+    "label" : "SLES15-LTSS-PPC",
+    "name" : "SUSE Linux Enterprise Server LTSS 15 PPC"
+  },
+  {
+    "label" : "SLES15-LTSS-X86",
+    "name" : "SUSE Linux Enterprise Server LTSS 15 x86_64"
+  },
+  {
+    "label" : "SLES15-LTSS-Z",
+    "name" : "SUSE Linux Enterprise Server LTSS 15 Z-Series"
   },
   {
     "label" : "SLESMT",

--- a/susemanager-sync-data/channel_families.json
+++ b/susemanager-sync-data/channel_families.json
@@ -1,302 +1,302 @@
 [
-    {
-        "label": "SLE-HAE-PPC", 
-        "name": "SUSE Linux Enterprise High Availability Extension (PPC)"
-    }, 
-    {
-        "label": "HPC-X86", 
-        "name": "SUSE Linux Enterprise High Performance Computing (x86)"
-    }, 
-    {
-        "label": "10040", 
-        "name": "SUSE Linux Enterprise Point of Service"
-    }, 
-    {
-        "label": "RES", 
-        "name": "SUSE Linux Enterprise RedHat Expanded Support"
-    }, 
-    {
-        "label": "AiO-PPC", 
-        "name": "SUSE Linux Enterprise Server for SAP Power"
-    }, 
-    {
-        "label": "ATI", 
-        "name": "ATI"
-    }, 
-    {
-        "label": "SLE-M-T", 
-        "name": "SUSE Manager Tools"
-    }, 
-    {
-        "label": "SLE-TC", 
-        "name": "SUSE Linux Enterprise Thin Client"
-    }, 
-    {
-        "label": "SMRBS", 
-        "name": "SUSE Manager for Retail Branch Server"
-    }, 
-    {
-        "label": "SLE-LP-PPC", 
-        "name": "SUSE Linux Enterprise Live Patching PPC"
-    }, 
-    {
-        "label": "SUSE_CLOUD", 
-        "name": "SUSE Cloud"
-    }, 
-    {
-        "label": "SUSE", 
-        "name": "openSUSE"
-    }, 
-    {
-        "label": "OPENSUSE",
-        "name": "openSUSE Products"
-    },
-    {
-        "label": "SLES12-GA-LTSS-X86", 
-        "name": "SUSE Linux Enterprise Server 12 LTSS (x86)"
-    }, 
-    {
-        "label": "SLESMT", 
-        "name": "SUSE Linux Enterprise Subscription Management Tool"
-    }, 
-    {
-        "label": "NAM-AGA", 
-        "name": "Novell Access Manager"
-    }, 
-    {
-        "label": "SLES-Z", 
-        "name": "SUSE Linux Enterprise Server (Z-Series)"
-    }, 
-    {
-        "label": "STUDIOONSITE", 
-        "name": "SUSE Studio Onsite"
-    }, 
-    {
-        "label": "SLMS", 
-        "name": "SUSE Lifecycle Management Server"
-    }, 
-    {
-        "label": "DSMP", 
-        "name": "Data Synchronizer Mobility Pack"
-    }, 
-    {
-        "label": "SLES12-SP2-LTSS-Z", 
-        "name": "SUSE Linux Enterprise Server LTSS 12 SP2 Z-Series"
-    }, 
-    {
-        "label": "MONO", 
-        "name": "SUSE Linux Enterprise Mono Extension"
-    }, 
-    {
-        "label": "7261", 
-        "name": "SUSE Linux Enterprise Server"
-    }, 
-    {
-        "label": "7260", 
-        "name": "SUSE Linux Enterprise Desktop"
-    }, 
-    {
-        "label": "SES", 
-        "name": "SUSE Enterprise Storage"
-    }, 
-    {
-        "label": "VMDP", 
-        "name": "SUSE Linux Enterprise Virtual Machine Driver Pack"
-    }, 
-    {
-        "label": "SLE-HAS", 
-        "name": "SUSE Linux Enterprise HA Server"
-    }, 
-    {
-        "label": "SLE-SDK", 
-        "name": "SUSE Linux Enterprise Software Development Kit"
-    }, 
-    {
-        "label": "RES-HA", 
-        "name": "SUSE Linux Enterprise RedHat Expanded Support HA"
-    }, 
-    {
-        "label": "OES2", 
-        "name": "Novell Open Enterprise Server"
-    }, 
-    {
-        "label": "SLE-LP", 
-        "name": "SUSE Linux Enterprise Live Patching"
-    }, 
-    {
-        "label": "Moblin-2.1-MSI", 
-        "name": "Moblin for MSI"
-    }, 
-    {
-        "label": "SMS-Z", 
-        "name": "SUSE Manager Server System Z"
-    }, 
-    {
-        "label": "SLES-EC2", 
-        "name": "SUSE Linux Enterprise Server for Amazon EC2"
-    }, 
-    {
-        "label": "HP-HWREF", 
-        "name": "SUSE Linux Enterprise Desktop HW Refresh 2011A"
-    }, 
-    {
-        "label": "SLES-RPI-ARM64", 
-        "name": "SUSE Linux Enterprise Server (RPI ARM64)"
-    }, 
-    {
-        "label": "SLE-WE", 
-        "name": "SUSE Linux Enterprise Workstation Extension"
-    }, 
-    {
-        "label": "JBEAP", 
-        "name": "Novell Support for JBoss"
-    }, 
-    {
-        "label": "SLE-HAE-IA", 
-        "name": "SUSE Linux Enterprise High Availability Extension (Itanium)"
-    }, 
-    {
-        "label": "WEBYAST", 
-        "name": "WebYaST for SUSE Linux Enterprise"
-    }, 
-    {
-        "label": "WebYast-SLMS", 
-        "name": "WebYaST for SUSE Appliance Toolkit"
-    }, 
-    {
-        "label": "SLES12-GA-LTSS-Z", 
-        "name": "SUSE Linux Enterprise Server 12 LTSS (Z-Series)"
-    }, 
-    {
-        "label": "20082", 
-        "name": "Novell Open Workgroup Suite - Small Business Edition"
-    }, 
-    {
-        "label": "MODULE", 
-        "name": "SUSE Linux Enterprise Modules"
-    }, 
-    {
-        "label": "jeos", 
-        "name": "Just enough OS"
-    }, 
-    {
-        "label": "MEEGO-1", 
-        "name": "MEEGO"
-    }, 
-    {
-        "label": "SLM", 
-        "name": "Novell Sentinel Log Manager"
-    }, 
-    {
-        "label": "ZLM7", 
-        "name": "ZENworks Linux Management"
-    }, 
-    {
-        "label": "ZOS", 
-        "name": "ZENworks Orchestrator"
-    }, 
-    {
-        "label": "Moblin-2-Samsung", 
-        "name": "Moblin for Samsung"
-    }, 
-    {
-        "label": "nVidia", 
-        "name": "nVidia"
-    }, 
-    {
-        "label": "STUDIOONSITERUNNER", 
-        "name": "SUSE Studio OnSite Runner"
-    }, 
-    {
-        "label": "SMS-PPC", 
-        "name": "SUSE Manager Server PPC"
-    }, 
-    {
-        "label": "SMP", 
-        "name": "SUSE Manager Proxy"
-    }, 
-    {
-        "label": "SLES12-SP1-LTSS-Z", 
-        "name": "SUSE Linux Enterprise Server LTSS 12 SP1 Z-Series"
-    }, 
-    {
-        "label": "SLE-POS-AS-SMRBS-X86", 
-        "name": "SUSE Manager for Retail"
-    }, 
-    {
-        "label": "SLE-HAE-Z", 
-        "name": "SUSE Linux Enterprise High Availability Extension (Z-Series)"
-    }, 
-    {
-        "label": "SMS-X86", 
-        "name": "SUSE Manager Server X86-64"
-    }, 
-    {
-        "label": "SLES-X86-VMWARE", 
-        "name": "SUSE Linux Enterprise Server for VMware"
-    }, 
-    {
-        "label": "13319", 
-        "name": "SUSE Linux Enterprise Real Time"
-    }, 
-    {
-        "label": "HPC-ARM64", 
-        "name": "SUSE Linux Enterprise High Performance Computing (ARM64)"
-    }, 
-    {
-        "label": "SES-ARM", 
-        "name": "SUSE Enterprise Storage (ARM64)"
-    }, 
-    {
-        "label": "SLE-HAE-GEO", 
-        "name": "GEO Clustering for SLE HA Extension"
-    }, 
-    {
-        "label": "SLES-ARM64", 
-        "name": "SUSE Linux Enterprise Server (ARM64)"
-    }, 
-    {
-        "label": "18962", 
-        "name": "Novell ZENworks Configuration Management"
-    }, 
-    {
-        "label": "CAASP_X86", 
-        "name": "SUSE Container as a Service Platform x86_64"
-    }, 
-    {
-        "label": "SLE-HAE-X86", 
-        "name": "SUSE Linux Enterprise High Availability Extension (x86)"
-    }, 
-    {
-        "label": "AiO", 
-        "name": "SUSE Linux Enterprise Server for SAP"
-    }, 
-    {
-        "label": "SLES-IA", 
-        "name": "SUSE Linux Enterprise Server (Itanium)"
-    }, 
-    {
-        "label": "SLES-PPC", 
-        "name": "SUSE Linux Enterprise Server (PPC)"
-    }, 
-    {
-        "label": "SLES12-SP1-LTSS-X86", 
-        "name": "SUSE Linux Enterprise Server LTSS 12 SP1 x86_64"
-    }, 
-    {
-        "label": "SLES12-SP2-LTSS-X86", 
-        "name": "SUSE Linux Enterprise Server LTSS 12 SP2 x86_64"
-    },
-    {
-        "label": "SLES12-SP3-LTSS-X86",
-        "name": "SUSE Linux Enterprise Server LTSS 12 SP3 x86_64"
-    },
-    {
-        "label": "SLES12-SP3-LTSS-PPC",
-        "name": "SUSE Linux Enterprise Server LTSS 12 SP3 PPC"
-    },
-    {
-        "label": "SLES12-SP3-LTSS-Z",
-        "name": "SUSE Linux Enterprise Server LTSS 12 SP3 Z-Series"
-    }
+  {
+    "label" : "10040",
+    "name" : "SUSE Linux Enterprise Point of Service"
+  },
+  {
+    "label" : "13319",
+    "name" : "SUSE Linux Enterprise Real Time"
+  },
+  {
+    "label" : "18962",
+    "name" : "Novell ZENworks Configuration Management"
+  },
+  {
+    "label" : "20082",
+    "name" : "Novell Open Workgroup Suite - Small Business Edition"
+  },
+  {
+    "label" : "7260",
+    "name" : "SUSE Linux Enterprise Desktop"
+  },
+  {
+    "label" : "7261",
+    "name" : "SUSE Linux Enterprise Server"
+  },
+  {
+    "label" : "ATI",
+    "name" : "ATI"
+  },
+  {
+    "label" : "AiO",
+    "name" : "SUSE Linux Enterprise Server for SAP"
+  },
+  {
+    "label" : "AiO-PPC",
+    "name" : "SUSE Linux Enterprise Server for SAP Power"
+  },
+  {
+    "label" : "CAASP_X86",
+    "name" : "SUSE Container as a Service Platform x86_64"
+  },
+  {
+    "label" : "DSMP",
+    "name" : "Data Synchronizer Mobility Pack"
+  },
+  {
+    "label" : "HP-HWREF",
+    "name" : "SUSE Linux Enterprise Desktop HW Refresh 2011A"
+  },
+  {
+    "label" : "HPC-ARM64",
+    "name" : "SUSE Linux Enterprise High Performance Computing (ARM64)"
+  },
+  {
+    "label" : "HPC-X86",
+    "name" : "SUSE Linux Enterprise High Performance Computing (x86)"
+  },
+  {
+    "label" : "JBEAP",
+    "name" : "Novell Support for JBoss"
+  },
+  {
+    "label" : "MEEGO-1",
+    "name" : "MEEGO"
+  },
+  {
+    "label" : "MODULE",
+    "name" : "SUSE Linux Enterprise Modules"
+  },
+  {
+    "label" : "MONO",
+    "name" : "SUSE Linux Enterprise Mono Extension"
+  },
+  {
+    "label" : "Moblin-2-Samsung",
+    "name" : "Moblin for Samsung"
+  },
+  {
+    "label" : "Moblin-2.1-MSI",
+    "name" : "Moblin for MSI"
+  },
+  {
+    "label" : "NAM-AGA",
+    "name" : "Novell Access Manager"
+  },
+  {
+    "label" : "OES2",
+    "name" : "Novell Open Enterprise Server"
+  },
+  {
+    "label" : "OPENSUSE",
+    "name" : "openSUSE Products"
+  },
+  {
+    "label" : "RES",
+    "name" : "SUSE Linux Enterprise RedHat Expanded Support"
+  },
+  {
+    "label" : "RES-HA",
+    "name" : "SUSE Linux Enterprise RedHat Expanded Support HA"
+  },
+  {
+    "label" : "SES",
+    "name" : "SUSE Enterprise Storage"
+  },
+  {
+    "label" : "SES-ARM",
+    "name" : "SUSE Enterprise Storage (ARM64)"
+  },
+  {
+    "label" : "SLE-HAE-GEO",
+    "name" : "GEO Clustering for SLE HA Extension"
+  },
+  {
+    "label" : "SLE-HAE-IA",
+    "name" : "SUSE Linux Enterprise High Availability Extension (Itanium)"
+  },
+  {
+    "label" : "SLE-HAE-PPC",
+    "name" : "SUSE Linux Enterprise High Availability Extension (PPC)"
+  },
+  {
+    "label" : "SLE-HAE-X86",
+    "name" : "SUSE Linux Enterprise High Availability Extension (x86)"
+  },
+  {
+    "label" : "SLE-HAE-Z",
+    "name" : "SUSE Linux Enterprise High Availability Extension (Z-Series)"
+  },
+  {
+    "label" : "SLE-HAS",
+    "name" : "SUSE Linux Enterprise HA Server"
+  },
+  {
+    "label" : "SLE-LP",
+    "name" : "SUSE Linux Enterprise Live Patching"
+  },
+  {
+    "label" : "SLE-LP-PPC",
+    "name" : "SUSE Linux Enterprise Live Patching PPC"
+  },
+  {
+    "label" : "SLE-M-T",
+    "name" : "SUSE Manager Tools"
+  },
+  {
+    "label" : "SLE-POS-AS-SMRBS-X86",
+    "name" : "SUSE Manager for Retail"
+  },
+  {
+    "label" : "SLE-SDK",
+    "name" : "SUSE Linux Enterprise Software Development Kit"
+  },
+  {
+    "label" : "SLE-TC",
+    "name" : "SUSE Linux Enterprise Thin Client"
+  },
+  {
+    "label" : "SLE-WE",
+    "name" : "SUSE Linux Enterprise Workstation Extension"
+  },
+  {
+    "label" : "SLES-ARM64",
+    "name" : "SUSE Linux Enterprise Server (ARM64)"
+  },
+  {
+    "label" : "SLES-EC2",
+    "name" : "SUSE Linux Enterprise Server for Amazon EC2"
+  },
+  {
+    "label" : "SLES-IA",
+    "name" : "SUSE Linux Enterprise Server (Itanium)"
+  },
+  {
+    "label" : "SLES-PPC",
+    "name" : "SUSE Linux Enterprise Server (PPC)"
+  },
+  {
+    "label" : "SLES-RPI-ARM64",
+    "name" : "SUSE Linux Enterprise Server (RPI ARM64)"
+  },
+  {
+    "label" : "SLES-X86-VMWARE",
+    "name" : "SUSE Linux Enterprise Server for VMware"
+  },
+  {
+    "label" : "SLES-Z",
+    "name" : "SUSE Linux Enterprise Server (Z-Series)"
+  },
+  {
+    "label" : "SLES12-GA-LTSS-X86",
+    "name" : "SUSE Linux Enterprise Server 12 LTSS (x86)"
+  },
+  {
+    "label" : "SLES12-GA-LTSS-Z",
+    "name" : "SUSE Linux Enterprise Server 12 LTSS (Z-Series)"
+  },
+  {
+    "label" : "SLES12-SP1-LTSS-X86",
+    "name" : "SUSE Linux Enterprise Server LTSS 12 SP1 x86_64"
+  },
+  {
+    "label" : "SLES12-SP1-LTSS-Z",
+    "name" : "SUSE Linux Enterprise Server LTSS 12 SP1 Z-Series"
+  },
+  {
+    "label" : "SLES12-SP2-LTSS-X86",
+    "name" : "SUSE Linux Enterprise Server LTSS 12 SP2 x86_64"
+  },
+  {
+    "label" : "SLES12-SP2-LTSS-Z",
+    "name" : "SUSE Linux Enterprise Server LTSS 12 SP2 Z-Series"
+  },
+  {
+    "label" : "SLES12-SP3-LTSS-PPC",
+    "name" : "SUSE Linux Enterprise Server LTSS 12 SP3 PPC"
+  },
+  {
+    "label" : "SLES12-SP3-LTSS-X86",
+    "name" : "SUSE Linux Enterprise Server LTSS 12 SP3 x86_64"
+  },
+  {
+    "label" : "SLES12-SP3-LTSS-Z",
+    "name" : "SUSE Linux Enterprise Server LTSS 12 SP3 Z-Series"
+  },
+  {
+    "label" : "SLESMT",
+    "name" : "SUSE Linux Enterprise Subscription Management Tool"
+  },
+  {
+    "label" : "SLM",
+    "name" : "Novell Sentinel Log Manager"
+  },
+  {
+    "label" : "SLMS",
+    "name" : "SUSE Lifecycle Management Server"
+  },
+  {
+    "label" : "SMP",
+    "name" : "SUSE Manager Proxy"
+  },
+  {
+    "label" : "SMRBS",
+    "name" : "SUSE Manager for Retail Branch Server"
+  },
+  {
+    "label" : "SMS-PPC",
+    "name" : "SUSE Manager Server PPC"
+  },
+  {
+    "label" : "SMS-X86",
+    "name" : "SUSE Manager Server X86-64"
+  },
+  {
+    "label" : "SMS-Z",
+    "name" : "SUSE Manager Server System Z"
+  },
+  {
+    "label" : "STUDIOONSITE",
+    "name" : "SUSE Studio Onsite"
+  },
+  {
+    "label" : "STUDIOONSITERUNNER",
+    "name" : "SUSE Studio OnSite Runner"
+  },
+  {
+    "label" : "SUSE",
+    "name" : "openSUSE"
+  },
+  {
+    "label" : "SUSE_CLOUD",
+    "name" : "SUSE Cloud"
+  },
+  {
+    "label" : "VMDP",
+    "name" : "SUSE Linux Enterprise Virtual Machine Driver Pack"
+  },
+  {
+    "label" : "WEBYAST",
+    "name" : "WebYaST for SUSE Linux Enterprise"
+  },
+  {
+    "label" : "WebYast-SLMS",
+    "name" : "WebYaST for SUSE Appliance Toolkit"
+  },
+  {
+    "label" : "ZLM7",
+    "name" : "ZENworks Linux Management"
+  },
+  {
+    "label" : "ZOS",
+    "name" : "ZENworks Orchestrator"
+  },
+  {
+    "label" : "jeos",
+    "name" : "Just enough OS"
+  },
+  {
+    "label" : "nVidia",
+    "name" : "nVidia"
+  }
 ]

--- a/susemanager-sync-data/susemanager-sync-data.changes
+++ b/susemanager-sync-data/susemanager-sync-data.changes
@@ -1,3 +1,6 @@
+- add SLE 15 LTSS and ESPOS channel families (bsc#1160043)
+- add missing channel families for older products
+
 -------------------------------------------------------------------
 Wed Nov 27 17:08:56 CET 2019 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

SLE 15 GA got LTSS which introduce new product classes aka channel families which needs to be added to SUSE Manager. Now we generate the list which added some more missing classes and removed obsolete product classes.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/10457

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
