### PR TITLE
Testsuite: Workaround for spacewalk #9165

### DIFF
--- a/testsuite/features/core/proxy_register_as_minion_with_script.feature
+++ b/testsuite/features/core/proxy_register_as_minion_with_script.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2019 SUSE LLC
+# Copyright (c) 2017-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # The scenarios in this feature are skipped if there is no proxy
@@ -23,8 +23,8 @@ Feature: Setup SUSE Manager proxy
   Scenario: Accept the key for the proxy
     Given I am authorized as "testing" with password "testing"
     When I go to the minion onboarding page
-    Then I should see a "pending" text
-    When I accept "proxy" key
+    And I wait until I see "pending" text, refreshing the page
+    And I accept "proxy" key
 
 @proxy
   Scenario: Wait until the proxy appears

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -834,7 +834,15 @@ When(/^I configure the proxy$/) do
   filename = File.basename(path)
   cmd = "configure-proxy.sh --non-interactive --rhn-user=admin --rhn-password=admin --answer-file=#{filename}"
   proxy_timeout = 600
-  $proxy.run(cmd, true, proxy_timeout, 'root')
+  return_code = 0
+  # WORKAROUND bsc#1138952
+  # Wrap the shell command inside a begin block to catch the exception
+  begin
+    return_code = $proxy.run(cmd, true, proxy_timeout, 'root')
+  rescue StandardError => e
+    puts "Catched exception (see bsc#1138952): #{e}"
+    return_code
+  end
 end
 
 Then(/^The metadata buildtime from package "(.*?)" match the one in the rpm on "(.*?)"$/) do |pkg, host|

--- a/testsuite/run_sets/core.yml
+++ b/testsuite/run_sets/core.yml
@@ -23,7 +23,7 @@
   # one of: proxy_register_as_trad_with_script.feature
   #         proxy_register_as_minion_with_script.feature
   #         proxy_register_as_minion_with_gui.feature
-- features/core/proxy_register_as_minion_with_gui.feature
+- features/core/proxy_register_as_minion_with_script.feature
 - features/core/proxy_branch_network.feature
 
 ## Core features END ###


### PR DESCRIPTION
## What does this PR change?

Add a workaround for https://github.com/SUSE/spacewalk/issues/9165
so that we can configure the proxy via script in the test suite.

- testsuite/features/step_definitions/command_steps.rb
  Catch the exception.

- testsuite/run_sets/core.yml: Setup the proxy with the script.
  This is significantly faster that using the GUI; it also
  increases the test coverage.

## Links

### Ports

- Manager-3.2: https://github.com/SUSE/spacewalk/pull/10785
- Manager-4.0: https://github.com/SUSE/spacewalk/pull/10784

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
