### PR TITLE
Filter out AppStream packages by MODULARITYLABEL RPM header

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
@@ -36,6 +36,7 @@ import static com.redhat.rhn.domain.contentmgmt.ContentFilter.EntityType.MODULE;
 import static com.redhat.rhn.domain.contentmgmt.ContentFilter.EntityType.PACKAGE;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.CONTAINS;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.EQUALS;
+import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.EXISTS;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.GREATER;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.GREATEREQ;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.MATCHES;
@@ -87,6 +88,7 @@ public class FilterCriteria {
         validCombinations.add(Triple.of(ERRATUM, CONTAINS_PKG_GE_EVR, "package_nevr"));
         validCombinations.add(Triple.of(ERRATUM, CONTAINS_PKG_GT_EVR, "package_nevr"));
         validCombinations.add(Triple.of(MODULE, EQUALS, "module_stream"));
+        validCombinations.add(Triple.of(PACKAGE, EXISTS, "module_stream"));
     }
 
     /**
@@ -104,7 +106,8 @@ public class FilterCriteria {
         EQUALS("equals"),
         GREATER("greater"),
         GREATEREQ("greatereq"),
-        MATCHES("matches");
+        MATCHES("matches"),
+        EXISTS("exists");
 
         private String label;
 

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
@@ -16,6 +16,7 @@
 package com.redhat.rhn.domain.contentmgmt;
 
 import com.redhat.rhn.domain.rhnpackage.Package;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
@@ -48,6 +49,8 @@ public class PackageFilter extends ContentFilter<Package> {
                     pattern = Pattern.compile(value);
                 }
                 return pattern.matcher(getField(pack, field, String.class)).matches();
+            case EXISTS:
+                return StringUtils.isNotEmpty(getField(pack, field, String.class));
             default:
                 throw new UnsupportedOperationException("Matcher " + matcher + " not supported");
         }
@@ -63,6 +66,8 @@ public class PackageFilter extends ContentFilter<Package> {
                 //Case for null epoch: Module metadata reports epoch as '0' even if there's none. We need to match it.
                 // pack.getNameEvra() omits the epoch if null so instead, pack.getNevraWithEpoch() is used here.
                 return type.cast(pack.getNevraWithEpoch());
+            case "module_stream":
+                return type.cast(pack.getExtraTag("modularitylabel"));
             default:
                 throw new UnsupportedOperationException("Field " + field + " not supported");
         }

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/Package.java
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/Package.java
@@ -786,6 +786,18 @@ public class Package extends BaseDomainHelper {
     }
 
     /**
+     * Get an rpm tag value for a specific key
+     *
+     * @param key the rpm tag key
+     * @return the rpm tag value
+     */
+    public String getExtraTag(String key) {
+        PackageExtraTagsKeys headerKey = new PackageExtraTagsKeys();
+        headerKey.setName(key);
+        return this.extraTags.get(headerKey);
+    }
+
+    /**
      * @param extraTagsIn to set
      */
     public void setExtraTags(Map<PackageExtraTagsKeys, String> extraTagsIn) {

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/test/PackageTest.java
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/test/PackageTest.java
@@ -38,6 +38,7 @@ import com.redhat.rhn.domain.rhnpackage.PackageSource;
 import com.redhat.rhn.domain.rpm.SourceRpm;
 import com.redhat.rhn.domain.rpm.test.SourceRpmTest;
 import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.manager.rhnpackage.test.PackageManagerTest;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.RhnBaseTestCase;
 import com.redhat.rhn.testing.TestUtils;
@@ -255,5 +256,13 @@ public class PackageTest extends BaseTestCaseWithUser {
 
     public void testIsInChannel() {
         // TODO make this work on sate
+    }
+
+    public void testGetExtraTag() throws Exception {
+        Package pkg = createTestPackage(user.getOrg());
+        pkg.getExtraTags().put(PackageManagerTest.createExtraTagKey("mytag"), "myvalue");
+
+        assertEquals("myvalue", pkg.getExtraTag("mytag"));
+        assertNull(pkg.getExtraTag("doesnotexist"));
     }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Filter out AppStream packages by 'modularitylabel' rpm tag
+
 -------------------------------------------------------------------
 Wed Mar 11 10:54:21 CET 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
Filter out AppStream packages by the existence of `MODULARITYLABEL` RPM header instead of getting a full list from the `modules.yaml` file.

This PR adds a new CLM filter matcher `EXISTS`, that tests for the existence of any field value. In this PR's scope, this matcher is meant to be used internally and is not served to the frontend.

This helps filter out modular packages even if they are not listed in the `modules.yaml` file. With this improvement, the CentOS 8 repositories, which only serve the latest snapshots of the module metadata can also be supported.

Furthermore, this also improves performance by reducing the amount of the transient filters generated, and removes an extra call to the `mgr-libmod` api.

In order for this implementation to work properly, `MODULARITYLABEL` RPM headers must be imported on reposync (see https://github.com/SUSE/spacewalk/issues/10897).

## Documentation
- No documentation needed: No user-visible changes

## Test coverage
- Unit tests were added

## Links

Fixes https://github.com/SUSE/spacewalk/issues/10898

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
