### PR TITLE
orion-dummy is not on this minion

### DIFF
--- a/testsuite/features/secondary/trad_migrate_to_minion.feature
+++ b/testsuite/features/secondary/trad_migrate_to_minion.feature
@@ -81,9 +81,8 @@ Feature: Migrate a traditional client into a Salt minion
     When I wait until file "/tmp/remote-command-on-migrated-test" exists on "sle_migrated_minion"
     And I remove "/tmp/remote-command-on-migrated-test" from "sle_migrated_minion"
 
-  Scenario: Cleanup: remove packages from the migrated minion
+  Scenario: Cleanup: remove package from the migrated minion
     When I remove package "perseus-dummy-1.1-1.1" from this "sle_migrated_minion"
-    And I remove package "orion-dummy-1.1-1.1" from this "sle_migrated_minion"
 
   Scenario: Cleanup: unregister migrated minion
     Given I am on the Systems overview page of this "sle_migrated_minion"


### PR DESCRIPTION
## What does this PR change?

This PR corrects the copy and paste :blush: from last PR: on the normal minion, we only have one package to remove.

## Links

* 3.2: SUSE/spacewalk#10535
* 4.0: SUSE/spacewalk#10534

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
