### PR TITLE
Adjust postgresql-jdbc version for ivy

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -60,7 +60,7 @@
         <dependency org="suse" name="netty-transport-native-unix-common" rev="4.1.44.Final" />
         <dependency org="suse" name="oro" rev="2.0.8" />
         <dependency org="suse" name="pgjdbc-ng" rev="0.8.3" />
-        <dependency org="suse" name="postgresql-jdbc" rev="9.4" />
+        <dependency org="suse" name="postgresql-jdbc" rev="42.2.10" />
         <dependency org="suse" name="quartz" rev="2.3.0" />
         <dependency org="suse" name="redstone-xmlrpc" rev="1.1_20071120" />
         <dependency org="suse" name="redstone-xmlrpc-client" rev="1.1_20071120" />


### PR DESCRIPTION
## What does this PR change?

Adjust postgresql-jdbc version for ivy, to fix the tests and get the correct version for development.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Development and testing

- [x] **DONE**

## Test coverage
- No tests: This will fix tests.

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
