### PR TITLE
Spell "successfully" correctly

### DIFF
--- a/client/rhel/spacewalk-client-tools/src/actions/README
+++ b/client/rhel/spacewalk-client-tools/src/actions/README
@@ -125,7 +125,7 @@ fields:
 The rest of the fields are action specific.
 
 A success example:
-        return (0, "Ate Cheese Succesfully", {})
+        return (0, "Ate Cheese Successfully", {})
 
         return (61, "Item that claimed to be cheese was not in fact cheese",
                 {'name':'cheese.eat.thats_not_cheese",

--- a/client/rhel/spacewalk-client-tools/src/actions/reboot.py
+++ b/client/rhel/spacewalk-client-tools/src/actions/reboot.py
@@ -43,7 +43,7 @@ def reboot(test=None, cache_only=None):
     log.log_me("Rebooting the system now")
     # no point in waiting around
 
-    return (0, "Reboot sucessfully started", data)
+    return (0, "Reboot successfully started", data)
 
 
 def main():

--- a/client/rhel/spacewalk-client-tools/src/bin/rhn_check.py
+++ b/client/rhel/spacewalk-client-tools/src/bin/rhn_check.py
@@ -280,8 +280,8 @@ class CheckCli(rhncli.RhnCli):
                     data['process_end'] = '1970-01-01 00:00:00'    # and especially about the end
                     with open(action_lock) as f:
                         data['output'] = base64.encodestring(f.read())
-                log.log_debug("Sending back response", (255, "Previous run of action didn't completed sucessfully, aborting.", data))
-                ret = self.submit_response(action['id'], 255, "Previous run of action didn't completed sucessfully, aborting.", data)
+                log.log_debug("Sending back response", (255, "Previous run of action didn't complete successfully, aborting.", data))
+                ret = self.submit_response(action['id'], 255, "Previous run of action didn't complete successfully, aborting.", data)
             os.remove(action_lock)
             return ret
 

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/config_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/config_queries.xml
@@ -1751,7 +1751,7 @@ WHERE CCT.id = CC.confchan_type_id
 
         <!--
                 List all systems (NAME, ID) from the specified channel.  For each system, list the
-                most-recent succcessful deploy action of a file with the specified filename-id
+                most-recent successful deploy action of a file with the specified filename-id
                 (REV_ID).  For each system, show how many
                 global-overrides there are of the specified file-name (OUTRANKED_COUNT), and how
                 many local overrides there are of the specified filename (OVERRIDEN_COUNT)

--- a/java/code/src/com/redhat/rhn/frontend/action/help/ForgotCredentialsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/help/ForgotCredentialsAction.java
@@ -203,7 +203,7 @@ public class ForgotCredentialsAction extends RhnAction {
         if (prevRequest != null &&
                 ((now - prevRequest) < timeout * 1000) &&
                 (user.toUpperCase().equals(prevRequestUser))) {
-            log.debug("Unsuccesful try to request email for " + user);
+            log.debug("Unsuccessful try to request email for " + user);
             return false;
         }
 

--- a/java/code/src/com/redhat/rhn/frontend/dto/LastDeployDto.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/LastDeployDto.java
@@ -21,7 +21,7 @@ import com.redhat.rhn.domain.config.ConfigurationFactory;
 import java.util.Date;
 
 /**
- * LastDeployDto - information about the last sucessful deploy of a given filename to a
+ * LastDeployDto - information about the last successful deploy of a given filename to a
  * specific server.  See config_queries.successful_deploys_for
  * @version $Rev$
  */
@@ -82,7 +82,7 @@ public class LastDeployDto extends BaseDto {
     }
 
     /**
-     * Set the date of the last-sucessful deploy
+     * Set the date of the last successful deploy
      * @param inWhen date of deploy
      */
     public void setWhen(Date inWhen) {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/ServerGroupHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/ServerGroupHandlerTest.java
@@ -202,7 +202,7 @@ public class ServerGroupHandlerTest extends BaseHandlerTestCase {
             fail("Should throw a lookup exception");
         }
         catch (Exception e) {
-            //exception succesfully thrown.
+            //exception successfully thrown.
         }
     }
 

--- a/java/code/src/com/redhat/rhn/taskomatic/TaskoJob.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskoJob.java
@@ -228,7 +228,7 @@ public class TaskoJob implements Job {
                             email += taskRun.getStdErrorPath() + ".";
                         }
                         else {
-                            email += " finished successfuly and is back to normal.";
+                            email += " finished successfully and is back to normal.";
                         }
                         log.info("Sending e-mail ... " + task.getName());
                         TaskHelper.sendTaskoEmail(taskRun.getOrgId(), email);

--- a/java/code/src/com/redhat/rhn/taskomatic/TaskoQuartzHelper.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskoQuartzHelper.java
@@ -117,7 +117,7 @@ public class TaskoQuartzHelper {
         try {
             Date date =
                     SchedulerKernel.getScheduler().scheduleJob(jobDetail.build(), trigger);
-            log.info("Job " + schedule.getJobLabel() + " scheduled succesfully.");
+            log.info("Job " + schedule.getJobLabel() + " scheduled successfully.");
             return date;
         }
         catch (SchedulerException e) {
@@ -189,7 +189,7 @@ public class TaskoQuartzHelper {
         try {
             SchedulerKernel.getScheduler()
                     .unscheduleJob(triggerKey(jobLabel, getGroupName(orgId)));
-            log.info("Job " + jobLabel + " unscheduled succesfully.");
+            log.info("Job " + jobLabel + " unscheduled successfully.");
             return 1;
         }
         catch (SchedulerException e) {

--- a/java/code/src/org/cobbler/CobblerObject.java
+++ b/java/code/src/org/cobbler/CobblerObject.java
@@ -159,7 +159,7 @@ public abstract class CobblerObject {
 
     /**
      * removes the kickstart object from cobbler.
-     * @return true if sucessfull
+     * @return true if successful
      */
     public boolean remove() {
         return invokeRemove();

--- a/scripts/channel-from-system/create-channel-from-system.pl
+++ b/scripts/channel-from-system/create-channel-from-system.pl
@@ -124,7 +124,7 @@ foreach $line (@needed_packages) {
 
 }
 
-print("\n\nChannel $new_channel_label created succesfully!\n");
+print("\n\nChannel $new_channel_label created successfully!\n");
 exit(0);
 
 

--- a/spacewalk/setup/bin/spacewalk-setup-ipa-authentication
+++ b/spacewalk/setup/bin/spacewalk-setup-ipa-authentication
@@ -362,7 +362,7 @@ for my $service ( 'sssd', $tomcat_service, 'httpd' ) {
 system '/usr/sbin/spacewalk-startup-helper wait-for-tomcat';
 
 print <<"EOF";
-Authentication against [$ipa_server] sucessfully enabled.
+Authentication against [$ipa_server] successfully enabled.
 As admin, at Admin > Users > External Authentication, select
           Default organization to autopopulate new users into.
 EOF

--- a/spacewalk/setup/lib/Spacewalk/Setup.pm
+++ b/spacewalk/setup/lib/Spacewalk/Setup.pm
@@ -768,7 +768,7 @@ sub _oracle_check_connect_info {
         } else {
                 # Bugzilla 466747: On s390x, stty: standard input: Bad file descriptor
                 # For some reason DBI mistakenly sets FD_CLOEXEC on a stdin file descriptor
-                # here. This made it impossible for us to succesfully call `stty -echo`
+                # here. This made it impossible for us to successfully call `stty -echo`
                 # later in the code. Following two lines work around the problem.
 
                 my $flags = fcntl(STDIN, F_GETFD, 0);
@@ -1696,7 +1696,7 @@ sub get_dbh {
 
                 # Bugzilla 466747: On s390x, stty: standard input: Bad file descriptor
                 # For some reason DBI mistakenly sets FD_CLOEXEC on a stdin file descriptor
-                # here. This made it impossible for us to succesfully call `stty -echo`
+                # here. This made it impossible for us to successfully call `stty -echo`
                 # later in the code. Following two lines work around the problem.
 
                 my $flags = fcntl(STDIN, F_GETFD, 0);

--- a/utils/spacewalk-hostname-rename
+++ b/utils/spacewalk-hostname-rename
@@ -584,4 +584,4 @@ fi
 /usr/sbin/spacewalk-service start >> $LOG 2>&1
 print_status 0  # just simulate end
 
-echo "[$(date)]: $(basename $0) finished sucessfully." >> $LOG
+echo "[$(date)]: $(basename $0) finished successfully." >> $LOG

--- a/web/html/src/manager/content-management/shared/components/panels/build/build.js
+++ b/web/html/src/manager/content-management/shared/components/panels/build/build.js
@@ -122,7 +122,7 @@ const Build = ({projectId, onBuild, currentHistoryEntry = {}, changesToBuild, di
                           }, "action", projectId)
                             .then((projectWithUpdatedSources) => {
                               closeDialog(modalNameId);
-                              showSuccessToastr(t('Version {0} succesfully built into {1}', buildVersionForm.version, projectWithUpdatedSources.environments[0].name))
+                              showSuccessToastr(t('Version {0} successfully built into {1}', buildVersionForm.version, projectWithUpdatedSources.environments[0].name))
                               onBuild(projectWithUpdatedSources)
                             })
                             .catch((error) => {


### PR DESCRIPTION
## What does this PR change?

* "successfully" takes two "C", two "S", and two "L"
* "successful" takes two "C", two "S", and one "L"

Needed for test suite to become green.

## GUI diff

Spelling differences in output.

## Links

Ports:
* 4.0: SUSE/spacewalk#10637
* 3.2: SUSE/spacewalk#10638

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
