### PR TITLE
Prevent timestamp format exception on "mgr-inter-sync" while processing comps (bsc#1157346)

### DIFF
--- a/backend/satellite_tools/satellite-sync
+++ b/backend/satellite_tools/satellite-sync
@@ -38,6 +38,11 @@ def systemExit(code, msgs=None):
 import os
 import socket
 
+if hasattr(socket, 'sslerror'):
+    socket_error = socket.sslerror
+else:
+    from ssl import socket_error
+
 
 # quick check to see if you are a super-user.
 if os.getuid() != 0:
@@ -143,7 +148,7 @@ def main():
     except socket.error as e:
         msg = "\nERROR: a general socket exception occurred:"
         systemExit_exception(3, msg, e)
-    except socket.sslerror as e:
+    except socket_error as e:
         msg = ("""
 ERROR: an SSL error occurred. Recheck your SSL settings. Those settings may
        include URL's, SSL Certificate settings, firewall rules, etc..

--- a/backend/satellite_tools/sync_handlers.py
+++ b/backend/satellite_tools/sync_handlers.py
@@ -450,7 +450,8 @@ def _to_timestamp(t):
     # The cache expects YYYYMMDDHH24MISS as format; so just drop the
     # spaces, dashes and columns
     # python 2.4 can't handle t.translate(None, ' -:')
-    last_modified = t.translate(' -:')
+    table = t.maketrans('', '', ' -:')
+    last_modified = t.translate(table)
     return last_modified
 
 # Generic container handler

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- Prevent timestamp format exception on mgr-inter-sync while processing comps (bsc#1157346)
+
 -------------------------------------------------------------------
 Wed Jan 22 12:10:51 CET 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes two issues with `mgr-inter-sync` when running with Python3:

- Do not produce an extra exception when handling exceptions:
```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/mgr-inter-sync", line 166, in <module>
    sys.exit(abs(main() or 0))
  File "/usr/bin/mgr-inter-sync", line 146, in main
    except socket.sslerror as e:
AttributeError: module 'socket' has no attribute 'sslerror'
```
---
- Fix `sync_handlers._to_timestamp` to properly remove unwanted characters when processing "comps":
```
spacewalk.server.rhnSQL.sql_base.SQLSchemaError: (99999, 'ERROR:  invalid value "1-" for "DD"', 'DETAIL:  Field requires 2 characters, but only 1 could be parsed.
HINT:  If your source string is not fixed-width, try using the "FM" modifier.
CONTEXT:  SQL statement "insert into rhnChannelComps (id, channel_id, relative_filename, comps_type_id, last_modified, created, modified)
        values (sequence_nextval(\'rhn_channelcomps_id_seq\'), channel_id_in, path_in, comps_type_id_in, to_timestamp(timestamp_in, \'YYYYMMDDHH24MISS\'), current_timestamp, current_timestamp)"
PL/pgSQL function rhn_channel.set_comps(numeric,character varying,numeric,character varying) line 18 at SQL statement
', DataError('invalid value "1-" for "DD"
DETAIL:  Field requires 2 characters, but only 1 could be parsed.
HINT:  If your source string is not fixed-width, try using the "FM" modifier.
CONTEXT:  SQL statement "insert into rhnChannelComps (id, channel_id, relative_filename, comps_type_id, last_modified, created, modified)
        values (sequence_nextval(\'rhn_channelcomps_id_seq\'), channel_id_in, path_in, comps_type_id_in, to_timestamp(timestamp_in, \'YYYYMMDDHH24MISS\'), current_timestamp, current_timestamp)"
PL/pgSQL function rhn_channel.set_comps(numeric,character varying,numeric,character varying) line 18 at SQL statement
',))
```
## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **bugfix**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/10125

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
