### PR TITLE
Align with QAM test suite code

### DIFF
--- a/testsuite/features/init_clients/sle_client.feature
+++ b/testsuite/features/init_clients/sle_client.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 SUSE LLC
+# Copyright (c) 2015-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Register a traditional client
@@ -6,7 +6,9 @@ Feature: Register a traditional client
   I want to create, parametrize and run boostrap script from proxy
 
   Scenario: Register a traditional client
+    Given I am authorized
     When I bootstrap traditional client "sle_client" using bootstrap script with activation key "1-SUSE-DEV-x86_64" from the proxy
+    And I wait until onboarding is completed for "sle_client"
     Then I should see "sle_client" via spacecmd
 
   Scenario: Check registration values

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -813,6 +813,23 @@ And(/^I register "([^*]*)" as traditional client with activation key "([^*]*)"$/
   node.run(command2, true, 500, 'root')
 end
 
+When(/^I wait until onboarding is completed for "([^"]*)"$/) do |host|
+  steps %(
+    When I follow the left menu "Systems > Overview"
+    And I wait until I see the name of "#{host}", refreshing the page
+    And I follow this "#{host}" link
+  )
+  if get_client_type(host) == 'traditional'
+    get_target(host).run('rhn_check -vvv')
+  else
+    steps %(
+      And I wait until event "Hardware List Refresh" is completed
+      And I wait until event "Apply states" is completed
+      And I wait until event "Package List Refresh" is completed
+    )
+  end
+end
+
 Then(/^I should see "([^"]*)" via spacecmd$/) do |host|
   $server.run("spacecmd -u admin -p admin clear_caches")
   command = "spacecmd -u admin -p admin system_list"

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -65,20 +65,6 @@ When(/^I wait until no Salt job is running on "([^"]*)"$/) do |minion|
   end
 end
 
-When(/^I wait until onboarding is completed for "([^"]*)"$/) do |host|
-  steps %(
-    When I follow the left menu "Systems > Overview"
-    And I wait until I see the name of "#{host}", refreshing the page
-    And I follow this "#{host}" link
-  )
-  get_target(host).run('rhn_check -vvv') if get_client_type(host) == 'traditional'
-  steps %(
-    And I wait until event "Hardware List Refresh" is completed
-    And I wait until event "Apply states" is completed
-    And I wait until event "Package List Refresh" is completed
-  )
-end
-
 When(/^I delete "([^"]*)" key in the Salt master$/) do |host|
   system_name = get_system_name(host)
   $output, _code = $server.run("salt-key -y -d #{system_name}", false)


### PR DESCRIPTION
## What does this PR change?

Backport of one of QAM test suite changes.

@srbarrios does it make sense to you to have this here as well?

## Links

Ports:
* 4.0: SUSE/spacewalk#11232
* 3.2: SUSE/spacewalk#11233

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
