### PR TITLE
Auto generate bootstrap repositories

### DIFF
--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -656,7 +656,8 @@ class RepoSync(object):
             taskomatic.add_to_erratacache_queue(self.channel_label)
         self.update_date()
         rhnSQL.commit()
-        subprocess.call(["/usr/sbin/mgr-create-bootstrap-repo", "--auto"])
+        if CFG.AUTO_GENERATE_BOOTSTRAP_REPO:
+            subprocess.call(["/usr/sbin/mgr-create-bootstrap-repo", "--auto"])
 
         # update permissions
         fileutils.createPath(os.path.join(CFG.MOUNT_POINT, 'rhn'))  # if the directory exists update ownership only

--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -18,6 +18,7 @@ import os
 import re
 import shutil
 import socket
+import subprocess
 import sys
 import time
 import traceback
@@ -655,6 +656,7 @@ class RepoSync(object):
             taskomatic.add_to_erratacache_queue(self.channel_label)
         self.update_date()
         rhnSQL.commit()
+        subprocess.call(["/usr/sbin/mgr-create-bootstrap-repo", "--auto"])
 
         # update permissions
         fileutils.createPath(os.path.join(CFG.MOUNT_POINT, 'rhn'))  # if the directory exists update ownership only

--- a/backend/satellite_tools/test/unit/test_reposync.py
+++ b/backend/satellite_tools/test/unit/test_reposync.py
@@ -704,6 +704,7 @@ class RepoSyncTest(unittest.TestCase):
         self.reposync.CFG = Mock()
         self.reposync.CFG.MOUNT_POINT = '/tmp'
         self.reposync.CFG.PREPENDED_DIR = ''
+        self.reposync.CFG.AUTO_GENERATE_BOOTSTRAP_REPO = 1
         self.reposync.fileutils.createPath = Mock()
         self.reposync.os.walk = Mock(return_value=[])
         self.reposync.subprocess.call = Mock()
@@ -715,8 +716,7 @@ class SyncTest(unittest.TestCase):
     def setUp(self):
         module_patcher = patch.multiple(
             'spacewalk.satellite_tools.reposync',
-            rhnSQL=Mock(),
-            initCFG=Mock()
+            rhnSQL=Mock()
         )
         class_patcher = patch.multiple(
             'spacewalk.satellite_tools.reposync.RepoSync',
@@ -937,6 +937,7 @@ class RunScriptTest(unittest.TestCase):
     def test_config_parameter_channel_as_list(self):
         self.repo_sync.CFG = Mock()
         self.repo_sync.CFG.DEBUG = 3
+        self.repo_sync.CFG.AUTO_GENERATE_BOOTSTRAP_REPO = 1
         self.repo_sync.main()
         self.assertEqual(self.repo_sync.reposync.RepoSync.call_count, 2)
 
@@ -950,6 +951,7 @@ def test_channel_exceptions():
     repoSync.CFG = repoSync.initCFG = Mock()
     repoSync.CFG.MOUNT_POINT = '/tmp'
     repoSync.CFG.PREPENDED_DIR = ''
+    repoSync.CFG.AUTO_GENERATE_BOOTSTRAP_REPO = 1
     repoSync.fileutils.createPath = Mock()
     repoSync.os.walk = Mock(return_value=[])
     backup_os = repoSync.os

--- a/backend/satellite_tools/test/unit/test_reposync.py
+++ b/backend/satellite_tools/test/unit/test_reposync.py
@@ -706,6 +706,7 @@ class RepoSyncTest(unittest.TestCase):
         self.reposync.CFG.PREPENDED_DIR = ''
         self.reposync.fileutils.createPath = Mock()
         self.reposync.os.walk = Mock(return_value=[])
+        self.reposync.subprocess.call = Mock()
         return rs
 
 

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- call mgr-create-bootstrap-repo after repo sync
 - fix mgrcfg-client python3 breakage (bsc#1164309
 - Remove oracle backend support and tests
 - remove code to handle tables used for forwarding registrations

--- a/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -202,7 +202,7 @@ public class ConfigDefaults {
      * SUSE Manager defaults
      */
     public static final String SCC_URL = "server.susemanager.scc_url";
-    public static final String PRODUCT_TREE_TAG = "java.product_tree.tag";
+    public static final String PRODUCT_TREE_TAG = "java.product_tree_tag";
 
     public static final String MESSAGE_QUEUE_THREAD_POOL_SIZE = "java.message_queue_thread_pool_size";
 

--- a/java/conf/rhn_java.conf
+++ b/java/conf/rhn_java.conf
@@ -213,7 +213,7 @@ java.mgr_sync_max_connections = 4
 java.max_changelog_entries = 0
 
 # Determins which product tree variation to use.
-java.product_tree.tag = SUMA4.1
+java.product_tree_tag = SUMA4.1
 
 # If true, login is enabled via Single Sign-On (SSO)
 java.sso = false

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -500,9 +500,9 @@ install -m 644 conf/rhn_java_sso.conf $RPM_BUILD_ROOT%{_prefix}/share/rhn/config
 
 # Adjust product tree tag
 %if 0%{?sle_version} && !0%{?is_opensuse}
-sed -i -e 's/^java.product_tree.tag =.*$/java.product_tree.tag = Beta/' $RPM_BUILD_ROOT%{_prefix}/share/rhn/config-defaults/rhn_java.conf
+sed -i -e 's/^java.product_tree_tag =.*$/java.product_tree_tag = Beta/' $RPM_BUILD_ROOT%{_prefix}/share/rhn/config-defaults/rhn_java.conf
 %else
-sed -i -e 's/^java.product_tree.tag =.*$/java.product_tree.tag = Uyuni/' $RPM_BUILD_ROOT%{_prefix}/share/rhn/config-defaults/rhn_java.conf
+sed -i -e 's/^java.product_tree_tag =.*$/java.product_tree_tag = Uyuni/' $RPM_BUILD_ROOT%{_prefix}/share/rhn/config-defaults/rhn_java.conf
 %endif
 install -m 644 conf/logrotate/rhn_web_api $RPM_BUILD_ROOT%{_sysconfdir}/logrotate.d/rhn_web_api
 install -m 644 conf/logrotate/gatherer $RPM_BUILD_ROOT%{_sysconfdir}/logrotate.d/gatherer

--- a/susemanager/etc/logrotate.d/susemanager-tools
+++ b/susemanager/etc/logrotate.d/susemanager-tools
@@ -1,6 +1,6 @@
 # logrotation file for susemanager
 
-/var/log/rhn/mgr-sync.log {
+/var/log/rhn/mgr-sync.log /var/log/rhn/mgr-create-bootstrap-repo.log {
     compress
     dateext
     maxage 365

--- a/susemanager/rhn-conf/rhn_server_susemanager.conf
+++ b/susemanager/rhn-conf/rhn_server_susemanager.conf
@@ -28,3 +28,9 @@ temp_token_lifetime = 60
 token_lifetime = 525600
 # automatically deploy tokens once they are refreshed
 token_refresh_auto_deploy = true
+
+# when re-generating bootstrap repos remove old content first
+bootstrap_repo_flush = 1
+
+# data module used for mgr-create-bootstrap-repo
+bootstrap_repo_datamodule = mgr_bootstrap_data

--- a/susemanager/rhn-conf/rhn_server_susemanager.conf
+++ b/susemanager/rhn-conf/rhn_server_susemanager.conf
@@ -34,3 +34,6 @@ bootstrap_repo_flush = 1
 
 # data module used for mgr-create-bootstrap-repo
 bootstrap_repo_datamodule = mgr_bootstrap_data
+
+# automatically generate all bootstrap repos of synced products
+auto_generate_bootstrap_repo = 1

--- a/susemanager/src/mgr-create-bootstrap-repo
+++ b/susemanager/src/mgr-create-bootstrap-repo
@@ -1,40 +1,56 @@
 #!/usr/bin/python3
-from __future__ import print_function
+
 import sys
 import os
 import shutil
-import logging
 import subprocess
-from spacewalk.server import rhnSQL
-from uyuni.common import usix
-from spacewalk.common.rhnConfig import CFG, initCFG
+import time
+import traceback
 from optparse import OptionParser
-import textwrap
+from rhn import rhnLockfile
+from spacewalk.server import rhnSQL
+from spacewalk.common.rhnLog import initLOG, log_time, log_clean
+from spacewalk.common.rhnConfig import CFG, initCFG
 from string import Template
-
-try:
-   input = raw_input
-except NameError:
-   pass
-
-msg_wrapper = textwrap.TextWrapper()
-msg_wrapper.initial_indent = '- '
-msg_wrapper.width = 75
-msg_wrapper.subsequent_indent = '  '
+from uyuni.common import usix, rhnLib
 
 sys.path.append("/usr/share/susemanager")
 
-initCFG('server.susemanager')
+initCFG('java')
 rhnSQL.initDB()
 
 basepath = CFG.MOUNT_POINT or '/var/spacewalk'
+logfile = '/var/log/rhn/mgr-create-bootstrap-repo.log'
+LOCK = None
 
 _sql_synced_proucts = rhnSQL.Statement("""
-SELECT distinct sp.product_id as id
-FROM suseProducts sp
-JOIN suseProductChannel spc ON sp.id = spc.product_id
-WHERE spc.channel_id IS NOT NULL
+   SELECT sp.product_id id, spsr.root_product_id
+     FROM suseProducts sp
+     JOIN suseProductSCCRepository spsr ON spsr.product_id = sp.id
+LEFT JOIN rhnChannel c ON spsr.channel_label = c.label
+    WHERE spsr.mandatory = 'Y'
+ GROUP BY sp.id, spsr.root_product_id
+   HAVING COUNT(c.label) = COUNT(spsr.mandatory)
 """)
+
+_sql_find_root_channel_label = """
+SELECT label
+ FROM rhnChannel
+WHERE id IN (
+  SELECT DISTINCT c.parent_channel
+    FROM rhnChannel c
+    JOIN suseProductChannel pc ON pc.channel_id = c.id
+    JOIN suseProducts p ON pc.product_id = p.id
+   WHERE p.product_id IN ( {0} )
+)
+""";
+
+_sql_find_custom_parent_channel_labels = """
+SELECT label
+  FROM rhnChannel
+ WHERE parent_channel IS NULL
+   AND org_id IS NOT NULL
+""";
 
 _sql_find_pkgs = """
 SELECT distinct
@@ -44,24 +60,24 @@ SELECT distinct
         pkg.path
   FROM  (
          SELECT  I_P.name_id name_id,
-                 max(I_PE.evr) evr,
-                 I_PA.id as arch_id,
-                 I_PA.label as arch_label,
-                 (CASE WHEN channels.parent_channel IS NULL THEN channels.id ELSE channels.parent_channel END) as root
+                 MAX(I_PE.evr) evr,
+                 I_PA.id AS arch_id,
+                 I_PA.label AS arch_label,
+                 (CASE WHEN channels.parent_channel IS NULL THEN channels.id ELSE channels.parent_channel END) AS root
            FROM  (
-                  select I_C.*
-                   from suseProducts I_SP
+                  SELECT I_C.*
+                   FROM suseProducts I_SP
                    JOIN suseProductChannel I_PC ON I_SP.id = I_PC.product_id
                    JOIN rhnChannel I_C ON I_PC.channel_id = I_C.id
-                  WHERE  I_SP.product_id in ( %s )
-                  union
-                  select *
-                    from rhnChannel
-                   where org_id is not null
-                     and parent_channel in (
-                                            select pc.id
-                                              from rhnChannel pc
-                                             where pc.label = :parentchannel)
+                  WHERE  I_SP.product_id IN ( %s )
+                  UNION
+                  SELECT *
+                    FROM rhnChannel
+                   WHERE org_id IS NOT NULL
+                     AND parent_channel IN (
+                                            SELECT pc.id
+                                              FROM rhnChannel pc
+                                             WHERE pc.label = :parentchannel)
                   ) channels
            JOIN  rhnChannelNewestPackage I_CNP ON channels.id = I_CNP.channel_id
            JOIN  rhnPackage I_P ON I_CNP.package_id = I_P.id
@@ -70,39 +86,39 @@ SELECT distinct
        GROUP BY  I_P.name_id, I_PA.label, I_PA.id, root
      ) full_list,
        rhnPackage pkg
-       join rhnPackageName pn on pkg.name_id = pn.id
-       join rhnPackageEVR pevr on pkg.evr_id = pevr.id
-       join rhnChannelPackage CP on CP.package_id = pkg.id
-       join rhnChannel c on CP.channel_id = c.id
+       JOIN rhnPackageName pn ON pkg.name_id = pn.id
+       JOIN rhnPackageEVR pevr ON pkg.evr_id = pevr.id
+       JOIN rhnChannelPackage CP ON CP.package_id = pkg.id
+       JOIN rhnChannel c ON CP.channel_id = c.id
  WHERE full_list.name_id = pkg.name_id
    AND full_list.evr = pevr.evr
    AND full_list.arch_id = pkg.package_arch_id
    AND (c.parent_channel = full_list.root OR c.id = full_list.root)
    AND pn.name = :pkgname
-order by pkg.id
+ORDER BY pkg.id
 """;
 
 _sql_find_pkgs_custom = """
-SELECT distinct
+SELECT DISTINCT
         pkg.id AS id,
         PN.name || '-' || evr_t_as_vre_simple(full_list.evr) || '.' || full_list.arch_label AS nvrea,
         full_list.arch_label AS arch,
         pkg.path
   FROM  (
          SELECT  I_P.name_id name_id,
-                 max(I_PE.evr) evr,
-                 I_PA.id as arch_id,
-                 I_PA.label as arch_label,
-                 (CASE WHEN channels.parent_channel IS NULL THEN channels.id ELSE channels.parent_channel END) as root
+                 MAX(I_PE.evr) evr,
+                 I_PA.id AS arch_id,
+                 I_PA.label AS arch_label,
+                 (CASE WHEN channels.parent_channel IS NULL THEN channels.id ELSE channels.parent_channel END) AS root
            FROM  (
-                  select *
-                    from rhnChannel
-                   where org_id is not null
-                     and label = :parentchannel
-                      or parent_channel in (
-                                            select pc.id
-                                              from rhnChannel pc
-                                             where pc.label = :parentchannel)
+                  SELECT *
+                    FROM rhnChannel
+                   WHERE org_id IS NOT NULL
+                     AND label = :parentchannel
+                      OR parent_channel IN (
+                                            SELECT pc.id
+                                              FROM rhnChannel pc
+                                             WHERE pc.label = :parentchannel)
                   ) channels
            JOIN  rhnChannelNewestPackage I_CNP ON channels.id = I_CNP.channel_id
            JOIN  rhnPackage I_P ON I_CNP.package_id = I_P.id
@@ -111,37 +127,125 @@ SELECT distinct
        GROUP BY  I_P.name_id, I_PA.label, I_PA.id, root
      ) full_list,
        rhnPackage pkg
-       join rhnPackageName pn on pkg.name_id = pn.id
-       join rhnPackageEVR pevr on pkg.evr_id = pevr.id
-       join rhnChannelPackage CP on CP.package_id = pkg.id
-       join rhnChannel c on CP.channel_id = c.id
+       JOIN rhnPackageName pn ON pkg.name_id = pn.id
+       JOIN rhnPackageEVR pevr ON pkg.evr_id = pevr.id
+       JOIN rhnChannelPackage CP ON CP.package_id = pkg.id
+       JOIN rhnChannel c ON CP.channel_id = c.id
  WHERE full_list.name_id = pkg.name_id
    AND full_list.evr = pevr.evr
    AND full_list.arch_id = pkg.package_arch_id
    AND (c.parent_channel = full_list.root OR c.id = full_list.root)
    AND pn.name = :pkgname
-order by pkg.id
+ORDER BY pkg.id
 """;
 
 
-_sql_find_root_channel_label = """
-select label
-from rhnChannel
-where id in (
-  select distinct c.parent_channel
-    from rhnChannel c
-    join suseProductChannel pc on pc.channel_id = c.id
-    join suseProducts p on pc.product_id = p.id
-   WHERE p.product_id in ( {0} )
-)
+_find_mand_modified_repos = """
+select X.product_id, c0.label, c0.last_synced,
+       (select 1 from dual where c0.last_synced > :filemod) as newer
+from rhnChannel c0
+join suseProductChannel spc ON spc.channel_id = c0.id
+join suseProducts p ON spc.product_id = p.id
+join (
+     select sp.product_id , spsr.root_product_id
+       from suseProducts sp
+       join suseProductSCCRepository spsr ON spsr.product_id = sp.id
+  left join rhnChannel c ON spsr.channel_label = c.label
+      where spsr.mandatory = 'Y'
+   group by sp.id, spsr.root_product_id
+     having COUNT(c.label) = COUNT(spsr.mandatory)
+   ) X on X.product_id = p.product_id
+where X.product_id in ( %s )
 """;
 
-_sql_find_custom_parent_channel_labels = """
-select label
-from rhnChannel
-where parent_channel IS NULL
-and org_id IS NOT NULL
+_find_modified_repos_by_basechannel = """
+SELECT c.label, c.last_synced,
+       (SELECT 1 FROM DUAL WHERE c.last_synced > :filemod) AS newer
+  FROM rhnchannel c
+ WHERE (SELECT id FROM rhnchannel WHERE label = :basechannel) IN (c.parent_channel, c.id);
 """;
+
+def releaseLOCK():
+    global LOCK
+    if LOCK:
+        LOCK.release()
+        LOCK = None
+
+
+def log_error(msg):
+    frame = traceback.extract_stack()[-2]
+    log_clean(0, "{0}: {1}.{2}({3}) - {4}".format(log_time(), frame[0], frame[2], frame[1], msg))
+    sys.stderr.write("{0}\n".format(msg))
+
+
+def log(msg, level=0):
+    frame = traceback.extract_stack()[-2]
+    log_clean(level, "{0}: {1}.{2}({3}) - {4}".format(log_time(), frame[0], frame[2], frame[1], msg))
+    if level < 1:
+        sys.stdout.write("{0}\n".format(msg))
+
+def isBeta():
+    return CFG.PRODUCT_TREE_TAG == 'Beta'
+
+def cli():
+
+    usage = "usage: %prog [options] [additional_pkg1 additional_pkg2 ...]"
+    parser = OptionParser(usage=usage)
+    parser.add_option('-n', '--dryrun', action='store_true', dest='dryrun',
+                      help='Dry run. Show only changes - do not execute them')
+    parser.add_option('-i', '--interactive', action='store_true', dest='interactive',
+                      help='Interactive mode (default)')
+    parser.add_option('-l', '--list', action='store_true', dest='list',
+                      help='list available distributions')
+    parser.add_option('-c', '--create', action='store', dest='create',
+                      help='create bootstrap repo for given distribution label')
+    parser.add_option('-a', '--auto', action='store_true', dest='auto',
+                      help='Automatic Mode. Generate all available bootstrap repos')
+    parser.add_option('', '--datamodule', action="store", dest='datamodule',
+                      help='Use an own datamodule (Default: mgr_bootstrap_data)')
+    parser.add_option('-d', '--debug', action='store_true', dest='debug',
+                      help='Enable debug mode')
+
+
+    parser.add_option('-f', '--flush', action='store_true', dest='flush',
+                      help='when used in conjuction with --create, deletes the target repository before creating it')
+    parser.add_option('', '--with-custom-channels', action='store_true', dest='usecustomchannels',
+                      help='Take custom channels into account when searching for newest package versions')
+    parser.add_option('', '--with-parent-channel', action="store", dest='parentchannel',
+                      help='use child channels below this parent')
+
+    options, args = parser.parse_args()
+
+    if options.debug:
+        initLOG(logfile, level=5)
+    else:
+        initLOG(logfile, CFG.DEBUG or 1)
+    log(sys.argv, 1)
+    if isBeta():
+        log("Is a Beta installation", 1)
+
+    modulename = options.datamodule or "mgr_bootstrap_data"
+    try:
+        bootstrap_data = __import__(modulename)
+        for label in bootstrap_data.DATA:
+            if 'PDID' in bootstrap_data.DATA[label]:
+                if not isinstance(bootstrap_data.DATA[label]['PDID'], usix.ListType):
+                    bootstrap_data.DATA[label]['PDID'] = list(map(str, [int(bootstrap_data.DATA[label]['PDID'])]))
+                else:
+                    bootstrap_data.DATA[label]['PDID'] = list(map(str, [int(pdid) for pdid in bootstrap_data.DATA[label]['PDID']]))
+                if isBeta() and 'BETAPDID' in bootstrap_data.DATA[label]:
+                    bootstrap_data.DATA[label]['PDID'].extend(list(map(str, [int(pdid) for pdid in bootstrap_data.DATA[label]['BETAPDID']])))
+
+    except ImportError as e:
+        log_error("Unable to load module '%s'" % modulename)
+        log_error(str(e))
+        sys.exit(1)
+
+    if not options.list and not options.create:
+        options.auto = True
+
+    return options, args, bootstrap_data
+
 
 def find_root_channel_labels(pdids):
     """
@@ -151,6 +255,7 @@ def find_root_channel_labels(pdids):
     """
     h = rhnSQL.Statement( _sql_find_root_channel_label.format(pdids))
     return [x['label'] for x in rhnSQL.fetchall_dict(h) or []]
+
 
 def find_custom_parent_channel_labels():
     """
@@ -162,31 +267,38 @@ def find_custom_parent_channel_labels():
     return [x['label'] for x in rhnSQL.fetchall_dict(h) or []]
 
 
-def list_labels():
+def list_labels(mgr_bootstrap_data, do_print=True):
     """
     Create list of labels and return a structure of them for the menu.
 
     :return:
     """
     label_map = {}
-    synced_products = [x['id'] for x in rhnSQL.fetchall_dict(_sql_synced_proucts) or []]
+    synced_products = list(map(str, [x['id'] for x in rhnSQL.fetchall_dict(_sql_synced_proucts) or []]))
     custom_parent_channels = find_custom_parent_channel_labels()
     label_index = 1
     for label in sorted(mgr_bootstrap_data.DATA.keys()):
-        if 'PDID' in mgr_bootstrap_data.DATA[label] and int(mgr_bootstrap_data.DATA[label]['PDID'][0]) in synced_products:
-            print("{0}. {1}".format(label_index, label))
+        if 'PDID' in mgr_bootstrap_data.DATA[label] and all(elem in synced_products for elem in mgr_bootstrap_data.DATA[label]['PDID']):
+            if do_print:
+                print("{0}. {1}".format(label_index, label))
             label_map[label_index] = label
             label_index += 1
         elif 'BASECHANNEL' in mgr_bootstrap_data.DATA[label] and mgr_bootstrap_data.DATA[label]['BASECHANNEL'] in custom_parent_channels:
-            print("{0}. {1}".format(label_index, label))
+            if do_print:
+                print("{0}. {1}".format(label_index, label))
             label_map[label_index] = label
             label_index += 1
     return label_map
 
-def create_repo(label, flush, additional=[]):
+
+def create_repo(label, options, mgr_bootstrap_data, additional=[]):
     pdids = None
+    flush = options.flush
+
     if 'PDID' in mgr_bootstrap_data.DATA[label]:
         pdids = ', '.join(mgr_bootstrap_data.DATA[label]['PDID'])
+        if (label.startswith('RES') or label.startswith('RHEL') or label.lower().startswith('ubuntu')):
+            options.usecustomchannels = True
     else:
         options.usecustomchannels = True
         options.parentchannel = mgr_bootstrap_data.DATA[label]['BASECHANNEL']
@@ -204,40 +316,40 @@ def create_repo(label, flush, additional=[]):
         else:
             root_labels = find_custom_parent_channel_labels()
         if options.parentchannel and options.parentchannel not in root_labels:
-            print("'{0}' not found in existing parent channel options '{1}'".format(options.parentchannel, root_labels))
-            sys.exit(1)
+            log_error("'{0}' not found in existing parent channel options '{1}'".format(options.parentchannel, root_labels))
+            return 1
         elif not options.parentchannel:
             if len(root_labels) > 1:
-                print("Multiple options for parent channel found. Please use option --with-parent-channel <label>")
-                print("and choose one of:")
+                log_error("Multiple options for parent channel found. Please use option --with-parent-channel <label>")
+                log_error("and choose one of:")
                 for l in root_labels:
-                    print("- {0}".format(l))
-                sys.exit(1)
+                    log_error("- {0}".format(l))
+                return 1
             elif len(root_labels) == 1:
                 options.parentchannel = root_labels[0]
             else:
-                print("WARNING: no parent channel found. Execute without using custom channels")
+                log("WARNING: no parent channel found. Execute without using custom channels")
                 options.parentchannel = ""
     else:
         options.parentchannel = ""
 
     if flush:
-        print("Removing directory:", destdir)
+        log("Removing directory:", destdir)
         try:
             shutil.rmtree(destdir)
         except OSError as err:
-            print('Error while deleting {0}: {1}'.format(destdir, err))
+            log_error('Error while deleting {0}: {1}'.format(destdir, err))
 
     if not os.path.exists(destdir):
-        if dryrun:
-            print("Create directory:", destdir)
+        if options.dryrun:
+            log("Create directory:", destdir)
         else:
             os.makedirs(destdir)
 
     if label.startswith('RES') or label.startswith('RHEL'):
-        print("Creating bootstrap repo for latest Service Pack of {0}".format(label))
+        log("Creating bootstrap repo for latest Service Pack of {0}".format(label))
     else:
-        print("Creating bootstrap repo for {0}".format(label))
+        log("Creating bootstrap repo for {0}".format(label))
     print()
 
     if pdids:
@@ -247,7 +359,7 @@ def create_repo(label, flush, additional=[]):
     packagelist = mgr_bootstrap_data.DATA[label]['PKGLIST']
     repotype = mgr_bootstrap_data.DATA[label].get('TYPE', 'yum')
     packagelist.extend(additional)
-    logging.debug("The bootstrap repo should contain the following packages: {0}".format(packagelist))
+    log("The bootstrap repo should contain the following packages: {0}".format(packagelist), 2)
 
     debs_dir = os.path.join(destdir, 'debs')
     for pkgaltstr in packagelist:
@@ -258,8 +370,8 @@ def create_repo(label, flush, additional=[]):
             altcount += 1
             h.execute(parentchannel=options.parentchannel, pkgname=pkgname)
             pkgs = h.fetchall_dict() or []
-            logging.debug("Package {0} found {1} resulting packages:".format(
-                pkgname, len(pkgs)))
+            log("Package {0} found {1} resulting packages:".format(
+                pkgname, len(pkgs)), 2)
             if len(pkgs) == 0:
                 if altcount >= len(alt):
                     if len(alt) > 1:
@@ -268,28 +380,28 @@ def create_repo(label, flush, additional=[]):
                         messages.append("ERROR: package '%s' not found" % pkgname)
                     errors += 1
                     if not suggestions['no-packages']:
-                        suggestions['no-packages'] = ('mgr-create-bootstrap-repo uses the locally synchronized ' +
-                                                      'versions of files from the Tools repository, ' +
-                                                      'and uses the locally synchronized pool channel for dependency resolution. ' +
-                                                      'Both should be fully synced before running the mgr-create-bootstrap-repo script.')
+                        suggestions['no-packages'] = (
+                             'mgr-create-bootstrap-repo uses the locally synchronized versions of files\n' +
+                             'from the Tools repository, and uses the locally synchronized pool channel\n' +
+                             'for dependency resolution.\n' +
+                             'Both should be fully synced before running the mgr-create-bootstrap-repo script.\n')
                 continue
             for p in pkgs:
-                logging.debug(p)
+                log(p, 2)
                 rpmdir = os.path.join(destdir, p['arch']) if repotype != 'deb' else debs_dir
                 if not os.path.exists(rpmdir):
                     os.makedirs(rpmdir)
-                print("copy '%s'" % p['nvrea'])
-                logging.debug("copy {0} / {1} to {2}".format(basepath, p['path'], rpmdir))
-                if not dryrun:
+                log("copy '%s'" % p['nvrea'])
+                log("copy {0} / {1} to {2}".format(basepath, p['path'], rpmdir), 2)
+                if not options.dryrun:
                     shutil.copy2(os.path.join(basepath, p['path']), rpmdir)
             break
-
-    if dryrun:
+    if options.dryrun:
         if repotype == 'deb':
             debs = " ".join([os.path.join(debs_dir, f) for f in os.listdir(debs_dir)])
-            print("/usr/bin/reprepro -b {0} includedeb {1} {2}".format(destdir, "bootstrap", debs))
+            log("/usr/bin/reprepro -b {0} includedeb {1} {2}".format(destdir, "bootstrap", debs))
         else:
-            print("createrepo -s sha %s" % destdir)
+            log("createrepo -s sha %s" % destdir)
     else:
         if repotype == 'deb':
             reprepro_conf_tmpl = Template("Origin: $origin\n" \
@@ -306,99 +418,146 @@ def create_repo(label, flush, additional=[]):
                 os.makedirs(reprepro_conf_dir)
             with open(os.path.join(reprepro_conf_dir, "distributions"), "w") as conf_file:
                 conf_file.write(reprepro_conf)
-            logging.debug("Created reprepro config file in {0}".format(os.path.join(destdir, "distributions")))
+            log("Created reprepro config file in {0}".format(os.path.join(destdir, "distributions")), 2)
             debs = [os.path.join(debs_dir, f) for f in os.listdir(debs_dir)]
             try:
                 subprocess.run(["/usr/bin/reprepro", "-b", destdir, "includedeb", codename] + debs, check=True)
-                logging.debug("Removing directory {0}".format(debs_dir))
+                log("Removing directory {0}".format(debs_dir), 2)
                 shutil.rmtree(debs_dir, ignore_errors=True)
             except subprocess.CalledProcessError as err:
-                print("Error creating bootstrap repo.")
-                logging.debug(err)
-                sys.exit(1)
-        else:    
+                log_error("Error creating bootstrap repo.")
+                log(err, 2)
+                return 1
+        else:
             os.system("createrepo -s sha %s" % destdir)
     if errors:
         for m in messages:
-            print(m)
+            log_error(m)
         if (label.startswith('RES') or label.startswith('RHEL') or label.lower().startswith('ubuntu'))  and not options.usecustomchannels:
-            print("If the installation media was imported into a custom channel, try to run again with --with-custom-channels option")
+            log_error("If the installation media was imported into a custom channel, try to run again with --with-custom-channels option")
         suggestions = list([_f for _f in list(suggestions.values()) if _f])
         if suggestions:
-            print("\nSuggestions:")
+            log_error("\nSuggestions:")
             for suggestion in suggestions:
-                print(msg_wrapper.fill(suggestion) + "\n")
-        sys.exit(1)
+                log_error(suggestion)
+        return 1
+    return 0
 
-usage = "usage: %prog [options] [additional_pkg1 additional_pkg2 ...]"
-parser = OptionParser(usage=usage)
-parser.add_option('-n', '--dryrun', action='store_true', dest='dryrun',
-                  help='Dry run. Show only changes - do not execute them')
-parser.add_option('-i', '--interactive', action='store_true', dest='interactive',
-                  help='Interactive mode (default)')
-parser.add_option('-l', '--list', action='store_true', dest='list',
-                  help='list available distributions')
-parser.add_option('-c', '--create', action='store', dest='create',
-                  help='create bootstrap repo for given distribution label')
-parser.add_option('-f', '--flush', action='store_true', dest='flush',
-                  help='when used in conjuction with --create, deletes the target repository before creating it')
-parser.add_option('', '--datamodule', action="store", dest='datamodule',
-                  help='Use an own datamodule (Default: mgr_bootstrap_data)')
-parser.add_option('', '--with-custom-channels', action='store_true', dest='usecustomchannels',
-                  help='Take custom channels into account when searching for newest package versions')
-parser.add_option('', '--with-parent-channel', action="store", dest='parentchannel',
-                  help='use child channels below this parent')
-parser.add_option('-d', '--debug', action='store_true', dest='debug',
-                  help='Enable debug mode')
+def generate_all(options, mgr_bootstrap_data, additional=[]):
+    repos = {}
+    errors = 0
 
-(options, args) = parser.parse_args()
+    for dist in sorted(list_labels(mgr_bootstrap_data, do_print=False).values()):
+        if mgr_bootstrap_data.DATA[dist]['DEST'] in repos:
+            continue
+        repos[mgr_bootstrap_data.DATA[dist]['DEST']] = mgr_bootstrap_data.DATA[dist]
+        repos[mgr_bootstrap_data.DATA[dist]['DEST']]['DIST'] = dist
 
-if options.debug:
-    logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.DEBUG)
+    for dest, repo in repos.items():
+        destfile = os.path.join(dest, 'repodata', 'repomd.xml')
+        if 'TYPE' in repo and repo['TYPE'] == 'deb':
+            destfile = os.path.join(dest, 'dists', 'bootstrap', 'Release')
 
-modulename = "mgr_bootstrap_data"
-if options.datamodule and options.datamodule != '':
-    modulename = options.datamodule
+        filemodtime = 0
+        if os.path.exists(destfile):
+            filemodtime = os.path.getmtime(destfile)
 
-try:
-    mgr_bootstrap_data = __import__(modulename)
-    for label in mgr_bootstrap_data.DATA:
-        if 'PDID' in mgr_bootstrap_data.DATA[label]:
-            if not isinstance(mgr_bootstrap_data.DATA[label]['PDID'], usix.ListType):
-                mgr_bootstrap_data.DATA[label]['PDID'] = list(map(str, [int(mgr_bootstrap_data.DATA[label]['PDID'])]))
+        log("{0} modified: {1}".format(destfile, filemodtime), 2)
+        if 'PDID' in repo:
+            pdids = ', '.join(repo['PDID'])
+            h = rhnSQL.prepare(rhnSQL.Statement(_find_mand_modified_repos % (pdids)))
+            h.execute(filemod=time.strftime('%Y-%m-%d %H:%M:%S %z', time.localtime(filemodtime)))
+        if 'BASECHANNEL' in repo:
+            h = rhnSQL.prepare(rhnSQL.Statement(_find_modified_repos_by_basechannel))
+            h.execute(filemod=time.strftime('%Y-%m-%d %H:%M:%S %z', time.localtime(filemodtime)), basechannel=repo['BASECHANNEL'])
+
+        res = h.fetchall_dict() or []
+        if not res:
+            continue
+        regen = True
+        oneNewerTimestamp = 0
+        for channelinfo in res:
+            if channelinfo['newer'] == 1:
+                log("{0} modified after last bootstrap generation".format(channelinfo['label']), 2)
+                regen = regen and True
+                if channelinfo['last_synced'] and channelinfo['last_synced'].timestamp() > oneNewerTimestamp:
+                    oneNewerTimestamp = channelinfo['last_synced'].timestamp()
             else:
-                mgr_bootstrap_data.DATA[label]['PDID'] = list(map(str, [int(pdid) for pdid in mgr_bootstrap_data.DATA[label]['PDID']]))
+                log("{0} not modified".format(channelinfo['label']), 2)
+                regen = regen and False
+        if not regen and oneNewerTimestamp > 0 and time.time() - oneNewerTimestamp > 4 * 60 * 60:
+            log("latest channel sync at: {0}. Grace period over. Regenarate bootstrap repo.".format(oneNewerTimestamp), 2)
+            regen = True
+        if regen:
+            errors += create_repo(repo['DIST'], options, mgr_bootstrap_data, additional=additional)
 
-except ImportError as e:
-    sys.stderr.write("Unable to load module '%s'\n" % modulename)
-    sys.stderr.write(str(e) + "\n")
-    sys.exit(1)
+    return errors
 
-dryrun = options.dryrun
 
-if not options.list and not options.create:
-    options.interactive = True
 
-if options.interactive:
-    label_map = list_labels()
+#################################################################################
+### main
+#################################################################################
 
-    elabel = None
-    while True:
-        try:
-            elabel = label_map.get(int(input("Enter a number of a product label: ")), '')
-            break
-        except Exception:
-            print("Please enter a number.")
-
-    if elabel not in mgr_bootstrap_data.DATA:
-        print("'%s' not found" % elabel)
+def main():
+    # quick check to see if you are a super-user.
+    if os.getuid() != 0:
+        sys.stderr.write('ERROR: must be root to execute.\n')
         sys.exit(1)
 
-    create_repo(elabel, options.flush, additional=args)
-elif options.list:
-    list_labels()
-elif options.create:
-    if options.create not in mgr_bootstrap_data.DATA:
-        print("'%s' not found" % options.create)
+    global LOCK
+    try:
+        LOCK = rhnLockfile.Lockfile('/var/run/mgr-create-bootstrap-repo.pid')
+    except rhnLockfile.LockfileLockedException:
+        sys.stderr.write("ERROR: attempting to run more than one instance of "
+                         "mgr-create-bootstrap-repo Exiting.\n")
         sys.exit(1)
-    create_repo(options.create, options.flush, additional=args)
+
+
+    opts, args, mgr_bootstrap_data = cli()
+    r = 0
+
+    if opts.auto:
+        r = generate_all(opts, mgr_bootstrap_data, additional=args)
+    elif opts.interactive:
+        label_map = list_labels(mgr_bootstrap_data)
+        if not label_map:
+            log("No products available")
+            sys.exit(0)
+
+        elabel = None
+        while True:
+            try:
+                elabel = label_map.get(int(input("Enter a number of a product label: ")), '')
+                break
+            except Exception:
+                print("Please enter a number.")
+
+        if elabel not in mgr_bootstrap_data.DATA:
+            log_error("'%s' not found" % elabel)
+            sys.exit(1)
+
+        r = create_repo(elabel, opts, mgr_bootstrap_data, additional=args)
+    elif opts.list:
+        list_labels(mgr_bootstrap_data)
+    elif opts.create:
+        if opts.create not in mgr_bootstrap_data.DATA:
+            log_error("'%s' not found" % opts.create)
+            sys.exit(1)
+        r = create_repo(opts.create, opts, mgr_bootstrap_data, additional=args)
+    releaseLOCK()
+    return r
+
+if __name__ == '__main__':
+    try:
+        sys.exit(abs(main() or 0))
+    except KeyboardInterrupt:
+        sys.stderr.write("\nProcess has been interrupted.\n")
+        sys.exist(1)
+    except SystemExit as e:
+        releaseLOCK()
+        sys.exit(e.code)
+    except Exception as e:
+        releaseLOCK()
+        raise
+

--- a/susemanager/src/mgr-create-bootstrap-repo
+++ b/susemanager/src/mgr-create-bootstrap-repo
@@ -16,12 +16,13 @@ from uyuni.common import usix, rhnLib
 
 sys.path.append("/usr/share/susemanager")
 
-initCFG('java')
+initCFG('server.susemanager')
 rhnSQL.initDB()
 
 basepath = CFG.MOUNT_POINT or '/var/spacewalk'
 logfile = '/var/log/rhn/mgr-create-bootstrap-repo.log'
 LOCK = None
+BETA = None
 
 _sql_synced_proucts = rhnSQL.Statement("""
    SELECT sp.product_id id, spsr.root_product_id
@@ -185,7 +186,11 @@ def log(msg, level=0):
         sys.stdout.write("{0}\n".format(msg))
 
 def isBeta():
-    return CFG.PRODUCT_TREE_TAG == 'Beta'
+    if BETA is None:
+        initCFG('java')
+        BETA = CFG.PRODUCT_TREE_TAG == 'Beta'
+        initCFG('server.susemanager')
+    return BETA
 
 def cli():
 
@@ -220,11 +225,14 @@ def cli():
         initLOG(logfile, level=5)
     else:
         initLOG(logfile, CFG.DEBUG or 1)
+    if not options.flush:
+        options.flush = CFG.BOOTSTRAP_REPO_FLUSH
+
     log(sys.argv, 1)
     if isBeta():
         log("Is a Beta installation", 1)
 
-    modulename = options.datamodule or "mgr_bootstrap_data"
+    modulename = options.datamodule or CFG.BOOTSTRAP_REPO_DATAMODULE
     try:
         bootstrap_data = __import__(modulename)
         for label in bootstrap_data.DATA:
@@ -293,7 +301,6 @@ def list_labels(mgr_bootstrap_data, do_print=True):
 
 def create_repo(label, options, mgr_bootstrap_data, additional=[]):
     pdids = None
-    flush = options.flush
 
     if 'PDID' in mgr_bootstrap_data.DATA[label]:
         pdids = ', '.join(mgr_bootstrap_data.DATA[label]['PDID'])
@@ -333,7 +340,7 @@ def create_repo(label, options, mgr_bootstrap_data, additional=[]):
     else:
         options.parentchannel = ""
 
-    if flush:
+    if options.flush:
         log("Removing directory:", destdir)
         try:
             shutil.rmtree(destdir)

--- a/susemanager/src/mgr-create-bootstrap-repo
+++ b/susemanager/src/mgr-create-bootstrap-repo
@@ -196,7 +196,11 @@ def isBeta():
 def cli():
 
     usage = "usage: %prog [options] [additional_pkg1 additional_pkg2 ...]"
-    parser = OptionParser(usage=usage)
+    parser = OptionParser(usage=usage, description=""
+            "Tool to generate repositories containing the required software to "
+            "register at SUSE Manager Server. Logs are written to "
+            "/var/log/rhn/mgr-create-bootstrap-repo.log .")
+
     parser.add_option('-n', '--dryrun', action='store_true', dest='dryrun',
                       help='Dry run. Show only changes - do not execute them')
     parser.add_option('-i', '--interactive', action='store_true', dest='interactive',

--- a/susemanager/src/mgr-create-bootstrap-repo
+++ b/susemanager/src/mgr-create-bootstrap-repo
@@ -186,6 +186,7 @@ def log(msg, level=0):
         sys.stdout.write("{0}\n".format(msg))
 
 def isBeta():
+    global BETA
     if BETA is None:
         initCFG('java')
         BETA = CFG.PRODUCT_TREE_TAG == 'Beta'
@@ -298,6 +299,15 @@ def list_labels(mgr_bootstrap_data, do_print=True):
             label_index += 1
     return label_map
 
+def cleanup_dir(path):
+    if os.path.exists(path):
+        try:
+            shutil.rmtree(path)
+        except OSError as err:
+            log_error('Error while deleting {0}: {1}'.format(path, err))
+            return False
+    return True
+
 
 def create_repo(label, options, mgr_bootstrap_data, additional=[]):
     pdids = None
@@ -310,7 +320,10 @@ def create_repo(label, options, mgr_bootstrap_data, additional=[]):
         options.usecustomchannels = True
         options.parentchannel = mgr_bootstrap_data.DATA[label]['BASECHANNEL']
 
-    destdir = mgr_bootstrap_data.DATA[label]['DEST']
+    destdir = os.path.normpath(mgr_bootstrap_data.DATA[label]['DEST'])
+    dirprefix, lastdir = os.path.split(destdir)
+    destdirtmp = os.path.join(dirprefix, "{0}.{1}".format(lastdir, "tmp"))
+    destdirold = os.path.join(dirprefix, "{0}.{1}".format(lastdir, "old"))
     errors = 0
     messages = []
     suggestions = {
@@ -340,18 +353,18 @@ def create_repo(label, options, mgr_bootstrap_data, additional=[]):
     else:
         options.parentchannel = ""
 
-    if options.flush:
-        log("Removing directory:", destdir)
-        try:
-            shutil.rmtree(destdir)
-        except OSError as err:
-            log_error('Error while deleting {0}: {1}'.format(destdir, err))
+    if not cleanup_dir(destdirtmp):
+        return 1
+    if not cleanup_dir(destdirold):
+        return 1
 
-    if not os.path.exists(destdir):
-        if options.dryrun:
-            log("Create directory:", destdir)
+    if options.dryrun:
+        log("Create directory:", destdirtmp)
+    else:
+        if options.flush:
+            os.makedirs(destdirtmp)
         else:
-            os.makedirs(destdir)
+            shutil.copytree(destdir, destdirtmp)
 
     if label.startswith('RES') or label.startswith('RHEL'):
         log("Creating bootstrap repo for latest Service Pack of {0}".format(label))
@@ -368,7 +381,7 @@ def create_repo(label, options, mgr_bootstrap_data, additional=[]):
     packagelist.extend(additional)
     log("The bootstrap repo should contain the following packages: {0}".format(packagelist), 2)
 
-    debs_dir = os.path.join(destdir, 'debs')
+    debs_dir = os.path.join(destdirtmp, 'debs')
     for pkgaltstr in packagelist:
         alt = pkgaltstr.split("|")
         altpretty =  ', '.join("'%s'" %(e) for e in alt)
@@ -395,7 +408,7 @@ def create_repo(label, options, mgr_bootstrap_data, additional=[]):
                 continue
             for p in pkgs:
                 log(p, 2)
-                rpmdir = os.path.join(destdir, p['arch']) if repotype != 'deb' else debs_dir
+                rpmdir = os.path.join(destdirtmp, p['arch']) if repotype != 'deb' else debs_dir
                 if not os.path.exists(rpmdir):
                     os.makedirs(rpmdir)
                 log("copy '%s'" % p['nvrea'])
@@ -406,9 +419,9 @@ def create_repo(label, options, mgr_bootstrap_data, additional=[]):
     if options.dryrun:
         if repotype == 'deb':
             debs = " ".join([os.path.join(debs_dir, f) for f in os.listdir(debs_dir)])
-            log("/usr/bin/reprepro -b {0} includedeb {1} {2}".format(destdir, "bootstrap", debs))
+            log("/usr/bin/reprepro -b {0} includedeb {1} {2}".format(destdirtmp, "bootstrap", debs))
         else:
-            log("createrepo -s sha %s" % destdir)
+            log("createrepo -s sha %s" % destdirtmp)
     else:
         if repotype == 'deb':
             reprepro_conf_tmpl = Template("Origin: $origin\n" \
@@ -420,15 +433,15 @@ def create_repo(label, options, mgr_bootstrap_data, additional=[]):
             codename="bootstrap"
             reprepro_conf = reprepro_conf_tmpl.substitute(origin="mgr",
                     label="mgr", codename=codename, arches="amd64 i386", comps="main", desc="Bootstrap repo")
-            reprepro_conf_dir = os.path.join(destdir, "conf")
+            reprepro_conf_dir = os.path.join(destdirtmp, "conf")
             if not os.path.exists(reprepro_conf_dir):
                 os.makedirs(reprepro_conf_dir)
             with open(os.path.join(reprepro_conf_dir, "distributions"), "w") as conf_file:
                 conf_file.write(reprepro_conf)
-            log("Created reprepro config file in {0}".format(os.path.join(destdir, "distributions")), 2)
+            log("Created reprepro config file in {0}".format(os.path.join(destdirtmp, "distributions")), 2)
             debs = [os.path.join(debs_dir, f) for f in os.listdir(debs_dir)]
             try:
-                subprocess.run(["/usr/bin/reprepro", "-b", destdir, "includedeb", codename] + debs, check=True)
+                subprocess.run(["/usr/bin/reprepro", "-b", destdirtmp, "includedeb", codename] + debs, check=True)
                 log("Removing directory {0}".format(debs_dir), 2)
                 shutil.rmtree(debs_dir, ignore_errors=True)
             except subprocess.CalledProcessError as err:
@@ -436,7 +449,12 @@ def create_repo(label, options, mgr_bootstrap_data, additional=[]):
                 log(err, 2)
                 return 1
         else:
-            os.system("createrepo -s sha %s" % destdir)
+            os.system("createrepo -s sha %s" % destdirtmp)
+        # move tmp dir to final location
+        os.rename(destdir, destdirold)
+        os.rename(destdirtmp, destdir)
+        cleanup_dir(destdirold)
+
     if errors:
         for m in messages:
             log_error(m)
@@ -483,6 +501,7 @@ def generate_all(options, mgr_bootstrap_data, additional=[]):
             continue
         regen = True
         oneNewerTimestamp = 0
+        #import pdb; pdb.set_trace()
         for channelinfo in res:
             if channelinfo['newer'] == 1:
                 log("{0} modified after last bootstrap generation".format(channelinfo['label']), 2)
@@ -520,6 +539,7 @@ def main():
                          "mgr-create-bootstrap-repo Exiting.\n")
         sys.exit(1)
 
+    global BETA
 
     opts, args, mgr_bootstrap_data = cli()
     r = 0

--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -545,7 +545,7 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/11/3/bootstrap/'
     },
     'SLE-11-SP4-i586' : {
-        'PDID' : 1299, 'PKGLIST' : PKGLIST11 + ENHANCE11 + PKGLIST11_X86_I586,
+        'PDID' : [1299], 'BETAPDID' : [2071], 'PKGLIST' : PKGLIST11 + ENHANCE11 + PKGLIST11_X86_I586,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/11/4/bootstrap/'
     },
     'SLE-11-SP4-ia64' : {
@@ -553,15 +553,15 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/11/4/bootstrap/'
     },
     'SLE-11-SP4-ppc64' : {
-        'PDID' : 1301, 'PKGLIST' : PKGLIST11 + ENHANCE11,
+        'PDID' : [1301], 'BETAPDID' : [2072], 'PKGLIST' : PKGLIST11 + ENHANCE11,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/11/4/bootstrap/'
     },
     'SLE-11-SP4-s390x' : {
-        'PDID' : 1303, 'PKGLIST' : PKGLIST11 + ENHANCE11,
+        'PDID' : [1303], 'BETAPDID' : [2073], 'PKGLIST' : PKGLIST11 + ENHANCE11,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/11/4/bootstrap/'
     },
     'SLE-11-SP4-x86_64' : {
-        'PDID' : 1300, 'PKGLIST' : PKGLIST11 + ENHANCE11 + PKGLIST11_X86_I586,
+        'PDID' : [1300], 'BETAPDID' : [2074], 'PKGLIST' : PKGLIST11 + ENHANCE11 + PKGLIST11_X86_I586,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/11/4/bootstrap/'
     },
     'SLE-10-SP3-i586' : {
@@ -617,175 +617,175 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/11/3/bootstrap/'
     },
     'SLES4SAP-11-SP4-x86_64' : {
-        'PDID' : 1329, 'PKGLIST' : PKGLIST11 + ENHANCE11 + PKGLIST11_X86_I586,
+        'PDID' : [1329], 'BETAPDID' : [2074], 'PKGLIST' : PKGLIST11 + ENHANCE11 + PKGLIST11_X86_I586,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/11/4/bootstrap/'
     },
     'SLES4SAP-11-SP4-ppc64' : {
-        'PDID' : 1331, 'PKGLIST' : PKGLIST11 + ENHANCE11,
+        'PDID' : [1331], 'BETAPDID' : [2072], 'PKGLIST' : PKGLIST11 + ENHANCE11,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/11/4/bootstrap/'
     },
     'SLE-12-ppc64le' : {
-        'PDID' : 1116, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12,
+        'PDID' : 1116, 'BETAPDID' : [1745], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/0/bootstrap/'
     },
     'SLE-12-s390x' : {
-        'PDID' : 1115, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12,
+        'PDID' : 1115, 'BETAPDID' : [1746], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/0/bootstrap/'
     },
     'SLE-12-x86_64' : {
-        'PDID' : 1117, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12 + PKGLIST12_X86_ARM,
+        'PDID' : 1117, 'BETAPDID' : [1747], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/0/bootstrap/'
     },
     'SLES4SAP-12-x86_64' : {
-        'PDID' : 1319, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12 + PKGLIST12_X86_ARM,
+        'PDID' : 1319, 'BETAPDID' : [1747], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/0/1/bootstrap/'
     },
     'SLE-12-SP1-ppc64le' : {
-        'PDID' : 1334, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
+        'PDID' : 1334, 'BETAPDID' : [1745], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/1/bootstrap/'
     },
     'SLE-12-SP1-s390x' : {
-        'PDID' : 1335, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
+        'PDID' : 1335, 'BETAPDID' : [1746], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/1/bootstrap/'
     },
     'SLE-12-SP1-x86_64' : {
-        'PDID' : 1322, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
+        'PDID' : 1322, 'BETAPDID' : [1747], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/1/bootstrap/'
     },
     'SLES4SAP-12-SP1-ppc64le' : {
-        'PDID' : 1437, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
+        'PDID' : 1437, 'BETAPDID' : [1745], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/1/0/1/bootstrap/'
     },
     'SLES4SAP-12-SP1-x86_64' : {
-        'PDID' : 1346, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
+        'PDID' : 1346, 'BETAPDID' : [1747], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/1/0/1/bootstrap/'
     },
     'RES6-x86_64' : {
-        'PDID' : 1138, 'PKGLIST' : RES6,
+        'PDID' : [1138], 'BETAPDID' : [2064], 'PKGLIST' : RES6,
         'DEST' : '/srv/www/htdocs/pub/repositories/res/6/bootstrap/'
     },
     'RES7-x86_64' : {
-        'PDID' : 1251, 'PKGLIST' : RES7,
+        'PDID' : [1251], 'BETAPDID' : [2065], 'PKGLIST' : RES7,
         'DEST' : '/srv/www/htdocs/pub/repositories/res/7/bootstrap/'
     },
     'SLE-12-SP2-aarch64' : {
-        'PDID' : 1375, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
+        'PDID' : 1375, 'BETAPDID' : [1744], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/2/bootstrap/'
     },
     'SLES_RPI-12-SP2-aarch64' : {
-        'PDID' : 1418, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
+        'PDID' : 1418, 'BETAPDID' : [1744], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/2/bootstrap/'
     },
     'SLE-12-SP2-ppc64le' : {
-        'PDID' : 1355, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
+        'PDID' : 1355, 'BETAPDID' : [1745], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/2/bootstrap/'
     },
     'SLE-12-SP2-s390x' : {
-        'PDID' : 1356, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
+        'PDID' : 1356, 'BETAPDID' : [1746], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/2/bootstrap/'
     },
     'SLE-12-SP2-x86_64' : {
-        'PDID' : 1357, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
+        'PDID' : 1357, 'BETAPDID' : [1747], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/2/bootstrap/'
     },
     'SLES4SAP-12-SP2-x86_64' : {
-        'PDID' : 1414, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
+        'PDID' : 1414, 'BETAPDID' : [1747], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/2/bootstrap/'
     },
     'SLES4SAP-12-SP2-ppc64le' : {
-        'PDID' : 1521, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
+        'PDID' : 1521, 'BETAPDID' : [1745], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/2/bootstrap/'
     },
     'SLE-12-SP3-aarch64' : {
-        'PDID' : 1424, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
+        'PDID' : 1424, 'BETAPDID' : [1744], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/3/bootstrap/'
     },
     'SLE-12-SP3-ppc64le' : {
-        'PDID' : 1422, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
+        'PDID' : 1422, 'BETAPDID' : [1745], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/3/bootstrap/'
     },
     'SLE-12-SP3-s390x' : {
-        'PDID' : 1423, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
+        'PDID' : 1423, 'BETAPDID' : [1746], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/3/bootstrap/'
     },
     'SLE-12-SP3-x86_64' : {
-        'PDID' : 1421, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
+        'PDID' : 1421, 'BETAPDID' : [1747], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/3/bootstrap/'
     },
     'SLES4SAP-12-SP3-x86_64' : {
-        'PDID' : 1426, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
+        'PDID' : 1426, 'BETAPDID' : [1747], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/3/bootstrap/'
     },
     'SLES4SAP-12-SP3-ppc64le' : {
-        'PDID' : 1572, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
+        'PDID' : 1572, 'BETAPDID' : [1745], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/3/bootstrap/'
     },
     'SLE-12-SP4-aarch64' : {
-        'PDID' : 1628, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
+        'PDID' : [1628], 'BETAPDID' : [1744], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/4/bootstrap/'
     },
     'SLE-12-SP4-ppc64le' : {
-        'PDID' : 1626, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
+        'PDID' : [1626], 'BETAPDID' : [1745], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/4/bootstrap/'
     },
     'SLE-12-SP4-s390x' : {
-        'PDID' : 1627, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
+        'PDID' : [1627], 'BETAPDID' : [1746], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/4/bootstrap/'
     },
     'SLE-12-SP4-x86_64' : {
-        'PDID' : 1625, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
+        'PDID' : [1625], 'BETAPDID' : [1747], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/4/bootstrap/'
     },
     'SLED-12-SP4-x86_64' : {
-        'PDID' : 1629, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
+        'PDID' : [1629], 'BETAPDID' : [1747], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/4/bootstrap/'
     },
     'SLES4SAP-12-SP4-x86_64' : {
-        'PDID' : 1755, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
+        'PDID' : [1755], 'BETAPDID' : [1747], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/4/bootstrap/'
     },
     'SLES4SAP-12-SP4-ppc64le' : {
-        'PDID' : 1754, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
+        'PDID' : [1754], 'BETAPDID' : [1745], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/4/bootstrap/'
     },
     'SLE4HPC-12-SP4-x86_64' : {
-        'PDID' : 1759, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
+        'PDID' : [1759], 'BETAPDID' : [1747], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/4/bootstrap/'
     },
     'SLE4HPC-12-SP4-aarch64' : {
-        'PDID' : 1758, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
+        'PDID' : [1758], 'BETAPDID' : [1744], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/4/bootstrap/'
     },
     'SLE-12-SP5-aarch64' : {
-        'PDID' : 1875, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
+        'PDID' : [1875], 'BETAPDID' : [1744], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/5/bootstrap/'
     },
     'SLE-12-SP5-ppc64le' : {
-        'PDID' : 1876, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
+        'PDID' : [1876], 'BETAPDID' : [1745], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/5/bootstrap/'
     },
     'SLE-12-SP5-s390x' : {
-        'PDID' : 1877, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
+        'PDID' : [1877], 'BETAPDID' : [1746], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/5/bootstrap/'
     },
     'SLE-12-SP5-x86_64' : {
-        'PDID' : 1878, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
+        'PDID' : [1878], 'BETAPDID' : [1747], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/5/bootstrap/'
     },
     'SLES4SAP-12-SP5-x86_64' : {
-        'PDID' : 1880, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
+        'PDID' : [1880], 'BETAPDID' : [1747], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/5/bootstrap/'
     },
     'SLES4SAP-12-SP5-ppc64le' : {
-        'PDID' : 1879, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
+        'PDID' : [1879], 'BETAPDID' : [1745], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/5/bootstrap/'
     },
     'SLE4HPC-12-SP5-x86_64' : {
-        'PDID' : 1873, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
+        'PDID' : [1873], 'BETAPDID' : [1747], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/5/bootstrap/'
     },
     'SLE4HPC-12-SP5-aarch64' : {
-        'PDID' : 1872, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
+        'PDID' : [1872], 'BETAPDID' : [1744], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/5/bootstrap/'
     },
     'OES2018-x86_64' : {
@@ -801,51 +801,51 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/5/bootstrap/'
     },
     'SLE-15-aarch64' : {
-        'PDID' : [1589, 1709], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_X86_ARM,
+        'PDID' : [1589, 1709], 'BETAPDID' : [1925], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/0/bootstrap/'
     },
     'SLE-15-ppc64le' : {
-        'PDID' : [1588, 1710], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_PPC,
+        'PDID' : [1588, 1710], 'BETAPDID' : [1926], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_PPC,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/0/bootstrap/'
     },
     'SLE-15-s390x' : {
-        'PDID' : [1587, 1711], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_Z,
+        'PDID' : [1587, 1711], 'BETAPDID' : [1927], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_Z,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/0/bootstrap/'
     },
     'SLE-15-x86_64' : {
-        'PDID' : [1576, 1712], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_X86_ARM,
+        'PDID' : [1576, 1712], 'BETAPDID' : [1928], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/0/bootstrap/'
     },
     'SLE-15-SP1-aarch64' : {
-        'PDID' : [1769, 1709], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_X86_ARM,
+        'PDID' : [1769, 1709], 'BETAPDID' : [1925], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/1/bootstrap/'
     },
     'SLE-15-SP1-ppc64le' : {
-        'PDID' : [1770, 1710], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_PPC,
+        'PDID' : [1770, 1710], 'BETAPDID' : [1926], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_PPC,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/1/bootstrap/'
     },
     'SLE-15-SP1-s390x' : {
-        'PDID' : [1771, 1711], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_Z,
+        'PDID' : [1771, 1711], 'BETAPDID' : [1927], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_Z,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/1/bootstrap/'
     },
     'SLE-15-SP1-x86_64' : {
-        'PDID' : [1772, 1712], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_X86_ARM,
+        'PDID' : [1772, 1712], 'BETAPDID' : [1928], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/1/bootstrap/'
     },
     'SLE-15-SP2-aarch64' : {
-        'PDID' : [1943, 1709], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_X86_ARM,
+        'PDID' : [1943, 1709], 'BETAPDID' : [1925], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/2/bootstrap/'
     },
     'SLE-15-SP2-ppc64le' : {
-        'PDID' : [1944, 1710], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_PPC,
+        'PDID' : [1944, 1710], 'BETAPDID' : [1926], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_PPC,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/2/bootstrap/'
     },
     'SLE-15-SP2-s390x' : {
-        'PDID' : [1945, 1711], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_Z,
+        'PDID' : [1945, 1711], 'BETAPDID' : [1927], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_Z,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/2/bootstrap/'
     },
     'SLE-15-SP2-x86_64' : {
-        'PDID' : [1946, 1712], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_X86_ARM,
+        'PDID' : [1946, 1712], 'BETAPDID' : [1928], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/2/bootstrap/'
     },
     'openSUSE-Leap-42.3-x86_64' : {
@@ -881,32 +881,32 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/centos/8/bootstrap/'
     },
     'RHEL6-x86_64' : {
-        'PDID' : [-5, 1682], 'PKGLIST' : RES6,
+        'PDID' : [-5, 1682], 'BETAPDID' : [2064], 'PKGLIST' : RES6,
         'DEST' : '/srv/www/htdocs/pub/repositories/res/6/bootstrap/'
     },
     'RHEL6-i386' : {
-        'PDID' : [-6, 1681], 'PKGLIST' : RES6,
+        'PDID' : [-6, 1681], 'BETAPDID' : [2063], 'PKGLIST' : RES6,
         'DEST' : '/srv/www/htdocs/pub/repositories/res/6/bootstrap/'
     },
     'RHEL7-x86_64' : {
-        'PDID' : [-7, 1683], 'PKGLIST' : RES7,
+        'PDID' : [-7, 1683], 'BETAPDID' : [2065], 'PKGLIST' : RES7,
         'DEST' : '/srv/www/htdocs/pub/repositories/res/7/bootstrap/'
     },
     'SLE-ES8-x86_64' : {
-        'PDID' : [-8, 1921, 2007], 'PKGLIST' : RES8,
+        'PDID' : [-8, 1921, 2007], 'BETAPDID' : [2066], 'PKGLIST' : RES8,
         'DEST' : '/srv/www/htdocs/pub/repositories/res/8/bootstrap/'
     },
     'RHEL8-x86_64' : {
-        'PDID' : [-8, 2007], 'PKGLIST' : RES8,
+        'PDID' : [-8, 2007], 'BETAPDID' : [2066], 'PKGLIST' : RES8,
         'DEST' : '/srv/www/htdocs/pub/repositories/res/8/bootstrap/'
     },
     'ubuntu-16.04-amd64' : {
-        'PDID' : [-2, 1917], 'PKGLIST' : PKGLISTUBUNTU1604,
+        'PDID' : [-2, 1917], 'BETAPDID' : [2061], 'PKGLIST' : PKGLISTUBUNTU1604,
         'DEST' : '/srv/www/htdocs/pub/repositories/ubuntu/16/4/bootstrap/',
         'TYPE' : 'deb'
     },
     'ubuntu-18.04-amd64' : {
-        'PDID' : [-1, 1918], 'PKGLIST' : PKGLISTUBUNTU1804,
+        'PDID' : [-1, 1918], 'BETAPDID' : [2062], 'PKGLIST' : PKGLISTUBUNTU1804,
         'DEST' : '/srv/www/htdocs/pub/repositories/ubuntu/18/4/bootstrap/',
         'TYPE' : 'deb'
     },

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- add automatic mode to mgr-create-bootstrap-repo
 - Add missing python libraries to RES8/RHEL8/CentOS 8 boostrap repos (bsc#1164875)
 - add bootstrap-repo data for OES 2018 SP2 (bsc#1161862)
 - remove oracle backend support and tooling

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,4 +1,5 @@
 - add automatic mode to mgr-create-bootstrap-repo
+- during beta testing use also beta tools channels (bsc#1164563, bsc#1164863)
 - Add missing python libraries to RES8/RHEL8/CentOS 8 boostrap repos (bsc#1164875)
 - add bootstrap-repo data for OES 2018 SP2 (bsc#1161862)
 - remove oracle backend support and tooling


### PR DESCRIPTION
## What does this PR change?

Bootstrap repos are nearly always needed. So we want to generate them automatcially.
To achieve this an automtic mode was added to `mgr-create-bootstrap-repo` which is used when calling it from `spacewalk-repo-sync`.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- https://github.com/SUSE/spacewalk/issues/10899

- [x] **DONE**

## Test coverage
- No tests: **to test we would need to really sync channels - taking too long**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/5876 https://github.com/SUSE/spacewalk/issues/10804

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
