### PR TITLE
Uyuni Proxy is not shown as product - other scripts

### DIFF
--- a/testsuite/features/core/proxy_register_as_minion_with_gui.feature
+++ b/testsuite/features/core/proxy_register_as_minion_with_gui.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2019 SUSE LLC
+# Copyright (c) 2017-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # The scenarios in this feature are skipped if there is no proxy
@@ -43,7 +43,8 @@ Feature: Setup SUSE Manager proxy
     When I am on the Systems overview page of this "proxy"
     Then I should see "proxy" hostname
     # TODO: uncomment when SCC product becomes available
-    # And I wait until I see "$PRODUCT Proxy" text, refreshing the page
+    # When I wait until I see "$PRODUCT Proxy" text, refreshing the page
+    Then I should see a "Proxy" link in the content area
 
 @proxy
   Scenario: Check events history for failures on the proxy

--- a/testsuite/features/core/proxy_register_as_minion_with_script.feature
+++ b/testsuite/features/core/proxy_register_as_minion_with_script.feature
@@ -45,8 +45,9 @@ Feature: Setup SUSE Manager proxy
   Scenario: Check proxy system details
     When I am on the Systems overview page of this "proxy"
     Then I should see "proxy" hostname
-    #And I wait until I see "$PRODUCT Proxy" text, refreshing the page
-    And I should see a "Proxy" link in the content area
+    # TODO: uncomment when SCC product becomes available
+    # When I wait until I see "$PRODUCT Proxy" text, refreshing the page
+    Then I should see a "Proxy" link in the content area
 
 @proxy
   Scenario: Cleanup: remove proxy bootstrap scripts

--- a/testsuite/features/core/proxy_register_as_trad_with_script.feature
+++ b/testsuite/features/core/proxy_register_as_trad_with_script.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2018 SUSE LLC
+# Copyright (c) 2017-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # The scenarios in this feature are skipped if there is no proxy
@@ -29,7 +29,9 @@ Feature: Setup SUSE Manager proxy
   Scenario: Check proxy system details
     When I am on the Systems overview page of this "proxy"
     Then I should see "proxy" hostname
-    And I wait until I see "$PRODUCT Proxy" text, refreshing the page
+    # TODO: uncomment when SCC product becomes available
+    # When I wait until I see "$PRODUCT Proxy" text, refreshing the page
+    Then I should see a "Proxy" link in the content area
 
 @proxy
   Scenario: Cleanup: remove proxy bootstrap scripts


### PR DESCRIPTION
## What does this PR change?

Adaptation of #1964 for the two other proxy scripts.

## Links

Ports:
* 3.2: SUSE/spacewalk#10876
* 4.0: SUSE/spacewalk#10875

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
