### PR TITLE
Testsuite - salt parser json exception catch

### DIFF
--- a/testsuite/features/upload_files/salt_event_parser.py
+++ b/testsuite/features/upload_files/salt_event_parser.py
@@ -5,7 +5,7 @@ import json
 
 # open salt event log and create correct json from it
 errors = []
-item = [] 
+item = []
 f = open('/var/log/rhn/salt-event.log', "r")
 for line in f.readlines():
     item.append(line)
@@ -13,15 +13,19 @@ for line in f.readlines():
         if '\"result\": false' in "".join(item):
             item[0] = "{"
             errors.append(item)
-        item = [] 
+        item = []
 f.close()
 
 # parse json and find results ending as failed
 failure_count = 0
 for error in errors:
-    j = json.loads("".join(error))
-    if not "return" in j:
-        break
+    try:
+        j = json.loads("".join(error))
+        if not "return" in j:
+            break
+    except ValueError as e:
+        print("JSON cannot be parsed due to {0}".format(e))
+        continue
     for k in j["return"]:
         if not j["return"][k]["result"]:
             failure_count += 1


### PR DESCRIPTION
## What does this PR change?

This PR adds exception to catch improper JSON item to input. 

More complex solution of this issue will follow.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
