### PR TITLE
Do not run client tests if client system does not exist

### DIFF
--- a/testsuite/features/secondary/allcli_action_chain.feature
+++ b/testsuite/features/secondary/allcli_action_chain.feature
@@ -1,0 +1,104 @@
+# Copyright (c) 2018-2020 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@sle_client
+@sle_minion
+Feature: Action chains on several systems at once
+
+  Scenario: Pre-requisite: downgrade packages before action chain test on several systems
+    Given I am authorized as "admin" with password "admin"
+    When I enable repository "test_repo_rpm_pool" on this "sle_minion"
+    And I enable repository "test_repo_rpm_pool" on this "sle_client"
+    And I run "zypper -n rm andromeda-dummy" on "sle_client" without error control
+    And I run "zypper -n rm andromeda-dummy" on "sle_minion" without error control
+    And I run "zypper -n in --oldpackage andromeda-dummy-1.0" on "sle_minion"
+    And I run "zypper -n in --oldpackage andromeda-dummy-1.0" on "sle_client"
+    And I run "zypper -n ref" on "sle_minion"
+    And I run "zypper -n ref" on "sle_client"
+    And I run "rhn_check -vvv" on "sle_client"
+
+  Scenario: Pre-requisite: refresh package list and check installed packages before action chain test on several systems
+    When I refresh packages list via spacecmd on "sle_minion"
+    And I wait until refresh package list on "sle_minion" is finished
+    Then spacecmd should show packages "andromeda-dummy-1.0" installed on "sle_minion"
+    When I refresh packages list via spacecmd on "sle_client"
+    And I wait until refresh package list on "sle_client" is finished
+    Then spacecmd should show packages "andromeda-dummy-1.0" installed on "sle_client"
+
+  Scenario: Ensure the errata cache is computed before action chain test on several systems
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow the left menu "Admin > Task Schedules"
+    And I follow "errata-cache-default"
+    And I follow "errata-cache-bunch"
+    And I click on "Single Run Schedule"
+    Then I should see a "bunch was scheduled" text
+    And I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows
+    When I am on the Systems overview page of this "sle_client"
+    When I follow the left menu "Admin > Task Schedules"
+    And I follow "errata-cache-default"
+    And I follow "errata-cache-bunch"
+    And I click on "Single Run Schedule"
+    Then I should see a "bunch was scheduled" text
+    And I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows
+
+  Scenario: Add an action chain using system set manager for traditional client and Salt minion
+    Given I am authorized as "admin" with password "admin"
+    When I am on the System Overview page
+    And I check the "sle_minion" client
+    And I check the "sle_client" client
+    And I am on System Set Manager Overview
+    And I follow "Install" in the content area
+    And I follow "Test-Channel-x86_64" in the content area
+    And I enter "andromeda-dummy" as the filtered package name
+    And I click on the filter button
+    And I check "andromeda-dummy" in the list
+    And I click on "Install Selected Packages"
+    Then I should see "sle_minion" hostname
+    And I should see "sle_client" hostname
+    When I check radio button "schedule-by-action-chain"
+    And I click on "Confirm"
+    Then I should see a "Package installations are being scheduled" text
+    When I am on System Set Manager Overview
+    And I follow "remote commands" in the content area
+    And I enter as remote command this script in
+      """
+      #!/bin/bash
+      touch /tmp/action_chain_done
+      """
+    And I check radio button "schedule-by-action-chain"
+    And I click on "Schedule"
+    Then I should see "sle_minion" hostname
+    And I should see "sle_client" hostname
+
+  Scenario: Verify action chain for two systems
+    Given I am on the Systems overview page of this "sle_minion"
+    When I run "rhn-actions-control --enable-all" on "sle_client"
+    And I follow "Schedule"
+    And I follow "Action Chains"
+    And I follow "new action chain"
+    And I should see a "1. Install or update andromeda-dummy on 2 systems" text
+    And I should see a "2. Run a remote command on 2 systems" text
+    And I click on "Save and Schedule"
+    Then I should see a "Action Chain new action chain has been scheduled for execution." text
+
+  Scenario: Verify that the action chain from the system set manager was executed successfully
+    Given I am authorized as "admin" with password "admin"
+    When I run "rhn_check -vvv" on "sle_client"
+    And I wait until file "/tmp/action_chain_done" exists on "sle_client"
+    And I wait until file "/tmp/action_chain_done" exists on "sle_minion"
+    Then "andromeda-dummy" should be installed on "sle_client"
+    And "andromeda-dummy" should be installed on "sle_minion"
+
+  Scenario: Cleanup: remove package and repository used in action chain for several systems
+    When I run "zypper -n rm andromeda-dummy" on "sle_minion" without error control
+    And I run "zypper -n rm andromeda-dummy" on "sle_client" without error control
+    And I disable repository "test_repo_rpm_pool" on this "sle_minion" without error control
+    And I disable repository "test_repo_rpm_pool" on this "sle_client" without error control
+
+  Scenario: Cleanup: remove temporary files for testing action chains on several systems
+    When I run "rm /tmp/action_chain_done" on "sle_minion" without error control
+    And I run "rm /tmp/action_chain_done" on "sle_client" without error control
+
+  Scenario: Cleanup: remove remaining systems from SSM after action chain tests on several systems
+    When I am authorized as "admin" with password "admin"
+    And I follow "Clear"

--- a/testsuite/features/secondary/min_action_chain.feature
+++ b/testsuite/features/secondary/min_action_chain.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2019 SUSE LLC
+# Copyright (c) 2018-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @sle_minion
@@ -188,59 +188,8 @@ Feature: Action chains on Salt minions
     And I follow "delete action chain" in the content area
     And I click on "Delete"
 
-  Scenario: Add an action chain using system set manager for traditional client and Salt minion
-    Given I am authorized as "admin" with password "admin"
-    When I run "zypper -n rm andromeda-dummy" on "sle_client" without error control
-    And I run "zypper -n rm andromeda-dummy" on "sle_minion" without error control
-    When I am on the System Overview page
-    And I check the "sle_minion" client
-    And I check the "sle_client" client
-    And I am on System Set Manager Overview
-    And I follow "Install" in the content area
-    And I follow "Test-Channel-x86_64" in the content area
-    And I enter "andromeda-dummy" as the filtered package name
-    And I click on the filter button
-    And I check "andromeda-dummy" in the list
-    And I click on "Install Selected Packages"
-    Then I should see "sle_minion" hostname
-    And I should see "sle_client" hostname
-    When I check radio button "schedule-by-action-chain"
-    And I click on "Confirm"
-    Then I should see a "Package installations are being scheduled" text
-    When I am on System Set Manager Overview
-    And I follow "remote commands" in the content area
-    And I enter as remote command this script in
-      """
-      #!/bin/bash
-      touch /tmp/action_chain_done
-      """
-    And I check radio button "schedule-by-action-chain"
-    And I click on "Schedule"
-    Then I should see "sle_minion" hostname
-    And I should see "sle_client" hostname
-
-  Scenario: Verify action chain for two systems
-    Given I am on the Systems overview page of this "sle_minion"
-    When I run "rhn-actions-control --enable-all" on "sle_client"
-    And I follow "Schedule"
-    And I follow "Action Chains"
-    And I follow "new action chain"
-    And I should see a "1. Install or update andromeda-dummy on 2 systems" text
-    And I should see a "2. Run a remote command on 2 systems" text
-    And I click on "Save and Schedule"
-    Then I should see a "Action Chain new action chain has been scheduled for execution." text
-
-  Scenario: Verify that the action chain from the system set manager was executed successfully
-    Given I am authorized as "admin" with password "admin"
-    When I run "rhn_check -vvv" on "sle_client"
-    And I wait until file "/tmp/action_chain_done" exists on "sle_client"
-    And I wait until file "/tmp/action_chain_done" exists on "sle_minion"
-    Then "andromeda-dummy" should be installed on "sle_client"
-    And "andromeda-dummy" should be installed on "sle_minion"
-
   Scenario: Downgrade again repositories to lower version on Salt minion
-    When I run "rm /tmp/action_chain_done" on "sle_minion" without error control
-    And I run "zypper -n rm andromeda-dummy" on "sle_minion" without error control
+    When I run "zypper -n rm andromeda-dummy" on "sle_minion" without error control
     And I run "zypper -n rm virgo-dummy" on "sle_minion" without error control
     And I run "zypper -n in milkyway-dummy" on "sle_minion" without error control
     And I run "zypper -n in --oldpackage andromeda-dummy-1.0" on "sle_minion"
@@ -315,7 +264,3 @@ Feature: Action chains on Salt minions
     And I run "rm -f /tmp/action_chain_done" on "sle_minion" without error control
     And I run "rm -f /etc/action-chain.cnf" on "sle_minion" without error control
     And I run "rm -f /tmp/action_chain_one_system_done" on "sle_minion" without error control
-
-  Scenario: Cleanup: remove remaining systems from SSM after action chain tests on normal minion
-    When I am authorized as "admin" with password "admin"
-    And I follow "Clear"

--- a/testsuite/features/secondary/min_bootstrap_negative.feature
+++ b/testsuite/features/secondary/min_bootstrap_negative.feature
@@ -2,7 +2,7 @@
 # Licensed under the terms of the MIT license.
 
 @sle_minion
-Feature: Negative tests for bootstrap normal minions
+Feature: Negative tests for bootstrapping normal minions
   In order to register only valid minions 
   As an authorized user
   I want to avoid registration with invalid input parameters

--- a/testsuite/features/secondary/minssh_action_chain.feature
+++ b/testsuite/features/secondary/minssh_action_chain.feature
@@ -1,11 +1,9 @@
-# Copyright (c) 2018-2019 SUSE LLC
+# Copyright (c) 2018-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
-#
-# This feature is not tested if there is no SSH minion running
-
-Feature: Salt SSH action chain
 
 @ssh_minion
+Feature: Salt SSH action chain
+
   Scenario: Pre-requisite: downgrade repositories to lower version on SSH minion
     Given I am authorized as "admin" with password "admin"
     When I enable repository "test_repo_rpm_pool" on this "ssh_minion"
@@ -15,13 +13,11 @@ Feature: Salt SSH action chain
     And I run "zypper -n in --oldpackage andromeda-dummy-1.0" on "ssh_minion"
     And I run "zypper -n ref" on "ssh_minion"
 
-@ssh_minion
   Scenario: Pre-requisite: refresh package list and check newly installed packages on SSH minion
     When I refresh packages list via spacecmd on "ssh_minion"
     And I wait until refresh package list on "ssh_minion" is finished
     Then spacecmd should show packages "milkyway-dummy andromeda-dummy-1.0" installed on "ssh_minion"
 
-@ssh_minion
   Scenario: Pre-requisite: wait until downgrade is finished on SSH minion
     Given I am on the Systems overview page of this "ssh_minion"
     When I follow "Software" in the content area
@@ -29,7 +25,6 @@ Feature: Salt SSH action chain
     And I enter "andromeda-dummy" as the filtered package name
     And I click on the filter button until page does contain "andromeda-dummy-1.0" text
 
-@ssh_minion
   Scenario: Pre-requisite: ensure the errata cache is computed before testing on SSH minion
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Admin > Task Schedules"
@@ -39,13 +34,11 @@ Feature: Salt SSH action chain
     Then I should see a "bunch was scheduled" text
     And I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows
 
-@ssh_minion
   Scenario: Pre-requisite: remove all action chains before testing on SSH minion
     Given I am logged in via XML-RPC actionchain as user "admin" and password "admin"
     When I delete all action chains
     And I cancel all scheduled actions
 
-@ssh_minion
   Scenario: Add a patch installation to the action chain on SSH minion
     Given I am on the Systems overview page of this "ssh_minion"
     When I follow "Software" in the content area
@@ -56,7 +49,6 @@ Feature: Salt SSH action chain
     And I click on "Confirm"
     Then I should see a "Action has been successfully added to the Action Chain" text
 
-@ssh_minion
   Scenario: Add a package removal to the action chain on SSH minion
     Given I am on the Systems overview page of this "ssh_minion"
     When I follow "Software" in the content area
@@ -69,7 +61,6 @@ Feature: Salt SSH action chain
     And I click on "Confirm"
     Then I should see a "Action has been successfully added to the Action Chain" text
 
-@ssh_minion
   Scenario: Add a package installation to an action chain on SSH minion
     Given I am on the Systems overview page of this "ssh_minion"
     When I follow "Software" in the content area
@@ -80,7 +71,6 @@ Feature: Salt SSH action chain
     And I click on "Confirm"
     Then I should see a "Action has been successfully added to the Action Chain" text
 
-@ssh_minion
   Scenario: Create a configuration channel for testing action chain on SSH minion
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Configuration > Channels"
@@ -91,7 +81,6 @@ Feature: Salt SSH action chain
     And I click on "Create Config Channel"
     Then I should see a "Action Chain Channel" text
 
-@ssh_minion
   Scenario: Add a configuration file to configuration channel for testing action chain on SSH minion
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Configuration > Channels"
@@ -103,7 +92,6 @@ Feature: Salt SSH action chain
     Then I should see a "Revision 1 of /etc/action-chain.cnf from channel Action Chain Channel" text
     And I should see a "Update Configuration File" button
 
-@ssh_minion
   Scenario: Subscribe system to configuration channel for testing action chain on SSH minion
     Given I am on the Systems overview page of this "ssh_minion"
     When I follow "Configuration" in the content area
@@ -114,7 +102,6 @@ Feature: Salt SSH action chain
     And I click on "Update Channel Rankings"
     Then I should see a "Channel Subscriptions successfully changed for" text
 
-@ssh_minion
   Scenario: Add a configuration file deployment to the action chain on SSH minion
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Configuration > Channels"
@@ -127,14 +114,12 @@ Feature: Salt SSH action chain
     And I click on "Deploy Files to Selected Systems"
     Then I should see a "Action has been successfully added to the Action Chain" text
 
-@ssh_minion
   Scenario: Add apply highstate to action chain on SSH minion
     Given I am on the Systems overview page of this "ssh_minion"
     When I follow "States" in the content area
     And I check radio button "schedule-by-action-chain"
     And I click on "Apply Highstate"
 
-@ssh_minion
   Scenario: Add a reboot action to the action chain on SSH minion
     Given I am on the Systems overview page of this "ssh_minion"
     When I follow first "Schedule System Reboot"
@@ -142,7 +127,6 @@ Feature: Salt SSH action chain
     And I click on "Reboot system"
     Then I should see a "Action has been successfully added to the Action Chain" text
 
-@ssh_minion
   Scenario: Add a remote command to the action chain on SSH minion
     Given I am on the Systems overview page of this "ssh_minion"
     When I follow "Remote Command"
@@ -155,7 +139,6 @@ Feature: Salt SSH action chain
     And I click on "Schedule"
     Then I should see a "Action has been successfully added to the Action Chain" text
 
-@ssh_minion
   Scenario: Verify the action chain list on SSH minion
     Given I am on the Systems overview page of this "ssh_minion"
     When I follow the left menu "Schedule > Action Chains"
@@ -168,13 +151,11 @@ Feature: Salt SSH action chain
     And I should see a "6. Reboot 1 system" text
     And I should see a "7. Run a remote command on 1 system" text
 
-@ssh_minion
   Scenario: Check that a different user cannot see the action chain for SSH minion
     Given I am authorized as "testing" with password "testing"
     When I follow the left menu "Schedule > Action Chains"
     Then I should not see a "new action chain" link
 
-@ssh_minion
   Scenario: Execute the action chain from the web UI on SSH minion
     Given I am on the Systems overview page of this "ssh_minion"
     When I follow the left menu "Schedule > Action Chains"
@@ -182,12 +163,10 @@ Feature: Salt SSH action chain
     Then I click on "Save and Schedule"
     And I should see a "Action Chain new action chain has been scheduled for execution." text
 
-@ssh_minion
   Scenario: Verify that the action chain was executed successfully
     When I wait for "virgo-dummy" to be installed on this "ssh_minion"
     And I wait at most 300 seconds until file "/tmp/action_chain_one_system_done" exists on "ssh_minion"
 
-@ssh_minion
   Scenario: Add a remote command to the new action chain on SSH minion
     Given I am on the Systems overview page of this "ssh_minion"
     When I follow "Remote Command"
@@ -200,7 +179,6 @@ Feature: Salt SSH action chain
     And I click on "Schedule"
     Then I should see a "Action has been successfully added to the Action Chain" text
 
-@ssh_minion
   Scenario: Delete the action chain for SSH minion
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Schedule > Action Chains"
@@ -208,7 +186,6 @@ Feature: Salt SSH action chain
     And I follow "delete action chain" in the content area
     Then I click on "Delete"
 
-@ssh_minion
   Scenario: Cleanup: roll back action chain effects on SSH minion
     Given I am on the Systems overview page of this "ssh_minion"
     When I run "rm /tmp/action_chain_done" on "ssh_minion" without error control
@@ -231,7 +208,6 @@ Feature: Salt SSH action chain
     Then I should see a "bunch was scheduled" text
     And I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows
 
-@ssh_minion
   Scenario: Add operations to the action chain via XML-RPC for SSH minions
     Given I am logged in via XML-RPC actionchain as user "admin" and password "admin"
     And I want to operate on this "ssh_minion"
@@ -246,7 +222,6 @@ Feature: Salt SSH action chain
     Then the current action chain should be empty
     And I delete the action chain
 
-@ssh_minion
   Scenario: Run an action chain via XML-RPC on SSH minion
     Given I am logged in via XML-RPC actionchain as user "admin" and password "admin"
     And I want to operate on this "ssh_minion"
@@ -262,7 +237,6 @@ Feature: Salt SSH action chain
     Then file "/tmp/action_chain.log" should contain "123" on "ssh_minion"
     And I wait until there are no more scheduled actions
 
-@ssh_minion
   Scenario: Cleanup: remove SSH minion from configuration channel
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Configuration > Channels"
@@ -272,7 +246,6 @@ Feature: Salt SSH action chain
     And I click on "Unsubscribe systems"
     Then I should see a "Successfully unsubscribed 1 system(s)." text
 
-@ssh_minion
   Scenario: Cleanup: remove configuration channel for SSH minion
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Configuration > Channels"
@@ -280,20 +253,14 @@ Feature: Salt SSH action chain
     And I follow "Delete Channel"
     And I click on "Delete Config Channel"
 
-@ssh_minion
   Scenario: Cleanup: remove packages and repository used in action chain for SSH minion
     When I run "zypper -n rm andromeda-dummy" on "ssh_minion" without error control
     And I run "zypper -n rm virgo-dummy" on "ssh_minion" without error control
     And I run "zypper -n rm milkyway-dummy" on "ssh_minion" without error control
     And I disable repository "test_repo_rpm_pool" on this "ssh_minion" without error control
 
-@ssh_minion
   Scenario: Cleanup: remove temporary files for testing action chains on SSH minion
     When I run "rm -f /tmp/action_chain.log" on "ssh_minion" without error control
     And I run "rm -f /tmp/action_chain_done" on "ssh_minion" without error control
     And I run "rm -f /etc/action-chain.cnf" on "ssh_minion" without error control
     And I run "rm -f /tmp/action_chain_one_system_done" on "ssh_minion" without error control
-
-  Scenario: Cleanup: remove remaining systems from SSM after action chain tests on SSH minion
-    When I am authorized as "admin" with password "admin"
-    And I follow "Clear"

--- a/testsuite/features/secondary/trad_action_chain.feature
+++ b/testsuite/features/secondary/trad_action_chain.feature
@@ -1,6 +1,7 @@
-# Copyright (c) 2018-2019 SUSE LLC
+# Copyright (c) 2018-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
+@sle_client
 Feature: Action chain on traditional clients
 
   Scenario: Pre-requisite: downgrade repositories to lower version on traditional client
@@ -256,7 +257,3 @@ Feature: Action chain on traditional clients
 
   Scenario: Cleanup: remove temporary files for testing action chains on traditional client
     When I run "rm -f /tmp/action_chain.log" on "sle_client" without error control
-
-  Scenario: Cleanup: remove remaining systems from SSM after action chain tests on traditional client
-    When I am authorized as "admin" with password "admin"
-    And I follow "Clear"

--- a/testsuite/features/secondary/trad_cve_audit.feature
+++ b/testsuite/features/secondary/trad_cve_audit.feature
@@ -1,10 +1,11 @@
-# Copyright (c) 2015-2018 SUSE LLC
+# Copyright (c) 2015-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-Feature: CVE Audit
+@sle_client
+Feature: CVE Audit on traditional clients
   In order to check if systems are patched against certain vulnerabilities
   As an authorized user
-  I want to see the systems that need to be patched
+  I want to see the traditional clients that need to be patched
 
   Scenario: Pre-requisite: downgrade milkyway-dummy to lower version
     Given I am authorized as "admin" with password "admin"

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -33,6 +33,7 @@
 - features/secondary/trad_action_chain.feature
 - features/secondary/min_action_chain.feature
 - features/secondary/minssh_action_chain.feature
+- features/secondary/allcli_action_chain.feature
 - features/secondary/srv_delete_channel_from_ui.feature
 - features/secondary/srv_delete_channel_with_tool.feature
 - features/secondary/min_docker_build_image.feature

--- a/testsuite/run_sets/secondary_parallelizable.yml
+++ b/testsuite/run_sets/secondary_parallelizable.yml
@@ -13,7 +13,6 @@
 - features/secondary/srv_check_sync_source_packages.feature
 - features/secondary/srv_change_password.feature
 - features/secondary/srv_clone_channel_npn.feature
-- features/secondary/srv_cve_audit.feature
 - features/secondary/srv_xmlrpc_activationkey.feature
 - features/secondary/srv_distro_cobbler.feature
 - features/secondary/srv_mainpage.feature
@@ -63,6 +62,7 @@
 - features/secondary/min_custom_pkg_download_endpoint.feature
 
 - features/secondary/trad_metadata_check.feature
+- features/secondary/trad_cve_audit.feature
 - features/secondary/trad_cve_id_new_syntax.feature
 - features/secondary/trad_weak_deps.feature
 - features/secondary/trad_openscap_audit.feature

--- a/testsuite/run_sets/sle-updates.yml
+++ b/testsuite/run_sets/sle-updates.yml
@@ -33,7 +33,7 @@
 - features/secondary/min_docker_xmlrpc.feature
 - features/secondary/min_docker_build_image.feature
 - features/secondary/trad_metadata_check.feature
-- features/secondary/srv_cve_audit.feature
+- features/secondary/trad_cve_audit.feature
 - features/secondary/srv_distro_cobbler.feature
 - features/secondary/srv_mainpage.feature
 - features/secondary/srv_xmlrpc_user.feature

--- a/testsuite/run_sets/testsuite.yml
+++ b/testsuite/run_sets/testsuite.yml
@@ -71,9 +71,9 @@
 - features/secondary/srv_clone_channel_npn.feature
 - features/secondary/srv_delete_channel_from_ui.feature
 - features/secondary/srv_delete_channel_with_tool.feature
+- features/secondary/trad_cve_audit.feature
 - features/secondary/trad_cve_id_new_syntax.feature
 - features/secondary/trad_weak_deps.feature
-- features/secondary/srv_cve_audit.feature
 - features/secondary/min_salt_install_with_staging.feature
 - features/secondary/srv_xmlrpc_activationkey.feature
 - features/secondary/allcli_overview_systems_details.feature
@@ -86,6 +86,7 @@
 - features/secondary/trad_action_chain.feature
 - features/secondary/min_action_chain.feature
 - features/secondary/minssh_action_chain.feature
+- features/secondary/allcli_action_chain.feature
 - features/secondary/min_salt_formulas.feature
 - features/secondary/min_salt_formulas_advanced.feature
 - features/secondary/min_docker_auth_registry.feature

--- a/testsuite/run_sets/uyuni.yml
+++ b/testsuite/run_sets/uyuni.yml
@@ -71,9 +71,9 @@
 - features/secondary/srv_clone_channel_npn.feature
 - features/secondary/srv_delete_channel_from_ui.feature
 - features/secondary/srv_delete_channel_with_tool.feature
+- features/secondary/trad_cve_audit.feature
 - features/secondary/trad_cve_id_new_syntax.feature
 - features/secondary/trad_weak_deps.feature
-- features/secondary/srv_cve_audit.feature
 - features/secondary/min_salt_install_with_staging.feature
 - features/secondary/srv_xmlrpc_activationkey.feature
 - features/secondary/allcli_overview_systems_details.feature
@@ -86,6 +86,7 @@
 - features/secondary/trad_action_chain.feature
 - features/secondary/min_action_chain.feature
 - features/secondary/minssh_action_chain.feature
+- features/secondary/allcli_action_chain.feature
 - features/secondary/min_salt_formulas.feature
 - features/secondary/min_salt_formulas_advanced.feature
 - features/secondary/min_docker_auth_registry.feature


### PR DESCRIPTION
## What does this PR change?

Modularity: two feature tests (CVE audit and action chains on minion) would fail if traditional client does not exist. This PR fixes that.

## Links

Ports:
* 4.0: SUSE/spacewalk#10582
* 3.2: SUSE/spacewalk#10583

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
