### PR TITLE
Always test the SCC credentials

### DIFF
--- a/testsuite/features/secondary/srv_organization_credentials.feature
+++ b/testsuite/features/secondary/srv_organization_credentials.feature
@@ -8,6 +8,7 @@ Feature: Organization credentials in the Setup Wizard
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Organization Credentials"
     And I enter the SCC credentials
+    And I click on "Save"
 
 @no_mirror
   Scenario: Create some organization credentials

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -992,14 +992,11 @@ end
 When(/^I enter the SCC credentials$/) do
   scc_username = ENV['SCC_CREDENTIALS'].split('|')[0]
   scc_password = ENV['SCC_CREDENTIALS'].split('|')[1]
-  unless has_content?(scc_username)
-    steps %(
-      When I want to add a new credential
-      And I enter "#{scc_username}" as "edit-user"
-      And I enter "#{scc_password}" as "edit-password"
-      And I click on "Save"
-    )
-  end
+  steps %(
+    When I want to add a new credential
+    And I enter "#{scc_username}" as "edit-user"
+    And I enter "#{scc_password}" as "edit-password"
+  )
 end
 
 When(/^I enter the MU repository for (salt|traditional) "([^"]*)" as URL$/) do |client_type, client|


### PR DESCRIPTION
Always test the SCC credentials, even if they are already entered

Previously this test was always green, but never done for real, because it would give up if they existed previously.

## Links

Ports:
* 4.0: SUSE/spacewalk#10541

No 3.2 branch

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
