### PR TITLE
count only changes which are tagged with a sign

### DIFF
--- a/web/html/src/manager/content-management/shared/components/panels/build/build.js
+++ b/web/html/src/manager/content-management/shared/components/panels/build/build.js
@@ -9,6 +9,7 @@ import {Form} from "../../../../../../components/input/Form";
 import {Text} from "../../../../../../components/input/Text";
 import {Loading} from "../../../../../../components/loading/loading";
 import DownArrow from '../../down-arrow/down-arrow';
+import statesEnum from "../../../../shared/business/states.enum";
 
 import type {ProjectHistoryEntry} from '../../../type/project.type.js';
 import {showErrorToastr, showSuccessToastr} from "../../../../../../components/toastr/toastr";
@@ -50,7 +51,9 @@ const Build = ({projectId, onBuild, currentHistoryEntry = {}, changesToBuild, di
           id={`build-contentmngt-modal-link`}
           className={ disabled ? `btn-secondary` : `btn-success` }
           text={changesToBuild.length > 0 ?
-            t('Build ({0})', changesToBuild.filter(s => !s.includes('Software Channels:') && !s.includes('Software Filter:')).length)
+            t('Build ({0})', changesToBuild.filter(s =>
+                    s.includes(` ${statesEnum.findByKey(statesEnum.enum.ATTACHED.key).sign} `) ||
+                    s.includes(` ${statesEnum.findByKey(statesEnum.enum.DETACHED.key).sign} `)).length)
             : t('Build')}
           disabled={disabled}
           target={modalNameId}


### PR DESCRIPTION
## What does this PR change?

Additional fix for https://github.com/uyuni-project/uyuni/pull/1829 .
The variable hold the current state of channels and filters.
Changes are flagged with a sign (" + " or " - ") similar as in `diff`.
We need to count the lines which contains the signs and ignore all the rest.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **already covered**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/10604

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
