### PR TITLE
CLM Module filters: Make AppStream filter pane full-width

### DIFF
--- a/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project.js
+++ b/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project.js
@@ -124,51 +124,55 @@ const FiltersProject = (props:  FiltersProps) => {
       }}
       renderContent={() =>
         <div className="min-height-panel">
-          <div className="col-md-6">
-            {
-              denyFilters.length > 0 &&
-              <>
-                <h4>{t("Deny")} <small>{t("filter out")}</small></h4>
-                <ul className="list-group">
-                  {
-                    denyFilters.map((filter, index) => renderFilterEntry(filter, props.projectId,
-                      <i class="fa fa-filter"/>, index === denyFilters.length - 1))
-                  }
-                </ul>
-              </>
-            }
+          <div className="row">
+            <div className="col-md-12">
+              {
+                moduleFilters.length > 0 &&
+                  <>
+                    <h4>{t("AppStreams")} <small>{t("enabled module streams")}</small>
+                    </h4>
+                    <ul className="list-group">
+                      {
+                        moduleFilters.map((filter, index) => renderFilterEntry(filter, props.projectId,
+                          <i className="fa fa-plus-circle"/>, index === moduleFilters.length - 1))
+                      }
+                    </ul>
+                  </>
+              }
+            </div>
           </div>
 
-          <div className="col-md-6">
-            {
-              allowFilters.length > 0 &&
+          <div className="row">
+            <div className="col-md-6">
+              {
+                denyFilters.length > 0 &&
                 <>
-                  <h4>{t("Allow")} <small>{t("select from the full source even if you have excluded them before with deny")}</small>
-                  </h4>
+                  <h4>{t("Deny")} <small>{t("filter out")}</small></h4>
                   <ul className="list-group">
                     {
-                      allowFilters.map((filter, index) => renderFilterEntry(filter, props.projectId,
-                        <i className="fa fa-plus-circle"/>, index === allowFilters.length - 1))
+                      denyFilters.map((filter, index) => renderFilterEntry(filter, props.projectId,
+                        <i class="fa fa-filter"/>, index === denyFilters.length - 1))
                     }
                   </ul>
                 </>
-            }
-          </div>
+              }
+            </div>
 
-          <div className="col-md-6">
-            {
-              moduleFilters.length > 0 &&
-                <>
-                  <h4>{t("AppStreams")} <small>{t("enabled module streams")}</small>
-                  </h4>
-                  <ul className="list-group">
-                    {
-                      moduleFilters.map((filter, index) => renderFilterEntry(filter, props.projectId,
-                        <i className="fa fa-plus-circle"/>, index === moduleFilters.length - 1))
-                    }
-                  </ul>
-                </>
-            }
+            <div className="col-md-6">
+              {
+                allowFilters.length > 0 &&
+                  <>
+                    <h4>{t("Allow")} <small>{t("select from the full source even if you have excluded them before with deny")}</small>
+                    </h4>
+                    <ul className="list-group">
+                      {
+                        allowFilters.map((filter, index) => renderFilterEntry(filter, props.projectId,
+                          <i className="fa fa-plus-circle"/>, index === allowFilters.length - 1))
+                      }
+                    </ul>
+                  </>
+              }
+            </div>
           </div>
         </div>
       }


### PR DESCRIPTION
Update the AppStream filter pane to be full-width to avoid confusion with Deny/Allow filters.

## GUI diff

Before:
![clm-modules-after1](https://user-images.githubusercontent.com/1103552/74664714-879b3580-519e-11ea-9ede-1cb20ec05595.png)

After:
![clm-filter-panel-after](https://user-images.githubusercontent.com/1103552/74664713-866a0880-519e-11ea-9d4c-142bad53ad1f.png)


## Documentation
- No documentation needed: Minor fix


## Test coverage
- No tests: Minor UI fix


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
