### PR TITLE
Testsuite - accessing element to trigger DOM refresh

### DIFF
--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -271,14 +271,14 @@ When(/^I ([^ ]*) the "([^"]*)" formula$/) do |action, formula|
   # Complicated code because the checkbox is not a <input type=checkbox> but an <i>
   xpath_query = "//a[@id = '#{formula}']/i[@class = 'fa fa-lg fa-square-o']" if action == 'check'
   xpath_query = "//a[@id = '#{formula}']/i[@class = 'fa fa-lg fa-check-square-o']" if action == 'uncheck'
-  puts "Selected formulas [beginning]:\n#{find('#chooseFormulas')['innerHTML']}"
+  # WORKAROUND
+  # DOM refreshes content of chooseFormulas element by accessing it. Then conditions are evaluated properly.
+  find('#chooseFormulas')['innerHTML']
   if all(:xpath, xpath_query, wait: DEFAULT_TIMEOUT).any?
-    puts "Selected formulas [if]:\n#{find('#chooseFormulas')['innerHTML']}"
     raise "xpath: #{xpath_query} not found" unless find(:xpath, xpath_query, wait: DEFAULT_TIMEOUT).click
   else
     xpath_query = "//a[@id = '#{formula}']/i[@class = 'fa fa-lg fa-check-square-o']" if action == 'check'
     xpath_query = "//a[@id = '#{formula}']/i[@class = 'fa fa-lg fa-square-o']" if action == 'uncheck'
-    puts "Selected formulas [else]:\n#{find('#chooseFormulas')['innerHTML']}"
     raise "xpath: #{xpath_query} not found" unless all(:xpath, xpath_query, wait: DEFAULT_TIMEOUT).any?
   end
 end
@@ -287,7 +287,9 @@ Then(/^the "([^"]*)" formula should be ([^ ]*)$/) do |formula, state|
   # Complicated code because the checkbox is not a <input type=checkbox> but an <i>
   xpath_query = "//a[@id = '#{formula}']/i[@class = 'fa fa-lg fa-square-o']" if state == 'checked'
   xpath_query = "//a[@id = '#{formula}']/i[@class = 'fa fa-lg fa-check-square-o']" if state == 'unchecked'
-  puts "Selected formulas [test]:\n#{find('#chooseFormulas')['innerHTML']}"
+  # WORKAROUND
+  # DOM refreshes content of chooseFormulas element by accessing it. Then conditions are evaluated properly.
+  find('#chooseFormulas')['innerHTML']
   raise "Checkbox is not #{state}" if all(:xpath, xpath_query).any?
   xpath_query = "//a[@id = '#{formula}']/i[@class = 'fa fa-lg fa-check-square-o']" if state == 'checked'
   xpath_query = "//a[@id = '#{formula}']/i[@class = 'fa fa-lg fa-square-o']" if state == 'unchecked'


### PR DESCRIPTION
## What does this PR change?

Replacement of #1839 after further investigation. Additional delay caused by `puts` doesn't solve the issue. Accessing DOM does, so there is no need to keep these debug outputs.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
