### PR TITLE
New Channels for Uyuni Stable, unify those for devel

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -955,18 +955,18 @@ name      = OpenStack 3.0 packages for Oracle Linux 6 (%(arch)s)
 base_channels = oraclelinux6-%(arch)s
 repo_url = http://yum.oracle.com/repo/OracleLinux/OL6/openstack30/%(arch)s/
 
-[uyuni-server-40-leap-151]
-name     = Uyuni Server 4.0 for %(base_channel_name)s
+[uyuni-server-stable-leap-151]
+name     = Uyuni Server Stable for %(base_channel_name)s
 archs    = x86_64
 base_channels = opensuse_leap15_1-%(arch)s
 checksum = sha256
-gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-4.0-POOL-x86_64-Media1/repodata/repomd.xml.key
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-POOL-x86_64-Media1/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-4.0-POOL-x86_64-Media1/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-POOL-x86_64-Media1/
 
-[uyuni-server-devel]
-name     = Uyuni Server for %(base_channel_name)s (Development)
+[uyuni-server-devel-leap]
+name     = Uyuni Server Devel for %(base_channel_name)s (Development)
 archs    = x86_64
 base_channels = opensuse_leap15_1-%(arch)s
 checksum = sha256
@@ -975,18 +975,18 @@ gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Uyuni-Server-POOL-x86_64-Media1/
 
-[uyuni-proxy-40-leap-151]
-name     = Uyuni Proxy 4.0 for %(base_channel_name)s
+[uyuni-proxy-stable-leap-151]
+name     = Uyuni Proxy Stable for %(base_channel_name)s
 archs    = x86_64
 base_channels = opensuse_leap15_1-%(arch)s
 checksum = sha256
-gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Proxy-4.0-POOL-x86_64-Media1/repodata/repomd.xml.key
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Proxy-4.0-POOL-x86_64-Media1/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/
 
 [uyuni-proxy-devel-leap]
-name     = Uyuni Proxy for %(base_channel_name)s (Development)
+name     = Uyuni Proxy Devel for %(base_channel_name)s (Development)
 archs    = x86_64
 base_channels = opensuse_leap15_1-%(arch)s
 checksum = sha256

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,6 @@
+- Use new URLs for Uyuni Server and Proxy Stable, and unify channel
+  names for Devel
+
 -------------------------------------------------------------------
 Thu Jan 30 14:49:16 CET 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

New Channels for Uyuni Stable, unify those for devel

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Couldn't find mentions to the changed channel names at the doc. @Loquacity this is strange, as we should have a mention for configuring the proxy.

- [x] **DONE**

## Test coverage
- No tests: Not covered by tests.

- [x] **DONE**

## Links

None.

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
