### PR TITLE
Basic Astra Linux CE "Orel" support

### DIFF
--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,5 @@
+- Enable support for bootstrapping Astra Linux CE "Orel"
+
 -------------------------------------------------------------------
 Thu Mar 19 12:08:00 CET 2020 - jgonzalez@suse.com
 

--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -36,6 +36,8 @@ mgr_server_localhost_alias_absent:
 {%- set osrelease = grains['osrelease'].split('.') %}
 {%- if grains['os'] == 'Ubuntu' %}
 {% set bootstrap_repo_url = 'https://' ~ salt['pillar.get']('mgr_server') ~ '/pub/repositories/ubuntu/' ~ osrelease[0] ~ '/' ~ osrelease[1].lstrip('0') ~ '/bootstrap/' %}
+{%- elif grains['os'] == 'AstraLinuxCE' %}
+{% set bootstrap_repo_url = 'https://' ~ salt['pillar.get']('mgr_server') ~ '/pub/repositories/astra/' ~ grains['oscodename'] ~ '/bootstrap/' %}
 {%- else %}
 {% set bootstrap_repo_url = 'https://' ~ salt['pillar.get']('mgr_server') ~ '/pub/repositories/debian/' ~ grains['osmajorrelease'] ~ '/bootstrap/' %}
 {%- endif %}

--- a/susemanager-utils/susemanager-sls/salt/certs/AstraLinuxCEorel.sls
+++ b/susemanager-utils/susemanager-sls/salt/certs/AstraLinuxCEorel.sls
@@ -1,0 +1,1 @@
+Debian9.sls

--- a/susemanager-utils/susemanager-sls/salt/certs/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/certs/init.sls
@@ -20,5 +20,9 @@
 {{ includesls(grains['os'], grains['osrelease_info']|first|string) }}
 {% endif -%}
 {% elif grains['os_family'] == 'Debian' %}
+{% if grains ['os'] == 'AstraLinuxCE' %}
+{{ includesls(grains['os'], grains['oscodename']) }}
+{% else %}
 {{ includesls(grains['os'], grains['osrelease_info']|first|string) }}
+{% endif %}
 {% endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Enable support for bootstrapping Astra Linux CE "Orel"
 - remove key grains only when file and grain exists (bsc#1167237)
 - Add virtual storage pool actions
 

--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -597,7 +597,57 @@ PKGLISTDEBIAN10 = [
     "python-systemd",
     "python-tornado",
     "python-yaml",
+    "python-zmq"
+]
+
+PKGLISTASTRALINUXOREL = [
+    "dctrl-tools",
+    "dirmngr",
+    "iso-codes",
+    "libjs-jquery",
+    "libjs-sphinxdoc",
+    "libjs-underscore",
+    "libpgm-5.2-0",
+    "libpython-stdlib",
+    "libpython2.7-minimal",
+    "libpython2.7-stdlib",
+    "libsodium18",
+    "libyaml-0-2",
+    "libzmq5",
+    "python",
+    "python-apt",
+    "python-apt-common",
+    "python-backports-abc",
+    "python-cffi-backend",
+    "python-chardet",
+    "python-concurrent.futures",
+    "python-crypto",
+    "python-cryptography",
+    "python-dateutil",
+    "python-enum34",
+    "python-idna",
+    "python-ipaddress",
+    "python-jinja2",
+    "python-markupsafe",
+    "python-minimal",
+    "python-msgpack",
+    "python-openssl",
+    "python-pkg-resources",
+    "python-pyasn1",
+    "python-psutil",
+    "python-requests",
+    "python-setuptools",
+    "python-singledispatch",
+    "python-six",
+    "python-systemd",
+    "python-tornado",
+    "python-urllib3",
+    "python-yaml",
     "python-zmq",
+    "python2.7",
+    "python2.7-minimal",
+    "salt-common",
+    "salt-minion"
 ]
 
 DATA = {
@@ -1055,6 +1105,11 @@ DATA = {
      'debian10-amd64-uyuni' : {
          'BASECHANNEL' : 'debian-10-pool-amd64-uyuni', 'PKGLIST' : PKGLISTDEBIAN10,
          'DEST' : '/srv/www/htdocs/pub/repositories/debian/10/bootstrap/',
+         'TYPE' : 'deb'
+     },
+     'astralinux-orel-amd64': {
+         'BASECHANNEL' : 'astralinux-orel-pool-amd64', 'PKGLIST' : PKGLISTASTRALINUXOREL,
+         'DEST' : '/srv/www/htdocs/pub/repositories/astra/orel/bootstrap/',
          'TYPE' : 'deb'
      }
 }

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- Enable support for bootstrapping Astra Linux CE "Orel"
 - add database 10 to 12 migration script
 
 -------------------------------------------------------------------

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -1717,3 +1717,32 @@ repo_type = deb
 checksum = sha256
 base_channels = debian-10-pool-amd64-uyuni
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/Debian10-Uyuni-Client-Tools/Debian_10/
+
+[astralinux-orel-pool-amd64]
+label    = astralinux-orel-pool-amd64
+checksum = sha256
+archs    = amd64-deb
+repo_type = deb
+name     = Astra Linux Orel pool for amd64
+gpgkey_url =
+gpgkey_id =
+gpgkey_fingerprint =
+repo_url = https://download.astralinux.ru/astra/stable/orel/repository/dists/orel/main/binary-amd64/
+
+[astralinux-orel-amd64-contrib]
+label    = astralinux-orel-amd64-contrib
+name     = Astra Linux Orel AMD64 Contrib
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = astralinux-orel-pool-amd64
+repo_url = https://download.astralinux.ru/astra/stable/orel/repository/dists/orel/contrib/binary-amd64/
+
+[astralinux-orel-amd64-non-free]
+label    = astralinux-orel-amd64-non-free
+name     = Astra Linux Orel AMD64 non-free
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = astralinux-orel-pool-amd64
+repo_url = https://download.astralinux.ru/astra/stable/orel/repository/dists/orel/non-free/binary-amd64/

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,4 @@
+- Add Astra Linux CE "Orel" repositories
 - check for delimiter as well when detecting current phase (bsc#1164771)
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

![image](https://user-images.githubusercontent.com/4226070/74461652-2cf89580-4e8f-11ea-80a5-b64ecaba9de4.png)

**NOTE**: [Astra Linux](https://astralinux.ru/en/) CE "Oriol" is basicall Debian 9 rebranded with some packages removed and some others added. The system identifies itself as:
```
root@astra:~# cat /etc/os-release 
PRETTY_NAME="Astra Linux (Orel 2.12.22)"
NAME="Astra Linux (Orel)"
ID=astra
ID_LIKE=debian
ANSI_COLOR="1;31"
HOME_URL="http://astralinux.ru"
SUPPORT_URL="http://astralinux.ru/support"
VARIANT_ID=orel
VARIANT=Orel
VERSION_ID=2.12.22
```

As you can see 'CE'  ('Common Edition') doesn't appear here, but still it is the commercial name and salt uses it as the `os` grain. At all other places I am calling it only Astra Linux Orel.

Unlike Debian or Ubuntu, here the codename doesn't change with the major version. "Orel" was 1.x.y in the past, and it's now 2.x.y, so it's what identify (for now) the "Common Edition" version.

**Hackweek project:** https://hackweek.suse.com/19/projects/testing-gnu-slash-linux-distributions-on-uyuni

### What was tested:
- Adding and syncing Astra Linux CE "Orel" repositories/channels
- Bootstrap repo creation
- WebUI Onboarding, with two caveats
  - `python3-apt` needs to be installed before starting the onboard, this affects Debian as well (#1912)
  - For now Ubuntu 18.04 client tools (master or stable) are to be used (they need to be added manually). As they are built for Ubuntu, and the Astra Linux Orel repositories are pinned with priority 900 and contain salt, the user needs to either lower pinning to 500 (`sed -i -e 's/Pin-Priority: 900/Pin-Priority: 500/g' /etc/apt/preferences.d/orel`), either add the client tools with more priority:
     ```
      echo "Package: *\
      Pin: release n=bionic\
      Pin-Priority: 901\
      " > /etc/apt/preferences.d/uyuni-client-tools
     ```
     NOTE: If we could build for Astra Linux at OBS, we could fix this :-)
- Applying highstate
- Listing packages
- Installing packages
- Running salt remote commands

### What was NOT tested:
- Patching (as basically I don't have any patch to install yet)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: FMPOV, not to be documented yet.

- [x] **DONE**

## Test coverage
- No tests: We dont cover unsupported distributions for now.

- [x] **DONE**

## Links

https://hackweek.suse.com/19/projects/testing-gnu-slash-linux-distributions-on-uyuni

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
