### PR TITLE
Redirect renewals to SCC

### DIFF
--- a/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-www.conf
+++ b/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-www.conf
@@ -99,7 +99,7 @@ XSendFilePath /var/cache/rhn/repodata
     </IfVersion>
 </Directory>
 
-RedirectMatch ^/renew/.* http://www.novell.com/center/
+RedirectMatch ^/renew/.* https://scc.suse.com/
 
 # switch all cookies into HttpOnly cookies
 # we have to do it on apache level because tomcat5-5.5.23 doesn't support them


### PR DESCRIPTION
Redirect product renewal URLs to SCC. The current URL (novell.com/center) goes to the Microfocus Customer Center.

I'm not really sure this is even used but better be on the safe side.

## What does this PR change?

**add description**

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
