### PR TITLE
obs-to-maven: correct specification of pgjdbc/spy

### DIFF
--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -181,6 +181,7 @@ artifacts:
   - artifact: oro
     repository: Leap
   - artifact: pgjdbc-ng
+    jar: pgjdbc-ng
     repository: Uyuni_Other
   - artifact: postgresql-jdbc
     repository: Uyuni_Other
@@ -236,6 +237,7 @@ artifacts:
     repository: Uyuni_Other
   - artifact: spy
     package: pgjdbc-ng
+    jar: spy
     repository: Uyuni_Other
   - artifact: statistics
     repository: Uyuni_Other


### PR DESCRIPTION
## What does this PR change?

It fixes an incorrect jar specification in obs-to-maven. This only affects developers deploying own built versions of the Java codebase via `ant`.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **developer only**

- [x] **DONE**

## Test coverage
- No tests: **only for development**

- [x] **DONE**

## Links

no links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
