### PR TITLE
Fix hw refresh

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/hardware/profileupdate.sls
+++ b/susemanager-utils/susemanager-sls/salt/hardware/profileupdate.sls
@@ -1,3 +1,14 @@
+
+{%- if grains['cpuarch'] in ['i386', 'i486', 'i586', 'i686', 'x86_64', 'aarch64'] %}
+mgr_install_dmidecode:
+  pkg.installed:
+{%- if grains['os_family'] == 'Suse' and grains['osrelease'] in ['11.3', '11.4'] %}
+    - name: pmtools
+{%- else %}
+    - name: dmidecode
+{%- endif %}
+{%- endif %}
+
 grains:
   module.run:
     - name: grains.items

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- install dmidecode before HW profile update when missing
 - Add mgr_start_event_grains.sls to update minion config
 - Add 'product' custom state module to handle installation of
   SUSE products at client side (bsc#1157447)


### PR DESCRIPTION
## What does this PR change?

Bootstrapping salt via UI execute a state which install dmidecode on special hosts.
But when bootstrapping via bootstrap script this state is not executed. This cause
Hardware Profile update failure when dmidecode package is not installed.

To prevent this, we take care that it is installed directly before refreshing the profile.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **already covered**

- [x] **DONE**

## Links

Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
