### PR TITLE
Testsuite: Fix a typo

### DIFF
--- a/testsuite/documentation/guidelines.md
+++ b/testsuite/documentation/guidelines.md
@@ -66,7 +66,7 @@ Avoid reinventing function names and variables. Cucumber is all about human-read
    * "minxen": feature testing Xen host SLES minions
    * "ubuntu": feature testing Ubuntu
    * "centos": feature testing CentOS (should become "rhes" in the future when we start using Extended Support images)
-   * "trad": feature testing tradional client
+   * "trad": feature testing traditional client
    * "allcli: feature testing all clients
  * `<topic>` must contain "salt" or "docker" for features related to salt or docker, and is then specific to the feature.
  * Inside `init_clients` features we'll see the features in charge of the bootstrap process for each client. They will follow the format:

--- a/testsuite/features/secondary/allcli_reboot.feature
+++ b/testsuite/features/secondary/allcli_reboot.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2019 SUSE LLC.
+# Copyright (c) 2017-2020 SUSE LLC.
 # Licensed under the terms of the MIT license.
 #
 # Idempotency note:
@@ -28,7 +28,7 @@ Feature: Reboot systems managed by SUSE Manager
     When I wait at most 600 seconds until event "System reboot scheduled by admin" is completed
     And I should see a "Reboot completed." text
 
-  Scenario: Reboot a SLES tradional client
+  Scenario: Reboot a SLES traditional client
     Given I am on the Systems overview page of this "sle_client"
     When I follow first "Schedule System Reboot"
     Then I should see a "System Reboot Confirmation" text


### PR DESCRIPTION
## What does this PR change?
Fix a typo:
- testsuite/documentation/guidelines.md
- testsuite/features/secondary/allcli_reboot.feature:
tradional -> traditional.

## Links
### Ports
- Manager-3.2: https://github.com/SUSE/spacewalk/pull/10867
- Manager-4.0: https://github.com/SUSE/spacewalk/pull/10868


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
