### PR TITLE
Fix idempotency of trad -> salt minion migration

### DIFF
--- a/testsuite/documentation/idempotency.md
+++ b/testsuite/documentation/idempotency.md
@@ -52,7 +52,7 @@ Typical workflow for patches test:
 
 Examples:
 
-Take a look at this feature: ``features/trad_check_patches_install.feature``
+Take a look at this feature: ``features/secondary/trad_check_patches_install.feature``
 
 
 ## Build host

--- a/testsuite/features/secondary/trad_migrate_to_minion.feature
+++ b/testsuite/features/secondary/trad_migrate_to_minion.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2019 SUSE LLC
+# Copyright (c) 2017-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Migrate a traditional client into a Salt minion
@@ -80,6 +80,10 @@ Feature: Migrate a traditional client into a Salt minion
     Then I should see a "Remote Command has been scheduled successfully" text
     When I wait until file "/tmp/remote-command-on-migrated-test" exists on "sle_migrated_minion"
     And I remove "/tmp/remote-command-on-migrated-test" from "sle_migrated_minion"
+
+  Scenario: Cleanup: remove packages from the migrated minion
+    When I remove package "perseus-dummy-1.1-1.1" from this "sle_migrated_minion"
+    And I remove package "orion-dummy-1.1-1.1" from this "sle_migrated_minion"
 
   Scenario: Cleanup: unregister migrated minion
     Given I am on the Systems overview page of this "sle_migrated_minion"

--- a/testsuite/features/secondary/trad_migrate_to_sshminion.feature
+++ b/testsuite/features/secondary/trad_migrate_to_sshminion.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 SUSE LLC
+# Copyright (c) 2019-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Migrate a traditional client into a Salt SSH minion
@@ -8,7 +8,7 @@ Feature: Migrate a traditional client into a Salt SSH minion
 
   Scenario: Install a package before migration to Salt SSH minion
     Given I am on the Systems overview page of this "sle_client"
-    And I follow "Software" in the content area
+    When I follow "Software" in the content area
     And I follow "Install"
     And I check "orion-dummy-1.1-1.1" in the list
     And I click on "Install Selected Packages"
@@ -103,7 +103,7 @@ Feature: Migrate a traditional client into a Salt SSH minion
     When I wait until file "/tmp/remote-command-on-migrated-test" exists on "sle_migrated_minion"
     And I remove "/tmp/remote-command-on-migrated-test" from "sle_migrated_minion"
 
-  Scenario: Cleanup: remove package from the migrated SSH minion
+  Scenario: Cleanup: remove packages from the migrated SSH minion
     When I remove package "perseus-dummy-1.1-1.1" from this "sle_migrated_minion"
     And I remove package "orion-dummy-1.1-1.1" from this "sle_migrated_minion"
 


### PR DESCRIPTION
## What does this PR change?

We have a failed salt event
```
"comment": "The following packages failed to install/update: perseus-dummy=1.1-1.1"
```
at the end of test suite. This package could probably not be installed because it was already there, due to a missing cleanup in previous feature.

This PR adds the missing cleanup scenario.

## Links

Ports:
* 3.2: SUSE/spacewalk#10524
* 4.0: SUSE/spacewalk#10523

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
