### PR TITLE
Ivy: force https for repo1.maven.org

### DIFF
--- a/java/buildconf/ivy/ivyconf.xml
+++ b/java/buildconf/ivy/ivyconf.xml
@@ -4,7 +4,7 @@
     <filesystem name="suse" m2compatible="true" local="true">
       <artifact pattern="${ivy.conf.dir}/repository/[organization]/[artifact]/[revision]/[artifact]-[revision].[ext]" />
     </filesystem>
-    <ibiblio name="central" m2compatible="true"/>
+    <ibiblio name="central" m2compatible="true" root="https://repo1.maven.org/maven2/"/>
   </resolvers>
   <modules>
     <module organisation="suse" name="*" resolver="suse"/>


### PR DESCRIPTION
## What does this PR change?

Try to force httpS for maven repos.

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
