### PR TITLE
No "And when" in test suite

### DIFF
--- a/testsuite/features/finishing/srv_smdba.feature
+++ b/testsuite/features/finishing/srv_smdba.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2018 SUSE LLC
+# Copyright (c) 2015-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: SMBDA database helper tool
@@ -12,34 +12,34 @@ Feature: SMBDA database helper tool
   Scenario: Check embedded database running
     Given a postgresql database is running
     When I start database with the command "smdba db-start"
-    And when I issue command "smdba db-status"
-    Then I want to see if "online" is in the output
+    And I issue command "smdba db-status"
+    Then "online" should be in the output
 
   Scenario: Check embedded database can be stopped, started and restarted
     Given a postgresql database is running
     When I start database with the command "smdba db-start"
-    And when I see that the database is "online" or "failed" as it might already running
-    And when I stop the database with the command "smdba db-stop"
-    And when I check the database status with the command "smdba db-status"
-    Then I want to see if the database is "offline"
+    And I see that the database is "online" or "failed" as it might already running
+    And I stop the database with the command "smdba db-stop"
+    And I check the database status with the command "smdba db-status"
+    Then the database should be "offline"
     When I start database with the command "smdba db-start"
-    And when I issue command "smdba db-status"
-    Then I want to see if the database is "online"
+    And I issue command "smdba db-status"
+    Then the database should be "online"
 
   Scenario: Check system check of the database sets optimal configuration
     Given a postgresql database is running
     When I stop the database with the command "smdba db-stop"
-    And when I configure "/var/lib/pgsql/data/postgresql.conf" parameter "wal_level" to "logical"
+    And I configure "/var/lib/pgsql/data/postgresql.conf" parameter "wal_level" to "logical"
     Then I start database with the command "smdba db-start"
-    And when I issue command "smdba db-status"
-    Then I want to see if the database is "online"
-    And when I check internally configuration for "wal_level" option
-    Then I expect to see the configuration is set to "logical"
-    And I issue command "smdba system-check"
-    And when I stop the database with the command "smdba db-stop"
+    When I issue command "smdba db-status"
+    Then the database should be "online"
+    When I check internally configuration for "wal_level" option
+    Then the configuration should be set to "logical"
+    When I issue command "smdba system-check"
+    And I stop the database with the command "smdba db-stop"
     And I start database with the command "smdba db-start"
-    And when I check internally configuration for "wal_level" option
-    Then I expect to see the configuration is not set to "logical"
+    And I check internally configuration for "wal_level" option
+    Then the configuration should not be set to "logical"
 
   Scenario: Check database utilities
     Given a postgresql database is running
@@ -57,11 +57,11 @@ Feature: SMBDA database helper tool
     Given a postgresql database is running
     And there is no such "/smdba-backup-test" directory
     When I create backup directory "/smdba-backup-test" with UID "root" and GID "root"
-    And when I issue command "smdba backup-hot --enable=on --backup-dir=/smdba-backup-test"
+    And I issue command "smdba backup-hot --enable=on --backup-dir=/smdba-backup-test"
     Then I should see error message that asks "/smdba-backup-test" belong to the same UID/GID as "/var/lib/pgsql/data" directory
     And I remove backup directory "/smdba-backup-test"
     When I create backup directory "/smdba-backup-test" with UID "postgres" and GID "postgres"
-    And when I issue command "smdba backup-hot --enable=on --backup-dir=/smdba-backup-test"
+    And I issue command "smdba backup-hot --enable=on --backup-dir=/smdba-backup-test"
     Then I should see error message that asks "/smdba-backup-test" has same permissions as "/var/lib/pgsql/data" directory
     And I remove backup directory "/smdba-backup-test"
 
@@ -69,8 +69,8 @@ Feature: SMBDA database helper tool
     Given a postgresql database is running
     And there is no such "/smdba-backup-test" directory
     When I create backup directory "/smdba-backup-test" with UID "postgres" and GID "postgres"
-    And when I change Access Control List on "/smdba-backup-test" directory to "0700"
-    And when I issue command "smdba backup-hot --enable=on --backup-dir=/smdba-backup-test"
+    And I change Access Control List on "/smdba-backup-test" directory to "0700"
+    And I issue command "smdba backup-hot --enable=on --backup-dir=/smdba-backup-test"
     Then base backup is taken
     And in "/smdba-backup-test" directory there is "base.tar.gz" file and at least one backup checkpoint file
     And parameter "archive_command" in the configuration file "/var/lib/pgsql/data/postgresql.conf" is "/usr/bin/smdba-pgarchive"
@@ -80,18 +80,20 @@ Feature: SMBDA database helper tool
     Given a postgresql database is running
     And database "susemanager" has no table "dummy"
     When I set a checkpoint
-    And when I issue command "smdba backup-hot"
-    And when in the database I create dummy table "dummy" with column "test" and value "bogus data"
+    And I issue command "smdba backup-hot"
+    And in the database I create dummy table "dummy" with column "test" and value "bogus data"
     And I destroy "/var/lib/pgsql/data/pg_xlog" directory on server
     And I destroy "/var/lib/pgsql/data/pg_wal" directory on server
-    And when I restore database from the backup
-    And when I issue command "smdba db-status"
+    And I restore database from the backup
+    And I issue command "smdba db-status"
+
+  Scenario: Cleanup: remove backup directory
     Given a postgresql database is running
     And database "susemanager" has no table "dummy"
     When I disable backup in the directory "/smdba-backup-test"
     And I remove backup directory "/smdba-backup-test"
 
-  Scenario: Start spacewalk services
+  Scenario: Cleanup: start spacewalk services
     When I stop the database with the command "smdba db-stop"
     And I start database with the command "smdba db-start"
-    Then I restart the spacewalk service
+    And I restart the spacewalk service

--- a/testsuite/features/step_definitions/smdba_steps.rb
+++ b/testsuite/features/step_definitions/smdba_steps.rb
@@ -24,55 +24,47 @@ When(/^I start database with the command "(.*?)"$/) do |start_command|
   $output = sshcmd(start_command)
 end
 
-When(/^when I stop the database with the command "(.*?)"$/) do |stop_command|
-  $output = sshcmd(stop_command)
-end
-
-When(/^when I check the database status with the command "(.*?)"$/) do |check_command|
-  $output = sshcmd(check_command)
-end
-
 When(/^I stop the database with the command "(.*?)"$/) do |stop_command|
   $output = sshcmd(stop_command)
 end
 
-Then(/^when I issue command "(.*?)"$/) do |command|
-  $output = sshcmd(command, ignore_err: true)
+When(/^I check the database status with the command "(.*?)"$/) do |check_command|
+  $output = sshcmd(check_command)
 end
 
-When(/^when I see that the database is "(.*?)" or "(.*?)" as it might already running$/) do |scs_status, fl_status|
+When(/^I see that the database is "(.*?)" or "(.*?)" as it might already running$/) do |scs_status, fl_status|
   assert_match(/#{scs_status}|#{fl_status}/, $output[:stdout])
 end
 
-Then(/^I want to see if the database is "(.*?)"$/) do |status|
+Then(/^the database should be "(.*?)"$/) do |status|
   assert_includes($output[:stdout], status)
 end
 
-Then(/^I want to see if "(.*?)" is in the output$/) do |status|
+Then(/^"(.*?)" should be in the output$/) do |status|
   assert_includes($output[:stdout], status)
 end
 
-When(/^when I configure "(.*?)" parameter "(.*?)" to "(.*?)"$/) do |config_file, param, value|
+When(/^I configure "(.*?)" parameter "(.*?)" to "(.*?)"$/) do |config_file, param, value|
   sshcmd("sed -i '/wal_level/d' #{config_file}", ignore_err: true)
   sshcmd("echo \"#{param} = #{value}\" >> #{config_file}", ignore_err: true)
   local_output = sshcmd("cat #{config_file} | grep #{param}", ignore_err: true)
   assert_includes(local_output[:stdout], value)
 end
 
-Then(/^when I check internally configuration for "(.*?)" option$/) do |_config_key|
+Then(/^I check internally configuration for "(.*?)" option$/) do |_config_key|
   $current_checked_config_value = sshcmd("cd /;sudo -u postgres psql -c 'show wal_level;'")[:stdout]
 end
 
-Then(/^I expect to see the configuration is set to "(.*?)"$/) do |value|
+Then(/^the configuration should be set to "(.*?)"$/) do |value|
   assert_includes($current_checked_config_value, value)
 end
 
-Then(/^I expect to see the configuration is not set to "(.*?)"$/) do |value|
+Then(/^the configuration should not be set to "(.*?)"$/) do |value|
   refute_includes($current_checked_config_value, value)
 end
 
-Then(/^I issue command "(.*?)"$/) do |cmd|
-  $output = sshcmd(cmd, ignore_err: true)
+Then(/^I issue command "(.*?)"$/) do |command|
+  $output = sshcmd(command, ignore_err: true)
 end
 
 Then(/^tablespace "([^"]*)" should be listed$/) do |ts|
@@ -118,7 +110,7 @@ Then(/^I remove backup directory "(.*?)"$/) do |bkp_dir|
   sshcmd("test -d #{bkp_dir} && rm -rf #{bkp_dir}")
 end
 
-When(/^when I change Access Control List on "(.*?)" directory to "(.*?)"$/) do |bkp_dir, acl_octal|
+When(/^I change Access Control List on "(.*?)" directory to "(.*?)"$/) do |bkp_dir, acl_octal|
   bkp_dir.sub!('/', '')
   sshcmd("test -d /#{bkp_dir} && chmod #{acl_octal} /#{bkp_dir}")
   puts "Backup directory, ACL to \"#{acl_octal}\":"
@@ -154,7 +146,7 @@ When(/^I set a checkpoint$/) do
   sshcmd("sudo -u postgres psql -d #{$db} -c 'checkpoint' 2>/dev/null", ignore_err: true)
 end
 
-When(/^when in the database I create dummy table "(.*?)" with column "(.*?)" and value "(.*?)"$/) do |tbl, clm, val|
+When(/^in the database I create dummy table "(.*?)" with column "(.*?)" and value "(.*?)"$/) do |tbl, clm, val|
   fn = '/tmp/smdba-data-test.sql'
   sshcmd("echo \"create table #{tbl} (#{clm} varchar);insert into #{tbl} (#{clm}) values (\'#{val}\');\" > #{fn}", ignore_err: false)
   sshcmd("sudo -u postgres psql -d #{$db} -c 'drop table dummy' 2>/dev/null", ignore_err: true)
@@ -167,7 +159,7 @@ When(/^when in the database I create dummy table "(.*?)" with column "(.*?)" and
   puts "Table \"#{tbl}\" has been created with some dummy data inside"
 end
 
-When(/^when I restore database from the backup$/) do
+When(/^I restore database from the backup$/) do
   puts "\n*** Restoring database from the backup. This will may take a while. ***\n\n"
   sshcmd('smdba backup-restore')
 end


### PR DESCRIPTION
## What does this PR change?

This PR aligns SMDBA feature tests with test suite conventions.

It also removes two duplicate steps.

## Links

Ports:
* 3.2: SUSE/spacewalk#10676
* 4.0: SUSE/spacewalk#10677

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
