### PR TITLE
Reactivation key for salt

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -158,10 +158,13 @@ public class RegisterMinionEventMessageAction implements MessageAction {
                 Optional<String> managmentKeyLabel = getManagementKeyLabelFromGrains(grains);
                 if (managmentKeyLabel.isPresent()) {
                     ak = ActivationKeyFactory.lookupByKey(managmentKeyLabel.get());
-                    if (ak.getKickstartSession() != null) {
+                    if (ak != null && ak.getKickstartSession() != null) {
                         ak.getKickstartSession().markComplete("Installation completed.");
                     }
-                    if (ak.getServer() == null) {
+                    if (ak == null) {
+                        LOG.info("Outdated Management Key defined for " + minionId + ": " + managmentKeyLabel.get());
+                    }
+                    else if (ak.getServer() == null) {
                         LOG.error("Management Key is not a reactivation key: " + managmentKeyLabel.get());
                     }
                     else {

--- a/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
@@ -415,7 +415,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                              with(any(String.class)));
                     will(returnValue(Optional.of(pil)));
                 }},
-                (DEFAULT_CONTACT_METHOD) -> {
+                (contactMethod) -> {
                     return null;
                 },
                 (optMinion, machineId, key) -> {
@@ -458,7 +458,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                              with(any(String.class)));
                     will(returnValue(Optional.of(pil)));
                 }},
-                (DEFAULT_CONTACT_METHOD) -> {
+                (contactMethod) -> {
                     return null;
                 },
                 (optMinion, machineId, key) -> {
@@ -506,7 +506,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                              with(any(String.class)));
                     will(returnValue(Optional.of(pil)));
                 }},
-                (DEFAULT_CONTACT_METHOD) -> {
+                (contactMethod) -> {
                     ActivationKey key = ActivationKeyTest.createTestActivationKey(user);
                     key.setOrg(user.getOrg());
                     ActivationKeyFactory.save(key);
@@ -557,7 +557,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                              with(any(String.class)));
                     will(returnValue(Optional.of(pil)));
                 }},
-                (DEFAULT_CONTACT_METHOD) -> {
+                (contactMethod) -> {
                     ActivationKey key = ActivationKeyTest.createTestActivationKey(user);
                     key.setBaseChannel(baseChannelX8664);
                     key.setOrg(user.getOrg());
@@ -603,7 +603,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                     allowing(saltServiceMock).getGrains(MINION_ID);
                     will(returnValue(getGrains(MINION_ID, null, key)));
                 }},
-                (DEFAULT_CONTACT_METHOD) -> {
+                (contactMethod) -> {
                     ActivationKey key = ActivationKeyTest.createTestActivationKey(user);
                     key.setBaseChannel(baseChannelX8664);
                     baseChannelX8664.getAccessibleChildrenFor(user)
@@ -678,7 +678,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                         with(any(String.class)));
                 will(returnValue(Optional.of(pil)));
             }
-        }, (DEFAULT_CONTACT_METHOD) -> {
+        }, (contactMethod) -> {
             ActivationKey key = ActivationKeyTest.createTestActivationKey(user);
             key.setBaseChannel(null);
             // Channels unrelated to the product added as child channels in the
@@ -771,7 +771,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                             readFile("dummy_packages_redhatprodinfo_rhel.json")))));
 
                 }},
-                (DEFAULT_CONTACT_METHOD) -> {
+                (contactMethod) -> {
                     ActivationKey key = ActivationKeyTest.createTestActivationKey(user);
                     key.setBaseChannel(resChannel);
                     key.setOrg(user.getOrg());
@@ -821,7 +821,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                             readFile("dummy_packages_redhatprodinfo_rhel.json")))));
 
                 }},
-                (DEFAULT_CONTACT_METHOD) -> {
+                (contactMethod) -> {
                     ActivationKey key = ActivationKeyTest.createTestActivationKey(user);
                     key.setBaseChannel(resChannel_x86_64);
                     key.setOrg(user.getOrg());
@@ -1424,7 +1424,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                 allowing(saltServiceMock).getGrains(MINION_ID);
                 will(returnValue(getGrains(MINION_ID, null, key)));
             }
-        }, (DEFAULT_CONTACT_METHOD) -> {
+        }, (contactMethod) -> {
             ActivationKey key = ActivationKeyTest.createTestActivationKey(user);
             key.setBaseChannel(akBaseChannel);
             key.addChannel(akChildChannel);
@@ -1481,7 +1481,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                 allowing(saltServiceMock).getGrains(MINION_ID);
                 will(returnValue(getGrains(MINION_ID, null, key)));
             }
-        }, (DEFAULT_CONTACT_METHOD) -> {
+        }, (contactMethod) -> {
             ActivationKey key = ActivationKeyTest.createTestActivationKey(user);
             key.setBaseChannel(akBaseChannel);
             key.addChannel(akChildChannel);
@@ -1534,7 +1534,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                 allowing(saltServiceMock).getGrains(MINION_ID);
                 will(returnValue(getGrains(MINION_ID, null, key)));
             }
-        }, (DEFAULT_CONTACT_METHOD) -> null,
+        }, (contactMethod) -> null,
         (optMinion, machineId, key) -> {
             assertTrue(optMinion.isPresent());
             MinionServer minion = optMinion.get();
@@ -1575,7 +1575,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                     allowing(saltServiceMock).getGrains(MINION_ID);
                     will(returnValue(getGrains(MINION_ID, null, null, key)));
                 }},
-                (DEFAULT_CONTACT_METHOD) -> {
+                (contactMethod) -> {
                     ActivationKey key = ActivationKeyTest.createTestActivationKey(user);
                     // setting a server makes it a re-activation key
                     key.setServer(oldMinion);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- handle not found re-activation key (bsc#1159012)
 - write a list of formulas sorted by execution order (bsc#1083326)
 - change product_tree tag to reflect new product 4.1 and Beta phase
 - Use 'changes' field if 'pchanges' field doesn't exist (bsc#1159202)

--- a/schema/spacewalk/common/data/rhnServerGroupTypeFeature.sql
+++ b/schema/spacewalk/common/data/rhnServerGroupTypeFeature.sql
@@ -226,6 +226,11 @@ values (lookup_sg_type('salt_entitled'), lookup_feature_type('ftr_reboot'),
 
 insert into rhnServerGroupTypeFeature (server_group_type_id, feature_id,
                                        created, modified)
+values (lookup_sg_type('salt_entitled'), lookup_feature_type('ftr_agent_smith'),
+        current_timestamp,current_timestamp);
+
+insert into rhnServerGroupTypeFeature (server_group_type_id, feature_id,
+                                       created, modified)
 values (lookup_sg_type('salt_entitled'), lookup_feature_type('ftr_remote_command'),
         current_timestamp,current_timestamp);
 

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- enable re-activation keys for salt managed systems (bsc#1159012)
 - generate metadata with empty vendor (bsc#1158480)
 - Prevent SELECT INSTR error in Postgres logs every minute (bsc#1157034)
 - Fix rhnActionVirtDelete when migrating from 3.2 to 4.0 (bsc#1158178)

--- a/schema/spacewalk/upgrade/susemanager-schema-4.0.17-to-susemanager-schema-4.0.18/010_reactivation_keys_for_salt.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.0.17-to-susemanager-schema-4.0.18/010_reactivation_keys_for_salt.sql
@@ -1,0 +1,7 @@
+insert into rhnServerGroupTypeFeature (server_group_type_id, feature_id,
+                                       created, modified)
+select lookup_sg_type('salt_entitled'), lookup_feature_type('ftr_agent_smith'),
+        current_timestamp,current_timestamp from dual
+where not exists ( select 1 from rhnServerGroupTypeFeature
+    where server_group_type_id = lookup_sg_type('salt_entitled')
+      and feature_id = lookup_feature_type('ftr_agent_smith') );

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.1-to-susemanager-schema-4.1.2/010_reactivation_keys_for_salt.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.1-to-susemanager-schema-4.1.2/010_reactivation_keys_for_salt.sql
@@ -1,0 +1,7 @@
+insert into rhnServerGroupTypeFeature (server_group_type_id, feature_id,
+                                       created, modified)
+select lookup_sg_type('salt_entitled'), lookup_feature_type('ftr_agent_smith'),
+        current_timestamp,current_timestamp from dual
+where not exists ( select 1 from rhnServerGroupTypeFeature
+    where server_group_type_id = lookup_sg_type('salt_entitled')
+      and feature_id = lookup_feature_type('ftr_agent_smith') );


### PR DESCRIPTION
## What does this PR change?

Show re-activation key page in web ui and handle an already used one correctly during registration.

Port of https://github.com/SUSE/spacewalk/pull/10469

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
