### PR TITLE
Adjust color to distinguish patch severity level

### DIFF
--- a/branding/css/susemanager-theme.less
+++ b/branding/css/susemanager-theme.less
@@ -1120,10 +1120,10 @@ time:hover {
   color: @spacewalk-gray;
 }
 .errata-moderate {
-  color: @spacewalk-yellow-dark;
+  color: @spacewalk-yellow;
 }
 .errata-important {
-  color: @spacewalk-orange-light;
+  color: @spacewalk-orange;
 }
 .errata-critical {
   color: @spacewalk-red;

--- a/branding/css/susemanager-variables.less
+++ b/branding/css/susemanager-variables.less
@@ -10,11 +10,11 @@
 @spacewalk-gray:         #a7a9ac; // gray
 @spacewalk-gray-light:   #dcddde; // gray-light
 @spacewalk-gray-dark:    #5f5f5f; // gray-dark
-@spacewalk-orange:       #ed6924; // orange
+@spacewalk-orange:       #F87429; // $eos-bc-orange-400
 @spacewalk-orange-light: #fd9a2b; // orange-light
 @spacewalk-yellow-dark:  #c5b345; // yellow-dark
-@spacewalk-yellow:       #ffef8d; // yellow
-@spacewalk-red:          #a42800; // red
+@spacewalk-yellow:       #FFC107; // $eos-bc-yellow-500
+@spacewalk-red:          #DC3545; // $eos-bc-red-500
 @spacewalk-background:   #FFF;
 @spacewalk-blue:         #0D2C40; // blue
 @spacewalk-blue-light:   #314C5D; // light blue


### PR DESCRIPTION
## What does this PR change?

https://github.com/SUSE/spacewalk/issues/5152

## GUI diff

Before:

![image](https://user-images.githubusercontent.com/7080830/74062610-ec140300-49ee-11ea-9bc0-c96a749bb336.png)

After:
![Screenshot from 2020-02-07 21-17-31](https://user-images.githubusercontent.com/7080830/74062753-4a40e600-49ef-11ea-95ad-b370d3b9c77e.png)



- [x] **DONE**

## Documentation
- No documentation needed: 

- [x] **DONE**

## Test coverage
- No tests: 

- [x] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/5152
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
