### PR TITLE
Fix image store form credentials validation

### DIFF
--- a/web/html/src/components/input/InputBase.js
+++ b/web/html/src/components/input/InputBase.js
@@ -85,6 +85,15 @@ export class InputBase extends React.Component<Props, State> {
     }
   }
 
+  componentDidUpdate(prevProps) {
+    // Support validation when changing the following props on-the-fly
+    if (this.props.required !== prevProps.required ||
+        this.props.disabled !== prevProps.disabled ||
+        this.props.validators !== prevProps.validators) {
+      this.validate(this.context.model[this.props.name]);
+    }
+  }
+
   componentWillUnmount() {
     if (Object.keys(this.context).length > 0) {
       this.context.unregisterInput(this);


### PR DESCRIPTION
Triggers validation when enabling "Use credentials" checkbox.

## Documentation
- No documentation needed: Bugfix

## Test coverage
- Covered by Cucumber tests

## Links

Fixes partly https://github.com/SUSE/spacewalk/issues/10538

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
