### PR TITLE
Matcher messages frontend fixes

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/subscriptionmatching/SubscriptionMatchProcessor.java
+++ b/java/code/src/com/suse/manager/webui/services/subscriptionmatching/SubscriptionMatchProcessor.java
@@ -140,7 +140,7 @@ public class SubscriptionMatchProcessor {
     private List<MessageJson> messages(InputJson input, OutputJson output) {
         return output.getMessages().stream()
                 .filter(m -> !m.getType().equals("unsatisfied_pinned_match"))
-                .map(m -> translateMessage(m, input)) .collect(toList());
+                .map(m -> new MessageJson(m.getType(), m.getData())) .collect(toList());
     }
 
     private Map<String, Subscription> subscriptions(OutputJson output) {
@@ -178,26 +178,6 @@ public class SubscriptionMatchProcessor {
                 -> matchedQuantity.put(sid, (cents + 100 - 1) / 100));
 
         return matchedQuantity;
-    }
-
-    private static MessageJson translateMessage(MessageJson message, InputJson input) {
-        if (message.getType().equals("unknown_part_number")) {
-            return new MessageJson("unknownPartNumber", new HashMap<String, String>() { {
-                put("partNumber", message.getData().get("part_number"));
-            } });
-        }
-        if (message.getType().equals("physical_guest")) {
-            return new MessageJson("physicalGuest", message.getData());
-        }
-        if (message.getType().equals("guest_with_unknown_host")) {
-            return new MessageJson("guestWithUnknownHost", message.getData());
-        }
-        if (message.getType().equals("unknown_cpu_count")) {
-            return new MessageJson("unknownCpuCount", message.getData());
-        }
-
-        // pass it through
-        return new MessageJson(message.getType(), message.getData());
     }
 
     private Map<String, Product> products(InputJson input, OutputJson output) {

--- a/java/code/src/com/suse/manager/webui/services/subscriptionmatching/test/SubscriptionMatchProcessorTest.java
+++ b/java/code/src/com/suse/manager/webui/services/subscriptionmatching/test/SubscriptionMatchProcessorTest.java
@@ -107,7 +107,7 @@ public class SubscriptionMatchProcessorTest extends BaseTestCaseWithUser {
         List<MessageJson> jsonMessages = ((MatcherUiData)
                 processor.getData(of(input), of(output))).getMessages();
         List<MessageJson> outputList = jsonMessages.stream()
-                .filter(m -> m.getType().equals("unknownCpuCount"))
+                .filter(m -> m.getType().equals("unknown_cpu_count"))
                 .collect(toList());
         assertEquals(1, outputList.size());
         assertEquals("1", outputList.get(0).getData().get("id"));

--- a/web/html/src/manager/audit/subscription-matching/subscription-matching-messages.js
+++ b/web/html/src/manager/audit/subscription-matching/subscription-matching-messages.js
@@ -19,19 +19,19 @@ const Messages = createReactClass({
       var message;
       var additionalInformation;
       switch(rawMessage["type"]) {
-        case "unknownPartNumber" :
+        case "unknown_part_number" :
           message = t("Unsupported part number detected");
-          additionalInformation = data["partNumber"];
+          additionalInformation = data["part_number"];
           break;
-        case "physicalGuest" :
+        case "physical_guest" :
           message = t("Physical system is reported as virtual guest, please check hardware data");
           additionalInformation = systems[data["id"]].name;
           break;
-        case "guestWithUnknownHost" :
+        case "guest_with_unknown_host" :
           message = t("Virtual guest has unknown host, assuming it is a physical system");
           additionalInformation = systems[data["id"]].name;
           break;
-        case "unknownCpuCount" :
+        case "unknown_cpu_count" :
           message = t("System has an unknown number of sockets, assuming 16");
           additionalInformation = systems[data["id"]].name;
           break;

--- a/web/html/src/manager/audit/subscription-matching/subscription-matching-messages.js
+++ b/web/html/src/manager/audit/subscription-matching/subscription-matching-messages.js
@@ -43,6 +43,12 @@ const Messages = createReactClass({
           message = t("Two subscriptions with the same part number (and other properties) have been merged together - start/end dates might be indicative");
           additionalInformation = data["part_number"];
           break;
+        case "adjust_pinned_match" :
+          message = t("Pinned match adjusted due to merged subscriptions");
+          additionalInformation = t("Subscription IDs") + ": " +
+              data["new_subscription_id"] + ", " + data["old_subscription_id"] + ", " +
+              t("System") + ": " + systems[data["system_id"]].name;
+          break;
         default:
           message = rawMessage["type"];
           // we do not know the shape of the data, it could even be a complex nested object (bsc#1125600)


### PR DESCRIPTION
## What does this PR change?

This upkeep PR revisits matcher messages handling in the UI:
- it removes unnecessary complexity and adds  
- it adds handling of the missing `adjust_pinned_match` message type

## GUI diff

TODO

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: it's only refactoring & bugfixing

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/8122

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
