### PR TITLE
    Testsuite: Fix interpolation string

### DIFF
--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -674,7 +674,7 @@ Then(/^I wait for "([^"]*)" to be installed on this "([^"]*)"$/) do |package, ho
     pkg_version = package.split('-')[-1]
     pkg_name = package.delete_suffix("-#{pkg_version}")
     pkg_version_regexp = pkg_version.gsub('.', '\\.')
-    node.run_until_ok("dpkg -l | grep -E '^ii +#{pkg_name} +{pkg_version_regexp} +'")
+    node.run_until_ok("dpkg -l | grep -E '^ii +#{pkg_name} +#{pkg_version_regexp} +'")
   else
     node.run_until_ok("rpm -q #{package}")
   end


### PR DESCRIPTION
## What does this PR change?
- It fixes an interpolation string: add missing '#' in front of the variable.

## Links

### Ports

- Manager-3.2: https://github.com/SUSE/spacewalk/pull/10624
- Manager-4.0: https://github.com/SUSE/spacewalk/pull/10623


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

