### PR TITLE
spacewalk-config: %{rhnconfigdefaults} not needed, as this package doesn't have files there anymore

### DIFF
--- a/spacewalk/config/spacewalk-config.spec
+++ b/spacewalk/config/spacewalk-config.spec
@@ -27,8 +27,6 @@
 %define apache_group apache
 %endif
 
-%global rhnconfigdefaults %{_prefix}/share/rhn/config-defaults
-
 Name:           spacewalk-config
 Summary:        Spacewalk Configuration
 License:        GPL-2.0-only
@@ -113,7 +111,6 @@ ln -sf  %{apacheconfdir}/conf/ssl.crt/server.crt $RPM_BUILD_ROOT/etc/pki/tls/cer
 %dir %{_var}/lib/cobbler/
 %dir %{_var}/lib/cobbler/kickstarts/
 %dir %{_var}/lib/cobbler/snippets/
-%attr(0755,root,%{apache_group}) %dir %{rhnconfigdefaults}
 %config(noreplace) %{_var}/lib/cobbler/kickstarts/spacewalk-sample.ks
 %config(noreplace) %{_var}/lib/cobbler/snippets/spacewalk_file_preservation
 %attr(0640,root,%{apache_group}) %config(noreplace) %{_sysconfdir}/rhn/rhn.conf


### PR DESCRIPTION
## What does this PR change?

%{rhnconfigdefaults} not needed, as this package doesn't have files there anymore

We removed the only file using that directory at https://github.com/uyuni-project/uyuni/pull/1838/files#diff-68b9472dc4618534975dbf925a3f8e5f

I built the SPEC locally. No issues.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Fix
- [x] **DONE**

## Test coverage
- No tests: SPEC building covered by OBS

- [x] **DONE**

## Links

Related: https://github.com/SUSE/spacewalk/issues/1573

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
