### PR TITLE
Migrate pillar and formula data on minion id change

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/SaltStateGeneratorService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltStateGeneratorService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 SUSE LLC
+ * Copyright (c) 2016--2020 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -186,7 +186,7 @@ public enum SaltStateGeneratorService {
         try {
             Files.createDirectories(pillarDataPath);
             Path filePath = pillarDataPath.resolve(
-                    getServerPillarFileName(minion)
+                    getServerPillarFileName(minion.getMinionId())
             );
             com.suse.manager.webui.utils.SaltStateGenerator saltStateGenerator =
                     new com.suse.manager.webui.utils.SaltStateGenerator(filePath.toFile());
@@ -368,9 +368,9 @@ public enum SaltStateGeneratorService {
         }
     }
 
-    private String getServerPillarFileName(MinionServer minion) {
+    private String getServerPillarFileName(String minionId) {
         return PILLAR_DATA_FILE_PREFIX + "_" +
-            minion.getMinionId() + "." +
+            minionId + "." +
                 PILLAR_DATA_FILE_EXT;
     }
 
@@ -380,13 +380,21 @@ public enum SaltStateGeneratorService {
     }
 
     /**
-     * Remove the corresponding pillar data if the server is a minion.
+     * Remove the corresponding pillar data of minion server
      * @param minion the minion server
      */
     public void removePillar(MinionServer minion) {
-        LOG.debug("Removing pillar file for minion: " + minion.getMinionId());
+        removePillar(minion.getMinionId());
+    }
+
+    /**
+     * Remove the corresponding pillar data by minionId
+     * @param minionId the server minionId
+     */
+    public void removePillar(String minionId) {
+        LOG.debug("Removing pillar file for minion: " + minionId);
         Path filePath = pillarDataPath.resolve(
-                getServerPillarFileName(minion));
+                getServerPillarFileName(minionId));
         try {
             Files.deleteIfExists(filePath);
         }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Migrate pillar and formula data on minion id change (bsc#1161755)
 - Remove auditlog-keeper
 - Exclude base products from PAYG (Pay-As-You-Go) instances when doing subscription matching
 - call saltutil.sync_all before calling highstate (bsc#1152673)


### PR DESCRIPTION
## What does this PR change?

When salt client change its minion id, uyuni correctly recognized this and adapt the database entry. However do nothing else and pillar data together with formula data are not renamed/recreated. This then causes missing pillar information for new minion id.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: bugfix

- [X] **DONE**

## Test coverage
- Unit tests **TODO**
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/10496
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
