### PR TITLE
Don't start configuring the proxy before it appeared

### DIFF
--- a/testsuite/features/core/proxy_register_as_minion_with_gui.feature
+++ b/testsuite/features/core/proxy_register_as_minion_with_gui.feature
@@ -22,8 +22,11 @@ Feature: Setup SUSE Manager proxy
     And I enter "linux" as "password"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
-    When I navigate to "rhn/systems/Overview.do" page
-    And I wait until I see the name of "proxy", refreshing the page
+
+@proxy
+  Scenario: Wait until the proxy appears
+    Given I am authorized
+    When I wait until onboarding is completed for "proxy"
 
 @proxy
   Scenario: Detect latest Salt changes on the proxy

--- a/testsuite/features/core/proxy_register_as_minion_with_script.feature
+++ b/testsuite/features/core/proxy_register_as_minion_with_script.feature
@@ -27,6 +27,11 @@ Feature: Setup SUSE Manager proxy
     When I accept "proxy" key
 
 @proxy
+  Scenario: Wait until the proxy appears
+    Given I am authorized
+    When I wait until onboarding is completed for "proxy"
+
+@proxy
   Scenario: Detect latest Salt changes on the proxy
     When I query latest Salt changes on "proxy"
 


### PR DESCRIPTION
On very slow machines, `configure-proxy` might fail, because it uses Salt to get the certificate, and the proxy might not be a salt minion yet.

This PR ensures the proxy is a fully registered salt minion before we configure the proxy. We were already doing that when registering from GUI. Now we also do it when registering with script, and while we are at it, we also wait for main events to be finished.

## Links

It's a port of SUSE/spacewalk@0799da6

Ports:
* 4.0: SUSE/spacewalk#10691
* 3.2: SUSE/spacewalk

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
