### PR TITLE
ssh prompt changed - using compatible regexp with old and new prompt

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -583,7 +583,7 @@ When(/^I register this client for SSH push via tunnel$/) do
            "while {1} {\n" \
            "  expect {\n" \
            "    eof                                                        {break}\n" \
-           "    \"Are you sure you want to continue connecting (yes/no)?\" {send \"yes\r\"}\n" \
+	   "    -re \"Are you sure you want to continue connecting.*\" {send \"yes\r\"}\n" \
            "    \"Password:\"                                              {send \"linux\r\"}\n" \
            "  }\n" \
            "}\n"


### PR DESCRIPTION
## What does this PR change?

The ssh prompt has changed and cause a deadlock in the expect script.

  `Are you sure you want to continue connecting (yes/no/[fingerprint])?`

This change provide a compatible way of old and new prompt.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **testsuite**

- [x] **DONE**

## Test coverage
- No tests: **already covered**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
