### PR TITLE
Typo in CentOS 7 Software Collection

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -301,12 +301,12 @@ name     = CentOS 7 RT (%(arch)s)
 base_channels = centos7-%(arch)s
 repo_url = http://mirror.centos.org/centos-7/7/rt/%(arch)s
 
-[centos7-scio]
-label    = %(base_channel)s-scio
+[centos7-sclo]
+label    = %(base_channel)s-sclo
 archs    = x86_64
-name     = CentOS 7 Scio (%(arch)s)
+name     = CentOS 7 Sclo (%(arch)s)
 base_channels = centos7-%(arch)s
-repo_url = http://mirror.centos.org/centos-7/7/scio/%(arch)s
+repo_url = http://mirror.centos.org/centos-7/7/sclo/%(arch)s
 
 [centos7-storage]
 label    = %(base_channel)s-storage


### PR DESCRIPTION
## What does this PR change?

Just fixed a minor typo:
centos7-scio should be centos7-sclo

