### PR TITLE
SLE 15 SP1 clients batch 2

### DIFF
--- a/testsuite/documentation/optional.md
+++ b/testsuite/documentation/optional.md
@@ -140,17 +140,6 @@ Inside of the testsuite, the scenarios that are tagged with
 are executed only if the Ubuntu minion is available.
 
 
-### Testing with a SLE 15 system
-
-The test suite will determine automatically whether your minion
-is a SLE15 system or not.
-
-Inside of the testsuite, the scenarios that are tagged with
-```
-@sle15_minion
-```
-are executed only if the minion is a SLE 15 system.
-
 ### Testing Uyuni
 
 The test suite will determine automatically whether your server

--- a/testsuite/features/secondary/allcli_software_channels_dependencies.feature
+++ b/testsuite/features/secondary/allcli_software_channels_dependencies.feature
@@ -1,9 +1,8 @@
-# Copyright (c) 2019 SUSE LLC
+# Copyright (c) 2019-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Chanel subscription with recommended/required dependencies
 
-@sle15_minion
 @scc_credentials
   Scenario: Play with recommended and required child channels selection for a single system
     Given I am on the Systems overview page of this "sle_minion"
@@ -24,7 +23,6 @@ Feature: Chanel subscription with recommended/required dependencies
     When I click on the "disabled" toggler
     Then I should see the child channel "SLE-Module-Server-Applications15-Pool for x86_64" "selected"
 
-@sle15_minion
 @scc_credentials
   Scenario: Play with recommended and required child channels selection in SSM
     Given I am authorized as "admin" with password "admin"
@@ -46,6 +44,7 @@ Feature: Chanel subscription with recommended/required dependencies
     Then I should see "Subscribe" "selected" for the "SLE-Module-Basesystem15-Pool for x86_64" channel
     And I should see "No change" "unselected" for the "SLE-Module-Basesystem15-Pool for x86_64" channel
 
+@scc_credentials
   Scenario: Cleanup: remove remaining systems from SSM after software channel tests
     When I am authorized as "admin" with password "admin"
     And I follow "Clear"

--- a/testsuite/features/secondary/min_osimage_build_image.feature
+++ b/testsuite/features/secondary/min_osimage_build_image.feature
@@ -12,6 +12,11 @@
 @sle_minion
 Feature: Build OS images
 
+  # WORKAROUND
+  # Remove as soon as the issue is fixed
+  Scenario: Work around issue https://github.com/SUSE/spacewalk/issues/10360
+    When I let Kiwi build from external repositories
+
   Scenario: Login as Kiwi image administrator and build an image
     Given I am authorized as "kiwikiwi" with password "kiwikiwi"
     When I navigate to images build webpage

--- a/testsuite/features/secondary/trad_openscap_audit.feature
+++ b/testsuite/features/secondary/trad_openscap_audit.feature
@@ -1,30 +1,10 @@
-# Copyright (c) 2015-2018 SUSE LLC
+# Copyright (c) 2015-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: openSCAP audit of traditional client
   In order to audit a traditional client
   As an authorized user
   I want to run an openSCAP scan on it
-
-  Scenario: Schedule an audit job
-    Given I am on the Systems overview page of this "sle_client"
-    When I follow "Audit" in the content area
-    And I follow "Schedule" in the content area
-    And I enter "--profile RHEL6-Default" as "params"
-    And I enter "/usr/share/openscap/scap-rhel6-xccdf.xml" as "path"
-    And I click on "Schedule"
-    And I run "rhn_check -vvv" on "sle_client"
-    Then I should see a "XCCDF scan has been scheduled" text
-
-  Scenario: Check results of the audit job
-    Given I am on the Systems overview page of this "sle_client"
-    When I follow "Audit" in the content area
-    And I follow first "xccdf_org.open-scap_testresult_RHEL6-Default"
-    Then I should see a "Details of XCCDF Scan" text
-    And I should see a "RHEL6-Default" text
-    And I should see a "XCCDF Rule Results" text
-    And I should see a "CCE-" text
-    And I should see a "rule-" link
 
   Scenario: Schedule an audit job using the SUSE profile
     Given I am on the Systems overview page of this "sle_client"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1089,6 +1089,13 @@ When(/^I reduce virtpoller run interval on "([^"]*)"$/) do |host|
   node.run("systemctl restart salt-minion")
 end
 
+# WORKAROUND
+# Work around issue https://github.com/SUSE/spacewalk/issues/10360
+# Remove as soon as the issue is fixed
+When(/^I let Kiwi build from external repositories$/) do
+  $server.run("sed -i 's/--ignore-repos-used-for-build//' /usr/share/susemanager/salt/images/kiwi-image-build.sls")
+end
+
 When(/^I refresh packages list via spacecmd on "([^"]*)"$/) do |client|
   node = get_system_name(client)
   $server.run("spacecmd -u admin -p admin clear_caches")

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -149,6 +149,7 @@ When(/^I execute mgr\-sync refresh$/) do
 end
 
 When(/^I make sure no spacewalk\-repo\-sync is executing, excepted the ones needed to bootstrap$/) do
+  do_not_kill = compute_list_to_leave_running
   reposync_not_running_streak = 0
   reposync_left_running_streak = 0
   while reposync_not_running_streak <= 30 && reposync_left_running_streak <= 7200
@@ -160,18 +161,18 @@ When(/^I make sure no spacewalk\-repo\-sync is executing, excepted the ones need
       next
     end
     reposync_not_running_streak = 0
+
     process = command_output.split("\n")[0]
-    pid = process.split(' ')[0]
     channel = process.split(' ')[5]
-    # The following assumes the clients are SLE 12 SP4
-    if ['sles12-sp4-pool-x86_64', 'sle-manager-tools12-pool-x86_64-sp4', 'sle-module-containers12-pool-x86_64-sp4',
-        'sles12-sp4-updates-x86_64', 'sle-manager-tools12-updates-x86_64-sp4', 'sle-module-containers12-updates-x86_64-sp4'].include? channel
+    if do_not_kill.include? channel
       STDOUT.puts "Reposync of channel #{channel} left running" if (reposync_left_running_streak % 60).zero?
       reposync_left_running_streak += 1
       sleep 1
       next
     end
     reposync_left_running_streak = 0
+
+    pid = process.split(' ')[0]
     $server.run("kill #{pid}", false)
     STDOUT.puts "Reposync of channel #{channel} killed"
   end

--- a/testsuite/features/support/client_stack.rb
+++ b/testsuite/features/support/client_stack.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2019 SUSE LLC.
+# Copyright (c) 2010-2020 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'nokogiri'
@@ -84,10 +84,4 @@ end
 def sle11family?(node)
   _out, code = node.run('pidof systemd', false)
   code.nonzero?
-end
-
-def sle15family?(node)
-  os_version, os_family = get_os_version(node)
-  return false if os_version.nil? || os_family.nil?
-  (os_version =~ /^15/) && (os_family =~ /^sles/)
 end

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -173,7 +173,6 @@ end
 
 # Other global variables
 $product = product
-$sle15_minion = sle15family?($minion)
 $pxeboot_mac = ENV['PXEBOOT_MAC']
 $private_net = ENV['PRIVATENET'] if ENV['PRIVATENET']
 $mirror = ENV['MIRROR']

--- a/testsuite/features/upload_files/massive-import-terminals.yml
+++ b/testsuite/features/upload_files/massive-import-terminals.yml
@@ -16,50 +16,50 @@ branches:
     terminals:
       terminal1:
         IP: <NET_PREFIX>201
-        hwAddress: 01:02:03:04:05:01
+        hwAddress: "01:02:03:04:05:01"
         hwtype: Intel-Genuine
       terminal2:
         IP: <NET_PREFIX>202
-        hwAddress: 01:02:03:04:05:02
+        hwAddress: "01:02:03:04:05:02"
         hwtype: Intel-Genuine
       terminal3:
         IP: <NET_PREFIX>203
-        hwAddress: 01:02:03:04:05:03
+        hwAddress: "01:02:03:04:05:03"
         hwtype: Intel-Genuine
       terminal4:
         IP: <NET_PREFIX>204
-        hwAddress: 01:02:03:04:05:04
+        hwAddress: "01:02:03:04:05:04"
         hwtype: Intel-Genuine
       terminal5:
         IP: <NET_PREFIX>205
-        hwAddress: 01:02:03:04:05:05
+        hwAddress: "01:02:03:04:05:05"
         hwtype: Intel-Genuine
       terminal6:
         IP: <NET_PREFIX>206
-        hwAddress: 01:02:03:04:05:06
+        hwAddress: "01:02:03:04:05:06"
         hwtype: Intel-Genuine
       terminal7:
         IP: <NET_PREFIX>207
-        hwAddress: 01:02:03:04:05:07
+        hwAddress: "01:02:03:04:05:07"
         hwtype: Intel-Genuine
       terminal8:
         IP: <NET_PREFIX>208
-        hwAddress: 01:02:03:04:05:08
+        hwAddress: "01:02:03:04:05:08"
         hwtype: Intel-Genuine
       terminal9:
         IP: <NET_PREFIX>209
-        hwAddress: 01:02:03:04:05:09
+        hwAddress: "01:02:03:04:05:09"
         hwtype: Intel-Genuine
       pxeboot:
         IP: <NET_PREFIX><PXEBOOT>
-        hwAddress: <PXEBOOT_MAC>
+        hwAddress: "<PXEBOOT_MAC>"
         hwtype: Intel-Genuine
       client:
         IP: <NET_PREFIX><CLIENT>
-        hwAddress: <CLIENT_MAC>
+        hwAddress: "<CLIENT_MAC>"
       minion:
         IP: <NET_PREFIX><MINION>
-        hwAddress: <MINION_MAC>
+        hwAddress: "<MINION_MAC>"
 
 hwtypes:
   Intel-Genuine:

--- a/testsuite/run_sets/secondary_parallelizable.yml
+++ b/testsuite/run_sets/secondary_parallelizable.yml
@@ -38,7 +38,8 @@
 - features/secondary/allcli_system_group.feature
 - features/secondary/allcli_config_channel.feature
 - features/secondary/allcli_software_channels.feature
-- features/secondary/allcli_software_channels_dependencies.feature
+# tests to be rewritten using the "dummy" packages instead of real synced packages
+# - features/secondary/allcli_software_channels_dependencies.feature
 
 - features/secondary/minssh_centos_salt_install_package_and_patch.feature
 - features/secondary/minssh_salt_install_package.feature

--- a/testsuite/run_sets/testsuite.yml
+++ b/testsuite/run_sets/testsuite.yml
@@ -119,7 +119,8 @@
 - features/secondary/srv_patches_page.feature
 - features/secondary/srv_spacewalk_channel.feature
 - features/secondary/allcli_software_channels.feature
-- features/secondary/allcli_software_channels_dependencies.feature
+# tests to be rewritten using the "dummy" packages instead of real synced packages
+# - features/secondary/allcli_software_channels_dependencies.feature
 - features/secondary/srv_change_task_schedule.feature
 - features/secondary/srv_notifications.feature
 - features/secondary/min_empty_system_profiles.feature

--- a/testsuite/run_sets/uyuni.yml
+++ b/testsuite/run_sets/uyuni.yml
@@ -123,7 +123,8 @@
 - features/secondary/srv_spacewalk_channel.feature
 - features/secondary/srv_content_lifecycle.feature
 - features/secondary/allcli_software_channels.feature
-- features/secondary/allcli_software_channels_dependencies.feature
+# tests to be rewritten using the "dummy" packages instead of real synced packages
+# - features/secondary/allcli_software_channels_dependencies.feature
 - features/secondary/srv_change_task_schedule.feature
 - features/secondary/srv_notifications.feature
 - features/secondary/minkvm_guests.feature


### PR DESCRIPTION
## What does this PR change?

Various changes to support SLE 15 SP1 clients:
* Adapt "abort reposync" to more client types:
  The "abort all reposyncs" feature avoids aborting synchronization of directories that might serve as base repositories for minions. The code to do that was a) specific to SLE 12 SP4 b) assuming all minions use same OS c) not useful if the minions did not exist. The new code fixes all these 3 issues. To be noticed, this is only a safety net and it's much better not to start those reposyncs at all.
* Work around issue with Kiwi-NG:
   Kiwi-NG does not allow anymore to get the repositories used by the OS image directly. It assumes they are declared in an activation key and synchronized. This is not acceptable in the context of the test suite where we do not synchronize real repos. @nadvornik has been informed of the issue, in the meantime we will cheat to restore old behavior.
* `openscap-content` 1.3.0 contains less profiles:
  SLE 15 clients come with an `openscap-content` package without the RedHat profiles. Therefore we cannot test those profiles anymore. The corresponding tests have been removed, leaving only the SLES tests.
* Get rid of `@sle15_minion` tags:
   The test of the software channel dependencies feature was written for SLE 15 clients, but assumed synchronized repos. It has to be rewritten for our `dummy` packages which are the only ones we do synchronize. @ncounter has been informed, meanwhile this test has been disabled. When done, the test will work both on SLE 12 and on SLE 15. I take the occasion to remove the `@sle15_minion` conditional tag, which will take another meaning in the code to support QAM testing from @srbarrios .
* Make sure the MAC address is always a string
   In some circumstances (with 0.4 % probability 😸 ), a MAC address inside the massive import yaml file can be considered as integer instead of string. This last commit fixes the issue by adding quotes.

## Links

Ports:
* 3.2: SUSE/spacewalk#10459
* 4.0: SUSE/spacewalk#10458

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
