### PR TITLE
hide functions from XMLRPC API

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
@@ -139,6 +139,8 @@ public class ChannelSoftwareHandler extends BaseHandler {
     /**
      * Only needed for unit tests.
      * @return the {@link TaskomaticApi} instance used by this class
+     *
+     * @xmlrpc.ignore
      */
     public TaskomaticApi getTaskomaticApi() {
         return taskomaticApi;
@@ -3339,6 +3341,7 @@ public class ChannelSoftwareHandler extends BaseHandler {
      * @param label of the repo to use
      * @return list of filters
      *
+     * @xmlrpc.ignore
     **/
     public List<ContentSourceFilter> listVendorRepoFilters(User loggedInUser, String label) {
         Role orgAdminRole = RoleFactory.lookupByLabel("org_admin");
@@ -3361,6 +3364,7 @@ public class ChannelSoftwareHandler extends BaseHandler {
      * @param label of the repo to use
      * @param filterIn list of filters
      * @return sort order for the new filter
+     * @xmlrpc.ignore
      */
     public int addVendorRepoFilter(User loggedInUser, String label, Map<String, String> filterIn) {
         Role orgAdminRole = RoleFactory.lookupByLabel("org_admin");
@@ -3402,6 +3406,7 @@ public class ChannelSoftwareHandler extends BaseHandler {
      * @param label of the repo to use
      * @param filterIn list of filters
      * @return 1 on success
+     * @xmlrpc.ignore
      */
     public int removeVendorRepoFilter(User loggedInUser, String label,
             Map<String, String> filterIn) {
@@ -3444,6 +3449,7 @@ public class ChannelSoftwareHandler extends BaseHandler {
      * @param label of the repo to use
      * @param filtersIn list of filters
      * @return 1 on success
+     * @xmlrpc.ignore
      */
     public int setVendorRepoFilters(User loggedInUser, String label,
             List<Map<String, String>> filtersIn) {
@@ -3492,6 +3498,7 @@ public class ChannelSoftwareHandler extends BaseHandler {
     * @param loggedInUser The current user
     * @param label of the repo to use
     * @return 1 on success
+    * @xmlrpc.ignore
    **/
     public int clearVendorRepoFilters(User loggedInUser, String label) {
         Role orgAdminRole = RoleFactory.lookupByLabel("org_admin");

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -7055,6 +7055,7 @@ public class SystemHandler extends BaseHandler {
     /**
      * Only needed for unit tests.
      * @return the {@link TaskomaticApi} instance used by this class
+     * @xmlrpc.ignore
      */
     public TaskomaticApi getTaskomaticApi() {
         return taskomaticApi;


### PR DESCRIPTION
## What does this PR change?

Hide some functions from XMLRPC docs

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **fixes docs**

- [x] **DONE**

## Test coverage
- No tests: **do not test docs**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
