### PR TITLE
Add 'product' custom state module (bsc#1157447)

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/packages/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/packages/init.sls
@@ -1,2 +1,12 @@
+{%- if grains['os_family'] == 'Suse' %}
+mgr_install_products:
+  product.all_installed:
+    - refresh: True
+    - require:
+      - file: mgrchannels_*
+      - module: sync_states
+{%- endif %}
+
 include:
+  - util.syncstates
   - .packages_{{ grains['machine_id'] }}

--- a/susemanager-utils/susemanager-sls/salt/util/synccustomall.sls
+++ b/susemanager-utils/susemanager-sls/salt/util/synccustomall.sls
@@ -1,4 +1,5 @@
 include:
   - util.syncmodules
+  - util.syncstates
   - util.syncgrains
   - util.syncbeacons

--- a/susemanager-utils/susemanager-sls/salt/util/systeminfo.sls
+++ b/susemanager-utils/susemanager-sls/salt/util/systeminfo.sls
@@ -1,5 +1,6 @@
 include:
   - util.syncmodules
+  - util.syncstates
   - util.syncgrains
   - util.syncbeacons
 status_uptime:

--- a/susemanager-utils/susemanager-sls/src/tests/mockery.py
+++ b/susemanager-utils/susemanager-sls/src/tests/mockery.py
@@ -15,6 +15,7 @@ def setup_environment():
     if 'salt' not in sys.modules or not isinstance(sys.modules['salt'], MagicMock):
         sys.modules['salt'] = MagicMock()
         sys.modules['salt.utils'] = MagicMock()
+        sys.modules['salt.utils.path'] = MagicMock()
         sys.modules['salt.modules'] = MagicMock()
         sys.modules['salt.modules.cmdmod'] = MagicMock()
         sys.modules['salt.exceptions'] = MagicMock(CommandExecutionError=Exception)

--- a/susemanager-utils/susemanager-sls/src/tests/test_state_product.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_state_product.py
@@ -1,0 +1,96 @@
+'''
+Author: cbbayburt@suse.com
+'''
+
+import sys
+from mock import MagicMock, patch, call
+from . import mockery
+mockery.setup_environment()
+
+from ..states import product
+
+# Mock globals
+product.log = MagicMock()
+product.__salt__ = {}
+product.__grains__ = {}
+
+def test_virtual():
+    '''
+    Test if the state module is only available for SUSE OS
+    with Zypper available.
+    '''
+    with patch.dict(product.__grains__, {'os_family': 'Suse'}):
+        with patch('src.states.product.salt.utils.path.which', MagicMock(return_value="/my/zypper")):
+            assert product.__virtual__() is 'product'
+            product.salt.utils.path.which.assert_called_once_with('zypper')
+        with patch('src.states.product.salt.utils.path.which', MagicMock(return_value=None)):
+            assert product.__virtual__() == (False, "Module product: zypper package manager not found")
+            product.salt.utils.path.which.assert_called_once_with('zypper')
+
+    with patch.dict(product.__grains__, {'os_family': 'Non-Suse'}):
+            assert product.__virtual__() == (False, "Module product: non SUSE OS not supported")
+
+def test_get_missing_products():
+    '''
+    Test if the missing products are returned correctly, excluding
+    the ones that are provided by another installed product.
+    '''
+    test_data = {
+        'not_installed': {'product1': True, 'product2': True},
+        'provides-product1': {'this-provides-product1': True}
+    }
+
+    pkg_search_mock = MagicMock(side_effect=[
+        test_data['not_installed'],
+        test_data['provides-product1'],
+        sys.modules['salt.exceptions'].CommandExecutionError])
+
+    with patch.dict(product.__salt__, {'pkg.search': pkg_search_mock}):
+        res = product._get_missing_products(False)
+
+        # Expected pkg.search calls
+        calls = [
+            call('product()', refresh=False, match='exact', provides=True, not_installed_only=True),
+            call('product1', match='exact', provides=True),
+            call('product2', match='exact', provides=True)
+        ]
+
+        pkg_search_mock.assert_has_calls(calls)
+        assert pkg_search_mock.call_count == 3
+        # Assert that only the non-provided product is returned
+        assert res == ['product2']
+
+
+def test_not_installed_provides():
+    '''
+    Test if the provided packages are correctly excluded when
+    provided by another missing product.
+    '''
+    test_data = {
+        'not_installed': {'product1': True, 'this-provides-product1': True},
+        'provides-product1': {'this-provides-product1': True}
+    }
+
+    pkg_search_mock = MagicMock(side_effect=[
+        test_data['not_installed'],
+        test_data['provides-product1'],
+        sys.modules['salt.exceptions'].CommandExecutionError])
+
+    with patch.dict(product.__salt__, {'pkg.search': pkg_search_mock}):
+        res = product._get_missing_products(False)
+
+        # Expected pkg.search calls
+        calls = [
+            call('product()', refresh=False, match='exact', provides=True, not_installed_only=True),
+            call('product1', match='exact', provides=True),
+            call('this-provides-product1', match='exact', provides=True)
+        ]
+
+        pkg_search_mock.assert_has_calls(calls)
+        assert pkg_search_mock.call_count == 3
+        # Assert that not both products are returned
+        assert len(res) == 1
+        # Assert that the provided product is not returned
+        assert 'product1' not in res
+        # Assert that the providing product is returned
+        assert 'this-provides-product1' in res

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- Add 'product' custom state module to handle installation of
+  SUSE products at client side (bsc#1157447)
 - Support reading of pillar data for minions from multiple files (bsc#1158754)
 
 -------------------------------------------------------------------

--- a/susemanager-utils/susemanager-sls/susemanager-sls.spec
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.spec
@@ -54,6 +54,7 @@ provided for the integration between infrastructure components.
 mkdir -p %{buildroot}/usr/share/susemanager/salt/_grains
 mkdir -p %{buildroot}/usr/share/susemanager/salt/_beacons
 mkdir -p %{buildroot}/usr/share/susemanager/salt/_modules
+mkdir -p %{buildroot}/usr/share/susemanager/salt/_states
 mkdir -p %{buildroot}/usr/share/susemanager/modules/pillar
 mkdir -p %{buildroot}/usr/share/susemanager/modules/tops
 mkdir -p %{buildroot}/usr/share/susemanager/modules/runners
@@ -86,6 +87,7 @@ cp src/modules/udevdb.py %{buildroot}/usr/share/susemanager/salt/_modules
 cp src/modules/mgractionchains.py %{buildroot}/usr/share/susemanager/salt/_modules
 cp src/modules/kiwi_info.py %{buildroot}/usr/share/susemanager/salt/_modules
 cp src/modules/kiwi_source.py %{buildroot}/usr/share/susemanager/salt/_modules
+cp src/states/product.py %{buildroot}/usr/share/susemanager/salt/_states
 
 %check
 cd test


### PR DESCRIPTION
Add a custom state module to SUSE Manager to handle the installation of missing SUSE products on the client side.

This change replaces the logic to determine the missing products to be installed in SUMA and adding them as package states by delegating the resolution to the client via a state module.

Deprecated code will be removed in a separate PR.

### See also
https://bugzilla.suse.com/1157447
https://bugzilla.suse.com/1130551

## CLI Diff (from highstate test run)
Before (using package states):
```
          ID: pkg_latest
    Function: pkg.latest
      Result: None
     Comment: The following packages would be installed/upgraded: sle-manager-tools-release, sles-ltss-release
     Started: 18:06:14.185443
    Duration: 3675.215 ms
     Changes: 
```
After (with `product.all_installed`):
```
          ID: mgr_install_products
    Function: product.all_installed
      Result: None
     Comment: The following packages would be installed/updated: sles-ltss-release, sle-manager-tools-release
     Started: 18:06:17.862483
    Duration: 1966.39 ms
     Changes:   
```
## Documentation
- No documentation needed: only internal changes

## Test coverage
- Unit tests were added

## Links

Tracks https://github.com/SUSE/spacewalk/pull/10389

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
