### PR TITLE
Use HTTP proxy params when fetching mirrorlist from RPM repo on "spacewalk-repo-sync" (bsc1159076)

### DIFF
--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -475,7 +475,9 @@ class ContentSource:
         returnlist = []
         content = []
         try:
-            urlgrabber.urlgrab(url, mirrorlist_path)
+            urlgrabber_opts = {}
+            self.set_download_parameters(urlgrabber_opts, url, mirrorlist_path)
+            urlgrabber.urlgrab(url, mirrorlist_path, **urlgrabber_opts)
         except Exception as exc:
             # no mirror list found continue without
             return returnlist

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Use HTTP proxy settings when fetching the mirrorlist on spacewalk-repo-sync (bsc#1159076)
 - enhance suseProducts via ISS to fix SP migration on slave server (bsc#1159184)
 - generate metadata with empty vendor (bsc#1158480)
 - prevent a traceback when reposyncing openSUSE 15.1 (bsc#1158672)


### PR DESCRIPTION
## What does this PR change?

This PR fix `spacewalk-repo-sync` to use the HTTP proxy settings while fetching a possible "mirrorlist" from the repository to sync.

Before this PR, the HTTP proxy settings were not passed to the underlying `urlgrabber` call, so it might happen that, depending on network environment, the execution gets stuck until some timeout is triggered.

With this PR, all HTTP requests done from within the RPM plugin of `spacewalk-repo-sync` should take in care the HTTP proxy settings, and therefore prevent those stuck situations.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bufix**

- [x] **DONE**

## Test coverage
- No tests: **bugfix**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/10350
Fixes https://github.com/SUSE/spacewalk/issues/10376

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
