### PR TITLE
Additional fixes for pgjdbc-0.8.3 compatibility

### DIFF
--- a/java/buildconf/build-props.xml
+++ b/java/buildconf/build-props.xml
@@ -144,7 +144,7 @@
              regexp ${jmock-jars} strutstest" / -->
 
   <!-- SUSE extra dependencies: build and runtime -->
-  <property name="suse-common-jars" value="jade4j jose4j salt-netapi-client spark-core spark-template-jade httpclient httpcore httpasyncclient httpcore-nio simpleclient simpleclient_common simpleclient_servlet simpleclient_httpserver pgjdbc-ng netty-common netty-buffer netty-resolver netty-transport netty-codec netty-handler java-saml java-saml-core joda-time woodstox-core-asl xmlsec stax2-api stax-api" />
+  <property name="suse-common-jars" value="jade4j jose4j salt-netapi-client spark-core spark-template-jade httpclient httpcore httpasyncclient httpcore-nio simpleclient simpleclient_common simpleclient_servlet simpleclient_httpserver pgjdbc-ng netty-common netty-buffer netty-resolver netty-transport netty-codec netty-handler netty-transport-native-unix-common java-saml java-saml-core joda-time woodstox-core-asl xmlsec stax2-api stax-api" />
 
   <!-- SUSE extra dependencies: runtime only -->
   <property name="suse-runtime-jars" value="commons-jexl ${commons-lang} concurrentlinkedhashmap-lru

--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -57,6 +57,7 @@
         <dependency org="suse" name="netty-handler" rev="4.1.44.Final" />
         <dependency org="suse" name="netty-resolver" rev="4.1.44.Final" />
         <dependency org="suse" name="netty-transport" rev="4.1.44.Final" />
+        <dependency org="suse" name="netty-transport-native-unix-common" rev="4.1.44.Final" />
         <dependency org="suse" name="oro" rev="2.0.8" />
         <dependency org="suse" name="pgjdbc-ng" rev="0.8.3" />
         <dependency org="suse" name="postgresql-jdbc" rev="9.4" />

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -174,6 +174,10 @@ artifacts:
     package: netty
     jar: netty-transport
     repository: Uyuni_Other
+  - artifact: netty-transport-native-unix-common
+    package: netty
+    jar: netty-transport-native-unix-common
+    repository: Uyuni_Other
   - artifact: oro
     repository: Leap
   - artifact: pgjdbc-ng

--- a/java/code/src/com/suse/manager/reactor/PGEventStream.java
+++ b/java/code/src/com/suse/manager/reactor/PGEventStream.java
@@ -28,6 +28,7 @@ import com.redhat.rhn.frontend.events.TransactionHelper;
 import com.impossibl.postgres.api.jdbc.PGConnection;
 import com.impossibl.postgres.api.jdbc.PGNotificationListener;
 import com.impossibl.postgres.jdbc.PGDataSource;
+import com.impossibl.postgres.system.SystemSettings;
 import com.suse.salt.netapi.event.AbstractEventStream;
 import com.suse.salt.netapi.exception.SaltException;
 import com.suse.salt.netapi.parser.JsonParser;
@@ -87,6 +88,7 @@ public class PGEventStream extends AbstractEventStream implements PGNotification
         dataSource.setUser(config.getString(ConfigDefaults.DB_USER));
         dataSource.setPassword(config.getString(ConfigDefaults.DB_PASSWORD));
         dataSource.setSslMode("allow");
+        dataSource.setProtocolIoMode(SystemSettings.ProtocolIOMode.NIO);
 
         try {
             connection = (PGConnection) dataSource.getConnection();


### PR DESCRIPTION
## What does this PR change?

Adds more fixes to unbreak Uyuni after the merge of pgjdbc-0.8.3.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internals**

- [x] **DONE**

## Test coverage
- No tests: **covered**

- [x] **DONE**

## Links

https://build.suse.de/request/show/211032
https://build.suse.de/request/show/211033
https://build.opensuse.org/request/show/772515

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
