### PR TITLE
Make "spacewalk-repo-sync" to always use the same centralized RPM database (bsc#1163468)

### DIFF
--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -582,7 +582,7 @@ type=rpm-md
             zypper_cmd,
             REPOSYNC_ZYPPER_ROOT,
             os.path.join(repo.root, "etc/zypp/repos.d/"),
-            'var/lib/rpm',
+            REPOSYNC_ZYPPER_RPMDB_PATH,
             os.path.join(repo.root, "var/cache/zypp/raw/"),
             os.path.join(repo.root, "var/cache/zypp/solv/")
         ))

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- Always use the same RPM database when running "spacewalk-repo-sync"
+  from the command line or via taskomatic (bsc#1163468)
 - call mgr-create-bootstrap-repo after repo sync
 - fix mgrcfg-client python3 breakage (bsc#1164309
 - Remove oracle backend support and tests


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue on `spacewalk-repo-sync` which is making the underlying `zypper` call to not always use the same RPM database path (where the GPG keys are stored).

This situation might produce issues and inconsistencies between `spacewalk-repo-sync` executions done by the CLI or via Taskomatic

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **no tests for GPG handling**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/10712

- [x] **DONE**
