### PR TITLE
check for all handled macros

### DIFF
--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -425,13 +425,13 @@ xargs checkstyle -c buildconf/checkstyle.xml
 
 # catch macro name errors
 find . -type f -name '*.xml' | xargs perl -CSAD -lne '
-          for (grep { $_ ne "PRODUCT_NAME" } /\@\@(\w+)\@\@/g) {
+          for (grep { $_ ne "PRODUCT_NAME" && $_ ne "VENDOR_NAME" && $_ ne "ENTERPRISE_LINUX_NAME" && $_ ne "VENDOR_SERVICE_NAME" } /\@\@(\w+)\@\@/g) {
               print;
               $exit = 1;
           }
-          @r = /((..)?PRODUCT_NAME(..)?)/g ;
+          @r = /((..)?(PRODUCT_NAME|VENDOR_NAME|ENTERPRISE_LINUX_NAME|VENDOR_SERVICE_NAME)(..)?)/g ;
           while (@r) {
-              $s = shift(@r); $f = shift(@r); $l = shift(@r);
+              $s = shift(@r); $f = shift(@r); $skip = shift(@r); $l = shift(@r);
               if ($f ne "@@" or $l ne "@@") {
                   print $s;
                   $exit = 1;


### PR DESCRIPTION
## What does this PR change?

Fix package building as the macro test failed. We support more macros as we test for.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **already covered**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
