### PR TITLE
TESTSUITE: Add tests for content staging in Ubuntu minion

### DIFF
--- a/testsuite/features/secondary/min_ubuntu_salt_install_with_staging.feature
+++ b/testsuite/features/secondary/min_ubuntu_salt_install_with_staging.feature
@@ -1,0 +1,66 @@
+# Copyright (c) 2017-2020 SUSE LLC
+# Licensed under the terms of the MIT license.
+#
+# This feature relies on having properly configured
+#   /etc/rhn/rhn.conf
+# file on your SUSE Manager server.
+#
+# For the scope of these tests, we configure it as follows:
+#   java.salt_content_staging_window = 0.033 (2 minutes)
+#   java.salt_content_staging_advance = 0.05 (3 minutes)
+# which means "between 3 and 1 minutes before package installation or patching"
+
+@ubuntu_minion
+Feature: Install a package on the Ubuntu minion with staging enabled
+
+  Scenario: Pre-requisite: install virgo-dummy-1.0 package, make sure orion-dummy is not present on Ubuntu minion
+    When I enable repository "test_repo_deb_pool" on this "ubuntu_minion"
+    And I run "apt update" on "ubuntu_minion"
+    And I remove package "orion-dummy" from this "ubuntu_minion"
+    And I install old package "virgo-dummy=1.0" on this "ubuntu_minion"
+
+  Scenario: Pre-requisite: refresh package list on Ubuntu minion
+    When I refresh packages list via spacecmd on "ubuntu_minion"
+    And I wait until refresh package list on "ubuntu_minion" is finished
+    Then spacecmd should show packages "virgo-dummy-1.0" installed on "ubuntu_minion"
+
+  Scenario: Pre-requisite: ensure the errata cache is computed for Ubuntu minion
+    Given I am authorized as "admin" with password "admin"
+    When I follow the left menu "Admin > Task Schedules"
+    And I follow "errata-cache-default"
+    And I follow "errata-cache-bunch"
+    Then I click on "Single Run Schedule"
+    And I should see a "bunch was scheduled" text
+    Then I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows
+
+  Scenario: Enable content staging for Ubuntu minion
+    Given I am authorized as "admin" with password "admin"
+    When I follow the left menu "Admin > Organizations"
+    And I follow first "SUSE Test"
+    And I follow first "Configuration"
+    And I check "staging_content_enabled"
+    And I click on "Update Organization"
+    Then I should see a "was successfully updated." text
+
+  Scenario: Install package in the future and check for staging on Ubuntu minion
+    Given I am on the Systems overview page of this "ubuntu_minion"
+    And I follow "Software" in the content area
+    And I follow "Packages" in the content area
+    And I follow "Install" in the content area
+    When I check "orion-dummy-1.1-X" in the list
+    And I click on "Install Selected Packages"
+    And I pick 2 minutes from now as schedule time
+    And I click on "Confirm"
+    Then I should see a "1 package install has been scheduled for" text
+    And I wait until the package "orion-dummy_1.1" has been cached on this "ubuntu_minion"
+    And I wait for "orion-dummy-1.1" to be installed on "ubuntu_minion"
+
+  # Scenario: Install patch in the future and check for staging on Ubuntu minion
+  # Untested because we don't have patches for Ubuntu
+
+  Scenario: Cleanup: remove virgo-dummy and orion-dummy packages from Ubuntu minion
+    Given I am authorized as "admin" with password "admin"
+    And I remove package "orion-dummy" from this "ubuntu_minion"
+    And I remove package "virgo-dummy" from this "ubuntu_minion"
+    And I disable repository "test_repo_deb_pool" on this "ubuntu_minion"
+    And I run "apt update" on "ubuntu_minion"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -770,7 +770,11 @@ end
 
 When(/^I wait until the package "(.*?)" has been cached on this "(.*?)"$/) do |pkg_name, host|
   node = get_target(host)
-  cmd = "ls /var/cache/zypp/packages/susemanager:test-channel-x86_64/getPackage/*/*/#{pkg_name}*.rpm"
+  if host == 'sle_minion'
+    cmd = "ls /var/cache/zypp/packages/susemanager:test-channel-x86_64/getPackage/*/*/#{pkg_name}*.rpm"
+  elsif host.include? 'ubuntu'
+    cmd = "ls /var/cache/apt/archives/#{pkg_name}*.deb"
+  end
   repeat_until_timeout(message: "Package #{pkg_name} was not cached") do
     result, return_code = node.run(cmd, false)
     break if return_code.zero?

--- a/testsuite/run_sets/secondary_parallelizable.yml
+++ b/testsuite/run_sets/secondary_parallelizable.yml
@@ -46,6 +46,7 @@
 - features/secondary/minssh_centos_salt_install_package_and_patch.feature
 - features/secondary/min_centos_monitoring.feature
 - features/secondary/minssh_salt_install_package.feature
+- features/secondary/min_ubuntu_salt_install_with_staging.feature
 - features/secondary/min_ubuntu_salt_install_package.feature
 - features/secondary/min_bootstrap_xmlrpc.feature
 - features/secondary/min_bootstrap_negative.feature


### PR DESCRIPTION
## What does this PR change?
Add cucumber tests for content staging in Ubuntu minion.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #
Tracks https://github.com/SUSE/spacewalk/pull/9977

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
