### PR TITLE
Improve test for adding system to group with monitoring

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -111,19 +111,14 @@ import com.suse.manager.webui.controllers.utils.ContactMethodUtil;
 import com.suse.manager.webui.services.impl.SaltSSHService;
 import com.suse.manager.webui.services.impl.SaltService;
 
-import org.apache.commons.io.IOUtils;
 import org.cobbler.test.MockConnection;
 import org.hibernate.Session;
 import org.hibernate.type.IntegerType;
 import org.jmock.Expectations;
 import org.jmock.lib.legacy.ClassImposteriser;
 
-import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -165,10 +160,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         ActionManager.setTaskomaticApi(taskomaticMock);
         saltServiceMock = mock(SaltService.class);
         tmpSaltRoot = Files.createTempDirectory("salt");
-        metadataDirOfficial = Files.createTempDirectory("meta");
-        createMetadataFiles();
         FormulaFactory.setDataDir(tmpSaltRoot.toString());
-        FormulaFactory.setMetadataDirOfficial(metadataDirOfficial.toString() + File.separator);
         SystemManager.mockSaltService(saltServiceMock);
         context().checking(new Expectations() {
             {
@@ -176,22 +168,6 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
                     .scheduleActionExecution(with(any(Action.class)));
             }
         });
-    }
-
-    private void createMetadataFiles() {
-        try {
-            Path prometheusDir = metadataDirOfficial.resolve("prometheus-exporters");
-            Files.createDirectories(prometheusDir);
-            try (InputStream src = this.getClass().getResourceAsStream("prometheus/pillar.example");
-                 OutputStream dst = new FileOutputStream(prometheusDir.resolve("pillar.example").toFile())
-            ) {
-                IOUtils.copy(src, dst);
-            }
-        }
-        catch (IOException e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        }
     }
 
     public void testSnapshotServer() throws Exception {

--- a/java/code/src/com/redhat/rhn/manager/system/test/prometheus/pillar.example
+++ b/java/code/src/com/redhat/rhn/manager/system/test/prometheus/pillar.example
@@ -1,6 +1,0 @@
-node_exporter:
-  enabled: False
-
-postgres_exporter:
-  enabled: False
-  data_source_name: postgresql://user:passwd@localhost:5432/database?sslmode=disable


### PR DESCRIPTION
## What does this PR change?

This patch is finalizing an incomplete unit test for handling monitoring entitlements in `SystemManager.addServerToGroup()`  and `SystemManager.removeServerFromGroup()` respectively.

## GUI diff

No difference.

- [X] **DONE**

## Documentation

- No documentation needed, patch is only affecting unit tests.

- [X] **DONE**

## Test coverage

- Unit tests were changed with this patch.

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below).

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
