### PR TITLE
OES 2018 sp2 and other product data changes

### DIFF
--- a/susemanager-sync-data/additional_products.json
+++ b/susemanager-sync-data/additional_products.json
@@ -329,13 +329,13 @@
     },
     {
         "id" : -8,
-        "name" : "RHEL8 Base",
+        "name" : "RHEL or SLES ES or CentOS 8 Base",
         "identifier" : "rhel-base",
         "former_identifier" : "",
         "version" : "8",
         "release_type" : null,
         "arch" : "x86_64",
-        "friendly_name" : "RHEL8 Base x86_64",
+        "friendly_name" : "RHEL or SLES ES or CentOS 8 Base",
         "product_class" : "SLE-M-T",
         "cpe" : null,
         "free" : false,
@@ -390,7 +390,7 @@
         ],
         "repositories" : [
             {
-                "id" : -81,
+                "id" : -83,
                 "url" : "http://localhost/pub/repositories/empty/",
                 "name" : "RHEL7-Pool",
                 "distro_target" : "x86_64",

--- a/susemanager-sync-data/additional_products.json
+++ b/susemanager-sync-data/additional_products.json
@@ -1,5 +1,333 @@
 [
     {
+        "id" : -9,
+        "name" : "Open Enterprise Server 2018 SP2",
+        "identifier" : "Open_Enterprise_Server",
+        "former_identifier" : "",
+        "version" : "2018.2",
+        "release_type" : null,
+        "arch" : "x86_64",
+        "friendly_name" : "Open Enterprise Server 2018 SP2",
+        "product_class" : "OES2",
+        "cpe" : null,
+        "free" : false,
+        "description" : null,
+        "release_stage" : "beta",
+        "eula_url" : "",
+        "product_type" : "base",
+        "offline_predecessor_ids" : [
+        ],
+        "online_predecessor_ids" : [
+            46
+        ],
+        "shortname" : null,
+        "recommended" : false,
+        "extensions" : [
+        ],
+        "repositories" : [
+            {
+                "id" : -84,
+                "url" : "https://nu.novell.com/repo/$RCE/OES2018-SP2-Pool/sle-12-x86_64/",
+                "name" : "OES2018-SP2-Pool",
+                "distro_target" : "sle-12-x86_64",
+                "description" : "Open Enterprise Server 2018 SP2",
+                "enabled" : true,
+                "autorefresh" : false,
+                "installer_updates" : false
+            },
+            {
+                "id" : -85,
+                "url" : "https://nu.novell.com/repo/$RCE/OES2018-SP2-Updates/sle-12-x86_64/",
+                "name" : "OES2018-SP2-Updates",
+                "distro_target" : "sle-12-x86_64",
+                "description" : "Open Enterprise Server 2018 SP2",
+                "enabled" : true,
+                "autorefresh" : true,
+                "installer_updates" : false
+            },
+            {
+                "id" : -86,
+                "url" : "https://nu.novell.com/repo/$RCE/OES2018-SP1-SLES12-SP5-Debuginfo-Pool/sle-12-x86_64/",
+                "name" : "OES2018-SP2-SLES12-SP5-Debuginfo-Pool",
+                "distro_target" : "sle-12-x86_64",
+                "description" : "SUSE Linux Enterprise offers a comprehensive suite of products built on a single code base. The platform addresses business needs from the smallest thin-client devices to the world's most powerful high-performance computing and mainframe servers. SUSE Linux Enterprise offers common management tools and technology certifications across the platform, and each product is enterprise-class.",
+                "enabled" : false,
+                "autorefresh" : false,
+                "installer_updates" : false
+            },
+            {
+                "id" : -87,
+                "url" : "https://nu.novell.com/repo/$RCE/OES2018-SP2-SLES12-SP5-Debuginfo-Updates/sle-12-x86_64/",
+                "name" : "OES2018-SP2-SLES12-SP5-Debuginfo-Updates",
+                "distro_target" : "sle-12-x86_64",
+                "description" : "SUSE Linux Enterprise offers a comprehensive suite of products built on a single code base. The platform addresses business needs from the smallest thin-client devices to the world's most powerful high-performance computing and mainframe servers. SUSE Linux Enterprise offers common management tools and technology certifications across the platform, and each product is enterprise-class.",
+                "enabled" : false,
+                "autorefresh" : true,
+                "installer_updates" : false
+            },
+            {
+                "id" : -88,
+                "url" : "https://nu.novell.com/repo/$RCE/OES2018-SP2-SLES12-SP5-Pool/sle-12-x86_64/",
+                "name" : "OES2018-SP2-SLES12-SP5-Pool",
+                "distro_target" : "sle-12-x86_64",
+                "description" : "SUSE Linux Enterprise offers a comprehensive suite of products built on a single code base. The platform addresses business needs from the smallest thin-client devices to the world's most powerful high-performance computing and mainframe servers. SUSE Linux Enterprise offers common management tools and technology certifications across the platform, and each product is enterprise-class.",
+                "enabled" : true,
+                "autorefresh" : false,
+                "installer_updates" : false
+            },
+            {
+                "id" : -89,
+                "url" : "https://nu.novell.com/repo/$RCE/OES2018-SP2-SLES12-SP5-Updates/sle-12-x86_64/",
+                "name" : "OES2018-SP2-SLES12-SP5-Updates",
+                "distro_target" : "sle-12-x86_64",
+                "description" : "SUSE Linux Enterprise offers a comprehensive suite of products built on a single code base. The platform addresses business needs from the smallest thin-client devices to the world's most powerful high-performance computing and mainframe servers. SUSE Linux Enterprise offers common management tools and technology certifications across the platform, and each product is enterprise-class.",
+                "enabled" : true,
+                "autorefresh" : true,
+                "installer_updates" : false
+            },
+            {
+                "id" : -90,
+                "url" : "https://nu.novell.com/repo/$RCE/OES2018-SP2-SLE-Module-Containers12-Pool/sle-12-x86_64/media.1/",
+                "name" : "OES2018-SP2-SLE-Module-Containers12-Pool",
+                "distro_target" : "sle-12-x86_64",
+                "description" : "This Module contains several packages revolving around containers and related tools.",
+                "enabled" : true,
+                "autorefresh" : false,
+                "installer_updates" : false
+            },
+            {
+                "id" : -91,
+                "url" : "https://nu.novell.com/repo/$RCE/OES2018-SP2-SLE-Module-Containers12-Updates/sle-12-x86_64/",
+                "name" : "OES2018-SP2-SLE-Module-Containers12-Updates",
+                "distro_target" : "sle-12-x86_64",
+                "description" : "This Module contains several packages revolving around containers and related tools.",
+                "enabled" : true,
+                "autorefresh" : true,
+                "installer_updates" : false
+            },
+            {
+                "id" : -92,
+                "url" : "https://nu.novell.com/repo/$RCE/OES2018-SP2-SLE-Module-Containers12-Debuginfo-Pool/sle-12-x86_64/",
+                "name" : "OES2018-SP2-SLE-Module-Containers12-Debuginfo-Pool",
+                "distro_target" : "sle-12-x86_64",
+                "description" : "This Module contains several packages revolving around containers and related tools.",
+                "enabled" : false,
+                "autorefresh" : false,
+                "installer_updates" : false
+            },
+            {
+                "id" : -93,
+                "url" : "https://nu.novell.com/repo/$RCE/OES2018-SP2-SLE-Module-Containers12-Debuginfo-Updates/sle-12-x86_64/",
+                "name" : "OES2018-SP2-SLE-Module-Containers12-Debuginfo-Updates",
+                "distro_target" : "sle-12-x86_64",
+                "description" : "This Module contains several packages revolving around containers and related tools.",
+                "enabled" : false,
+                "autorefresh" : true,
+                "installer_updates" : false
+            },
+            {
+                "id" : -94,
+                "url" : "https://nu.novell.com/repo/$RCE/OES2018-SP2-SLE-Manager-Tools12-Debuginfo-Pool/sle-12-x86_64/",
+                "name" : "OES2018-SP2-SLE-Manager-Tools12-Debuginfo-Pool ",
+                "distro_target" : "sle-12-x86_64",
+                "description" : "SUSE Manager Tools provide packages required to connect to a SUSE Manager Server.",
+                "enabled" : false,
+                "autorefresh" : false,
+                "installer_updates" : false
+            },
+            {
+                "id" : -95,
+                "url" : "https://nu.novell.com/repo/$RCE/OES2018-SP2-SLE-Manager-Tools12-Debuginfo-Updates/sle-12-x86_64/",
+                "name" : "OES2018-SP2-SLE-Manager-Tools12-Debuginfo-Updates",
+                "distro_target" : "sle-12-x86_64",
+                "description" : "SUSE Manager Tools provide packages required to connect to a SUSE Manager Server.",
+                "enabled" : false,
+                "autorefresh" : true,
+                "installer_updates" : false
+            },
+            {
+                "id" : -96,
+                "url" : "https://nu.novell.com/repo/$RCE/OES2018-SP2-SLE-Manager-Tools12-Pool/sle-12-x86_64/",
+                "name" : "OES2018-SP2-SLE-Manager-Tools12-Pool",
+                "distro_target" : "sle-12-x86_64",
+                "description" : "SUSE Manager Tools provide packages required to connect to a SUSE Manager Server.",
+                "enabled" : true,
+                "autorefresh" : false,
+                "installer_updates" : false
+            },
+            {
+                "id" : -97,
+                "url" : "https://nu.novell.com/repo/$RCE/OES2018-SP2-SLE-Manager-Tools12-Updates/sle-12-x86_64/",
+                "name" : "OES2018-SP2-SLE-Manager-Tools12-Updates",
+                "distro_target" : "sle-12-x86_64",
+                "description" : "SUSE Manager Tools provide packages required to connect to a SUSE Manager Server.",
+                "enabled" : true,
+                "autorefresh" : true,
+                "installer_updates" : false
+            },
+            {
+                "id" : -98,
+                "url" : "https://nu.novell.com/repo/$RCE/OES2018-SP2-SLE-SDK-12-SP5-Pool/sle-12-x86_64/",
+                "name" : "OES2018-SP2-SLE-SDK-12-SP5-Pool",
+                "distro_target" : "sle-12-x86_64",
+                "description" : "SUSE Linux Enterprise Software Development Kit 12 is the Software Development Kit for the family of SUSE Linux Enterprise products. It is a free of charge extension for partners and customers working with SUSE Linux Enterprise Server and Desktop and derived products. \\n Packages on the SDK are delivered without L3 support; maintenance updates will be done for critical security and critical non-security issues, and where needed to remain in sync with packages delivered in the SUSE Linux Enterprise Server and Desktop products. \\n Packages to rebuild SUSE Linux Enterprise Server are not part of the SUSE Linux Enterprise Software Development Kit.",
+                "enabled" : false,
+                "autorefresh" : false,
+                "installer_updates" : false
+            },
+            {
+                "id" : -99,
+                "url" : "https://nu.novell.com/repo/$RCE/OES2018-SP2-SLE-SDK-12-SP5-Updates/sle-12-x86_64/",
+                "name" : "OES2018-SP2-SLE-SDK-12-SP5-Updates",
+                "distro_target" : "sle-12-x86_64",
+                "description" : "SUSE Linux Enterprise Software Development Kit 12 is the Software Development Kit for the family of SUSE Linux Enterprise products. It is a free of charge extension for partners and customers working with SUSE Linux Enterprise Server and Desktop and derived products. \\n Packages on the SDK are delivered without L3 support; maintenance updates will be done for critical security and critical non-security issues, and where needed to remain in sync with packages delivered in the SUSE Linux Enterprise Server and Desktop products. \\n Packages to rebuild SUSE Linux Enterprise Server are not part of the SUSE Linux Enterprise Software Development Kit.",
+                "enabled" : false,
+                "autorefresh" : true,
+                "installer_updates" : false
+            },
+            {
+                "id" : -100,
+                "url" : "https://nu.novell.com/repo/$RCE/OES2018-SP2-SLE-SDK-12-SP5-Debuginfo-Pool/sle-12-x86_64/",
+                "name" : "OES2018-SP2-SLE-SDK-12-SP5-Debuginfo-Pool",
+                "distro_target" : "sle-12-x86_64",
+                "description" : "SUSE Linux Enterprise Software Development Kit 12 is the Software Development Kit for the family of SUSE Linux Enterprise products. It is a free of charge extension for partners and customers working with SUSE Linux Enterprise Server and Desktop and derived products. \\n Packages on the SDK are delivered without L3 support; maintenance updates will be done for critical security and critical non-security issues, and where needed to remain in sync with packages delivered in the SUSE Linux Enterprise Server and Desktop products. \\n Packages to rebuild SUSE Linux Enterprise Server are not part of the SUSE Linux Enterprise Software Development Kit.",
+                "enabled" : false,
+                "autorefresh" : false,
+                "installer_updates" : false
+            },
+            {
+                "id" : -101,
+                "url" : "https://nu.novell.com/repo/$RCE/OES2018-SP2-SLE-SDK-12-SP5-Debuginfo-Updates/sle-12-x86_64/",
+                "name" : "OES2018-SP2-SLE-SDK-12-SP5-Debuginfo-Updates",
+                "distro_target" : "sle-12-x86_64",
+                "description" : "SUSE Linux Enterprise Software Development Kit 12 is the Software Development Kit for the family of SUSE Linux Enterprise products. It is a free of charge extension for partners and customers working with SUSE Linux Enterprise Server and Desktop and derived products. \\n Packages on the SDK are delivered without L3 support; maintenance updates will be done for critical security and critical non-security issues, and where needed to remain in sync with packages delivered in the SUSE Linux Enterprise Server and Desktop products. \\n Packages to rebuild SUSE Linux Enterprise Server are not part of the SUSE Linux Enterprise Software Development Kit.",
+                "enabled" : false,
+                "autorefresh" : true,
+                "installer_updates" : false
+            },
+            {
+                "id" : -102,
+                "url" : "https://nu.novell.com/repo/$RCE/OES2018-SP2-SLE-Module-Public-Cloud12-Pool/sle-12-x86_64/",
+                "name" : "OES2018-SP2-SLE-Module-Public-Cloud12-Pool",
+                "distro_target" : "sle-12-x86_64",
+                "description" : "The Public Cloud Module is a collection of tools that enables you to create and manage cloud images from the commandline on SUSE Linux Enterprise Server. When building your own images with KIWI or SUSE Studio, initialization code specific to the target cloud is included in that image. \\n Access to the Public Cloud Module is included in your SUSE Linux Enterprise Server subscription. The module has a different lifecycle than SUSE Linux Enterprise Server itself; please check the Release Notes for further details.",
+                "enabled" : false,
+                "autorefresh" : false,
+                "installer_updates" : false
+            },
+            {
+                "id" : -103,
+                "url" : "https://nu.novell.com/repo/$RCE/OES2018-SP2-SLE-Module-Public-Cloud12-Updates/sle-12-x86_64/",
+                "name" : "OES2018-SP2-SLE-Module-Public-Cloud12-Updates",
+                "distro_target" : "sle-12-x86_64",
+                "description" : "The Public Cloud Module is a collection of tools that enables you to create and manage cloud images from the commandline on SUSE Linux Enterprise Server. When building your own images with KIWI or SUSE Studio, initialization code specific to the target cloud is included in that image. \\n Access to the Public Cloud Module is included in your SUSE Linux Enterprise Server subscription. The module has a different lifecycle than SUSE Linux Enterprise Server itself; please check the Release Notes for further details.",
+                "enabled" : false,
+                "autorefresh" : true,
+                "installer_updates" : false
+            },
+            {
+                "id" : -104,
+                "url" : "https://nu.novell.com/repo/$RCE/OES2018-SP2-SLE-Module-Public-Cloud12-Debuginfo-Pool/sle-12-x86_64/",
+                "name" : "OES2018-SP2-SLE-Module-Public-Cloud12-Debuginfo-Pool",
+                "distro_target" : "sle-12-x86_64",
+                "description" : "The Public Cloud Module is a collection of tools that enables you to create and manage cloud images from the commandline on SUSE Linux Enterprise Server. When building your own images with KIWI or SUSE Studio, initialization code specific to the target cloud is included in that image. \\n Access to the Public Cloud Module is included in your SUSE Linux Enterprise Server subscription. The module has a different lifecycle than SUSE Linux Enterprise Server itself; please check the Release Notes for further details.",
+                "enabled" : false,
+                "autorefresh" : false,
+                "installer_updates" : false
+            },
+            {
+                "id" : -105,
+                "url" : "https://nu.novell.com/repo/$RCE/OES2018-SP2-SLE-Module-Public-Cloud12-Debuginfo-Updates/sle-12-x86_64/",
+                "name" : "OES2018-SP2-SLE-Module-Public-Cloud12-Debuginfo-Updates",
+                "distro_target" : "sle-12-x86_64",
+                "description" : "The Public Cloud Module is a collection of tools that enables you to create and manage cloud images from the commandline on SUSE Linux Enterprise Server. When building your own images with KIWI or SUSE Studio, initialization code specific to the target cloud is included in that image. \\n Access to the Public Cloud Module is included in your SUSE Linux Enterprise Server subscription. The module has a different lifecycle than SUSE Linux Enterprise Server itself; please check the Release Notes for further details.",
+                "enabled" : false,
+                "autorefresh" : true,
+                "installer_updates" : false
+            },
+            {
+                "id" : -106,
+                "url" : "https://nu.novell.com/repo/$RCE/OES2018-SP2-SLE-Module-Web-Scripting12-Pool/sle-12-x86_64/",
+                "name" : "OES2018-SP2-SLE-Module-Web-Scripting12-Pool",
+                "distro_target" : "sle-12-x86_64",
+                "description" : "The SUSE Linux Enterprise Web and Scripting Module delivers a comprehensive suite of scripting languages, frameworks, and related tools helping developers and systems administrators accelerate the creation of stable, modern web applications, using dynamic languages, such as PHP, Ruby on Rails, and Python. \\n Access to the Web and Scripting Module is included in your SUSE Linux Enterprise Server subscription. The module has a different lifecycle than SUSE Linux Enterprise Server itself: Package versions in the this module are usually supported for at most three years. We are planning to release more recent versions on a schedule of approximately 18 month; the exact dates may differ per package.",
+                "enabled" : false,
+                "autorefresh" : false,
+                "installer_updates" : false
+            },
+            {
+                "id" : -107,
+                "url" : "https://nu.novell.com/repo/$RCE/OES2018-SP2-SLE-Module-Web-Scripting12-Updates/sle-12-x86_64/",
+                "name" : "OES2018-SP2-SLE-Module-Web-Scripting12-Updates",
+                "distro_target" : "sle-12-x86_64",
+                "description" : "The SUSE Linux Enterprise Web and Scripting Module delivers a comprehensive suite of scripting languages, frameworks, and related tools helping developers and systems administrators accelerate the creation of stable, modern web applications, using dynamic languages, such as PHP, Ruby on Rails, and Python. \\n Access to the Web and Scripting Module is included in your SUSE Linux Enterprise Server subscription. The module has a different lifecycle than SUSE Linux Enterprise Server itself: Package versions in the this module are usually supported for at most three years. We are planning to release more recent versions on a schedule of approximately 18 month; the exact dates may differ per package.",
+                "enabled" : false,
+                "autorefresh" : true,
+                "installer_updates" : false
+            },
+            {
+                "id" : -108,
+                "url" : "https://nu.novell.com/repo/$RCE/OES2018-SP2-SLE-Module-Web-Scripting12-Debuginfo-Pool/sle-12-x86_64/",
+                "name" : "OES2018-SP2-SLE-Module-Toolchain12-Debuginfo-Pool",
+                "distro_target" : "sle-12-x86_64",
+                "description" : "The SUSE Linux Enterprise Web and Scripting Module delivers a comprehensive suite of scripting languages, frameworks, and related tools helping developers and systems administrators accelerate the creation of stable, modern web applications, using dynamic languages, such as PHP, Ruby on Rails, and Python. \\n Access to the Web and Scripting Module is included in your SUSE Linux Enterprise Server subscription. The module has a different lifecycle than SUSE Linux Enterprise Server itself: Package versions in the this module are usually supported for at most three years. We are planning to release more recent versions on a schedule of approximately 18 month; the exact dates may differ per package.",
+                "enabled" : false,
+                "autorefresh" : false,
+                "installer_updates" : false
+            },
+            {
+                "id" : -109,
+                "url" : "https://nu.novell.com/repo/$RCE/OES2018-SP2-SLE-Module-Web-Scripting12-Debuginfo-Updates/sle-12-x86_64/",
+                "name" : "OES2018-SP2-SLE-Module-Web-Scripting12-Debuginfo-Updates",
+                "distro_target" : "sle-12-x86_64",
+                "description" : "The SUSE Linux Enterprise Web and Scripting Module delivers a comprehensive suite of scripting languages, frameworks, and related tools helping developers and systems administrators accelerate the creation of stable, modern web applications, using dynamic languages, such as PHP, Ruby on Rails, and Python. \\n Access to the Web and Scripting Module is included in your SUSE Linux Enterprise Server subscription. The module has a different lifecycle than SUSE Linux Enterprise Server itself: Package versions in the this module are usually supported for at most three years. We are planning to release more recent versions on a schedule of approximately 18 month; the exact dates may differ per package.",
+                "enabled" : false,
+                "autorefresh" : true,
+                "installer_updates" : false
+            },
+            {
+                "id" : -110,
+                "url" : "https://nu.novell.com/repo/$RCE/OES2018-SP2-SLE-Module-Toolchain12-Pool/sle-12-x86_64/",
+                "name" : "OES2018-SP2-SLE-Module-Toolchain12-Pool",
+                "distro_target" : "sle-12-x86_64",
+                "description" : "Via this Module you will have access to a more recent GCC and Toolchain in addition to the default compiler of SUSE Linux Enterprise. Access to the Toolchain Module is included in your SUSE Linux Enterprise Server subscription. The module has a different lifecycle than SUSE Linux Enterprise Server itself. Please check the Release Notes for further details.",
+                "enabled" : false,
+                "autorefresh" : false,
+                "installer_updates" : false
+            },
+            {
+                "id" : -111,
+                "url" : "https://nu.novell.com/repo/$RCE/OES2018-SP2-SLE-Module-Toolchain12-Updates/sle-12-x86_64/",
+                "name" : "OES2018-SP2-SLE-Module-Toolchain12-Updates",
+                "distro_target" : "sle-12-x86_64",
+                "description" : "Via this Module you will have access to a more recent GCC and Toolchain in addition to the default compiler of SUSE Linux Enterprise. Access to the Toolchain Module is included in your SUSE Linux Enterprise Server subscription. The module has a different lifecycle than SUSE Linux Enterprise Server itself. Please check the Release Notes for further details.",
+                "enabled" : false,
+                "autorefresh" : true,
+                "installer_updates" : false
+            },
+            {
+                "id" : -112,
+                "url" : "https://nu.novell.com/repo/$RCE/OES2018-SP2-SLE-Module-Toolchain12-Debuginfo-Pool/sle-12-x86_64/",
+                "name" : "OES2018-SP2-SLE-Module-Toolchain12-Debuginfo-Pool",
+                "distro_target" : "sle-12-x86_64",
+                "description" : "Via this Module you will have access to a more recent GCC and Toolchain in addition to the default compiler of SUSE Linux Enterprise. Access to the Toolchain Module is included in your SUSE Linux Enterprise Server subscription. The module has a different lifecycle than SUSE Linux Enterprise Server itself. Please check the Release Notes for further details.",
+                "enabled" : false,
+                "autorefresh" : false,
+                "installer_updates" : false
+            },
+            {
+                "id" : -113,
+                "url" : "https://nu.novell.com/repo/$RCE/OES2018-SP2-SLE-Module-Toolchain12-Debuginfo-Updates/sle-12-x86_64/",
+                "name" : "OES2018-SP2-SLE-Module-Toolchain12-Debuginfo-Updates",
+                "distro_target" : "sle-12-x86_64",
+                "description" : "Via this Module you will have access to a more recent GCC and Toolchain in addition to the default compiler of SUSE Linux Enterprise. Access to the Toolchain Module is included in your SUSE Linux Enterprise Server subscription. The module has a different lifecycle than SUSE Linux Enterprise Server itself. Please check the Release Notes for further details.",
+                "enabled" : false,
+                "autorefresh" : true,
+                "installer_updates" : false
+            }
+        ]
+    },
+    {
         "id" : -8,
         "name" : "RHEL8 Base",
         "identifier" : "rhel-base",

--- a/susemanager-sync-data/channel_families.json
+++ b/susemanager-sync-data/channel_families.json
@@ -196,20 +196,20 @@
     "name" : "SUSE Linux Enterprise Server LTSS 12 SP3 Z-Series"
   },
   {
+    "label" : "SLES15-GA-LTSS-PPC",
+    "name" : "SUSE Linux Enterprise Server LTSS 15 GA PPC"
+  },
+  {
+    "label" : "SLES15-GA-LTSS-X86",
+    "name" : "SUSE Linux Enterprise Server LTSS 15 GA x86_64"
+  },
+  {
+    "label" : "SLES15-GA-LTSS-Z",
+    "name" : "SUSE Linux Enterprise Server LTSS 15 GA Z-Series"
+  },
+  {
     "label" : "SLES15-LTSS-ARM64",
     "name" : "SUSE Linux Enterprise Server LTSS 15 ARM64"
-  },
-  {
-    "label" : "SLES15-LTSS-PPC",
-    "name" : "SUSE Linux Enterprise Server LTSS 15 PPC"
-  },
-  {
-    "label" : "SLES15-LTSS-X86",
-    "name" : "SUSE Linux Enterprise Server LTSS 15 x86_64"
-  },
-  {
-    "label" : "SLES15-LTSS-Z",
-    "name" : "SUSE Linux Enterprise Server LTSS 15 Z-Series"
   },
   {
     "label" : "SLESMT",

--- a/susemanager-sync-data/susemanager-sync-data.changes
+++ b/susemanager-sync-data/susemanager-sync-data.changes
@@ -1,3 +1,7 @@
+- add OES 2018 SP2 (bsc#1161862)
+- rename RHEL 8 Base product
+- change channel family name according to SCC data
+
 -------------------------------------------------------------------
 Wed Jan 22 12:25:37 CET 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

- Add OES 2018 SP2 via additional products
- rename RHEL8 Base product
- change channel family name according to SCC data

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **OES will be tested by OES Team**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/10606
Tracks https://github.com/SUSE/spacewalk/pull/10787 https://github.com/SUSE/spacewalk/pull/10788

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
