### PR TITLE
Add spy library, needed by pgjdbc-ng 0.8.3

### DIFF
--- a/java/buildconf/build-props.xml
+++ b/java/buildconf/build-props.xml
@@ -144,7 +144,7 @@
              regexp ${jmock-jars} strutstest" / -->
 
   <!-- SUSE extra dependencies: build and runtime -->
-  <property name="suse-common-jars" value="jade4j jose4j salt-netapi-client spark-core spark-template-jade httpclient httpcore httpasyncclient httpcore-nio simpleclient simpleclient_common simpleclient_servlet simpleclient_httpserver pgjdbc-ng netty-common netty-buffer netty-resolver netty-transport netty-codec netty-handler netty-transport-native-unix-common java-saml java-saml-core joda-time woodstox-core-asl xmlsec stax2-api stax-api" />
+  <property name="suse-common-jars" value="jade4j jose4j salt-netapi-client spark-core spark-template-jade httpclient httpcore httpasyncclient httpcore-nio simpleclient simpleclient_common simpleclient_servlet simpleclient_httpserver pgjdbc-ng spy netty-common netty-buffer netty-resolver netty-transport netty-codec netty-handler netty-transport-native-unix-common java-saml java-saml-core joda-time woodstox-core-asl xmlsec stax2-api stax-api" />
 
   <!-- SUSE extra dependencies: runtime only -->
   <property name="suse-runtime-jars" value="commons-jexl ${commons-lang} concurrentlinkedhashmap-lru

--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -77,6 +77,7 @@
         <dependency org="suse" name="snakeyaml" rev="1.10" />
         <dependency org="suse" name="spark-core" rev="2.7.2" />
         <dependency org="suse" name="spark-template-jade" rev="2.3" />
+        <dependency org="suse" name="spy" rev="0.8.3" />
         <dependency org="suse" name="statistics" rev="1.0.2" />
         <dependency org="suse" name="stax-api" rev="1.0.1" />
         <dependency org="suse" name="stax2-api" rev="3.1.4" />

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -234,6 +234,9 @@ artifacts:
     repository: Uyuni_Other
   - artifact: spark-template-jade
     repository: Uyuni_Other
+  - artifact: spy
+    package: pgjdbc-ng
+    repository: Uyuni_Other
   - artifact: statistics
     repository: Uyuni_Other
   - artifact: stax-api


### PR DESCRIPTION
## What does this PR change?

Adds spy as a dependency for pgjdbc-ng, as it is a requirement for the new version.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internals**

- [x] **DONE**

## Test coverage
- No tests: **covered**

- [x] **DONE**

## Links

https://build.suse.de/request/show/211045
https://build.opensuse.org/request/show/772611

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"