### PR TITLE
Fix promotion when channel has phase as prefix

### DIFF
--- a/utils/spacewalk-manage-channel-lifecycle
+++ b/utils/spacewalk-manage-channel-lifecycle
@@ -378,7 +378,7 @@ def get_current_phase(source):
     """
     out = None
     for phase in phases:
-        if source.startswith(phase):
+        if source.startswith("{phase}{dlm}".format(phase=phase, dlm=options.delimiter)):
             out = phase
             break
     return out

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,5 @@
+- check for delimiter as well when detecting current phase (bsc#1164771)
+
 -------------------------------------------------------------------
 Thu Mar 19 12:16:45 CET 2020 - jgonzalez@suse.com
 

--- a/utils/tests/test_spacewalk_manage_channel_lifecycle.py
+++ b/utils/tests/test_spacewalk_manage_channel_lifecycle.py
@@ -24,7 +24,12 @@ class TestSMCL:
         :return:
         """
         smcl.phases = ["dev", "test", "prod"]
-        assert smcl.get_current_phase("develop") == "dev"
+        class DummyOptions:
+            delimiter = '-'
+
+        smcl.options = DummyOptions
+        assert smcl.get_current_phase("develop") is None
+        assert smcl.get_current_phase("dev-develop") == "dev"
 
     @pytest.mark.skip(reason="TBD")
     def test_argparse_port(self):


### PR DESCRIPTION
## What does this PR change?

In case a child channel label in a tree which should be cloned start with the characters of a phase, `spacewalk-manage-channel-lifecycle` will create a mess.

During "init", it check for `<phase><delimiter>`, but during promotion it just checked for `.startswith(phase)` .

This PR change it to check for <phase><delimiter> to prevent this.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/10889
Tracks https://github.com/SUSE/spacewalk/pull/10916 https://github.com/SUSE/spacewalk/pull/10917

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
