### PR TITLE
Remove duplicated and stale query

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
@@ -68,33 +68,6 @@ ORDER BY UPPER(PN.name), PEVR.evr
   </query>
 </mode>
 
-<mode name="system_all_available_packages_expanded">
-  <query params="sid">
-SELECT PKG.id AS id,
-       PN.name AS name,
-       NVL((PEVR.evr).version, ' ') AS version,
-       NVL((PEVR.evr).release, ' ') AS release,
-       NVL((PEVR.evr).epoch, ' ') AS epoch,
-       NVL(PA.label, ' ') AS arch_label,
-       PN.id nameid,
-       PEVR.id evrid,
-       PA.id archid
-  FROM rhnPackage PKG
-       join rhnPackageName PN on PKG.name_id = PN.id
-       join rhnPackageEVR PEVR on PKG.evr_id = PEVR.id
-       join rhnPackageArch PA on PKG.package_arch_id = PA.id
-       join rhnChannelPackage CP on CP.package_id = PKG.id
-       join rhnServerChannel SC on SC.channel_id = CP.channel_id
- WHERE SC.server_id = :sid
-   AND NOT EXISTS (SELECT 1
-                     FROM rhnServerPackage SP
-                    WHERE SP.server_id = :sid
-                      AND SP.name_id = PN.id
-                      AND (SP.package_arch_id = PA.id or SP.package_arch_id is null))
-ORDER BY UPPER(PN.name), PEVR.evr
-  </query>
-</mode>
-
 <mode name="system_packages_from_channel">
   <query params="sid, cid">
 SELECT PKG.id AS id,
@@ -117,33 +90,6 @@ SELECT PKG.id AS id,
    AND SP.name_id = PKG.name_id
    AND SP.evr_id = PKG.evr_id
    AND SP.package_arch_id = PKG.package_arch_id
-  </query>
-</mode>
-
-<mode name="system_all_available_packages_expanded">
-  <query params="sid">
-SELECT PKG.id AS id,
-       PN.name AS name,
-       NVL((PEVR.evr).version, ' ') AS version,
-       NVL((PEVR.evr).release, ' ') AS release,
-       NVL((PEVR.evr).epoch, ' ') AS epoch,
-       NVL(PA.label, ' ') AS arch_label,
-       PN.id nameid,
-       PEVR.id evrid,
-       PA.id archid
-  FROM rhnPackage PKG
-       join rhnPackageName PN on PKG.name_id = PN.id
-       join rhnPackageEVR PEVR on PKG.evr_id = PEVR.id
-       join rhnPackageArch PA on PKG.package_arch_id = PA.id
-       join rhnChannelPackage CP on CP.package_id = PKG.id
-       join rhnServerChannel SC on SC.channel_id = CP.channel_id
- WHERE SC.server_id = :sid
-   AND NOT EXISTS (SELECT 1
-                     FROM rhnServerPackage SP
-                    WHERE SP.server_id = :sid
-                      AND SP.name_id = PN.id
-                      AND (SP.package_arch_id = PA.id or SP.package_arch_id is null))
-ORDER BY UPPER(PN.name), PEVR.evr
   </query>
 </mode>
 


### PR DESCRIPTION
## What does this PR change?

Simply get rid of a duplicated and stale query.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Fixes #
Tracks #

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
