### PR TITLE
Update copyright notice

### DIFF
--- a/testsuite/features/core/srv_docker.feature
+++ b/testsuite/features/core/srv_docker.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2018 SUSE LLC
+# Copyright (c) 2017-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Prepare server for using Docker

--- a/testsuite/features/secondary/min_docker_build_image.feature
+++ b/testsuite/features/secondary/min_docker_build_image.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2018 SUSE LLC
+# Copyright (c) 2017-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # Basic images do not contain zypper nor the name of the server,


### PR DESCRIPTION
#  What does this PR change?

Update copyright notice of recently updated files.

- testsuite/features/core/srv_docker.feature
- testsuite/features/secondary/min_docker_build_image.feature:
Use 2020.
## Links

### Ports
- Manager-3.2: https://github.com/SUSE/spacewalk/pull/10687
- Manager-4.0: https://github.com/SUSE/spacewalk/pull/10688

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

