### PR TITLE
Auto select recommended and mandatory channels by default

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
@@ -15,12 +15,6 @@
 
 package com.suse.manager.reactor.messaging;
 
-import static java.util.Collections.emptyList;
-import static java.util.Collections.emptySet;
-import static java.util.Optional.ofNullable;
-import static java.util.stream.Collectors.partitioningBy;
-import static java.util.stream.Collectors.toSet;
-
 import com.redhat.rhn.common.messaging.MessageQueue;
 import com.redhat.rhn.common.validator.ValidatorResult;
 import com.redhat.rhn.domain.channel.Channel;
@@ -46,19 +40,16 @@ import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
-
 import com.suse.manager.reactor.utils.RhelUtils;
 import com.suse.manager.reactor.utils.ValueMap;
 import com.suse.manager.virtualization.VirtManagerSalt;
 import com.suse.manager.webui.controllers.StatesAPI;
 import com.suse.manager.webui.services.iface.RedhatProductInfo;
+import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.services.pillar.MinionPillarManager;
-import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.salt.netapi.calls.modules.Zypper;
 import com.suse.utils.Opt;
-import org.apache.log4j.Logger;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -68,6 +59,13 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
+import org.apache.log4j.Logger;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+import static java.util.Optional.ofNullable;
+import static java.util.stream.Collectors.partitioningBy;
+import static java.util.stream.Collectors.toSet;
 
 /**
  * Common registration logic that can be used from multiple places

--- a/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
@@ -434,8 +434,12 @@ public class RegistrationUtils {
         }
 
         // identify the product by the base channel name
-        SUSEProduct baseProduct = SUSEProductFactory.findProductByChannelLabel(baseChannel.getLabel()).get();
-        return baseProduct.getSuseProductChannels().stream()
+        Optional<SUSEProduct> baseProduct = SUSEProductFactory.findProductByChannelLabel(baseChannel.getLabel());
+        if (baseProduct.isEmpty()) {
+            return Stream.empty();
+        }
+
+        return baseProduct.get().getSuseProductChannels().stream()
                 .filter(pc -> pc.isMandatory())
                 .map(SUSEProductChannel::getChannel)
                 // filter out channels with different base than the given one

--- a/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
@@ -44,6 +44,7 @@ import com.suse.manager.reactor.utils.RhelUtils;
 import com.suse.manager.reactor.utils.ValueMap;
 import com.suse.manager.virtualization.VirtManagerSalt;
 import com.suse.manager.webui.controllers.StatesAPI;
+import com.suse.manager.webui.controllers.channels.ChannelsUtils;
 import com.suse.manager.webui.services.iface.RedhatProductInfo;
 import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.impl.SaltService;
@@ -262,7 +263,7 @@ public class RegistrationUtils {
                                 return Stream.concat(
                                         Stream.concat(
                                                 Stream.of(baseChannel),
-                                                mandatoryChannelsByBaseChannel(baseChannel)),
+                                                ChannelsUtils.mandatoryChannelsByBaseChannel(baseChannel)),
                                         ak.getChannels().stream()
                                                 .filter(c -> c.getParentChannel() != null &&
                                                         c.getParentChannel().getId().equals(baseChannel.getId())))
@@ -274,7 +275,7 @@ public class RegistrationUtils {
                                 Stream.concat(
                                     Stream.of(baseChannel),
                                     Stream.concat(
-                                            mandatoryChannelsByBaseChannel(baseChannel),
+                                            ChannelsUtils.mandatoryChannelsByBaseChannel(baseChannel),
                                             ak.getChannels().stream())
                                 ).collect(toSet())
                 )
@@ -420,30 +421,5 @@ public class RegistrationUtils {
                             stream
                     );
                 }).orElseGet(Stream::empty);
-    }
-
-    /**
-     * Returns a Stream of mandatory channels for a certain product, given its base channel in input
-     *
-     * @param baseChannel the product base channel
-     * @return the Stream of mandatory channels
-     */
-    private static Stream<Channel> mandatoryChannelsByBaseChannel(Channel baseChannel) {
-        if (!baseChannel.isBaseChannel()) {
-            return Stream.empty();
-        }
-
-        // identify the product by the base channel name
-        Optional<SUSEProduct> baseProduct = SUSEProductFactory.findProductByChannelLabel(baseChannel.getLabel());
-        if (baseProduct.isEmpty()) {
-            return Stream.empty();
-        }
-
-        return baseProduct.get().getSuseProductChannels().stream()
-                .filter(pc -> pc.isMandatory())
-                .map(SUSEProductChannel::getChannel)
-                // filter out channels with different base than the given one
-                .filter(c -> c.getParentChannel() == null ||
-                        c.getParentChannel().getLabel().equals(baseChannel.getLabel()));
     }
 }

--- a/java/code/webapp/WEB-INF/pages/systems/sdc/overview.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/sdc/overview.jsp
@@ -217,17 +217,20 @@
         </div>
         <div class="panel-body">
           <c:if test="${system.baseChannel != null}">
+            <h4>Base Channel</h4>
             <ul class="channel-list">
-            <li>
-              <a href="/rhn/channels/ChannelDetail.do?cid=${baseChannel['id']}"><c:out value="${baseChannel['name']}" /></a>
-            </li>
+              <li>
+                <a href="/rhn/channels/ChannelDetail.do?cid=${baseChannel['id']}"><c:out value="${baseChannel['name']}" /></a>
+              </li>
+            </ul>
 
-            <c:forEach items="${childChannels}" var="childChannel">
-            <li class="child-channel">
-              <a href="/rhn/channels/ChannelDetail.do?cid=${childChannel['id']}"><c:out value="${childChannel['name']}" /></a>
-            </li>
-            </c:forEach>
-
+            <h4>Child Channels</h4>
+            <ul class="channel-list">
+              <c:forEach items="${childChannels}" var="childChannel">
+              <li class="child-channel">
+                <a href="/rhn/channels/ChannelDetail.do?cid=${childChannel['id']}"><c:out value="${childChannel['name']}" /></a>
+              </li>
+              </c:forEach>
             </ul>
           </c:if>
         </div>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Assign Activation Key channels only (bsc#1166516)
 - Pass image profile custom info values as Docker buildargs during image build
 - Fix activation keys request error in image import page (bsc#1170046)
 - Fix custom info values input in image profile edit form (bsc#1169773)

--- a/web/html/src/manager/systems/activation-key/activation-key-channels-api.js
+++ b/web/html/src/manager/systems/activation-key/activation-key-channels-api.js
@@ -73,7 +73,7 @@ class ActivationKeyChannelsApi extends React.Component<ActivationKeyChannelsProp
 
   fetchActivationKeyChannels = () => {
     let future: Promise<void>;
-    if (this.props.activationKeyId != -1) {
+    if (this.props.activationKeyId && this.props.activationKeyId != -1) {
       this.setState({loading: true});
 
       future = Network.get(`/rhn/manager/api/activation-keys/${this.props.activationKeyId}/channels`)

--- a/web/html/src/manager/systems/activation-key/child-channels.js
+++ b/web/html/src/manager/systems/activation-key/child-channels.js
@@ -113,14 +113,14 @@ class ChildChannels extends React.Component<ChildChannelsProps, ChildChannelsSta
           const mandatoryChannelsForBaseId: ?Set<number> = this.props.base && this.props.requiredChannelsResult.requiredChannels.get(this.props.base.id);
 
           const isMandatory = mandatoryChannelsForBaseId && mandatoryChannelsForBaseId.has(c.id);
-          const isDisabled = isMandatory && this.props.selectedChannelsIds.includes(c.id);
+          const isDisabled = isMandatory;
           return (
             <div key={c.id} className='checkbox'>
               <input type='checkbox'
                      value={c.id}
                      id={'child_' + c.id}
                      name='childChannels'
-                     checked={this.props.selectedChannelsIds.includes(c.id)}
+                     checked={isMandatory || this.props.selectedChannelsIds.includes(c.id)}
                      disabled={isDisabled}
                      onChange={(event) => this.handleChannelChange(event)}
               />
@@ -128,7 +128,7 @@ class ChildChannels extends React.Component<ChildChannelsProps, ChildChannelsSta
                 // add an hidden carbon-copy of the disabled input since the disabled one will not be included in the form submit
                 isDisabled ?
                   <input type='checkbox' value={c.id} name='childChannels'
-                         hidden='hidden' checked={this.props.selectedChannelsIds.includes(c.id)} readOnly={true}/>
+                         hidden='hidden' checked={isMandatory || this.props.selectedChannelsIds.includes(c.id)} readOnly={true}/>
                   : null
               }
               <label title={toolTip} htmlFor={"child_" + c.id}>{c.name}</label>

--- a/web/html/src/manager/systems/activation-key/child-channels.js
+++ b/web/html/src/manager/systems/activation-key/child-channels.js
@@ -39,8 +39,7 @@ class ChildChannels extends React.Component<ChildChannelsProps, ChildChannelsSta
   }
 
   componentDidMount = () => {
-    !this.state.collapsed
-        && this.props.fetchMandatoryChannelsByChannelIds({base: this.props.base, channels: this.props.channels})
+    this.props.fetchMandatoryChannelsByChannelIds({base: this.props.base, channels: this.props.channels});
   };
 
   handleChannelChange = (event: SyntheticInputEvent<*>) => {
@@ -79,16 +78,8 @@ class ChildChannels extends React.Component<ChildChannelsProps, ChildChannelsSta
     }
   };
 
-  toggleChannelVisibility = ({onShow}: {onShow: Function})  => {
-    const prevState = this.state;
-    this.setState(
-      {collapsed: !this.state.collapsed},
-      () => {
-        if (prevState.collapsed != this.state.collapsed && !this.state.collapsed) {
-          onShow();
-        }
-      }
-    );
+  toggleChannelVisibility = () => {
+    this.setState({collapsed: !this.state.collapsed});
   };
 
   areRecommendedChildrenSelected = () : boolean => {
@@ -161,10 +152,7 @@ class ChildChannels extends React.Component<ChildChannelsProps, ChildChannelsSta
 
     return (
       <div className='child-channels-block'>
-        <h4 className='pointer'
-            onClick={() => this.toggleChannelVisibility({
-                onShow: () => this.props.fetchMandatoryChannelsByChannelIds({base: this.props.base, channels: this.props.channels})
-              })} >
+        <h4 className='pointer' onClick={() => this.toggleChannelVisibility()}>
           <i className={'fa ' + (this.state.collapsed ? 'fa-angle-right' : 'fa-angle-down')} />
           {this.props.base.name}
         </h4>

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- auto select recommended and mandatory channels by default (bsc#1162843)
 - Add hint to edit formulas before applying state (bsc#1168805)
 - Fix custom info values input in image profile edit form (bsc#1169773)
 - Web UI: Implement bootstrapping minions using an SSH private key


### PR DESCRIPTION
## What does this PR change?

Auto select all recommended and mandatory channels on system details software channel selection, and mandatory in activation key (https://bugzilla.suse.com/show_bug.cgi?id=1162843)

Additional fix within this PR: respect Activation Key channels selection (https://bugzilla.suse.com/show_bug.cgi?id=1166516)

## GUI diff

Minor change in the UI available like the following

Before:
![Screenshot from 2020-04-30 17-22-46](https://user-images.githubusercontent.com/7080830/80730933-807f9480-8b0a-11ea-91eb-6642fcb3576f.png)


After:
![Screenshot from 2020-04-30 14-08-14](https://user-images.githubusercontent.com/7080830/80730950-85dcdf00-8b0a-11ea-81b6-55c7c46a8b84.png)


- [x] **DONE**

## Documentation
- No documentation needed: fix expected behavior

- [x] **DONE**

## Test coverage
- No tests: no specific implied scenario

- [x] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/10678
Tracks # 

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
