### PR TITLE
require javamail directly

### DIFF
--- a/java/buildconf/build-props.xml
+++ b/java/buildconf/build-props.xml
@@ -72,6 +72,10 @@
     <available file="${java.lib.dir}/geronimo-jta-1.1-api.jar" />
   </condition>
 
+  <condition property="javamail" value="javax.mail" else="javamail">
+    <available file="${java.lib.dir}/javax.mail.jar" />
+  </condition>
+
   <available file="${java.lib.dir}/ehcache.jar" type="file" property="ehcache" value="ehcache" />
   <available file="${java.lib.dir}/ehcache-core.jar" type="file" property="ehcache" value="ehcache-core" />
 
@@ -100,7 +104,7 @@
       value="bcel ${cglib-jar} commons-beanutils commons-cli commons-codec
              commons-collections commons-digester commons-discovery
              commons-el commons-fileupload commons-io ${commons-lang} commons-logging ${commons-validator} ${hibernate}
-             javamail smtp jdom ${jmock-jars}
+             ${javamail} smtp jdom ${jmock-jars}
              ${log4j-jars} oro redstone-xmlrpc-client redstone-xmlrpc ${struts-jars} ${tomcat-jars}
              bcprov bcpg jcommon stringtree-json postgresql-jdbc
              taglibs-standard-impl taglibs-standard-jstlel taglibs-standard-spec
@@ -159,7 +163,7 @@
       value="bcel ${cglib-jar} commons-beanutils commons-cli commons-codec
              commons-collections commons-digester commons-discovery
              commons-el commons-fileupload commons-io ${commons-lang} commons-logging ${commons-validator} ${hibernate}
-             ${tomcat-jars} javamail jdom jsch dwr google-gson
+             ${tomcat-jars} ${javamail} jdom jsch dwr google-gson
              ${log4j-jars} oro redstone-xmlrpc-client redstone-xmlrpc ${struts-jars}
              jcommon stringtree-json postgresql-jdbc
              taglibs-standard-impl taglibs-standard-jstlel taglibs-standard-spec quartz
@@ -172,7 +176,7 @@
              commons-digester commons-discovery commons-el commons-fileupload commons-io
              ${commons-lang} commons-logging
              ${commons-validator} concurrent dom4j google-gson ${hibernate} ${jta11-jars}
-             jaf ${jasper-jars} javamail jcommon jdom ${other-jars}
+             jaf ${jasper-jars} ${javamail} jcommon jdom ${other-jars}
              ${tomcat-jars} ${log4j-jars} redstone-xmlrpc-client redstone-xmlrpc
              oro quartz stringtree-json sitemesh ${struts-jars}
              taglibs-standard-impl taglibs-standard-jstlel taglibs-standard-spec

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -91,7 +91,7 @@ BuildRequires:  c3p0 >= 0.9.1
 BuildRequires:  cglib
 %if 0%{?suse_version}
 BuildRequires:  classmate
-BuildRequires:  classpathx-mail
+BuildRequires:  javamail
 %endif
 BuildRequires:  concurrent
 BuildRequires:  dom4j
@@ -163,7 +163,7 @@ Requires:       c3p0 >= 0.9.1
 Requires:       cglib
 %if 0%{?suse_version}
 Requires:       classmate
-Requires:       classpathx-mail
+Requires:       javamail
 %endif
 Requires:       cobbler >= 3.0.0
 Requires:       concurrent
@@ -689,7 +689,11 @@ chown tomcat:%{apache_group} /var/log/rhn/gatherer.log
 %{jardir}/statistics.jar
 
 %{jardir}/jaf.jar
+%if 0%{?sle_version} >= 150200
+%{jardir}/javax.mail.jar
+%else
 %{jardir}/javamail.jar
+%endif
 %{jardir}/jcommon*.jar
 %{jardir}/jdom.jar
 %{jardir}/geronimo-jta-1.1-api.jar


### PR DESCRIPTION
## What does this PR change?

Old classpathx-mail package provides it and with 15.2 we ship the package
under this name

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **dependency shaking**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
