### PR TITLE
Add changelog entries for "sucessfully" patch

### DIFF
--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes
@@ -1,3 +1,5 @@
+- spell correctly "successful" and "successfully"
+
 -------------------------------------------------------------------
 Wed Nov 27 17:00:43 CET 2019 - jgonzalez@suse.com
 

--- a/spacewalk/admin/spacewalk-admin.changes
+++ b/spacewalk/admin/spacewalk-admin.changes
@@ -1,3 +1,4 @@
+- spell correctly "successful" and "successfully"
 - Remove auditlog-keeper
 
 -------------------------------------------------------------------

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,5 @@
+- spell correctly "successful" and "successfully"
+
 -------------------------------------------------------------------
 Wed Jan 22 12:13:54 CET 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR describes the fixes to misspelled "successful" and "successfully" in the changelogs.

## Links

Ports:
* 4.0: SUSE/spacewalk#10658
* 3.2: SUSE/spacewalk#10659