### PR TITLE
Don't add "/" to the repo url when getting repo url (bsc#1158899)

### DIFF
--- a/backend/satellite_tools/repo_plugins/deb_src.py
+++ b/backend/satellite_tools/repo_plugins/deb_src.py
@@ -149,7 +149,7 @@ class DebRepo(object):
         for extension in FORMAT_PRIORITY:
             (scheme, netloc, path, query, fragid) = urlparse.urlsplit(self.url)
             url = urlparse.urlunsplit((scheme, netloc,
-                                       path + '/Packages' + extension, query, fragid))
+                                       path + ('/' if not path.endswith('/') else '') + 'Packages' + extension, query, fragid))
             filename = self._download(url)
             if filename:
                 if query:

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- When downloading repo metadata, don't add "/" to the repo url if it already ends with one (bsc#1158899)
 - Use HTTP proxy settings when fetching the mirrorlist on spacewalk-repo-sync (bsc#1159076)
 - enhance suseProducts via ISS to fix SP migration on slave server (bsc#1159184)
 - generate metadata with empty vendor (bsc#1158480)


### PR DESCRIPTION
## What does this PR change?

When downloading repo metadata, don't add "/" to the repo url if it already ends with it.
Some web servers don't handle double / well. E.g.

https://download.docker.com/linux/ubuntu/dists/bionic/stable/binary-amd64/Packages.gz. works but
https://download.docker.com/linux/ubuntu/dists/bionic/stable/binary-amd64//Packages.gz doesn't.

## GUI diff

No difference.

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
- No tests: simple fix

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/10307
Tracks https://github.com/SUSE/spacewalk/pull/10423

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
