### PR TITLE
point to new doc server and 4.0 docs

### DIFF
--- a/backend/common/rhnConfig.py
+++ b/backend/common/rhnConfig.py
@@ -538,6 +538,9 @@ except ConfigParserError:
     PRODUCT_NAME = "SUSE Manager"
 
 
+def isUyuni():
+    return (PRODUCT_NAME == "Uyuni")
+
 def runTest():
     print("Test script:")
     import pprint

--- a/backend/server/rhnServer/server_hardware.py
+++ b/backend/server/rhnServer/server_hardware.py
@@ -25,7 +25,7 @@ import uuid
 from rhn.UserDictCase import UserDictCase
 from uyuni.common.usix import raise_with_tb
 from spacewalk.common.rhnLog import log_debug, log_error
-from spacewalk.common.rhnConfig import CFG
+from spacewalk.common.rhnConfig import CFG, isUyuni
 from spacewalk.common.rhnException import rhnFault
 from spacewalk.common.rhnTB import Traceback
 from spacewalk.common import rhnMail
@@ -1051,7 +1051,11 @@ class MachineInformation:
             "From"    : "{0} <{1}>".format(hostname, fr),
             "To"      : to,
         }
-        body = MACHINE_ID_EMAIL_TEMPLATE.format(machine_id, sysid, name)
+
+        docurl = "https://documentation.suse.com/external-tree/en-us/suma/4.0/suse-manager/administration/tshoot-registerclones.html"
+        if isUyuni():
+            docurl = "https://www.uyuni-project.org/uyuni-docs/uyuni/administration/tshoot-registerclones.html"
+        body = MACHINE_ID_EMAIL_TEMPLATE.format(machine_id, sysid, name, docurl)
         rhnMail.send(headers, body)
 
 
@@ -1231,5 +1235,5 @@ For SLES11 and RHEL5/RHEL6:
 
 
 For more information on generating a new machine_id for traditional systems refer to:
-https://www.suse.com/documentation/suse-manager-3/book_suma_best_practices_31/data/bp_chapt_suma3_troubleshooting_registering_cloned_traditional_systems.html
+{3}
 """

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- update doc link to point to new documentation server
+
 -------------------------------------------------------------------
 Thu Jan 30 14:48:13 CET 2020 - jgonzalez@suse.com
 

--- a/java/code/src/com/suse/manager/webui/menu/MenuTree.java
+++ b/java/code/src/com/suse/manager/webui/menu/MenuTree.java
@@ -17,7 +17,6 @@ package com.suse.manager.webui.menu;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.jsp.PageContext;
 
-import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.security.acl.Access;
 import com.redhat.rhn.common.security.acl.Acl;
@@ -395,7 +394,9 @@ public class MenuTree {
                     .withPrimaryUrl("https://www.suse.com/support/kb/product.php?id=SUSE_Manager")
                     .withTarget("_blank"))
                 .addChild(new MenuItem("header.jsp.documentation")
-                    .withPrimaryUrl("https://www.suse.com/documentation/suse_manager/")
+                    .withPrimaryUrl(ConfigDefaults.get().isUyuni() ?
+                            "https://www.uyuni-project.org/uyuni-docs/uyuni/index.html"
+                            : "https://documentation.suse.com/suma/")
                     .withTarget("_blank"))
                 );
         }
@@ -435,7 +436,9 @@ public class MenuTree {
                     .withPrimaryUrl("https://www.suse.com/support/kb/product.php?id=SUSE_Manager")
                     .withTarget("_blank"))
                 .addChild(new MenuItem("header.jsp.documentation")
-                    .withPrimaryUrl("https://www.suse.com/documentation/suse_manager/")
+                    .withPrimaryUrl(ConfigDefaults.get().isUyuni() ?
+                            "https://www.uyuni-project.org/uyuni-docs/uyuni/index.html"
+                            : "https://documentation.suse.com/suma/")
                     .withTarget("_blank"))
                 );
         }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- change doc links pointing to new documentation server
+
 -------------------------------------------------------------------
 Thu Jan 30 14:48:34 CET 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Email send with outdated link to the documentation.
Just update the link to 4.0 docs.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **just point to new docs**

- [x] **DONE**

## Test coverage
- No tests: **no tests for docs**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
