### PR TITLE
Manager bsc1154590

### DIFF
--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- fix documentation URL in installer (bsc#1154590)
 - fix product id of SLES12 SP5 x86_64 and remove never released
   SLED product (bsc#1158963)
 - Allow creating bootstrap repositories for CentoS8 (bsc#1159206)

--- a/susemanager/yast/susemanager_congratulate.rb
+++ b/susemanager/yast/susemanager_congratulate.rb
@@ -17,7 +17,7 @@ module Yast
       @migration_file = Ops.add(Directory.tmpdir, "/susemanager_migration")
       @migration = FileUtils.Exists(@migration_file)
       @product_name = SCR.Read(path(".usr_share_rhn_config_defaults_rhn.product_name")) || "SUSE Manager"
-      @product_doc_url = "https://www.suse.com/documentation/suse-manager/"
+      @product_doc_url = "https://documentation.suse.com/suma"
       if @product_name == "Uyuni"
           @product_doc_url = "https://www.uyuni-project.org/"
       end
@@ -34,7 +34,7 @@ module Yast
               _(
                 "<p>#{@product_name} Setup is now complete.</p><br>\n" +
                   "<p>Visit <b>https://%1</b> to create the #{@product_name} administrator account.</p>\n" +
-                  "<p>For more information, refer to the #{@product_name} Installation and Troubleshooting guide or see <b>#{@product_doc_url}</b>.</p>"
+                  "<p>For more information, refer to the #{@product_name} Installation Guide or see <b>#{@product_doc_url}</b>.</p>"
               ),
               Hostname.CurrentFQ
             )


### PR DESCRIPTION
## What does this PR change?

After installing SUSE Manager, the UI is printing a screen telling the user where to find documentation. This was still using the old URL and title. This PR fixes this.

## GUI diff

Before:
"For more information, refer to the SUSE Manager Installation and Troubleshooting guide or see https://www.suse.com/documentation/suse-manager/"

After:
"For more information, refer to the SUSE Manager Installation Guide or see https://documentation.suse.com/suma"

The URL will auto-redirect to "https://documentation.suse.com/suma/4.0/", so use the generic URL

- [X] **DONE**

## Documentation
- No documentation needed: Fix is part of documentation

- [X] **DONE**

## Test coverage
- No tests: Interactive installer is not autotested

- [X] **DONE**

## Links

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1154590

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
