### PR TITLE
Fix tests of organization credentials

### DIFF
--- a/testsuite/features/core/first_settings.feature
+++ b/testsuite/features/core/first_settings.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2019 SUSE LLC
+# Copyright (c) 2017-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Very first settings
@@ -85,7 +85,7 @@ Feature: Very first settings
     And I enter "suma" as "HTTP Proxy Username"
     And I enter "P4$$word" as "HTTP Proxy Password"
     And I click on "Save and Verify"
-    Then I see verification succeeded
+    Then HTTP proxy verification should have succeeded
 
   Scenario: Detect latest Salt changes on the server
     When I query latest Salt changes on "server"

--- a/testsuite/features/secondary/srv_organization_credentials.feature
+++ b/testsuite/features/secondary/srv_organization_credentials.feature
@@ -7,40 +7,45 @@ Feature: Organization credentials in the Setup Wizard
   Scenario: Enter valid SCC credentials
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Organization Credentials"
+    And I ask to add new credentials
     And I enter the SCC credentials
+    And I click on "Save"
+    Then the SCC credentials should be valid
 
 @no_mirror
-  Scenario: Create some organization credentials
+  Scenario: Enter some invalid organization credentials
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Organization Credentials"
-    And I want to add a new credential
+    And I ask to add new credentials
     And I enter "SCC user" as "edit-user"
     And I enter "SCC password" as "edit-password"
     And I click on "Save"
     Then I should see a "SCC user" text
+    And the credentials for "SCC user" should be invalid
 
 @no_mirror
   Scenario: Make the credentials primary
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Organization Credentials"
-    And I make the credentials primary
+    And I make the credentials for "SCC user" primary
+    Then the credentials for "SCC user" should be primary
 
 @no_mirror
   Scenario: Check the associated subscription list
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Organization Credentials"
-    And I view the primary subscription list for SCC user
+    And I view the subscription list for "SCC user"
     And I wait until I see "No subscriptions available" text
     And I click on "Close"
 
-# Missing: edit the credentials
+# TODO
+# A test to edit the credentials is missing
 
 @no_mirror
   Scenario: Cleanup: delete the new organization credentials
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Organization Credentials"
-    And I delete the primary credentials
-    And I view the primary subscription list
-    And I click on "Close"
+    And I wait for the trash icon to appear for "SCC user"
+    And I ask to delete the credentials for "SCC user"
+    And I click on "Delete"
     Then I should not see a "SCC user" text
-    And I see verification succeeded

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -371,22 +371,69 @@ end
 
 # setup wizard
 
-When(/^I make the credentials primary$/) do
-  raise 'xpath: i.fa-star-o not found' unless find('i.fa-star-o').click
+Then(/^HTTP proxy verification should have succeeded$/) do
+  raise 'Success icon not found' unless find('i.text-success', wait: DEFAULT_TIMEOUT)
 end
 
-When(/^I delete the primary credentials$/) do
-  raise 'xpath: i.fa-trash-o not found' unless find('i.fa-trash-o', match: :first).click
-  step 'I click on "Delete"'
+When(/^I enter the address of the HTTP proxy as "([^"]*)"/) do |hostname|
+  step %(I enter "#{$server_http_proxy}" as "#{hostname}")
 end
 
-When(/^I view the primary subscription list$/) do
-  raise 'xpath: i.fa-th-list not found' unless find('i.fa-th-list', match: :first).click
+When(/^I ask to add new credentials$/) do
+  raise 'Click on plus icon failed' unless find('i.fa-plus-circle').click
 end
 
-When(/^I view the primary subscription list for SCC user$/) do
-  within(:xpath, "//h3[contains(text(), 'SCC user')]/../..") do
-    raise 'xpath: i.fa-th-list not found' unless find('i.fa-th-list', match: :first).click
+When(/^I enter the SCC credentials$/) do
+  scc_username, scc_password = ENV['SCC_CREDENTIALS'].split('|')
+  steps %(
+    And I enter "#{scc_username}" as "edit-user"
+    And I enter "#{scc_password}" as "edit-password"
+  )
+end
+
+Then(/^the SCC credentials should be valid$/) do
+  scc_username, scc_password = ENV['SCC_CREDENTIALS'].split('|')
+  within(:xpath, "//h3[contains(text(), '#{scc_username}')]/../..") do
+    raise 'Success icon not found' unless find('i.text-success', wait: DEFAULT_TIMEOUT)
+  end
+end
+
+Then(/^the credentials for "([^"]*)" should be invalid$/) do |user|
+  within(:xpath, "//h3[contains(text(), '#{user}')]/../..") do
+    raise 'Failure icon not found' unless find('i.text-danger', wait: DEFAULT_TIMEOUT)
+  end
+end
+
+When(/^I make the credentials for "([^"]*)" primary$/) do |user|
+  within(:xpath, "//h3[contains(text(), '#{user}')]/../..") do
+    raise 'Click on star icon failed' unless find('i.fa-star-o').click
+  end
+end
+
+Then(/^the credentials for "([^"]*)" should be primary$/) do |user|
+  within(:xpath, "//h3[contains(text(), '#{user}')]/../..") do
+    raise 'Star icon not selected' unless find('i.fa-star')
+  end
+end
+
+When(/^I wait for the trash icon to appear for "([^"]*)"$/) do |user|
+  within(:xpath, "//h3[contains(text(), '#{user}')]/../..") do
+    repeat_until_timeout(message: 'Trash icon is still greyed out') do
+      break unless find('i.fa-trash-o')[:style].include? "not-allowed"
+      sleep 1
+    end
+  end
+end
+
+When(/^I ask to delete the credentials for "([^"]*)"$/) do |user|
+  within(:xpath, "//h3[contains(text(), '#{user}')]/../..") do
+    raise 'Click on trash icon failed' unless find('i.fa-trash-o').click
+  end
+end
+
+When(/^I view the subscription list for "([^"]*)"$/) do |user|
+  within(:xpath, "//h3[contains(text(), '#{user}')]/../..") do
+    raise 'Click on list icon failed' unless find('i.fa-th-list').click
   end
 end
 
@@ -467,14 +514,6 @@ end
 When(/^I click the channel list of product "(.*?)"$/) do |product|
   xpath = "//span[contains(text(), '#{product}')]/ancestor::div[contains(@class, 'product-details-wrapper')]/div/a[contains(@class, 'showChannels')]"
   raise "xpath: #{xpath} not found" unless find(:xpath, xpath).click
-end
-
-Then(/^I see verification succeeded/) do
-  raise "xpath: i.text-success not found" unless find('i.text-success', wait: 100)
-end
-
-When(/^I enter the address of the HTTP proxy as "([^"]*)"/) do |hostname|
-  step %(I enter "#{$server_http_proxy}" as "#{hostname}")
 end
 
 # configuration management steps
@@ -966,19 +1005,6 @@ end
 Then(/^I should see a list item with text "([^"]*)" and bullet with style "([^"]*)"$/) do |text, class_name|
   item_xpath = "//ul/li[text()='#{text}']/i[contains(@class, '#{class_name}')]"
   find(:xpath, item_xpath)
-end
-
-When(/^I enter the SCC credentials$/) do
-  scc_username = ENV['SCC_CREDENTIALS'].split('|')[0]
-  scc_password = ENV['SCC_CREDENTIALS'].split('|')[1]
-  unless has_content?(scc_username)
-    steps %(
-      When I want to add a new credential
-      And I enter "#{scc_username}" as "edit-user"
-      And I enter "#{scc_password}" as "edit-password"
-      And I click on "Save"
-    )
-  end
 end
 
 When(/^I enter the MU repository for (salt|traditional) "([^"]*)" as URL$/) do |client_type, client|

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -208,10 +208,6 @@ When(/^I follow "([^"]*)" in element "([^"]*)"$/) do |arg1, arg2|
   end
 end
 
-When(/^I want to add a new credential$/) do
-  raise 'xpath: i.fa-plus-circle not found' unless find('i.fa-plus-circle').click
-end
-
 When(/^I follow "([^"]*)" in the (.+)$/) do |arg1, arg2|
   tag = case arg2
         when /tab bar|tabs/ then 'header'

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -777,18 +777,19 @@ end
 
 # Image-specific steps
 When(/^I enter "([^"]*)" relative to profiles as "([^"]*)"$/) do |path, field|
-  step %(I enter "#{$git_profiles}/#{path}" as "#{field}")
+  git_profiles = ENV['GITPROFILES']
+  step %(I enter "#{git_profiles}/#{path}" as "#{field}")
 end
 
 When(/^I enter the image filename relative to profiles as "([^"]*)"$/) do |field|
+  git_profiles = ENV['GITPROFILES']
   path = compute_image_filename
-  step %(I enter "#{$git_profiles}/#{path}" as "#{field}")
+  step %(I enter "#{git_profiles}/#{path}" as "#{field}")
 end
 
 When(/^I enter URI, username and password for portus$/) do
   portus_uri = ENV['PORTUS_URI']
-  portus_username = ENV['PORTUS_CREDENTIALS'].split('|')[0]
-  portus_password = ENV['PORTUS_CREDENTIALS'].split('|')[1]
+  portus_username, portus_password = ENV['PORTUS_CREDENTIALS'].split('|')
   steps %(
     When I enter "#{portus_uri}" as "uri"
     And I enter "#{portus_username}" as "username"

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -176,9 +176,11 @@ $product = product
 $pxeboot_mac = ENV['PXEBOOT_MAC']
 $private_net = ENV['PRIVATENET'] if ENV['PRIVATENET']
 $mirror = ENV['MIRROR']
-$git_profiles = ENV['GITPROFILES']
 $server_http_proxy = ENV['SERVER_HTTP_PROXY'] if ENV['SERVER_HTTP_PROXY']
-$scc_credentials = ENV['SCC_CREDENTIALS'] if ENV['SCC_CREDENTIALS']
+if ENV['SCC_CREDENTIALS']
+  scc_username, scc_password = ENV['SCC_CREDENTIALS'].split('|')
+  $scc_credentials = !scc_username.to_s.empty? && !scc_password.to_s.empty?
+end
 $node_by_host = { 'server'                => $server,
                   'proxy'                 => $proxy,
                   'ceos_minion'           => $ceos_minion,


### PR DESCRIPTION
## What does this PR change?

On the organization pages, we can have several organizations. The tests were almost always looking for the first icon (trash bin, star, list), no matter to which organization it would belong. It sometimes triggered race conditions where we would click on the wrong icon.

This PR fixes that problem.

It also fixes wrong test of existence of credentials in case sumaform sets them to "|".

## Links

Ports:
* 4.0: SUSE/spacewalk#10611
* 3.2: SUSE/spacewalk#10612

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
