### PR TITLE
Virt test fixes

### DIFF
--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -168,35 +168,35 @@ Feature: Be able to manage KVM virtual machines via the GUI
     Then I should see a "Hosted Virtual Systems" text
     When I wait until I see "test-vm2" text
     And I wait until table row for "test-vm2" contains button "Stop"
-    And "test-vm2" virtual machine on "kvm-server" should have 1024MB memory and 1 vcpus
-    And "test-vm2" virtual machine on "kvm-server" should have 1 NIC using "test-net0" network
-    And "test-vm2" virtual machine on "kvm-server" should have a "test-vm2_system.qcow2" virtio disk
+    And "test-vm2" virtual machine on "kvm_server" should have 1024MB memory and 1 vcpus
+    And "test-vm2" virtual machine on "kvm_server" should have 1 NIC using "test-net0" network
+    And "test-vm2" virtual machine on "kvm_server" should have a "test-vm2_system.qcow2" virtio disk
 
 @virthost_kvm
   Scenario: Show the Spice graphical console for KVM
-    Given I am on the "Virtualization" page of this "kvm-server"
+    Given I am on the "Virtualization" page of this "kvm_server"
     When I click on "Graphical Console" in row "test-vm2"
     Then I wait until I see the spice graphical console
     And I close the window
 
 @virthost_kvm
   Scenario: Show the virtual storage pools and volumes for KVM
-    Given I am on the "Virtualization" page of this "kvm-server"
-    When I refresh the "test-pool0" storage pool of this "kvm-server"
+    Given I am on the "Virtualization" page of this "kvm_server"
+    When I refresh the "test-pool0" storage pool of this "kvm_server"
     When I follow "Storage"
     And I open the sub-list of the product "test-pool0"
     Then I wait until I see "test-vm2_system.qcow2" text
 
 @virthost_kvm
   Scenario: delete a running KVM virtual machine
-    Given I am on the "Virtualization" page of this "kvm-server"
+    Given I am on the "Virtualization" page of this "kvm_server"
     When I click on "Delete" in row "test-vm2"
     And I click on "Delete" in "Delete Guest" modal
-    Then I should not see a "test-vm2" virtual machine on "kvm-server"
+    Then I should not see a "test-vm2" virtual machine on "kvm_server"
 
 @virthost_kvm
   Scenario: Cleanup: Unregister the KVM virtualization host
-    Given I am on the Systems overview page of this "kvm-server"
+    Given I am on the Systems overview page of this "kvm_server"
     When I follow "Delete System"
     And I should see a "Confirm System Profile Deletion" text
     And I click on "Delete Profile"
@@ -204,19 +204,19 @@ Feature: Be able to manage KVM virtual machines via the GUI
 
 @virthost_kvm
   Scenario: Cleanup: Cleanup KVM virtualization host
-    When I run "zypper -n mr -e --all" on "kvm-server" without error control
-    And I run "zypper -n rr SUSE-Manager-Bootstrap" on "kvm-server" without error control
-    And I run "systemctl stop salt-minion" on "kvm-server" without error control
-    And I run "rm /etc/salt/minion.d/susemanager*" on "kvm-server" without error control
-    And I run "rm /etc/salt/minion.d/libvirt-events.conf" on "kvm-server" without error control
-    And I run "rm /etc/salt/pki/minion/minion_master.pub" on "kvm-server" without error control
+    When I run "zypper -n mr -e --all" on "kvm_server" without error control
+    And I run "zypper -n rr SUSE-Manager-Bootstrap" on "kvm_server" without error control
+    And I run "systemctl stop salt-minion" on "kvm_server" without error control
+    And I run "rm /etc/salt/minion.d/susemanager*" on "kvm_server" without error control
+    And I run "rm /etc/salt/minion.d/libvirt-events.conf" on "kvm_server" without error control
+    And I run "rm /etc/salt/pki/minion/minion_master.pub" on "kvm_server" without error control
     # In case the delete VM test failed we need to clean up ourselves.
-    And I run "virsh undefine --remove-all-storage test-vm" on "kvm-server" without error control
-    And I run "virsh destroy test-vm2" on "kvm-server" without error control
-    And I run "virsh undefine --remove-all-storage test-vm2" on "kvm-server" without error control
-    And I delete test-net0 virtual network on "kvm-server" without error control
-    And I delete test-net1 virtual network on "kvm-server" without error control
-    And I delete test-pool0 virtual storage pool on "kvm-server" without error control
-    And I delete all "test-vm.*" volumes from "test-pool0" pool on "kvm-server" without error control
+    And I run "virsh undefine --remove-all-storage test-vm" on "kvm_server" without error control
+    And I run "virsh destroy test-vm2" on "kvm_server" without error control
+    And I run "virsh undefine --remove-all-storage test-vm2" on "kvm_server" without error control
+    And I delete test-net0 virtual network on "kvm_server" without error control
+    And I delete test-net1 virtual network on "kvm_server" without error control
+    And I delete test-pool0 virtual storage pool on "kvm_server" without error control
+    And I delete all "test-vm.*" volumes from "test-pool0" pool on "kvm_server" without error control
     # Remove the virtpoller cache to avoid problems
-    And I run "rm /var/cache/virt_state.cache" on "kvm-server" without error control
+    And I run "rm /var/cache/virt_state.cache" on "kvm_server" without error control

--- a/testsuite/features/secondary/minxen_guests.feature
+++ b/testsuite/features/secondary/minxen_guests.feature
@@ -190,27 +190,27 @@ Feature: Be able to manage XEN virtual machines via the GUI
     Then I should see a "Hosted Virtual Systems" text
     When I wait until I see "test-vm3" text
     And I wait until table row for "test-vm3" contains button "Stop"
-    And "test-vm3" virtual machine on "xen-server" should have 1024MB memory and 1 vcpus
-    And "test-vm3" virtual machine on "xen-server" should have 1 NIC using "test-net0" network
-    And "test-vm3" virtual machine on "xen-server" should have a "test-vm3_system.qcow2" xen disk
+    And "test-vm3" virtual machine on "xen_server" should have 1024MB memory and 1 vcpus
+    And "test-vm3" virtual machine on "xen_server" should have 1 NIC using "test-net0" network
+    And "test-vm3" virtual machine on "xen_server" should have a "test-vm3_system.qcow2" xen disk
 
 @virthost_xen
   Scenario: Show the virtual storage pools and volumes for Xen
-    Given I am on the "Virtualization" page of this "xen-server"
+    Given I am on the "Virtualization" page of this "xen_server"
     When I follow "Storage"
     And I open the sub-list of the product "default"
     Then I wait until I see "test-vm2_system.qcow2" text
 
 @virthost_xen
   Scenario: delete a running Xen virtual machine
-    Given I am on the "Virtualization" page of this "xen-server"
+    Given I am on the "Virtualization" page of this "xen_server"
     When I click on "Delete" in row "test-vm3"
     And I click on "Delete" in "Delete Guest" modal
-    Then I should not see a "test-vm3" virtual machine on "xen-server"
+    Then I should not see a "test-vm3" virtual machine on "xen_server"
 
 @virthost_xen
   Scenario: Cleanup: Unregister the Xen virtualization host
-    Given I am on the Systems overview page of this "xen-server"
+    Given I am on the Systems overview page of this "xen_server"
     When I follow "Delete System"
     And I should see a "Confirm System Profile Deletion" text
     And I click on "Delete Profile"
@@ -218,21 +218,21 @@ Feature: Be able to manage XEN virtual machines via the GUI
 
 @virthost_xen
   Scenario: Cleanup: Cleanup Xen virtualization host
-    When I run "zypper -n mr -e --all" on "xen-server" without error control
-    And I run "zypper -n rr SUSE-Manager-Bootstrap" on "xen-server" without error control
-    And I run "systemctl stop salt-minion" on "xen-server" without error control
-    And I run "rm /etc/salt/minion.d/susemanager*" on "xen-server" without error control
-    And I run "rm /etc/salt/minion.d/libvirt-events.conf" on "xen-server" without error control
-    And I run "rm /etc/salt/pki/minion/minion_master.pub" on "xen-server" without error control
+    When I run "zypper -n mr -e --all" on "xen_server" without error control
+    And I run "zypper -n rr SUSE-Manager-Bootstrap" on "xen_server" without error control
+    And I run "systemctl stop salt-minion" on "xen_server" without error control
+    And I run "rm /etc/salt/minion.d/susemanager*" on "xen_server" without error control
+    And I run "rm /etc/salt/minion.d/libvirt-events.conf" on "xen_server" without error control
+    And I run "rm /etc/salt/pki/minion/minion_master.pub" on "xen_server" without error control
     # In case the delete VM test failed we need to clean up ourselves.
-    And I run "virsh undefine --remove-all-storage test-vm" on "xen-server" without error control
-    And I run "virsh destroy test-vm2" on "xen-server" without error control
-    And I run "virsh undefine --remove-all-storage test-vm2" on "xen-server" without error control
-    And I run "virsh destroy test-vm3" on "xen-server" without error control
-    And I run "virsh undefine --remove-all-storage test-vm3" on "xen-server" without error control
-    And I delete test-net0 virtual network on "xen-server" without error control
-    And I delete test-net1 virtual network on "xen-server" without error control
-    And I delete test-pool0 virtual storage pool on "xen-server" without error control
-    And I delete all "test-vm.*" volumes from "default" pool on "xen-server" without error control
+    And I run "virsh undefine --remove-all-storage test-vm" on "xen_server" without error control
+    And I run "virsh destroy test-vm2" on "xen_server" without error control
+    And I run "virsh undefine --remove-all-storage test-vm2" on "xen_server" without error control
+    And I run "virsh destroy test-vm3" on "xen_server" without error control
+    And I run "virsh undefine --remove-all-storage test-vm3" on "xen_server" without error control
+    And I delete test-net0 virtual network on "xen_server" without error control
+    And I delete test-net1 virtual network on "xen_server" without error control
+    And I delete test-pool0 virtual storage pool on "xen_server" without error control
+    And I delete all "test-vm.*" volumes from "default" pool on "xen_server" without error control
     # Remove the virtpoller cache to avoid problems
-    And I run "rm /var/cache/virt_state.cache" on "xen-server" without error control
+    And I run "rm /var/cache/virt_state.cache" on "xen_server" without error control

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -888,8 +888,8 @@ When(/^I create "([^"]*)" virtual machine on "([^"]*)"$/) do |vm_name, host|
   disk_path = "/tmp/#{vm_name}_disk.qcow2"
 
   # Create the throwable overlay image
-  raise 'not found: qemu-img or /var/testsuite-data/disk-image-template.qcow2' unless file_exists?(node, '/usr/bin/qemu-img') and file_exists?(node, '/var/testsuite-data/disk-image-template.qcow2')
-  node.run("qemu-img create -f qcow2 -b /var/testsuite-data/disk-image-template.qcow2 #{disk_path}")
+  raise '/var/testsuite-data/disk-image-template.qcow2 not found' unless file_exists?(node, '/var/testsuite-data/disk-image-template.qcow2')
+  node.run("cp /var/testsuite-data/disk-image-template.qcow2 #{disk_path}")
 
   # Actually define the VM, but don't start it
   raise 'not found: virt-install' unless file_exists?(node, '/usr/bin/virt-install')


### PR DESCRIPTION
## What does this PR change?

Brings several fixes for the KVM and Xen cucumber tests

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: test fixes

- [X] **DONE**

## Test coverage
- Cucumber tests were fixed

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
