### PR TITLE
Get CLM build version from up-to-date properties

### DIFF
--- a/web/html/src/manager/content-management/shared/components/panels/build/build.js
+++ b/web/html/src/manager/content-management/shared/components/panels/build/build.js
@@ -14,6 +14,7 @@ import statesEnum from "../../../../shared/business/states.enum";
 import type {ProjectHistoryEntry} from '../../../type/project.type.js';
 import {showErrorToastr, showSuccessToastr} from "../../../../../../components/toastr/toastr";
 import useLifecycleActionsApi from "../../../api/use-lifecycle-actions-api";
+import _last from "lodash/last";
 
 type Props = {
   projectId: string,
@@ -122,7 +123,12 @@ const Build = ({projectId, onBuild, currentHistoryEntry = {}, changesToBuild, di
                           }, "action", projectId)
                             .then((projectWithUpdatedSources) => {
                               closeDialog(modalNameId);
-                              showSuccessToastr(t('Version {0} successfully built into {1}', buildVersionForm.version, projectWithUpdatedSources.environments[0].name))
+                              showSuccessToastr(
+                                t('Version {0} successfully built into {1}',
+                                  _last(projectWithUpdatedSources.properties.historyEntries).version,
+                                  projectWithUpdatedSources.environments[0].name
+                                )
+                              );
                               onBuild(projectWithUpdatedSources)
                             })
                             .catch((error) => {


### PR DESCRIPTION
## What does this PR change?

Fix version number in Content Lifecycle Management Build message: fetch the value from the up-to-date project properties.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: fix

- [x] **DONE**

## Test coverage
- No tests: fix testsuite

- [x] **DONE**

## Links

Fixes #
Tracks # https://github.com/SUSE/spacewalk/pull/10666

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
