### PR TITLE
Prevent issues with SSH minions when custom modules are not synced (bsc#1162609, bsc#1162683)

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/actionchains/resumessh.sls
+++ b/susemanager-utils/susemanager-sls/salt/actionchains/resumessh.sls
@@ -1,3 +1,8 @@
 resumessh:
     module.run:
     -   name: mgractionchains.resume
+    -   require:
+      - module: sync_modules
+
+include:
+  - util.synccustomall

--- a/susemanager-utils/susemanager-sls/salt/actionchains/startssh.sls
+++ b/susemanager-utils/susemanager-sls/salt/actionchains/startssh.sls
@@ -2,3 +2,8 @@ startssh:
     module.run:
     -   name: mgractionchains.start
     -   actionchain_id: {{ pillar.get('actionchain_id')}}
+    -   require:
+      - module: sync_modules
+
+include:
+  - util.synccustomall

--- a/susemanager-utils/susemanager-sls/salt/util/syncmodules.sls
+++ b/susemanager-utils/susemanager-sls/salt/util/syncmodules.sls
@@ -1,8 +1,3 @@
 sync_modules:
   module.run:
-# workaround for https://github.com/saltstack/salt/issues/38095
-{%- if salt['pillar.get']('contact_method') in ['ssh-push', 'ssh-push-tunnel'] %}
-    - name: test.true
-{%- else %}
     - name: saltutil.sync_modules
-{% endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,5 +1,5 @@
 - Do not workaround util.syncmodules for SSH minions (bsc#1162609)
-- Force to run util.synccustomall when triggering action chains on SSH minions.
+- Force to run util.synccustomall when triggering action chains on SSH minions (bsc#1162683).
 - Adapt sls file for pre-downloading in Ubuntu minions
 - Add custom 'is_payg_instance' grain when instance is PAYG and not BYOS.
 

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- Do not workaround util.syncmodules for SSH minions (bsc#1162609)
+- Force to run util.synccustomall when triggering action chains on SSH minions.
 - Adapt sls file for pre-downloading in Ubuntu minions
 - Add custom 'is_payg_instance' grain when instance is PAYG and not BYOS.
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes some issues with SSH minions that happen in case some custom Salt modules/grains/beacons are not properly synced with the SSH minion:

- Package Refresh fails due `sumautil` module is not available.
- Actions Chains are not triggered because `mgractionchains` module is not available.
- Remove the workaround for `util.syncmodules` on SSH minions which prevents the custom modules to be "synced" when this function is executed [1].

[1] this workaround was added on 2016 to avoid https://github.com/saltstack/salt/issues/38095 but it seems to me that this is now not longer valid and causing issues.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **already covered by cucumber testsuite**

- [x] **DONE**

## Links

Tracks
https://github.com/SUSE/spacewalk/issues/10663
https://github.com/SUSE/spacewalk/issues/10700

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
