### PR TITLE
Fix the compilation of SystemManagerTest

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -1561,7 +1561,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         assertTrue(SystemManager.hasEntitlement(server.getId(), EntitlementManager.MONITORING));
 
         // Remove server from group, entitlement should be removed
-        SystemManager.removeServerFromServerGroup(server, group);
+        SystemManager.removeServersFromServerGroup(Arrays.asList(server), group);
         assertFalse(SystemManager.hasEntitlement(server.getId(), EntitlementManager.MONITORING));
     }
 }


### PR DESCRIPTION
## What does this PR change?

This is a fixup for the previously merged #1918: The underlying code has been changed since that PR was opened and checked, so the method used / tested does no longer exist.

## GUI diff

No difference.

- [X] **DONE**

## Documentation

- No documentation needed, just a fix for tests.

- [X] **DONE**

## Test coverage

- No tests needed, this is just a fix for tests.

- [X] **DONE**

## Links

Fixes up #1918

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle" 		 
- [ ] Re-run test "java_pgsql_tests" 		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
