### PR TITLE
Use correct parameter for protocol io mode

### DIFF
--- a/java/code/src/com/suse/manager/reactor/PGEventStream.java
+++ b/java/code/src/com/suse/manager/reactor/PGEventStream.java
@@ -28,11 +28,9 @@ import com.redhat.rhn.frontend.events.TransactionHelper;
 import com.impossibl.postgres.api.jdbc.PGConnection;
 import com.impossibl.postgres.api.jdbc.PGNotificationListener;
 import com.impossibl.postgres.jdbc.PGDataSource;
-import com.impossibl.postgres.system.SystemSettings;
 import com.suse.salt.netapi.event.AbstractEventStream;
 import com.suse.salt.netapi.exception.SaltException;
 import com.suse.salt.netapi.parser.JsonParser;
-
 import org.apache.commons.lang3.concurrent.BasicThreadFactory;
 import org.apache.log4j.Logger;
 
@@ -88,7 +86,7 @@ public class PGEventStream extends AbstractEventStream implements PGNotification
         dataSource.setUser(config.getString(ConfigDefaults.DB_USER));
         dataSource.setPassword(config.getString(ConfigDefaults.DB_PASSWORD));
         dataSource.setSslMode("allow");
-        dataSource.setProtocolIoMode(SystemSettings.ProtocolIOMode.NIO);
+        dataSource.setProtocolIoMode("nio");
 
         try {
             connection = (PGConnection) dataSource.getConnection();


### PR DESCRIPTION
## What does this PR change?

Addresses an issue inadvertedly introduced in #1888 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internals**

- [x] **DONE**

## Test coverage
- No tests: **covered**

- [x] **DONE**

## Links

None


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
