### PR TITLE
Add spy (dependency to pgjdbc-ng 0.8.3)

### DIFF
--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -663,6 +663,7 @@ chown tomcat:%{apache_group} /var/log/rhn/gatherer.log
 %{jardir}/slf4j_log4j12*.jar
 %{jardir}/spark-core.jar
 %{jardir}/spark-template-jade.jar
+%{jardir}/spy.jar
 %{jardir}/simpleclient*.jar
 %{jardir}/pgjdbc-ng.jar
 %{jardir}/java-saml-core.jar


### PR DESCRIPTION
## What does this PR change?

Adds spy as a dependency for pgjdbc-ng in the specfile, as it is a requirement for the new version.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internals**

- [x] **DONE**

## Test coverage
- No tests: **covered**

- [x] **DONE**

## Links

None

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"