### PR TITLE
Another puts in the hope to have fresh content

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -1016,6 +1016,7 @@ end
 # content lifecycle steps
 When(/^I click the environment build button$/) do
   raise "Click on environment build failed" unless find(:xpath, '//*[@id="cm-build-modal-save-button"]').click
+  puts "Page body:\n#{find('#page-body')['innerHTML']}"
 end
 
 When(/^I click promote from Development to QA$/) do


### PR DESCRIPTION
## What does this PR change?

Like for the checkboxes, it looks like we are sometimes we are sometimes looking at old HTML contents in capybara. This PR displays that content in the hope to refresh it.

## Links

No ports for now, experimental stuff.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
