### PR TITLE
Execute salt-ssh actions asynchronously

### DIFF
--- a/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -227,6 +227,8 @@ public class ConfigDefaults {
 
     public static final String SALT_SSH_CONNECT_TIMEOUT = "java.salt_ssh_connect_timeout";
 
+    private static final String SALT_SSH_API_RATE_LIMIT = "java.salt_ssh_api_rate_limit";
+
     /**
      * Duration in hours of the time window for Salt minions to stage
      * packages in advance of scheduled installations or upgrades
@@ -317,6 +319,11 @@ public class ConfigDefaults {
      * Single Sign-On associated config option name in rhn.conf
      */
     public static final String SINGLE_SIGN_ON_ENABLED = "java.sso";
+
+    /**
+     * Timeout of salt-ssh calls
+     */
+    public static final String SALT_SSH_TIMEOUT = "java.salt_ssh_timeout";
 
     private ConfigDefaults() {
     }
@@ -1002,4 +1009,11 @@ public class ConfigDefaults {
         return Config.get().getBoolean(SINGLE_SIGN_ON_ENABLED);
     }
 
+    public int getSaltSSHAPIRateLimit() {
+        return Config.get().getInt(SALT_SSH_API_RATE_LIMIT, 10);
+    }
+
+    public int getSaltSSHTimeout() {
+        return Config.get().getInt(SALT_SSH_TIMEOUT, 0);
+    }
 }

--- a/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -1009,10 +1009,16 @@ public class ConfigDefaults {
         return Config.get().getBoolean(SINGLE_SIGN_ON_ENABLED);
     }
 
+    /**
+     * @return the rate of calls to salt-api for salt-ssh calls
+     */
     public int getSaltSSHAPIRateLimit() {
         return Config.get().getInt(SALT_SSH_API_RATE_LIMIT, 10);
     }
 
+    /**
+     * @return timeout of salt-ssh actions
+     */
     public int getSaltSSHTimeout() {
         return Config.get().getInt(SALT_SSH_TIMEOUT, 0);
     }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/test/SSHPushWorkerSaltTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/test/SSHPushWorkerSaltTest.java
@@ -328,15 +328,6 @@ public class SSHPushWorkerSaltTest extends JMockBaseTestCaseWithUser {
         return serverAction;
     }
 
-//    private void mockSyncCallResult() {
-//        context().checking(new Expectations() {{
-//            oneOf(saltServiceMock).callSync(
-//                    with(any(LocalCall.class)),
-//                    with(any(String.class)));
-//            will(returnValue(Optional.of(Boolean.TRUE)));
-//        }});
-//    }
-
     private TaskQueue mockQueue() {
         TaskQueue mockQueue = mock(TaskQueue.class);
         context().checking(new Expectations() {{

--- a/java/code/src/com/redhat/rhn/taskomatic/task/threaded/TaskQueue.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/threaded/TaskQueue.java
@@ -23,6 +23,8 @@ import EDU.oswego.cs.dl.util.concurrent.Channel;
 import EDU.oswego.cs.dl.util.concurrent.LinkedQueue;
 import EDU.oswego.cs.dl.util.concurrent.PooledExecutor;
 
+import static com.suse.manager.utils.ThreadUtils.threadName;
+
 /**
  * Generic threaded queue suitable for use wherever Taskomatic
  * tasks need to process a number of work items in parallel.
@@ -177,7 +179,10 @@ public class TaskQueue {
         int maxPoolSize = queueDriver.getMaxWorkers();
         executor = new PooledExecutor(workers);
         executor.waitWhenBlocked();
-        executor.setThreadFactory(new TaskThreadFactory());
+        executor.setThreadFactory(runnable ->
+                new Thread(runnable,
+                        threadName("TaskQueueWorker-" +
+                                queueDriver.getClass().getSimpleName() + "-")));
         executor.setKeepAliveTime(5000);
         executor.setMinimumPoolSize(1);
         executor.setMaximumPoolSize(maxPoolSize);

--- a/java/code/src/com/suse/manager/utils/ExecutorsFactory.java
+++ b/java/code/src/com/suse/manager/utils/ExecutorsFactory.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.utils;
+
+import com.google.common.util.concurrent.RateLimiter;
+import org.apache.log4j.Logger;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static com.suse.manager.utils.ThreadUtils.threadName;
+
+/**
+ * Factory for creating {@link Executor} instances.
+ */
+public class ExecutorsFactory {
+
+    private static final Logger LOG = Logger.getLogger(ExecutorsFactory.class);
+
+    private ExecutorsFactory() { }
+
+    /**
+     * Creates a cached thread pool with a {@link java.util.concurrent.ThreadFactory}
+     * that sets the thread names to the given prefix.
+     *
+     * @param namePrefix thread name prefix
+     * @return a cached thread pool
+     */
+    public static ExecutorService newCachedThreadPool(String namePrefix) {
+        return Executors.newCachedThreadPool(runnable -> new Thread(runnable, threadName(namePrefix)));
+    }
+
+    /**
+     * Creates an {@link Executor} backed by a cached tread pool that limits the rate of execution.
+     * @param ratePerSecond rate of execution
+     * @param namePrefix thread name prefix
+     * @return an rate limiting executor
+     */
+    public static Executor rateLimitingExecutor(double ratePerSecond, String namePrefix) {
+        return new Executor() {
+
+            private Executor exec = Executors.newCachedThreadPool(runnable ->
+                    new Thread(runnable, threadName(namePrefix)));
+            private RateLimiter rateLimiter = RateLimiter.create(ratePerSecond);
+
+            @Override
+            public void execute(Runnable runnable) {
+                rateLimiter.acquire();
+                LOG.debug("Submitting task to rate limiting SSH executor");
+                exec.execute(runnable);
+            }
+        };
+    }
+
+}

--- a/java/code/src/com/suse/manager/utils/ThreadUtils.java
+++ b/java/code/src/com/suse/manager/utils/ThreadUtils.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.utils;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Utilities for threads.
+ */
+public class ThreadUtils {
+
+    private static final DateTimeFormatter TIMESTAMP = DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS");
+
+    private ThreadUtils() { }
+
+    /**
+     * @param namePrefix name prefix
+     * @return a thread name with the given prefix and the current timestamp as sufix
+     */
+    public static String threadName(String namePrefix) {
+        return namePrefix + TIMESTAMP.format(LocalDateTime.now());
+    }
+
+}

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,6 @@
+- make salt-ssh action execution asynchronous and change the
+  ssh-push job to use short transactions
+
 -------------------------------------------------------------------
 Thu Jan 30 14:48:34 CET 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

* Execute `salt-ssh` actions asynchronously.
* Refactoring and use short transactions in the ssh-push job

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: internal changes

- [x] **DONE**

## Test coverage
- No tests: unit tests adapted, Cucumber tests exist

- [X] **DONE**

## Links

Fix for https://github.com/SUSE/spacewalk/issues/4295

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
