### PR TITLE
Fix misalignment on "actionchains.startssh" and "actionchains.resumessh"

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/actionchains/resumessh.sls
+++ b/susemanager-utils/susemanager-sls/salt/actionchains/resumessh.sls
@@ -1,7 +1,7 @@
 resumessh:
     module.run:
     -   name: mgractionchains.resume
-    -   require:
+    - require:
       - module: sync_modules
 
 include:

--- a/susemanager-utils/susemanager-sls/salt/actionchains/startssh.sls
+++ b/susemanager-utils/susemanager-sls/salt/actionchains/startssh.sls
@@ -2,7 +2,7 @@ startssh:
     module.run:
     -   name: mgractionchains.start
     -   actionchain_id: {{ pillar.get('actionchain_id')}}
-    -   require:
+    - require:
       - module: sync_modules
 
 include:


### PR DESCRIPTION
## What does this PR change?

This PR follows-up https://github.com/uyuni-project/uyuni/pull/1894 and fixes a typo that creates a misalignment on `actionchains.startssh` and `actionchains.resumessh` state files.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **bugfix**

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
