### PR TITLE
Support postgresql12

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_bn_IN.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_bn_IN.xml
@@ -3268,6 +3268,9 @@
         <trans-unit id="error.unsupported_db_migrate">
           <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
         </trans-unit>
+        <trans-unit id="error.unfinished_schema_upgrade">
+          <source>Database schema upgrade in progress!</source>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_bn_IN.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_bn_IN.xml
@@ -3255,6 +3255,20 @@
           <target>Kickstart ব্যর্থ।</target>
         </trans-unit>
       </group>
+      <group>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/Login.do</context>
+        </context-group>
+        <trans-unit id="error.unsupported_db_min">
+          <source>Running postgresql {0} is not supported. Minimal required version is {1}.</source>
+        </trans-unit>
+        <trans-unit id="error.unsupported_db_max">
+          <source>Running postgresql {0} is not supported. Maximal allowed version is {1}.</source>
+        </trans-unit>
+        <trans-unit id="error.unsupported_db_migrate">
+          <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
+        </trans-unit>
+      </group>
     </body>
   </file>
 </xliff>

--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_ca.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_ca.xml
@@ -2780,6 +2780,20 @@
           <source>Autoinstallation failed.</source>
         </trans-unit>
       </group>
+      <group>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/Login.do</context>
+        </context-group>
+        <trans-unit id="error.unsupported_db_min">
+          <source>Running postgresql {0} is not supported. Minimal required version is {1}.</source>
+        </trans-unit>
+        <trans-unit id="error.unsupported_db_max">
+          <source>Running postgresql {0} is not supported. Maximal allowed version is {1}.</source>
+        </trans-unit>
+        <trans-unit id="error.unsupported_db_migrate">
+          <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
+        </trans-unit>
+      </group>
     </body>
   </file>
 </xliff>

--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_ca.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_ca.xml
@@ -2793,6 +2793,9 @@
         <trans-unit id="error.unsupported_db_migrate">
           <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
         </trans-unit>
+        <trans-unit id="error.unfinished_schema_upgrade">
+          <source>Database schema upgrade in progress!</source>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_de.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_de.xml
@@ -3275,6 +3275,9 @@
         <trans-unit id="error.unsupported_db_migrate">
           <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
         </trans-unit>
+        <trans-unit id="error.unfinished_schema_upgrade">
+          <source>Database schema upgrade in progress!</source>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_de.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_de.xml
@@ -3262,6 +3262,20 @@
           <target>Kickstart fehlgeschlagen.</target>
         </trans-unit>
       </group>
+      <group>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/Login.do</context>
+        </context-group>
+        <trans-unit id="error.unsupported_db_min">
+          <source>Running postgresql {0} is not supported. Minimal required version is {1}.</source>
+        </trans-unit>
+        <trans-unit id="error.unsupported_db_max">
+          <source>Running postgresql {0} is not supported. Maximal allowed version is {1}.</source>
+        </trans-unit>
+        <trans-unit id="error.unsupported_db_migrate">
+          <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
+        </trans-unit>
+      </group>
     </body>
   </file>
 </xliff>

--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_en_US.xml
@@ -2771,6 +2771,9 @@
         <trans-unit id="error.unsupported_db_migrate">
           <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
         </trans-unit>
+        <trans-unit id="error.unfinished_schema_upgrade">
+          <source>Database schema upgrade in progress!</source>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_en_US.xml
@@ -2758,6 +2758,20 @@
           <source>Autoinstallation failed.</source>
         </trans-unit>
       </group>
+      <group>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/Login.do</context>
+        </context-group>
+        <trans-unit id="error.unsupported_db_min">
+          <source>Running postgresql {0} is not supported. Minimal required version is {1}.</source>
+        </trans-unit>
+        <trans-unit id="error.unsupported_db_max">
+          <source>Running postgresql {0} is not supported. Maximal allowed version is {1}.</source>
+        </trans-unit>
+        <trans-unit id="error.unsupported_db_migrate">
+          <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
+        </trans-unit>
+      </group>
     </body>
   </file>
 </xliff>

--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_es.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_es.xml
@@ -3275,6 +3275,9 @@
         <trans-unit id="error.unsupported_db_migrate">
           <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
         </trans-unit>
+        <trans-unit id="error.unfinished_schema_upgrade">
+          <source>Database schema upgrade in progress!</source>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_es.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_es.xml
@@ -3262,6 +3262,20 @@
           <target>Falló la instalación kickstart.</target>
         </trans-unit>
       </group>
+      <group>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/Login.do</context>
+        </context-group>
+        <trans-unit id="error.unsupported_db_min">
+          <source>Running postgresql {0} is not supported. Minimal required version is {1}.</source>
+        </trans-unit>
+        <trans-unit id="error.unsupported_db_max">
+          <source>Running postgresql {0} is not supported. Maximal allowed version is {1}.</source>
+        </trans-unit>
+        <trans-unit id="error.unsupported_db_migrate">
+          <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
+        </trans-unit>
+      </group>
     </body>
   </file>
 </xliff>

--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_fr.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_fr.xml
@@ -3262,6 +3262,20 @@
           <target>Kickstart échoué.</target>
         </trans-unit>
       </group>
+      <group>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/Login.do</context>
+        </context-group>
+        <trans-unit id="error.unsupported_db_min">
+          <source>Running postgresql {0} is not supported. Minimal required version is {1}.</source>
+        </trans-unit>
+        <trans-unit id="error.unsupported_db_max">
+          <source>Running postgresql {0} is not supported. Maximal allowed version is {1}.</source>
+        </trans-unit>
+        <trans-unit id="error.unsupported_db_migrate">
+          <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
+        </trans-unit>
+      </group>
     </body>
   </file>
 </xliff>

--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_fr.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_fr.xml
@@ -3275,6 +3275,9 @@
         <trans-unit id="error.unsupported_db_migrate">
           <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
         </trans-unit>
+        <trans-unit id="error.unfinished_schema_upgrade">
+          <source>Database schema upgrade in progress!</source>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_gu.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_gu.xml
@@ -3267,6 +3267,9 @@
         <trans-unit id="error.unsupported_db_migrate">
           <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
         </trans-unit>
+        <trans-unit id="error.unfinished_schema_upgrade">
+          <source>Database schema upgrade in progress!</source>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_gu.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_gu.xml
@@ -3254,6 +3254,20 @@
           <target>કિકસ્ટાર્ટ નિષ્ફળ.</target>
         </trans-unit>
       </group>
+      <group>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/Login.do</context>
+        </context-group>
+        <trans-unit id="error.unsupported_db_min">
+          <source>Running postgresql {0} is not supported. Minimal required version is {1}.</source>
+        </trans-unit>
+        <trans-unit id="error.unsupported_db_max">
+          <source>Running postgresql {0} is not supported. Maximal allowed version is {1}.</source>
+        </trans-unit>
+        <trans-unit id="error.unsupported_db_migrate">
+          <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
+        </trans-unit>
+      </group>
     </body>
   </file>
 </xliff>

--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_hi.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_hi.xml
@@ -3267,6 +3267,9 @@
         <trans-unit id="error.unsupported_db_migrate">
           <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
         </trans-unit>
+        <trans-unit id="error.unfinished_schema_upgrade">
+          <source>Database schema upgrade in progress!</source>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_hi.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_hi.xml
@@ -3254,6 +3254,20 @@
           <target>किकस्टार्ट विफल.</target>
         </trans-unit>
       </group>
+      <group>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/Login.do</context>
+        </context-group>
+        <trans-unit id="error.unsupported_db_min">
+          <source>Running postgresql {0} is not supported. Minimal required version is {1}.</source>
+        </trans-unit>
+        <trans-unit id="error.unsupported_db_max">
+          <source>Running postgresql {0} is not supported. Maximal allowed version is {1}.</source>
+        </trans-unit>
+        <trans-unit id="error.unsupported_db_migrate">
+          <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
+        </trans-unit>
+      </group>
     </body>
   </file>
 </xliff>

--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_it.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_it.xml
@@ -3275,6 +3275,9 @@
         <trans-unit id="error.unsupported_db_migrate">
           <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
         </trans-unit>
+        <trans-unit id="error.unfinished_schema_upgrade">
+          <source>Database schema upgrade in progress!</source>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_it.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_it.xml
@@ -3262,6 +3262,20 @@
           <target>Kickstart fallito.</target>
         </trans-unit>
       </group>
+      <group>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/Login.do</context>
+        </context-group>
+        <trans-unit id="error.unsupported_db_min">
+          <source>Running postgresql {0} is not supported. Minimal required version is {1}.</source>
+        </trans-unit>
+        <trans-unit id="error.unsupported_db_max">
+          <source>Running postgresql {0} is not supported. Maximal allowed version is {1}.</source>
+        </trans-unit>
+        <trans-unit id="error.unsupported_db_migrate">
+          <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
+        </trans-unit>
+      </group>
     </body>
   </file>
 </xliff>

--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_ja.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_ja.xml
@@ -3275,6 +3275,9 @@
         <trans-unit id="error.unsupported_db_migrate">
           <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
         </trans-unit>
+        <trans-unit id="error.unfinished_schema_upgrade">
+          <source>Database schema upgrade in progress!</source>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_ja.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_ja.xml
@@ -3262,6 +3262,20 @@
           <target>キックスタートは失敗しました。</target>
         </trans-unit>
       </group>
+      <group>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/Login.do</context>
+        </context-group>
+        <trans-unit id="error.unsupported_db_min">
+          <source>Running postgresql {0} is not supported. Minimal required version is {1}.</source>
+        </trans-unit>
+        <trans-unit id="error.unsupported_db_max">
+          <source>Running postgresql {0} is not supported. Maximal allowed version is {1}.</source>
+        </trans-unit>
+        <trans-unit id="error.unsupported_db_migrate">
+          <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
+        </trans-unit>
+      </group>
     </body>
   </file>
 </xliff>

--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_ko.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_ko.xml
@@ -3275,6 +3275,9 @@
         <trans-unit id="error.unsupported_db_migrate">
           <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
         </trans-unit>
+        <trans-unit id="error.unfinished_schema_upgrade">
+          <source>Database schema upgrade in progress!</source>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_ko.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_ko.xml
@@ -3262,6 +3262,20 @@
           <target>킥스타트가 실패하였습니다.</target>
         </trans-unit>
       </group>
+      <group>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/Login.do</context>
+        </context-group>
+        <trans-unit id="error.unsupported_db_min">
+          <source>Running postgresql {0} is not supported. Minimal required version is {1}.</source>
+        </trans-unit>
+        <trans-unit id="error.unsupported_db_max">
+          <source>Running postgresql {0} is not supported. Maximal allowed version is {1}.</source>
+        </trans-unit>
+        <trans-unit id="error.unsupported_db_migrate">
+          <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
+        </trans-unit>
+      </group>
     </body>
   </file>
 </xliff>

--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_pa.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_pa.xml
@@ -3267,6 +3267,9 @@
         <trans-unit id="error.unsupported_db_migrate">
           <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
         </trans-unit>
+        <trans-unit id="error.unfinished_schema_upgrade">
+          <source>Database schema upgrade in progress!</source>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_pa.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_pa.xml
@@ -3254,6 +3254,20 @@
           <target>ਕਿੱਕਸਟਾਰਟ ਫੇਲ ਹੋ ਗਈ।</target>
         </trans-unit>
       </group>
+      <group>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/Login.do</context>
+        </context-group>
+        <trans-unit id="error.unsupported_db_min">
+          <source>Running postgresql {0} is not supported. Minimal required version is {1}.</source>
+        </trans-unit>
+        <trans-unit id="error.unsupported_db_max">
+          <source>Running postgresql {0} is not supported. Maximal allowed version is {1}.</source>
+        </trans-unit>
+        <trans-unit id="error.unsupported_db_migrate">
+          <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
+        </trans-unit>
+      </group>
     </body>
   </file>
 </xliff>

--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_pt.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_pt.xml
@@ -2836,6 +2836,9 @@
         <trans-unit id="error.unsupported_db_migrate">
           <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
         </trans-unit>
+        <trans-unit id="error.unfinished_schema_upgrade">
+          <source>Database schema upgrade in progress!</source>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_pt.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_pt.xml
@@ -2823,6 +2823,20 @@
           <source>Autoinstallation failed.</source>
         </trans-unit>
       </group>
+      <group>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/Login.do</context>
+        </context-group>
+        <trans-unit id="error.unsupported_db_min">
+          <source>Running postgresql {0} is not supported. Minimal required version is {1}.</source>
+        </trans-unit>
+        <trans-unit id="error.unsupported_db_max">
+          <source>Running postgresql {0} is not supported. Maximal allowed version is {1}.</source>
+        </trans-unit>
+        <trans-unit id="error.unsupported_db_migrate">
+          <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
+        </trans-unit>
+      </group>
     </body>
   </file>
 </xliff>

--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_pt_BR.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_pt_BR.xml
@@ -3262,6 +3262,20 @@
           <target>Kickstart falhou.</target>
         </trans-unit>
       </group>
+      <group>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/Login.do</context>
+        </context-group>
+        <trans-unit id="error.unsupported_db_min">
+          <source>Running postgresql {0} is not supported. Minimal required version is {1}.</source>
+        </trans-unit>
+        <trans-unit id="error.unsupported_db_max">
+          <source>Running postgresql {0} is not supported. Maximal allowed version is {1}.</source>
+        </trans-unit>
+        <trans-unit id="error.unsupported_db_migrate">
+          <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
+        </trans-unit>
+      </group>
     </body>
   </file>
 </xliff>

--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_pt_BR.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_pt_BR.xml
@@ -3275,6 +3275,9 @@
         <trans-unit id="error.unsupported_db_migrate">
           <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
         </trans-unit>
+        <trans-unit id="error.unfinished_schema_upgrade">
+          <source>Database schema upgrade in progress!</source>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_ru.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_ru.xml
@@ -3262,6 +3262,20 @@
           <target>Сбой кикстарта.</target>
         </trans-unit>
       </group>
+      <group>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/Login.do</context>
+        </context-group>
+        <trans-unit id="error.unsupported_db_min">
+          <source>Running postgresql {0} is not supported. Minimal required version is {1}.</source>
+        </trans-unit>
+        <trans-unit id="error.unsupported_db_max">
+          <source>Running postgresql {0} is not supported. Maximal allowed version is {1}.</source>
+        </trans-unit>
+        <trans-unit id="error.unsupported_db_migrate">
+          <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
+        </trans-unit>
+      </group>
     </body>
   </file>
 </xliff>

--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_ru.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_ru.xml
@@ -3275,6 +3275,9 @@
         <trans-unit id="error.unsupported_db_migrate">
           <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
         </trans-unit>
+        <trans-unit id="error.unfinished_schema_upgrade">
+          <source>Database schema upgrade in progress!</source>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_ta.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_ta.xml
@@ -3267,6 +3267,9 @@
         <trans-unit id="error.unsupported_db_migrate">
           <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
         </trans-unit>
+        <trans-unit id="error.unfinished_schema_upgrade">
+          <source>Database schema upgrade in progress!</source>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_ta.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_ta.xml
@@ -3254,6 +3254,20 @@
           <target>கிக்ஸ்டார்ட் செய்ய முடியவில்லை.</target>
         </trans-unit>
       </group>
+      <group>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/Login.do</context>
+        </context-group>
+        <trans-unit id="error.unsupported_db_min">
+          <source>Running postgresql {0} is not supported. Minimal required version is {1}.</source>
+        </trans-unit>
+        <trans-unit id="error.unsupported_db_max">
+          <source>Running postgresql {0} is not supported. Maximal allowed version is {1}.</source>
+        </trans-unit>
+        <trans-unit id="error.unsupported_db_migrate">
+          <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
+        </trans-unit>
+      </group>
     </body>
   </file>
 </xliff>

--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_zh_CN.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_zh_CN.xml
@@ -3275,6 +3275,9 @@
         <trans-unit id="error.unsupported_db_migrate">
           <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
         </trans-unit>
+        <trans-unit id="error.unfinished_schema_upgrade">
+          <source>Database schema upgrade in progress!</source>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_zh_CN.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_zh_CN.xml
@@ -3262,6 +3262,20 @@
           <target>Kickstart 失败。</target>
         </trans-unit>
       </group>
+      <group>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/Login.do</context>
+        </context-group>
+        <trans-unit id="error.unsupported_db_min">
+          <source>Running postgresql {0} is not supported. Minimal required version is {1}.</source>
+        </trans-unit>
+        <trans-unit id="error.unsupported_db_max">
+          <source>Running postgresql {0} is not supported. Maximal allowed version is {1}.</source>
+        </trans-unit>
+        <trans-unit id="error.unsupported_db_migrate">
+          <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
+        </trans-unit>
+      </group>
     </body>
   </file>
 </xliff>

--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_zh_TW.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_zh_TW.xml
@@ -3275,6 +3275,9 @@
         <trans-unit id="error.unsupported_db_migrate">
           <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
         </trans-unit>
+        <trans-unit id="error.unfinished_schema_upgrade">
+          <source>Database schema upgrade in progress!</source>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_zh_TW.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_zh_TW.xml
@@ -3262,6 +3262,20 @@
           <target>Kickstart 失敗。</target>
         </trans-unit>
       </group>
+      <group>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/Login.do</context>
+        </context-group>
+        <trans-unit id="error.unsupported_db_min">
+          <source>Running postgresql {0} is not supported. Minimal required version is {1}.</source>
+        </trans-unit>
+        <trans-unit id="error.unsupported_db_max">
+          <source>Running postgresql {0} is not supported. Maximal allowed version is {1}.</source>
+        </trans-unit>
+        <trans-unit id="error.unsupported_db_migrate">
+          <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
+        </trans-unit>
+      </group>
     </body>
   </file>
 </xliff>

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_bn_IN.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_bn_IN.xml
@@ -1400,12 +1400,6 @@
           <context context-type="sourcefile">/rhn/users/CreateUser</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="error.unsupported_db">
-        <source>Running postgresql {0} is not supported. Minimal required version is {1}.</source>
-      </trans-unit>
-      <trans-unit id="error.unsupported_db_on_os">
-        <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
-      </trans-unit>
       <trans-unit id="error.invalid_login">
         <source>Either the password or username is incorrect.</source>
         <target>পাসওয়ার্ড অথবা ব্যবহারকারীর নাম সঠিক নয়।</target>

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_ca.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_ca.xml
@@ -1389,12 +1389,6 @@
         </context-group>
         <target>Confirmació de la contrasenya</target>
       </trans-unit>
-      <trans-unit id="error.unsupported_db">
-        <source>Running postgresql {0} is not supported. Minimal required version is {1}.</source>
-      </trans-unit>
-      <trans-unit id="error.unsupported_db_on_os">
-        <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
-      </trans-unit>
       <trans-unit id="error.invalid_login">
         <source>Either the password or username is incorrect.</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_de.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_de.xml
@@ -1435,12 +1435,6 @@
         </context-group>
         <target>Passwort bestätigen</target>
       </trans-unit>
-      <trans-unit id="error.unsupported_db">
-        <source>Running postgresql {0} is not supported. Minimal required version is {1}.</source>
-      </trans-unit>
-      <trans-unit id="error.unsupported_db_on_os">
-        <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
-      </trans-unit>
       <trans-unit id="error.invalid_login">
         <source>Either the password or username is incorrect.</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -1247,12 +1247,6 @@
           <context context-type="sourcefile">/rhn/users/CreateUser</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="error.unsupported_db">
-        <source>Running postgresql {0} is not supported. Minimal required version is {1}.</source>
-      </trans-unit>
-      <trans-unit id="error.unsupported_db_on_os">
-        <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
-      </trans-unit>
       <trans-unit id="error.invalid_login">
         <source>Either the password or username is incorrect.</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_es.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_es.xml
@@ -1435,12 +1435,6 @@
         </context-group>
         <target>Confirmar contraseña</target>
       </trans-unit>
-      <trans-unit id="error.unsupported_db">
-        <source>Running postgresql {0} is not supported. Minimal required version is {1}.</source>
-      </trans-unit>
-      <trans-unit id="error.unsupported_db_on_os">
-        <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
-      </trans-unit>
       <trans-unit id="error.invalid_login">
         <source>Either the password or username is incorrect.</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_fr.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_fr.xml
@@ -1437,12 +1437,6 @@ utilisateur avant de supprimer son compte.</target>
         </context-group>
         <target>Confirmer le mot de passe</target>
       </trans-unit>
-      <trans-unit id="error.unsupported_db">
-        <source>Running postgresql {0} is not supported. Minimal required version is {1}.</source>
-      </trans-unit>
-      <trans-unit id="error.unsupported_db_on_os">
-        <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
-      </trans-unit>
       <trans-unit id="error.invalid_login">
         <source>Either the password or username is incorrect.</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_gu.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_gu.xml
@@ -1404,12 +1404,6 @@
         </context-group>
         <target>ખાતરી પાસવર્ડ</target>
       </trans-unit>
-      <trans-unit id="error.unsupported_db">
-        <source>Running postgresql {0} is not supported. Minimal required version is {1}.</source>
-      </trans-unit>
-      <trans-unit id="error.unsupported_db_on_os">
-        <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
-      </trans-unit>
       <trans-unit id="error.invalid_login">
         <source>Either the password or username is incorrect.</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_hi.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_hi.xml
@@ -1404,12 +1404,6 @@
         </context-group>
         <target>शब्दकूट संपुष्ट करें</target>
       </trans-unit>
-      <trans-unit id="error.unsupported_db">
-        <source>Running postgresql {0} is not supported. Minimal required version is {1}.</source>
-      </trans-unit>
-      <trans-unit id="error.unsupported_db_on_os">
-        <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
-      </trans-unit>
       <trans-unit id="error.invalid_login">
         <source>Either the password or username is incorrect.</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_it.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_it.xml
@@ -1435,12 +1435,6 @@
         </context-group>
         <target>Conferma password</target>
       </trans-unit>
-      <trans-unit id="error.unsupported_db">
-        <source>Running postgresql {0} is not supported. Minimal required version is {1}.</source>
-      </trans-unit>
-      <trans-unit id="error.unsupported_db_on_os">
-        <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
-      </trans-unit>
       <trans-unit id="error.invalid_login">
         <source>Either the password or username is incorrect.</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_ja.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_ja.xml
@@ -1435,12 +1435,6 @@
         </context-group>
         <target>パスワードの確認</target>
       </trans-unit>
-      <trans-unit id="error.unsupported_db">
-        <source>Running postgresql {0} is not supported. Minimal required version is {1}.</source>
-      </trans-unit>
-      <trans-unit id="error.unsupported_db_on_os">
-        <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
-      </trans-unit>
       <trans-unit id="error.invalid_login">
         <source>Either the password or username is incorrect.</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_ko.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_ko.xml
@@ -1435,12 +1435,6 @@
         </context-group>
         <target>암호 확인</target>
       </trans-unit>
-      <trans-unit id="error.unsupported_db">
-        <source>Running postgresql {0} is not supported. Minimal required version is {1}.</source>
-      </trans-unit>
-      <trans-unit id="error.unsupported_db_on_os">
-        <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
-      </trans-unit>
       <trans-unit id="error.invalid_login">
         <source>Either the password or username is incorrect.</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_pa.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_pa.xml
@@ -1406,12 +1406,6 @@
         </context-group>
         <target>ਪਾਸਵਰਡ ਪੁਸ਼ਟੀ</target>
       </trans-unit>
-      <trans-unit id="error.unsupported_db">
-        <source>Running postgresql {0} is not supported. Minimal required version is {1}.</source>
-      </trans-unit>
-      <trans-unit id="error.unsupported_db_on_os">
-        <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
-      </trans-unit>
       <trans-unit id="error.invalid_login">
         <source>Either the password or username is incorrect.</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_pt_BR.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_pt_BR.xml
@@ -1435,12 +1435,6 @@
         </context-group>
         <target>Confirmar Senha </target>
       </trans-unit>
-      <trans-unit id="error.unsupported_db">
-        <source>Running postgresql {0} is not supported. Minimal required version is {1}.</source>
-      </trans-unit>
-      <trans-unit id="error.unsupported_db_on_os">
-        <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
-      </trans-unit>
       <trans-unit id="error.invalid_login">
         <source>Either the password or username is incorrect.</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_ru.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_ru.xml
@@ -1435,12 +1435,6 @@
         </context-group>
         <target>Подтвердите пароль</target>
       </trans-unit>
-      <trans-unit id="error.unsupported_db">
-        <source>Running postgresql {0} is not supported. Minimal required version is {1}.</source>
-      </trans-unit>
-      <trans-unit id="error.unsupported_db_on_os">
-        <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
-      </trans-unit>
       <trans-unit id="error.invalid_login">
         <source>Either the password or username is incorrect.</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_ta.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_ta.xml
@@ -1404,12 +1404,6 @@
         </context-group>
         <target>கடவுச்சொல்லை உறுதிப்படுத்தல்</target>
       </trans-unit>
-      <trans-unit id="error.unsupported_db">
-        <source>Running postgresql {0} is not supported. Minimal required version is {1}.</source>
-      </trans-unit>
-      <trans-unit id="error.unsupported_db_on_os">
-        <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
-      </trans-unit>
       <trans-unit id="error.invalid_login">
         <source>Either the password or username is incorrect.</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_uk.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_uk.xml
@@ -1401,12 +1401,6 @@
         </context-group>
         <target>Підтвердження пароля</target>
       </trans-unit>
-      <trans-unit id="error.unsupported_db">
-        <source>Running postgresql {0} is not supported. Minimal required version is {1}.</source>
-      </trans-unit>
-      <trans-unit id="error.unsupported_db_on_os">
-        <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
-      </trans-unit>
       <trans-unit id="error.invalid_login">
         <source>Either the password or username is incorrect.</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_zh_CN.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_zh_CN.xml
@@ -1435,12 +1435,6 @@
         </context-group>
         <target>确认密码</target>
       </trans-unit>
-      <trans-unit id="error.unsupported_db">
-        <source>Running postgresql {0} is not supported. Minimal required version is {1}.</source>
-      </trans-unit>
-      <trans-unit id="error.unsupported_db_on_os">
-        <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
-      </trans-unit>
       <trans-unit id="error.invalid_login">
         <source>Either the password or username is incorrect.</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_zh_TW.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_zh_TW.xml
@@ -1435,12 +1435,6 @@
         </context-group>
         <target>確認密碼</target>
       </trans-unit>
-      <trans-unit id="error.unsupported_db">
-        <source>Running postgresql {0} is not supported. Minimal required version is {1}.</source>
-      </trans-unit>
-      <trans-unit id="error.unsupported_db_on_os">
-        <source>Running postgresql {0} on {1} is not supported. Please migrate to postgresql {2}.</source>
-      </trans-unit>
       <trans-unit id="error.invalid_login">
         <source>Either the password or username is incorrect.</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -5056,18 +5056,18 @@ organization. You may grant or remove the organization administrator role in the
           <context context-type="sourcefile">/rhn/systems/@@PRODUCT_NAME@@</context>
         </context-group>
       </trans-unit>
-        <trans-unit id="systemlist.jsp.isproxy">
-            <source>Proxy</source>
-            <context-group name="ctx">
-                <context context-type="sourcefile">/rhn/systems/Overview</context>
-                <context context-type="sourcefile">/rhn/systems/SystemList</context>
-                <context context-type="sourcefile">/rhn/systems/OutOfDate</context>
-                <context context-type="sourcefile">/rhn/systems/Unentitled</context>
-                <context context-type="sourcefile">/rhn/systems/Ungrouped</context>
-                <context context-type="sourcefile">/rhn/systems/Proxy</context>
-                <context context-type="sourcefile">/rhn/systems/@@PRODUCT_NAME@@</context>
-            </context-group>
-        </trans-unit>
+      <trans-unit id="systemlist.jsp.isproxy">
+        <source>Proxy</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/systems/Overview</context>
+          <context context-type="sourcefile">/rhn/systems/SystemList</context>
+          <context context-type="sourcefile">/rhn/systems/OutOfDate</context>
+          <context context-type="sourcefile">/rhn/systems/Unentitled</context>
+          <context context-type="sourcefile">/rhn/systems/Ungrouped</context>
+          <context context-type="sourcefile">/rhn/systems/Proxy</context>
+          <context context-type="sourcefile">/rhn/systems/@@PRODUCT_NAME@@</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="systemlist.jsp.up2date">
         <source>System is up to date</source>
         <context-group name="ctx">

--- a/java/code/src/com/suse/manager/webui/utils/LoginHelper.java
+++ b/java/code/src/com/suse/manager/webui/utils/LoginHelper.java
@@ -67,7 +67,7 @@ public class LoginHelper {
     private static Logger log = Logger.getLogger(LoginHelper.class);
     private static final String DEFAULT_KERB_USER_PASSWORD = "0";
     private static final Long MIN_PG_DB_VERSION = 100001L;
-    private static final Long MAX_PG_DB_VERSION = 130000L;
+    private static final Long MAX_PG_DB_VERSION = 129999L;
     private static final String MIN_PG_DB_VERSION_STRING = "10";
     private static final String MAX_PG_DB_VERSION_STRING = "12";
     private static final Double OS_VERSION_CHECK = 15.2;

--- a/java/code/src/com/suse/manager/webui/utils/LoginHelper.java
+++ b/java/code/src/com/suse/manager/webui/utils/LoginHelper.java
@@ -330,6 +330,7 @@ public class LoginHelper {
      */
     public static List<String> validateDBVersion() {
         List<String> validationErrors = new ArrayList<>();
+        LocalizationService ls = LocalizationService.getInstance();
         if (ConfigDefaults.get().isPostgresql()) {
             Long serverVersion = 0L;
             String pgVersion = "";
@@ -369,7 +370,6 @@ public class LoginHelper {
                 log.debug("PG DB version is: " + serverVersion);
                 log.debug("OS Version is: " + osVersion + " " + osVersion);
             }
-            LocalizationService ls = LocalizationService.getInstance();
             if (serverVersion < MIN_PG_DB_VERSION) {
                 validationErrors.add(ls.getMessage("error.unsupported_db_min", pgVersion, MIN_PG_DB_VERSION_STRING));
                 log.error(ls.getMessage("error.unsupported_db_min", pgVersion, MIN_PG_DB_VERSION_STRING));
@@ -384,6 +384,12 @@ public class LoginHelper {
                 log.error(ls.getMessage("error.unsupported_db_migrate", pgVersion, osName,
                         OS_VERSION_WANTED_DB_VERSION));
             }
+        }
+        SelectMode m = ModeFactory.getMode("General_queries", "installed_schema_version");
+        DataResult<HashMap> dr = m.execute();
+        if (dr.size() == 0) {
+            validationErrors.add(ls.getMessage("error.unfinished_schema_upgrade"));
+            log.error(ls.getMessage("error.unfinished_schema_upgrade"));
         }
         return validationErrors;
     }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- change DB check before login
 - fix error when adding systems to ssm with 'add to ssm' button (bsc#1160246)
 
 -------------------------------------------------------------------

--- a/schema/spacewalk/spacewalk-schema-upgrade
+++ b/schema/spacewalk/spacewalk-schema-upgrade
@@ -7,8 +7,13 @@ use Spacewalk::Setup ();
 use IPC::Open3 ();
 use File::Basename;
 
-my $MIN_PG_DB_VERSION = 90600;
-my $MIN_PG_DB_VERSION_STRING = "9.6";
+my $MIN_PG_DB_VERSION = 100001;
+my $MAX_PG_DB_VERSION = 129999;
+my $MIN_PG_DB_VERSION_STRING = "10";
+my $MAX_PG_DB_VERSION_STRING = "12";
+my $OS_VERSION_CHECK = 15.2;
+my $OS_VERSION_MIN_DB_VERSION = 120000;
+my $OS_VERSION_WANTED_DB_VERSION = "12";
 my $SCHEMA_UPGRADE_DIR = '/etc/sysconfig/rhn/schema-upgrade';
 my $SCHEMA_UPGRADE_LOGDIR = '/var/log/spacewalk/schema-upgrade';
 
@@ -65,8 +70,12 @@ if ($server_version < $MIN_PG_DB_VERSION) {
     print "\nRunning postgresql $pg_version is not supported. Minimal required version is $MIN_PG_DB_VERSION_STRING.\n\n";
     exit 1;
 }
-elsif(!$isUyuni && $server_version < 100001 && $os_version >= 12.4) {
-    print "\nRunning postgresql $pg_version on $os_name is unsupported. Please migrate to postgresql 10.\n\n";
+elsif($server_version > $MAX_PG_DB_VERSION) {
+    print "\nRunning postgresql $pg_version is not supported. Maximal allowed version is $MAX_PG_DB_VERSION_STRING.\n\n";
+    exit 1;
+}
+elsif($os_version >= $OS_VERSION_CHECK && $server_version < $OS_VERSION_MIN_DB_VERSION) {
+    print "\nRunning postgresql $pg_version on $os_name is unsupported. Please migrate to postgresql $OS_VERSION_WANTED_DB_VERSION.\n\n";
     exit 1;
 }
 

--- a/spacewalk/admin/Makefile.admin
+++ b/spacewalk/admin/Makefile.admin
@@ -45,7 +45,11 @@ GPGKEY_FILES = RHN-GPG-KEY
 
 SYSTEMD_FILES = spacewalk.target spacewalk-wait-for-tomcat.service spacewalk-wait-for-salt.service \
 		spacewalk-wait-for-jabberd.service spacewalk-wait-for-taskomatic.service mgr-events-config.service \
-		mgr-websockify.service
+		mgr-websockify.service uyuni-check-database.service
+
+SYSTEMD_OVERRIDE_SERVICES = tomcat.service apache2.service salt-master.service salt-api.service rhn-search.service \
+			    taskomatic.service mgr-events-config.service
+
 
 BIN_INSTALL    = install -m 755
 CONF_INSTALL   = install -m 644
@@ -64,6 +68,10 @@ install: $(SCRIPTS) $(PERL_DEST) $(CONF_FILES) $(CONF_DEST) $(GPGKEY_FILES) $(GP
 
 install_systemd: $(SYSTEMD_DEST) $(SYSTEMD_FILES)
 	$(SYSTEMD_INSTALL) $(SYSTEMD_FILES) $(SYSTEMD_DEST)
+	for service in $(SYSTEMD_OVERRIDE_SERVICES); do \
+	  $(DIR_INSTALL) $(SYSTEMD_DEST)/$$service.d; \
+	  $(SYSTEMD_INSTALL) uyuni-service-override.conf $(SYSTEMD_DEST)/$$service.d/override.conf; \
+	done
 
 $(PERL_DEST):
 	$(DIR_INSTALL) $@

--- a/spacewalk/admin/spacewalk-admin.changes
+++ b/spacewalk/admin/spacewalk-admin.changes
@@ -1,3 +1,5 @@
+- add DB check service and prevent service start with wrong DB version
+
 -------------------------------------------------------------------
 Mon Feb 17 12:47:29 CET 2020 - jgonzalez@suse.com
 

--- a/spacewalk/admin/spacewalk-admin.spec
+++ b/spacewalk/admin/spacewalk-admin.spec
@@ -118,6 +118,8 @@ sed -i 's|#!/usr/bin/python|#!/usr/bin/python3|' $RPM_BUILD_ROOT/usr/bin/mgr-eve
 %{_unitdir}/spacewalk-wait-for-taskomatic.service
 %{_unitdir}/mgr-events-config.service
 %{_unitdir}/mgr-websockify.service
+%{_unitdir}/uyuni-check-database.service
+%{_unitdir}/*.service.d
 %endif
 
 %changelog

--- a/spacewalk/admin/spacewalk-service.systemd
+++ b/spacewalk/admin/spacewalk-service.systemd
@@ -67,7 +67,16 @@ start() {
     else
         touch $DISABLE_FILE
     fi
-    systemctl start spacewalk.target
+    MSG1=$(systemctl start spacewalk.target 2>&1) || {
+        MSG2=$(systemctl status uyuni-check-database.service)
+        if [ $? -ne 0 ]; then
+            echo -e "$MSG2"
+        else
+            echo -e "$MSG1"
+        fi
+        echo "FAILED"
+        return 1
+    }
     if systemctl is-enabled osa-dispatcher > /dev/null 2>&1; then
         systemctl start jabberd
         /usr/sbin/spacewalk-startup-helper wait-for-jabberd

--- a/spacewalk/admin/spacewalk-startup-helper
+++ b/spacewalk/admin/spacewalk-startup-helper
@@ -5,13 +5,17 @@ if [ -x "/usr/bin/lsof" ]; then
     LSOF="/usr/bin/lsof"
 fi
 
-wait_for_database() {
+check_database() {
     RETRIES=10;
     while [ $RETRIES -gt 0 ]; do
 
-        echo "select 0 from dual;" | spacewalk-sql --select-mode - &> /dev/null
+        IFS="." read -ra VARR <<< $(echo "show server_version;" | spacewalk-sql --select-mode - | sed -n 3p | xargs)
 
         if [ $? -eq 0 ]; then
+            if [ "${VARR[0]}" != "12" ]; then
+                echo "Database version '${VARR[0]}' is not supported for SUSE Manager. Perform database migration."
+                exit 1
+            fi
             exit 0 # db is running
         fi
 
@@ -102,6 +106,7 @@ case $1 in
         ensure-httpd-down) ensure_httpd_down;;
         wait-for-jabberd) wait_for_jabberd;;
         wait-for-tomcat) wait_for_tomcat;;
-        wait-for-database) wait_for_database;;
+        wait-for-database) check_database;;
+        check-database) check_database;;
         wait-for-taskomatic) wait_for_taskomatic;;
 esac

--- a/spacewalk/admin/spacewalk-startup-helper
+++ b/spacewalk/admin/spacewalk-startup-helper
@@ -7,13 +7,14 @@ fi
 
 check_database() {
     RETRIES=10;
+    source /etc/os-release
     while [ $RETRIES -gt 0 ]; do
 
         IFS="." read -ra VARR <<< $(echo "show server_version;" | spacewalk-sql --select-mode - | sed -n 3p | xargs)
 
         if [ $? -eq 0 ]; then
-            if [ "${VARR[0]}" != "12" ]; then
-                echo "Database version '${VARR[0]}' is not supported for SUSE Manager. Perform database migration."
+            if [ $VERSION_ID == "15.2" -a "${VARR[0]}" != "12" ]; then
+                echo "Database version '${VARR[0]}' is not supported for SUSE Manager/Uyuni on $PRETTY_NAME. Perform database migration."
                 exit 1
             fi
             exit 0 # db is running

--- a/spacewalk/admin/spacewalk.target
+++ b/spacewalk/admin/spacewalk.target
@@ -1,5 +1,6 @@
 [Unit]
 Description=Spacewalk
+Requires=uyuni-check-database.service
 Requires=jabberd.service
 Requires=tomcat.service
 Requires=spacewalk-wait-for-tomcat.service

--- a/spacewalk/admin/spacewalk.target.SUSE
+++ b/spacewalk/admin/spacewalk.target.SUSE
@@ -1,5 +1,6 @@
 [Unit]
 Description=Spacewalk
+Requires=uyuni-check-database.service
 Requires=tomcat.service
 Requires=spacewalk-wait-for-tomcat.service
 Requires=salt-master.service

--- a/spacewalk/admin/uyuni-check-database.service
+++ b/spacewalk/admin/uyuni-check-database.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Uyuni check database
+Before=tomcat.service apache2.service salt-master.service salt-api.service rhn-search.service cobblerd.service taskomatic.service mgr-events-config.service mgr-websockify.service
+
+[Service]
+ExecStart=/usr/sbin/spacewalk-startup-helper check-database 
+Type=oneshot
+RemainAfterExit=yes

--- a/spacewalk/admin/uyuni-service-override.conf
+++ b/spacewalk/admin/uyuni-service-override.conf
@@ -1,0 +1,2 @@
+[Unit]
+Requires=uyuni-check-database.service

--- a/spacewalk/package/spacewalk.changes
+++ b/spacewalk/package/spacewalk.changes
@@ -1,3 +1,6 @@
+- change supported DB to postgresql 12
+- change release files to uyuni-release and susemanager-release
+
 -------------------------------------------------------------------
 Wed Mar 11 10:48:54 CET 2020 - jgonzalez@suse.com
 

--- a/spacewalk/package/spacewalk.spec
+++ b/spacewalk/package/spacewalk.spec
@@ -147,7 +147,7 @@ Version for PostgreSQL database backend.
 RDBMS="postgresql"
 install -d $RPM_BUILD_ROOT/%{_sysconfdir}
 SW_REL=$(echo %{version} | awk -F. '{print $1"."$2}')
-echo "Spacewalk release $SW_REL (%{release_name})" > $RPM_BUILD_ROOT/%{_sysconfdir}/spacewalk-release
+echo "Uyuni release $SW_REL (%{release_name})" > $RPM_BUILD_ROOT/%{_sysconfdir}/uyuni-release
 install -d $RPM_BUILD_ROOT/%{_datadir}/spacewalk/setup/defaults.d
 for i in ${RDBMS} ; do
         cat <<EOF >$RPM_BUILD_ROOT/%{_datadir}/spacewalk/setup/defaults.d/$i-backend.conf
@@ -157,7 +157,7 @@ EOF
 done
 
 %files common
-%{_sysconfdir}/spacewalk-release
+%{_sysconfdir}/uyuni-release
 %if 0%{?suse_version}
 %dir %{_datadir}/spacewalk
 %dir %{_datadir}/spacewalk/setup

--- a/spacewalk/package/spacewalk.spec
+++ b/spacewalk/package/spacewalk.spec
@@ -17,13 +17,6 @@
 #
 
 
-%define release_name Smile
-%if 0%{?suse_version}
-%global postgresql postgresql >= 12
-%else
-%global postgresql /usr/bin/psql
-%endif
-
 Name:           spacewalk
 Version:        4.1.2
 Release:        1%{?dist}
@@ -116,16 +109,23 @@ Requires:       spacewalk-common = %{version}-%{release}
 Conflicts:      spacewalk-oracle
 Provides:       spacewalk-db-virtual = %{version}-%{release}
 
-Requires:       %{postgresql}
 Requires:       spacewalk-backend-sql-postgresql
 Requires:       spacewalk-java-postgresql
 Requires:       perl(DBD::Pg)
 %if 0%{?suse_version}
+%if %{?sle_version} > 150200
 Requires:       postgresql12
 Requires:       postgresql12-contrib
 # we do not support postgresql versions > 12.x yet
 Conflicts:      postgresql-implementation >= 13
 Conflicts:      postgresql-contrib-implementation >= 13
+%else
+# mainly for openSUSE Leap 15.1
+Requires:       postgresql10
+Requires:       postgresql10-contrib
+Conflicts:      postgresql-implementation >= 12
+Conflicts:      postgresql-contrib-implementation >= 12
+%endif
 %else
 Requires:       postgresql >= 12
 Requires:       postgresql-contrib >= 12

--- a/spacewalk/package/spacewalk.spec
+++ b/spacewalk/package/spacewalk.spec
@@ -19,7 +19,7 @@
 
 %define release_name Smile
 %if 0%{?suse_version}
-%global postgresql postgresql >= 10
+%global postgresql postgresql >= 12
 %else
 %global postgresql /usr/bin/psql
 %endif
@@ -43,8 +43,8 @@ Summary:        Spacewalk Systems Management Application with postgresql databas
 Group:          Applications/Internet
 Obsoletes:      spacewalk < 0.7.0
 
-BuildRequires:  python >= 3
-Requires:       python >= 3
+BuildRequires:  python3
+Requires:       python3
 Requires:       spacewalk-setup
 
 # Java
@@ -119,16 +119,17 @@ Requires:       spacewalk-backend-sql-postgresql
 Requires:       spacewalk-java-postgresql
 Requires:       perl(DBD::Pg)
 %if 0%{?suse_version}
-Requires:       postgresql10
-Requires:       postgresql10-contrib
-Conflicts:      postgresql12
-Conflicts:      postgresql12-contrib
+Requires:       postgresql12
+Requires:       postgresql12-contrib
+# we do not support postgresql versions > 12.x yet
+Conflicts:      postgresql-implementation >= 13
+Conflicts:      postgresql-contrib-implementation >= 13
 %else
-Requires:       postgresql >= 10
-Requires:       postgresql-contrib >= 10
-# we do not support postgresql versions > 10.x yet
-Conflicts:      postgresql >= 11
-Conflicts:      postgresql-contrib >= 11
+Requires:       postgresql >= 12
+Requires:       postgresql-contrib >= 12
+# we do not support postgresql versions > 12.x yet
+Conflicts:      postgresql >= 13
+Conflicts:      postgresql-contrib >= 13
 %endif
 
 %description postgresql

--- a/spacewalk/package/spacewalk.spec
+++ b/spacewalk/package/spacewalk.spec
@@ -44,6 +44,8 @@ Group:          Applications/Internet
 Obsoletes:      spacewalk < 0.7.0
 
 BuildRequires:  python3
+BuildRequires:  spacewalk-base-minimal-config
+BuildRequires:  spacewalk-backend
 Requires:       python3
 Requires:       spacewalk-setup
 
@@ -146,18 +148,22 @@ Version for PostgreSQL database backend.
 %install
 RDBMS="postgresql"
 install -d $RPM_BUILD_ROOT/%{_sysconfdir}
-SW_REL=$(echo %{version} | awk -F. '{print $1"."$2}')
-echo "Uyuni release $SW_REL (%{release_name})" > $RPM_BUILD_ROOT/%{_sysconfdir}/uyuni-release
+SUMA_REL=$(echo %{version} | awk -F. '{print $1"."$2}')
+UYUNI_REL=$(grep -F 'web.version.uyuni' %{_datadir}/rhn/config-defaults/rhn_web.conf | sed 's/^.*= *\([[:digit:]\.]\+\) *$/\1/')
+echo "Uyuni release $UYUNI_REL" > $RPM_BUILD_ROOT/%{_sysconfdir}/uyuni-release
+if grep -F 'product_name' %{_datadir}/rhn/config-defaults/rhn.conf | grep 'SUSE Manager' >/dev/null; then
+  echo "SUSE Manager release $SUMA_REL ($UYUNI_REL)" > $RPM_BUILD_ROOT/%{_sysconfdir}/susemanager-release
+fi
 install -d $RPM_BUILD_ROOT/%{_datadir}/spacewalk/setup/defaults.d
 for i in ${RDBMS} ; do
-        cat <<EOF >$RPM_BUILD_ROOT/%{_datadir}/spacewalk/setup/defaults.d/$i-backend.conf
+    cat <<EOF >$RPM_BUILD_ROOT/%{_datadir}/spacewalk/setup/defaults.d/$i-backend.conf
 # database backend to be used by spacewalk
 db-backend = $i
 EOF
 done
 
 %files common
-%{_sysconfdir}/uyuni-release
+%{_sysconfdir}/*-release
 %if 0%{?suse_version}
 %dir %{_datadir}/spacewalk
 %dir %{_datadir}/spacewalk/setup

--- a/susemanager/bin/pg-migrate-10-to-12.sh
+++ b/susemanager/bin/pg-migrate-10-to-12.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+
+FAST_UPGRADE=""
+DIR=/var/lib/pgsql
+
+if [ $# -gt 1 ]; then
+    echo "`date +"%H:%M:%S"`   Usage: '$0' or '$0 fast'"
+    exit 1
+fi
+
+if [ $# == 1 ]; then
+    if [ $1 == "fast" ]; then
+        echo "`date +"%H:%M:%S"`   Performing fast upgrade..."
+        FAST_UPGRADE=" --link"
+    else
+        echo "`date +"%H:%M:%S"`   Unknown option '$1'"
+        echo "`date +"%H:%M:%S"`   Usage: '$0' or '$0 fast'"
+        exit 1
+    fi
+else
+    echo -n "`date +"%H:%M:%S"`   Checking diskspace... "
+
+    FREESPACE=`df $DIR | awk '{v=$4} END {print v}'`
+    USEDSPACE=`du -s $DIR | awk '{v=$1} END {print v}'`
+
+    # add 10 percent for safety
+    NEEDSPACE=`expr $USEDSPACE + $USEDSPACE / 10`
+
+    if [ $FREESPACE -lt $NEEDSPACE ]; then
+        echo "failed!"
+        NEEDSPACE=`expr $NEEDSPACE / 1024 / 1024`
+        FREESPACE=`expr $FREESPACE / 1024 / 1024`
+
+        echo
+        echo "`date +"%H:%M:%S"`   Insufficient diskspace in $DIR ($NEEDSPACE GB needed, $FREESPACE GB available)!"
+        echo
+        echo "`date +"%H:%M:%S"`   A fast migration does not need this additional diskspace, because"
+        echo "`date +"%H:%M:%S"`   database files will be hardlinked instead of copied."
+        echo
+        echo "`date +"%H:%M:%S"`   If you have a backup of the database, run \"$0 fast\""
+        echo
+        exit 1
+    else
+        echo "ok."
+    fi
+fi
+
+grep "^archive_command.*smdba-pgarchive" /var/lib/pgsql/data/postgresql.conf > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+    BACKUP_CONFIGURED=1
+else
+    BACKUP_CONFIGURED=0
+fi
+
+echo "`date +"%H:%M:%S"`   Shut down spacewalk services..."
+spacewalk-service stop
+systemctl stop postgresql
+
+echo "`date +"%H:%M:%S"`   Checking postgresql version..."
+rpm -q postgresql12-server > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+    echo "`date +"%H:%M:%S"`   postgresql 12 is already installed. Good."
+else
+    echo "`date +"%H:%M:%S"`   Installing postgresql 10..."
+    zypper --non-interactive in postgresql12 postgresql12-contrib postgresql12-server
+
+    if [ ! $? -eq 0 ]; then
+        echo "`date +"%H:%M:%S"`   Installation of postgresql 10 failed!"
+        exit 1
+    fi
+fi
+
+echo "`date +"%H:%M:%S"`   Ensure postgresql 12 is being used as default..."
+/usr/sbin/update-alternatives --set postgresql /usr/lib/postgresql12
+if [ $? -eq 0 ]; then
+    echo "`date +"%H:%M:%S"`   Successfully switched to new postgresql version 12."
+else
+    echo "`date +"%H:%M:%S"`   Could not switch to new postgresql version 12!"
+    exit 1
+fi
+
+echo "`date +"%H:%M:%S"`   Create new database directory..."
+mv /var/lib/pgsql/data /var/lib/pgsql/data-pg10
+mkdir /var/lib/pgsql/data
+chown postgres:postgres /var/lib/pgsql/data
+
+echo "`date +"%H:%M:%S"`   Initialize new postgresql 12 database..."
+. /etc/sysconfig/postgresql
+if [ -z $POSTGRES_LANG ]; then
+    POSTGRES_LANG="en_US.UTF-8"
+fi
+su -s /bin/bash - postgres -c "initdb -D /var/lib/pgsql/data --locale=$POSTGRES_LANG"
+if [ $? -eq 0 ]; then
+    echo "`date +"%H:%M:%S"`   Successfully initialized new postgresql 12 database."
+else
+    echo "`date +"%H:%M:%S"`   Initialization of new postgresql 12 database failed!"
+    echo "`date +"%H:%M:%S"`   Trying to restore previous state..."
+    mv /var/lib/pgsql/data /var/lib/pgsql/data-new-failed
+    mv /var/lib/pgsql/data-pg10 /var/lib/pgsql/data
+    /usr/sbin/update-alternatives --set postgresql /usr/lib/postgresql10
+    exit 1
+fi
+
+echo "`date +"%H:%M:%S"`   Upgrade database to new version postgresql 12..."
+su -s /bin/bash - postgres -c "pg_upgrade --old-bindir=/usr/lib/postgresql10/bin --new-bindir=/usr/lib/postgresql12/bin --old-datadir=/var/lib/pgsql/data-pg10 --new-datadir=/var/lib/pgsql/data $FAST_UPGRADE"
+if [ $? -eq 0 ]; then
+    echo "`date +"%H:%M:%S"`   Successfully upgraded database to postgresql 12."
+else
+    echo "`date +"%H:%M:%S"`   Upgrading database to version 12 failed!"
+    echo "`date +"%H:%M:%S"`   Trying to restore previous state..."
+    mv /var/lib/pgsql/data /var/lib/pgsql/data-new-failed
+    mv /var/lib/pgsql/data-pg10 /var/lib/pgsql/data
+    /usr/sbin/update-alternatives --set postgresql /usr/lib/postgresql10
+    exit 1
+fi
+
+echo "`date +"%H:%M:%S"`   Tune new postgresql configuration..."
+smdba system-check autotuning
+if [ $? -eq 0 ]; then
+    echo "`date +"%H:%M:%S"`   Successfully tuned new postgresql configuration."
+else
+    echo "`date +"%H:%M:%S"`   Tuning of new postgresql configuration failed!"
+    exit 1
+fi
+
+cp /var/lib/pgsql/data-pg10/pg_hba.conf /var/lib/pgsql/data
+chown postgres:postgres /var/lib/pgsql/data/*
+
+echo "`date +"%H:%M:%S"`   Starting spacewalk services..."
+systemctl start postgresql
+spacewalk-service start
+
+if [ $BACKUP_CONFIGURED -eq 1 ]; then
+    echo
+    echo "It seems database backups via smdba had been configured for postgresql 10."
+    echo "Please re-configure backup for new database version!"
+    echo
+fi
+

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- add database 10 to 12 migration script
+
 -------------------------------------------------------------------
 Thu Mar 19 12:17:24 CET 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Support officially postgresql 12 as database.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- https://github.com/SUSE/spacewalk/issues/10993

- [x] **DONE**

## Test coverage
- No tests: **alrealy covered**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/10921 https://github.com/SUSE/spacewalk/issues/10938

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
