### PR TITLE
Remove experimental feature

### DIFF
--- a/testsuite/features/secondary/minion_datacenter.feature
+++ b/testsuite/features/secondary/minion_datacenter.feature
@@ -1,8 +1,0 @@
-# Copyright (c) 2017 SUSE LLC
-# Licensed under the terms of the MIT license.
-
-Feature: SUSE Manager can handle a lot of minions
-
-  Scenario: Create dockerized minions
-  Given I am authorized as "admin" with password "admin"
-  Then I create dockerized minions


### PR DESCRIPTION
## What does this PR change?

We continue the cleanup: this PR removes an experimental feature test that has never been run in production.

## Links

Ports:
* 3.2: SUSE/spacewalk#10537
* 4.0: SUSE/spacewalk#10536

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
