### PR TITLE
Enable provisioning api for salt systems

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -2575,19 +2575,19 @@ public class SystemHandler extends BaseHandler {
     }
 
     /**
-     * Provision a system using the specified kickstart profile.
+     * Provision a system using the specified kickstart/autoinstallation profile.
      *
      * @param loggedInUser The current user
      * @param serverId of the system to be provisioned
-     * @param profileName of Kickstart Profile to be used.
+     * @param profileName of Profile to be used.
      * @return Returns 1 if successful, exception otherwise
      * @throws FaultException A FaultException is thrown if the server corresponding to
-     * id cannot be found or kickstart profile is not found.
+     * id cannot be found or profile is not found.
      *
-     * @xmlrpc.doc Provision a system using the specified kickstart profile.
+     * @xmlrpc.doc Provision a system using the specified kickstart/autoinstallation profile.
      * @xmlrpc.param #param("string", "sessionKey")
      * @xmlrpc.param #param_desc("int", "serverId", "ID of the system to be provisioned.")
-     * @xmlrpc.param #param_desc("string", "profileName", "Kickstart profile to use.")
+     * @xmlrpc.param #param_desc("string", "profileName", "Profile to use.")
      * @xmlrpc.returntype int - ID of the action scheduled, otherwise exception thrown
      * on error
      */
@@ -2597,9 +2597,9 @@ public class SystemHandler extends BaseHandler {
 
         // Lookup the server so we can validate it exists and throw error if not.
         Server server = lookupServer(loggedInUser, serverId);
-        if (!(server.hasEntitlement(EntitlementManager.MANAGEMENT))) {
+        if (server.hasEntitlement(EntitlementManager.FOREIGN)) {
             throw new FaultException(-2, "provisionError",
-                    "System does not have management entitlement");
+                    "System does not have required entitlement");
         }
 
         KickstartData ksdata = KickstartFactory.
@@ -2625,20 +2625,20 @@ public class SystemHandler extends BaseHandler {
     }
 
     /**
-     * Provision a system using the specified kickstart profile at specified time.
+     * Provision a system using the specified kickstart/autoinstallation profile at specified time.
      *
      * @param loggedInUser The current user
      * @param serverId of the system to be provisioned
-     * @param profileName of Kickstart Profile to be used.
-     * @param earliestDate when the kickstart needs to be scheduled
+     * @param profileName of Profile to be used.
+     * @param earliestDate when the autoinstallation needs to be scheduled
      * @return Returns 1 if successful, exception otherwise
      * @throws FaultException A FaultException is thrown if the server corresponding to
-     * id cannot be found or kickstart profile is not found.
+     * id cannot be found or profile is not found.
      *
-     * @xmlrpc.doc Provision a system using the specified kickstart profile.
+     * @xmlrpc.doc Provision a system using the specified kickstart/autoinstallation profile.
      * @xmlrpc.param #param("string", "sessionKey")
      * @xmlrpc.param #param_desc("int", "serverId", "ID of the system to be provisioned.")
-     * @xmlrpc.param #param_desc("string", "profileName", "Kickstart profile to use.")
+     * @xmlrpc.param #param_desc("string", "profileName", "Profile to use.")
      * @xmlrpc.param #param("dateTime.iso8601", "earliestDate")
      * @xmlrpc.returntype int - ID of the action scheduled, otherwise exception thrown
      * on error
@@ -2650,9 +2650,9 @@ public class SystemHandler extends BaseHandler {
 
         // Lookup the server so we can validate it exists and throw error if not.
         Server server = lookupServer(loggedInUser, serverId);
-        if (!(server.hasEntitlement(EntitlementManager.MANAGEMENT))) {
+        if (server.hasEntitlement(EntitlementManager.FOREIGN)) {
             throw new FaultException(-2, "provisionError",
-                    "System cannot be provisioned");
+                    "System does not have required entitlement");
         }
 
         KickstartData ksdata = KickstartFactory.
@@ -5900,9 +5900,9 @@ public class SystemHandler extends BaseHandler {
             throw new NoSuchSystemException();
         }
 
-        if (!(server.hasEntitlement(EntitlementManager.MANAGEMENT))) {
+        if (server.hasEntitlement(EntitlementManager.FOREIGN)) {
             throw new FaultException(-2, "provisionError",
-                    "System cannot be provisioned");
+                    "System does not have required entitlement");
         }
 
         KickstartData ksData = lookupKsData(ksLabel, loggedInUser.getOrg());
@@ -6063,9 +6063,9 @@ public class SystemHandler extends BaseHandler {
             throw new NoSuchSystemException();
         }
 
-        if (!(server.hasEntitlement(EntitlementManager.MANAGEMENT))) {
+        if (server.hasEntitlement(EntitlementManager.FOREIGN)) {
             throw new FaultException(-2, "provisionError",
-                    "System cannot be provisioned");
+                    "System does not have required entitlement");
         }
 
         SystemRecord rec = SystemRecord.lookupById(
@@ -6124,9 +6124,9 @@ public class SystemHandler extends BaseHandler {
             throw new NoSuchSystemException();
         }
 
-        if (!(server.hasEntitlement(EntitlementManager.MANAGEMENT))) {
+        if (server.hasEntitlement(EntitlementManager.FOREIGN)) {
             throw new FaultException(-2, "provisionError",
-                    "System cannot be provisioned");
+                    "System does not have required entitlement");
         }
 
         SystemRecord rec = SystemRecord.lookupById(
@@ -6328,7 +6328,7 @@ public class SystemHandler extends BaseHandler {
         Server server = lookupServer(loggedInUser, serverId);
         if (!(server.hasEntitlement(EntitlementManager.MANAGEMENT))) {
             throw new FaultException(-2, "provisionError",
-                    "System cannot be provisioned");
+                    "System does not support snapshots");
         }
         List<ServerSnapshot> snps = ServerFactory.listSnapshots(loggedInUser.getOrg(),
                 server, null, null);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- enable provisioning API with salt and bootstrap entitled systems
 - remove oracle DB support
 - improve performance when adding systems to system groups (bsc#1158754)
 - remove NccRegister Task


### PR DESCRIPTION
## What does this PR change?

UI allows already to use provisioning with Salt system, but the API had extra checks.
This enable "Salt" and "Bootstrap" entitled systems to use these API calls

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **no test available for provisioning**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/10789

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
