### PR TITLE
Testsuite: update YAML files with renamed core features

### DIFF
--- a/testsuite/run_sets/core.yml
+++ b/testsuite/run_sets/core.yml
@@ -16,8 +16,8 @@
 - features/core/srv_push_package.feature
 - features/core/srv_create_repository.feature
 - features/core/srv_create_activationkey.feature
-- features/core/srv_osimage_profiles.feature
-- features/core/srv_docker_profiles.feature
+- features/core/srv_osimage.feature
+- features/core/srv_docker.feature
 
 # initialize SUSE Manager proxy
   # one of: proxy_register_as_trad_with_script.feature

--- a/testsuite/run_sets/refhost.yml
+++ b/testsuite/run_sets/refhost.yml
@@ -15,7 +15,7 @@
 - features/core/srv_push_package.feature
 - features/core/srv_create_repository.feature
 - features/core/srv_create_activationkey.feature
-- features/core/srv_docker_profiles.feature
+- features/core/srv_docker.feature
 # initialize clients
 - features/init_clients/sle_client.feature
 - features/init_clients/sle_minion.feature

--- a/testsuite/run_sets/sle-updates.yml
+++ b/testsuite/run_sets/sle-updates.yml
@@ -14,8 +14,8 @@
 - features/core/srv_push_package.feature
 - features/core/srv_create_repository.feature
 - features/core/srv_create_activationkey.feature
-- features/core/srv_osimage_profiles.feature
-- features/core/srv_docker_profiles.feature
+- features/core/srv_osimage.feature
+- features/core/srv_docker.feature
 # initialize clients
 - features/init_clients/sle_client.feature
 - features/init_clients/sle_minion.feature

--- a/testsuite/run_sets/virtualization.yml
+++ b/testsuite/run_sets/virtualization.yml
@@ -15,8 +15,8 @@
 - features/core/srv_push_package.feature
 - features/core/srv_create_repository.feature
 - features/core/srv_create_activationkey.feature
-- features/core/srv_osimage_profiles.feature
-- features/core/srv_docker_profiles.feature
+- features/core/srv_osimage.feature
+- features/core/srv_docker.feature
 # these features sync real channels (last core features)
 - features/reposync/srv_sync_channels.feature
 - features/reposync/srv_sync_products.feature


### PR DESCRIPTION
## What does this PR change?

Update YAML files with recently renamed features.

- testsuite/run_sets/virtualization.yml
- testsuite/run_sets/refhost.yml
- testsuite/run_sets/core.yml
- testsuite/run_sets/sle-updates.yml:

Use srv_osimage.feature and srv_docker.feature.

## Links

### Ports
- Manager-3.2: https://github.com/SUSE/spacewalk/pull/10684
- manager-4.0: https://github.com/SUSE/spacewalk/pull/10683


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
