### PR TITLE
  Adapt sls file for pre-downloading in Ubuntu minions

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/packages/pkgdownload.sls
+++ b/susemanager-utils/susemanager-sls/salt/packages/pkgdownload.sls
@@ -3,7 +3,9 @@ pkg_downloaded:
   pkg.downloaded:
     - pkgs:
 {%- for pkg, arch, version in pillar.get('param_pkgs', []) %}
-    {%- if grains.get('__suse_reserved_pkg_all_versions_support', False) %}
+    {%- if grains['os_family'] == 'Debian' %}
+        - {{ pkg }}:{{ arch }}: {{ version }}
+    {%- elif grains.get('__suse_reserved_pkg_all_versions_support', False) %}
         - {{ pkg }}.{{ arch }}: {{ version }}
     {%- else %}
         - {{ pkg }}: {{ version }}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Adapt sls file for pre-downloading in Ubuntu minions
 - Add custom 'is_payg_instance' grain when instance is PAYG and not BYOS.
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?
Adapt sls file for pre-downloading in Ubuntu minions

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: documentation exists already regarding this feature.

- [x] **DONE**

## Test coverage
- No unit tests:  already covered
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #
Tracks https://github.com/SUSE/spacewalk/pull/9976

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
