### PR TITLE
Fix salt bootstrapping on SLE15 (bsc#1164563)

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -328,7 +328,7 @@ PKGLIST15_SALT = [
     "python3-msgpack",
     "python3-psutil",
     "python3-py",
-    "python3-pycrypto",
+    "python3-pycrypto|python3-M2Crypto",
     "python3-pytz",
     "python3-PyYAML",
     "python3-pyzmq",

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,6 @@
+- Fix salt bootstrapping on SLE15 (require python3-pycrypto or 
+  python3-M2Crypto to support all variants) (bsc#1164563)
+
 -------------------------------------------------------------------
 Mon Feb 17 12:55:34 CET 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Fix salt bootstrapping on SLE15 (bsc#1164563).

According to `salt.spec`:

```
%if 0%{?suse_version} >= 1500
BuildRequires:  python3-M2Crypto
%else
BuildRequires:  python3-pycrypto >= 2.6.1
%endif
```
We require either. If `python3-pycrypto` is found it will be used (it means a bootstrap repository for SLE15GA is being created). Otherwise it's a bootstrap repository for any other SLE15 and `python3-pycrypto` can be used.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Bugfix

- [x] **DONE**

## Test coverage
- No tests: Not covered, but should be covered soon (by testsuite)
- [x] **DONE**

## Links

Tracks: https://github.com/SUSE/spacewalk/issues/10804

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
