### PR TITLE
Handle case where credentials already exist

### DIFF
--- a/testsuite/features/secondary/srv_organization_credentials.feature
+++ b/testsuite/features/secondary/srv_organization_credentials.feature
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 SUSE LLC
+# Copyright 2017-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Organization credentials in the Setup Wizard
@@ -8,7 +8,6 @@ Feature: Organization credentials in the Setup Wizard
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Organization Credentials"
     And I enter the SCC credentials
-    And I click on "Save"
 
 @no_mirror
   Scenario: Create some organization credentials

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -997,6 +997,7 @@ When(/^I enter the SCC credentials$/) do
       When I want to add a new credential
       And I enter "#{scc_username}" as "edit-user"
       And I enter "#{scc_password}" as "edit-password"
+      And I click on "Save"
     )
   end
 end


### PR DESCRIPTION
## What does this PR change?

This PR handles better the case where credentials already exist by avoiding to press "Save" in that case.

## Links

Ports:
* 4.0: SUSE/spacewalk

No 3.2 branch.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
