### PR TITLE
Uyuni extra tags with iss

### DIFF
--- a/backend/satellite_tools/xmlSource.py
+++ b/backend/satellite_tools/xmlSource.py
@@ -658,6 +658,7 @@ class PackageItem(IncompletePackageItem):
         'rhn-package-changelog': 'changelog',
         'suse-product-file': 'product_files',
         'suse-eula': 'eulas',
+        'pkg-extratag': 'extra_tags',
     }
     tagMap.update(IncompletePackageItem.tagMap)
 
@@ -734,6 +735,15 @@ class EulaItem(BaseItem):
         'suse-eula-entry-checksum' : 'checksum',
     }
 addItem(EulaItem)
+
+class ExtraTagItem(BaseItem):
+    item_name = 'pkg-extratag-entry'
+    item_class = importLib.ExtraTag
+    tagMap = {
+        'pkg-extratag-entry-name'     : 'name',
+        'pkg-extratag-entry-value'    : 'value',
+    }
+addItem(ExtraTagItem)
 
 class DependencyItem(BaseItem):
 

--- a/backend/server/importlib/backend.py
+++ b/backend/server/importlib/backend.py
@@ -1344,9 +1344,9 @@ class Backend:
             """)
         _query_product.execute()
         existing_data = ["%s" % (x['product_id']) for x in _query_product.fetchall_dict() or []]
-        toinsert = [[], [], [], [], [], [], [], []]
+        toinsert = [[], [], [], [], [], [], [], [], [], [], []]
         todelete = [[]]
-        toupdate = [[], [], [], [], [], [], []]
+        toupdate = [[], [], [], [], [], [], [], [], [], []]
         for item in batch:
             ident = "%s" % (item['product_id'])
             if ident in existing_data:

--- a/backend/server/importlib/backend.py
+++ b/backend/server/importlib/backend.py
@@ -1348,6 +1348,8 @@ class Backend:
         todelete = [[]]
         toupdate = [[], [], [], [], [], [], [], [], [], []]
         for item in batch:
+            if not item['channel_family_id']:
+                continue
             ident = "%s" % (item['product_id'])
             if ident in existing_data:
                 existing_data.remove(ident)

--- a/backend/server/importlib/backend.py
+++ b/backend/server/importlib/backend.py
@@ -1605,6 +1605,10 @@ class Backend:
         """Check if SCC Repository is already in DB.
            If yes, update it, if not add it.
         """
+        # suseSCCRepositoryAuth should be empty in ISS case
+        self.dbmodule.prepare("""
+            DELETE FROM suseSCCRepositoryAuth
+        """).execute()
         insert_repo = self.dbmodule.prepare("""
             INSERT INTO suseSCCRepository (id, scc_id, autorefresh, name, distro_target, description, url, signed)
             VALUES (:rid, :sccid, :autorefresh, :name, :target, :description, :url, :signed)

--- a/backend/server/importlib/importLib.py
+++ b/backend/server/importlib/importLib.py
@@ -436,6 +436,12 @@ class Eula(Information):
         'checksum'          : StringType,
     }
 
+class ExtraTag(Information):
+    attributeTypes = {
+        'name'           : StringType,
+        'value'          : StringType,
+    }
+
 class IncompletePackage(BaseInformation):
     attributeTypes = {
         'package_id': StringType,  # RH db id
@@ -527,6 +533,7 @@ class Package(IncompletePackage):
         'checksum_list'     : [Checksum],
         'product_files'     : [ProductFile],
         'eulas'             : [Eula],
+        'extra_tags'        : [ExtraTag],
     }
 
     def __init__(self):
@@ -535,7 +542,6 @@ class Package(IncompletePackage):
         # And initialize the specific ones
         for k in list(self.attributeTypes.keys()):
             self[k] = None
-        self['extra_tags'] = None
 
 
 class SourcePackage(IncompletePackage):

--- a/backend/server/importlib/packageImport.py
+++ b/backend/server/importlib/packageImport.py
@@ -312,7 +312,7 @@ class PackageImport(ChannelPackageSubscription):
                 key = (eula['text'], eula['checksum'])
                 self.suseEula_data[key] = None
 
-        if package['extra_tags'] is not None:
+        if 'extra_tags' in package and package['extra_tags'] is not None:
             for tag in package['extra_tags']:
                 self.extraTags[tag['name']] = None
 
@@ -415,7 +415,7 @@ class PackageImport(ChannelPackageSubscription):
         fileList = package['files']
         for f in fileList:
             f['checksum_id'] = self.checksums[(f['checksum_type'], f['checksum'])]
-        if package['extra_tags'] is not None:
+        if 'extra_tags' in package and package['extra_tags'] is not None:
             for t in package['extra_tags']:
                 t['key_id'] = self.extraTags[t['name']]
 


### PR DESCRIPTION
## What does this PR change?

Extra Tags are not transported via ISS. The implementation is incomplete.
This PR should provide a complete implementation.

Follow up of https://github.com/uyuni-project/uyuni/pull/1742

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **Manual tested**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/10723

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
