### PR TITLE
Add react-html-parser lib and use it in the menu

### DIFF
--- a/susemanager-frontend/susemanager-nodejs-sdk-devel/package.json
+++ b/susemanager-frontend/susemanager-nodejs-sdk-devel/package.json
@@ -56,6 +56,7 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-hot-loader": "^4.12.9",
+    "react-html-parser": "^2.0.2",
     "react-select": "^3.0.8",
     "senna": "^2.7.8",
     "toastr": "^2.1.4",

--- a/susemanager-frontend/yarn.lock
+++ b/susemanager-frontend/yarn.lock
@@ -5804,7 +5804,7 @@ html-webpack-plugin@^4.0.0-beta.2:
     tapable "^1.1.3"
     util.promisify "1.0.0"
 
-htmlparser2@^3.3.0:
+htmlparser2@^3.3.0, htmlparser2@^3.9.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.1.tgz#bd679dc3f59897b6a34bb10749c855bb53a9392f"
   integrity sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==
@@ -7282,7 +7282,7 @@ lodash.uniq@4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
+lodash@4.17.15, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -9093,6 +9093,13 @@ react-hotkeys@2.0.0-pre4:
   integrity sha512-oa+UncSWyOwMK3GExt+oELXaR7T3ItgcMolsupQFdKvwkEhVAluJd5rYczsRSQpQlVkdNoHG46De2NUeuS+88Q==
   dependencies:
     prop-types "^15.6.1"
+
+react-html-parser@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/react-html-parser/-/react-html-parser-2.0.2.tgz#6dbe1ddd2cebc1b34ca15215158021db5fc5685e"
+  integrity sha512-XeerLwCVjTs3njZcgCOeDUqLgNIt/t+6Jgi5/qPsO/krUWl76kWKXMeVs2LhY2gwM6X378DkhLjur0zUQdpz0g==
+  dependencies:
+    htmlparser2 "^3.9.0"
 
 react-input-autosize@^2.2.2:
   version "2.2.2"

--- a/web/html/src/manager/shared/menu/menu.js
+++ b/web/html/src/manager/shared/menu/menu.js
@@ -1,6 +1,7 @@
 /* eslint-disable */
 "use strict";
 import SpaRenderer from "../../../core/spa/spa-renderer";
+import ReactHtmlParser from 'react-html-parser';
 
 const React = require("react");
 const ReactDOM = require("react-dom");
@@ -28,7 +29,7 @@ class Node extends React.Component {
           <i className={'fa ' + this.props.icon}></i>
           : null
         }
-        <Link url={this.props.url} target={this.props.target} label={this.props.label} onClick={(event) => this.handleClick(event)} />
+        <Link url={this.props.url} target={this.props.target} label={ReactHtmlParser(this.props.label)} onClick={(event) => this.handleClick(event)} />
         { this.props.isLeaf ?
             null
             :
@@ -222,7 +223,7 @@ class Breadcrumb extends React.Component {
           breadcrumbArray.map((a, i) => {
             return (
               <span key={a.label + '_' + i}>
-                <Link url={a.submenu ? a.submenu[0].primaryUrl : a.primaryUrl} label={a.label} target={a.target} />
+                <Link url={a.submenu ? a.submenu[0].primaryUrl : a.primaryUrl} label={ReactHtmlParser(a.label)} target={a.target} />
                 { i == breadcrumbArray.length -1 ? null : '>'}
               </span>
             );

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Add react-html-parser to fix umlaut in the menu and breadcrumb
 - Add placeholder for product name to formula forms
 - Fix ordering by date (bsc#1158818)
 - Add debug packages containing Javascript source map files


### PR DESCRIPTION
## What does this PR change?

Introduce the `react-html-parser` lib module to render `String` as they are whenever they are already translated and *escaped* from the backend, having React only rendering the content **as it is**.

## GUI diff

Before:
![Screenshot from 2020-01-17 16-19-06](https://user-images.githubusercontent.com/7080830/72623301-2b49b980-3945-11ea-95d4-10e8b14ac076.png)


After:
![Screenshot from 2020-01-17 16-25-08](https://user-images.githubusercontent.com/7080830/72623746-f5f19b80-3945-11ea-88af-6da34ce96afb.png)



- [x] **DONE**

## Documentation
- No documentation needed: 

- [x] **DONE**

## Test coverage
- No tests:

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/4439
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
