### PR TITLE
Upgrade pjdbc and netty to last versions

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -51,14 +51,14 @@
         <dependency org="suse" name="jose4j" rev="0.5.1" />
         <dependency org="suse" name="log4j" rev="1.2.17" />
         <dependency org="suse" name="jsch" rev="0.1.55" />
-        <dependency org="suse" name="netty-buffer" rev="4.1.8.Final" />
-        <dependency org="suse" name="netty-codec" rev="4.1.8.Final" />
-        <dependency org="suse" name="netty-common" rev="4.1.8.Final" />
-        <dependency org="suse" name="netty-handler" rev="4.1.8.Final" />
-        <dependency org="suse" name="netty-resolver" rev="4.1.8.Final" />
-        <dependency org="suse" name="netty-transport" rev="4.1.8.Final" />
+        <dependency org="suse" name="netty-buffer" rev="4.1.44.Final" />
+        <dependency org="suse" name="netty-codec" rev="4.1.44.Final" />
+        <dependency org="suse" name="netty-common" rev="4.1.44.Final" />
+        <dependency org="suse" name="netty-handler" rev="4.1.44.Final" />
+        <dependency org="suse" name="netty-resolver" rev="4.1.44.Final" />
+        <dependency org="suse" name="netty-transport" rev="4.1.44.Final" />
         <dependency org="suse" name="oro" rev="2.0.8" />
-        <dependency org="suse" name="pgjdbc-ng" rev="0.7.1" />
+        <dependency org="suse" name="pgjdbc-ng" rev="0.8.3" />
         <dependency org="suse" name="postgresql-jdbc" rev="9.4" />
         <dependency org="suse" name="quartz" rev="2.3.0" />
         <dependency org="suse" name="redstone-xmlrpc" rev="1.1_20071120" />


### PR DESCRIPTION
## What does this PR change?

It upgrades pgjdbc and its dependency, netty.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal only change**

- [x] **DONE**

## Test coverage
- No tests: **abundantly covered by existing suites**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
