### PR TITLE
Support for Amazon Linux 2

### DIFF
--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -391,6 +391,9 @@ if [ "$INSTALLER" == yum ]; then
         elif [ -f /etc/redhat-release ]; then
             grep -v '^#' /etc/redhat-release | grep -q '\(Red Hat\)' && BASE="res"
             VERSION=`grep -v '^#' /etc/redhat-release | grep -Po '(?<=release )\d+'`
+        elif [ -f /etc/os-release ]; then
+            BASE=$(source /etc/os-release; echo $ID)
+            VERSION=$(source /etc/os-release; echo $VERSION_ID)
         fi
         Y_CLIENT_CODE_BASE="${{BASE:-unknown}}"
         Y_CLIENT_CODE_VERSION="${{VERSION:-unknown}}"

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,5 @@
+- Prepare the bootstrap script generator for Amazon Linux 2
+
 -------------------------------------------------------------------
 Thu Feb 25 12:04:35 CET 2021 - jgonzalez@suse.com
 

--- a/suseRegisterInfo/suseRegister/info.py
+++ b/suseRegisterInfo/suseRegister/info.py
@@ -49,6 +49,10 @@ def getRedHatLikeProducts():
         ret = parseReleaseInfo(release='/etc/centos-release')
         if ret:
             ret['name'] = "CentOS"
+    elif os.path.exists('/etc/system-release'):
+        ret = parseReleaseInfo(release='/etc/system-release')
+        if ret:
+            ret['name'] = "AmazonLinux"
     else:
         ret = parseReleaseInfo()
         if ret:

--- a/suseRegisterInfo/suseRegisterInfo.changes
+++ b/suseRegisterInfo/suseRegisterInfo.changes
@@ -1,3 +1,5 @@
+- Add support for Amazon Linux 2
+
 -------------------------------------------------------------------
 Thu Dec 03 13:55:56 CET 2020 - jgonzalez@suse.com
 

--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -34,6 +34,9 @@ mgr_server_localhost_alias_absent:
 {%- elif salt['file.file_exists']('/usr/share/doc/sles_es-release') %}
 {% set bootstrap_repo_url = 'https://' ~ salt['pillar.get']('mgr_server') ~ '/pub/repositories/res/' ~ grains['osmajorrelease'] ~ '/bootstrap/' %}
 
+{%- elif salt['file.file_exists']('/etc/system-release') %}
+{% set bootstrap_repo_url = 'https://' ~ salt['pillar.get']('mgr_server') ~ '/pub/repositories/amzn/' ~ grains['osmajorrelease'] ~ '/bootstrap/' %}
+
 {%- elif salt['file.file_exists']('/etc/centos-release') %}
 {# We try CentOS bootstrap repository first, if not avaiable then fallback to RES #}
 {% set bootstrap_repo_url = 'https://' ~ salt['pillar.get']('mgr_server') ~ '/pub/repositories/centos/' ~ grains['osmajorrelease'] ~ '/bootstrap/' %}

--- a/susemanager-utils/susemanager-sls/salt/certs/Amazon2.sls
+++ b/susemanager-utils/susemanager-sls/salt/certs/Amazon2.sls
@@ -1,0 +1,1 @@
+RedHat7.sls

--- a/susemanager-utils/susemanager-sls/salt/packages/redhatproductinfo.sls
+++ b/susemanager-utils/susemanager-sls/salt/packages/redhatproductinfo.sls
@@ -11,6 +11,10 @@ oraclerelease:
   cmd.run:
     - name: cat /etc/oracle-release
     - onlyif: test -f /etc/oracle-release
+amazonrelease:
+  cmd.run:
+    - name: cat /etc/system-release
+    - onlyif: test -f /etc/system-release
 respkgquery:
   cmd.run:
     - name: rpm -q --whatprovides 'sles_es-release-server'

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Add support for Amazon Linux 2
 - add allow vendor change option to pathing via salt 
 - Add SALT_RUNNING config in case it's not present on the minion (bsc#1183661)
 - Skip removed product classes with satellite-sync

--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -318,7 +318,7 @@ RES7 = [
     "python-psutil",
     "python-pycrypto",
     "python-requests",
-    "python-setuptools",
+    "python-setuptools|python2-setuptools", # python-setuptools is the Amazon Linux name
     "python-singledispatch",
     "python-tornado",
     "python-zmq",
@@ -340,7 +340,7 @@ RES7 = [
     "openssl",
     "openssl-libs",
     "python-ipaddress",
-    "redhat-rpm-config",
+    "redhat-rpm-config|system-rpm-config", # system-rpm-config is the Amazon Linux name
     "rpm-python",
     "spacewalk-check",
     "python2-spacewalk-check",
@@ -387,6 +387,40 @@ RES8 = [
 
 RES8_X86 = [
     "dmidecode"
+]
+
+AMAZONLINUX2 = [
+    "dwz",
+    "groff-base",
+    "perl",
+    "perl-Carp",
+    "perl-Encode",
+    "perl-Exporter",
+    "perl-File-Path",
+    "perl-File-Temp",
+    "perl-Filter",
+    "perl-Getopt-Long",
+    "perl-HTTP-Tiny",
+    "perl-PathTools",
+    "perl-Pod-Escapes",
+    "perl-Pod-Perldoc",
+    "perl-Pod-Simple",
+    "perl-Pod-Usage",
+    "perl-Scalar-List-Utils",
+    "perl-Socket",
+    "perl-Storable",
+    "perl-Text-ParseWords",
+    "perl-Time-HiRes",
+    "perl-Time-Local",
+    "perl-constant",
+    "perl-libs",
+    "perl-macros",
+    "perl-parent",
+    "perl-podlators",
+    "perl-srpm-macros",
+    "perl-threads",
+    "perl-threads-shared",
+    "zip"
 ]
 
 PKGLIST15_SALT = [
@@ -1202,6 +1236,15 @@ DATA = {
     'oracle-8-x86_64-uyuni' : {
         'BASECHANNEL' : 'oraclelinux8-x86_64', 'PKGLIST' : RES8 + RES8_X86,
         'DEST' : '/srv/www/htdocs/pub/repositories/oracle/8/bootstrap/'
+    },
+    'amazonlinux-2-x86_64' : {
+        # We will need to update the IDs when we have the definitions for SUSE Manager
+        'PDID' : [-14, 1683], 'BETAPDID' : [2065], 'PKGLIST' : RES7 + RES7_X86 + AMAZONLINUX2,
+        'DEST' : '/srv/www/htdocs/pub/repositories/amzn/2/bootstrap/'
+    },
+    'amazonlinux-2-x86_64-uyuni' : {
+        'BASECHANNEL' : 'amazonlinux2-core-x86_64', 'PKGLIST' : RES7 + RES7_X86 + AMAZONLINUX2,
+        'DEST' : '/srv/www/htdocs/pub/repositories/amzn/2/bootstrap/'
     },
     'RHEL6-x86_64' : {
         'PDID' : [-5, 1682], 'BETAPDID' : [2064], 'PKGLIST' : RES6,

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- Add bootstrap repository for Amazon Linux 2
 - Add bootstrap repository definition for SUSE Manager Proxy 4.2 (bsc#1183645)
 - Removed workaround for bnc#668908.
 - Require bind-utils so dig is available for mgr-setup

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -2164,3 +2164,41 @@ repo_type = deb
 checksum = sha256
 base_channels = astralinux-orel-pool-amd64
 repo_url = https://download.astralinux.ru/astra/stable/orel/repository/dists/orel/non-free/binary-amd64/
+
+[amazonlinux2-core]
+archs    =  x86_64, aarch64
+name     = Amazon Linux 2 Core %(arch)s
+label    = amazonlinux2-core-%(arch)s
+checksum  = sha256
+gpgkey_url =
+gpgkey_id = C87F5B1A
+gpgkey_fingerprint = 99E6 17FE 5DB5 27C0 D8BD  5F8E 11CF 1F95 C87F 5B1A
+repo_url = http://amazonlinux.default.amazonaws.com/2/core/latest/%(arch)s/mirror.list
+
+[amazonlinux2-extra-docker]
+archs    =  x86_64, aarch64
+name     = Amazon Extras 2 repo for Docker %(arch)s
+label    = amazonlinux2-extras-docker-%(arch)s
+base_channels = amazonlinux2-core-%(arch)s
+checksum = sha256
+gpgkey_id = C87F5B1A
+gpgkey_fingerprint = 99E6 17FE 5DB5 27C0 D8BD  5F8E 11CF 1F95 C87F 5B1A
+repo_url = http://amazonlinux.default.amazonaws.com/2/extras/docker/latest/%(arch)s/mirror.list
+
+[amazonlinux2-uyuni-client]
+name     = Uyuni Client Tools for %(base_channel_name)s
+archs    =  x86_64, aarch64
+base_channels = amazonlinux2-core-%(arch)s
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7/
+
+[amazonlinux2-uyuni-client-devel]
+name     = Uyuni Client Tools for %(base_channel_name)s (Development)
+archs    =  x86_64, aarch64
+base_channels = amazonlinux2-core-%(arch)s
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS7-Uyuni-Client-Tools/CentOS_7/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS7-Uyuni-Client-Tools/CentOS_7/

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,4 @@
+- Add Amazon Linux 2 repositories
 - Add current UEK repos to Oracle Linux
 - Add multiverse, restricted and backports to Ubuntu 20.04
 - Add the Universe Security repositories for Ubuntu


### PR DESCRIPTION
## What does this PR change?

Support for Amazon Linux 2, which is the recommended OS for AWS.



To use:

```
# spacewalk-common-channels -a x86_64 amazonlinux2-core amazonlinux2-uyuni-client
# spacewalk-repo-sync -p amazonlinux2-core-x86_64
# mgr-create-bootstrap-repo
```
Onboard normally.

For now `amazonlinux2-uyuni-client` uses the centos7 client tools, but we should add Amazon Linux 2 to OBS before shipping this. Reason is simple: without it we can't support Amazon Linux 2 aaarch64 which is cheaper and it's being used more and more each day.

**WARNING:** This PR also requires a SR for `uyuni-build-keys` at https://build.opensuse.org/project/show/home:juliogonzalezgil:branches:systemsmanagement:Uyuni:Master (will require a SR to `systemsmanagement:Uyuni:Master`, and a port of the same change to `susemanager-build-keys` at Head!

### What DOES NOT work

- All Amazon Linux instances I created have the same `/etc/machine-id`: `ec214dee1f497e5a0c3f972da49e4684`. That's a problem because we us it to identify the instances, so with that you get: `2021-03-23 15:52:57,520 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-4] WARN  com.suse.manager.reactor.messaging.RegisterMinionEventMessageAction - Minion '10.0.0.82' already registered, updating profile to '10.0.0.139' [ec214dee1f497e5a0c3f972da49e4684]` at the logs. Registration does NOT fail, but only one minion shows at the system list, with the IP of `'10.0.0.139` but that it's in fact `10.0.0.82`. Looks to me as an Amazon Linux bug! I started two instances using the Leap 15.2 images, and they have different `/etc/machine-id`. 
  NOTE: Confirmed by @danielmayor. Thanks Dani! :-)
  NOTE2: This is indeed a bug that some other AMIs (Amazon Images) for other OS share: https://bugs.launchpad.net/ubuntu/+source/cloud-init/+bug/1563951 https://bugs.centos.org/view.php?id=13327. But openSUSE Leap 15.2 does not have it, so it can be fixed there. Uyuni can't do anything, because we must not change the machine-id in case the user already did, and we should not create whitelist to change it in some cases, as the current machine ID from the Amazon Linux image can change if they repackage.
- Product detection (requires Java changes)
- Monitoring enablement (requires Java changes)

### What was TESTED and DOES work.

- Reposync
- Bootstrap repo generator
- Bootstrap script generator
- Bootstrapping as salt minion from WebUI (with an activation key)
- Bootstrapping as salt minion from Bootstrap Script (with an activation key)
- salt minion: Detect Packages requiring an update
- salt minion: Updating packages (problems with the GPG from Uyuni, but that's not something new)
- salt minion: Installing a package
- salt minion: Removing a package
- salt minion: Running a salt command
- salt minion: Enabled `locale` and `cpu-mitigations` formulas and applied highstate
- Bootstrapping as salt ssh minion from WebUI (with an activation key)
- salt ssh minion: Detect Packages requiring an update
- salt ssh minion: Updating packages (problems with the GPG from Uyuni, but that's not something new)
- salt ssh minion: Installing a package
- salt ssh minion: Removing a package
- salt ssh minion: Running a salt command
- salt ssh minion: Enabled `locale` and `cpu-mitigations` formulas and applied highstate
- Bootstrapping as traditional client from script (with an activation key, most likely won't be supported)
- traditional: Detect Packages requiring an update
- traditional: Updating packages (problems with the GPG from Uyuni, but that's not something new)
- traditional: Installing a package
- traditional: Removing a package
- traditional: configuration management, deploy a file

Apparently CVE auditing works, or at least I get a image saying that none of my servers are affected (which is true). I asked @Bischoff if he knows how to use a fully updated instance to simulate it being affected by a CVE.

### What is NOT tested

- Patching. The reposync got information for patches, but nothing applies to our instances. They are too new.
- CVE auditing: don't have any Amazon Linux affected by any CVEs right now (see "What was tested). I installed `milkyway-dummy 1.0` as the testsuite does to detect the CVE-1999-9999 and the UI says `The specified CVE number was not found. This can happen for very old or yet-unknown numbers, please also check it for possible typing errors.`. However if I look for `CVE-2021-23841`, works fine and tells me no instances are affected.

### Conclusion

Tests are looking really good. We can request Amazon Linux to be added to OBS (to see if we can provide a specific salt package for the distribution).

Ion squad has to have a look at the salt package about the CPE error.
```
2020-02-14 16:38:31,902 [salt.loaded.int.grains.core:1854][ERROR ][5673] Broken CPE_NAME format in /etc/os-release!
```
As it is still present.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- PR: https://github.com/uyuni-project/uyuni-docs/pull/867

- [x] **DONE**

## Test coverage
- No tests: We don't have them for unsupported distributions.

- [x] **DONE**

## Links

https://hackweek.suse.com/20/projects/testing-gnu-slash-linux-distributions-on-uyuni

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
