### PR TITLE
Manager bsc1162129

### DIFF
--- a/proxy/installer/configure-proxy.sh
+++ b/proxy/installer/configure-proxy.sh
@@ -347,6 +347,9 @@ SYSTEMID_PATH=$(awk -F '=[[:space:]]*' '/^[[:space:]]*systemIdPath[[:space:]]*=/
 systemctl status salt-minion > /dev/null 2>&1
 if [ $? -eq 0 ]; then
     /usr/sbin/fetch-certificate $SYSTEMID_PATH
+    PROPOSED_PARENT=$(grep ^[[:blank:]]*master /etc/salt/minion.d/susemanager.conf | sed -e "s/.*:[[:blank:]]*//")
+else
+    PROPOSED_PARENT=$(awk -F= '/serverURL=/ {split($2, a, "/")} END { print a[3]}' $UP2DATE_FILE)
 fi
 
 if [ ! -r $SYSTEMID_PATH ]; then
@@ -359,7 +362,7 @@ SYSTEM_ID=$(/usr/bin/xsltproc /usr/share/rhn/get_system_id.xslt $SYSTEMID_PATH |
 DIR=/usr/share/doc/proxy/conf-template
 HOSTNAME=$(hostname -f)
 
-default_or_input "SUSE Manager Parent" RHN_PARENT $(awk -F= '/serverURL=/ {split($2, a, "/")} END { print a[3]}' $UP2DATE_FILE)
+default_or_input "SUSE Manager Parent" RHN_PARENT $PROPOSED_PARENT
 
 if [ "$RHN_PARENT" == "rhn.redhat.com" ]; then
    RHN_PARENT="xmlrpc.rhn.redhat.com"

--- a/proxy/installer/spacewalk-proxy-installer.changes
+++ b/proxy/installer/spacewalk-proxy-installer.changes
@@ -1,3 +1,5 @@
+- use salt master as parent for minion based proxies (bsc#1162129)
+
 -------------------------------------------------------------------
 Wed Jan 22 12:12:44 CET 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

SUSE Manager proxies are no longer required to be traditional clients, but can also be salt minions. In this case the configure-proxy script needs to obtain the name of the parent in a different way. This PR fixes this.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: Implementation detail; fixing a regression

- [X] **DONE**

## Test coverage
- No tests: Only visible when manually configuring a proxy; using an answer file is not affected

- [X] **DONE**

## Links

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1162129

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
