### PR TITLE
Manager bsc1164452

### DIFF
--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -982,6 +982,11 @@ echo "------------"
 # change the string as needed.
 #
 
+if [[ $ACTIVATION_KEYS =~ , ]] ; then
+    echo "*** ERROR: Multiple activation keys are not supported with salt!"
+    exit 1
+fi
+
 MINION_ID_FILE="/etc/salt/minion_id"
 SUSEMANAGER_MASTER_FILE="/etc/salt/minion.d/susemanager.conf"
 

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,5 @@
+- forbid multiple activation keys for salt minions during bootstrap (bsc#1164452)
+
 -------------------------------------------------------------------
 Mon Feb 17 12:48:49 CET 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

For salt minions, multiple activation keys are not allowed, only the first one specified is being used. In order to avoid surprises for the admin, the bootstrap script should terminate if more than one activation key is specified.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: Script already printed some warning, but did continue, so some people were not aware of this limitation.

- [X] **DONE**

## Links

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1164452

- [X] **DONE**