### PR TITLE
Use specialized steps to handle packages

### DIFF
--- a/testsuite/features/secondary/allcli_action_chain.feature
+++ b/testsuite/features/secondary/allcli_action_chain.feature
@@ -9,10 +9,10 @@ Feature: Action chains on several systems at once
     Given I am authorized as "admin" with password "admin"
     When I enable repository "test_repo_rpm_pool" on this "sle_minion"
     And I enable repository "test_repo_rpm_pool" on this "sle_client"
-    And I run "zypper -n rm andromeda-dummy" on "sle_client" without error control
-    And I run "zypper -n rm andromeda-dummy" on "sle_minion" without error control
-    And I run "zypper -n in --oldpackage andromeda-dummy-1.0" on "sle_minion"
-    And I run "zypper -n in --oldpackage andromeda-dummy-1.0" on "sle_client"
+    And I remove package "andromeda-dummy" from this "sle_client" without error control
+    And I remove package "andromeda-dummy" from this "sle_minion" without error control
+    And I install old package "andromeda-dummy-1.0" on this "sle_minion"
+    And I install old package "andromeda-dummy-1.0" on this "sle_client"
     And I run "zypper -n ref" on "sle_minion"
     And I run "zypper -n ref" on "sle_client"
     And I run "rhn_check -vvv" on "sle_client"
@@ -99,8 +99,8 @@ Feature: Action chains on several systems at once
     And "andromeda-dummy" should be installed on "sle_minion"
 
   Scenario: Cleanup: remove package and repository used in action chain for several systems
-    When I run "zypper -n rm andromeda-dummy" on "sle_minion" without error control
-    And I run "zypper -n rm andromeda-dummy" on "sle_client" without error control
+    When I remove package "andromeda-dummy" from this "sle_minion" without error control
+    And I remove package "andromeda-dummy" from this "sle_client" without error control
     And I disable repository "test_repo_rpm_pool" on this "sle_minion" without error control
     And I disable repository "test_repo_rpm_pool" on this "sle_client" without error control
 

--- a/testsuite/features/secondary/min_action_chain.feature
+++ b/testsuite/features/secondary/min_action_chain.feature
@@ -7,10 +7,10 @@ Feature: Action chains on Salt minions
   Scenario: Pre-requisite: downgrade repositories to lower version on Salt minion
     Given I am authorized as "admin" with password "admin"
     When I enable repository "test_repo_rpm_pool" on this "sle_minion"
-    And I run "zypper -n rm andromeda-dummy" on "sle_minion" without error control
-    And I run "zypper -n rm virgo-dummy" on "sle_minion" without error control
-    And I run "zypper -n in milkyway-dummy" on "sle_minion" without error control
-    And I run "zypper -n in --oldpackage andromeda-dummy-1.0" on "sle_minion"
+    And I remove package "andromeda-dummy" from this "sle_minion" without error control
+    And I remove package "virgo-dummy" from this "sle_minion" without error control
+    And I install package "milkyway-dummy" on this "sle_minion" without error control
+    And I install old package "andromeda-dummy-1.0" on this "sle_minion"
     And I run "zypper -n ref" on "sle_minion"
 
   Scenario: Pre-requisite: refresh package list and check installed packages after downgrade on SLE minion
@@ -189,10 +189,10 @@ Feature: Action chains on Salt minions
     And I click on "Delete"
 
   Scenario: Downgrade again repositories to lower version on Salt minion
-    When I run "zypper -n rm andromeda-dummy" on "sle_minion" without error control
-    And I run "zypper -n rm virgo-dummy" on "sle_minion" without error control
-    And I run "zypper -n in milkyway-dummy" on "sle_minion" without error control
-    And I run "zypper -n in --oldpackage andromeda-dummy-1.0" on "sle_minion"
+    When I remove package "andromeda-dummy" from this "sle_minion" without error control
+    And I remove package "virgo-dummy" from this "sle_minion" without error control
+    And I install package "milkyway-dummy" on this "sle_minion" without error control
+    And I install old package "andromeda-dummy-1.0" on this "sle_minion"
 
   Scenario: Refresh package list and check installed packages after second downgrade on SLE minion
     When I refresh packages list via spacecmd on "sle_minion"
@@ -254,9 +254,9 @@ Feature: Action chains on Salt minions
     And I click on "Delete Config Channel"
 
   Scenario: Cleanup: remove packages and repository used in action chain for Salt minion
-    When I run "zypper -n rm andromeda-dummy" on "sle_minion" without error control
-    And I run "zypper -n rm virgo-dummy" on "sle_minion" without error control
-    And I run "zypper -n rm milkyway-dummy" on "sle_minion" without error control
+    When I remove package "andromeda-dummy" from this "sle_minion" without error control
+    And I remove package "virgo-dummy" from this "sle_minion" without error control
+    And I remove package "milkyway-dummy" from this "sle_minion" without error control
     And I disable repository "test_repo_rpm_pool" on this "sle_minion" without error control
 
   Scenario: Cleanup: remove temporary files for testing action chains on Salt minion

--- a/testsuite/features/secondary/min_salt_install_package.feature
+++ b/testsuite/features/secondary/min_salt_install_package.feature
@@ -1,12 +1,12 @@
-# Copyright (c) 2015-2019 SUSE LLC
+# Copyright (c) 2015-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Install a patch on the client via Salt through the UI
 
-  Scenario: Pre-requisite: install virgo-dummy-1.0 packages on SLE minion
+  Scenario: Pre-requisite: install virgo-dummy-1.0 package on SLE minion
     When I enable repository "test_repo_rpm_pool" on this "sle_minion"
     And I run "zypper -n ref" on "sle_minion"
-    And I run "zypper -n in --oldpackage virgo-dummy-1.0" on "sle_minion" without error control
+    And I install old package "virgo-dummy-1.0" on this "sle_minion" without error control
 
   Scenario: Pre-requisite: refresh package list and check old packages installed on SLE minion
     When I refresh packages list via spacecmd on "sle_minion"
@@ -37,7 +37,7 @@ Feature: Install a patch on the client via Salt through the UI
     Then I should see a "1 patch update has been scheduled for" text
     And I wait for "virgo-dummy-2.0-1.1" to be installed on this "sle_minion"
 
-  Scenario: Cleanup: remove virgo-dummy packages from SLES minion
+  Scenario: Cleanup: remove virgo-dummy package from SLE minion
     When I disable repository "test_repo_rpm_pool" on this "sle_minion"
-    And I run "zypper -n rm virgo-dummy" on "sle_minion" without error control
+    And I remove package "virgo-dummy" from this "sle_minion" without error control
     And I run "zypper -n ref" on "sle_minion"

--- a/testsuite/features/secondary/min_salt_install_with_staging.feature
+++ b/testsuite/features/secondary/min_salt_install_with_staging.feature
@@ -15,7 +15,7 @@ Feature: Install a package on the SLES minion with staging enabled
 
   Scenario: Pre-requisite: install virgo-dummy-1.0 package, make sure orion-dummy is not present
     When I enable repository "test_repo_rpm_pool" on this "sle_minion"
-    And I run "zypper --non-interactive remove -y orion-dummy" on "sle_minion" without error control
+    And I remove package "orion-dummy" from this "sle_minion" without error control
     And I install package "virgo-dummy-1.0" on this "sle_minion"
 
   Scenario: Pre-requisite: refresh package list

--- a/testsuite/features/secondary/min_salt_pkgset_beacon.feature
+++ b/testsuite/features/secondary/min_salt_pkgset_beacon.feature
@@ -1,13 +1,13 @@
-# Copyright (c) 2016-2019 SUSE LLC
+# Copyright (c) 2016-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: System package list is updated if packages are manually installed or removed
 
-  Scenario: Pre-requisite: install milkyway-dummy-1.0 packages
+  Scenario: Pre-requisite: install milkyway-dummy-1.0 package
     Given I am authorized as "admin" with password "admin"
     When I enable repository "test_repo_rpm_pool" on this "sle_minion"
     And I run "zypper -n ref" on "sle_minion"
-    And I run "zypper -n in --oldpackage milkyway-dummy-1.0" on "sle_minion" without error control
+    And I install old package "milkyway-dummy-1.0" on this "sle_minion" without error control
 
   Scenario: Pre-requisite: refresh package list and check installed packages on SLE minion client
     When I refresh packages list via spacecmd on "sle_minion"
@@ -49,5 +49,5 @@ Feature: System package list is updated if packages are manually installed or re
 
   Scenario: Cleanup: remove milkyway-dummy packages from SLES minion
     When I disable repository "test_repo_rpm_pool" on this "sle_minion"
-    And I run "zypper -n rm milkyway-dummy" on "sle_minion" without error control
+    And I remove package "milkyway-dummy" from this "sle_minion" without error control
     And I run "zypper -n ref" on "sle_minion"

--- a/testsuite/features/secondary/min_salt_software_states.feature
+++ b/testsuite/features/secondary/min_salt_software_states.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2019 SUSE LLC
+# Copyright (c) 2016-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Salt package states
@@ -8,9 +8,9 @@ Feature: Salt package states
     Then I apply highstate on "sle_minion"
     And I enable repository "test_repo_rpm_pool" on this "sle_minion"
     And I run "zypper -n ref" on "sle_minion"
-    And I run "zypper -n in --oldpackage milkyway-dummy-1.0" on "sle_minion" without error control
-    And I run "zypper -n in --oldpackage virgo-dummy-1.0" on "sle_minion" without error control
-    And I run "zypper -n in --oldpackage andromeda-dummy-1.0" on "sle_minion" without error control
+    And I install old package "milkyway-dummy-1.0" on this "sle_minion" without error control
+    And I install old package "virgo-dummy-1.0" on this "sle_minion" without error control
+    And I install old package "andromeda-dummy-1.0" on this "sle_minion" without error control
 
   Scenario: Pre-requisite: refresh package list and check installed packages on SLE minion
     When I refresh packages list via spacecmd on "sle_minion"
@@ -126,7 +126,7 @@ Feature: Salt package states
 
   Scenario: Cleanup: remove old packages from SLES minion
     When I disable repository "test_repo_rpm_pool" on this "sle_minion"
-    And I run "zypper -n rm milkyway-dummy" on "sle_minion" without error control
-    And I run "zypper -n rm virgo-dummy" on "sle_minion" without error control
-    And I run "zypper -n rm andromeda-dummy" on "sle_minion" without error control
+    And I remove package "milkyway-dummy" from this "sle_minion" without error control
+    And I remove package "virgo-dummy" from this "sle_minion" without error control
+    And I remove package "andromeda-dummy" from this "sle_minion" without error control
     And I run "zypper -n ref" on "sle_minion"

--- a/testsuite/features/secondary/min_ubuntu_salt_install_package.feature
+++ b/testsuite/features/secondary/min_ubuntu_salt_install_package.feature
@@ -1,14 +1,14 @@
-# Copyright (c) 2019 SUSE LLC
+# Copyright (c) 2019-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Install and upgrade package on the Ubuntu minion via Salt through the UI
 
 @ubuntu_minion
-  Scenario: Pre-requisite: install virgo-dummy-1.0 packages on Ubuntu minion
+  Scenario: Pre-requisite: install virgo-dummy-1.0 package on Ubuntu minion
     When I enable repository "test_repo_deb_pool" on this "ubuntu_ssh_minion"
     And I run "apt update" on "ubuntu_ssh_minion" with logging
     And I remove package "andromeda-dummy" from this "ubuntu_ssh_minion"
-    And I install package "virgo-dummy=1.0" on this "ubuntu_ssh_minion"
+    And I install old package "virgo-dummy=1.0" on this "ubuntu_ssh_minion"
     And I am on the Systems overview page of this "ubuntu_ssh_minion"
     And I follow "Software" in the content area
     And I click on "Update Package List"
@@ -45,8 +45,6 @@ Feature: Install and upgrade package on the Ubuntu minion via Salt through the U
   Scenario: Cleanup: remove virgo-dummy and andromeda-dummy packages from Ubuntu minion
     Given I am authorized as "admin" with password "admin"
     And I remove package "andromeda-dummy" from this "ubuntu_ssh_minion"
-    And I install package "andromeda-dummy=1.0" on this "ubuntu_ssh_minion"
     And I remove package "virgo-dummy" from this "ubuntu_ssh_minion"
     And I disable repository "test_repo_deb_pool" on this "ubuntu_ssh_minion"
     And I run "apt update" on "ubuntu_ssh_minion" with logging
-

--- a/testsuite/features/secondary/minssh_action_chain.feature
+++ b/testsuite/features/secondary/minssh_action_chain.feature
@@ -7,10 +7,10 @@ Feature: Salt SSH action chain
   Scenario: Pre-requisite: downgrade repositories to lower version on SSH minion
     Given I am authorized as "admin" with password "admin"
     When I enable repository "test_repo_rpm_pool" on this "ssh_minion"
-    And I run "zypper -n rm andromeda-dummy" on "ssh_minion" without error control
-    And I run "zypper -n rm virgo-dummy" on "ssh_minion" without error control
-    And I run "zypper -n in milkyway-dummy" on "ssh_minion" without error control
-    And I run "zypper -n in --oldpackage andromeda-dummy-1.0" on "ssh_minion"
+    And I remove package "andromeda-dummy" from this "ssh_minion" without error control
+    And I remove package "virgo-dummy" from this "ssh_minion" without error control
+    And I install package "milkyway-dummy" on this "ssh_minion" without error control
+    And I install old package "andromeda-dummy-1.0" on this "ssh_minion"
     And I run "zypper -n ref" on "ssh_minion"
 
   Scenario: Pre-requisite: refresh package list and check newly installed packages on SSH minion
@@ -189,10 +189,10 @@ Feature: Salt SSH action chain
   Scenario: Cleanup: roll back action chain effects on SSH minion
     Given I am on the Systems overview page of this "ssh_minion"
     When I run "rm /tmp/action_chain_done" on "ssh_minion" without error control
-    And I run "zypper -n rm andromeda-dummy" on "ssh_minion" without error control
-    And I run "zypper -n rm virgo-dummy" on "ssh_minion" without error control
-    And I run "zypper -n in milkyway-dummy" on "ssh_minion" without error control
-    And I run "zypper -n in --oldpackage andromeda-dummy-1.0" on "ssh_minion"
+    And I remove package "andromeda-dummy" from this "ssh_minion" without error control
+    And I remove package "virgo-dummy" from this "ssh_minion" without error control
+    And I install package "milkyway-dummy" on this "ssh_minion" without error control
+    And I install old package "andromeda-dummy-1.0" on this "ssh_minion"
     And I follow "Software" in the content area
     And I click on "Update Package List"
     And I follow "Events" in the content area
@@ -254,9 +254,9 @@ Feature: Salt SSH action chain
     And I click on "Delete Config Channel"
 
   Scenario: Cleanup: remove packages and repository used in action chain for SSH minion
-    When I run "zypper -n rm andromeda-dummy" on "ssh_minion" without error control
-    And I run "zypper -n rm virgo-dummy" on "ssh_minion" without error control
-    And I run "zypper -n rm milkyway-dummy" on "ssh_minion" without error control
+    When I remove package "andromeda-dummy" from this "ssh_minion" without error control
+    And I remove package "virgo-dummy" from this "ssh_minion" without error control
+    And I remove package "milkyway-dummy" from this "ssh_minion" without error control
     And I disable repository "test_repo_rpm_pool" on this "ssh_minion" without error control
 
   Scenario: Cleanup: remove temporary files for testing action chains on SSH minion

--- a/testsuite/features/secondary/trad_action_chain.feature
+++ b/testsuite/features/secondary/trad_action_chain.feature
@@ -7,10 +7,10 @@ Feature: Action chain on traditional clients
   Scenario: Pre-requisite: downgrade repositories to lower version on traditional client
     Given I am authorized as "admin" with password "admin"
     When I enable repository "test_repo_rpm_pool" on this "sle_client"
-    And I run "zypper -n rm andromeda-dummy" on "sle_client" without error control
-    And I run "zypper -n rm virgo-dummy" on "sle_client" without error control
-    And I run "zypper -n in milkyway-dummy" on "sle_client" without error control
-    And I run "zypper -n in --oldpackage andromeda-dummy-1.0" on "sle_client"
+    And I remove package "andromeda-dummy" from this "sle_client" without error control
+    And I remove package "virgo-dummy" from this "sle_client" without error control
+    And I install package "milkyway-dummy" on this "sle_client" without error control
+    And I install old package "andromeda-dummy-1.0" on this "sle_client"
     And I run "zypper -n ref" on "sle_client"
     And I run "rhn_check -vvv" on "sle_client"
 
@@ -250,9 +250,9 @@ Feature: Action chain on traditional clients
     And I click on "Delete Config Channel"
 
   Scenario: Cleanup: remove packages and repository used in action chain for traditional client
-    When I run "zypper -n rm andromeda-dummy" on "sle_client" without error control
-    And I run "zypper -n rm virgo-dummy" on "sle_client" without error control
-    And I run "zypper -n rm milkyway-dummy" on "sle_client" without error control
+    When I remove package "andromeda-dummy" from this "sle_client" without error control
+    And I remove package "virgo-dummy" from this "sle_client" without error control
+    And I remove package "milkyway-dummy" from this "sle_client" without error control
     And I disable repository "test_repo_rpm_pool" on this "sle_client" without error control
 
   Scenario: Cleanup: remove temporary files for testing action chains on traditional client

--- a/testsuite/features/secondary/trad_check_patches_install.feature
+++ b/testsuite/features/secondary/trad_check_patches_install.feature
@@ -1,14 +1,14 @@
-# Copyright (c) 2015-2019 SUSE LLC
+# Copyright (c) 2015-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-Feature: Patches display
+Feature: Display patches
 
   Scenario: Pre-require: enable old packages to fake a possible installation
     Given I am authorized as "admin" with password "admin"
     When I enable repository "test_repo_rpm_pool" on this "sle_client"
     And I run "zypper -n ref" on "sle_client"
-    And I run "zypper -n in --oldpackage andromeda-dummy-1.0" on "sle_client"
-    And I run "zypper -n in --oldpackage virgo-dummy-1.0" on "sle_client"
+    And I install old package "andromeda-dummy-1.0" on this "sle_client"
+    And I install old package "virgo-dummy-1.0" on this "sle_client"
     And I run "rhn_check -vvv" on "sle_client"
     When I follow the left menu "Admin > Task Schedules"
     And I follow "errata-cache-default"
@@ -23,7 +23,7 @@ Feature: Patches display
     Then I should see an update in the list
     And I should see a "virgo-dummy-3456" link
 
-  Scenario: check SLES release 6789 patches
+  Scenario: Check SLES release 6789 patches
     Given I am on the patches page
     And I follow "andromeda-dummy-6789"
     Then I should see a "andromeda-dummy-6789 - Bug Fix Advisory" text
@@ -54,6 +54,6 @@ Feature: Patches display
   Scenario: Cleanup: remove old packages
     When I disable repository "test_repo_rpm_pool" on this "sle_client" without error control
     And I run "zypper -n ref" on "sle_client" without error control
-    And I run "zypper -n rm --oldpackage andromeda-dummy-1.0" on "sle_client" without error control
-    And I run "zypper -n rm --oldpackage virgo-dummy-1.0" on "sle_client" without error control
+    And I remove package "andromeda-dummy" from this "sle_client" without error control
+    And I remove package "virgo-dummy" from this "sle_client" without error control
     And I run "rhn_check -vvv" on "sle_client" without error control

--- a/testsuite/features/secondary/trad_cve_audit.feature
+++ b/testsuite/features/secondary/trad_cve_audit.feature
@@ -10,7 +10,7 @@ Feature: CVE Audit on traditional clients
   Scenario: Pre-requisite: downgrade milkyway-dummy to lower version
     Given I am authorized as "admin" with password "admin"
     When I enable repository "test_repo_rpm_pool" on this "sle_client"
-    And I run "zypper -n in --oldpackage milkyway-dummy-1.0" on "sle_client"
+    And I install old package "milkyway-dummy-1.0" on this "sle_client"
     And I run "zypper -n ref" on "sle_client"
     And I run "rhn_check -vvv" on "sle_client"
     And I follow the left menu "Admin > Task Schedules"
@@ -110,7 +110,7 @@ Feature: CVE Audit on traditional clients
 
   Scenario: Cleanup: remove installed packages
     When I disable repository "test_repo_rpm_pool" on this "sle_client" without error control
-    And I run "zypper -n rm milkyway-dummy" on "sle_client" without error control
+    And I remove package "milkyway-dummy" from this "sle_client" without error control
     And I run "rhn_check -vvv" on "sle_client" without error control
 
   Scenario: Cleanup: remove remaining systems from SSM after CVE audit tests

--- a/testsuite/features/secondary/trad_inst_package_and_patch.feature
+++ b/testsuite/features/secondary/trad_inst_package_and_patch.feature
@@ -1,15 +1,16 @@
-# Copyright (c) 2017-2018 SUSE LLC
+# Copyright (c) 2017-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Install a package to the traditional client
 
+  Scenario: Pre-requisite: remove packages before traditional client package test
+    When I remove package "andromeda-dummy" from this "sle_client" without error control
+    And I remove package "virgo-dummy" from this "sle_client" without error control
+
   Scenario: Install a package to the traditional client
     Given I am on the Systems overview page of this "sle_client"
-    # we don't know if the pkgs are installed before, just remove or don't fail
-    When I run "zypper -n rm andromeda-dummy" on "sle_client" without error control
-    And I run "zypper -n rm virgo-dummy" on "sle_client" without error control
     And metadata generation finished for "test-channel-x86_64"
-    And I follow "Software" in the content area
+    When I follow "Software" in the content area
     And I follow "Install"
     And I check "virgo-dummy" in the list
     And I click on "Install Selected Packages"
@@ -21,7 +22,7 @@ Feature: Install a package to the traditional client
 
   Scenario: Enable old packages for testing a patch install
     When I enable repository "test_repo_rpm_pool" on this "sle_client"
-    And I run "zypper -n in --oldpackage andromeda-dummy-1.0" on "sle_client"
+    And I install old package "andromeda-dummy-1.0" on this "sle_client"
     And I run "rhn_check -vvv" on "sle_client"
 
   Scenario: Schedule errata refresh after reverting to old package
@@ -47,7 +48,7 @@ Feature: Install a package to the traditional client
     And The metadata buildtime from package "andromeda-dummy" match the one in the rpm on "sle_client"
 
   Scenario: Cleanup: remove packages and restore non-update repo
-    When I run "zypper -n rm andromeda-dummy" on "sle_client"
-    And I run "zypper -n rm virgo-dummy" on "sle_client"
+    When I remove package "andromeda-dummy" from this "sle_client"
+    And I remove package "virgo-dummy" from this "sle_client"
     And I disable repository "test_repo_rpm_pool" on this "sle_client"
     And I run "rhn_check -vvv" on "sle_client"

--- a/testsuite/features/secondary/trad_lock_packages.feature
+++ b/testsuite/features/secondary/trad_lock_packages.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2019 SUSE LLC
+# Copyright (c) 2015-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Lock packages on traditional client
@@ -6,10 +6,10 @@ Feature: Lock packages on traditional client
   Background:
     Given I am on the Systems overview page of this "sle_client"
 
-  Scenario: Pre-requisite: install package needed for test
-    When I run "zypper -n in orion-dummy" on "sle_client"
-    And I run "zypper -n in milkyway-dummy" on "sle_client"
-    And I run "zypper -n rm hoag-dummy" on "sle_client" without error control
+  Scenario: Pre-requisite: install packages needed for locking test
+    When I install package "orion-dummy" on this "sle_client"
+    And I install package "milkyway-dummy" on this "sle_client"
+    And I remove package "hoag-dummy" from this "sle_client" without error control
 
   Scenario: Lock a package on the client
     When I follow "Software" in the content area

--- a/testsuite/features/secondary/trad_need_reboot.feature
+++ b/testsuite/features/secondary/trad_need_reboot.feature
@@ -1,4 +1,4 @@
-# COPYRIGHT (c) 2017-2019 SUSE LLC
+# COPYRIGHT (c) 2017-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 # TODO: This feature must run before install a patch in the client
@@ -22,7 +22,7 @@ Feature: Reboot required after patch
     Given I am authorized as "admin" with password "admin"
     When I enable repository "test_repo_rpm_pool" on this "sle_client"
     And I run "zypper -n ref" on "sle_client"
-    And I run "zypper -n in --oldpackage andromeda-dummy-1.0" on "sle_client"
+    And I install old package "andromeda-dummy-1.0" on this "sle_client"
     And I run "rhn_check -vvv" on "sle_client"
     When I follow the left menu "Admin > Task Schedules"
     And I follow "errata-cache-default"
@@ -46,5 +46,5 @@ Feature: Reboot required after patch
     Then I should see "sle_client" as link
 
   Scenario: Cleanup: remove packages and restore non-update repo after needing reboot tests
-    When I run "zypper -n rm andromeda-dummy" on "sle_client"
+    When I remove package "andromeda-dummy" from this "sle_client"
     And I disable repository "test_repo_rpm_pool" on this "sle_client"

--- a/testsuite/features/secondary/trad_weak_deps.feature
+++ b/testsuite/features/secondary/trad_weak_deps.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-17 SUSE LLC
+# Copyright (c) 2015-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Weak dependencies in the package page and in the metadata on the client
@@ -8,9 +8,9 @@ Feature: Weak dependencies in the package page and in the metadata on the client
     When I follow the left menu "Software > Channel List > All"
 
   Scenario: Pre-requisite: remove packages before weak-dependancies test
-   When I run "zypper -n in virgo-dummy" on "sle_client" without error control
-   And I run "zypper -n in milkyway-dummy" on "sle_client" without error control
-   And I run "zypper -n in orion-dummy" on "sle_client" without error control
+   When I install package "virgo-dummy" on this "sle_client" without error control
+   And I install package "milkyway-dummy" on this "sle_client" without error control
+   And I install package "orion-dummy" on this "sle_client" without error control
 
   Scenario: Show Supplements information
     When I follow "Test-Channel-x86_64"
@@ -59,6 +59,6 @@ Feature: Weak dependencies in the package page and in the metadata on the client
     And I should have 'rpm:enhances.*foobar.*rpm:enhances' in the metadata for "sle_client"
 
   Scenario: Cleanup: remove packages after weak dependancies tests
-   And I run "zypper -n rm virgo-dummy" on "sle_client"
-   And I run "zypper -n rm milkyway-dummy" on "sle_client"
-   And I run "zypper -n rm orion-dummy" on "sle_client"
+   And I remove package "virgo-dummy" from this "sle_client"
+   And I remove package "milkyway-dummy" from this "sle_client"
+   And I remove package "orion-dummy" from this "sle_client"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -668,7 +668,16 @@ When(/^I install package "([^"]*)" on this "([^"]*)"((?: without error control)?
     cmd = "zypper --non-interactive install -y #{package}"
     successcodes = [0, 100, 101, 102, 103, 106]
   end
-  node.run(cmd, error_control.empty?, DEFAULT_TIMEOUT, 'root', successcodes)
+  # node.run(cmd, error_control.empty?, DEFAULT_TIMEOUT, 'root', successcodes)
+  # TEMPORARY DEBUG CODE
+  _output, code = node.run(cmd)
+  if successcodes.include?(code)
+    puts "success installing #{package} on #{host} (code #{code})"
+  else
+    puts "error installing #{package} on #{host} (code #{code})"
+    output, _code = node.run('zypper lr; echo; ps aux | grep zypper; echo')
+    puts output
+  end
 end
 
 When(/^I install old package "([^"]*)" on this "([^"]*)"((?: without error control)?)$/) do |package, host, error_control|


### PR DESCRIPTION
## What does this PR change?

This PR uses specialized steps to install or remove packages instead of a generic SSH command.

Rationale:
* be able to debug package operation from a central place
  (that was the initial motivation for this PR, I was unable to debug zypper
   failures on Uyuni without creating a specialized step just for this)
* uniformize features
* hide technical details in Ruby implementation
* have tests readable by not technical stakeholders

This PR also accelerates package steps. Before, we were checking each time for existence of zypper, yum, and apt-get on the node, with SSH calls. It's enough to test for which type of node we have, SLES, CentOS, or Ubuntu.

@srbarrios we need to discuss, this might not work on QAM test suite. But there are other places where we use such constructs, with same problem.

Uyuni branch only: there are debugging tests attached (temporary).

## Links

Ports:
* 3.2: SUSE/spacewalk#10580
* 4.0: SUSE/spacewalk#10605

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
