### PR TITLE
Manager bsc1165571

### DIFF
--- a/web/html/src/manager/images/image-store-edit.js
+++ b/web/html/src/manager/images/image-store-edit.js
@@ -189,7 +189,7 @@ class CreateImageStore extends React.Component {
             }
           </Select>
           <Text name="label" label={t("Label")} required validators={this.isLabelUnique} invalidHint={t("Label is required and must be unique.")} labelClass="col-md-3" divClass="col-md-6"/>
-          <Text name="uri" label={t("Store URI")} required hint={<span>The URI to the store's API endpoint</span>} labelClass="col-md-3" divClass="col-md-6"/>
+          <Text name="uri" label={t("Store URI")} required hint={<span>The URI to the store's API endpoint (without scheme - use 'registry.suse.com' instead of 'https://registry.suse.com')</span>} labelClass="col-md-3" divClass="col-md-6"/>
           { this.renderTypeInputs(this.state.model.storeType) }
           <div className="form-group">
             <div className="col-md-offset-3 col-md-6">

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- scheme is not allowed for URI of image store's API endpoint (bsc#1165571)
+
 -------------------------------------------------------------------
 Mon Feb 17 12:54:30 CET 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

When specifying the URI for the store's API endpoint in image building it needs to be in the format docker expects, that means: no scheme is allowed. Else the user will run into error that looks unrelated and is not easy to find. So at least the user should be notified about this.

## GUI diff

Before: "The URI to the store's API endpoint"

After: "The URI to the store's API endpoint (without scheme - use 'registry.suse.com' instead of 'https://registry.suse.com')"

- [X] **DONE**

## Documentation
-  Doc team has been alerted that this should also be reflected in documentation

- [X] **DONE**

## Test coverage
- No tests: no code changes, only hint for user

- [X] **DONE**

## Links

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1165571

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

