### PR TITLE
Add missing python libraries to RES/RHEL/CentOS 8 bootstrap repos

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -313,6 +313,12 @@ RES8 = [
     "openpgm",
     "zeromq",
     "dmidecode",
+    "python3-urllib3",
+    "python3-idna",
+    "python3-chardet",
+    "python3-pysocks",
+    "python3-pytz",
+    "python3-setuptools"
 ]
 
 PKGLIST15_SALT = [

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- Add missing python libraries to RES8/RHEL8/CentOS 8 boostrap repos (bsc#1164875)
 - add bootstrap-repo data for OES 2018 SP2 (bsc#1161862)
 - remove oracle backend support and tooling
 - remove mgr-register dummy


### PR DESCRIPTION
Adds the missing python libraries to the RHEL/CentOS 8 bootstrap repository.

## Links

Fixes #1939 
Port of https://github.com/SUSE/spacewalk/pull/10843

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
