### PR TITLE
Add 'inst.repo' kernel option to RHEL 8 kickstart tree (bsc#1163884)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartInstallType.java
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartInstallType.java
@@ -53,6 +53,13 @@ public class KickstartInstallType extends BaseDomainHelper {
     private String name;
 
     /**
+     * @return if this installer type is rhel 8 or greater
+     */
+    public boolean isRhel8OrGreater() {
+        return (isRhel7OrGreater() && !isRhel7());
+    }
+
+    /**
      * @return if this installer type is rhel 7 or greater (for rhel8)
      */
     public boolean isRhel7OrGreater() {

--- a/java/code/src/com/redhat/rhn/manager/kickstart/tree/test/TreeCreateOperationTest.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/tree/test/TreeCreateOperationTest.java
@@ -16,6 +16,7 @@
 package com.redhat.rhn.manager.kickstart.tree.test;
 
 import com.redhat.rhn.domain.kickstart.KickstartFactory;
+import com.redhat.rhn.domain.kickstart.KickstartInstallType;
 import com.redhat.rhn.manager.kickstart.tree.TreeCreateOperation;
 
 /**
@@ -64,6 +65,16 @@ public class TreeCreateOperationTest extends TreeOperationTestBase {
         cmd.setKernelOptions("");
         cmd.store();
         assertNull(cmd.getKernelOptions());
+    }
+
+    public void testPopulateKernelOptsForRhel8() throws Exception {
+        TreeCreateOperation cmd = new TreeCreateOperation(user);
+        setTestTreeParams(cmd);
+        cmd.setInstallType(KickstartFactory.
+                lookupKickstartInstallTypeByLabel(KickstartInstallType.RHEL_8));
+        cmd.setKernelOptions("");
+        cmd.store();
+        assertContains(cmd.getKernelOptions(), "inst.repo=");
     }
 
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add 'inst.repo' kernel option to RHEL 8 kickstart tree (bsc#1163884)
 - Show proxy icon in system list
 - Disable modularity failsafe mechanism for RHEL 8 channels (bsc#1164875)
 - Handle the non-existent requested grains gracefully


### PR DESCRIPTION
Adds the required `inst.repo` kernel option to RHEL 8 kickstart trees.

https://bugzilla.suse.com/1163884

Port of https://github.com/SUSE/spacewalk/pull/10851

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
