### PR TITLE
Don't check for tools when on Uyuni

### DIFF
--- a/testsuite/features/reposync/srv_sync_channels.feature
+++ b/testsuite/features/reposync/srv_sync_channels.feature
@@ -27,12 +27,20 @@ Feature: Be able to list available channels and enable them
     And I should get "[ ] SUSE Manager Proxy 2.1 x86_64"
 
 @scc_credentials
+@susemanager
   Scenario: List all products
     When I execute mgr-sync "list products --expand"
     Then I should get "[ ] SUSE Linux Enterprise Server 12 x86_64"
     And I should get "[ ] SUSE Manager Proxy 2.1 x86_64"
     And I should get "  [ ] (R) SUSE Linux Enterprise Client Tools RES 7 x86_64"
     And I should get "  [ ] (R) SUSE Manager Tools 15 x86_64"
+
+@scc_credentials
+@uyuni
+  Scenario: List all products
+    When I execute mgr-sync "list products --expand"
+    Then I should get "[ ] SUSE Linux Enterprise Server 12 x86_64"
+    And I should get "[ ] SUSE Manager Proxy 2.1 x86_64"
 
 @scc_credentials
   Scenario: List products with filter

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -500,7 +500,9 @@ end
 Then(/^the SLE12 products should be added$/) do
   output = sshcmd('echo -e "admin\nadmin\n" | mgr-sync list channels', ignore_err: true)
   raise unless output[:stdout].include? '[I] SLES12-SP2-Pool for x86_64 SUSE Linux Enterprise Server 12 SP2 x86_64 [sles12-sp2-pool-x86_64]'
-  raise unless output[:stdout].include? '[I] SLE-Manager-Tools12-Pool for x86_64 SP2 SUSE Linux Enterprise Server 12 SP2 x86_64 [sle-manager-tools12-pool-x86_64-sp2]'
+  if $product != 'Uyuni'
+    raise unless output[:stdout].include? '[I] SLE-Manager-Tools12-Pool for x86_64 SP2 SUSE Linux Enterprise Server 12 SP2 x86_64 [sle-manager-tools12-pool-x86_64-sp2]'
+  end
   raise unless output[:stdout].include? '[I] SLE-Module-Legacy12-Updates for x86_64 Legacy Module 12 x86_64 [sle-module-legacy12-updates-x86_64-sp2]'
 end
 


### PR DESCRIPTION
## What does this PR change?

After resurrecting reposync features on Uyuni pipeline, a few errors emerged.

This PR addresses those errors, by not checking SUSE Manager-related channels on Uyuni.

## Links

Uyuni only.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
