### PR TITLE
Testsuite: Pacify rubocop

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -806,6 +806,7 @@ Then(/^name resolution should work on terminal "([^"]*)"$/) do |host|
   end
 end
 
+# rubocop:disable Metrics/BlockLength
 When(/^I configure the proxy$/) do
   # prepare the settings file
   settings = "RHN_PARENT=#{$server.ip}\n" \
@@ -844,6 +845,7 @@ When(/^I configure the proxy$/) do
     return_code
   end
 end
+# rubocop:enable Metrics/BlockLength
 
 Then(/^The metadata buildtime from package "(.*?)" match the one in the rpm on "(.*?)"$/) do |pkg, host|
   # for testing buildtime of generated metadata - See bsc#1078056


### PR DESCRIPTION
## What does this PR change?

Pacify Rubocop
- testsuite/features/step_definitions/command_steps.rb (/^I configure the proxy$/)
Disable Metrics/BlockLength rule for this method.

## Links

### Ports
- Manager-3.2: https://github.com/SUSE/spacewalk/pull/10799
- Manager-4.0: https://github.com/SUSE/spacewalk/pull/10800

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

