### PR TITLE
Also check python[2]-Jinja when installing python2-salt at buildhosts

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/services/docker.sls
+++ b/susemanager-utils/susemanager-sls/salt/services/docker.sls
@@ -15,7 +15,7 @@ mgr_install_docker:
 {%- endif %}
 {%- if grains['saltversioninfo'][0] >= 2018 %}
       - python3-salt
-    {%- if salt['pkg.info_available']('python', 'python2') and salt['pkg.info_available']('python2-salt') %}
+    {%- if salt['pkg.info_available']('python', 'python2') and salt['pkg.info_available']('python2-salt') and salt['pkg.info_available']('python-Jinja2', 'python2-Jinja2') %}
       - python2-salt
     {%- endif %}
 {%- endif %}


### PR DESCRIPTION
## What does this PR change?

As otherwise in some cases python2-salt is available at SLE15, but not the required dependencies.

So for python2-salt to be installed, user needs make sure (for SLE15 >= SP1) that the Python2 Module is available to the instance.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: We already have an issue for this.

- [x] **DONE**

## Test coverage
- No tests: Covered by cucumber testsuite.

- [x] **DONE**

## Links

None.

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
