### PR TITLE
Only install python2-salt on buildhosts if it is available

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/services/docker.sls
+++ b/susemanager-utils/susemanager-sls/salt/services/docker.sls
@@ -15,7 +15,7 @@ mgr_install_docker:
 {%- endif %}
 {%- if grains['saltversioninfo'][0] >= 2018 %}
       - python3-salt
-    {%- if salt['pkg.info_available']('python', 'python2') %}
+    {%- if salt['pkg.info_available']('python', 'python2') and salt['pkg.info_available']('python2-salt') %}
       - python2-salt
     {%- endif %}
 {%- endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Only install python2-salt on buildhosts if it is available
 - sort formulas by execution order (bsc#1083326)
 - split remove_traditional_stack into two parts. One for all systems and
   another for clients not being a Uyuni Server or Proxy (bsc#1121640)


### PR DESCRIPTION
## What does this PR change?

On SLE15 >= SP1 `python` package part of Base System Module, while python2-salt is part of Python2 Module. 

As maybe "Python2 Module" is not always available, we need to check if `python2-salt` is available before installing it.

Proof:

```
SLE-Module-Basesystem_15_aarch64/_channel:    <binary name="python2-salt" package="salt" supportstatus="l3"/>
SLE-Module-Basesystem_15_ppc64le/_channel:    <binary name="python2-salt" package="salt" supportstatus="l3"/>
SLE-Module-Basesystem_15_s390x/_channel:    <binary name="python2-salt" package="salt" supportstatus="l3"/>
SLE-Module-Basesystem_15_x86_64/_channel:    <binary name="python2-salt" package="salt" supportstatus="l3"/>
SLE-Module-Python2_15-SP1_aarch64/_channel:    <binary name="python2-salt" package="salt" supportstatus="l3"/>
SLE-Module-Python2_15-SP1_ppc64le/_channel:    <binary name="python2-salt" package="salt" supportstatus="l3"/>
SLE-Module-Python2_15-SP1_s390x/_channel:    <binary name="python2-salt" package="salt" supportstatus="l3"/>
SLE-Module-Python2_15-SP1_x86_64/_channel:    <binary name="python2-salt" package="salt" supportstatus="l3"/>
SLE-Module-Python2_15-SP2_aarch64/_channel:    <binary name="python2-salt" package="salt" supportstatus="l3"/>
SLE-Module-Python2_15-SP2_ppc64le/_channel:    <binary name="python2-salt" package="salt" supportstatus="l3"/>
SLE-Module-Python2_15-SP2_s390x/_channel:    <binary name="python2-salt" package="salt" supportstatus="l3"/>
SLE-Module-Python2_15-SP2_x86_64/_channel:    <binary name="python2-salt" package="salt" supportstatus="l3"/>
```
As you can see, the package `python2-salt` moved from Base System module at SP0, to to Python2 module at >= SP1.

However, `python` is still available at Base System for all SLE15 Service Packs:
```
SLE-Module-Basesystem_15_aarch64/_channel:    <binary name="python" package="python" supportstatus="l3"/>
SLE-Module-Basesystem_15_ppc64le/_channel:    <binary name="python" package="python" supportstatus="l3"/>
SLE-Module-Basesystem_15_s390x/_channel:    <binary name="python" package="python" supportstatus="l3"/>
SLE-Module-Basesystem_15-SP1_aarch64/_channel:    <binary name="python" package="python" supportstatus="l3"/>
SLE-Module-Basesystem_15-SP1_ppc64le/_channel:    <binary name="python" package="python" supportstatus="l3"/>
SLE-Module-Basesystem_15-SP1_s390x/_channel:    <binary name="python" package="python" supportstatus="l3"/>
SLE-Module-Basesystem_15-SP1_x86_64/_channel:    <binary name="python" package="python" supportstatus="l3"/>
SLE-Module-Basesystem_15_x86_64/_channel:    <binary name="python" package="python" supportstatus="l3"/>
SLE-Module-Basesystem_15-SP2_aarch64/_channel:    <binary name="python" package="python" supportstatus="l3"/>
SLE-Module-Basesystem_15-SP2_ppc64le/_channel:    <binary name="python" package="python" supportstatus="l3"/>
SLE-Module-Basesystem_15-SP2_s390x/_channel:    <binary name="python" package="python" supportstatus="l3"/>
SLE-Module-Basesystem_15-SP2_x86_64/_channel:    <binary name="python" package="python" supportstatus="l3"/>
```


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Not sure, @mcalmer? Should the doc mention that you need the python2 module at SLE15 >= SP1 clients if you are to build images that require `python2-salt`?

- [ ] **DONE**

## Test coverage
- No tests: Sadly we didn't catch this because we include `python2-salt` at the devel client tools, so we can test the most recent version. I don't see how we can fix this.

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/9749

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
