### PR TITLE
[WIP] Filter patches on advisory instead of synopsis

### DIFF
--- a/java/code/webapp/WEB-INF/pages/common/fragments/errata/relevant-errata-list.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/errata/relevant-errata-list.jspf
@@ -47,13 +47,13 @@
         <rl:column headerkey="erratalist.jsp.advisory"
                    sortable="true"
                    sortattr="advisoryName"
+                   filterattr="advisoryName"
                    defaultsort="asc">
             <a href="/rhn/errata/details/Details.do?eid=${current.id}">${current.advisoryName}</a>
         </rl:column>
         <rl:column headerkey="erratalist.jsp.synopsis"
                    sortable="true"
-                   sortattr="advisorySynopsis"
-                   filterattr="advisorySynopsis">
+                   sortattr="advisorySynopsis">
             ${current.advisorySynopsis}
         </rl:column>
         <rl:column headerkey="erratalist.jsp.systems"

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- filter patches on advisory instead of synopsis
 - merge java translations from branding back to this package
 - fix mgr-sync add channel when fromdir is configured (bsc#1160184)
 - handle not found re-activation key (bsc#1159012)


### PR DESCRIPTION
## What does this PR change?

https://github.com/SUSE/spacewalk/issues/10068

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/10068
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
