### PR TITLE
Remove debugging code

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -668,16 +668,7 @@ When(/^I install package "([^"]*)" on this "([^"]*)"((?: without error control)?
     cmd = "zypper --non-interactive install -y #{package}"
     successcodes = [0, 100, 101, 102, 103, 106]
   end
-  # node.run(cmd, error_control.empty?, DEFAULT_TIMEOUT, 'root', successcodes)
-  # TEMPORARY DEBUG CODE
-  _output, code = node.run(cmd)
-  if successcodes.include?(code)
-    puts "success installing #{package} on #{host} (code #{code})"
-  else
-    puts "error installing #{package} on #{host} (code #{code})"
-    output, _code = node.run('zypper lr; echo; ps aux | grep zypper; echo')
-    puts output
-  end
+  node.run(cmd, error_control.empty?, DEFAULT_TIMEOUT, 'root', successcodes)
 end
 
 When(/^I install old package "([^"]*)" on this "([^"]*)"((?: without error control)?)$/) do |package, host, error_control|


### PR DESCRIPTION
## What does this PR change?

We've got 3 runs of the uyuni test suite and the error this debugging code was supposed to catch did not happen. Also, I'm getting increasingly convinced the problems on Uyuni branch might stem from the network infrastructure, making theses tests moot.

Removing this debugging code.

This will fix the Rubocop issue btw.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
