### PR TITLE
Fix count of changes to build in CLM (bsc#1160940)

### DIFF
--- a/web/html/src/manager/content-management/shared/components/panels/build/build.js
+++ b/web/html/src/manager/content-management/shared/components/panels/build/build.js
@@ -49,7 +49,9 @@ const Build = ({projectId, onBuild, currentHistoryEntry = {}, changesToBuild, di
         <ModalButton
           id={`build-contentmngt-modal-link`}
           className={ disabled ? `btn-secondary` : `btn-success` }
-          text={changesToBuild.length > 0 ? t('Build ({0})', changesToBuild.length) : t('Build')}
+          text={changesToBuild.length > 0 ?
+            t('Build ({0})', changesToBuild.filter(s => !s.includes('Software Channels:') && !s.includes('Software Filter:')).length)
+            : t('Build')}
           disabled={disabled}
           target={modalNameId}
           onClick={() => {

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- Fix count of changes to build (bsc#1160940)
+
 -------------------------------------------------------------------
 Wed Jan 22 12:16:08 CET 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Fix count of Build in CLM

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed:
- [x] **DONE**

## Test coverage
- No tests: already covered, fixing tests 
- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
