### PR TITLE
Fix form infinite rendering loop

### DIFF
--- a/susemanager-frontend/yarn.lock
+++ b/susemanager-frontend/yarn.lock
@@ -7306,7 +7306,7 @@ lodash.uniq@4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.15, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
+lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==

--- a/web/html/src/components/input/InputBase.js
+++ b/web/html/src/components/input/InputBase.js
@@ -88,8 +88,7 @@ export class InputBase extends React.Component<Props, State> {
   componentDidUpdate(prevProps) {
     // Support validation when changing the following props on-the-fly
     if (this.props.required !== prevProps.required ||
-        this.props.disabled !== prevProps.disabled ||
-        this.props.validators !== prevProps.validators) {
+        this.props.disabled !== prevProps.disabled) {
       this.validate(this.context.model[this.props.name]);
     }
   }


### PR DESCRIPTION
## What does this PR change?

For some reason the validators array is always considered different.
Since there is no place where validators are changed on the fly, remove
that problematic check.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: regression fix

- [X] **DONE**

## Test coverage
- No tests: Fixing broken tests

- [X] **DONE**

## Links

Fixes SUSE/spacewalk#10569

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
