### PR TITLE
Debuglog refresh

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/common/ManagerInfoFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/common/ManagerInfoFactory.java
@@ -62,8 +62,16 @@ public class ManagerInfoFactory extends HibernateFactory {
      * set last mgr-sync refresh to now
      */
     public static void setLastMgrSyncRefresh() {
+        setLastMgrSyncRefresh(System.currentTimeMillis());
+    }
+
+    /**
+     * set last mgr-sync refresh to the specified time
+     * @param milliseconds the time in milliseconds
+     */
+    public static void setLastMgrSyncRefresh(long milliseconds) {
         Map<String, Object> params = new HashMap<String, Object>();
-        params.put("lastrefresh", new Timestamp(System.currentTimeMillis()));
+        params.put("lastrefresh", new Timestamp(milliseconds));
 
         WriteMode m = ModeFactory.getWriteMode("util_queries",
                 getLastMgrSyncRefresh() == null ? "set_last_mgr_sync_refresh" : "update_last_mgr_sync_refresh");

--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -82,10 +82,12 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -613,8 +615,21 @@ public class ContentSyncManager {
             ContentSource cs = a.getContentSource();
             String overwriteUrl = contentSourceUrlOverwrite(a.getRepository(), a.getUrl(), mirrorUrl);
             if (!cs.getSourceUrl().equals(overwriteUrl)) {
+                log.debug("Source and overwrite urls differ: " + cs.getSourceUrl() + " != " + overwriteUrl);
                 return true;
             }
+        }
+        if (Config.get().getString(ContentSyncManager.RESOURCE_PATH, null) != null) {
+            log.debug("Syncing from dir");
+            Date modifiedCache = ManagerInfoFactory.getLastMgrSyncRefresh();
+            long hours24 = 24 * 60 * 60 * 1000;
+            Timestamp t = new Timestamp(System.currentTimeMillis() - hours24);
+            if (t.after(modifiedCache)) {
+                log.debug("Last sync more than 24 hours ago: " + modifiedCache.toString() +
+                        " (" + t.toString() + ")");
+                return true;
+            }
+            return false;
         }
         return SCCCachingFactory.refreshNeeded();
     }

--- a/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
@@ -1282,6 +1282,41 @@ public class ContentSyncManagerTest extends BaseTestCaseWithUser {
     }
 
     /**
+     * Tests {@link ContentSyncManager#isRefreshNeeded} when fromdir is configured
+     * @throws Exception if anything goes wrong
+     */
+    public void testIsRefreshNeededFromDir() throws Exception {
+        SUSEProductTestUtils.createVendorSUSEProductEnvironment(user, "/com/redhat/rhn/manager/content/test/smallBase", true, true);
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().clear();
+
+        // SLES12 GA
+        SUSEProductTestUtils.addChannelsForProduct(SUSEProductFactory.lookupByProductId(1117));
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().clear();
+
+        ContentSyncManager csm = new ContentSyncManager() {
+            @Override
+            protected boolean accessibleUrl(String url) {
+                return true;
+            }
+
+            @Override
+            protected boolean accessibleUrl(String url, String user, String password) {
+                return true;
+            }
+        };
+
+        assertFalse(csm.isRefreshNeeded(null));
+
+        // different mirror has no effect as you cannot overwrite fromdir option
+        assertFalse(csm.isRefreshNeeded("https://mirror.example.com/"));
+
+        ManagerInfoFactory.setLastMgrSyncRefresh(System.currentTimeMillis() - (48 * 60 * 60 * 1000));
+        assertTrue(csm.isRefreshNeeded(null));
+    }
+
+    /**
      * Test for {@link ContentSyncManager#addChannel}.
      * @throws Exception if anything goes wrong
      */

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- fix mgr-sync add channel when fromdir is configured (bsc#1160184)
 - handle not found re-activation key (bsc#1159012)
 - write a list of formulas sorted by execution order (bsc#1083326)
 - change product_tree tag to reflect new product 4.1 and Beta phase


### PR DESCRIPTION
## What does this PR change?

The detection of "isRefreshNeeded" does not work with fromdir when no credential is configured.

https://github.com/SUSE/spacewalk/pull/10464

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/10466
Tracks https://github.com/SUSE/spacewalk/pull/10464

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
