### PR TITLE
Sync all before show highstate

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/StatesAPI.java
+++ b/java/code/src/com/suse/manager/webui/controllers/StatesAPI.java
@@ -667,8 +667,12 @@ public class StatesAPI {
                 .map(minion -> {
                     final String minionId = minion.getMinionId();
                     try {
+                        MinionList minions = new MinionList(minionId);
+                        // sync to minion before showing highstate
+                        SaltService.INSTANCE.syncAll(minions);
+
                         Map<String, Result<Object>> result = SaltService.INSTANCE
-                                .callSync(State.showHighstate(), new MinionList(minionId));
+                                .callSync(State.showHighstate(), minions);
 
                         return Optional.ofNullable(result.get(minionId))
                                 .map(r -> r.fold(

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -721,6 +721,21 @@ public class SaltService {
     }
 
     /**
+     * Call 'saltutil.sync_all' to sync everything to the target minion(s).
+     * @param minionList minion list
+     */
+    public void syncAll(MinionList minionList) {
+        try {
+             LocalCall<Map<String, Object>> call = SaltUtil.syncAll(Optional.empty(),
+                    Optional.empty());
+            callSync(call, minionList);
+        }
+        catch (SaltException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
      * Execute a LocalCall synchronously on the default Salt client.
      * Note that salt-ssh systems are also called by this method.
      *

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- call saltutil.sync_all before calling highstate (bsc#1152673)
 - change doc links pointing to new documentation server
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Sometimes it is needed to sync the modules, states, grains, etc. from master to minion before a show_highstate can be executed successfully.

This change call a sync_all explicitly before calling show_hightstate.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/10570

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
