### PR TITLE
Cleanup keys on minions

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/services/salt-minion.sls
+++ b/susemanager-utils/susemanager-sls/salt/services/salt-minion.sls
@@ -2,6 +2,23 @@ include:
   - bootstrap.remove_traditional_stack
 
 {%- if salt['pillar.get']('contact_method') not in ['ssh-push', 'ssh-push-tunnel'] %}
+
+{# management keys should be used only once #}
+{# removed to prevent trouble on the next regular minion restart #}
+mgr_remove_management_key_grains:
+  file.replace:
+    - name: /etc/salt/minion.d/susemanager.conf
+    - pattern: '^\s*management_key:.*$'
+    - repl: ''
+
+{# activation keys are only usefull on first registration #}
+{# removed to prevent trouble on the next regular minion restart #}
+mgr_remove_activation_key_grains:
+  file.replace:
+    - name: /etc/salt/minion.d/susemanager.conf
+    - pattern: '^\s*activation_key:.*$'
+    - repl: ''
+
 mgr_salt_minion:
   pkg.installed:
     - name: salt-minion

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- cleanup key grains after usage
 - Disable modularity failsafe mechanism for RHEL 8 repos (bsc#1164875)
 - install dmidecode before HW profile update when missing
 - Add mgr_start_event_grains.sls to update minion config

--- a/testsuite/features/secondary/min_activationkey.feature
+++ b/testsuite/features/secondary/min_activationkey.feature
@@ -80,6 +80,7 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
   Scenario: Verify that minion bootstrapped with activation key
     Given I am on the Systems overview page of this "sle_minion"
     Then I should see a "Activation Key: 	1-MINION-TEST" text
+    And the "activation_key" on "sle_minion" grains does not exist
 
   Scenario: Verify that minion bootstrapped with base channel
     Given I am on the Systems page

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1201,3 +1201,9 @@ When(/^I remove the bind zones created by retail_yaml$/) do
   raise unless find(:xpath, "//*[text()='Configured Zones']/../..//*[@value='#{domain}']/../../../..//*[@title='Remove item']").click
   raise unless find(:xpath, "//*[text()='Available Zones']/../..//*[@value='#{domain}' and @name='Name']/../../../..//i[@title='Remove item']").click
 end
+
+Then(/^the "([^"]*)" on "([^"]*)" grains does not exist$/) do |key, client|
+  node = get_target(client)
+  _result, code = node.run("grep #{key} /etc/salt/minion.d/susemanager.conf", fatal = false)
+  raise if code.zero?
+end


### PR DESCRIPTION
## What does this PR change?

Key grains (activation_key or management_key) are only used on the first start/registration of a minion. Management Keys are even removed on server side and cause "key not found" errors when used a second time.

The idea is, to remove them from the `susemanager.conf` on the next regular highstate
which should happen after bootstrap state or registration state from autoinstallation profile.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
