### PR TITLE
Adjust REGEX for username validation

### DIFF
--- a/java/code/src/com/suse/manager/webui/utils/InputValidator.java
+++ b/java/code/src/com/suse/manager/webui/utils/InputValidator.java
@@ -33,8 +33,8 @@ public enum InputValidator {
      */
     INSTANCE;
 
-    // Allow letters (of all languages), numbers, '.', '/', '\' and '-'
-    private static final Pattern USERNAME = Pattern.compile("^[\\p{L}\\p{N}.-/\\\\]*$");
+    // Allow English letters, numbers, '.', '\', '_' and '-'
+    private static final Pattern USERNAME = Pattern.compile("^[a-zA-Z0-9\\.\\\\_-]*$");
 
     /**
      * Validate input as sent from the minion bootstrapping UI.
@@ -50,7 +50,7 @@ public enum InputValidator {
         String user = input.getUser();
         if (StringUtils.isEmpty(user) || !USERNAME.matcher(user).matches()) {
             errors.add("Non-valid user. Allowed characters are: letters, numbers, '.'," +
-                    " '\\' and '/'");
+                    " '\\', '-' and '_'");
         }
 
         String port = input.getPort();

--- a/java/code/src/com/suse/manager/webui/utils/test/InputValidatorTest.java
+++ b/java/code/src/com/suse/manager/webui/utils/test/InputValidatorTest.java
@@ -29,7 +29,7 @@ public class InputValidatorTest extends TestCase {
 
     private static final String HOST_ERROR_MESSAGE = "Invalid host name.";
     private static final String USER_ERROR_MESSAGE = "Non-valid user. Allowed characters" +
-            " are: letters, numbers, '.', '\\' and '/'";
+            " are: letters, numbers, '.', '\\', '-' and '_'";
     private static final String PORT_ERROR_MESSAGE = "Port must be a number within range" +
             " 1-65535.";
 
@@ -46,10 +46,50 @@ public class InputValidatorTest extends TestCase {
     }
 
     /**
+     * Test the check for user with letters and numbers.
+     */
+    public void testValidateBootstrapInputUserLettersNumbers() {
+        String json = "{user: 'Admin1', host: 'host.domain.com'}";
+        BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
+        List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(input);
+        assertTrue(validationErrors.isEmpty());
+    }
+
+    /**
+     * Test the check for user with dot.
+     */
+    public void testValidateBootstrapInputUserDot() {
+        String json = "{user: 'my.admin', host: 'host.domain.com'}";
+        BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
+        List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(input);
+        assertTrue(validationErrors.isEmpty());
+    }
+
+    /**
      * Test the check for user with backslash.
      */
     public void testValidateBootstrapInputUserBackslash() {
         String json = "{user: 'domain\\\\admin', host: 'host.domain.com'}";
+        BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
+        List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(input);
+        assertTrue(validationErrors.isEmpty());
+    }
+
+    /**
+     * Test the check for user with dash.
+     */
+    public void testValidateBootstrapInputUserDash() {
+        String json = "{user: 'my-admin', host: 'host.domain.com'}";
+        BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
+        List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(input);
+        assertTrue(validationErrors.isEmpty());
+    }
+
+    /**
+     * Test the check for user with underscore.
+     */
+    public void testValidateBootstrapInputUserUnderscore() {
+        String json = "{user: 'my_admin', host: 'host.domain.com'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(input);
         assertTrue(validationErrors.isEmpty());


### PR DESCRIPTION
## What does this PR change?

Adjust REGEX for username validation: 

- `/` is not valid for the GNU/Linux Distributions I tested (Debian, openSUSE, CentOS) or Windows (I kept `\` as it's the separator between user and domain in Windows)
- Only English alphabetic are valid at the same distributions (tried with cyrillic)
- `_` is a valid character.
- `-` was allowed, but it didn't work on the REGEX (see screenshots). Works now (it's used by for a lot of images at AWS: `ec2-user`)
- The error message was not really correct as it didn't mention `-` 
- Add some more testcases


## GUI diff

No difference.

Before:

![before](https://user-images.githubusercontent.com/4226070/74362943-d8d7ad80-4dc9-11ea-8935-4f817e599376.png)

After:

![after](https://user-images.githubusercontent.com/4226070/74362946-daa17100-4dc9-11ea-8bda-24f26dd8f350.png)

- [x] **DONE**

## Documentation
- No documentation needed: `modules/client-configuration/pages/registration-webui.adoc` does not talk about the username restrictions.

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

No sure we really need a changelog here.

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
