### PR TITLE
Testsuite: Re-add min_bootstrap_negative

### DIFF
--- a/testsuite/features/secondary/min_bootstrap_negative.feature
+++ b/testsuite/features/secondary/min_bootstrap_negative.feature
@@ -1,6 +1,7 @@
 # Copyright (c) 2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
+@sle_minion
 Feature: Negative tests for bootstrap normal minions
   In order to register only valid minions 
   As an authorized user
@@ -67,6 +68,21 @@ Feature: Negative tests for bootstrap normal minions
      And I select the hostname of "proxy" from "proxies"
      And I click on "Bootstrap"
      And I wait until I see "Successfully bootstrapped host!" text
+     And I navigate to "rhn/systems/Overview.do" page
+     And I wait until I see the name of "sle_minion", refreshing the page
+
+  Scenario: Cleanup: subscribe again to base channel after negative tests
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Software" in the content area
+    And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
+    And I check radio button "Test-Channel-x86_64"
+    And I wait until I do not see "Loading..." text
+    And I click on "Next"
+    Then I should see a "Confirm Software Channel Change" text
+    When I click on "Confirm"
+    Then I should see a "Changing the channels has been scheduled." text
+    And I wait until event "Subscribe channels scheduled by admin" is completed
 
   Scenario: Cleanup: turn the SLES minion into a container build
     Given I am on the Systems overview page of this "sle_minion"

--- a/testsuite/run_sets/secondary_parallelizable.yml
+++ b/testsuite/run_sets/secondary_parallelizable.yml
@@ -48,8 +48,7 @@
 - features/secondary/minssh_salt_install_package.feature
 - features/secondary/min_ubuntu_salt_install_package.feature
 - features/secondary/min_bootstrap_xmlrpc.feature
-# temporarily disabled, just the time to fix these tests
-# - features/secondary/min_bootstrap_negative.feature
+- features/secondary/min_bootstrap_negative.feature
 - features/secondary/min_salt_software_states.feature
 - features/secondary/min_salt_install_with_staging.feature
 - features/secondary/min_salt_formulas.feature


### PR DESCRIPTION
## What does this PR change?

Fix a broken feature file and re-add it to the  CI pipeline.
The fix is to add a missing cleanup scenario:
'Cleanup: subscribe again to base channel after negative tests'

## Links

Ports:
- 32: https://github.com/SUSE/spacewalk/pull/10572
- 40: https://github.com/SUSE/spacewalk/pull/10573

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

