### PR TITLE
Manager bsc1010746

### DIFF
--- a/spacewalk/certs-tools/rhn_bootstrap.py
+++ b/spacewalk/certs-tools/rhn_bootstrap.py
@@ -277,7 +277,7 @@ def getOptionsTable():
 def parseCommandline():
     "parse the commandline/options, sanity checking, et c."
 
-    _progName = os.path.basename(sys.argv[0])
+    _progName = "mgr-bootstrap"
     _usage = """\
 %s [options]
 

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,4 @@
+- fix --help output for mgr-ssl-tool and mgr-bootstrap (bsc#1010746)
 - fix manpages for mgr-ssl-tool and mgr-bootstrap (bsc#1010746)
 
 -------------------------------------------------------------------

--- a/spacewalk/certs-tools/sslToolCli.py
+++ b/spacewalk/certs-tools/sslToolCli.py
@@ -266,7 +266,7 @@ def setIntersection(*sets):
 
 
 ## custom usage text
-_progName = os.path.basename(sys.argv[0])
+_progName = "mgr-ssl-tool"
 BASE_USAGE = """\
 %s [options]
 


### PR DESCRIPTION
## What does this PR change?

"mgr-ssl-tool --help" will still print "Usage: rhn-ssl-tool ..."

This PR fixes this.

We need to hardcode the program names here. In fact, they are already hardcoded because renaming does not immediately work because the names of python modules are derived from the name, see this gem:

# management decisions lead to funny code
sys.argv[0] = os.path.join(os.path.dirname(sys.argv[0]), os.path.basename(sys.argv[0]).replace('mgr', 'rhn'))

