### PR TITLE
fix missing data from suseproductchannel table

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -347,6 +347,26 @@ public class ContentSyncManager {
     }
 
     /**
+     * Verify suseProductChannel is present for all synced channels, if not re-add it.
+     */
+    public void ensureSUSEProductChannelData() {
+        List<Channel> syncedChannels = ChannelFactory.listVendorChannels();
+        for (Channel sc : syncedChannels) {
+            List<SUSEProductChannel> spcList = SUSEProductFactory.lookupSyncedProductChannelsByLabel(sc.getLabel());
+            if (spcList.isEmpty()) {
+                List<SUSEProductSCCRepository> missingData = SUSEProductFactory.lookupByChannelLabel(sc.getLabel());
+                missingData.forEach(md -> {
+                        SUSEProductChannel correctedData = new SUSEProductChannel();
+                        correctedData.setProduct(md.getProduct());
+                        correctedData.setChannel(sc);
+                        correctedData.setMandatory(md.isMandatory());
+                        SUSEProductFactory.save(correctedData);
+                });
+            }
+        }
+    }
+
+    /**
      * Returns all available products in user-friendly format.
      * @return list of all available products
      */
@@ -516,6 +536,7 @@ public class ContentSyncManager {
                 throw new ContentSyncException(e);
             }
         }
+        ensureSUSEProductChannelData();
         linkAndRefreshContentSource(mirrorUrl);
         ManagerInfoFactory.setLastMgrSyncRefresh();
     }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Validate the suseproductchannel table and update missing date when running mgr-sync refresh (bsc#1163538)
 - Add 'inst.repo' kernel option to RHEL 8 kickstart tree (bsc#1163884)
 - Show proxy icon in system list
 - Disable modularity failsafe mechanism for RHEL 8 channels (bsc#1164875)


### PR DESCRIPTION

port of 10870
## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
