### PR TITLE
Extract generation of minion pillar files

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/Server.java
+++ b/java/code/src/com/redhat/rhn/domain/server/Server.java
@@ -2146,4 +2146,17 @@ public class Server extends BaseDomainHelper implements Identifiable {
         return this.getEntitledGroups().stream().filter(g -> g.getGroupType().getLabel().equals(entitlementLabel))
                 .findFirst();
     }
+
+    /**
+     * Return the channel hostname for this server
+     *
+     * If case this server is directly connected to the SUMA Server, this method returns the
+     * this server's hostname. If, otherwise, the client is connected to the SUMA Server via a Proxy, this
+     * method returns the hostname of the first Proxy the client is connected to
+     * @return the channel hostname
+     */
+    public String getChannelHost() {
+        return this.getFirstServerPath().map(p -> p.getHostname())
+                .orElseGet(() -> ConfigDefaults.get().getCobblerHost());
+    }
 }

--- a/java/code/src/com/redhat/rhn/frontend/action/channel/ChannelDetailsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/channel/ChannelDetailsAction.java
@@ -25,8 +25,10 @@ import com.redhat.rhn.frontend.struts.RhnHelper;
 import com.redhat.rhn.manager.channel.ChannelManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.user.UserManager;
+
+import com.suse.manager.webui.services.pillar.MinionPillarManager;
+
 import com.redhat.rhn.domain.server.ServerFactory;
-import com.suse.manager.webui.services.SaltStateGeneratorService;
 
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.struts.action.ActionForm;
@@ -47,6 +49,7 @@ import javax.servlet.http.HttpServletResponse;
 public class ChannelDetailsAction extends RhnAction {
 
     /** {@inheritDoc} */
+    @Override
     public ActionForward execute(ActionMapping mapping,
             ActionForm formIn,
             HttpServletRequest request,
@@ -84,7 +87,7 @@ public class ChannelDetailsAction extends RhnAction {
             params.put("cid", cid);
             fwd = "success";
             ServerFactory.listMinionsByChannel(cid).stream().forEach(ms -> {
-                SaltStateGeneratorService.INSTANCE.generatePillar(ms, false,
+                MinionPillarManager.INSTANCE.generatePillar(ms, false,
                         Collections.emptySet());
             });
         }

--- a/java/code/src/com/redhat/rhn/frontend/action/channel/manage/EditChannelAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/channel/manage/EditChannelAction.java
@@ -46,7 +46,7 @@ import com.redhat.rhn.manager.download.DownloadManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.user.UserManager;
 
-import com.suse.manager.webui.services.SaltStateGeneratorService;
+import com.suse.manager.webui.services.pillar.MinionPillarManager;
 
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -113,6 +113,7 @@ public class EditChannelAction extends RhnAction implements Listable<OrgTrust> {
     public static final boolean DEFAULT_GPG_CHECK = true;
 
     /** {@inheritDoc} */
+    @Override
     public ActionForward execute(ActionMapping mapping,
                                  ActionForm formIn,
                                  HttpServletRequest request,
@@ -416,7 +417,7 @@ public class EditChannelAction extends RhnAction implements Listable<OrgTrust> {
                     ("all".equals(sharing)), loggedInUser.getOrg());
             updated = (Channel) ChannelFactory.reload(updated);
             ServerFactory.listMinionsByChannel(updated.getId()).stream().forEach(ms -> {
-                SaltStateGeneratorService.INSTANCE.generatePillar(ms, false,
+                MinionPillarManager.INSTANCE.generatePillar(ms, false,
                         Collections.emptySet());
             });
 
@@ -833,6 +834,7 @@ public class EditChannelAction extends RhnAction implements Listable<OrgTrust> {
     }
 
     /** {@inheritDoc} */
+    @Override
     public List<OrgTrust> getResult(RequestContext ctx) {
         Org org = ctx.getCurrentUser().getOrg();
         Set<Org> trustedorgs = org.getTrustedOrgs();

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/activationkey/ActivationKeyHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/activationkey/ActivationKeyHandler.java
@@ -53,7 +53,6 @@ import com.redhat.rhn.manager.token.ActivationKeyCloneCommand;
 import com.redhat.rhn.manager.token.ActivationKeyManager;
 
 import com.suse.manager.utils.MachinePasswordUtils;
-import com.suse.manager.webui.services.SaltStateGeneratorService;
 import com.suse.manager.webui.utils.DownloadTokenBuilder;
 
 import org.apache.commons.lang3.StringUtils;
@@ -275,8 +274,7 @@ public class ActivationKeyHandler extends BaseHandler {
                 .collect(Collectors.toSet()));
 
         try {
-            String url = "https://" + SaltStateGeneratorService.getChannelHost(minion) +
-                    "/rhn/manager/download/";
+            String url = "https://" + minion.getChannelHost() + "/rhn/manager/download/";
             String token = tokenBuilder.getToken();
             return key.getChannels().stream().map(
                 c -> new ChannelInfo(c.getLabel(), c.getName(), url + c.getLabel(), token)

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
@@ -86,7 +86,8 @@ import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.task.TaskConstants;
 import com.redhat.rhn.taskomatic.task.errata.ErrataCacheWorker;
 
-import com.suse.manager.webui.services.SaltStateGeneratorService;
+import com.suse.manager.webui.services.pillar.MinionPillarManager;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.StopWatch;
@@ -737,8 +738,7 @@ public class ChannelSoftwareHandler extends BaseHandler {
 
         ucc.update(channelId.longValue());
         ServerFactory.listMinionsByChannel(channelId).stream().forEach(ms -> {
-            SaltStateGeneratorService.INSTANCE.generatePillar(ms, false,
-                    Collections.emptySet());
+            MinionPillarManager.INSTANCE.generatePillar(ms, false, Collections.emptySet());
         });
         return 1;
     }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/test/BaseHandlerTestCase.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/test/BaseHandlerTestCase.java
@@ -22,6 +22,10 @@ import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.testing.RhnBaseTestCase;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
+
+import com.suse.manager.webui.services.pillar.MinionGeneralPillarGenerator;
+import com.suse.manager.webui.services.pillar.MinionGroupMembershipPillarGenerator;
+import com.suse.manager.webui.services.pillar.MinionPillarFileManager;
 import com.suse.manager.webui.services.SaltStateGeneratorService;
 
 import java.nio.file.Files;
@@ -44,7 +48,12 @@ public class BaseHandlerTestCase extends RhnBaseTestCase {
     protected String satAdminKey;
     protected Path tmpPillarRoot;
     protected Path tmpSaltRoot;
+    protected MinionPillarFileManager minionGroupMembershipPillarFileManager =
+            new MinionPillarFileManager(new MinionGroupMembershipPillarGenerator());
+    protected MinionPillarFileManager minionGeneralPillarFileManager =
+            new MinionPillarFileManager(new MinionGeneralPillarGenerator());
 
+    @Override
     public void setUp() throws Exception {
         super.setUp();
         admin = UserTestUtils.createUserInOrgOne();
@@ -75,8 +84,8 @@ public class BaseHandlerTestCase extends RhnBaseTestCase {
 
         tmpPillarRoot = Files.createTempDirectory("pillar");
         tmpSaltRoot = Files.createTempDirectory("salt");
-        SaltStateGeneratorService.INSTANCE.setPillarDataPath(tmpPillarRoot
-                .toAbsolutePath());
+        minionGroupMembershipPillarFileManager.setPillarDataPath(tmpPillarRoot.toAbsolutePath());
+        minionGeneralPillarFileManager.setPillarDataPath(tmpPillarRoot.toAbsolutePath());
         SaltStateGeneratorService.INSTANCE.setSuseManagerStatesFilesRoot(tmpSaltRoot
                 .toAbsolutePath());
         Files.createDirectory(tmpSaltRoot.resolve(SALT_CONFIG_STATES_DIR));

--- a/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
@@ -78,7 +78,8 @@ import com.redhat.rhn.manager.user.UserManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 import com.redhat.rhn.taskomatic.task.TaskConstants;
-import com.suse.manager.webui.services.SaltStateGeneratorService;
+
+import com.suse.manager.webui.services.pillar.MinionPillarManager;
 import com.suse.utils.Opt;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
@@ -639,7 +640,7 @@ public class ChannelManager extends BaseManager {
         Optional<Long> actionId = Optional.empty();
         if (minions.size() > 0) {
             for (MinionServer ms: minions) {
-                SaltStateGeneratorService.INSTANCE.generatePillar(ms, false, Collections.emptySet());
+                MinionPillarManager.INSTANCE.generatePillar(ms, false, Collections.emptySet());
             }
             actionId = Optional.of(ActionManager.scheduleChannelState(user, minions).getId());
         }

--- a/java/code/src/com/redhat/rhn/manager/system/ServerGroupManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/ServerGroupManager.java
@@ -29,7 +29,10 @@ import com.redhat.rhn.domain.server.ServerGroup;
 import com.redhat.rhn.domain.server.ServerGroupFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.domain.user.UserFactory;
+
 import com.suse.manager.webui.services.SaltStateGeneratorService;
+import com.suse.manager.webui.services.pillar.MinionGroupMembershipPillarGenerator;
+import com.suse.manager.webui.services.pillar.MinionPillarFileManager;
 import com.suse.utils.Opt;
 
 import org.apache.log4j.Logger;
@@ -53,6 +56,9 @@ public class ServerGroupManager {
 
     /** Logger */
     private static final Logger LOG = Logger.getLogger(ServerGroupManager.class);
+
+    private MinionPillarFileManager minionGroupMembershipPillarFileManager =
+            new MinionPillarFileManager(new MinionGroupMembershipPillarGenerator());
 
     /**
      * Singleton Instance to get manager object
@@ -352,7 +358,7 @@ public class ServerGroupManager {
      */
     public void updatePillarAfterGroupUpdateForServers(Collection<Server> servers) {
         servers.stream().map(server -> server.asMinionServer()).flatMap(Opt::stream)
-                .forEach(SaltStateGeneratorService.INSTANCE::generateGroupMemebershipsPillarData);
+                .forEach(this.minionGroupMembershipPillarFileManager::generatePillarFile);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/taskomatic/task/TokenCleanup.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/TokenCleanup.java
@@ -20,8 +20,8 @@ import com.redhat.rhn.domain.channel.AccessTokenFactory;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.MinionServerFactory;
 import com.suse.manager.reactor.messaging.ApplyStatesEventMessage;
-import com.suse.manager.webui.services.SaltStateGeneratorService;
 import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.pillar.MinionPillarManager;
 import com.suse.salt.netapi.calls.modules.State;
 import com.suse.salt.netapi.datatypes.target.MinionList;
 import org.quartz.JobExecutionContext;
@@ -42,6 +42,7 @@ public class TokenCleanup extends RhnJavaJob {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void execute(JobExecutionContext arg0In)
         throws JobExecutionException {
         if (log.isDebugEnabled()) {
@@ -52,8 +53,7 @@ public class TokenCleanup extends RhnJavaJob {
                 try {
                     if (AccessTokenFactory.refreshTokens(minionServer, Collections.emptySet())) {
                         // TODO schedule state.apply channels to refresh channels on minion ?
-                        SaltStateGeneratorService.INSTANCE.generatePillar(
-                                minionServer, false, Collections.emptySet());
+                        MinionPillarManager.INSTANCE.generatePillar(minionServer, false, Collections.emptySet());
                         return Stream.of(minionServer);
                     }
                     else {

--- a/java/code/src/com/redhat/rhn/testing/BaseTestCaseWithUser.java
+++ b/java/code/src/com/redhat/rhn/testing/BaseTestCaseWithUser.java
@@ -17,7 +17,12 @@ package com.redhat.rhn.testing;
 import com.redhat.rhn.domain.kickstart.test.KickstartDataTest;
 import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.user.User;
+
 import com.suse.manager.webui.services.SaltStateGeneratorService;
+import com.suse.manager.webui.services.pillar.MinionGeneralPillarGenerator;
+import com.suse.manager.webui.services.pillar.MinionGroupMembershipPillarGenerator;
+import com.suse.manager.webui.services.pillar.MinionPillarFileManager;
+
 import org.apache.commons.io.FileUtils;
 
 import java.nio.file.Files;
@@ -34,9 +39,15 @@ public abstract class BaseTestCaseWithUser extends RhnBaseTestCase {
     private boolean committed = false;
     protected Path tmpPillarRoot;
     protected Path tmpSaltRoot;
+    protected MinionPillarFileManager minionGroupMembershipPillarFileManager =
+            new MinionPillarFileManager(new MinionGroupMembershipPillarGenerator());
+    protected MinionPillarFileManager minionGeneralPillarFileManager =
+            new MinionPillarFileManager(new MinionGeneralPillarGenerator());
+
     /**
      * {@inheritDoc}
      */
+    @Override
     public void setUp() throws Exception {
         super.setUp();
         user = UserTestUtils.findNewUser("testUser", "testOrg" +
@@ -44,8 +55,8 @@ public abstract class BaseTestCaseWithUser extends RhnBaseTestCase {
         KickstartDataTest.setupTestConfiguration(user);
         tmpPillarRoot = Files.createTempDirectory("pillar");
         tmpSaltRoot = Files.createTempDirectory("salt");
-        SaltStateGeneratorService.INSTANCE.setPillarDataPath(tmpPillarRoot
-                .toAbsolutePath());
+        minionGroupMembershipPillarFileManager.setPillarDataPath(tmpPillarRoot.toAbsolutePath());
+        minionGeneralPillarFileManager.setPillarDataPath(tmpPillarRoot.toAbsolutePath());
         SaltStateGeneratorService.INSTANCE.setSuseManagerStatesFilesRoot(tmpSaltRoot
                 .toAbsolutePath());
         Files.createDirectory(tmpSaltRoot.resolve(SALT_CONFIG_STATES_DIR));
@@ -54,6 +65,7 @@ public abstract class BaseTestCaseWithUser extends RhnBaseTestCase {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void tearDown() throws Exception {
         super.tearDown();
 

--- a/java/code/src/com/redhat/rhn/testing/JMockBaseTestCaseWithUser.java
+++ b/java/code/src/com/redhat/rhn/testing/JMockBaseTestCaseWithUser.java
@@ -16,7 +16,12 @@ package com.redhat.rhn.testing;
 
 import com.redhat.rhn.domain.kickstart.test.KickstartDataTest;
 import com.redhat.rhn.domain.user.User;
+
 import com.suse.manager.webui.services.SaltStateGeneratorService;
+import com.suse.manager.webui.services.pillar.MinionGeneralPillarGenerator;
+import com.suse.manager.webui.services.pillar.MinionGroupMembershipPillarGenerator;
+import com.suse.manager.webui.services.pillar.MinionPillarFileManager;
+
 import org.apache.commons.io.FileUtils;
 
 import java.nio.file.Files;
@@ -32,10 +37,15 @@ public abstract class JMockBaseTestCaseWithUser extends RhnJmockBaseTestCase {
     protected User user;
     protected Path tmpPillarRoot;
     protected Path tmpSaltRoot;
+    protected MinionPillarFileManager minionGroupMembershipPillarFileManager =
+            new MinionPillarFileManager(new MinionGroupMembershipPillarGenerator());
+    protected MinionPillarFileManager minionGeneralPillarFileManager =
+            new MinionPillarFileManager(new MinionGeneralPillarGenerator());
 
     /**
      * {@inheritDoc}
      */
+    @Override
     public void setUp() throws Exception {
         super.setUp();
         user = UserTestUtils.findNewUser("testUser", "testOrg" +
@@ -43,8 +53,8 @@ public abstract class JMockBaseTestCaseWithUser extends RhnJmockBaseTestCase {
         KickstartDataTest.setupTestConfiguration(user);
         tmpPillarRoot = Files.createTempDirectory("pillar");
         tmpSaltRoot = Files.createTempDirectory("salt");
-        SaltStateGeneratorService.INSTANCE.setPillarDataPath(tmpPillarRoot
-                .toAbsolutePath());
+        minionGroupMembershipPillarFileManager.setPillarDataPath(tmpPillarRoot.toAbsolutePath());
+        minionGeneralPillarFileManager.setPillarDataPath(tmpPillarRoot.toAbsolutePath());
         SaltStateGeneratorService.INSTANCE.setSuseManagerStatesFilesRoot(tmpSaltRoot
                 .toAbsolutePath());
         Files.createDirectory(tmpSaltRoot.resolve(SALT_CONFIG_STATES_DIR));
@@ -53,6 +63,7 @@ public abstract class JMockBaseTestCaseWithUser extends RhnJmockBaseTestCase {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void tearDown() throws Exception {
         super.tearDown();
 

--- a/java/code/src/com/redhat/rhn/testing/RhnMockStrutsTestCase.java
+++ b/java/code/src/com/redhat/rhn/testing/RhnMockStrutsTestCase.java
@@ -23,6 +23,10 @@ import java.util.TimeZone;
 import javax.servlet.http.Cookie;
 
 import com.suse.manager.webui.services.SaltStateGeneratorService;
+import com.suse.manager.webui.services.pillar.MinionGeneralPillarGenerator;
+import com.suse.manager.webui.services.pillar.MinionGroupMembershipPillarGenerator;
+import com.suse.manager.webui.services.pillar.MinionPillarFileManager;
+
 import org.apache.struts.action.DynaActionForm;
 import org.hibernate.HibernateException;
 
@@ -50,10 +54,15 @@ import com.redhat.rhn.frontend.struts.RhnAction;
 public class RhnMockStrutsTestCase extends MockStrutsTestCase {
 
     protected User user;
+    protected MinionPillarFileManager minionGroupMembershipPillarFileManager =
+            new MinionPillarFileManager(new MinionGroupMembershipPillarGenerator());
+    protected MinionPillarFileManager minionGeneralPillarFileManager =
+            new MinionPillarFileManager(new MinionGeneralPillarGenerator());
 
     /**
      * {@inheritDoc}
      */
+    @Override
     public void setUp() throws Exception {
         super.setUp();
 
@@ -87,8 +96,8 @@ public class RhnMockStrutsTestCase extends MockStrutsTestCase {
         //Set temporary Salt directories for local runs
         Path tmpPillarRoot = Files.createTempDirectory("pillar");
         Path tmpSaltRoot = Files.createTempDirectory("salt");
-        SaltStateGeneratorService.INSTANCE.setPillarDataPath(tmpPillarRoot
-                .toAbsolutePath());
+        minionGroupMembershipPillarFileManager.setPillarDataPath(tmpPillarRoot.toAbsolutePath());
+        minionGeneralPillarFileManager.setPillarDataPath(tmpPillarRoot.toAbsolutePath());
         SaltStateGeneratorService.INSTANCE.setSuseManagerStatesFilesRoot(tmpSaltRoot
                 .toAbsolutePath());
     }
@@ -96,6 +105,7 @@ public class RhnMockStrutsTestCase extends MockStrutsTestCase {
     /**
      * Tears down the fixture, and closes the HibernateSession.
      */
+    @Override
     protected void tearDown() throws Exception {
         super.tearDown();
         TestCaseHelper.tearDownHelper();

--- a/java/code/src/com/suse/manager/reactor/messaging/ChannelsChangedEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/ChannelsChangedEventMessageAction.java
@@ -31,7 +31,8 @@ import com.redhat.rhn.manager.errata.ErrataManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
-import com.suse.manager.webui.services.SaltStateGeneratorService;
+import com.suse.manager.webui.services.pillar.MinionPillarManager;
+
 import org.apache.log4j.Logger;
 
 import java.util.Collections;
@@ -70,7 +71,7 @@ public class ChannelsChangedEventMessageAction implements MessageAction {
             ErrataManager.insertErrataCacheTask(minion);
 
             // Regenerate the pillar data
-            SaltStateGeneratorService.INSTANCE.generatePillar(minion,
+            MinionPillarManager.INSTANCE.generatePillar(minion,
                     true,
                     msg.getAccessTokenIds() != null ?
                             msg.getAccessTokenIds().stream()

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -53,9 +53,9 @@ import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 
 import com.suse.manager.reactor.utils.ValueMap;
-import com.suse.manager.webui.services.SaltStateGeneratorService;
 import com.suse.manager.webui.services.impl.MinionPendingRegistrationService;
 import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.pillar.MinionPillarManager;
 import com.suse.salt.netapi.datatypes.target.MinionList;
 import com.suse.salt.netapi.errors.SaltError;
 import com.suse.salt.netapi.exception.SaltException;
@@ -231,8 +231,8 @@ public class RegisterMinionEventMessageAction implements MessageAction {
                 registeredMinion.setMinionId(minionId);
                 ServerFactory.save(registeredMinion);
 
-                SaltStateGeneratorService.INSTANCE.generatePillar(registeredMinion);
-                SaltStateGeneratorService.INSTANCE.removePillar(oldMinionId);
+                MinionPillarManager.INSTANCE.generatePillar(registeredMinion);
+                MinionPillarManager.INSTANCE.removePillar(oldMinionId);
 
                 migrateMinionFormula(minionId, Optional.of(oldMinionId));
 
@@ -506,7 +506,7 @@ public class RegisterMinionEventMessageAction implements MessageAction {
             }
         }
 
-        minion.asMinionServer().ifPresent(SaltStateGeneratorService.INSTANCE::generatePillar);
+        minion.asMinionServer().ifPresent(MinionPillarManager.INSTANCE::generatePillar);
     }
 
     private void applySaltboot(MinionServer minion) {

--- a/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
@@ -50,8 +50,8 @@ import com.redhat.rhn.taskomatic.TaskomaticApiException;
 import com.suse.manager.reactor.utils.RhelUtils;
 import com.suse.manager.reactor.utils.ValueMap;
 import com.suse.manager.webui.controllers.StatesAPI;
-import com.suse.manager.webui.services.SaltStateGeneratorService;
 import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.pillar.MinionPillarManager;
 import com.suse.manager.webui.utils.salt.custom.PkgProfileUpdateSlsResult;
 import com.suse.salt.netapi.calls.modules.State;
 import com.suse.salt.netapi.calls.modules.Zypper;
@@ -110,7 +110,7 @@ public class RegistrationUtils {
 
         // Generate pillar data
         try {
-            SaltStateGeneratorService.INSTANCE.generatePillar(minion);
+            MinionPillarManager.INSTANCE.generatePillar(minion);
 
             // Subscribe to config channels assigned to the activation key or initialize empty channel profile
             minion.subscribeConfigChannels(

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -93,6 +93,8 @@ import com.suse.manager.reactor.messaging.JobReturnEventMessageAction;
 import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.webui.services.impl.SaltSSHService;
 import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.pillar.MinionGeneralPillarGenerator;
+import com.suse.manager.webui.services.pillar.MinionPillarManager;
 import com.suse.manager.webui.utils.DownloadTokenBuilder;
 import com.suse.manager.webui.utils.ElementCallJson;
 import com.suse.manager.webui.utils.SaltModuleRun;
@@ -1206,11 +1208,12 @@ public class SaltServerActionService {
                 actionDetails.getAccessTokens().add(newToken);
             });
 
+            MinionGeneralPillarGenerator minionGeneralPillarGenerator = new MinionGeneralPillarGenerator();
             Map<String, Object> chanPillar = new HashMap<>();
             newTokens.forEach(accessToken ->
                 accessToken.getChannels().forEach(chan -> {
                     Map<String, Object> chanProps =
-                            SaltStateGeneratorService.getChannelPillarData(minion, accessToken, chan);
+                            minionGeneralPillarGenerator.getChannelPillarData(minion, accessToken, chan);
                     chanPillar.put(chan.getLabel(), chanProps);
                 })
             );
@@ -1305,7 +1308,7 @@ public class SaltServerActionService {
                     final String token = t;
 
                     Map<String, Object> pillar = new HashMap<>();
-                    String host = SaltStateGeneratorService.getChannelHost(minion);
+                    String host = minion.getChannelHost();
 
                     profile.asDockerfileProfile().ifPresent(dockerfileProfile -> {
                         Map<String, Object> dockerRegistries = dockerRegPillar(imageStores);
@@ -1406,7 +1409,7 @@ public class SaltServerActionService {
             currentChannels.removeAll(unsubbed);
             currentChannels.addAll(subbed);
             ServerFactory.save(minion);
-            SaltStateGeneratorService.INSTANCE.generatePillar(minion);
+            MinionPillarManager.INSTANCE.generatePillar(minion);
         });
 
         Map<String, Object> pillar = new HashMap<>();

--- a/java/code/src/com/suse/manager/webui/services/SaltStateGeneratorService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltStateGeneratorService.java
@@ -15,38 +15,29 @@
 package com.suse.manager.webui.services;
 
 import static com.suse.manager.webui.services.SaltConstants.PILLAR_DATA_FILE_EXT;
-import static com.suse.manager.webui.services.SaltConstants.PILLAR_DATA_FILE_PREFIX;
 import static com.suse.manager.webui.services.SaltConstants.PILLAR_IMAGE_DATA_FILE_EXT;
 import static com.suse.manager.webui.services.SaltConstants.PILLAR_IMAGE_DATA_FILE_PREFIX;
 import static com.suse.manager.webui.services.SaltConstants.SALT_CONFIG_STATES_DIR;
 import static com.suse.manager.webui.services.SaltConstants.SALT_SERVER_STATE_FILE_PREFIX;
-import static com.suse.manager.webui.services.SaltConstants.SUMA_PILLAR_DATA_PATH;
 import static com.suse.manager.webui.services.SaltConstants.SUMA_PILLAR_IMAGES_DATA_PATH;
 import static com.suse.manager.webui.services.SaltConstants.SUMA_STATE_FILES_ROOT_PATH;
 import static com.suse.manager.webui.utils.SaltFileUtils.defaultExtension;
 
-import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.util.FileUtils;
-import com.redhat.rhn.domain.channel.AccessToken;
-import com.redhat.rhn.domain.channel.AccessTokenFactory;
-import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.config.ConfigChannel;
 import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.MinionServerFactory;
-import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerGroup;
-import com.redhat.rhn.domain.server.ServerGroupType;
-import com.redhat.rhn.domain.server.ServerPath;
 import com.redhat.rhn.domain.state.OrgStateRevision;
 import com.redhat.rhn.domain.state.ServerGroupStateRevision;
 import com.redhat.rhn.domain.state.ServerStateRevision;
 import com.redhat.rhn.domain.state.StateFactory;
 import com.redhat.rhn.domain.state.StateRevision;
 import com.redhat.rhn.domain.user.User;
-import com.suse.manager.utils.MachinePasswordUtils;
 import com.suse.manager.webui.controllers.StatesAPI;
+import com.suse.manager.webui.services.pillar.MinionPillarManager;
 import com.suse.manager.webui.utils.SaltConfigChannelState;
 import com.suse.manager.webui.utils.SaltPillar;
 import com.suse.manager.webui.utils.SaltStateGenerator;
@@ -59,10 +50,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -77,145 +65,13 @@ public enum SaltStateGeneratorService {
     // Singleton instance of this class
     INSTANCE;
 
-    private static final Map<String, Object> PKGSET_BEACON_PROPS = new HashMap<>();
-    private static final Map<String, Object> VIRTPOLLER_BEACON_PROPS = new HashMap<>();
-
-    private static final String PKGSET_COOKIE_PATH = "/var/cache/salt/minion/rpmdb.cookie";
-    private static final int PKGSET_INTERVAL = 5;
-    static {
-        PKGSET_BEACON_PROPS.put("cookie", PKGSET_COOKIE_PATH);
-        PKGSET_BEACON_PROPS.put("interval",  PKGSET_INTERVAL);
-    }
-
-    static {
-        VIRTPOLLER_BEACON_PROPS.put("cache_file", Config.get().getString(
-                ConfigDefaults.VIRTPOLLER_CACHE_FILE));
-        VIRTPOLLER_BEACON_PROPS.put("expire_time", Config.get().getInt(
-                ConfigDefaults.VIRTPOLLER_CACHE_EXPIRATION));
-        VIRTPOLLER_BEACON_PROPS.put("interval", Config.get().getInt(
-                ConfigDefaults.VIRTPOLLER_INTERVAL));
-    }
-
     /** Logger */
     private static final Logger LOG = Logger.getLogger(SaltStateGeneratorService.class);
 
     private Path suseManagerStatesFilesRoot;
 
-    private Path pillarDataPath;
-
     SaltStateGeneratorService() {
         suseManagerStatesFilesRoot = Paths.get(SUMA_STATE_FILES_ROOT_PATH);
-        pillarDataPath = Paths.get(SUMA_PILLAR_DATA_PATH);
-    }
-
-    /**
-     * Generate server specific pillar if the given server is a minion.
-     * @param minion the minion server
-     */
-    public void generatePillar(MinionServer minion) {
-        generatePillar(minion, true, Collections.emptySet());
-    }
-
-    /**
-     * Creates the directory to store the pillar file on disk.
-     * @throws IOException if an I/O error occurs
-     */
-    public void createPillarDirectory() throws IOException {
-        Files.createDirectories(pillarDataPath);
-    }
-
-    /**
-     * Generate pillar containing the information of the server groups the the passed minion is member of
-     * @param minion the minion server
-     */
-    public void generateGroupMemebershipsPillarData(MinionServer minion) {
-        LOG.debug("Generating group memberships pillar file for minion: " + minion.getMinionId());
-
-        SaltPillar pillar = new SaltPillar();
-
-        List<String> addonGroupTypes = minion.getEntitledGroupTypes().stream()
-                .map(ServerGroupType::getLabel).collect(Collectors.toList());
-
-        List<Long> groupIds = minion.getManagedGroups().stream().map(ServerGroup::getId).collect(Collectors.toList());
-
-        pillar.add("group_ids", groupIds.toArray(new Long[groupIds.size()]));
-        pillar.add("addon_group_types", addonGroupTypes.toArray(new String[addonGroupTypes.size()]));
-
-        try {
-            Files.createDirectories(pillarDataPath);
-            Path filePath = pillarDataPath.resolve(getServerGroupMembershipPillarFileName(minion.getMinionId()));
-            new SaltStateGenerator(filePath.toFile()).generate(pillar);
-        }
-        catch (IOException e) {
-            LOG.error(e.getMessage(), e);
-        }
-    }
-
-    /**
-     * Generate server specific pillar if the given server is a minion.
-     * @param minion the minion server
-     * @param refreshAccessTokens if access tokens should be refreshed first
-     * @param tokensToActivate channels access tokens to activate when refreshing
-     * the tokens
-     */
-    public void generatePillar(MinionServer minion, boolean refreshAccessTokens,
-                               Collection<AccessToken> tokensToActivate) {
-        LOG.debug("Generating pillar file for minion: " + minion.getMinionId());
-
-        generateGroupMemebershipsPillarData(minion);
-
-        if (refreshAccessTokens) {
-            AccessTokenFactory.refreshTokens(minion, tokensToActivate);
-        }
-
-        SaltPillar pillar = new SaltPillar();
-        pillar.add("org_id", minion.getOrg().getId());
-
-        pillar.add("contact_method", minion.getContactMethod().getLabel());
-        pillar.add("mgr_server", getChannelHost(minion));
-        pillar.add("machine_password", MachinePasswordUtils.machinePassword(minion));
-
-        Map<String, Object> chanPillar = new HashMap<>();
-        minion.getAccessTokens().stream().filter(AccessToken::getValid).forEach(accessToken -> {
-            accessToken.getChannels().forEach(chan -> {
-                Map<String, Object> chanProps = getChannelPillarData(minion, accessToken, chan);
-
-                chanPillar.put(chan.getLabel(), chanProps);
-            });
-        });
-        pillar.add("channels", chanPillar);
-
-        Map<String, Object> beaconConfig = new HashMap<>();
-        // this add the configuration for the beacon that tell us when the
-        // minion packages are modified locally
-        if (minion.getOsFamily().toLowerCase().equals("suse") ||
-                minion.getOsFamily().toLowerCase().equals("redhat")) {
-            beaconConfig.put("pkgset", PKGSET_BEACON_PROPS);
-        }
-        // this add the configuration for the beacon that tell us about
-        // virtual guests running on that minion
-        // The virtpoller is still usefull with the libvirt events: it will help
-        // synchronizing the DB with the actual guest lists in case we had a temporary shutdown.
-        // TODO: find a better way to detect when the beacon should be configured
-        if (minion.isVirtualHost()) {
-            beaconConfig.put("virtpoller", VIRTPOLLER_BEACON_PROPS);
-        }
-        if (!beaconConfig.isEmpty()) {
-            pillar.add("beacons", beaconConfig);
-        }
-
-        try {
-            Files.createDirectories(pillarDataPath);
-            Path filePath = pillarDataPath.resolve(
-                    getServerPillarFileName(minion.getMinionId())
-            );
-            com.suse.manager.webui.utils.SaltStateGenerator saltStateGenerator =
-                    new com.suse.manager.webui.utils.SaltStateGenerator(filePath.toFile());
-            saltStateGenerator.generate(pillar);
-        }
-        catch (IOException e) {
-            LOG.error(e.getMessage(), e);
-        }
     }
 
     /**
@@ -329,114 +185,10 @@ public enum SaltStateGeneratorService {
         return bootImagePillar;
     }
 
-    /**
-     * Create channel pillar data for the given minion, access token and channel.
-     * @param minion the minion
-     * @param accessToken the access token
-     * @param chan the channel
-     * @return a {@link Map} containing the pillar data
-     */
-    public static Map<String, Object> getChannelPillarData(MinionServer minion, AccessToken accessToken, Channel chan) {
-        Map<String, Object> chanProps = new HashMap<>();
-        chanProps.put("alias", "susemanager:" + chan.getLabel());
-        chanProps.put("name", chan.getName());
-        chanProps.put("enabled", "1");
-        chanProps.put("autorefresh", "1");
-        chanProps.put("host", getChannelHost(minion));
-        if ("ssh-push-tunnel".equals(minion.getContactMethod().getLabel())) {
-            chanProps.put("port", Config.get().getInt("ssh_push_port_https"));
-        }
-        chanProps.put("token", accessToken.getToken());
-        if (chan.isTypeRpm()) {
-            chanProps.put("type", "rpm-md");
-        }
-        else if (chan.isTypeDeb()) {
-            chanProps.put("type", "deb");
-        }
-        else {
-            LOG.warn("Unknown repo type for channel " + chan.getLabel());
-        }
-
-        if (ConfigDefaults.get().isMetadataSigningEnabled()) {
-            chanProps.put("gpgcheck", chan.isGPGCheck() ? "1" : "0");
-            // three state field. yes, no or default
-            chanProps.put("repo_gpgcheck", "default");
-            chanProps.put("pkg_gpgcheck", "default");
-        }
-        else {
-            chanProps.put("gpgcheck", "0");
-            chanProps.put("repo_gpgcheck", "0");
-            chanProps.put("pkg_gpgcheck", chan.isGPGCheck() ? "1" : "0");
-        }
-        return chanProps;
-    }
-
-    /**
-     * Return the channel hostname for a given server.
-     *
-     * @param server server to get the channel host for.
-     * @return channel hostname.
-     */
-    public static String getChannelHost(Server server) {
-        Optional<ServerPath> path = server.getFirstServerPath();
-        if (!path.isPresent()) {
-            // client is not proxied, return this server's hostname
-            // HACK: we currently have no better way
-            return ConfigDefaults.get().getCobblerHost();
-        }
-        else {
-            return path.get().getHostname();
-        }
-    }
-
-    private String getServerGroupMembershipPillarFileName(String minionId) {
-        return PILLAR_DATA_FILE_PREFIX + "_" +
-                minionId + "_" + "group_memberships" + "." +
-                PILLAR_DATA_FILE_EXT;
-    }
-
-    private String getServerPillarFileName(String minionId) {
-        return PILLAR_DATA_FILE_PREFIX + "_" +
-            minionId + "." +
-                PILLAR_DATA_FILE_EXT;
-    }
-
     private String getImagePillarFileName(OSImageInspectSlsResult.Bundle bundle) {
         return PILLAR_IMAGE_DATA_FILE_PREFIX + "-" + bundle.getBasename() + "-" +
                 bundle.getId().replace('.', '-') + "." + PILLAR_IMAGE_DATA_FILE_EXT;
     }
-
-    /**
-     * Remove the corresponding pillar data of minion server
-     * @param minion the minion server
-     */
-    public void removePillar(MinionServer minion) {
-        removePillar(minion.getMinionId());
-    }
-
-    /**
-     * Remove the corresponding pillar data by minionId
-     * @param minionId the server minionId
-     */
-    public void removePillar(String minionId) {
-        LOG.debug("Removing pillar file for minion: " + minionId);
-        this.getMinionPillarFilenames(minionId).stream().forEach(filename -> removePillarFile(filename));
-    }
-
-    private List<String> getMinionPillarFilenames(String minionId) {
-        return Arrays.asList(getServerPillarFileName(minionId), getServerGroupMembershipPillarFileName(minionId));
-    }
-
-    private void removePillarFile(String filename) {
-        Path filePath = pillarDataPath.resolve(filename);
-        try {
-            Files.deleteIfExists(filePath);
-        }
-        catch (IOException e) {
-            LOG.error("Could not remove pillar file " + filePath);
-        }
-    }
-
 
     /**
      * Remove the config channel assignments for minion server.
@@ -570,7 +322,7 @@ public enum SaltStateGeneratorService {
      * @param minion the minion
      */
     public void removeServer(MinionServer minion) {
-        removePillar(minion);
+        MinionPillarManager.INSTANCE.removePillar(minion.getMinionId());
         removeConfigChannelAssignments(minion);
         removeActionChains(minion);
     }
@@ -627,7 +379,7 @@ public enum SaltStateGeneratorService {
         StateFactory.save(newStateRev);
 
         // refresh pillar, config and package states
-        generatePillar(minion);
+        MinionPillarManager.INSTANCE.generatePillar(minion);
         generateConfigState(newStateRev);
         StatesAPI.generateServerPackageState(minion);
     }
@@ -659,13 +411,6 @@ public enum SaltStateGeneratorService {
      */
     public void setSuseManagerStatesFilesRoot(Path generatedSlsRootIn) {
         this.suseManagerStatesFilesRoot = generatedSlsRootIn;
-    }
-
-    /**
-     * @param pillarDataPathIn the root path where pillar files are generated
-     */
-    public void setPillarDataPath(Path pillarDataPathIn) {
-        this.pillarDataPath = pillarDataPathIn;
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.manager.webui.services.pillar;
+
+import static com.suse.manager.webui.services.SaltConstants.PILLAR_DATA_FILE_EXT;
+import static com.suse.manager.webui.services.SaltConstants.PILLAR_DATA_FILE_PREFIX;
+
+import com.redhat.rhn.common.conf.Config;
+import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.domain.channel.AccessToken;
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.server.MinionServer;
+
+import com.suse.manager.utils.MachinePasswordUtils;
+import com.suse.manager.webui.utils.SaltPillar;
+
+import org.apache.log4j.Logger;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Class for generating minion pillar data containing general information of minions
+ */
+public class MinionGeneralPillarGenerator implements MinionPillarGenerator {
+
+    /** Logger */
+    private static final Logger LOG = Logger.getLogger(MinionGeneralPillarGenerator.class);
+
+    public static final MinionGeneralPillarGenerator INSTANCE = new MinionGeneralPillarGenerator();
+
+    private static final Map<String, Object> PKGSET_BEACON_PROPS = new HashMap<>();
+    private static final String PKGSET_COOKIE_PATH = "/var/cache/salt/minion/rpmdb.cookie";
+    private static final int PKGSET_INTERVAL = 5;
+    static {
+        PKGSET_BEACON_PROPS.put("cookie", PKGSET_COOKIE_PATH);
+        PKGSET_BEACON_PROPS.put("interval", PKGSET_INTERVAL);
+    }
+
+    private static final Map<String, Object> VIRTPOLLER_BEACON_PROPS = new HashMap<>();
+
+    static {
+        VIRTPOLLER_BEACON_PROPS.put("cache_file", Config.get().getString(ConfigDefaults.VIRTPOLLER_CACHE_FILE));
+        VIRTPOLLER_BEACON_PROPS.put("expire_time", Config.get().getInt(ConfigDefaults.VIRTPOLLER_CACHE_EXPIRATION));
+        VIRTPOLLER_BEACON_PROPS.put("interval", Config.get().getInt(ConfigDefaults.VIRTPOLLER_INTERVAL));
+    }
+
+    /**
+     * Generates pillar data containing general information of the passed minion
+     * @param minion the minion server
+     * @return the SaltPillar containing the pillar data
+     */
+    @Override
+    public SaltPillar generatePillarData(MinionServer minion) {
+        SaltPillar pillar = new SaltPillar();
+        pillar.add("org_id", minion.getOrg().getId());
+
+        pillar.add("contact_method", minion.getContactMethod().getLabel());
+        pillar.add("mgr_server", minion.getChannelHost());
+        pillar.add("machine_password", MachinePasswordUtils.machinePassword(minion));
+
+        Map<String, Object> chanPillar = new HashMap<>();
+        minion.getAccessTokens().stream().filter(AccessToken::getValid).forEach(accessToken -> {
+            accessToken.getChannels().forEach(chan -> {
+                Map<String, Object> chanProps = getChannelPillarData(minion, accessToken, chan);
+
+                chanPillar.put(chan.getLabel(), chanProps);
+            });
+        });
+        pillar.add("channels", chanPillar);
+
+        Map<String, Object> beaconConfig = new HashMap<>();
+        // this add the configuration for the beacon that tell us when the
+        // minion packages are modified locally
+        if (minion.getOsFamily().toLowerCase().equals("suse") ||
+                minion.getOsFamily().toLowerCase().equals("redhat")) {
+            beaconConfig.put("pkgset", PKGSET_BEACON_PROPS);
+        }
+        // this add the configuration for the beacon that tell us about
+        // virtual guests running on that minion
+        // The virtpoller is still usefull with the libvirt events: it will help
+        // synchronizing the DB with the actual guest lists in case we had a temporary shutdown.
+        // TODO: find a better way to detect when the beacon should be configured
+        if (minion.isVirtualHost()) {
+            beaconConfig.put("virtpoller", VIRTPOLLER_BEACON_PROPS);
+        }
+        if (!beaconConfig.isEmpty()) {
+            pillar.add("beacons", beaconConfig);
+        }
+        return pillar;
+    }
+
+    /**
+     * Create channel pillar data for the given minion, access token and channel
+     * @param minion the minion
+     * @param accessToken the access token
+     * @param chan the channel
+     * @return a {@link Map} containing the pillar data
+     */
+    public Map<String, Object> getChannelPillarData(MinionServer minion, AccessToken accessToken,
+            Channel chan) {
+        Map<String, Object> chanProps = new HashMap<>();
+        chanProps.put("alias", "susemanager:" + chan.getLabel());
+        chanProps.put("name", chan.getName());
+        chanProps.put("enabled", "1");
+        chanProps.put("autorefresh", "1");
+        chanProps.put("host", minion.getChannelHost());
+        if ("ssh-push-tunnel".equals(minion.getContactMethod().getLabel())) {
+            chanProps.put("port", Config.get().getInt("ssh_push_port_https"));
+        }
+        chanProps.put("token", accessToken.getToken());
+        if (chan.isTypeRpm()) {
+            chanProps.put("type", "rpm-md");
+        }
+        else if (chan.isTypeDeb()) {
+            chanProps.put("type", "deb");
+        }
+        else {
+            LOG.warn("Unknown repo type for channel " + chan.getLabel());
+        }
+
+        if (ConfigDefaults.get().isMetadataSigningEnabled()) {
+            chanProps.put("gpgcheck", chan.isGPGCheck() ? "1" : "0");
+            // three state field. yes, no or default
+            chanProps.put("repo_gpgcheck", "default");
+            chanProps.put("pkg_gpgcheck", "default");
+        }
+        else {
+            chanProps.put("gpgcheck", "0");
+            chanProps.put("repo_gpgcheck", "0");
+            chanProps.put("pkg_gpgcheck", chan.isGPGCheck() ? "1" : "0");
+        }
+        return chanProps;
+    }
+
+    @Override
+    public String getFilename(String minionId) {
+        return PILLAR_DATA_FILE_PREFIX + "_" + minionId + "." + PILLAR_DATA_FILE_EXT;
+    }
+
+}

--- a/java/code/src/com/suse/manager/webui/services/pillar/MinionGroupMembershipPillarGenerator.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/MinionGroupMembershipPillarGenerator.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.manager.webui.services.pillar;
+
+import static com.suse.manager.webui.services.SaltConstants.PILLAR_DATA_FILE_EXT;
+import static com.suse.manager.webui.services.SaltConstants.PILLAR_DATA_FILE_PREFIX;
+
+import com.redhat.rhn.domain.server.MinionServer;
+import com.redhat.rhn.domain.server.ServerGroup;
+import com.redhat.rhn.domain.server.ServerGroupType;
+
+import com.suse.manager.webui.utils.SaltPillar;
+
+import org.apache.log4j.Logger;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Class for generating pillar data containing information of the server groups memberships of minions
+ */
+public class MinionGroupMembershipPillarGenerator implements MinionPillarGenerator {
+
+    /** Logger */
+    private static final Logger LOG = Logger.getLogger(MinionGroupMembershipPillarGenerator.class);
+
+    public static final MinionGroupMembershipPillarGenerator INSTANCE = new MinionGroupMembershipPillarGenerator();
+
+    /**
+     * Generates pillar containing the information of the server groups the passed minion is member of
+     * @param minion the minion server
+     * @return the SaltPillar containing the pillar data
+     */
+    @Override
+    public SaltPillar generatePillarData(MinionServer minion) {
+        LOG.debug("Generating group memberships pillar file for minion: " + minion.getMinionId());
+
+        SaltPillar pillar = new SaltPillar();
+
+        List<String> addonGroupTypes = minion.getEntitledGroupTypes().stream()
+                .map(ServerGroupType::getLabel).collect(Collectors.toList());
+
+        List<Long> groupIds = minion.getManagedGroups().stream().map(ServerGroup::getId).collect(Collectors.toList());
+
+        pillar.add("group_ids", groupIds.toArray(new Long[groupIds.size()]));
+        pillar.add("addon_group_types", addonGroupTypes.toArray(new String[addonGroupTypes.size()]));
+
+        return pillar;
+    }
+
+    @Override
+    public String getFilename(String minionId) {
+        return PILLAR_DATA_FILE_PREFIX + "_" + minionId + "_" + "group_memberships" + "." + PILLAR_DATA_FILE_EXT;
+    }
+}

--- a/java/code/src/com/suse/manager/webui/services/pillar/MinionPillarFileManager.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/MinionPillarFileManager.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.webui.services.pillar;
+
+import static com.suse.manager.webui.services.SaltConstants.SUMA_PILLAR_DATA_PATH;
+
+import com.redhat.rhn.domain.server.MinionServer;
+
+import com.suse.manager.webui.utils.SaltPillar;
+import com.suse.manager.webui.utils.SaltStateGenerator;
+
+import org.apache.log4j.Logger;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Abstract manager class for generating or removing minion pillar files
+ */
+public class MinionPillarFileManager {
+
+    private static final Logger LOG = Logger.getLogger(MinionPillarManager.class);
+
+    private Path pillarDataPath = Paths.get(SUMA_PILLAR_DATA_PATH);
+
+    private MinionPillarGenerator minionPillarGenerator;
+
+    /**
+     * Constructor for MinionPillarFileManager
+     * @param minionPillarGeneratorIn the minion pillar generator
+     */
+    public MinionPillarFileManager(MinionPillarGenerator minionPillarGeneratorIn) {
+        super();
+        this.minionPillarGenerator = minionPillarGeneratorIn;
+    }
+
+    /**
+     * Generates pillar containing the information of the server groups the the passed minion is member of
+     * @param minion the minion server
+     */
+    public void generatePillarFile(MinionServer minion) {
+        SaltPillar pillar = this.minionPillarGenerator.generatePillarData(minion);
+        this.saveFileToDisk(pillar, this.minionPillarGenerator.getFilename(minion.getMinionId()));
+    }
+
+    private void saveFileToDisk(SaltPillar pillar, String filename) {
+        try {
+            Files.createDirectories(this.pillarDataPath);
+            new SaltStateGenerator(this.pillarDataPath.resolve(filename).toFile()).generate(pillar);
+        }
+        catch (IOException e) {
+            LOG.error(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Remove the corresponding pillar file for the passed minion.
+     * @param minionId the minion Id
+     */
+    public void removePillarFile(String minionId) {
+        Path filePath = this.pillarDataPath.resolve(this.minionPillarGenerator.getFilename(minionId));
+        try {
+            Files.deleteIfExists(filePath);
+        }
+        catch (IOException e) {
+            LOG.error("Could not remove pillar file " + filePath);
+        }
+    }
+
+    /**
+     * @param pillarDataPathIn the root path where pillar files are generated
+     */
+    public void setPillarDataPath(Path pillarDataPathIn) {
+        this.pillarDataPath = pillarDataPathIn;
+    }
+
+}

--- a/java/code/src/com/suse/manager/webui/services/pillar/MinionPillarGenerator.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/MinionPillarGenerator.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.manager.webui.services.pillar;
+
+import com.redhat.rhn.domain.server.MinionServer;
+
+import com.suse.manager.webui.utils.SaltPillar;
+
+/**
+ * Common interface for generating specific minion pillar data
+ */
+public interface MinionPillarGenerator {
+
+    /**
+     * Generates specific pillar data for a the passed minion
+     * @param minion the minion server
+     * @return the SaltPillar containing the pillar data
+     */
+    SaltPillar generatePillarData(MinionServer minion);
+
+    /**
+     * Generates the filename of the file disk where the pillar data should be save
+     * @param minionId the minion Id
+     * @return the filename
+     */
+    String getFilename(String minionId);
+
+}

--- a/java/code/src/com/suse/manager/webui/services/pillar/MinionPillarManager.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/MinionPillarManager.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.manager.webui.services.pillar;
+
+import com.redhat.rhn.domain.channel.AccessToken;
+import com.redhat.rhn.domain.channel.AccessTokenFactory;
+import com.redhat.rhn.domain.server.MinionServer;
+
+import org.apache.log4j.Logger;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Manager class for generating or removing minion pillar files.
+ */
+public class MinionPillarManager {
+
+    /** Logger */
+    private static final Logger LOG = Logger.getLogger(MinionPillarManager.class);
+
+    public static final MinionPillarManager INSTANCE = new MinionPillarManager(
+            Arrays.asList(new MinionPillarFileManager(MinionGeneralPillarGenerator.INSTANCE),
+                    new MinionPillarFileManager(MinionGroupMembershipPillarGenerator.INSTANCE)));
+
+    private List<MinionPillarFileManager> pillarFileManagers;
+
+    /**
+     * Constructor for MinionPillarManager
+     * @param pillarFileManagersIn a list of minion pillar file managers
+     */
+    public MinionPillarManager(List<MinionPillarFileManager> pillarFileManagersIn) {
+        this.pillarFileManagers = pillarFileManagersIn;
+    }
+
+    /**
+     * Generates specific pillar for the passed minion
+     * @param minion the minion server
+     */
+    public void generatePillar(MinionServer minion) {
+        generatePillar(minion, true, Collections.emptySet());
+    }
+
+    /**
+     * Generates specific pillar for the passed minion
+     * @param minion the minion server
+     * @param refreshAccessTokens if access tokens should be refreshed first
+     * @param tokensToActivate channels access tokens to activate when refreshing the tokens
+     */
+    public void generatePillar(MinionServer minion, boolean refreshAccessTokens,
+                               Collection<AccessToken> tokensToActivate) {
+        LOG.debug("Generating pillar file for minion: " + minion.getMinionId());
+
+        if (refreshAccessTokens) {
+            AccessTokenFactory.refreshTokens(minion, tokensToActivate);
+        }
+        this.pillarFileManagers.stream().forEach(m -> m.generatePillarFile(minion));
+    }
+
+    /**
+     * Removes the corresponding pillar files for the passed minion
+     * @param minionId the minion Id
+     */
+    public void removePillar(String minionId) {
+        this.pillarFileManagers.stream().forEach(m -> m.removePillarFile(minionId));
+    }
+
+}

--- a/java/code/src/com/suse/manager/webui/services/pillar/test/MinionGroupMembershipPillarGeneratorTest.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/test/MinionGroupMembershipPillarGeneratorTest.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.webui.services.pillar.test;
+
+import com.redhat.rhn.common.conf.Config;
+import com.redhat.rhn.domain.entitlement.Entitlement;
+import com.redhat.rhn.domain.server.MinionServer;
+import com.redhat.rhn.domain.server.ServerFactory;
+import com.redhat.rhn.domain.server.ServerGroup;
+import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
+import com.redhat.rhn.domain.server.test.ServerGroupTest;
+import com.redhat.rhn.testing.BaseTestCaseWithUser;
+import com.redhat.rhn.testing.TestUtils;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.FileInputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.suse.manager.webui.services.SaltConstants.PILLAR_DATA_FILE_PREFIX;
+import static com.suse.manager.webui.services.SaltConstants.PILLAR_DATA_FILE_EXT;
+
+/**
+ * Tests for {@link MinionGroupMembershipPillarGenerator}
+ */
+public class MinionGroupMembershipPillarGeneratorTest extends BaseTestCaseWithUser {
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        Config.get().setString("server.secret_key",
+                DigestUtils.sha256Hex(TestUtils.randomString()));
+    }
+
+    public void testGenerateGroupMemebershipsPillarData() throws Exception {
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
+
+        ServerGroup group = ServerGroupTest.createTestServerGroup(user.getOrg(), null);
+        ServerFactory.addServerToGroup(minion, group);
+        ServerFactory.save(minion);
+        this.minionGroupMembershipPillarFileManager.generatePillarFile(minion);
+
+        Path filePath = tmpPillarRoot.resolve(PILLAR_DATA_FILE_PREFIX + "_" +
+        minion.getMinionId() + "_" + "group_memberships" + "." +
+            PILLAR_DATA_FILE_EXT);
+
+        assertTrue(Files.exists(filePath));
+
+        Map<String, Object> map;
+        try (FileInputStream fi = new FileInputStream(filePath.toFile())) {
+            map = new Yaml().loadAs(fi, Map.class);
+        }
+
+        assertTrue(map.containsKey("group_ids"));
+        List<Integer> groups = (List<Integer>) map.get("group_ids");
+        assertContains(groups.stream().map(id -> (long) id).collect(Collectors.toList()), group.getId());
+
+        assertTrue(map.containsKey("addon_group_types"));
+        List<String> addonGroupTypes = (List<String>) map.get("addon_group_types");
+
+        List<String> minionAddonEntitlements =
+                minion.getAddOnEntitlements().stream().map(Entitlement::getLabel).collect(Collectors.toList());
+
+        assertTrue(minionAddonEntitlements.stream().allMatch(g -> addonGroupTypes.contains(g)));
+        assertContains(addonGroupTypes, minion.getBaseEntitlement().getLabel());
+    }
+
+}

--- a/java/code/src/com/suse/manager/webui/services/pillar/test/MinionPillarManagerTest.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/test/MinionPillarManagerTest.java
@@ -1,0 +1,245 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.webui.services.pillar.test;
+
+import com.redhat.rhn.common.conf.Config;
+import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.server.MinionServer;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerFactory;
+import com.redhat.rhn.domain.server.ServerGroup;
+import com.redhat.rhn.domain.server.ServerPath;
+import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
+import com.redhat.rhn.domain.server.test.ServerGroupTest;
+import com.redhat.rhn.testing.BaseTestCaseWithUser;
+import com.redhat.rhn.testing.ChannelTestUtils;
+import com.redhat.rhn.testing.ServerTestUtils;
+import com.redhat.rhn.testing.TestUtils;
+
+import com.suse.manager.webui.services.pillar.MinionPillarManager;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.FileInputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+
+import static com.suse.manager.webui.services.SaltConstants.PILLAR_DATA_FILE_PREFIX;
+import static com.suse.manager.webui.services.SaltConstants.PILLAR_DATA_FILE_EXT;
+
+/**
+ * Tests for {@link MinionPillarManager}
+ */
+public class MinionPillarManagerTest extends BaseTestCaseWithUser {
+
+    protected MinionPillarManager minionPillarManager;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        Config.get().setString("server.secret_key",
+                DigestUtils.sha256Hex(TestUtils.randomString()));
+        minionPillarManager = new MinionPillarManager(
+                Arrays.asList(this.minionGeneralPillarFileManager, this.minionGroupMembershipPillarFileManager));
+    }
+
+    public void testGeneratePillarForServer() throws Exception {
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
+
+        ServerGroup group = ServerGroupTest.createTestServerGroup(user.getOrg(), null);
+        ServerFactory.addServerToGroup(minion, group);
+        String machineId = TestUtils.randomString();
+        minion.setDigitalServerId(machineId);
+
+        Channel channel1 = ChannelTestUtils.createBaseChannel(user);
+        minion.addChannel(channel1);
+
+        Channel channel2 = ChannelTestUtils.createBaseChannel(user);
+        minion.addChannel(channel2);
+
+        ServerFactory.save(minion);
+        minionPillarManager.generatePillar(minion);
+
+        Path filePath = tmpPillarRoot.resolve(
+                PILLAR_DATA_FILE_PREFIX + "_" +
+                minion.getMinionId() + "." +
+                PILLAR_DATA_FILE_EXT);
+
+        assertTrue(Files.exists(filePath));
+
+        Map<String, Object> map;
+        try (FileInputStream fi = new FileInputStream(filePath.toFile())) {
+            map = new Yaml().loadAs(fi, Map.class);
+        }
+
+        assertTrue(map.containsKey("org_id"));
+        assertEquals(minion.getOrg().getId(), Long.valueOf((int) map.get("org_id")));
+
+        assertTrue(map.containsKey("channels"));
+        Map<String, Object> channels = (Map<String, Object>) map.get("channels");
+        assertEquals(2, channels.size());
+        assertTrue(channels.containsKey(channel1.getLabel()));
+        assertTrue(channels.containsKey(channel2.getLabel()));
+
+        for (String chanLabel : channels.keySet()) {
+            Map<String, Object> values =  (Map<String, Object>) channels.get(chanLabel);
+
+            assertTrue(values.containsKey("alias"));
+            assertEquals("susemanager:" + chanLabel, (String) values.get("alias"));
+
+            assertTrue(values.containsKey("name"));
+            assertTrue(values.containsKey("enabled"));
+            assertEquals("1", (String) values.get("enabled"));
+
+            assertTrue(values.containsKey("autorefresh"));
+            assertEquals("1", (String) values.get("autorefresh"));
+
+            assertTrue(values.containsKey("host"));
+            assertEquals(ConfigDefaults.get().getCobblerHost(),
+                    (String) values.get("host"));
+
+            assertTrue(values.containsKey("token"));
+            assertFalse(((String) values.get("host")).isEmpty());
+
+            assertTrue(values.containsKey("type"));
+            assertEquals("rpm-md",
+                    (String) values.get("type"));
+
+            assertTrue(values.containsKey("gpgcheck"));
+            assertEquals("0", (String) values.get("gpgcheck"));
+
+            assertTrue(values.containsKey("repo_gpgcheck"));
+            assertEquals("0", (String) values.get("repo_gpgcheck"));
+
+            assertTrue(values.containsKey("pkg_gpgcheck"));
+            assertEquals("1", (String) values.get("pkg_gpgcheck"));
+        }
+    }
+
+    public void testGeneratePillarForServerGPGCheckOn() throws Exception {
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
+        Channel channel1 = ChannelTestUtils.createBaseChannel(user);
+        minion.addChannel(channel1);
+        ServerFactory.save(minion);
+
+        minionPillarManager.generatePillar(minion);
+
+        Path filePath = tmpPillarRoot
+                .resolve(PILLAR_DATA_FILE_PREFIX + "_" + minion.getMinionId() + "." + PILLAR_DATA_FILE_EXT);
+
+        assertTrue(Files.exists(filePath));
+
+        Map<String, Object> map;
+        try (FileInputStream fi = new FileInputStream(filePath.toFile())) {
+            map = new Yaml().loadAs(fi, Map.class);
+        }
+
+        Map<String, Object> channels = (Map<String, Object>) map.get("channels");
+        assertEquals(1, channels.size());
+        assertTrue(channels.containsKey(channel1.getLabel()));
+
+        Map<String, Object> values = (Map<String, Object>) channels.get(channel1.getLabel());
+
+        assertTrue(values.containsKey("pkg_gpgcheck"));
+        assertEquals("1", (String) values.get("pkg_gpgcheck"));
+    }
+
+    public void testGeneratePillarForServerGPGCheckOff() throws Exception {
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
+        Channel channel1 = ChannelTestUtils.createBaseChannel(user);
+        channel1.setGPGCheck(false);
+        minion.addChannel(channel1);
+        ServerFactory.save(minion);
+
+        minionPillarManager.generatePillar(minion);
+
+        Path filePath = tmpPillarRoot.resolve(
+            PILLAR_DATA_FILE_PREFIX + "_" +
+            minion.getMinionId() + "." +
+            PILLAR_DATA_FILE_EXT);
+
+        assertTrue(Files.exists(filePath));
+
+        Map<String, Object> map;
+        try (FileInputStream fi = new FileInputStream(filePath.toFile())) {
+            map = new Yaml().loadAs(fi, Map.class);
+        }
+
+        Map<String, Object> channels = (Map<String, Object>) map.get("channels");
+        assertEquals(1, channels.size());
+        assertTrue(channels.containsKey(channel1.getLabel()));
+
+        Map<String, Object> values = (Map<String, Object>) channels.get(channel1.getLabel());
+
+        assertTrue(values.containsKey("pkg_gpgcheck"));
+        assertEquals("0", (String) values.get("pkg_gpgcheck"));
+    }
+
+    /**
+     * Test that the "host" attribute of the channel of the minion connected to a proxy
+     * is populated with the proxy hostname.
+     *
+     * @throws Exception - if anything goes wrong
+     */
+    public void testGeneratePillarForProxyServer() throws Exception {
+        // create a minion
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
+
+        ServerGroup group = ServerGroupTest.createTestServerGroup(user.getOrg(), null);
+        ServerFactory.addServerToGroup(minion, group);
+        String machineId = TestUtils.randomString();
+        minion.setDigitalServerId(machineId);
+
+        // create a channel for the minion
+        Channel channel = ChannelTestUtils.createBaseChannel(user);
+        minion.addChannel(channel);
+        ServerFactory.save(minion);
+
+        // create proxy server
+        Server proxy = ServerTestUtils.createTestSystem();
+        String proxyHostname = "proxyHostname";
+
+        // create a serverPath linking the minion to the proxy
+        Set<ServerPath> proxyPaths = ServerFactory.createServerPaths(minion, proxy, proxyHostname);
+        minion.getServerPaths().addAll(proxyPaths);
+
+        // flush session & refresh the minion object
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().refresh(minion);
+
+        minionPillarManager.generatePillar(minion);
+
+        Path filePath = tmpPillarRoot.resolve(
+                PILLAR_DATA_FILE_PREFIX + "_" +
+                minion.getMinionId() + "." +
+                PILLAR_DATA_FILE_EXT);
+
+        Map<String, Object> map;
+        try (FileInputStream fi = new FileInputStream(filePath.toFile())) {
+            map = new Yaml().loadAs(fi, Map.class);
+        }
+
+        Map<String, Object> channels = (Map<String, Object>) map.get("channels");
+        assertEquals(1, channels.size());
+        Map<String, Object> channelFromFile = (Map<String, Object>) channels.values().iterator().next();
+        assertEquals(proxyHostname, channelFromFile.get("host"));
+    }
+
+}

--- a/java/code/src/com/suse/manager/webui/services/test/SaltStateGeneratorServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltStateGeneratorServiceTest.java
@@ -14,29 +14,25 @@
  */
 package com.suse.manager.webui.services.test;
 
+import static com.suse.manager.webui.services.SaltConstants.SALT_CONFIG_STATES_DIR;
+import static com.suse.manager.webui.services.SaltConstants.SALT_SERVER_STATE_FILE_PREFIX;
+import static com.suse.manager.webui.utils.SaltFileUtils.defaultExtension;
+
 import com.redhat.rhn.common.conf.Config;
-import com.redhat.rhn.common.conf.ConfigDefaults;
-import com.redhat.rhn.common.hibernate.HibernateFactory;
-import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.config.ConfigChannel;
 import com.redhat.rhn.domain.config.ConfigurationFactory;
-import com.redhat.rhn.domain.entitlement.Entitlement;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.Server;
-import com.redhat.rhn.domain.server.ServerFactory;
-import com.redhat.rhn.domain.server.ServerGroup;
-import com.redhat.rhn.domain.server.ServerPath;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
-import com.redhat.rhn.domain.server.test.ServerGroupTest;
 import com.redhat.rhn.domain.state.ServerStateRevision;
 import com.redhat.rhn.domain.state.StateFactory;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
-import com.redhat.rhn.testing.ChannelTestUtils;
 import com.redhat.rhn.testing.ConfigTestUtils;
-import com.redhat.rhn.testing.ServerTestUtils;
 import com.redhat.rhn.testing.TestUtils;
+
 import com.suse.manager.webui.services.ConfigChannelSaltManager;
 import com.suse.manager.webui.services.SaltStateGeneratorService;
+
 import org.apache.commons.codec.digest.DigestUtils;
 import org.yaml.snakeyaml.Yaml;
 
@@ -46,14 +42,6 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import static com.suse.manager.webui.utils.SaltFileUtils.defaultExtension;
-import static com.suse.manager.webui.services.SaltConstants.PILLAR_DATA_FILE_PREFIX;
-import static com.suse.manager.webui.services.SaltConstants.PILLAR_DATA_FILE_EXT;
-import static com.suse.manager.webui.services.SaltConstants.SALT_CONFIG_STATES_DIR;
-import static com.suse.manager.webui.services.SaltConstants.SALT_SERVER_STATE_FILE_PREFIX;
 
 /**
  * Tests for {@link SaltStateGeneratorService}
@@ -65,224 +53,6 @@ public class SaltStateGeneratorServiceTest extends BaseTestCaseWithUser {
         super.setUp();
         Config.get().setString("server.secret_key",
                 DigestUtils.sha256Hex(TestUtils.randomString()));
-    }
-
-    public void testGenerateGroupMemebershipsPillarData() throws Exception {
-        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
-
-        ServerGroup group = ServerGroupTest.createTestServerGroup(user.getOrg(), null);
-        ServerFactory.addServerToGroup(minion, group);
-        ServerFactory.save(minion);
-        SaltStateGeneratorService.INSTANCE.generateGroupMemebershipsPillarData(minion);
-
-        Path filePath = tmpPillarRoot.resolve(PILLAR_DATA_FILE_PREFIX + "_" +
-        minion.getMinionId() + "_" + "group_memberships" + "." +
-            PILLAR_DATA_FILE_EXT);
-
-        assertTrue(Files.exists(filePath));
-
-        Map<String, Object> map;
-        try (FileInputStream fi = new FileInputStream(filePath.toFile())) {
-            map = new Yaml().loadAs(fi, Map.class);
-        }
-
-        assertTrue(map.containsKey("group_ids"));
-        List<Integer> groups = (List<Integer>) map.get("group_ids");
-        assertContains(groups.stream().map(id -> (long) id)
-                .collect(Collectors.toList()), group.getId());
-
-        assertTrue(map.containsKey("addon_group_types"));
-        List<String> addonGroupTypes = (List<String>) map.get("addon_group_types");
-
-        List<String> minionAddonEntitlements =
-                minion.getAddOnEntitlements().stream().map(Entitlement::getLabel).collect(Collectors.toList());
-
-        assertTrue(minionAddonEntitlements.stream().allMatch(g -> addonGroupTypes.contains(g)));
-        assertContains(addonGroupTypes, minion.getBaseEntitlement().getLabel());
-    }
-
-    public void testGeneratePillarForServer() throws Exception {
-        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
-
-        ServerGroup group = ServerGroupTest.createTestServerGroup(user.getOrg(), null);
-        ServerFactory.addServerToGroup(minion, group);
-        String machineId = TestUtils.randomString();
-        minion.setDigitalServerId(machineId);
-
-        Channel channel1 = ChannelTestUtils.createBaseChannel(user);
-        minion.addChannel(channel1);
-
-        Channel channel2 = ChannelTestUtils.createBaseChannel(user);
-        minion.addChannel(channel2);
-
-        ServerFactory.save(minion);
-        SaltStateGeneratorService.INSTANCE.generatePillar(minion);
-
-        Path filePath = tmpPillarRoot.resolve(
-                PILLAR_DATA_FILE_PREFIX + "_" +
-                minion.getMinionId() + "." +
-                PILLAR_DATA_FILE_EXT);
-
-        assertTrue(Files.exists(filePath));
-
-        Map<String, Object> map;
-        try (FileInputStream fi = new FileInputStream(filePath.toFile())) {
-            map = new Yaml().loadAs(fi, Map.class);
-        }
-
-        assertTrue(map.containsKey("org_id"));
-        assertEquals(minion.getOrg().getId(), Long.valueOf((int) map.get("org_id")));
-
-        assertTrue(map.containsKey("channels"));
-        Map<String, Object> channels = (Map<String, Object>) map.get("channels");
-        assertEquals(2, channels.size());
-        assertTrue(channels.containsKey(channel1.getLabel()));
-        assertTrue(channels.containsKey(channel2.getLabel()));
-
-        for (String chanLabel : channels.keySet()) {
-            Map<String, Object> values =  (Map<String, Object>) channels.get(chanLabel);
-
-            assertTrue(values.containsKey("alias"));
-            assertEquals("susemanager:" + chanLabel, (String) values.get("alias"));
-
-            assertTrue(values.containsKey("name"));
-            assertTrue(values.containsKey("enabled"));
-            assertEquals("1", (String) values.get("enabled"));
-
-            assertTrue(values.containsKey("autorefresh"));
-            assertEquals("1", (String) values.get("autorefresh"));
-
-            assertTrue(values.containsKey("host"));
-            assertEquals(ConfigDefaults.get().getCobblerHost(),
-                    (String) values.get("host"));
-
-            assertTrue(values.containsKey("token"));
-            assertFalse(((String) values.get("host")).isEmpty());
-
-            assertTrue(values.containsKey("type"));
-            assertEquals("rpm-md",
-                    (String) values.get("type"));
-
-            assertTrue(values.containsKey("gpgcheck"));
-            assertEquals("0", (String) values.get("gpgcheck"));
-
-            assertTrue(values.containsKey("repo_gpgcheck"));
-            assertEquals("0", (String) values.get("repo_gpgcheck"));
-
-            assertTrue(values.containsKey("pkg_gpgcheck"));
-            assertEquals("1", (String) values.get("pkg_gpgcheck"));
-        }
-    }
-
-    public void testGeneratePillarForServerGPGCheckOn() throws Exception {
-        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
-        Channel channel1 = ChannelTestUtils.createBaseChannel(user);
-        minion.addChannel(channel1);
-        ServerFactory.save(minion);
-
-        SaltStateGeneratorService.INSTANCE.generatePillar(minion);
-
-        Path filePath = tmpPillarRoot.resolve(
-                PILLAR_DATA_FILE_PREFIX + "_" +
-                minion.getMinionId() + "." +
-                PILLAR_DATA_FILE_EXT);
-
-        assertTrue(Files.exists(filePath));
-
-        Map<String, Object> map;
-        try (FileInputStream fi = new FileInputStream(filePath.toFile())) {
-            map = new Yaml().loadAs(fi, Map.class);
-        }
-
-        Map<String, Object> channels = (Map<String, Object>) map.get("channels");
-        assertEquals(1, channels.size());
-        assertTrue(channels.containsKey(channel1.getLabel()));
-
-        Map<String, Object> values = (Map<String, Object>) channels.get(channel1.getLabel());
-
-        assertTrue(values.containsKey("pkg_gpgcheck"));
-        assertEquals("1", (String) values.get("pkg_gpgcheck"));
-    }
-
-    public void testGeneratePillarForServerGPGCheckOff() throws Exception {
-        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
-        Channel channel1 = ChannelTestUtils.createBaseChannel(user);
-        channel1.setGPGCheck(false);
-        minion.addChannel(channel1);
-        ServerFactory.save(minion);
-
-        SaltStateGeneratorService.INSTANCE.generatePillar(minion);
-
-        Path filePath = tmpPillarRoot.resolve(
-            PILLAR_DATA_FILE_PREFIX + "_" +
-            minion.getMinionId() + "." +
-            PILLAR_DATA_FILE_EXT);
-
-        assertTrue(Files.exists(filePath));
-
-        Map<String, Object> map;
-        try (FileInputStream fi = new FileInputStream(filePath.toFile())) {
-            map = new Yaml().loadAs(fi, Map.class);
-        }
-
-        Map<String, Object> channels = (Map<String, Object>) map.get("channels");
-        assertEquals(1, channels.size());
-        assertTrue(channels.containsKey(channel1.getLabel()));
-
-        Map<String, Object> values = (Map<String, Object>) channels.get(channel1.getLabel());
-
-        assertTrue(values.containsKey("pkg_gpgcheck"));
-        assertEquals("0", (String) values.get("pkg_gpgcheck"));
-    }
-
-    /**
-     * Test that the "host" attribute of the channel of the minion connected to a proxy
-     * is populated with the proxy hostname.
-     *
-     * @throws Exception - if anything goes wrong
-     */
-    public void testGeneratePillarForProxyServer() throws Exception {
-        // create a minion
-        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
-
-        ServerGroup group = ServerGroupTest.createTestServerGroup(user.getOrg(), null);
-        ServerFactory.addServerToGroup(minion, group);
-        String machineId = TestUtils.randomString();
-        minion.setDigitalServerId(machineId);
-
-        // create a channel for the minion
-        Channel channel = ChannelTestUtils.createBaseChannel(user);
-        minion.addChannel(channel);
-        ServerFactory.save(minion);
-
-        // create proxy server
-        Server proxy = ServerTestUtils.createTestSystem();
-        String proxyHostname = "proxyHostname";
-
-        // create a serverPath linking the minion to the proxy
-        Set<ServerPath> proxyPaths = ServerFactory.createServerPaths(minion, proxy, proxyHostname);
-        minion.getServerPaths().addAll(proxyPaths);
-
-        // flush session & refresh the minion object
-        HibernateFactory.getSession().flush();
-        HibernateFactory.getSession().refresh(minion);
-
-        SaltStateGeneratorService.INSTANCE.generatePillar(minion);
-
-        Path filePath = tmpPillarRoot.resolve(
-                PILLAR_DATA_FILE_PREFIX + "_" +
-                minion.getMinionId() + "." +
-                PILLAR_DATA_FILE_EXT);
-
-        Map<String, Object> map;
-        try (FileInputStream fi = new FileInputStream(filePath.toFile())) {
-            map = new Yaml().loadAs(fi, Map.class);
-        }
-
-        Map<String, Object> channels = (Map<String, Object>) map.get("channels");
-        assertEquals(1, channels.size());
-        Map<String, Object> channelFromFile = (Map<String, Object>) channels.values().iterator().next();
-        assertEquals(proxyHostname, channelFromFile.get("host"));
     }
 
     public void testGenerateServerConfigState() throws Exception {


### PR DESCRIPTION
## What does this PR change?

Extract generation of minion pillar files

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added / updated

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/10671

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
