### PR TITLE
Temporarily disable negative tests

### DIFF
--- a/testsuite/run_sets/secondary_parallelizable.yml
+++ b/testsuite/run_sets/secondary_parallelizable.yml
@@ -48,7 +48,8 @@
 - features/secondary/minssh_salt_install_package.feature
 - features/secondary/min_ubuntu_salt_install_package.feature
 - features/secondary/min_bootstrap_xmlrpc.feature
-- features/secondary/min_bootstrap_negative.feature
+# temporarily disabled, just the time to fix these tests
+# - features/secondary/min_bootstrap_negative.feature
 - features/secondary/min_salt_software_states.feature
 - features/secondary/min_salt_install_with_staging.feature
 - features/secondary/min_salt_formulas.feature


### PR DESCRIPTION
## What does this PR change?

Disable the new negative tests, just the time to fix problems like the ones in
  https://ci.suse.de/job/manager-4.0-cucumber-pipeline-NUE/267/TestSuite_20Report/ .

## Links

Ports:
* 3.2: SUSE/spacewalk#10565
* 4.0: SUSE/spacewalk#10564

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
