### PR TITLE
Branch ID field moved from PXE to branch network formula

### DIFF
--- a/testsuite/features/core/proxy_branch_network.feature
+++ b/testsuite/features/core/proxy_branch_network.feature
@@ -51,6 +51,7 @@ Feature: Setup SUSE Manager for Retail branch network
     And I enter the local IP address of "proxy" in IP field
     # bsc#1132908 - Branch network formula closes IPv6 default route, potentially making further networking fail
     And I check enable SLAAC with routing box
+    And I enter "example" in branch id field
     And I click on "Save Formula"
     Then I should see a "Formula saved" text
 

--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -124,7 +124,6 @@ Feature: PXE boot a Retail terminal
     Given I am on the Systems overview page of this "proxy"
     When I follow "Formulas" in the content area
     And I follow first "Pxe" in the content area
-    And I enter "example" in branch id field
     And I click on "Save Formula"
     Then I should see a "Formula saved" text
 


### PR DESCRIPTION
## What does this PR change?

Branch ID field was moved from pxe formula to branch network formula. This updates testsuite to reflect those changes.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: Testsuite change

- [X] **DONE**

## Test coverage
- Cucumber tests were modified

- [X] **DONE**

## Links

Tracks https://github.com/uyuni-project/retail/pull/21

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
