### PR TITLE
Move all the routes initialization calls into the controllers

### DIFF
--- a/java/code/src/com/suse/manager/webui/Router.java
+++ b/java/code/src/com/suse/manager/webui/Router.java
@@ -15,21 +15,13 @@
 package com.suse.manager.webui;
 
 import static com.suse.manager.webui.utils.SparkApplicationHelper.setup;
-import static com.suse.manager.webui.utils.SparkApplicationHelper.withCsrfToken;
-import static com.suse.manager.webui.utils.SparkApplicationHelper.withImageAdmin;
-import static com.suse.manager.webui.utils.SparkApplicationHelper.withOrgAdmin;
-import static com.suse.manager.webui.utils.SparkApplicationHelper.withProductAdmin;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.withUser;
-import static com.suse.manager.webui.utils.SparkApplicationHelper.withUserPreferences;
 import static spark.Spark.exception;
 import static spark.Spark.get;
-import static spark.Spark.head;
 import static spark.Spark.notFound;
 import static spark.Spark.post;
 
 import com.suse.manager.webui.controllers.ActivationKeysController;
-import com.suse.manager.webui.controllers.admin.AdminApiController;
-import com.suse.manager.webui.controllers.admin.AdminViewsController;
 import com.suse.manager.webui.controllers.CVEAuditController;
 import com.suse.manager.webui.controllers.DownloadController;
 import com.suse.manager.webui.controllers.FormulaCatalogController;
@@ -54,6 +46,8 @@ import com.suse.manager.webui.controllers.VirtualHostManagerController;
 import com.suse.manager.webui.controllers.VirtualNetsController;
 import com.suse.manager.webui.controllers.VirtualPoolsController;
 import com.suse.manager.webui.controllers.VisualizationController;
+import com.suse.manager.webui.controllers.admin.AdminApiController;
+import com.suse.manager.webui.controllers.admin.AdminViewsController;
 import com.suse.manager.webui.controllers.channels.ChannelsApiController;
 import com.suse.manager.webui.controllers.contentmanagement.ContentManagementApiController;
 import com.suse.manager.webui.controllers.contentmanagement.ContentManagementViewsController;
@@ -90,12 +84,7 @@ public class Router implements SparkApplication {
         LoginController.initRoutes(jade);
 
         //CVEAudit
-
-        get("/manager/audit/cve",
-                withUserPreferences(withCsrfToken(withUser(CVEAuditController::cveAuditView))), jade);
-
-        post("/manager/api/audit/cve", withUser(CVEAuditController::cveAudit));
-        get("/manager/api/audit/cve.csv", withUser(CVEAuditController::cveAuditCSV));
+        CVEAuditController.initRoutes(jade);
 
         initContentManagementRoutes(jade);
 
@@ -117,204 +106,49 @@ public class Router implements SparkApplication {
         AdminApiController.initRoutes();
 
         // Minions
-        get("/manager/systems/keys",
-                withUserPreferences(withCsrfToken(withUser(MinionController::list))),
-                jade);
-        get("/manager/systems/bootstrap",
-                withCsrfToken(withOrgAdmin(MinionController::bootstrap)),
-                jade);
-        get("/manager/systems/cmd",
-                withCsrfToken(MinionController::cmd),
-                jade);
-        get("/manager/systems/:id",
-                MinionController::show);
+        MinionController.initRoutes(jade);
 
         // Minions API
-        post("/manager/api/systems/bootstrap", withOrgAdmin(MinionsAPI::bootstrap));
-        post("/manager/api/systems/bootstrap-ssh", withOrgAdmin(MinionsAPI::bootstrapSSH));
-        get("/manager/api/systems/keys", withUser(MinionsAPI::listKeys));
-        post("/manager/api/systems/keys/:target/accept", withOrgAdmin(MinionsAPI::accept));
-        post("/manager/api/systems/keys/:target/reject", withOrgAdmin(MinionsAPI::reject));
-        post("/manager/api/systems/keys/:target/delete", withOrgAdmin(MinionsAPI::delete));
+        MinionsAPI.initRoutes();
 
-        // States
-        get("/manager/systems/details/packages",
-                withCsrfToken(MinionController::packageStates),
-                jade);
-        get("/manager/systems/details/custom",
-                withCsrfToken(MinionController::minionCustomStates),
-                jade);
-        get("/manager/systems/details/highstate",
-                withCsrfToken(withUser(MinionController::highstate)),
-                jade);
-        get("/manager/multiorg/details/custom",
-                withCsrfToken(MinionController::orgCustomStates),
-                jade);
-        get("/manager/yourorg/custom",
-                withCsrfToken(withUser(MinionController::yourOrgConfigChannels)),
-                jade);
-        get("/manager/groups/details/custom",
-                withCsrfToken(withUser(MinionController::serverGroupConfigChannels)),
-                jade);
-        get("/manager/groups/details/highstate",
-                withCsrfToken(withUser(MinionController::serverGroupHighstate)), jade);
-
-        // SSM API
-        get("/manager/systems/ssm/highstate",
-                withCsrfToken(withUser(MinionController::ssmHighstate)), jade);
-        get("/manager/systems/ssm/channels/bases",
-                withUser(SsmController::getBaseChannels));
-        post("/manager/systems/ssm/channels/allowed-changes",
-                withUser(SsmController::computeAllowedChannelChanges));
-        post("/manager/systems/ssm/channels",
-                withUser(SsmController::changeChannels));
 
         // Systems API
-        post("/manager/api/systems/:sid/delete", withUser(SystemsController::delete));
-        get("/manager/api/systems/:sid/channels", withUser(SystemsController::getChannels));
-        get("/manager/api/systems/:sid/channels-available-base",
-                withUser(SystemsController::getAvailableBaseChannels));
-        post("/manager/api/systems/:sid/channels", withUser(SystemsController::subscribeChannels));
-        get("/manager/api/systems/:sid/channels/:channelId/accessible-children",
-                withUser(SystemsController::getAccessibleChannelChildren));
+        SystemsController.initRoutes();
 
         // Activation Keys API
-        get("/manager/api/activation-keys/:tid/channels", withUser(ActivationKeysController::getChannels));
-        get("/manager/api/activation-keys/base-channels",
-                withUser(ActivationKeysController::getAccessibleBaseChannels));
-        get("/manager/api/activation-keys/base-channels/:cid/child-channels",
-                withUser(ActivationKeysController::getChildChannelsByBaseId));
+        ActivationKeysController.initRoutes();
+
+        SsmController.initRoutes();
 
         // States API
-        post("/manager/api/states/apply", withUser(StatesAPI::apply));
-        post("/manager/api/states/applyall", withUser(StatesAPI::applyHighstate));
-        get("/manager/api/states/match", withUser(StatesAPI::matchStates));
-        post("/manager/api/states/save", withUser(StatesAPI::saveConfigChannels));
-        get("/manager/api/states/packages", StatesAPI::packages);
-        post("/manager/api/states/packages/save", withUser(StatesAPI::savePackages));
-        get("/manager/api/states/packages/match", StatesAPI::matchPackages);
-        get("/manager/api/states/highstate", StatesAPI::showHighstate);
-        get("/manager/api/states/:channelId/content", withUser(StatesAPI::stateContent));
+        StatesAPI.initRoutes();
 
         // Subscription Matching
-        get("/manager/subscription-matching",
-                withUserPreferences(withCsrfToken(withProductAdmin(SubscriptionMatchingController::show))),
-                jade);
-        get("/manager/subscription-matching/:filename",
-                withProductAdmin(SubscriptionMatchingController::csv));
-
-        // Subscription Matching API
-        get("/manager/api/subscription-matching/data",
-                withProductAdmin(SubscriptionMatchingController::data));
-        post("/manager/api/subscription-matching/schedule-matcher-run",
-                withProductAdmin(SubscriptionMatchingController::scheduleMatcherRun));
-        post("/manager/api/subscription-matching/pins",
-                withProductAdmin(SubscriptionMatchingController::createPin));
-        post("/manager/api/subscription-matching/pins/:id/delete",
-                withProductAdmin(SubscriptionMatchingController::deletePin));
+        SubscriptionMatchingController.initRoutes(jade);
 
         // TaskoTop
-        get("/manager/admin/runtime-status",
-                withUserPreferences(withCsrfToken(withOrgAdmin(TaskoTop::show))), jade);
-        get("/manager/api/admin/runtime-status/data",
-                withOrgAdmin(TaskoTop::data));
+        TaskoTop.initRoutes(jade);
 
         // Download endpoint
-        get("/manager/download/:channel/getPackage/:file",
-                DownloadController::downloadPackage);
-        get("/manager/download/:channel/getPackage/:org/:checksum/:file",
-                DownloadController::downloadPackage);
-        get("/manager/download/:channel/repodata/:file",
-                DownloadController::downloadMetadata);
-        head("/manager/download/:channel/getPackage/:file",
-                DownloadController::downloadPackage);
-        head("/manager/download/:channel/getPackage/:org/:checksum/:file",
-                DownloadController::downloadPackage);
-        head("/manager/download/:channel/repodata/:file",
-                DownloadController::downloadMetadata);
+        DownloadController.initRoutes();
 
         // Formula catalog
-        get("/manager/formula-catalog",
-                withUserPreferences(withOrgAdmin(FormulaCatalogController::list)), jade);
-        get("/manager/formula-catalog/formula/:name",
-                withCsrfToken(withOrgAdmin(FormulaCatalogController::details)), jade);
-
-        // Formula catalog API
-        get("/manager/api/formula-catalog/data",
-                withOrgAdmin(FormulaCatalogController::data));
-        get("/manager/api/formula-catalog/formula/:name/data",
-                withOrgAdmin(FormulaCatalogController::detailsData));
+        FormulaCatalogController.initRoutes(jade);
 
         // Formulas
-        get("/manager/groups/details/formulas",
-                withCsrfToken(withUser(FormulaController::serverGroupFormulas)),
-                jade);
-        get("/manager/systems/details/formulas",
-                withCsrfToken(withUser(FormulaController::minionFormulas)),
-                jade);
-        get("/manager/groups/details/formula/:formula_id",
-                withCsrfToken(withUser(FormulaController::serverGroupFormula)),
-                jade);
-        get("/manager/systems/details/formula/:formula_id",
-                withCsrfToken(FormulaController::minionFormula),
-                jade);
-
-        // Formula API
-        get("/manager/api/formulas/list/:targetType/:id",
-                withUser(FormulaController::listSelectedFormulas));
-        get("/manager/api/formulas/form/:targetType/:id/:formula_id",
-                withUser(FormulaController::formulaData));
-        post("/manager/api/formulas/select",
-                withUser(FormulaController::saveSelectedFormulas));
-        post("/manager/api/formulas/save",
-                withUser(FormulaController::saveFormula));
+        FormulaController.initRoutes(jade);
 
         // Visualization
-        get("/manager/visualization/virtualization-hierarchy",
-                withCsrfToken(withOrgAdmin(VisualizationController::showVirtualizationHierarchy)), jade);
-        get("/manager/api/visualization/virtualization-hierarchy/data",
-                withOrgAdmin(VisualizationController::virtHierarchyData));
-        get("/manager/visualization/proxy-hierarchy",
-                withCsrfToken(withOrgAdmin(VisualizationController::showProxyHierarchy)), jade);
-        get("/manager/api/visualization/proxy-hierarchy/data",
-                withOrgAdmin(VisualizationController::proxyHierarchyData));
-        get("/manager/visualization/systems-with-managed-groups",
-                withCsrfToken(withOrgAdmin(VisualizationController::systemsWithManagedGroups)), jade);
-        get("/manager/api/visualization/systems-with-managed-groups/data",
-                withOrgAdmin(VisualizationController::systemsWithManagedGroupsData));
+        VisualizationController.initRoutes(jade);
 
         get("/manager/download/saltssh/pubkey", SaltSSHController::getPubKey);
 
 
         // NotificationMessages
-        get("/manager/notification-messages",
-                withUserPreferences(withCsrfToken(withUser(NotificationMessageController::getList))), jade);
-        get("/manager/notification-messages/data-unread", withUser(NotificationMessageController::dataUnread));
-        get("/manager/notification-messages/data-all", withUser(NotificationMessageController::dataAll));
-        post("/manager/notification-messages/update-messages-status",
-                withUser(NotificationMessageController::updateMessagesStatus));
-        post("/manager/notification-messages/delete",
-                withUser(NotificationMessageController::delete));
-        post("/manager/notification-messages/retry-onboarding/:minionId",
-                withUser(NotificationMessageController::retryOnboarding));
-        post("/manager/notification-messages/retry-reposync/:channelId",
-                withUser(NotificationMessageController::retryReposync));
+        NotificationMessageController.initRoutes(jade);
 
         // Products
-        get("/manager/admin/setup/products",
-                withUserPreferences(withCsrfToken(withOrgAdmin(ProductsController::show))), jade);
-        get("/manager/api/admin/products", withUser(ProductsController::data));
-        post("/manager/api/admin/mandatoryChannels", withUser(ProductsController::getMandatoryChannels));
-        post("/manager/admin/setup/products",
-                withProductAdmin(ProductsController::addProduct));
-        post("/manager/admin/setup/sync/products",
-                withProductAdmin(ProductsController::synchronizeProducts));
-        post("/manager/admin/setup/sync/channelfamilies",
-                withProductAdmin(ProductsController::synchronizeChannelFamilies));
-        post("/manager/admin/setup/sync/subscriptions",
-                withProductAdmin(ProductsController::synchronizeSubscriptions));
-        post("/manager/admin/setup/sync/repositories",
-                withProductAdmin(ProductsController::synchronizeRepositories));
+        ProductsController.initRoutes(jade);
 
         // Single Sign-On (SSO) via SAML
         SSOController.initRoutes();
@@ -342,80 +176,9 @@ public class Router implements SparkApplication {
     }
 
     private void initContentManagementRoutes(JadeTemplateEngine jade) {
-        get("/manager/cm/imagestores",
-                withUserPreferences(withCsrfToken(withUser(ImageStoreController::listView))), jade);
-        get("/manager/cm/imagestores/create",
-                withCsrfToken(withImageAdmin(ImageStoreController::createView)), jade);
-        get("/manager/cm/imagestores/edit/:id",
-                withCsrfToken(withImageAdmin(ImageStoreController::updateView)), jade);
-
-        get("/manager/api/cm/imagestores", withUser(ImageStoreController::list));
-        get("/manager/api/cm/imagestores/type/:type",
-                withUser(ImageStoreController::listAllWithType));
-        get("/manager/api/cm/imagestores/:id", withUser(ImageStoreController::getSingle));
-        get("/manager/api/cm/imagestores/find/:label",
-                withUser(ImageStoreController::getSingleByLabel));
-        post("/manager/api/cm/imagestores/create",
-                withImageAdmin(ImageStoreController::create));
-        post("/manager/api/cm/imagestores/update/:id",
-                withImageAdmin(ImageStoreController::update));
-        post("/manager/api/cm/imagestores/delete",
-                withImageAdmin(ImageStoreController::delete));
-
-        get("/manager/cm/imageprofiles",
-                withUserPreferences(withCsrfToken(withUser(ImageProfileController::listView))), jade);
-        get("/manager/cm/imageprofiles/create",
-                withCsrfToken(withImageAdmin(ImageProfileController::createView)), jade);
-        get("/manager/cm/imageprofiles/edit/:id",
-                withCsrfToken(withImageAdmin(ImageProfileController::updateView)), jade);
-
-        get("/manager/api/cm/imageprofiles", withUser(ImageProfileController::list));
-        get("/manager/api/cm/imageprofiles/:id",
-                withUser(ImageProfileController::getSingle));
-        get("/manager/api/cm/imageprofiles/find/:label",
-                withUser(ImageProfileController::getSingleByLabel));
-        get("/manager/api/cm/imageprofiles/channels/:token",
-                withUser(ImageProfileController::getChannels));
-        post("/manager/api/cm/imageprofiles/create",
-                withImageAdmin(ImageProfileController::create));
-        post("/manager/api/cm/imageprofiles/update/:id",
-                withImageAdmin(ImageProfileController::update));
-        post("/manager/api/cm/imageprofiles/delete",
-                withImageAdmin(ImageProfileController::delete));
-
-        get("/manager/cm/build", withCsrfToken(withUser(ImageBuildController::buildView)),
-                jade);
-        get("/manager/cm/import", withCsrfToken(withUser(ImageBuildController::importView)),
-                jade);
-        get("/manager/cm/rebuild/:id",
-                withCsrfToken(withUser(ImageBuildController::rebuild)), jade);
-
-        get("/manager/api/cm/build/hosts/:type", withUser(ImageBuildController::getBuildHosts));
-        post("/manager/api/cm/build/:id", withImageAdmin(ImageBuildController::build));
-
-        get("/manager/cm/images", withUserPreferences(withCsrfToken(withUser(ImageBuildController::listView))),
-                jade);
-
-        get("/manager/api/cm/images", withUser(ImageBuildController::list));
-        get("/manager/api/cm/images/:id", withUser(ImageBuildController::get));
-        get("/manager/api/cm/clusters", withUser(ImageBuildController::getClusterList));
-        get("/manager/api/cm/runtime/:clusterId",
-                withUser(ImageBuildController::getRuntimeSummaryAll));
-        get("/manager/api/cm/runtime/:clusterId/:id",
-                withUser(ImageBuildController::getRuntimeSummary));
-        get("/manager/api/cm/runtime/details/:clusterId/:id",
-                withUser(ImageBuildController::getRuntimeDetails));
-        get("/manager/api/cm/images/patches/:id",
-                withUser(ImageBuildController::getPatches));
-        get("/manager/api/cm/images/packages/:id",
-                withUser(ImageBuildController::getPackages));
-        post("/manager/api/cm/images/inspect/:id",
-                withImageAdmin(ImageBuildController::inspect));
-        post("/manager/api/cm/images/delete", withImageAdmin(ImageBuildController::delete));
-        post("/manager/api/cm/images/import",
-                withImageAdmin(ImageBuildController::importImage));
-        get("/manager/api/cm/activationkeys",
-                withUser(ImageProfileController::getActivationKeys));
+        ImageStoreController.initRoutes(jade);
+        ImageProfileController.initRoutes(jade);
+        ImageBuildController.initRoutes(jade);
     }
 
 }

--- a/java/code/src/com/suse/manager/webui/controllers/ActivationKeysController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/ActivationKeysController.java
@@ -17,6 +17,8 @@ package com.suse.manager.webui.controllers;
 import static com.suse.manager.webui.controllers.channels.ChannelsUtils.generateChannelJson;
 import static com.suse.manager.webui.controllers.channels.ChannelsUtils.getPossibleBaseChannels;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.json;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withUser;
+import static spark.Spark.get;
 
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.ChannelFactory;
@@ -55,6 +57,17 @@ public class ActivationKeysController {
             .registerTypeAdapterFactory(new OptionalTypeAdapterFactory())
             .serializeNulls()
             .create();
+
+    /**
+     * Invoked from Router. Init routes for Activation keys views.
+     */
+    public static void initRoutes() {
+        get("/manager/api/activation-keys/:tid/channels", withUser(ActivationKeysController::getChannels));
+        get("/manager/api/activation-keys/base-channels",
+                withUser(ActivationKeysController::getAccessibleBaseChannels));
+        get("/manager/api/activation-keys/base-channels/:cid/child-channels",
+                withUser(ActivationKeysController::getChildChannelsByBaseId));
+    }
 
     private static String withActivationKey(Request request, Response response,
                                             User user, Function<ActivationKey, String> handler) {

--- a/java/code/src/com/suse/manager/webui/controllers/CVEAuditController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/CVEAuditController.java
@@ -31,6 +31,7 @@ import org.apache.log4j.Logger;
 import spark.ModelAndView;
 import spark.Request;
 import spark.Response;
+import spark.template.jade.JadeTemplateEngine;
 
 import java.util.Collections;
 import java.util.EnumSet;
@@ -42,6 +43,11 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.suse.manager.webui.utils.SparkApplicationHelper.json;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withCsrfToken;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withUser;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withUserPreferences;
+import static spark.Spark.get;
+import static spark.Spark.post;
 
 /**
  * Spark controller class the CVE Audit page.
@@ -53,6 +59,19 @@ public class CVEAuditController {
     private static Logger log = Logger.getLogger(CVEAuditController.class);
 
     private CVEAuditController() { }
+
+    /**
+     * Invoked from Router. Initialize routes for Systems Views.
+     *
+     * @param jade the Jade engine to use to render the pages
+     */
+    public static void initRoutes(JadeTemplateEngine jade) {
+        get("/manager/audit/cve",
+                withUserPreferences(withCsrfToken(withUser(CVEAuditController::cveAuditView))), jade);
+
+        post("/manager/api/audit/cve", withUser(CVEAuditController::cveAudit));
+        get("/manager/api/audit/cve.csv", withUser(CVEAuditController::cveAuditCSV));
+    }
 
     /**
      * Returns the cve audit page

--- a/java/code/src/com/suse/manager/webui/controllers/DownloadController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/DownloadController.java
@@ -51,7 +51,9 @@ import java.util.Optional;
 import java.util.Set;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static spark.Spark.get;
 import static spark.Spark.halt;
+import static spark.Spark.head;
 
 
 /**
@@ -76,6 +78,24 @@ public class DownloadController {
      * this flag to false disables the checks.
      */
     private static boolean checkTokens = Config.get().getBoolean(ConfigDefaults.SALT_CHECK_DOWNLOAD_TOKENS);
+
+    /**
+     * Invoked from Router. Initialize routes for Systems Views.
+     */
+    public static void initRoutes() {
+        get("/manager/download/:channel/getPackage/:file",
+                DownloadController::downloadPackage);
+        get("/manager/download/:channel/getPackage/:org/:checksum/:file",
+                DownloadController::downloadPackage);
+        get("/manager/download/:channel/repodata/:file",
+                DownloadController::downloadMetadata);
+        head("/manager/download/:channel/getPackage/:file",
+                DownloadController::downloadPackage);
+        head("/manager/download/:channel/getPackage/:org/:checksum/:file",
+                DownloadController::downloadPackage);
+        head("/manager/download/:channel/repodata/:file",
+                DownloadController::downloadMetadata);
+    }
 
     /**
      * Encapsulates package info.

--- a/java/code/src/com/suse/manager/webui/controllers/FormulaCatalogController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/FormulaCatalogController.java
@@ -14,6 +14,11 @@
  */
 package com.suse.manager.webui.controllers;
 
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withCsrfToken;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withOrgAdmin;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withUserPreferences;
+import static spark.Spark.get;
+
 import com.redhat.rhn.domain.formula.FormulaFactory;
 import com.redhat.rhn.domain.user.User;
 
@@ -30,6 +35,7 @@ import java.util.Map;
 import spark.ModelAndView;
 import spark.Request;
 import spark.Response;
+import spark.template.jade.JadeTemplateEngine;
 
 /**
  * Controller class for the formula catalog page.
@@ -42,6 +48,24 @@ public class FormulaCatalogController {
             .create();
 
     private FormulaCatalogController() { }
+
+    /**
+     * Invoked from Router. Initialize routes for Systems Views.
+     *
+     * @param jade the Jade engine to use to render the pages
+     */
+    public static void initRoutes(JadeTemplateEngine jade) {
+        get("/manager/formula-catalog",
+                withUserPreferences(withOrgAdmin(FormulaCatalogController::list)), jade);
+        get("/manager/formula-catalog/formula/:name",
+                withCsrfToken(withOrgAdmin(FormulaCatalogController::details)), jade);
+
+        // Formula catalog API
+        get("/manager/api/formula-catalog/data",
+                withOrgAdmin(FormulaCatalogController::data));
+        get("/manager/api/formula-catalog/formula/:name/data",
+                withOrgAdmin(FormulaCatalogController::detailsData));
+    }
 
     /**
      * Show the list of formulas.

--- a/java/code/src/com/suse/manager/webui/controllers/FormulaController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/FormulaController.java
@@ -14,6 +14,11 @@
  */
 package com.suse.manager.webui.controllers;
 
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withCsrfToken;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withUser;
+import static spark.Spark.get;
+import static spark.Spark.post;
+
 import com.redhat.rhn.common.hibernate.LookupException;
 import com.redhat.rhn.common.security.PermissionException;
 import com.redhat.rhn.domain.formula.FormulaFactory;
@@ -55,6 +60,7 @@ import java.util.stream.Collectors;
 import spark.ModelAndView;
 import spark.Request;
 import spark.Response;
+import spark.template.jade.JadeTemplateEngine;
 
 /**
  * Controller class providing backend code for formulas pages and APIs.
@@ -79,6 +85,36 @@ public class FormulaController {
             .create();
 
     private FormulaController() { }
+
+    /**
+     * Invoked from Router. Initialize routes for Systems Views.
+     *
+     * @param jade the Jade engine to use to render the pages
+     */
+    public static void initRoutes(JadeTemplateEngine jade) {
+        get("/manager/groups/details/formulas",
+                withCsrfToken(withUser(FormulaController::serverGroupFormulas)),
+                jade);
+        get("/manager/systems/details/formulas",
+                withCsrfToken(withUser(FormulaController::minionFormulas)),
+                jade);
+        get("/manager/groups/details/formula/:formula_id",
+                withCsrfToken(withUser(FormulaController::serverGroupFormula)),
+                jade);
+        get("/manager/systems/details/formula/:formula_id",
+                withCsrfToken(FormulaController::minionFormula),
+                jade);
+
+        // Formula API
+        get("/manager/api/formulas/list/:targetType/:id",
+                withUser(FormulaController::listSelectedFormulas));
+        get("/manager/api/formulas/form/:targetType/:id/:formula_id",
+                withUser(FormulaController::formulaData));
+        post("/manager/api/formulas/select",
+                withUser(FormulaController::saveSelectedFormulas));
+        post("/manager/api/formulas/save",
+                withUser(FormulaController::saveFormula));
+    }
 
     /**
      * Handler for the server group formula page.

--- a/java/code/src/com/suse/manager/webui/controllers/ImageStoreController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/ImageStoreController.java
@@ -15,6 +15,12 @@
 package com.suse.manager.webui.controllers;
 
 import static com.suse.manager.webui.utils.SparkApplicationHelper.json;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withCsrfToken;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withImageAdmin;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withUser;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withUserPreferences;
+import static spark.Spark.get;
+import static spark.Spark.post;
 
 import com.redhat.rhn.domain.credentials.Credentials;
 import com.redhat.rhn.domain.credentials.CredentialsFactory;
@@ -47,6 +53,7 @@ import spark.ModelAndView;
 import spark.Request;
 import spark.Response;
 import spark.Spark;
+import spark.template.jade.JadeTemplateEngine;
 
 /**
  * Spark controller class for image store pages and API endpoints.
@@ -58,6 +65,33 @@ public class ImageStoreController {
     private static Logger log = Logger.getLogger(ImageStoreController.class);
 
     private ImageStoreController() { }
+
+    /**
+     * Invoked from Router. Initialize routes for Systems Views.
+     *
+     * @param jade the Jade engine to use to render the pages
+     */
+    public static void initRoutes(JadeTemplateEngine jade) {
+        get("/manager/cm/imagestores",
+                withUserPreferences(withCsrfToken(withUser(ImageStoreController::listView))), jade);
+        get("/manager/cm/imagestores/create",
+                withCsrfToken(withImageAdmin(ImageStoreController::createView)), jade);
+        get("/manager/cm/imagestores/edit/:id",
+                withCsrfToken(withImageAdmin(ImageStoreController::updateView)), jade);
+
+        get("/manager/api/cm/imagestores", withUser(ImageStoreController::list));
+        get("/manager/api/cm/imagestores/type/:type",
+                withUser(ImageStoreController::listAllWithType));
+        get("/manager/api/cm/imagestores/:id", withUser(ImageStoreController::getSingle));
+        get("/manager/api/cm/imagestores/find/:label",
+                withUser(ImageStoreController::getSingleByLabel));
+        post("/manager/api/cm/imagestores/create",
+                withImageAdmin(ImageStoreController::create));
+        post("/manager/api/cm/imagestores/update/:id",
+                withImageAdmin(ImageStoreController::update));
+        post("/manager/api/cm/imagestores/delete",
+                withImageAdmin(ImageStoreController::delete));
+    }
 
     /**
      * Returns a view to list image stores

--- a/java/code/src/com/suse/manager/webui/controllers/MinionController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/MinionController.java
@@ -14,6 +14,12 @@
  */
 package com.suse.manager.webui.controllers;
 
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withCsrfToken;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withOrgAdmin;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withUser;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withUserPreferences;
+import static spark.Spark.get;
+
 import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.MinionServerFactory;
@@ -42,6 +48,7 @@ import com.suse.utils.Json;
 import spark.ModelAndView;
 import spark.Request;
 import spark.Response;
+import spark.template.jade.JadeTemplateEngine;
 
 /**
  * Controller class providing backend code for the minions page.
@@ -52,6 +59,59 @@ public class MinionController {
     private static final SaltService SALT_SERVICE = SaltService.INSTANCE;
 
     private MinionController() { }
+
+    /**
+     * Invoked from Router. Initializes routes.
+     *
+     * @param jade jade engine to use to render pages
+     */
+    public static void initRoutes(JadeTemplateEngine jade) {
+        initSystemRoutes(jade);
+        initStatesRoutes(jade);
+        initSSMRoutes(jade);
+    }
+
+    private static void initSystemRoutes(JadeTemplateEngine jade) {
+        get("/manager/systems/keys",
+                withUserPreferences(withCsrfToken(withUser(MinionController::list))),
+                jade);
+        get("/manager/systems/bootstrap",
+                withCsrfToken(withOrgAdmin(MinionController::bootstrap)),
+                jade);
+        get("/manager/systems/cmd",
+                withCsrfToken(MinionController::cmd),
+                jade);
+        get("/manager/systems/:id",
+                MinionController::show);
+    }
+
+    private static void initStatesRoutes(JadeTemplateEngine jade) {
+        get("/manager/systems/details/packages",
+                withCsrfToken(MinionController::packageStates),
+                jade);
+        get("/manager/systems/details/custom",
+                withCsrfToken(MinionController::minionCustomStates),
+                jade);
+        get("/manager/systems/details/highstate",
+                withCsrfToken(withUser(MinionController::highstate)),
+                jade);
+        get("/manager/multiorg/details/custom",
+                withCsrfToken(MinionController::orgCustomStates),
+                jade);
+        get("/manager/yourorg/custom",
+                withCsrfToken(withUser(MinionController::yourOrgConfigChannels)),
+                jade);
+        get("/manager/groups/details/custom",
+                withCsrfToken(withUser(MinionController::serverGroupConfigChannels)),
+                jade);
+        get("/manager/groups/details/highstate",
+                withCsrfToken(withUser(MinionController::serverGroupHighstate)), jade);
+    }
+
+    private static void initSSMRoutes(JadeTemplateEngine jade) {
+        get("/manager/systems/ssm/highstate",
+                withCsrfToken(withUser(MinionController::ssmHighstate)), jade);
+    }
 
     /**
      * Displays a list of minions.

--- a/java/code/src/com/suse/manager/webui/controllers/MinionsAPI.java
+++ b/java/code/src/com/suse/manager/webui/controllers/MinionsAPI.java
@@ -45,6 +45,10 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.suse.manager.webui.utils.SparkApplicationHelper.json;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withOrgAdmin;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withUser;
+import static spark.Spark.get;
+import static spark.Spark.post;
 
 /**
  * Controller class providing backend code for the minions page.
@@ -63,6 +67,18 @@ public class MinionsAPI {
     private static final Logger LOG = Logger.getLogger(MinionsAPI.class);
 
     private MinionsAPI() { }
+
+    /**
+     * Invoked from Router. Initializes routes.
+     */
+    public static void initRoutes() {
+        post("/manager/api/systems/bootstrap", withOrgAdmin(MinionsAPI::bootstrap));
+        post("/manager/api/systems/bootstrap-ssh", withOrgAdmin(MinionsAPI::bootstrapSSH));
+        get("/manager/api/systems/keys", withUser(MinionsAPI::listKeys));
+        post("/manager/api/systems/keys/:target/accept", withOrgAdmin(MinionsAPI::accept));
+        post("/manager/api/systems/keys/:target/reject", withOrgAdmin(MinionsAPI::reject));
+        post("/manager/api/systems/keys/:target/delete", withOrgAdmin(MinionsAPI::delete));
+    }
 
     /**
      * API endpoint to get all minions matching a target glob

--- a/java/code/src/com/suse/manager/webui/controllers/NotificationMessageController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/NotificationMessageController.java
@@ -14,6 +14,12 @@
  */
 package com.suse.manager.webui.controllers;
 
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withCsrfToken;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withUser;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withUserPreferences;
+import static spark.Spark.get;
+import static spark.Spark.post;
+
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.ChannelFactory;
 import com.redhat.rhn.domain.notification.UserNotification;
@@ -43,6 +49,7 @@ import java.util.stream.Collectors;
 import spark.ModelAndView;
 import spark.Request;
 import spark.Response;
+import spark.template.jade.JadeTemplateEngine;
 
 /**
  * Controller class providing backend code for the messages page.
@@ -55,6 +62,26 @@ public class NotificationMessageController {
             .create();
 
     private NotificationMessageController() { }
+
+    /**
+     * Invoked from Router. Initialize routes for Systems Views.
+     *
+     * @param jade the Jade engine to use to render the pages
+     */
+    public static void initRoutes(JadeTemplateEngine jade) {
+        get("/manager/notification-messages",
+                withUserPreferences(withCsrfToken(withUser(NotificationMessageController::getList))), jade);
+        get("/manager/notification-messages/data-unread", withUser(NotificationMessageController::dataUnread));
+        get("/manager/notification-messages/data-all", withUser(NotificationMessageController::dataAll));
+        post("/manager/notification-messages/update-messages-status",
+                withUser(NotificationMessageController::updateMessagesStatus));
+        post("/manager/notification-messages/delete",
+                withUser(NotificationMessageController::delete));
+        post("/manager/notification-messages/retry-onboarding/:minionId",
+                withUser(NotificationMessageController::retryOnboarding));
+        post("/manager/notification-messages/retry-reposync/:channelId",
+                withUser(NotificationMessageController::retryReposync));
+    }
 
     /**
      * Displays a list of messages.

--- a/java/code/src/com/suse/manager/webui/controllers/ProductsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/ProductsController.java
@@ -41,6 +41,7 @@ import org.apache.log4j.Logger;
 import spark.ModelAndView;
 import spark.Request;
 import spark.Response;
+import spark.template.jade.JadeTemplateEngine;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -51,6 +52,13 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.suse.manager.webui.utils.SparkApplicationHelper.json;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withCsrfToken;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withOrgAdmin;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withProductAdmin;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withUser;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withUserPreferences;
+import static spark.Spark.get;
+import static spark.Spark.post;
 
 /**
  * Controller class providing backend code for the Products
@@ -65,6 +73,28 @@ public class ProductsController {
     private static Logger log = Logger.getLogger(ProductsController.class);
 
     private ProductsController() { }
+
+    /**
+     * Invoked from Router. Initialize routes for Systems Views.
+     *
+     * @param jade the Jade engine to use to render the pages
+     */
+    public static void initRoutes(JadeTemplateEngine jade) {
+        get("/manager/admin/setup/products",
+                withUserPreferences(withCsrfToken(withOrgAdmin(ProductsController::show))), jade);
+        get("/manager/api/admin/products", withUser(ProductsController::data));
+        post("/manager/api/admin/mandatoryChannels", withUser(ProductsController::getMandatoryChannels));
+        post("/manager/admin/setup/products",
+                withProductAdmin(ProductsController::addProduct));
+        post("/manager/admin/setup/sync/products",
+                withProductAdmin(ProductsController::synchronizeProducts));
+        post("/manager/admin/setup/sync/channelfamilies",
+                withProductAdmin(ProductsController::synchronizeChannelFamilies));
+        post("/manager/admin/setup/sync/subscriptions",
+                withProductAdmin(ProductsController::synchronizeSubscriptions));
+        post("/manager/admin/setup/sync/repositories",
+                withProductAdmin(ProductsController::synchronizeRepositories));
+    }
 
     /**
      * Displays the Products page

--- a/java/code/src/com/suse/manager/webui/controllers/SsmController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/SsmController.java
@@ -58,6 +58,9 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.suse.manager.webui.utils.SparkApplicationHelper.json;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withUser;
+import static spark.Spark.get;
+import static spark.Spark.post;
 
 /**
  * Controller class providing backend code for the SSM pages.
@@ -74,6 +77,18 @@ public class SsmController {
             .create();
 
     private SsmController() { }
+
+    /**
+     * Invoked from Router. Initialize routes for Systems Views.
+     */
+    public static void initRoutes() {
+        get("/manager/systems/ssm/channels/bases",
+                withUser(SsmController::getBaseChannels));
+        post("/manager/systems/ssm/channels/allowed-changes",
+                withUser(SsmController::computeAllowedChannelChanges));
+        post("/manager/systems/ssm/channels",
+                withUser(SsmController::changeChannels));
+    }
 
     /**
      * Get the list of base-channels available to the System Set.

--- a/java/code/src/com/suse/manager/webui/controllers/StatesAPI.java
+++ b/java/code/src/com/suse/manager/webui/controllers/StatesAPI.java
@@ -15,6 +15,9 @@
 package com.suse.manager.webui.controllers;
 
 import static com.suse.manager.webui.utils.SparkApplicationHelper.json;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withUser;
+import static spark.Spark.get;
+import static spark.Spark.post;
 
 import com.redhat.rhn.common.hibernate.LookupException;
 import com.redhat.rhn.common.security.PermissionException;
@@ -128,6 +131,21 @@ public class StatesAPI {
             = "/etc/yum.repos.d/susemanager:channels.repo";
 
     private StatesAPI() { }
+
+    /**
+     * Invoked from Router. Initialize routes for Systems Views.
+     */
+    public static void initRoutes() {
+        post("/manager/api/states/apply", withUser(StatesAPI::apply));
+        post("/manager/api/states/applyall", withUser(StatesAPI::applyHighstate));
+        get("/manager/api/states/match", withUser(StatesAPI::matchStates));
+        post("/manager/api/states/save", withUser(StatesAPI::saveConfigChannels));
+        get("/manager/api/states/packages", StatesAPI::packages);
+        post("/manager/api/states/packages/save", withUser(StatesAPI::savePackages));
+        get("/manager/api/states/packages/match", StatesAPI::matchPackages);
+        get("/manager/api/states/highstate", StatesAPI::showHighstate);
+        get("/manager/api/states/:channelId/content", withUser(StatesAPI::stateContent));
+    }
 
     /**
      * Query the current list of package states for a given server.

--- a/java/code/src/com/suse/manager/webui/controllers/SubscriptionMatchingController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/SubscriptionMatchingController.java
@@ -15,6 +15,12 @@
 
 package com.suse.manager.webui.controllers;
 
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withCsrfToken;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withProductAdmin;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withUserPreferences;
+import static spark.Spark.get;
+import static spark.Spark.post;
+
 import com.redhat.rhn.domain.matcher.MatcherRunData;
 import com.redhat.rhn.domain.matcher.MatcherRunDataFactory;
 import com.redhat.rhn.domain.server.PinnedSubscription;
@@ -34,6 +40,7 @@ import java.util.HashMap;
 import spark.ModelAndView;
 import spark.Request;
 import spark.Response;
+import spark.template.jade.JadeTemplateEngine;
 
 /**
  * Controller class providing backend code for subscription-matcher pages.
@@ -46,6 +53,29 @@ public class SubscriptionMatchingController {
         .create();
 
     private SubscriptionMatchingController() { }
+
+    /**
+     * Invoked from Router. Initialize routes for Systems Views.
+     *
+     * @param jade the jade template to use to render the pages
+     */
+    public static void initRoutes(JadeTemplateEngine jade) {
+        get("/manager/subscription-matching",
+                withUserPreferences(withCsrfToken(withProductAdmin(SubscriptionMatchingController::show))),
+                jade);
+        get("/manager/subscription-matching/:filename",
+                withProductAdmin(SubscriptionMatchingController::csv));
+
+        // Subscription Matching API
+        get("/manager/api/subscription-matching/data",
+                withProductAdmin(SubscriptionMatchingController::data));
+        post("/manager/api/subscription-matching/schedule-matcher-run",
+                withProductAdmin(SubscriptionMatchingController::scheduleMatcherRun));
+        post("/manager/api/subscription-matching/pins",
+                withProductAdmin(SubscriptionMatchingController::createPin));
+        post("/manager/api/subscription-matching/pins/:id/delete",
+                withProductAdmin(SubscriptionMatchingController::deletePin));
+    }
 
     /**
      * Displays the subscription-matcher report page

--- a/java/code/src/com/suse/manager/webui/controllers/SystemsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/SystemsController.java
@@ -69,6 +69,9 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.suse.manager.webui.utils.SparkApplicationHelper.json;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withUser;
+import static spark.Spark.get;
+import static spark.Spark.post;
 
 /**
  * Controller class providing backend code for the systems page.
@@ -85,6 +88,19 @@ public class SystemsController {
             .registerTypeAdapterFactory(new OptionalTypeAdapterFactory())
             .serializeNulls()
             .create();
+
+    /**
+     * Invoked from Router. Initialize routes for Systems Views.
+     */
+    public static void initRoutes() {
+        post("/manager/api/systems/:sid/delete", withUser(SystemsController::delete));
+        get("/manager/api/systems/:sid/channels", withUser(SystemsController::getChannels));
+        get("/manager/api/systems/:sid/channels-available-base",
+                withUser(SystemsController::getAvailableBaseChannels));
+        post("/manager/api/systems/:sid/channels", withUser(SystemsController::subscribeChannels));
+        get("/manager/api/systems/:sid/channels/:channelId/accessible-children",
+                withUser(SystemsController::getAccessibleChannelChildren));
+    }
 
     /**
      * Deletes a system.

--- a/java/code/src/com/suse/manager/webui/controllers/TaskoTop.java
+++ b/java/code/src/com/suse/manager/webui/controllers/TaskoTop.java
@@ -15,6 +15,11 @@
 
 package com.suse.manager.webui.controllers;
 
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withCsrfToken;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withOrgAdmin;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withUserPreferences;
+import static spark.Spark.get;
+
 import com.redhat.rhn.domain.user.User;
 
 import com.google.gson.Gson;
@@ -27,6 +32,7 @@ import java.util.HashMap;
 import spark.ModelAndView;
 import spark.Request;
 import spark.Response;
+import spark.template.jade.JadeTemplateEngine;
 
 /**
  * Controller class providing backend code for "Runtime Execution"
@@ -40,6 +46,18 @@ public class TaskoTop {
             .create();
 
     private TaskoTop() { }
+
+    /**
+     * Invoked from Router. Initialize routes for Systems Views.
+     *
+     * @param jade the jade engine to use to render the pages.
+     */
+    public static void initRoutes(JadeTemplateEngine jade) {
+        get("/manager/admin/runtime-status",
+                withUserPreferences(withCsrfToken(withOrgAdmin(TaskoTop::show))), jade);
+        get("/manager/api/admin/runtime-status/data",
+                withOrgAdmin(TaskoTop::data));
+    }
 
     /**
      * Displays the taskotop report page

--- a/java/code/src/com/suse/manager/webui/controllers/VisualizationController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/VisualizationController.java
@@ -20,11 +20,15 @@ import com.redhat.rhn.manager.visualization.VisualizationManager;
 import spark.ModelAndView;
 import spark.Request;
 import spark.Response;
+import spark.template.jade.JadeTemplateEngine;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import static com.suse.manager.webui.utils.SparkApplicationHelper.json;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withCsrfToken;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withOrgAdmin;
+import static spark.Spark.get;
 
 /**
  * Controller class providing backend code for visualization pages.
@@ -32,6 +36,26 @@ import static com.suse.manager.webui.utils.SparkApplicationHelper.json;
 public class VisualizationController {
 
     private VisualizationController() { }
+
+    /**
+     * Invoked from Router. Initialize routes for Systems Views.
+     *
+     * @param jade the Jade engine to use to render the pages
+     */
+    public static void initRoutes(JadeTemplateEngine jade) {
+        get("/manager/visualization/virtualization-hierarchy",
+                withCsrfToken(withOrgAdmin(VisualizationController::showVirtualizationHierarchy)), jade);
+        get("/manager/api/visualization/virtualization-hierarchy/data",
+                withOrgAdmin(VisualizationController::virtHierarchyData));
+        get("/manager/visualization/proxy-hierarchy",
+                withCsrfToken(withOrgAdmin(VisualizationController::showProxyHierarchy)), jade);
+        get("/manager/api/visualization/proxy-hierarchy/data",
+                withOrgAdmin(VisualizationController::proxyHierarchyData));
+        get("/manager/visualization/systems-with-managed-groups",
+                withCsrfToken(withOrgAdmin(VisualizationController::systemsWithManagedGroups)), jade);
+        get("/manager/api/visualization/systems-with-managed-groups/data",
+                withOrgAdmin(VisualizationController::systemsWithManagedGroupsData));
+    }
 
     /**
      * Display the Virtualization Hierarchy visualization page


### PR DESCRIPTION
## What does this PR change?

In order to make the Router class more readable, move all the route
initialization functions into the controller as it has already been
started.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: code move

- [X] **DONE**

## Test coverage
- No tests: code mode

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
