### PR TITLE
Log4j12 for spacewalk search

### DIFF
--- a/search-server/spacewalk-search/buildconf/build-props.xml
+++ b/search-server/spacewalk-search/buildconf/build-props.xml
@@ -1,8 +1,8 @@
 <project name="build-props">
 
-  <condition property="log4j" value="log4j-1" else="log4j">
-    <available file="/usr/share/java/log4j-1.jar" />
-  </condition>
+  <available file="/usr/share/java/log4j-1.jar" type="file" property="log4j-jars" value="log4j-1" />
+  <available file="/usr/share/java/log4j12/log4j-12.jar" type="file" property="log4j" value="log4j12/log4j-12" />
+  <available file="/usr/share/java/log4j.jar" type="file" property="log4j-jars" value="log4j" />
 
   <property name="ivy.settings.file" value="buildconf/ivyconf.xml" />
 

--- a/search-server/spacewalk-search/spacewalk-search.changes
+++ b/search-server/spacewalk-search/spacewalk-search.changes
@@ -1,3 +1,5 @@
+- change dependency to log4j12 on newer systems
+
 -------------------------------------------------------------------
 Wed Nov 27 16:49:11 CET 2019 - jgonzalez@suse.com
 

--- a/search-server/spacewalk-search/spacewalk-search.spec
+++ b/search-server/spacewalk-search/spacewalk-search.spec
@@ -88,7 +88,7 @@ Obsoletes:      rhn-search < 5.3.0
 %if 0%{?fedora} || 0%{?rhel} >=7
 Requires:       mchange-commons
 %endif
-%if 0%{?fedora} >= 21
+%if 0%{?fedora} >= 21 || %{?sle_version} > 150100
 Requires:       log4j12
 BuildRequires:  log4j12
 %else


### PR DESCRIPTION
## What does this PR change?

spacewalk-search should also use log4j12

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **fix installation**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
