### PR TITLE
Extract functionality to add/remove entitlements to/from servers

### DIFF
--- a/java/code/src/com/redhat/rhn/common/security/acl/test/AccessTest.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/test/AccessTest.java
@@ -28,6 +28,8 @@ import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.domain.user.legacy.UserImpl;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.ServerTestUtils;
 import com.redhat.rhn.testing.TestUtils;
@@ -220,7 +222,7 @@ public class AccessTest extends BaseTestCaseWithUser {
         assertTrue(acl.evalAcl(context, "system_has_salt_entitlement()"));
 
         // Change the base entitlement to MANAGEMENT
-        s.setBaseEntitlement(EntitlementManager.MANAGEMENT);
+        SystemEntitlementManager.INSTANCE.setBaseEntitlement(s, EntitlementManager.MANAGEMENT);
         context.put("sid", new String[] {s.getId().toString()});
         context.put("user", user);
         assertFalse(acl.evalAcl(context, "system_has_salt_entitlement()"));

--- a/java/code/src/com/redhat/rhn/domain/entitlement/test/BaseEntitlementTestCase.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/test/BaseEntitlementTestCase.java
@@ -17,6 +17,8 @@ package com.redhat.rhn.domain.entitlement.test;
 import com.redhat.rhn.domain.entitlement.Entitlement;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.ServerTestUtils;
 
@@ -43,8 +45,8 @@ public abstract class BaseEntitlementTestCase extends BaseTestCaseWithUser {
         Server traditional = ServerTestUtils.createTestSystem(user);
         Server foreign = ServerTestUtils.createForeignSystem(user, "9999");
 
-        traditional.setBaseEntitlement(EntitlementManager.MANAGEMENT);
-        foreign.setBaseEntitlement(EntitlementManager.FOREIGN);
+        SystemEntitlementManager.INSTANCE.setBaseEntitlement(traditional, EntitlementManager.MANAGEMENT);
+        SystemEntitlementManager.INSTANCE.setBaseEntitlement(foreign, EntitlementManager.FOREIGN);
 
         assertTrue(traditional.getValidAddonEntitlementsForServer().size() > 0);
         assertTrue(foreign.getValidAddonEntitlementsForServer().size() == 0);
@@ -54,8 +56,8 @@ public abstract class BaseEntitlementTestCase extends BaseTestCaseWithUser {
         Server traditional = ServerTestUtils.createTestSystem(user);
         Server foreign = ServerTestUtils.createForeignSystem(user, "9999");
 
-        traditional.setBaseEntitlement(EntitlementManager.MANAGEMENT);
-        foreign.setBaseEntitlement(EntitlementManager.FOREIGN);
+        SystemEntitlementManager.INSTANCE.setBaseEntitlement(traditional, EntitlementManager.MANAGEMENT);
+        SystemEntitlementManager.INSTANCE.setBaseEntitlement(foreign, EntitlementManager.FOREIGN);
 
         assertTrue(ent.isAllowedOnServer(traditional, null));
         assertFalse(ent.isAllowedOnServer(foreign, null));

--- a/java/code/src/com/redhat/rhn/domain/entitlement/test/ContainerBuildHostEntitlementTest.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/test/ContainerBuildHostEntitlementTest.java
@@ -19,6 +19,8 @@ import com.redhat.rhn.domain.entitlement.ContainerBuildHostEntitlement;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.testing.ServerTestUtils;
 
 import com.suse.manager.reactor.utils.ValueMap;
@@ -45,8 +47,8 @@ public class ContainerBuildHostEntitlementTest extends BaseEntitlementTestCase {
         minion.setOs("SLES");
         minion.setRelease("12.2");
 
-        traditional.setBaseEntitlement(EntitlementManager.MANAGEMENT);
-        minion.setBaseEntitlement(EntitlementManager.SALT);
+        SystemEntitlementManager.INSTANCE.setBaseEntitlement(traditional, EntitlementManager.MANAGEMENT);
+        SystemEntitlementManager.INSTANCE.setBaseEntitlement(minion, EntitlementManager.SALT);
 
         assertTrue(ent.isAllowedOnServer(minion));
         assertFalse(ent.isAllowedOnServer(traditional));
@@ -69,7 +71,7 @@ public class ContainerBuildHostEntitlementTest extends BaseEntitlementTestCase {
         grains.put("osmajorrelease", "7");
         assertTrue(ent.isAllowedOnServer(minion, new ValueMap(grains)));
 
-        minion.setBaseEntitlement(EntitlementManager.MANAGEMENT);
+        SystemEntitlementManager.INSTANCE.setBaseEntitlement(minion, EntitlementManager.MANAGEMENT);
         assertFalse(ent.isAllowedOnServer(minion, new ValueMap(grains)));
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/entitlement/test/OSImageBuildHostEntitlementTest.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/test/OSImageBuildHostEntitlementTest.java
@@ -6,6 +6,7 @@ import com.redhat.rhn.domain.entitlement.OSImageBuildHostEntitlement;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.testing.ServerTestUtils;
 
 import com.suse.manager.reactor.utils.ValueMap;
@@ -37,8 +38,8 @@ public class OSImageBuildHostEntitlementTest extends BaseEntitlementTestCase {
         minion.setOs("SLES");
         minion.setRelease("12.2");
 
-        traditional.setBaseEntitlement(EntitlementManager.MANAGEMENT);
-        minion.setBaseEntitlement(EntitlementManager.SALT);
+        SystemEntitlementManager.INSTANCE.setBaseEntitlement(traditional, EntitlementManager.MANAGEMENT);
+        SystemEntitlementManager.INSTANCE.setBaseEntitlement(minion, EntitlementManager.SALT);
 
         assertTrue(ent.isAllowedOnServer(minion));
         assertFalse(ent.isAllowedOnServer(traditional));
@@ -61,7 +62,7 @@ public class OSImageBuildHostEntitlementTest extends BaseEntitlementTestCase {
         grains.put("osmajorrelease", "7");
         assertTrue(ent.isAllowedOnServer(minion, new ValueMap(grains)));
 
-        minion.setBaseEntitlement(EntitlementManager.MANAGEMENT);
+        SystemEntitlementManager.INSTANCE.setBaseEntitlement(minion, EntitlementManager.MANAGEMENT);
         assertFalse(ent.isAllowedOnServer(minion, new ValueMap(grains)));
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/entitlement/test/VirtualizationEntitlementTest.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/test/VirtualizationEntitlementTest.java
@@ -19,6 +19,7 @@ import com.redhat.rhn.domain.entitlement.VirtualizationEntitlement;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.testing.ServerTestUtils;
 
 import com.suse.manager.reactor.utils.ValueMap;
@@ -42,7 +43,7 @@ public class VirtualizationEntitlementTest extends BaseEntitlementTestCase {
     public void testIsAllowedOnServer() throws Exception {
         Server host = ServerTestUtils.createVirtHostWithGuests(1);
         Server guest = host.getGuests().iterator().next().getGuestSystem();
-        guest.setBaseEntitlement(EntitlementManager.MANAGEMENT);
+        SystemEntitlementManager.INSTANCE.setBaseEntitlement(guest, EntitlementManager.MANAGEMENT);
 
         assertTrue(ent.isAllowedOnServer(host));
         assertFalse(ent.isAllowedOnServer(guest));
@@ -51,7 +52,7 @@ public class VirtualizationEntitlementTest extends BaseEntitlementTestCase {
     @Override
     public void testIsAllowedOnServerWithGrains() throws Exception {
         Server minion = MinionServerFactoryTest.createTestMinionServer(user);
-        minion.setBaseEntitlement(EntitlementManager.SALT);
+        SystemEntitlementManager.INSTANCE.setBaseEntitlement(minion, EntitlementManager.SALT);
 
         Map<String, Object> grains = new HashMap<>();
         grains.put("virtual", "physical");

--- a/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
@@ -14,6 +14,32 @@
  */
 package com.redhat.rhn.domain.formula;
 
+import com.redhat.rhn.common.validator.ValidatorError;
+import com.redhat.rhn.domain.org.Org;
+import com.redhat.rhn.domain.server.MinionServer;
+import com.redhat.rhn.domain.server.MinionServerFactory;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerFactory;
+import com.redhat.rhn.domain.server.ServerGroup;
+import com.redhat.rhn.domain.server.ServerGroupFactory;
+import com.redhat.rhn.manager.entitlement.EntitlementManager;
+import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.suse.manager.webui.controllers.ECMAScriptDateAdapter;
+import com.suse.utils.Opt;
+
+import org.apache.log4j.Logger;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+import org.yaml.snakeyaml.error.YAMLException;
+
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -35,32 +61,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import com.redhat.rhn.common.validator.ValidatorError;
-import com.redhat.rhn.domain.server.MinionServerFactory;
-import com.redhat.rhn.domain.server.Server;
-import com.suse.utils.Opt;
-import org.apache.log4j.Logger;
-import org.yaml.snakeyaml.Yaml;
-import org.yaml.snakeyaml.constructor.SafeConstructor;
-import org.yaml.snakeyaml.error.YAMLException;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonPrimitive;
-import com.google.gson.JsonSerializationContext;
-import com.google.gson.JsonSerializer;
-
-import com.redhat.rhn.domain.org.Org;
-import com.redhat.rhn.domain.server.MinionServer;
-import com.redhat.rhn.domain.server.ServerFactory;
-import com.redhat.rhn.domain.server.ServerGroup;
-import com.redhat.rhn.domain.server.ServerGroupFactory;
-import com.redhat.rhn.manager.entitlement.EntitlementManager;
-import com.redhat.rhn.manager.system.SystemManager;
-
-import com.suse.manager.webui.controllers.ECMAScriptDateAdapter;
 
 /**
  * Factory class for working with formulas.
@@ -103,6 +103,8 @@ public class FormulaFactory {
             .serializeNulls()
             .create();
     private static final Yaml YAML = new Yaml(new SafeConstructor());
+
+    private static SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
 
     private FormulaFactory() { }
 
@@ -262,7 +264,7 @@ public class FormulaFactory {
             minions.forEach(minion -> {
                 if (!hasMonitoringDataEnabled(formData)) {
                     if (!serverHasMonitoringFormulaEnabled(minion)) {
-                        SystemManager.removeServerEntitlement(minion, EntitlementManager.MONITORING);
+                        systemEntitlementManager.removeServerEntitlement(minion, EntitlementManager.MONITORING);
                     }
                 }
                 else {
@@ -278,8 +280,8 @@ public class FormulaFactory {
      */
     public static void grantMonitoringEntitlement(Server server) {
         boolean hasEntitlement = SystemManager.hasEntitlement(server.getId(), EntitlementManager.MONITORING);
-        if (!hasEntitlement && SystemManager.canEntitleServer(server, EntitlementManager.MONITORING)) {
-            SystemManager.entitleServer(server, EntitlementManager.MONITORING);
+        if (!hasEntitlement && systemEntitlementManager.canEntitleServer(server, EntitlementManager.MONITORING)) {
+            systemEntitlementManager.addEntitlementToServer(server, EntitlementManager.MONITORING);
             return;
         }
         if (LOG.isDebugEnabled() && hasEntitlement) {
@@ -308,12 +310,12 @@ public class FormulaFactory {
                                 " Not removing monitoring entitlement.", minionId));
                     }
                     else {
-                        SystemManager.removeServerEntitlement(s, EntitlementManager.MONITORING);
+                        systemEntitlementManager.removeServerEntitlement(s, EntitlementManager.MONITORING);
                     }
                 }
                 else if (!SystemManager.hasEntitlement(s.getId(), EntitlementManager.MONITORING) &&
-                        SystemManager.canEntitleServer(s, EntitlementManager.MONITORING)) {
-                    SystemManager.entitleServer(s, EntitlementManager.MONITORING);
+                        systemEntitlementManager.canEntitleServer(s, EntitlementManager.MONITORING)) {
+                    systemEntitlementManager.addEntitlementToServer(s, EntitlementManager.MONITORING);
                 }
             });
         }
@@ -562,7 +564,7 @@ public class FormulaFactory {
             minions.forEach(minion -> {
                 // remove entitlement only if formula not enabled at server level
                 if (!serverHasMonitoringFormulaEnabled(minion)) {
-                    SystemManager.removeServerEntitlement(minion, EntitlementManager.MONITORING);
+                    systemEntitlementManager.removeServerEntitlement(minion, EntitlementManager.MONITORING);
                 }
             });
         }
@@ -645,7 +647,7 @@ public class FormulaFactory {
         if (deletedFormulas.contains(PROMETHEUS_EXPORTERS)) {
             MinionServerFactory.findByMinionId(minionId).ifPresent(s -> {
                 if (!isMemberOfGroupHavingMonitoring(s)) {
-                    SystemManager.removeServerEntitlement(s, EntitlementManager.MONITORING);
+                    systemEntitlementManager.removeServerEntitlement(s, EntitlementManager.MONITORING);
                 }
             });
         }

--- a/java/code/src/com/redhat/rhn/domain/image/test/ImageInfoFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/image/test/ImageInfoFactoryTest.java
@@ -45,6 +45,8 @@ import com.redhat.rhn.domain.token.ActivationKey;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
@@ -76,6 +78,7 @@ public class ImageInfoFactoryTest extends BaseTestCaseWithUser {
     }};
 
     private static TaskomaticApi taskomaticApi;
+    private SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
 
     @Override
     public void setUp() throws Exception {
@@ -290,7 +293,7 @@ public class ImageInfoFactoryTest extends BaseTestCaseWithUser {
 
         assertEquals(0, ImageInfoFactory.listImageInfos(user.getOrg()).size());
 
-        SystemManager.entitleServer(buildHost, EntitlementManager.CONTAINER_BUILD_HOST);
+        systemEntitlementManager.addEntitlementToServer(buildHost, EntitlementManager.CONTAINER_BUILD_HOST);
 
         // Schedule
         ImageInfoFactory.scheduleBuild(buildHost.getId(), "v1.0", profile, new Date(),
@@ -394,7 +397,7 @@ public class ImageInfoFactoryTest extends BaseTestCaseWithUser {
 
         assertNull(info.getInspectAction());
 
-        SystemManager.entitleServer(buildHost, EntitlementManager.CONTAINER_BUILD_HOST);
+        systemEntitlementManager.addEntitlementToServer(buildHost, EntitlementManager.CONTAINER_BUILD_HOST);
 
         // Schedule
         assertNotNull(ImageInfoFactory.scheduleInspect(info, new Date(), user));
@@ -428,7 +431,7 @@ public class ImageInfoFactoryTest extends BaseTestCaseWithUser {
         assertFalse(
                 ImageInfoFactory.lookupByName("myimage", "1.0", store.getId()).isPresent());
 
-        SystemManager.entitleServer(buildHost, EntitlementManager.CONTAINER_BUILD_HOST);
+        systemEntitlementManager.addEntitlementToServer(buildHost, EntitlementManager.CONTAINER_BUILD_HOST);
 
         // Schedule
         assertNotNull(ImageInfoFactory.scheduleImport(buildHost.getId(), "myimage", "1.0",

--- a/java/code/src/com/redhat/rhn/domain/server/Server.java
+++ b/java/code/src/com/redhat/rhn/domain/server/Server.java
@@ -35,6 +35,7 @@ import com.redhat.rhn.manager.configuration.ConfigurationManager;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.kickstart.cobbler.CobblerXMLRPCHelper;
 import com.redhat.rhn.manager.system.SystemManager;
+
 import com.suse.utils.Opt;
 import java.net.IDN;
 import java.sql.Timestamp;
@@ -1401,26 +1402,6 @@ public class Server extends BaseDomainHelper implements Identifiable {
 
        return serverGroupTypes.stream().filter(ServerGroupType::isBase).findFirst()
                 .map(ServerGroupType::getId);
-    }
-
-    /**
-     * Base entitlement for the Server.
-     * @param baseIn to update to
-     */
-    public void setBaseEntitlement(Entitlement baseIn) {
-        if (!baseIn.isBase()) {
-            throw new IllegalArgumentException("baseIn is not a base entitlement");
-        }
-
-        Entitlement baseEntitlement = this.getBaseEntitlement();
-        if (baseEntitlement != null && baseIn.equals(baseEntitlement)) {
-            // noop if there is no change
-            return;
-        }
-        if (baseEntitlement != null) {
-            SystemManager.removeServerEntitlement(this, baseEntitlement);
-        }
-        SystemManager.entitleServer(this, baseIn);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
@@ -25,6 +25,7 @@ import com.redhat.rhn.common.db.datasource.WriteMode;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.validator.ValidatorError;
 import com.redhat.rhn.domain.channel.ChannelArch;
+import com.redhat.rhn.domain.entitlement.Entitlement;
 import com.redhat.rhn.domain.org.CustomDataKey;
 import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.rhnpackage.PackageEvrFactory;
@@ -361,6 +362,24 @@ public class ServerFactory extends HibernateFactory {
      */
     public static void addServerToGroup(Server serverIn, ServerGroup serverGroupIn) {
         addServersToGroup(Arrays.asList(serverIn), serverGroupIn);
+    }
+
+    /**
+     * Adds a server history event after an entitlement event occurred
+     * @param server the server
+     * @param ent the entitlement
+     * @param summary the summary of the event
+     */
+    public static void addServerHistoryWithEntitlementEvent(Server server, Entitlement ent, String summary) {
+        Map<String, Object> in = new HashMap<String, Object>();
+        in.put("sid", server.getId());
+        in.put("entitlement_label", ent.getLabel());
+        in.put("summary", summary);
+
+        WriteMode m = ModeFactory.getWriteMode("System_queries", "update_server_history_for_entitlement_event");
+        m.executeUpdate(in);
+
+        log.debug("update_server_history_for_entitlement_event mode query executed.");
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
@@ -73,6 +73,8 @@ import com.redhat.rhn.manager.rhnset.RhnSetDecl;
 import com.redhat.rhn.manager.rhnset.RhnSetManager;
 import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.manager.user.UserManager;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.ChannelTestUtils;
@@ -109,6 +111,8 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
     public static final int TYPE_SERVER_MINION = 4;
     public static final String RUNNING_KERNEL = "2.6.9-55.EL";
     public static final String HOSTNAME = "foo.bar.com";
+
+    private static SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
 
     @Override
     public void setUp() throws Exception {
@@ -527,7 +531,7 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
      */
     public void aTestServerHasSpecificEntitlement() throws Exception {
         Server s = createTestServer(user);
-        SystemManager.entitleServer(s, EntitlementManager.VIRTUALIZATION);
+        systemEntitlementManager.addEntitlementToServer(s, EntitlementManager.VIRTUALIZATION);
         assertTrue(s.hasEntitlement(EntitlementManager.VIRTUALIZATION));
     }
 
@@ -584,15 +588,14 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
             }
             assertNotNull(mgmt);
             assertNotNull(mgmt.getGroupType().getAssociatedEntitlement());
-            SystemManager.entitleServer(newS,
-                    mgmt.getGroupType().getAssociatedEntitlement());
+            systemEntitlementManager.addEntitlementToServer(newS, mgmt.getGroupType().getAssociatedEntitlement());
         }
 
 
         EntitlementServerGroup sg = ServerGroupTestUtils.createEntitled(owner.getOrg(),
                                                                         type);
 
-        SystemManager.entitleServer(newS, sg.getGroupType().getAssociatedEntitlement());
+        systemEntitlementManager.addEntitlementToServer(newS, sg.getGroupType().getAssociatedEntitlement());
         return TestUtils.saveAndReload(newS);
     }
 

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerTest.java
@@ -29,6 +29,9 @@ import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
+import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.redhat.rhn.manager.system.test.SystemManagerTest;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.ServerTestUtils;
@@ -47,6 +50,8 @@ import java.util.Optional;
  */
 public class ServerTest extends BaseTestCaseWithUser {
 
+    private SystemUnentitler systemUnentitler = SystemUnentitler.INSTANCE;
+
     public void testIsInactive() throws Exception {
         Server s = ServerFactory.createServer();
         s.setServerInfo(new ServerInfo());
@@ -59,11 +64,11 @@ public class ServerTest extends BaseTestCaseWithUser {
 
     public void testSetBaseEntitlement() throws Exception {
         Server s = ServerTestUtils.createTestSystem(user);
-        SystemManager.removeAllServerEntitlements(s);
+        systemUnentitler.removeAllServerEntitlements(s);
         UserTestUtils.addManagement(s.getCreator().getOrg());
         HibernateFactory.getSession().clear();
         s = ServerFactory.lookupById(s.getId());
-        s.setBaseEntitlement(EntitlementManager.MANAGEMENT);
+        SystemEntitlementManager.INSTANCE.setBaseEntitlement(s, EntitlementManager.MANAGEMENT);
         TestUtils.saveAndFlush(s);
         s = reload(s);
         assertTrue(s.getBaseEntitlement().equals(EntitlementManager.MANAGEMENT));

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/SystemEntitlementsSubmitAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/SystemEntitlementsSubmitAction.java
@@ -30,6 +30,7 @@ import com.redhat.rhn.frontend.struts.StrutsDelegate;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.rhnset.RhnSetDecl;
 import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 
 import org.apache.log4j.Logger;
 import org.apache.struts.action.ActionForm;
@@ -56,6 +57,8 @@ public class SystemEntitlementsSubmitAction extends
         "systementitlements.jsp.add_entitlement";
     public static final String KEY_REMOVE_ENTITLED =
         "systementitlements.jsp.remove_entitlement";
+
+    private static SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
 
     /**
      * {@inheritDoc}
@@ -176,10 +179,9 @@ public class SystemEntitlementsSubmitAction extends
                 //if the system already has the entitlement, do nothing
                 //  if so, neither success nor failure count will be updated.
                 if (!server.hasEntitlement(ent)) {
-                    if (SystemManager.canEntitleServer(server, ent)) {
+                    if (systemEntitlementManager.canEntitleServer(server, ent)) {
                             log.debug("we can entitle.  Lets entitle to : " + ent);
-                            ValidatorResult vr =
-                                SystemManager.entitleServer(server, ent);
+                            ValidatorResult vr = systemEntitlementManager.addEntitlementToServer(server, ent);
                             log.debug("entitleServer.VE: " + vr.getMessage());
                             if (vr.getErrors().size() > 0) {
                                 failureCount++;
@@ -199,7 +201,7 @@ public class SystemEntitlementsSubmitAction extends
             else {
                 if (server.hasEntitlement(ent)) {
                     log.debug("removing entitlement");
-                    SystemManager.removeServerEntitlement(server, ent);
+                    systemEntitlementManager.removeServerEntitlement(server, ent);
                     successCount++;
                 }
             } //else

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/test/SystemEntitlementsSetupActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/test/SystemEntitlementsSetupActionTest.java
@@ -30,6 +30,8 @@ import com.redhat.rhn.frontend.action.systems.entitlements.SystemEntitlementsSet
 import com.redhat.rhn.frontend.struts.RequestContext;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.testing.ChannelTestUtils;
 import com.redhat.rhn.testing.RhnMockStrutsTestCase;
 import com.redhat.rhn.testing.ServerTestUtils;
@@ -55,6 +57,7 @@ public class SystemEntitlementsSetupActionTest extends RhnMockStrutsTestCase {
 
     private Mockery context = new Mockery();
     private SaltService saltServiceMock;
+    private SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
 
     @Override
     public void setUp() throws Exception {
@@ -62,7 +65,7 @@ public class SystemEntitlementsSetupActionTest extends RhnMockStrutsTestCase {
         Config.get().setBoolean(ConfigDefaults.KIWI_OS_IMAGE_BUILDING_ENABLED, "true");
         context.setImposteriser(ClassImposteriser.INSTANCE);
         saltServiceMock = context.mock(SaltService.class);
-        SystemManager.mockSaltService(saltServiceMock);
+        SystemEntitler.INSTANCE.setSaltService(saltServiceMock);
         setRequestPathInfo("/systems/SystemEntitlements");
         UserTestUtils.addManagement(user.getOrg());
         UserTestUtils.addVirtualization(user.getOrg());
@@ -94,7 +97,8 @@ public class SystemEntitlementsSetupActionTest extends RhnMockStrutsTestCase {
         server.addChannel(ch[1]);
 
         assertTrue(EntitlementManager.VIRTUALIZATION.isAllowedOnServer(server));
-        boolean hasErrors = SystemManager.entitleServer(server, EntitlementManager.VIRTUALIZATION).hasErrors();
+        boolean hasErrors =
+                systemEntitlementManager.addEntitlementToServer(server, EntitlementManager.VIRTUALIZATION).hasErrors();
 
         assertFalse(hasErrors);
         assertTrue(SystemManager.hasEntitlement(server.getId(), EntitlementManager.VIRTUALIZATION));
@@ -114,7 +118,8 @@ public class SystemEntitlementsSetupActionTest extends RhnMockStrutsTestCase {
         Server server = MinionServerFactoryTest.createTestMinionServer(user);
 
         assertTrue(EntitlementManager.CONTAINER_BUILD_HOST.isAllowedOnServer(server));
-        boolean hasErrors = SystemManager.entitleServer(server, EntitlementManager.CONTAINER_BUILD_HOST).hasErrors();
+        boolean hasErrors = systemEntitlementManager
+                .addEntitlementToServer(server, EntitlementManager.CONTAINER_BUILD_HOST).hasErrors();
 
         assertFalse(hasErrors);
         assertTrue(SystemManager.hasEntitlement(server.getId(), EntitlementManager.CONTAINER_BUILD_HOST));
@@ -142,7 +147,8 @@ public class SystemEntitlementsSetupActionTest extends RhnMockStrutsTestCase {
 
         assertTrue(EntitlementManager.OSIMAGE_BUILD_HOST.isAllowedOnServer(server));
 
-        boolean hasErrors = SystemManager.entitleServer(server, EntitlementManager.OSIMAGE_BUILD_HOST).hasErrors();
+        boolean hasErrors = systemEntitlementManager
+                .addEntitlementToServer(server, EntitlementManager.OSIMAGE_BUILD_HOST).hasErrors();
 
         assertFalse(hasErrors);
         assertTrue(SystemManager.hasEntitlement(server.getId(), EntitlementManager.OSIMAGE_BUILD_HOST));

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/test/SystemEntitlementsSubmitActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/test/SystemEntitlementsSubmitActionTest.java
@@ -28,6 +28,9 @@ import com.redhat.rhn.frontend.action.systems.entitlements.SystemEntitlementsSub
 import com.redhat.rhn.frontend.struts.RhnAction;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
+import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.redhat.rhn.testing.RhnPostMockStrutsTestCase;
 import com.redhat.rhn.testing.ServerTestUtils;
 
@@ -42,6 +45,9 @@ public class SystemEntitlementsSubmitActionTest extends RhnPostMockStrutsTestCas
                                    "system_entitlements.setToManagementEntitled";
     private static final String UNENTITLED =
                                     "system_entitlements.unentitle";
+
+    private SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
+
 
     /**
      * {@inheritDoc}
@@ -84,7 +90,7 @@ public class SystemEntitlementsSubmitActionTest extends RhnPostMockStrutsTestCas
         ServerFactory.save(server);
         OrgFactory.save(user.getOrg());
         UserFactory.save(user);
-        SystemManager.removeAllServerEntitlements(server);
+        systemEntitlementManager.removeAllServerEntitlements(server);
         assertFalse(SystemManager.hasEntitlement(server.getId(), ent));
 
         /*
@@ -152,7 +158,7 @@ public class SystemEntitlementsSubmitActionTest extends RhnPostMockStrutsTestCas
 
         Server server = ServerTestUtils.createVirtHostWithGuests(user, 1);
 
-        SystemManager.removeServerEntitlement(server, EntitlementManager.VIRTUALIZATION);
+        systemEntitlementManager.removeServerEntitlement(server, EntitlementManager.VIRTUALIZATION);
         ServerGroupTest.createTestServerGroup(user.getOrg(),
                 groupType);
 
@@ -182,7 +188,7 @@ public class SystemEntitlementsSubmitActionTest extends RhnPostMockStrutsTestCas
 
         assertTrue(SystemManager.hasEntitlement(server.getId(),
                                         EntitlementManager.MANAGEMENT));
-        SystemManager.entitleServer(server, ent);
+        systemEntitlementManager.addEntitlementToServer(server, ent);
 
         addRequestParameter("addOnEntitlement", selectKey);
         dispatch(SystemEntitlementsSubmitAction.KEY_REMOVE_ENTITLED, server);

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/test/SystemDetailsEditActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/test/SystemDetailsEditActionTest.java
@@ -24,6 +24,9 @@ import com.redhat.rhn.frontend.struts.RhnAction;
 import com.redhat.rhn.frontend.struts.RhnHelper;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
+import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.redhat.rhn.testing.ChannelTestUtils;
 import com.redhat.rhn.testing.RhnPostMockStrutsTestCase;
 import com.redhat.rhn.testing.ServerTestUtils;
@@ -42,6 +45,7 @@ import java.util.Set;
 public class SystemDetailsEditActionTest extends RhnPostMockStrutsTestCase {
 
     protected Server s;
+    private SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
 
     /**
      * {@inheritDoc}
@@ -131,7 +135,7 @@ public class SystemDetailsEditActionTest extends RhnPostMockStrutsTestCase {
     }
 
     public void testBaseEntitlementListForUnetitledSystem() throws Exception {
-        SystemManager.removeAllServerEntitlements(s);
+        systemEntitlementManager.removeAllServerEntitlements(s);
         TestUtils.saveAndFlush(s);
         actionPerform();
         verifyForward(RhnHelper.DEFAULT_FORWARD);
@@ -174,7 +178,7 @@ public class SystemDetailsEditActionTest extends RhnPostMockStrutsTestCase {
         UserTestUtils.addManagement(user.getOrg());
         Long id = s.getId();
         String name = s.getName();
-        SystemManager.removeAllServerEntitlements(s);
+        systemEntitlementManager.removeAllServerEntitlements(s);
         s = ServerFactory.lookupById(id);
         assertTrue(s.getBaseEntitlement() == null);
 
@@ -242,7 +246,7 @@ public class SystemDetailsEditActionTest extends RhnPostMockStrutsTestCase {
 
         while (i.hasNext()) {
             Entitlement e = (Entitlement) i.next();
-            SystemManager.entitleServer(s, e);
+            systemEntitlementManager.addEntitlementToServer(s, e);
             TestUtils.flushAndEvict(s);
             s = ServerFactory.lookupById(s.getId());
             request.addParameter(e.getLabel(), Boolean.FALSE.toString());

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/test/SystemOverviewActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/test/SystemOverviewActionTest.java
@@ -29,6 +29,9 @@ import com.redhat.rhn.domain.server.test.ServerFactoryTest;
 import com.redhat.rhn.domain.user.UserFactory;
 import com.redhat.rhn.manager.errata.cache.ErrataCacheManager;
 import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
+import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.redhat.rhn.testing.RhnMockStrutsTestCase;
 import com.redhat.rhn.testing.TestUtils;
 
@@ -43,6 +46,7 @@ import java.util.Date;
 public class SystemOverviewActionTest extends RhnMockStrutsTestCase {
 
     protected Server s;
+    private SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
 
     /**
      * {@inheritDoc}
@@ -100,7 +104,7 @@ public class SystemOverviewActionTest extends RhnMockStrutsTestCase {
     }
 
     public void testSystemUnentitled() throws Exception {
-       SystemManager.removeAllServerEntitlements(s);
+       systemEntitlementManager.removeAllServerEntitlements(s);
        actionPerform();
        assertEquals(request.getAttribute("unentitled"), Boolean.TRUE);
     }

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/virtualization/test/ProvisionVirtualizationWizardActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/virtualization/test/ProvisionVirtualizationWizardActionTest.java
@@ -40,6 +40,8 @@ import com.redhat.rhn.manager.kickstart.KickstartScheduleCommand;
 import com.redhat.rhn.manager.profile.test.ProfileManagerTest;
 import com.redhat.rhn.manager.rhnpackage.test.PackageManagerTest;
 import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.testing.RhnMockStrutsTestCase;
 import com.redhat.rhn.testing.ServerGroupTestUtils;
 import com.redhat.rhn.testing.TestUtils;
@@ -57,6 +59,7 @@ import junit.framework.AssertionFailedError;
 public class ProvisionVirtualizationWizardActionTest extends RhnMockStrutsTestCase {
 
     private Server s;
+    private SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
 
     /**
      * {@inheritDoc}
@@ -71,7 +74,7 @@ public class ProvisionVirtualizationWizardActionTest extends RhnMockStrutsTestCa
         s.addChannel(ChannelFactoryTest.createBaseChannel(user));
         EntitlementServerGroup sg = ServerGroupTestUtils.createEntitled(user.getOrg(),
                 ServerFactory.lookupServerGroupTypeByLabel("enterprise_entitled"));
-        SystemManager.entitleServer(s, sg.getGroupType().getAssociatedEntitlement());
+        systemEntitlementManager.addEntitlementToServer(s, sg.getGroupType().getAssociatedEntitlement());
         Channel c = ChannelFactoryTest.createTestChannel(user);
         // Required so the Server has a base channel
         // otherwise we cant ks.

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/test/ImageInfoHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/test/ImageInfoHandlerTest.java
@@ -53,6 +53,8 @@ import com.redhat.rhn.manager.action.ActionManager;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.errata.cache.ErrataCacheManager;
 import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 import com.redhat.rhn.testing.ImageTestUtils;
@@ -84,6 +86,7 @@ public class ImageInfoHandlerTest extends BaseHandlerTestCase {
     }};
 
     private static TaskomaticApi taskomaticApi;
+    private static SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
 
     @Override
     public void setUp() throws Exception {
@@ -133,7 +136,7 @@ public class ImageInfoHandlerTest extends BaseHandlerTestCase {
         ImageInfoFactory.setTaskomaticApi(getTaskomaticApi());
 
         MinionServer server = MinionServerFactoryTest.createTestMinionServer(admin);
-        SystemManager.entitleServer(server, EntitlementManager.CONTAINER_BUILD_HOST);
+        systemEntitlementManager.addEntitlementToServer(server, EntitlementManager.CONTAINER_BUILD_HOST);
         ImageStore store = createImageStore("registry.reg", admin);
         ActivationKey ak = createActivationKey(admin);
         ImageProfile prof = createImageProfile("myprofile", store, ak, admin);
@@ -153,7 +156,7 @@ public class ImageInfoHandlerTest extends BaseHandlerTestCase {
     public final void testScheduleOSImageBuild() throws Exception {
         ImageInfoFactory.setTaskomaticApi(getTaskomaticApi());
         SaltService saltServiceMock = CONTEXT.mock(SaltService.class);
-        SystemManager.mockSaltService(saltServiceMock);
+        SystemEntitler.INSTANCE.setSaltService(saltServiceMock);
         MgrUtilRunner.ExecResult mockResult = new MgrUtilRunner.ExecResult();
         CONTEXT.checking(new Expectations() {{
                 allowing(saltServiceMock).generateSSHKey(with(equal(SaltSSHService.SSH_KEY_PATH)));
@@ -164,7 +167,7 @@ public class ImageInfoHandlerTest extends BaseHandlerTestCase {
         MinionServer server = MinionServerFactoryTest.createTestMinionServer(admin);
         server.setServerArch(ServerFactory.lookupServerArchByLabel("x86_64-redhat-linux"));
         ServerFactory.save(server);
-        SystemManager.entitleServer(server, EntitlementManager.OSIMAGE_BUILD_HOST);
+        systemEntitlementManager.addEntitlementToServer(server, EntitlementManager.OSIMAGE_BUILD_HOST);
         ActivationKey ak = createActivationKey(admin);
         ImageProfile prof = createKiwiImageProfile("myprofile", ak, admin);
 

--- a/java/code/src/com/redhat/rhn/manager/action/test/ActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/action/test/ActionManagerTest.java
@@ -79,6 +79,8 @@ import com.redhat.rhn.manager.profile.test.ProfileManagerTest;
 import com.redhat.rhn.manager.rhnset.RhnSetDecl;
 import com.redhat.rhn.manager.rhnset.RhnSetManager;
 import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.manager.system.test.SystemManagerTest;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
@@ -123,6 +125,8 @@ import java.util.stream.Collectors;
 public class ActionManagerTest extends JMockBaseTestCaseWithUser {
     private static Logger log = Logger.getLogger(ActionManagerTest.class);
     private static TaskomaticApi taskomaticApi;
+    private SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
+
     private final Mockery MOCK_CONTEXT = new JUnit3Mockery() {{
         setThreadingPolicy(new Synchroniser());
         setImposteriser(ClassImposteriser.INSTANCE);
@@ -934,7 +938,7 @@ public class ActionManagerTest extends JMockBaseTestCaseWithUser {
         ImageInfoFactory.setTaskomaticApi(taskomaticMock);
 
         MinionServer server = MinionServerFactoryTest.createTestMinionServer(user);
-        SystemManager.entitleServer(server, EntitlementManager.CONTAINER_BUILD_HOST);
+        systemEntitlementManager.addEntitlementToServer(server, EntitlementManager.CONTAINER_BUILD_HOST);
         ImageStore store = createImageStore("registry.reg", user);
         ActivationKey ak = createActivationKey(user);
         ImageProfile prof = createImageProfile("myprofile", store, ak, user);

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerXMLRPCHelper.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerXMLRPCHelper.java
@@ -62,6 +62,7 @@ public class CobblerXMLRPCHelper implements XMLRPCInvoker {
      * @return Object returned.
      * @throws XmlRpcFault if expected error occurs
      */
+    @Override
     public Object invokeMethod(String procedureName, List args) throws XmlRpcFault {
         log.debug("procedure: " + procedureName + " Orig args: " + args);
         Object retval;

--- a/java/code/src/com/redhat/rhn/manager/org/test/MigrationManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/org/test/MigrationManagerTest.java
@@ -31,6 +31,9 @@ import com.redhat.rhn.domain.user.UserFactory;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.org.MigrationManager;
 import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
+import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.ConfigTestUtils;
 import com.redhat.rhn.testing.ServerTestUtils;
@@ -53,7 +56,9 @@ public class MigrationManagerTest extends BaseTestCaseWithUser {
     private Org destOrg;
     private Server server;  // virt host w/guests
     private Server server2; // server w/provisioning ent
+    private SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
 
+    @Override
     public void setUp() throws Exception {
         super.setUp();
 
@@ -205,7 +210,7 @@ public class MigrationManagerTest extends BaseTestCaseWithUser {
         User origOrgAdmin = origOrgAdmins.iterator().next();
         Server bootstrapServer = ServerFactoryTest.createUnentitledTestServer(origOrgAdmin,
             true, ServerFactoryTest.TYPE_SERVER_NORMAL, getNow());
-        SystemManager.entitleServer(bootstrapServer, EntitlementManager.BOOTSTRAP);
+        systemEntitlementManager.addEntitlementToServer(bootstrapServer, EntitlementManager.BOOTSTRAP);
 
         assertEquals(1, bootstrapServer.getEntitlements().size());
 

--- a/java/code/src/com/redhat/rhn/manager/system/entitling/SystemEntitlementManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/entitling/SystemEntitlementManager.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.manager.system.entitling;
+
+import com.redhat.rhn.common.validator.ValidatorResult;
+import com.redhat.rhn.domain.entitlement.Entitlement;
+import com.redhat.rhn.domain.server.Server;
+
+/**
+ * Manager class for adding/removing entitlements to/from servers
+ */
+public class SystemEntitlementManager {
+
+    public static final SystemEntitlementManager INSTANCE =
+            new SystemEntitlementManager(SystemUnentitler.INSTANCE, SystemEntitler.INSTANCE);
+
+    private SystemUnentitler systemUnentitler;
+    private SystemEntitler systemEntitler;
+
+    /**
+     * Constructor for SystemEntitlementManager
+     * @param systemUnentitlerIn a system unentitler
+     * @param systemEntitlerIn a system entitler
+     */
+    public SystemEntitlementManager(SystemUnentitler systemUnentitlerIn, SystemEntitler systemEntitlerIn) {
+        this.systemUnentitler = systemUnentitlerIn;
+        this.systemEntitler = systemEntitlerIn;
+    }
+
+    /**
+     * Checks whether or not a given server can be entitled with a specific entitlement
+     * @param server The server in question
+     * @param ent The entitlement to test
+     * @return Returns true or false depending on whether or not the server can be
+     * entitled to the passed in entitlement.
+     */
+    public boolean canEntitleServer(Server server, Entitlement ent) {
+        return this.systemEntitler.canEntitleServer(server, ent);
+    }
+
+    /**
+     * Entitles the given server to the given Entitlement
+     * @param server Server to be entitled
+     * @param ent Level of Entitlement
+     * @return ValidatorResult of errors and warnings
+     */
+    public ValidatorResult addEntitlementToServer(Server server, Entitlement ent) {
+        return this.systemEntitler.addEntitlementToServer(server, ent);
+    }
+
+    /**
+     * Removes all the entitlements related to a server
+     * @param server server to be unentitled
+     */
+    public void removeAllServerEntitlements(Server server) {
+        this.systemUnentitler.removeAllServerEntitlements(server);
+    }
+
+    /**
+     * Removes an entitlement from the given Server. If the given entitlement is the base entitlement,
+     * removes all entitlements from the Server.
+     * @param server the server
+     * @param ent the entitlement
+     */
+    public void removeServerEntitlement(Server server, Entitlement ent) {
+        this.systemUnentitler.removeServerEntitlement(server, ent);
+    }
+
+    /**
+     * Sets the base entitlement for the passed server
+     * @param server the server
+     * @param baseIn the base entitlement
+     */
+    public void setBaseEntitlement(Server server, Entitlement baseIn) {
+        if (!baseIn.isBase()) {
+            throw new IllegalArgumentException("baseIn is not a base entitlement");
+        }
+
+        Entitlement baseEntitlement = server.getBaseEntitlement();
+        if (baseEntitlement != null && baseIn.equals(baseEntitlement)) {
+            // noop if there is no change
+            return;
+        }
+        if (baseEntitlement != null) {
+            this.systemUnentitler.removeServerEntitlement(server, baseEntitlement);
+        }
+        this.systemEntitler.addEntitlementToServer(server, baseIn);
+    }
+}

--- a/java/code/src/com/redhat/rhn/manager/system/entitling/SystemEntitler.java
+++ b/java/code/src/com/redhat/rhn/manager/system/entitling/SystemEntitler.java
@@ -1,0 +1,335 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.manager.system.entitling;
+
+import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.common.validator.ValidatorError;
+import com.redhat.rhn.common.validator.ValidatorResult;
+import com.redhat.rhn.common.validator.ValidatorWarning;
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.entitlement.Entitlement;
+import com.redhat.rhn.domain.formula.FormulaFactory;
+import com.redhat.rhn.domain.org.Org;
+import com.redhat.rhn.domain.rhnpackage.PackageFactory;
+import com.redhat.rhn.domain.server.InstalledPackage;
+import com.redhat.rhn.domain.server.MinionServer;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerFactory;
+import com.redhat.rhn.domain.server.ServerGroup;
+import com.redhat.rhn.domain.server.ServerGroupFactory;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.domain.user.UserFactory;
+import com.redhat.rhn.manager.action.ActionManager;
+import com.redhat.rhn.manager.channel.ChannelManager;
+import com.redhat.rhn.manager.channel.MultipleChannelsWithPackageException;
+import com.redhat.rhn.manager.entitlement.EntitlementManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
+import com.redhat.rhn.taskomatic.TaskomaticApiException;
+
+import com.suse.manager.webui.services.impl.SaltSSHService;
+import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.utils.salt.State;
+
+import org.apache.log4j.Logger;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Class for adding entitlements to servers
+ */
+public class SystemEntitler {
+
+    private static final Logger LOG = Logger.getLogger(SystemEntitler.class);
+
+    public static final SystemEntitler INSTANCE = new SystemEntitler();
+
+    private SaltService saltService = SaltService.INSTANCE;
+
+    /**
+     * Checks whether or not a given server can be entitled with a specific entitlement
+     * @param server The server in question
+     * @param ent The entitlement to test
+     * @return Returns true or false depending on whether or not the server can be
+     * entitled to the passed in entitlement.
+     */
+    public boolean canEntitleServer(Server server, Entitlement ent) {
+        return findServerGroupToEntitleServer(server, ent).isPresent();
+    }
+
+    /**
+     * Entitles the given server to the given Entitlement.
+     * @param server Server to be entitled.
+     * @param ent Level of Entitlement.
+     * @return ValidatorResult of errors and warnings.
+     */
+    public ValidatorResult addEntitlementToServer(Server server, Entitlement ent) {
+        LOG.debug("Entitling: " + ent.getLabel());
+        ValidatorResult result = new ValidatorResult();
+
+        if (server.hasEntitlement(ent)) {
+            LOG.debug("server already entitled.");
+            result.addError(new ValidatorError("system.entitle.alreadyentitled",
+                    ent.getHumanReadableLabel()));
+            return result;
+        }
+
+        boolean wasVirtEntitled = server.hasEntitlement(EntitlementManager.VIRTUALIZATION);
+        if (EntitlementManager.VIRTUALIZATION.equals(ent)) {
+            if (server.isVirtualGuest()) {
+                result.addError(new ValidatorError("system.entitle.guestcantvirt"));
+                return result;
+            }
+
+            LOG.debug("setting up system for virt.");
+            ValidatorResult virtSetupResults = setupSystemForVirtualization(server.getOrg(), server.getId());
+            result.append(virtSetupResults);
+            if (virtSetupResults.getErrors().size() > 0) {
+                LOG.debug("error trying to setup virt ent: " + virtSetupResults.getMessage());
+                return result;
+            }
+        }
+        else if (EntitlementManager.OSIMAGE_BUILD_HOST.equals(ent)) {
+            saltService.generateSSHKey(SaltSSHService.SSH_KEY_PATH);
+        }
+
+        entitleServer(server, ent);
+
+        server.asMinionServer().ifPresent(minion -> {
+            ServerGroupManager.getInstance().updatePillarAfterGroupUpdateForServers(Arrays.asList(minion));
+
+            if (wasVirtEntitled && !EntitlementManager.VIRTUALIZATION.equals(ent) ||
+                    !wasVirtEntitled && EntitlementManager.VIRTUALIZATION.equals(ent)) {
+                this.updateLibvirtEngine(minion);
+            }
+
+            if (EntitlementManager.MONITORING.equals(ent)) {
+                try {
+                    // Assign the monitoring formula to the system
+                    // unless the system belongs to a group having monitoring already enabled
+                    if (!FormulaFactory.isMemberOfGroupHavingMonitoring(server)) {
+                        List<String> formulas = FormulaFactory.getFormulasByMinionId(minion.getMinionId());
+                        if (!formulas.contains(FormulaFactory.PROMETHEUS_EXPORTERS)) {
+                            formulas.add(FormulaFactory.PROMETHEUS_EXPORTERS);
+                            FormulaFactory.saveServerFormulas(minion.getMinionId(), formulas);
+                        }
+                    }
+                }
+                catch (UnsupportedOperationException | IOException e) {
+                    LOG.error("Error assigning formula: " + e.getMessage(), e);
+                    result.addError(new ValidatorError("system.entitle.formula_error"));
+                }
+            }
+        });
+
+        LOG.debug("done.  returning null");
+        return result;
+    }
+
+    private void entitleServer(Server server, Entitlement ent) {
+        Optional<ServerGroup> serverGroup = findServerGroupToEntitleServer(server, ent);
+
+        if (serverGroup.isPresent()) {
+            ServerFactory.addServerHistoryWithEntitlementEvent(server, ent, "added system entitlement ");
+            ServerFactory.addServerToGroup(server, serverGroup.get());
+        }
+        else {
+            LOG.error("Cannot add entitlement: " + ent.getLabel() + " to system: " + server.getId());
+        }
+    }
+
+    private Optional<ServerGroup> findServerGroupToEntitleServer(Server server, Entitlement ent) {
+        Set<Entitlement> entitlements = server.getEntitlements();
+
+        if (entitlements.isEmpty()) {
+            return findServerGroupToEntitleAnUnentitledServer(server.getId(), ent);
+        }
+        return findServerGroupToEntitleAnEntitledServer(server, ent);
+    }
+
+    private Optional<ServerGroup> findServerGroupToEntitleAnUnentitledServer(Long serverId, Entitlement ent) {
+        if (ent.isBase()) {
+            Optional<ServerGroup> serverGroup = ServerGroupFactory
+                    .findCompatibleServerGroupForBaseEntitlement(serverId, ent);
+            if (!serverGroup.isPresent()) {
+                LOG.warn("Could not find a compatible ServerGroup for base entitlement: " + ent.getLabel() +
+                        ", and server: " + serverId);
+            }
+            return serverGroup;
+        }
+        return Optional.empty();
+    }
+
+    private Optional<ServerGroup> findServerGroupToEntitleAnEntitledServer(Server server, Entitlement ent) {
+        if (ent.isBase()) {
+            LOG.warn("Cannot set a base entitlement: " + ent.getLabel() + " as an addon entitlement for server: " +
+                    server.getId());
+            return Optional.empty();
+        }
+
+        Optional<Long> baseEntitlementId = server.getBaseEntitlementId();
+
+        if (baseEntitlementId.isEmpty()) {
+            LOG.warn("Cannot set a entitlement: " + ent.getLabel() + " as an addon entitlement for server: " +
+                    server.getId() + ". The server has no base entitlement yet.");
+            return Optional.empty();
+        }
+
+        Optional<ServerGroup> serverGroup = ServerGroupFactory
+                .findCompatibleServerGroupForAddonEntitlement(server.getId(), ent, baseEntitlementId.get());
+        if (!serverGroup.isPresent()) {
+            LOG.warn("Cannot set a entitlement: " + ent.getLabel() + " as an addon entitlement for server: " +
+                    server.getId() + ". The server base entitlement is not compatible.");
+        }
+        return serverGroup;
+    }
+
+    private void updateLibvirtEngine(MinionServer minion) {
+        Map<String, Object> pillar = new HashMap<>();
+        pillar.put("virt_entitled", minion.hasVirtualizationEntitlement());
+        saltService.callSync(State.apply(Collections.singletonList("virt.engine-events"),
+                                                 Optional.of(pillar)), minion.getMinionId());
+    }
+
+    // Need to do some extra logic here
+    // 1) Subscribe system to rhel-i386-server-vt-5 channel
+    // 2) Subscribe system to rhn-tools-rhel-i386-server-5
+    // 3) Schedule package install of rhn-virtualization-host
+    // Return a map with errors and warnings:
+    //      warnings -> list of ValidationWarnings
+    //      errors -> list of ValidationErrors
+    private ValidatorResult setupSystemForVirtualization(Org orgIn, Long sid) {
+
+        Server server = ServerFactory.lookupById(sid);
+        User user = UserFactory.findRandomOrgAdmin(orgIn);
+        ValidatorResult result = new ValidatorResult();
+
+        // If this is a Satellite
+        if (!ConfigDefaults.get().isSpacewalk()) {
+            // just install libvirt for RHEL6 base channel
+            Channel base = server.getBaseChannel();
+
+            if (base != null && base.isCloned()) {
+                base = base.getOriginal();
+            }
+
+            if ((base != null) &&
+                    (!base.isRhelChannel() || base.isReleaseXChannel(5))) {
+                // Do not automatically subscribe to virt channels (bnc#768856)
+                // subscribeToVirtChannel(server, user, result);
+            }
+        }
+
+        if (server.hasEntitlement(EntitlementManager.MANAGEMENT)) {
+            // Before we start looking to subscribe to a 'tools' channel for
+            // rhn-virtualization-host, check if the server already has a package by this
+            // name installed and leave it be if so.
+            InstalledPackage rhnVirtHost = PackageFactory.lookupByNameAndServer(
+                    ChannelManager.RHN_VIRT_HOST_PACKAGE_NAME, server);
+            if (rhnVirtHost != null) {
+                // System already has the package, we can stop here.
+                LOG.debug("System already has " +
+                        ChannelManager.RHN_VIRT_HOST_PACKAGE_NAME + " installed.");
+                return result;
+            }
+            try {
+                scheduleVirtualizationHostPackageInstall(server, user, result);
+            }
+            catch (TaskomaticApiException e) {
+                result.addError(new ValidatorError("taskscheduler.down"));
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Schedule installation of rhn-virtualization-host package.
+     *
+     * Implies that we locate a child channel with this package and automatically
+     * subscribe the system to it if possible. If multiple child channels have the package
+     * and the server is not already subscribed to one, we report the discrepancy and
+     * instruct the user to deal with this manually.
+     *
+     * @param server Server to schedule install for.
+     * @param user User performing the operation.
+     * @param result Validation result we'll be returning for the UI to render.
+     * @throws TaskomaticApiException if there was a Taskomatic error
+     * (typically: Taskomatic is down)
+     */
+    private void scheduleVirtualizationHostPackageInstall(Server server,
+            User user, ValidatorResult result) throws TaskomaticApiException {
+        // Now subscribe to a child channel with rhn-virtualization-host (RHN Tools in the
+        // case of Satellite) and schedule it for installation, or warn if we cannot find
+        // a child with the package:
+        Channel toolsChannel = null;
+        try {
+            toolsChannel = ChannelManager.subscribeToChildChannelWithPackageName(
+                    user, server, ChannelManager.RHN_VIRT_HOST_PACKAGE_NAME);
+
+            // If this is a Satellite and no RHN Tools channel is available
+            // report the error
+            if (!ConfigDefaults.get().isSpacewalk() && toolsChannel == null) {
+                LOG.warn("no tools channel found");
+                result.addError(new ValidatorError("system.entitle.notoolschannel"));
+            }
+            // If Spacewalk and no channel has the rhn-virtualization-host package,
+            // warn but allow the operation to proceed.
+            else if (toolsChannel == null) {
+                result.addWarning(new ValidatorWarning("system.entitle.novirtpackage",
+                        ChannelManager.RHN_VIRT_HOST_PACKAGE_NAME));
+            }
+            else {
+                List<Map<String, Object>> packageResults =
+                        ChannelManager.listLatestPackagesEqual(
+                        toolsChannel.getId(), ChannelManager.RHN_VIRT_HOST_PACKAGE_NAME);
+                if (packageResults.size() > 0) {
+                    Map<String, Object> row = packageResults.get(0);
+                    Long nameId = (Long) row.get("name_id");
+                    Long evrId = (Long) row.get("evr_id");
+                    Long archId = (Long) row.get("package_arch_id");
+                    ActionManager.schedulePackageInstall(
+                            user, server, nameId, evrId, archId);
+                }
+                else {
+                    result.addError(new ValidatorError("system.entitle.novirtpackage",
+                            ChannelManager.RHN_VIRT_HOST_PACKAGE_NAME));
+                }
+            }
+        }
+        catch (MultipleChannelsWithPackageException e) {
+            LOG.warn("Found multiple child channels with package: " +
+                    ChannelManager.RHN_VIRT_HOST_PACKAGE_NAME);
+            result.addWarning(new ValidatorWarning(
+                    "system.entitle.multiplechannelswithpackagepleaseinstall",
+                    ChannelManager.RHN_VIRT_HOST_PACKAGE_NAME));
+        }
+    }
+
+    /**
+     * Setter for the SaltService
+     * @param saltServiceIn The SaltService
+     */
+    public void setSaltService(SaltService saltServiceIn) {
+        this.saltService = saltServiceIn;
+    }
+}

--- a/java/code/src/com/redhat/rhn/manager/system/entitling/SystemUnentitler.java
+++ b/java/code/src/com/redhat/rhn/manager/system/entitling/SystemUnentitler.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.manager.system.entitling;
+
+import static com.redhat.rhn.domain.formula.FormulaFactory.PROMETHEUS_EXPORTERS;
+
+import com.redhat.rhn.domain.entitlement.Entitlement;
+import com.redhat.rhn.domain.formula.FormulaFactory;
+import com.redhat.rhn.domain.server.EntitlementServerGroup;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerFactory;
+import com.redhat.rhn.manager.entitlement.EntitlementManager;
+import com.redhat.rhn.manager.formula.FormulaManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
+
+import org.apache.log4j.Logger;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Class for removing entitlements from servers
+ */
+public class SystemUnentitler {
+
+    private static final Logger LOG = Logger.getLogger(SystemUnentitler.class);
+
+    public static final SystemUnentitler INSTANCE = new SystemUnentitler();
+
+    /**
+     * Removes all the entitlements related to a server.
+     * @param server server to be unentitled.
+     */
+    public void removeAllServerEntitlements(Server server) {
+        Set<Entitlement> entitlements = server.getEntitlements();
+        entitlements.stream().forEach(e -> unentitleServer(server, e));
+    }
+
+    /**
+     * Removes an entitlement from the given Server. If the given entitlement is the base entitlement,
+     * removes all entitlements from the Server.
+     * @param server the server
+     * @param ent the entitlement
+     */
+    public void removeServerEntitlement(Server server, Entitlement ent) {
+        if (!server.hasEntitlement(ent)) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("server doesnt have entitlement: " + ent);
+            }
+            return;
+        }
+
+        if (ent.isBase()) {
+            removeAllServerEntitlements(server);
+        }
+        else {
+            unentitleServer(server, ent);
+        }
+
+        server.asMinionServer().ifPresent(s -> {
+            ServerGroupManager.getInstance().updatePillarAfterGroupUpdateForServers(Arrays.asList(s));
+
+         // Configure the monitoring formula for cleanup if still assigned (disable exporters)
+            if (EntitlementManager.MONITORING.equals(ent)) {
+                if (FormulaManager.getInstance().isMonitoringCleanupNeeded(s)) {
+                    try {
+                     // Get the current data and set all exporters to disabled
+                        String minionId = s.getMinionId();
+                        Map<String, Object> data = FormulaFactory
+                                .getFormulaValuesByNameAndMinionId(PROMETHEUS_EXPORTERS, minionId)
+                                .orElse(FormulaFactory.getPillarExample(PROMETHEUS_EXPORTERS));
+                        FormulaFactory.saveServerFormulaData(
+                                FormulaFactory.disableMonitoring(data), minionId, PROMETHEUS_EXPORTERS);
+                    }
+                    catch (UnsupportedOperationException | IOException e) {
+                        LOG.warn("Exception on saving formula data: " + e.getMessage());
+                    }
+                }
+            }
+        });
+    }
+
+    private void unentitleServer(Server server, Entitlement ent) {
+        Optional<EntitlementServerGroup> entitlementServerGroup = server.findServerGroupByEntitlement(ent);
+
+        if (entitlementServerGroup.isPresent()) {
+            ServerFactory.addServerHistoryWithEntitlementEvent(server, ent, "removed system entitlement ");
+            ServerFactory.removeServerFromGroup(server, entitlementServerGroup.get());
+        }
+        else {
+            LOG.error("Cannot remove entitlement: " + ent.getLabel() + " from system: " + server.getId());
+        }
+    }
+
+}

--- a/java/code/src/com/redhat/rhn/manager/system/entitling/test/SystemEntitlementManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/entitling/test/SystemEntitlementManagerTest.java
@@ -1,0 +1,175 @@
+/**
+ * Copyright (c) 2009--2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.manager.system.entitling.test;
+
+import static com.redhat.rhn.testing.RhnBaseTestCase.reload;
+
+import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.common.validator.ValidatorResult;
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.role.RoleFactory;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerFactory;
+import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.manager.entitlement.EntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
+import com.redhat.rhn.testing.ChannelTestUtils;
+import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
+import com.redhat.rhn.testing.ServerTestUtils;
+import com.redhat.rhn.testing.TestUtils;
+import com.redhat.rhn.testing.UserTestUtils;
+
+import com.suse.manager.webui.services.impl.SaltSSHService;
+import com.suse.manager.webui.services.impl.SaltService;
+
+import org.jmock.Expectations;
+import org.jmock.lib.legacy.ClassImposteriser;
+
+
+public class SystemEntitlementManagerTest extends JMockBaseTestCaseWithUser {
+
+    private SaltService saltServiceMock;
+    private SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        setImposteriser(ClassImposteriser.INSTANCE);
+        saltServiceMock = mock(SaltService.class);
+        SystemEntitler.INSTANCE.setSaltService(saltServiceMock);
+    }
+
+    /**
+     * Tests adding and removing entitlement on a server
+     * @throws Exception if something goes wrong
+     */
+    public void testEntitleServer() throws Exception {
+        User user = UserTestUtils.findNewUser("testUser",
+                "testOrg" + this.getClass().getSimpleName());
+        user.addPermanentRole(RoleFactory.ORG_ADMIN);
+        Server server = ServerTestUtils.createTestSystem(user);
+        ChannelTestUtils.setupBaseChannelForVirtualization(user,
+                server.getBaseChannel());
+        UserTestUtils.addVirtualization(user.getOrg());
+        TestUtils.saveAndFlush(user.getOrg());
+
+        //Test Virtualization Host
+        assertTrue(systemEntitlementManager.canEntitleServer(server, EntitlementManager.VIRTUALIZATION));
+        boolean hasErrors =
+                systemEntitlementManager.addEntitlementToServer(server, EntitlementManager.VIRTUALIZATION).hasErrors();
+        assertFalse(hasErrors);
+        assertTrue(server.hasEntitlement(EntitlementManager.VIRTUALIZATION));
+
+        // Removal
+        systemEntitlementManager.removeServerEntitlement(server, EntitlementManager.VIRTUALIZATION);
+        server = reload(server);
+        assertFalse(server.hasEntitlement(EntitlementManager.VIRTUALIZATION));
+
+        //Test Container Build Host
+        Server minion = MinionServerFactoryTest.createTestMinionServer(user);
+        assertTrue(systemEntitlementManager.canEntitleServer(minion, EntitlementManager.CONTAINER_BUILD_HOST));
+        hasErrors = systemEntitlementManager.addEntitlementToServer(minion, EntitlementManager.CONTAINER_BUILD_HOST)
+                .hasErrors();
+        assertFalse(hasErrors);
+        assertTrue(minion.hasEntitlement(EntitlementManager.CONTAINER_BUILD_HOST));
+
+        // Removal
+        systemEntitlementManager.removeServerEntitlement(minion, EntitlementManager.CONTAINER_BUILD_HOST);
+        minion = reload(minion);
+        assertFalse(minion.hasEntitlement(EntitlementManager.CONTAINER_BUILD_HOST));
+
+        //Test OS Image Build Host
+
+        context().checking(new Expectations() {{
+            allowing(saltServiceMock).generateSSHKey(with(equal(SaltSSHService.SSH_KEY_PATH)));
+        }});
+
+        minion.setServerArch(ServerFactory.lookupServerArchByLabel("x86_64-redhat-linux"));
+        ServerFactory.save(minion);
+        assertTrue(systemEntitlementManager.canEntitleServer(minion, EntitlementManager.OSIMAGE_BUILD_HOST));
+        hasErrors = systemEntitlementManager.addEntitlementToServer(minion, EntitlementManager.OSIMAGE_BUILD_HOST)
+                .hasErrors();
+        assertFalse(hasErrors);
+        assertTrue(minion.hasEntitlement(EntitlementManager.OSIMAGE_BUILD_HOST));
+
+        // Removal
+        systemEntitlementManager.removeServerEntitlement(minion, EntitlementManager.OSIMAGE_BUILD_HOST);
+        minion = reload(minion);
+        assertFalse(minion.hasEntitlement(EntitlementManager.OSIMAGE_BUILD_HOST));
+    }
+
+    public void testEntitleVirtForGuest() throws Exception {
+        Server host = ServerTestUtils.createVirtHostWithGuest();
+        User user = host.getCreator();
+        UserTestUtils.addVirtualization(user.getOrg());
+
+        Server guest =
+            (host.getGuests().iterator().next()).getGuestSystem();
+        guest.addChannel(ChannelTestUtils.createBaseChannel(user));
+        ServerTestUtils.addVirtualization(user, guest);
+
+        assertTrue(
+                systemEntitlementManager.addEntitlementToServer(guest, EntitlementManager.VIRTUALIZATION).hasErrors());
+        assertFalse(guest.hasEntitlement(EntitlementManager.VIRTUALIZATION));
+    }
+
+    public void testVirtualEntitleServer() throws Exception {
+        // User and server
+        User user = UserTestUtils.findNewUser("testUser",
+                "testOrg" + this.getClass().getSimpleName());
+        user.addPermanentRole(RoleFactory.ORG_ADMIN);
+        Server server = ServerTestUtils.createTestSystem(user);
+        Channel[] children = ChannelTestUtils.setupBaseChannelForVirtualization(user,
+                server.getBaseChannel());
+
+        Channel rhnTools = children[0];
+        Channel rhelVirt = children[1];
+
+        // Entitlements
+        UserTestUtils.addVirtualization(user.getOrg());
+        TestUtils.saveAndFlush(user.getOrg());
+
+        assertTrue(systemEntitlementManager.canEntitleServer(server, EntitlementManager.VIRTUALIZATION));
+
+        ValidatorResult retval =
+                systemEntitlementManager.addEntitlementToServer(server, EntitlementManager.VIRTUALIZATION);
+
+        server = reload(server);
+
+        String key = null;
+        if (retval.getErrors().size() > 0) {
+            key = retval.getErrors().get(0).getKey();
+        }
+        assertFalse("Got back: " + key, retval.hasErrors());
+
+        // Test stuff!
+        assertTrue(server.hasEntitlement(EntitlementManager.VIRTUALIZATION));
+        assertTrue(server.getChannels().contains(rhnTools));
+        if (!ConfigDefaults.get().isSpacewalk()) {
+            // this is actually Satellite-specific
+            // assertTrue(server.getChannels().contains(rhelVirt));
+        }
+
+
+        // Test removal
+        systemEntitlementManager.removeServerEntitlement(server, EntitlementManager.VIRTUALIZATION);
+
+        server = reload(server);
+        assertFalse(server.hasEntitlement(EntitlementManager.VIRTUALIZATION));
+
+    }
+}

--- a/java/code/src/com/redhat/rhn/taskomatic/task/gatherer/VirtualHostManagerProcessor.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/gatherer/VirtualHostManagerProcessor.java
@@ -25,6 +25,7 @@ import com.redhat.rhn.domain.server.virtualhostmanager.VirtualHostManagerFactory
 import com.redhat.rhn.domain.server.virtualhostmanager.VirtualHostManagerNodeInfo;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.system.VirtualInstanceManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import com.suse.manager.gatherer.HostJson;
@@ -48,6 +49,7 @@ public class VirtualHostManagerProcessor {
     private Set<Server> serversToDelete;
     private Set<VirtualHostManagerNodeInfo> nodesToDelete;
     private Logger log;
+    private SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
 
     /**
      * Instantiates a new virtual host manager processor, will update a virtual
@@ -209,7 +211,7 @@ public class VirtualHostManagerProcessor {
         updateServerNetwork(server, hostId);
 
         if (server.getBaseEntitlement() == null) {
-            server.setBaseEntitlement(EntitlementManager.FOREIGN);
+            systemEntitlementManager.setBaseEntitlement(server, EntitlementManager.FOREIGN);
         }
         return server;
     }

--- a/java/code/src/com/redhat/rhn/testing/ImageTestUtils.java
+++ b/java/code/src/com/redhat/rhn/testing/ImageTestUtils.java
@@ -37,7 +37,7 @@ import com.redhat.rhn.domain.token.ActivationKey;
 import com.redhat.rhn.domain.token.ActivationKeyFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
-import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -46,6 +46,8 @@ import java.util.Set;
  * Utility methods for testing of the image features.
  */
 public class ImageTestUtils {
+
+    private static SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
 
     private ImageTestUtils() { }
 
@@ -391,7 +393,7 @@ public class ImageTestUtils {
      */
     public static MinionServer createBuildHost(User user) throws Exception {
         MinionServer server = MinionServerFactoryTest.createTestMinionServer(user);
-        SystemManager.entitleServer(server, EntitlementManager.CONTAINER_BUILD_HOST);
+        systemEntitlementManager.addEntitlementToServer(server, EntitlementManager.CONTAINER_BUILD_HOST);
         return server;
     }
 
@@ -404,7 +406,7 @@ public class ImageTestUtils {
      */
     public static MinionServer createOSImageBuildHost(User user) throws Exception {
         MinionServer server = MinionServerFactoryTest.createTestMinionServer(user);
-        SystemManager.entitleServer(server, EntitlementManager.OSIMAGE_BUILD_HOST);
+        systemEntitlementManager.addEntitlementToServer(server, EntitlementManager.OSIMAGE_BUILD_HOST);
         return server;
     }
 }

--- a/java/code/src/com/redhat/rhn/testing/ServerTestUtils.java
+++ b/java/code/src/com/redhat/rhn/testing/ServerTestUtils.java
@@ -43,7 +43,8 @@ import com.redhat.rhn.manager.errata.cache.ErrataCacheManager;
 import com.redhat.rhn.manager.rhnpackage.PackageManager;
 import com.redhat.rhn.manager.rhnset.RhnSetDecl;
 import com.redhat.rhn.manager.rhnset.RhnSetManager;
-import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+
 import org.hibernate.Session;
 
 import java.util.Set;
@@ -57,6 +58,7 @@ public class ServerTestUtils {
 
     private static final String REDHAT_RELEASE = "redhat-release";
     private static final Long I386_PACKAGE_ARCH_ID = 101L;
+    private static SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
 
     private ServerTestUtils() {
     }
@@ -178,7 +180,7 @@ public class ServerTestUtils {
         // Lets give the org/server virt.
         UserTestUtils.addVirtualization(user.getOrg());
         ServerTestUtils.addVirtualization(user, s);
-        SystemManager.entitleServer(s, EntitlementManager.VIRTUALIZATION);
+        systemEntitlementManager.addEntitlementToServer(s, EntitlementManager.VIRTUALIZATION);
 
         for (int i = 0; i < numberOfGuests; i++) {
             VirtualInstance vi = new VirtualInstanceManufacturer(user).newRegisteredGuestWithoutHost(salt);
@@ -312,7 +314,8 @@ public class ServerTestUtils {
         Server existingHost = ServerTestUtils.createTestSystem(user);
         existingHost.setName(TestUtils.randomString());
         existingHost.setDigitalServerId(digitalServerId);
-        existingHost.setBaseEntitlement(EntitlementManager.getByName("foreign_entitled"));
+        SystemEntitlementManager.INSTANCE.setBaseEntitlement(existingHost,
+                EntitlementManager.getByName("foreign_entitled"));
         ServerFactory.save(existingHost);
         return existingHost;
     }

--- a/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
+++ b/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
@@ -18,7 +18,7 @@ import com.redhat.rhn.domain.server.virtualhostmanager.VirtualHostManager;
 import com.redhat.rhn.domain.server.virtualhostmanager.VirtualHostManagerFactory;
 import com.redhat.rhn.manager.content.ContentSyncManager;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
-import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 import com.redhat.rhn.testing.ServerTestUtils;
 import com.redhat.rhn.testing.TestUtils;
@@ -77,7 +77,7 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
                     with(any(LocalCall.class)),
                     with(any(String.class)));
         }});
-        SystemManager.mockSaltService(saltServiceMock);
+        SystemEntitler.INSTANCE.setSaltService(saltServiceMock);
     }
 
     public void testSystemsToJson() throws Exception {

--- a/java/code/src/com/suse/manager/reactor/hardware/HardwareMapper.java
+++ b/java/code/src/com/suse/manager/reactor/hardware/HardwareMapper.java
@@ -33,6 +33,7 @@ import com.redhat.rhn.domain.server.VirtualInstanceState;
 import com.redhat.rhn.domain.server.VirtualInstanceType;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.system.VirtualInstanceManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 
 import com.suse.manager.reactor.utils.ValueMap;
 import com.suse.manager.utils.SaltUtils;
@@ -457,7 +458,7 @@ public class HardwareMapper {
 
                 ServerFactory.save(zhost);
 
-                zhost.setBaseEntitlement(EntitlementManager
+                SystemEntitlementManager.INSTANCE.setBaseEntitlement(zhost, EntitlementManager
                         .getByName(EntitlementManager.FOREIGN_ENTITLED));
                 LOG.debug("New host created: " + identifier);
             }

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -50,6 +50,7 @@ import com.redhat.rhn.frontend.dto.EssentialChannelDto;
 import com.redhat.rhn.manager.distupgrade.DistUpgradeManager;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 
 import com.suse.manager.reactor.utils.ValueMap;
 import com.suse.manager.webui.services.SaltStateGeneratorService;
@@ -358,7 +359,7 @@ public class RegisterMinionEventMessageAction implements MessageAction {
             giveCapabilities(minion);
 
             // Assign the Salt base entitlement by default
-            minion.setBaseEntitlement(EntitlementManager.SALT);
+            SystemEntitlementManager.INSTANCE.setBaseEntitlement(minion, EntitlementManager.SALT);
 
             // apply activation key properties that need to be set after saving the minion
             activationKey.ifPresent(ak -> RegistrationUtils.applyActivationKeyProperties(minion, ak, grains));

--- a/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
@@ -43,6 +43,8 @@ import com.redhat.rhn.domain.token.ActivationKeyFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.action.ActionManager;
 import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
 import com.suse.manager.reactor.utils.RhelUtils;
@@ -82,6 +84,7 @@ public class RegistrationUtils {
 
     private static final Logger LOG = Logger.getLogger(RegistrationUtils.class);
 
+    private static SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
 
     /**
      * Prevent instantiation.
@@ -198,8 +201,8 @@ public class RegistrationUtils {
             Entitlement e = sg.getAssociatedEntitlement();
             if (validEntits.contains(e) &&
                     e.isAllowedOnServer(server, grains) &&
-                    SystemManager.canEntitleServer(server, e)) {
-                ValidatorResult vr = SystemManager.entitleServer(server, e);
+                    SystemEntitler.INSTANCE.canEntitleServer(server, e)) {
+                ValidatorResult vr = systemEntitlementManager.addEntitlementToServer(server, e);
                 if (vr.getWarnings().size() > 0) {
                     LOG.warn(vr.getWarnings().toString());
                 }

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -51,11 +51,17 @@ import com.redhat.rhn.manager.action.ActionChainManager;
 import com.redhat.rhn.manager.action.ActionManager;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 import com.redhat.rhn.testing.ImageTestUtils;
 import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 import com.redhat.rhn.testing.TestUtils;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.reflect.TypeToken;
 import com.suse.manager.reactor.messaging.ApplyStatesEventMessage;
 import com.suse.manager.reactor.messaging.JobReturnEventMessage;
 import com.suse.manager.reactor.messaging.JobReturnEventMessageAction;
@@ -77,9 +83,6 @@ import com.suse.salt.netapi.results.StateApplyResult;
 import com.suse.salt.netapi.utils.Xor;
 import com.suse.utils.Json;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.reflect.TypeToken;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jmock.Expectations;
@@ -119,6 +122,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
     private TaskomaticApi taskomaticApi;
     private SaltService saltServiceMock;
+    private SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
 
     @Override
     public void setUp() throws Exception {
@@ -127,7 +131,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         Config.get().setString("server.secret_key",
                 DigestUtils.sha256Hex(TestUtils.randomString()));
         saltServiceMock = context().mock(SaltService.class);
-        SystemManager.mockSaltService(saltServiceMock);
+        SystemEntitler.INSTANCE.setSaltService(saltServiceMock);
     }
 
     /**
@@ -1197,7 +1201,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         ImageInfoFactory.setTaskomaticApi(getTaskomaticApi());
         MinionServer server = MinionServerFactoryTest.createTestMinionServer(user);
         server.setMinionId("minionsles12-suma3pg.vagrant.local");
-        SystemManager.entitleServer(server, EntitlementManager.CONTAINER_BUILD_HOST);
+        systemEntitlementManager.addEntitlementToServer(server, EntitlementManager.CONTAINER_BUILD_HOST);
 
         String imageName = "matei-apache-python" + TestUtils.randomString(5);
         String imageVersion = "latest";
@@ -1276,7 +1280,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         ImageInfoFactory.setTaskomaticApi(getTaskomaticApi());
         MinionServer server = MinionServerFactoryTest.createTestMinionServer(user);
         server.setMinionId("minionsles12-suma3pg.vagrant.local");
-        SystemManager.entitleServer(server, EntitlementManager.CONTAINER_BUILD_HOST);
+        systemEntitlementManager.addEntitlementToServer(server, EntitlementManager.CONTAINER_BUILD_HOST);
 
         String imageName = "meaksh-apache-python" + TestUtils.randomString(5);
         String imageVersion1 = "latest";
@@ -1345,7 +1349,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         ImageInfoFactory.setTaskomaticApi(getTaskomaticApi());
         MinionServer server = MinionServerFactoryTest.createTestMinionServer(user);
         server.setMinionId("minionsles12-suma3pg.vagrant.local");
-        SystemManager.entitleServer(server, EntitlementManager.CONTAINER_BUILD_HOST);
+        systemEntitlementManager.addEntitlementToServer(server, EntitlementManager.CONTAINER_BUILD_HOST);
 
         String imageName = "mbologna-apache-python" + TestUtils.randomString(5);
         String imageVersion = "latest";
@@ -1471,7 +1475,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         }});
         SaltUtils.INSTANCE.setSaltService(saltServiceMock);
 
-        SystemManager.entitleServer(server, EntitlementManager.OSIMAGE_BUILD_HOST);
+        systemEntitlementManager.addEntitlementToServer(server, EntitlementManager.OSIMAGE_BUILD_HOST);
 
         ActivationKey key = ImageTestUtils.createActivationKey(user);
         ImageProfile profile = ImageTestUtils.createKiwiImageProfile("my-kiwi-image", key, user);
@@ -1502,7 +1506,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         }});
         SaltUtils.INSTANCE.setSaltService(saltServiceMock);
 
-        SystemManager.entitleServer(server, EntitlementManager.OSIMAGE_BUILD_HOST);
+        systemEntitlementManager.addEntitlementToServer(server, EntitlementManager.OSIMAGE_BUILD_HOST);
 
         new File("/srv/susemanager/pillar_data/images").mkdirs();
 

--- a/java/code/src/com/suse/manager/reactor/messaging/test/LibvirtEngineDomainLifecycleMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/LibvirtEngineDomainLifecycleMessageActionTest.java
@@ -23,6 +23,7 @@ import com.redhat.rhn.domain.server.VirtualInstance;
 import com.redhat.rhn.domain.server.VirtualInstanceFactory;
 import com.redhat.rhn.frontend.dto.VirtualSystemOverview;
 import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 import com.redhat.rhn.testing.ServerTestUtils;
 import com.redhat.rhn.testing.TestUtils;
@@ -75,7 +76,7 @@ public class LibvirtEngineDomainLifecycleMessageActionTest extends JMockBaseTest
                     with(any(LocalCall.class)),
                     with(containsString("serverfactorytest")));
         }});
-        SystemManager.mockSaltService(saltServiceMock);
+        SystemEntitler.INSTANCE.setSaltService(saltServiceMock);
         VirtManager.setSaltService(saltServiceMock);
 
         host = ServerTestUtils.createVirtHostWithGuests(user, 1, true);

--- a/java/code/src/com/suse/manager/webui/controllers/test/VirtualGuestsControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/VirtualGuestsControllerTest.java
@@ -29,6 +29,7 @@ import com.redhat.rhn.frontend.dto.ScheduledAction;
 import com.redhat.rhn.manager.action.ActionManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.system.VirtualizationActionCommand;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.testing.ServerTestUtils;
 
@@ -86,7 +87,7 @@ public class VirtualGuestsControllerTest extends BaseControllerTestCase {
                     with(containsString("serverfactorytest")));
         }});
         VirtManager.setSaltService(saltServiceMock);
-        SystemManager.mockSaltService(saltServiceMock);
+        SystemEntitler.INSTANCE.setSaltService(saltServiceMock);
 
         host = ServerTestUtils.createVirtHostWithGuests(user, 2, true);
         host.asMinionServer().get().setMinionId("testminion.local");

--- a/java/code/src/com/suse/manager/webui/controllers/test/VirtualNetsControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/VirtualNetsControllerTest.java
@@ -19,8 +19,8 @@ import static org.hamcrest.Matchers.containsString;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.manager.action.ActionManager;
-import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.system.VirtualizationActionCommand;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.testing.ServerTestUtils;
 
@@ -67,7 +67,7 @@ public class VirtualNetsControllerTest extends BaseControllerTestCase {
                     with(containsString("serverfactorytest")));
         }});
         VirtManager.setSaltService(saltServiceMock);
-        SystemManager.mockSaltService(saltServiceMock);
+        SystemEntitler.INSTANCE.setSaltService(saltServiceMock);
 
         host = ServerTestUtils.createVirtHostWithGuests(user, 1, true);
         host.asMinionServer().get().setMinionId("testminion.local");

--- a/java/code/src/com/suse/manager/webui/controllers/test/VirtualPoolsControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/VirtualPoolsControllerTest.java
@@ -19,8 +19,8 @@ import static org.hamcrest.Matchers.containsString;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.manager.action.ActionManager;
-import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.system.VirtualizationActionCommand;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.testing.ServerTestUtils;
 
@@ -68,7 +68,7 @@ public class VirtualPoolsControllerTest extends BaseControllerTestCase {
                     with(containsString("serverfactorytest")));
         }});
         VirtManager.setSaltService(saltServiceMock);
-        SystemManager.mockSaltService(saltServiceMock);
+        SystemEntitler.INSTANCE.setSaltService(saltServiceMock);
 
         host = ServerTestUtils.createVirtHostWithGuests(user, 1, true);
     }

--- a/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
@@ -52,6 +52,8 @@ import com.redhat.rhn.domain.server.test.ServerFactoryTest;
 import com.redhat.rhn.manager.action.ActionChainManager;
 import com.redhat.rhn.manager.action.ActionManager;
 import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.task.checkin.SystemSummary;
 import com.redhat.rhn.testing.ConfigTestUtils;
@@ -113,7 +115,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         saltServerActionService = new SaltServerActionService();
         saltServerActionService.setSaltService(saltServiceMock);
         saltServerActionService.setSkipCommandScriptPerms(true);
-        SystemManager.mockSaltService(saltServiceMock);
+        SystemEntitler.INSTANCE.setSaltService(saltServiceMock);
 
         sshPushSystemMock = mock(SystemSummary.class);
     }


### PR DESCRIPTION
## What does this PR change?

Extract functionality to add/remove entitlements to/from servers.

This PR is not about refactoring methods.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added / updated

- [x] **DONE**

## Links

Tracks https://github.com/uyuni-project/uyuni/pull/1930

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
