### PR TITLE
Clean stale Content Environment targets & Prevent users from trigerring Content Project build/promote when colliding operation is in progress

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
@@ -568,6 +568,22 @@ public class ContentProjectFactory extends HibernateFactory {
     }
 
     /**
+     * Set all BUILDING {@link EnvironmentTarget}s to FAILED state.
+     *
+     * @return the number of updated targets
+     */
+    public static int failStaleTargets() {
+        List<EnvironmentTarget> targets = HibernateFactory.getSession()
+                .createQuery("SELECT tgt FROM EnvironmentTarget tgt " +
+                        "WHERE tgt.status = :status")
+                .setParameter("status", EnvironmentTarget.Status.BUILDING)
+                .list();
+
+        targets.forEach(tgt -> tgt.setStatus(EnvironmentTarget.Status.FAILED));
+        return targets.size();
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
@@ -573,14 +573,13 @@ public class ContentProjectFactory extends HibernateFactory {
      * @return the number of updated targets
      */
     public static int failStaleTargets() {
-        List<EnvironmentTarget> targets = HibernateFactory.getSession()
-                .createQuery("SELECT tgt FROM EnvironmentTarget tgt " +
-                        "WHERE tgt.status = :status")
-                .setParameter("status", EnvironmentTarget.Status.BUILDING)
-                .list();
-
-        targets.forEach(tgt -> tgt.setStatus(EnvironmentTarget.Status.FAILED));
-        return targets.size();
+        return HibernateFactory.getSession()
+                .createQuery("UPDATE EnvironmentTarget tgt " +
+                        "SET tgt.status = :statusFailed " +
+                        "WHERE tgt.status = :statusBuilding")
+                .setParameter("statusFailed", EnvironmentTarget.Status.FAILED)
+                .setParameter("statusBuilding", EnvironmentTarget.Status.BUILDING)
+                .executeUpdate();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentProjectFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentProjectFactoryTest.java
@@ -38,8 +38,11 @@ import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.ChannelTestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.redhat.rhn.domain.contentmgmt.ProjectSource.Type.SW_CHANNEL;
 import static com.redhat.rhn.domain.contentmgmt.ProjectSource.Type.lookupByLabel;
@@ -576,5 +579,32 @@ public class ContentProjectFactoryTest extends BaseTestCaseWithUser {
         assertEquals(cp, ContentProjectFactory.listFilterProjects(filter).get(0));
         cp.detachFilter(filter);
         assertTrue(ContentProjectFactory.listFilterProjects(filter).isEmpty());
+    }
+
+    public void testFailStaleTargets() {
+        // let's test all possible statuses
+        Map<EnvironmentTarget.Status, EnvironmentTarget> tgtsByStatus = Arrays.stream(EnvironmentTarget.Status.values())
+                .collect(Collectors.toMap(s -> s, s -> {
+                    EnvironmentTarget tgt = new SoftwareEnvironmentTarget();
+                    tgt.setStatus(s);
+                    ContentProjectFactory.save(tgt);
+                    return tgt;
+                }));
+
+        // this flips all BUILDING targets to FAILED
+        int numOfUpgradedTgts = ContentProjectFactory.failStaleTargets();
+
+        assertEquals(1, numOfUpgradedTgts);
+
+        tgtsByStatus.forEach((oldStatus, tgt) -> {
+            if (oldStatus.equals(EnvironmentTarget.Status.BUILDING)) {
+                // we expect the building targets to be set to FAILED
+                assertEquals(EnvironmentTarget.Status.FAILED, tgt.getStatus());
+            }
+            else {
+                // other targets should remain untouched
+                assertEquals(oldStatus, tgt.getStatus());
+            }
+        });
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentProjectFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentProjectFactoryTest.java
@@ -597,6 +597,7 @@ public class ContentProjectFactoryTest extends BaseTestCaseWithUser {
         assertEquals(1, numOfUpgradedTgts);
 
         tgtsByStatus.forEach((oldStatus, tgt) -> {
+            tgt = (EnvironmentTarget) HibernateFactory.reload(tgt);
             if (oldStatus.equals(EnvironmentTarget.Status.BUILDING)) {
                 // we expect the building targets to be set to FAILED
                 assertEquals(EnvironmentTarget.Status.FAILED, tgt.getStatus());

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -228,7 +228,7 @@ public class ContentManager {
                     // populating first environment will be implemented as soon as backward-promote is implemented
                     predecessor.ifPresent(p -> {
                         if (!p.getTargets().isEmpty()) {
-                            promoteProject(projectLabel, p.getLabel(), true, user);
+                            promoteProject(projectLabel, p.getLabel(), async, user);
                         }
                     });
                     return newEnv;

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
@@ -1217,11 +1217,10 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
      * @throws Exception if anything goes wrong
      */
     public void testBuildAlreadyBuildingProject() throws Exception {
-        // todo var
-        ContentProject cp = new ContentProject("cplabel", "cpname", "cpdesc", user.getOrg());
-        ContentProjectFactory.save(cp);
-        ContentEnvironment env = contentManager.createEnvironment(cp.getLabel(), empty(), "fst", "first env", "desc", false, user);
-        Channel channel = createPopulatedChannel();
+        var project = new ContentProject("cplabel", "cpname", "cpdesc", user.getOrg());
+        ContentProjectFactory.save(project);
+        var env = contentManager.createEnvironment(project.getLabel(), empty(), "fst", "first env", "desc", false, user);
+        var channel = createPopulatedChannel();
         contentManager.attachSource("cplabel", SW_CHANNEL, channel.getLabel(), empty(), user);
 
         contentManager.buildProject("cplabel", empty(), false, user);
@@ -1297,6 +1296,107 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
         catch (ContentManagementException e) {
             // should happen
         }
+    }
+
+    /**
+     * Complex scenario for testing building/promoting a project in which build/promote operations are in progress.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testBuildPromoteInProgress() throws Exception {
+        var project = new ContentProject("cplabel", "cpname", "cpdesc", user.getOrg());
+        ContentProjectFactory.save(project);
+        var env1 = contentManager.createEnvironment(project.getLabel(), empty(), "env1", "env 1", "1", false, user);
+        var env2 = contentManager.createEnvironment(project.getLabel(), of("env1"), "env2", "env 2", "2", false, user);
+        var env3 = contentManager.createEnvironment(project.getLabel(), of("env2"), "env3", "env 3", "3", false, user);
+        var env4 = contentManager.createEnvironment(project.getLabel(), of("env3"), "env4", "env 4", "4", false, user);
+        var env5 = contentManager.createEnvironment(project.getLabel(), of("env4"), "env5", "env 5", "5", false, user);
+        var channel = createPopulatedChannel();
+        contentManager.attachSource("cplabel", SW_CHANNEL, channel.getLabel(), empty(), user);
+
+        // build & promote everything possible
+        contentManager.buildProject("cplabel", empty(), false, user);
+        List.of(1, 2, 3, 4).forEach(i ->
+                contentManager.promoteProject("cplabel", "env" + i, false, user));
+
+        // PHASE 1: Test building
+        // 1st target BUILDING -> requested build should fail
+        getFirstTarget(env1).setStatus(Status.BUILDING);
+        assertBuildFails("cplabel");
+        getFirstTarget(env1).setStatus(Status.BUILT); // revert
+
+        // 2nd target BUILDING -> requested build should fail
+        getFirstTarget(env2).setStatus(Status.BUILDING);
+        assertBuildFails("cplabel");
+        getFirstTarget(env2).setStatus(Status.BUILT); // revert
+
+        // 3rd target BUILDING -> build passes
+        getFirstTarget(env3).setStatus(Status.BUILDING);
+        try {
+            contentManager.buildProject("cplabel", empty(), false, user);
+        }
+        catch (ContentManagementException e) {
+            fail("No ContentManagementException expected");
+        }
+        getFirstTarget(env3).setStatus(Status.BUILT); // revert
+
+        // PHASE 2: Test promoting of environment env2
+        // 1st promote is OK
+        try {
+            contentManager.promoteProject("cplabel", "env2", false, user);
+        }
+        catch (ContentManagementException e) {
+            fail("No ContentManagementException expected");
+        }
+
+        // env2 itself is building -> requested promote should fail
+        getFirstTarget(env2).setStatus(Status.BUILDING);
+        assertPromoteFails("cplabel", "env2");
+        getFirstTarget(env2).setStatus(Status.BUILT); // revert
+
+        // env3 is building -> requested promote should fail
+        getFirstTarget(env3).setStatus(Status.BUILDING);
+        assertPromoteFails("cplabel", "env2");
+        getFirstTarget(env3).setStatus(Status.BUILT); // revert
+
+        // env4 is building -> requested promote should fail
+        getFirstTarget(env4).setStatus(Status.BUILDING);
+        assertPromoteFails("cplabel", "env2");
+        getFirstTarget(env4).setStatus(Status.BUILT); // revert
+
+        // env5 is building -> requested promote should be ok
+        getFirstTarget(env5).setStatus(Status.BUILDING);
+        try {
+            contentManager.promoteProject("cplabel", "env2", false, user);
+        }
+        catch (ContentManagementException e) {
+            fail("No ContentManagementException expected");
+        }
+        getFirstTarget(env5).setStatus(Status.BUILT); // revert
+    }
+
+    private void assertBuildFails(String projectLabel) {
+        try {
+            contentManager.buildProject(projectLabel, empty(), false, user);
+            fail("An exception should have been thrown");
+        }
+        catch (ContentManagementException e) {
+            // should happen
+        }
+    }
+
+    private void assertPromoteFails(String projectLabel, String envLabel) {
+        try {
+            contentManager.promoteProject(projectLabel, envLabel, false, user);
+            fail("An exception should have been thrown");
+        }
+        catch (ContentManagementException e) {
+            // should happen
+        }
+    }
+
+    private EnvironmentTarget getFirstTarget(ContentEnvironment env) {
+        return env.getTargets().iterator().next();
     }
 
     private Channel createPopulatedChannel() throws Exception {

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
@@ -940,7 +940,7 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
         contentManager.buildProject("cplabel", empty(), false, user);
 
         // 2. add new environments
-        ContentEnvironment testEnv = contentManager.createEnvironment(cp.getLabel(), of("dev"), "test", "test env", "desc", false, user );
+        ContentEnvironment testEnv = contentManager.createEnvironment(cp.getLabel(), of("dev"), "test", "test env", "desc", false, user);
         ContentEnvironment prodEnv = contentManager.createEnvironment(cp.getLabel(), of("test"), "prod", "prod env", "desc", false, user);
 
         // 3. promote
@@ -1209,6 +1209,94 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
         contentManager.attachFilter("cplabel", filter.getId(), user);
         contentManager.buildProject("cplabel", empty(), false, user);
         assertEquals(0, env.getTargets().get(0).asSoftwareTarget().get().getChannel().getErrataCount());
+    }
+
+    /**
+     * Tests building a project for which build is already in progress
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testBuildAlreadyBuildingProject() throws Exception {
+        // todo var
+        ContentProject cp = new ContentProject("cplabel", "cpname", "cpdesc", user.getOrg());
+        ContentProjectFactory.save(cp);
+        ContentEnvironment env = contentManager.createEnvironment(cp.getLabel(), empty(), "fst", "first env", "desc", false, user);
+        Channel channel = createPopulatedChannel();
+        contentManager.attachSource("cplabel", SW_CHANNEL, channel.getLabel(), empty(), user);
+
+        contentManager.buildProject("cplabel", empty(), false, user);
+        env.getTargets().iterator().next().setStatus(Status.BUILDING);
+        HibernateFactory.getSession().flush();
+
+        try {
+            contentManager.buildProject("cplabel", empty(), false, user);
+            fail("An exception should have been thrown");
+        }
+        catch (ContentManagementException e) {
+            // should happen
+        }
+    }
+
+    /**
+     * Tests building a project for which build is already in progress
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testPromotingBuildingProject() throws Exception {
+        var project = new ContentProject("cplabel", "cpname", "cpdesc", user.getOrg());
+        ContentProjectFactory.save(project);
+        var fstEnv = contentManager.createEnvironment(project.getLabel(), empty(), "fst", "first env", "fst", false, user);
+        var sndEnv = contentManager.createEnvironment(project.getLabel(), of("fst"), "snd", "second env", "snd", false, user);
+        var channel = createPopulatedChannel();
+        contentManager.attachSource("cplabel", SW_CHANNEL, channel.getLabel(), empty(), user);
+
+        contentManager.buildProject("cplabel", empty(), false, user);
+
+        // 1st promote runs ok
+        contentManager.promoteProject("cplabel", "fst", false, user);
+
+        // now we change the target from the 1st environment to BUILDING
+        fstEnv.getTargets().iterator().next().setStatus(Status.BUILDING);
+
+        // now the promote must fail
+        try {
+            contentManager.promoteProject("cplabel", "fst", false, user);
+            fail("An exception should have been thrown");
+        }
+        catch (ContentManagementException e) {
+            // should happen
+        }
+    }
+
+    /**
+     * Tests building a project for which build is already in progress
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testPromotingPromotingProject() throws Exception {
+        var project = new ContentProject("cplabel", "cpname", "cpdesc", user.getOrg());
+        ContentProjectFactory.save(project);
+        var fstEnv = contentManager.createEnvironment(project.getLabel(), empty(), "fst", "first env", "fst", false, user);
+        var sndEnv = contentManager.createEnvironment(project.getLabel(), of("fst"), "snd", "second env", "snd", false, user);
+        var channel = createPopulatedChannel();
+        contentManager.attachSource("cplabel", SW_CHANNEL, channel.getLabel(), empty(), user);
+
+        contentManager.buildProject("cplabel", empty(), false, user);
+
+        // 1st promote runs ok
+        contentManager.promoteProject("cplabel", "fst", false, user);
+
+        // now we change the target from the 2nd environment to BUILDING
+        sndEnv.getTargets().iterator().next().setStatus(Status.BUILDING);
+
+        // now the promote must fail
+        try {
+            contentManager.promoteProject("cplabel", "fst", false, user);
+            fail("An exception should have been thrown");
+        }
+        catch (ContentManagementException e) {
+            // should happen
+        }
     }
 
     private Channel createPopulatedChannel() throws Exception {

--- a/java/code/src/com/redhat/rhn/manager/satellite/StartupTasksCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/satellite/StartupTasksCommand.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.manager.satellite;
+
+import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.domain.contentmgmt.ContentProjectFactory;
+import com.redhat.rhn.manager.BaseTransactionCommand;
+
+import org.apache.log4j.Logger;
+
+/**
+ * Tasks to be performed on the application startup
+ */
+public class StartupTasksCommand extends BaseTransactionCommand {
+
+    private static final Logger LOG = Logger.getLogger(StartupTasksCommand.class);
+
+    /**
+     * Constructor
+     */
+    public StartupTasksCommand() {
+        super(LOG);
+    }
+
+    /**
+     * Execution of application startup tasks
+     */
+    public void run() {
+        try {
+            int numOfUpgradedTgts = ContentProjectFactory.failStaleTargets();
+            if (numOfUpgradedTgts > 0) {
+                LOG.warn(String.format("Set %d stale Content Environment Targets to FAILED state", numOfUpgradedTgts));
+            }
+        }
+        catch (Exception e) {
+            LOG.error("Error when executing startup tasks", e);
+            HibernateFactory.rollbackTransaction();
+        }
+        finally {
+            handleTransaction();
+        }
+    }
+}

--- a/java/code/src/com/redhat/rhn/webapp/RhnServletListener.java
+++ b/java/code/src/com/redhat/rhn/webapp/RhnServletListener.java
@@ -16,6 +16,7 @@ package com.redhat.rhn.webapp;
 
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.messaging.MessageQueue;
+import com.redhat.rhn.manager.satellite.StartupTasksCommand;
 import com.redhat.rhn.manager.satellite.UpgradeCommand;
 
 import com.suse.manager.reactor.SaltReactor;
@@ -129,6 +130,9 @@ public class RhnServletListener implements ServletContextListener {
 
         log.debug("Starting upgrade check");
         executeUpgradeStep();
+
+        log.debug("Executing startup tasks");
+        executeStartupTasks();
     }
 
     private void executeUpgradeStep() {
@@ -136,7 +140,14 @@ public class RhnServletListener implements ServletContextListener {
         UpgradeCommand cmd = new UpgradeCommand();
         cmd.store();
         log.debug("UpgradeCommand done.");
+    }
 
+    /**
+     * Tasks that should be run on application startup.
+     */
+    private void executeStartupTasks() {
+        var startupTasksCommand = new StartupTasksCommand();
+        startupTasksCommand.run();
     }
 
     /** {@inheritDoc} */

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Prevent build/promote on content projects which have build/promote in progress
+- Clean stale Content Lifecycle targets on Tomcat startup (bsc#1164121)
 - Show warning on products page when no SUSE Manager Server Subscription is available
 - Implement recurring highstate scheduling
 - Notify VMs creation actions

--- a/web/html/src/manager/content-management/project/project.js
+++ b/web/html/src/manager/content-management/project/project.js
@@ -76,8 +76,8 @@ const Project = (props: Props) => {
   const isBuildDisabled = !hasEditingPermissions
         || _isEmpty(project.environments)
         || _isEmpty(project.softwareSources)
-        || project.environments[0].status === "building"
-        || (project.environments[1] || {}).status === "building";
+        || project.environments[0].status === "building" // already building
+        || (project.environments[1] || {}).status === "building"; // promoting 1st env to 2nd: we can't build as it would affect this promotion
 
   return (
     <TopPanel

--- a/web/html/src/manager/content-management/project/project.js
+++ b/web/html/src/manager/content-management/project/project.js
@@ -73,7 +73,11 @@ const Project = (props: Props) => {
   }
 
   const isProjectEdited = changesToBuild.length > 0;
-  const isBuildDisabled = !hasEditingPermissions || _isEmpty(project.environments) || _isEmpty(project.softwareSources);
+  const isBuildDisabled = !hasEditingPermissions
+        || _isEmpty(project.environments)
+        || _isEmpty(project.softwareSources)
+        || project.environments[0].status === "building"
+        || (project.environments[1] || {}).status === "building";
 
   return (
     <TopPanel

--- a/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-lifecycle.js
+++ b/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-lifecycle.js
@@ -144,6 +144,7 @@ const EnvironmentLifecycle = (props: Props) => {
                       projectId={props.projectId}
                       environmentPromote={environment}
                       environmentTarget={props.environments[i + 1]}
+                      environmentNextTarget={props.environments[i + 2]}
                       historyEntries={props.historyEntries}
                       versionToPromote={environment.version}
                       onChange={props.onChange}

--- a/web/html/src/manager/content-management/shared/components/panels/promote/promote.js
+++ b/web/html/src/manager/content-management/shared/components/panels/promote/promote.js
@@ -17,6 +17,7 @@ type Props = {
   projectId: string,
   environmentPromote: ProjectEnvironmentType,
   environmentTarget: ProjectEnvironmentType,
+  environmentNextTarget: ProjectEnvironmentType,
   versionToPromote: number,
   historyEntries: Array<ProjectHistoryEntry>,
   onChange: Function
@@ -37,13 +38,18 @@ const Promote = (props: Props) => {
   }, [open]);
 
   const modalNameId = `${props.environmentPromote.label}-cm-promote-env-modal`;
+
   const disabled =
     !hasEditingPermissions
     || !props.environmentPromote.version
-    || props.environmentPromote.version <= props.environmentTarget.version;
+    || props.environmentPromote.version <= props.environmentTarget.version
+    || props.environmentPromote.status === "building"
+    || props.environmentTarget.status === "building"
+    || (props.environmentNextTarget || {}).status === "building";
+
   return (
     <div
-      {...(disabled ? {title: t("No version to promote")} : {})}
+      {...(disabled ? {title: t("No version to promote or colliding environment build in progress")} : {})}
     >
       <DownArrow/>
       <div className="text-center">

--- a/web/html/src/manager/content-management/shared/components/panels/promote/promote.js
+++ b/web/html/src/manager/content-management/shared/components/panels/promote/promote.js
@@ -42,7 +42,6 @@ const Promote = (props: Props) => {
   const disabled =
     !hasEditingPermissions
     || !props.environmentPromote.version
-    || props.environmentPromote.version <= props.environmentTarget.version
     || props.environmentPromote.status === "building"
     || props.environmentTarget.status === "building"
     || (props.environmentNextTarget || {}).status === "building";

--- a/web/html/src/manager/content-management/shared/components/panels/promote/promote.js
+++ b/web/html/src/manager/content-management/shared/components/panels/promote/promote.js
@@ -42,9 +42,9 @@ const Promote = (props: Props) => {
   const disabled =
     !hasEditingPermissions
     || !props.environmentPromote.version
-    || props.environmentPromote.status === "building"
-    || props.environmentTarget.status === "building"
-    || (props.environmentNextTarget || {}).status === "building";
+    || props.environmentPromote.status === "building" // the source env is already building
+    || props.environmentTarget.status === "building" // the target environment is already building
+    || (props.environmentNextTarget || {}).status === "building"; // the "target+1" environment is already building - we can't promote as it would affect this build
 
   return (
     <div


### PR DESCRIPTION
## TODO
- [x] Address comments from @moio  & test again before merging

## What does this PR change?

This PR fixes 3 Content Lifecycle Management-related things:

### 1, Clean stale Content Environment targets (first 2 commits)

If user builds/promotes a Content Project, SUMA performs channel cloning (using
the `MessageQueue`), during which the Environment Targets are set to `BUILDING`
state. For huge channels with a lot of errata, it can take a long time. If SUMA
is restarted during this operation, the Environment Targets stay in `BUILDING`
state together.

This PR proposes cleaning up stale `BUILDING` channels on Tomcat startup (I
took inspiration in the `UpgradeCommand` class).

Especially the review of the "Clean stale Content Lifecycle targets on Tomcat startup" commit is very important.


### 2, Forbid triggering dangerous build/promote (rest of the commits minus the latest one)
This should prevent user from running build/promote, when there is a colliding build/promote in progress. 

Example: Imagine the following Environment path:

`dev -> test -> prod -> legacy`

When user triggers a promote `test -> prod`, following operations should be forbidden until the promote finishes:
- promote `dev -> test`, as this affects `test` (which is being promoted to `prod` now!)
- promote `test -> prod`, as this operation is running now,
- promote `prod -> legacy`, as the current promotion is changing `prod`.

This wasn't the case before and user could run build/promote without any limitation, possibly leading to inconsistencies during channel cloning.

Checks are implemented in backend and UI. XMLRPC API doesn't need to be changed as it relies on backend exception handling.

3, Allow re-promoting of an Environment (last commit)
In the UI, when 2 subsequent environments (`e1` and `e2`) have same version number, it's impossible to click the `Promote` button to trigger promotion from `e1` to `e2`. The last commit relaxes this condition as re-promoting could make sense in some cases (the previous build of `e2` has failed).

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: bugfix
- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/10742

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [x] Re-run test "java_pgsql_tests" 		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"