### PR TITLE
spacewalk-search: Require log4j12 for SLE15SP2 and openSUSE Leap 15.2

### DIFF
--- a/search-server/spacewalk-search/buildconf/build-props.xml
+++ b/search-server/spacewalk-search/buildconf/build-props.xml
@@ -1,14 +1,14 @@
 <project name="build-props">
 
-  <condition property="log4j" value="log4j-1" else="log4j">
-    <available file="/usr/share/java/log4j-1.jar" />
-  </condition>
+  <available file="/usr/share/java/log4j-1.jar" type="file" property="log4j-jars" value="log4j-1" />
+  <available file="/usr/share/java/log4j12/log4j-12.jar" type="file" property="log4j-jars" value="log4j12/log4j-12" />
+  <available file="/usr/share/java/log4j.jar" type="file" property="log4j-jars" value="log4j" />
 
   <property name="ivy.settings.file" value="buildconf/ivyconf.xml" />
 
   <property name="jpackage.jars"
       value="c3p0 cglib commons-cli commons-codec commons-httpclient commons-lang3
-             commons-logging ${log4j} objectweb-asm/asm oro
+             commons-logging ${log4j-jars} objectweb-asm/asm oro
              quartz redstone-xmlrpc redstone-xmlrpc-client simple-core
              slf4j/api slf4j/simple junit nutch-core hadoop picocontainer
              lucene lucene-analyzers lucene-misc mybatis" />

--- a/search-server/spacewalk-search/spacewalk-search.changes
+++ b/search-server/spacewalk-search/spacewalk-search.changes
@@ -1,3 +1,5 @@
+- Require log4j12 for SLE15SP2 and openSUSE Leap 15.2
+
 -------------------------------------------------------------------
 Wed Nov 27 16:49:11 CET 2019 - jgonzalez@suse.com
 

--- a/search-server/spacewalk-search/spacewalk-search.spec
+++ b/search-server/spacewalk-search/spacewalk-search.spec
@@ -88,7 +88,7 @@ Obsoletes:      rhn-search < 5.3.0
 %if 0%{?fedora} || 0%{?rhel} >=7
 Requires:       mchange-commons
 %endif
-%if 0%{?fedora} >= 21
+%if 0%{?fedora} >= 21 || 0%{?sle_version} >= 150200
 Requires:       log4j12
 BuildRequires:  log4j12
 %else


### PR DESCRIPTION
## What does this PR change?

spacewalk-search: Require log4j12 for SLE15SP2 and openSUSE Leap 15.2

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Not needed. Dependencies.

- [x] **DONE**

## Test coverage
- No tests: Covered by media setup test.

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
