### PR TITLE
Virt pool definition

### DIFF
--- a/java/code/src/com/suse/manager/virtualization/PoolDefinition.java
+++ b/java/code/src/com/suse/manager/virtualization/PoolDefinition.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.virtualization;
+
+import org.apache.log4j.Logger;
+
+/**
+ * Class representing the Virtual Storage Pool XML Definition.
+ */
+public class PoolDefinition {
+    private static final Logger LOG = Logger.getLogger(PoolDefinition.class);
+
+    private String type;
+    private String name;
+    private String uuid;
+    private boolean autostart;
+
+    private PoolTarget target;
+    private PoolSource source;
+
+    /**
+     * @return the pool type
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * @param typeIn The type to set.
+     */
+    public void setType(String typeIn) {
+        type = typeIn;
+    }
+
+    /**
+     * @return pool name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Set the pool name
+     *
+     * @param nameIn pool name
+     */
+    public void setName(String nameIn) {
+        this.name = nameIn;
+    }
+
+    /**
+     * @return pool UUID
+     */
+    public String getUuid() {
+        return uuid;
+    }
+
+    /**
+     * @param uuidIn The uuid to set.
+     */
+    public void setUuid(String uuidIn) {
+        uuid = uuidIn;
+    }
+
+    /**
+     * @return Returns whether the pool is to be autostarted.
+     */
+    public boolean isAutostart() {
+        return autostart;
+    }
+
+    /**
+     * @param autostartIn whether the pool is to be autostarted.
+     */
+    public void setAutostart(boolean autostartIn) {
+        autostart = autostartIn;
+    }
+
+    /**
+     * @return Returns the target.
+     */
+    public PoolTarget getTarget() {
+        return target;
+    }
+
+    /**
+     * @param targetIn The target to set.
+     */
+    public void setTarget(PoolTarget targetIn) {
+        target = targetIn;
+    }
+
+    /**
+     * @return Returns the source.
+     */
+    public PoolSource getSource() {
+        return source;
+    }
+
+    /**
+     * @param sourceIn The source to set.
+     */
+    public void setSource(PoolSource sourceIn) {
+        source = sourceIn;
+    }
+}

--- a/java/code/src/com/suse/manager/virtualization/PoolSource.java
+++ b/java/code/src/com/suse/manager/virtualization/PoolSource.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.virtualization;
+
+import java.util.List;
+
+/**
+ * Represents a virtual pool storage source definition
+ */
+public class PoolSource {
+
+    private String dir;
+    private List<PoolSourceDevice> devices;
+    private List<String> hosts;
+    private PoolSourceAdapter adapter;
+    private PoolSourceAuthentication auth;
+    private String name;
+    private String format;
+    private String initiator;
+
+    /**
+     * @return Returns the source directory.
+     */
+    public String getDir() {
+        return dir;
+    }
+
+    /**
+     * @param dirIn The source directory to set.
+     */
+    public void setDir(String dirIn) {
+        dir = dirIn;
+    }
+
+    /**
+     * @return Returns the source devices.
+     */
+    public List<PoolSourceDevice> getDevices() {
+        return devices;
+    }
+
+    /**
+     * @param devicesIn The source devices to set.
+     */
+    public void setDevices(List<PoolSourceDevice> devicesIn) {
+        devices = devicesIn;
+    }
+
+    /**
+     * @return Returns the source hosts.
+     */
+    public List<String> getHosts() {
+        return hosts;
+    }
+
+    /**
+     * @param hostsIn The source hosts to set.
+     */
+    public void setHosts(List<String> hostsIn) {
+        hosts = hostsIn;
+    }
+
+    /**
+     * @return Returns the source SCSI adapter.
+     */
+    public PoolSourceAdapter getAdapter() {
+        return adapter;
+    }
+
+    /**
+     * @param adapterIn The source SCSI adapter to set.
+     */
+    public void setAdapter(PoolSourceAdapter adapterIn) {
+        adapter = adapterIn;
+    }
+
+    /**
+     * @return Returns the source authentication.
+     */
+    public PoolSourceAuthentication getAuth() {
+        return auth;
+    }
+
+    /**
+     * @param authIn The source authentication to set.
+     */
+    public void setAuth(PoolSourceAuthentication authIn) {
+        auth = authIn;
+    }
+
+    /**
+     * @return Returns the source name.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param nameIn The source name to set.
+     */
+    public void setName(String nameIn) {
+        name = nameIn;
+    }
+
+    /**
+     * @return Returns the source format.
+     */
+    public String getFormat() {
+        return format;
+    }
+
+    /**
+     * @param formatIn The source format to set.
+     */
+    public void setFormat(String formatIn) {
+        format = formatIn;
+    }
+
+    /**
+     * @return Returns the initiator IQN.
+     */
+    public String getInitiator() {
+        return initiator;
+    }
+
+    /**
+     * @param initiatorIn The initiator IQN to set.
+     */
+    public void setInitiator(String initiatorIn) {
+        initiator = initiatorIn;
+    }
+}

--- a/java/code/src/com/suse/manager/virtualization/PoolSourceAdapter.java
+++ b/java/code/src/com/suse/manager/virtualization/PoolSourceAdapter.java
@@ -1,0 +1,210 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.virtualization;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Class representing the adapter parameters for SCSI sources.
+ */
+public class PoolSourceAdapter {
+    private String type;
+    private String name;
+    private String parent;
+    private boolean managed = false;
+    private String wwnn;
+    private String wwpn;
+    private String parentWwnn;
+    private String parentWwpn;
+    private String parentFabricWwn;
+    private String parentAddressUid;
+    private String parentAddress;
+
+    /**
+     * @return Returns the type.
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * @param typeIn The type to set. Should be one of 'scsi_host' or 'fc_host'.
+     */
+    public void setType(String typeIn) {
+        type = typeIn;
+    }
+
+    /**
+     * @return Returns the name.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param nameIn The name to set.
+     */
+    public void setName(String nameIn) {
+        name = nameIn;
+    }
+
+    /**
+     * @return Returns the parent.
+     */
+    public String getParent() {
+        return parent;
+    }
+
+    /**
+     * @param parentIn The parent to set.
+     */
+    public void setParent(String parentIn) {
+        parent = parentIn;
+    }
+
+    /**
+     * @return Returns true if the vHBA should be destroyed with the pool.
+     */
+    public boolean isManaged() {
+        return managed;
+    }
+
+    /**
+     * @param managedIn true if the vHBA should be destroyed with the pool.
+     */
+    public void setManaged(boolean managedIn) {
+        managed = managedIn;
+    }
+
+    /**
+     * @return Returns the wwnn.
+     */
+    public String getWwnn() {
+        return wwnn;
+    }
+
+    /**
+     * @param wwnnIn The wwnn to set.
+     */
+    public void setWwnn(String wwnnIn) {
+        wwnn = wwnnIn;
+    }
+
+    /**
+     * @return Returns the wwpn.
+     */
+    public String getWwpn() {
+        return wwpn;
+    }
+
+    /**
+     * @param wwpnIn The wwpn to set.
+     */
+    public void setWwpn(String wwpnIn) {
+        wwpn = wwpnIn;
+    }
+
+    /**
+     * @return Returns the parent wwnn.
+     */
+    public String getParentWwnn() {
+        return parentWwnn;
+    }
+
+    /**
+     * @param parentWwnnIn The parent wwnn to set.
+     */
+    public void setParentWwnn(String parentWwnnIn) {
+        parentWwnn = parentWwnnIn;
+    }
+
+    /**
+     * @return Returns the parent wwpn.
+     */
+    public String getParentWwpn() {
+        return parentWwpn;
+    }
+
+    /**
+     * @param parentWwpnIn The parent wwpn to set.
+     */
+    public void setParentWwpn(String parentWwpnIn) {
+        parentWwpn = parentWwpnIn;
+    }
+
+    /**
+     * @return Returns the parent fabric_wwn.
+     */
+    public String getParentFabricWwn() {
+        return parentFabricWwn;
+    }
+
+    /**
+     * @param parentFabricWwnIn The parent fabric_wwn to set.
+     */
+    public void setParentFabricWwn(String parentFabricWwnIn) {
+        parentFabricWwn = parentFabricWwnIn;
+    }
+
+    /**
+     * @return Returns the parent address unique id.
+     */
+    public String getParentAddressUid() {
+        return parentAddressUid;
+    }
+
+    /**
+     * @param parentAddressUidIn The parent address unique id to set.
+     */
+    public void setParentAddressUid(String parentAddressUidIn) {
+        parentAddressUid = parentAddressUidIn;
+    }
+
+    /**
+     * @return Returns the parent address domain part.
+     */
+    public String getParentAddress() {
+        return parentAddress;
+    }
+
+    /**
+     * @param parentAddressIn The parent PCI address.
+     * @throws IllegalArgumentException if the value is not in format 0000:00:00.0
+     */
+    public void setParentAddress(String parentAddressIn) throws IllegalArgumentException {
+        if (parentAddressIn != null &&
+                !parentAddressIn.matches("^([0-9a-fA-F]{4}):([0-9a-fA-F]{2}):([0-9a-fA-F]{2}).([0-9a-fA-F])$")) {
+            throw new IllegalArgumentException("Parent address not in format 0000:00:00.0: " + parentAddressIn);
+        }
+        parentAddress = parentAddressIn;
+    }
+
+    /**
+     * @return Returns the parent PCI address parsed into a map with keys 'domain', 'bus', 'slot' and 'function'
+     */
+    public Map<String, String> getParentAddressParsed() {
+        Matcher matcher = Pattern.compile("^([0-9a-fA-F]{4}):([0-9a-fA-F]{2}):([0-9a-fA-F]{2}).([0-9a-fA-F])$")
+            .matcher(parentAddress);
+        Map<String, String> result = new HashMap<>();
+        result.put("domain", matcher.group(1));
+        result.put("bus", matcher.group(2));
+        result.put("slot", matcher.group(3));
+        result.put("function", matcher.group(4));
+        return result;
+    }
+}

--- a/java/code/src/com/suse/manager/virtualization/PoolSourceAuthentication.java
+++ b/java/code/src/com/suse/manager/virtualization/PoolSourceAuthentication.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.virtualization;
+
+/**
+ * Class representing the virtual storage source authentication parameters.
+ */
+public class PoolSourceAuthentication {
+    private String username;
+    private String password;
+    private String type;
+    private String secretType;
+    private String secretValue;
+
+    /**
+     * Construct authentication
+     *
+     * @param usernameIn the username
+     * @param secretIn the secret
+     */
+    public PoolSourceAuthentication(String usernameIn, String secretIn) {
+        setUsername(usernameIn);
+        setPassword(secretIn);
+    }
+
+    /**
+     * @return Returns the username.
+     */
+    public String getUsername() {
+        return username;
+    }
+
+    /**
+     * @param usernameIn The username to set.
+     */
+    public void setUsername(String usernameIn) {
+        username = usernameIn;
+    }
+
+    /**
+     * @return Returns the secret.
+     */
+    public String getPassword() {
+        return password;
+    }
+
+    /**
+     * @param passwordIn The secret to set
+     */
+    public void setPassword(String passwordIn) {
+        password = passwordIn;
+    }
+
+
+    /**
+     * @return Returns the type.
+     */
+    public String getType() {
+        return type;
+    }
+
+
+    /**
+     * @param typeIn The type to set.
+     */
+    public void setType(String typeIn) {
+        type = typeIn;
+    }
+
+
+    /**
+     * @return Returns the secretType.
+     */
+    public String getSecretType() {
+        return secretType;
+    }
+
+
+    /**
+     * @param secretTypeIn The secretType to set.
+     */
+    public void setSecretType(String secretTypeIn) {
+        secretType = secretTypeIn;
+    }
+
+
+    /**
+     * @return Returns the secretValue.
+     */
+    public String getSecretValue() {
+        return secretValue;
+    }
+
+
+    /**
+     * @param secretValueIn The secretValue to set.
+     */
+    public void setSecretValue(String secretValueIn) {
+        secretValue = secretValueIn;
+    }
+}

--- a/java/code/src/com/suse/manager/virtualization/PoolSourceAuthentication.java
+++ b/java/code/src/com/suse/manager/virtualization/PoolSourceAuthentication.java
@@ -14,6 +14,8 @@
  */
 package com.suse.manager.virtualization;
 
+import org.jdom.Element;
+
 /**
  * Class representing the virtual storage source authentication parameters.
  */
@@ -109,5 +111,38 @@ public class PoolSourceAuthentication {
      */
     public void setSecretValue(String secretValueIn) {
         secretValue = secretValueIn;
+    }
+
+    /**
+     * Extract the data from the libvirt pool XML source authentication element.
+     *
+     * @param node the source authentication XML element
+     * @return the created source authentication
+     * @throws IllegalArgumentException if the node is missing required attributes or children
+     */
+    public static PoolSourceAuthentication parse(Element node) throws IllegalArgumentException {
+        PoolSourceAuthentication result = null;
+        if (node != null) {
+            String username = node.getAttributeValue("username");
+            if (username == null) {
+                throw new IllegalArgumentException("Missing required username in pool source authentication");
+            }
+            result = new PoolSourceAuthentication(username, null);
+            result.setType(node.getAttributeValue("type"));
+            Element secret = node.getChild("secret");
+            if (secret != null) {
+                String uuid = secret.getAttributeValue("uuid");
+                String usage = secret.getAttributeValue("usage");
+                if (uuid != null) {
+                    result.setSecretType("uuid");
+                    result.setSecretValue(uuid);
+                }
+                else if (usage != null) {
+                    result.setSecretType("usage");
+                    result.setSecretValue(usage);
+                }
+            }
+        }
+        return result;
     }
 }

--- a/java/code/src/com/suse/manager/virtualization/PoolSourceDevice.java
+++ b/java/code/src/com/suse/manager/virtualization/PoolSourceDevice.java
@@ -14,6 +14,8 @@
  */
 package com.suse.manager.virtualization;
 
+import org.jdom.Element;
+
 import java.util.Optional;
 
 /**
@@ -70,5 +72,30 @@ public class PoolSourceDevice {
      */
     public void setSeparator(Optional<Boolean> separatorIn) {
         separator = separatorIn;
+    }
+
+    /**
+     * Extract the data from a libvirt pool XML source device element.
+     *
+     * @param node the source device XML element
+     * @return the created device
+     * @throws IllegalArgumentException if the node is missing required attributes or children
+     */
+    public static PoolSourceDevice parse(Element node) throws IllegalArgumentException {
+        PoolSourceDevice result = null;
+        if (node != null) {
+            String path = node.getAttributeValue("path");
+            String separatorStr = node.getAttributeValue("part_separator");
+            if (path == null) {
+                throw new IllegalArgumentException("Missing mandatory path attribute in device");
+            }
+            Optional<Boolean> separator = Optional.empty();
+            if (separatorStr != null) {
+                separator = Optional.of("yes".equals(separatorStr));
+            }
+
+            result = new PoolSourceDevice(path, separator);
+        }
+        return result;
     }
 }

--- a/java/code/src/com/suse/manager/virtualization/PoolSourceDevice.java
+++ b/java/code/src/com/suse/manager/virtualization/PoolSourceDevice.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.virtualization;
+
+import java.util.Optional;
+
+/**
+ * Class representing a virtual storage pool device source.
+ */
+public class PoolSourceDevice {
+    private String path;
+    private Optional<Boolean> separator;
+
+    /**
+     * Device constructor
+     *
+     * @param pathIn the path or iSCSI Qualified Name
+     */
+    public PoolSourceDevice(String pathIn) {
+        setPath(pathIn);
+        setSeparator(Optional.empty());
+    }
+
+    /**
+     * Device constructor
+     *
+     * @param pathIn the path or iSCSI Qualified Name
+     * @param separatorIn the separator
+     */
+    public PoolSourceDevice(String pathIn, Optional<Boolean> separatorIn) {
+        setPath(pathIn);
+        setSeparator(separatorIn);
+    }
+
+    /**
+     * @return Returns the device path of iSCSI Qualified Name.
+     */
+    public String getPath() {
+        return path;
+    }
+
+    /**
+     * @param pathIn The device path of iSCSI Qualified Name to set.
+     */
+    public void setPath(String pathIn) {
+        path = pathIn;
+    }
+
+    /**
+     * @return Returns the separator.
+     */
+    public Optional<Boolean> isSeparator() {
+        return separator;
+    }
+
+    /**
+     * @param separatorIn The separator to set.
+     */
+    public void setSeparator(Optional<Boolean> separatorIn) {
+        separator = separatorIn;
+    }
+}

--- a/java/code/src/com/suse/manager/virtualization/PoolTarget.java
+++ b/java/code/src/com/suse/manager/virtualization/PoolTarget.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.virtualization;
+
+/**
+ * Describes the target properties of a virtual storage pool
+ */
+public class PoolTarget {
+    private String path;
+    private String owner;
+    private String group;
+    private String mode;
+    private String seclabel;
+
+    /**
+     * @return Returns the path.
+     */
+    public String getPath() {
+        return path;
+    }
+
+    /**
+     * @param pathIn The path to set.
+     */
+    public void setPath(String pathIn) {
+        path = pathIn;
+    }
+
+    /**
+     * @return Returns the owner.
+     */
+    public String getOwner() {
+        return owner;
+    }
+
+    /**
+     * @param ownerIn The owner to set.
+     */
+    public void setOwner(String ownerIn) {
+        owner = ownerIn;
+    }
+
+    /**
+     * @return Returns the group.
+     */
+    public String getGroup() {
+        return group;
+    }
+
+    /**
+     * @param groupIn The group to set.
+     */
+    public void setGroup(String groupIn) {
+        group = groupIn;
+    }
+
+    /**
+     * @return Returns the mode.
+     */
+    public String getMode() {
+        return mode;
+    }
+
+    /**
+     * @param modeIn The mode to set.
+     */
+    public void setMode(String modeIn) {
+        mode = modeIn;
+    }
+
+    /**
+     * @return Returns the seclabel.
+     */
+    public String getSeclabel() {
+        return seclabel;
+    }
+
+    /**
+     * @param seclabelIn The seclabel to set.
+     */
+    public void setSeclabel(String seclabelIn) {
+        seclabel = seclabelIn;
+    }
+}

--- a/java/code/src/com/suse/manager/virtualization/PoolTarget.java
+++ b/java/code/src/com/suse/manager/virtualization/PoolTarget.java
@@ -14,6 +14,8 @@
  */
 package com.suse.manager.virtualization;
 
+import org.jdom.Element;
+
 /**
  * Describes the target properties of a virtual storage pool
  */
@@ -92,5 +94,28 @@ public class PoolTarget {
      */
     public void setSeclabel(String seclabelIn) {
         seclabel = seclabelIn;
+    }
+
+    /**
+     * Extract the data from the libvirt pool XML target element.
+     *
+     * @param node the target XML element
+     * @return the created target
+     */
+    public static PoolTarget parse(Element node) {
+        PoolTarget result = null;
+        if (node != null) {
+            result = new PoolTarget();
+
+            result.setPath(node.getChildText("path"));
+            Element permissions = node.getChild("permissions");
+            if (permissions != null) {
+                result.setOwner(permissions.getChildText("owner"));
+                result.setGroup(permissions.getChildText("group"));
+                result.setMode(permissions.getChildText("mode"));
+                result.setSeclabel(permissions.getChildText("label"));
+            }
+        }
+        return result;
     }
 }

--- a/java/code/src/com/suse/manager/virtualization/test/PoolDefinitionTest.java
+++ b/java/code/src/com/suse/manager/virtualization/test/PoolDefinitionTest.java
@@ -1,0 +1,233 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.virtualization.test;
+
+import com.suse.manager.virtualization.PoolDefinition;
+
+import java.util.Arrays;
+
+import junit.framework.TestCase;
+
+public class PoolDefinitionTest extends TestCase {
+
+    public void testParseRbd() {
+        String xml =
+                "<pool type='rbd'>\n" +
+                "  <name>test-ses</name>\n" +
+                "  <uuid>ede33e0a-9df0-479f-8afd-55085a01b244</uuid>\n" +
+                "  <capacity unit='bytes'>0</capacity>\n" +
+                "  <allocation unit='bytes'>0</allocation>\n" +
+                "  <available unit='bytes'>0</available>\n" +
+                "  <source>\n" +
+                "    <host name='ses2.tf.local' port='1234'/>\n" +
+                "    <host name='ses3.tf.local'/>\n" +
+                "    <name>libvirt-pool</name>\n" +
+                "    <auth type='ceph' username='libvirt'>\n" +
+                "      <secret usage='pool_test-ses'/>\n" +
+                "    </auth>\n" +
+                "  </source>\n" +
+                "</pool>";
+        PoolDefinition actual = PoolDefinition.parse(xml);
+        assertEquals("test-ses", actual.getName());
+        assertEquals("ede33e0a-9df0-479f-8afd-55085a01b244", actual.getUuid());
+        assertEquals("rbd", actual.getType());
+        assertNull(actual.getTarget());
+        assertEquals("libvirt-pool", actual.getSource().getName());
+        assertEquals("ceph", actual.getSource().getAuth().getType());
+        assertEquals("libvirt", actual.getSource().getAuth().getUsername());
+        assertEquals("usage", actual.getSource().getAuth().getSecretType());
+        assertEquals("pool_test-ses", actual.getSource().getAuth().getSecretValue());
+        assertTrue(Arrays.asList("ses2.tf.local:1234", "ses3.tf.local").equals(actual.getSource().getHosts()));
+    }
+
+    public void testParseDir() {
+        String xml =
+                "<pool type='dir'>\n" +
+                "  <name>default</name>\n" +
+                "  <uuid>9f2d114f-4dc7-4f76-8831-062931c04a9a</uuid>\n" +
+                "  <capacity unit='bytes'>210303426560</capacity>\n" +
+                "  <allocation unit='bytes'>6631251968</allocation>\n" +
+                "  <available unit='bytes'>203672174592</available>\n" +
+                "  <source>\n" +
+                "  </source>\n" +
+                "  <target>\n" +
+                "    <path>/var/lib/libvirt/images</path>\n" +
+                "    <permissions>\n" +
+                "      <mode>0755</mode>\n" +
+                "      <owner>0</owner>\n" +
+                "      <group>123</group>\n" +
+                "      <label>virt_image_t</label>\n" +
+                "    </permissions>\n" +
+                "  </target>\n" +
+                "</pool>";
+        PoolDefinition actual = PoolDefinition.parse(xml);
+        assertEquals("default", actual.getName());
+        assertEquals("9f2d114f-4dc7-4f76-8831-062931c04a9a", actual.getUuid());
+        assertEquals("dir", actual.getType());
+        assertEquals("/var/lib/libvirt/images", actual.getTarget().getPath());
+        assertEquals("0755", actual.getTarget().getMode());
+        assertEquals("0", actual.getTarget().getOwner());
+        assertEquals("123", actual.getTarget().getGroup());
+        assertEquals("virt_image_t", actual.getTarget().getSeclabel());
+    }
+
+    public void testParseFs() {
+        String xml =
+                "<pool type=\"fs\">\n" +
+                "  <name>virtimages</name>\n" +
+                "  <source>\n" +
+                "    <device path=\"/dev/VolGroup00/VirtImages\"/>\n" +
+                "    <format type=\"ocfs2\"/> \n" +
+                "  </source>\n" +
+                "  <target>\n" +
+                "    <path>/var/lib/virt/images</path>\n" +
+                "  </target>\n" +
+                "</pool>";
+        PoolDefinition actual = PoolDefinition.parse(xml);
+        assertEquals("virtimages", actual.getName());
+        assertNull(actual.getUuid());
+        assertEquals("fs", actual.getType());
+        assertEquals("/var/lib/virt/images", actual.getTarget().getPath());
+        assertEquals(1, actual.getSource().getDevices().size());
+        assertEquals("/dev/VolGroup00/VirtImages", actual.getSource().getDevices().get(0).getPath());
+        assertEquals("ocfs2", actual.getSource().getFormat());
+    }
+
+    public void testParseNetfs() {
+        String xml =
+                "<pool type='netfs'>\n" +
+                "  <name>virtimages</name>\n" +
+                "  <source>\n" +
+                "    <host name='nfs.example.com'/>\n" +
+                "    <dir path='/var/lib/virt/images'/>\n" +
+                "    <format type='nfs'/>\n" +
+                "  </source>\n" +
+                "  <target>\n" +
+                "    <path>/var/lib/virt/images</path>\n" +
+                "  </target>\n" +
+                "</pool>";
+        PoolDefinition actual = PoolDefinition.parse(xml);
+        assertEquals("virtimages", actual.getName());
+        assertNull(actual.getUuid());
+        assertEquals("netfs", actual.getType());
+        assertEquals("/var/lib/virt/images", actual.getTarget().getPath());
+        assertTrue(Arrays.asList("nfs.example.com").equals(actual.getSource().getHosts()));
+        assertEquals("/var/lib/virt/images", actual.getSource().getDir());
+        assertEquals("nfs", actual.getSource().getFormat());
+    }
+
+    public void testParseLogical() {
+        String xml =
+                "<pool type='logical'>\n" +
+                "  <name>HostVG</name>\n" +
+                "  <source>\n" +
+                "    <device path='/dev/sda1' part_separator='yes'/>\n" +
+                "    <device path='/dev/sdb1'/>\n" +
+                "  </source>\n" +
+                "  <target>\n" +
+                "    <path>/dev/HostVG</path>\n" +
+                "  </target>\n" +
+                "</pool>";
+        PoolDefinition actual = PoolDefinition.parse(xml);
+        assertEquals("logical", actual.getType());
+        assertEquals("/dev/HostVG", actual.getTarget().getPath());
+        assertEquals(2, actual.getSource().getDevices().size());
+        assertEquals("/dev/sda1", actual.getSource().getDevices().get(0).getPath());
+        assertTrue(actual.getSource().getDevices().get(0).isSeparator().get());
+        assertEquals("/dev/sdb1", actual.getSource().getDevices().get(1).getPath());
+        assertTrue(actual.getSource().getDevices().get(1).isSeparator().isEmpty());
+    }
+
+    public void testParseScsi() {
+        String xml =
+                "<pool type='scsi'>\n" +
+                "  <name>virtimages</name>\n" +
+                "  <source>\n" +
+                "    <adapter name='host0'/>\n" +
+                "  </source>\n" +
+                "  <target>\n" +
+                "    <path>/dev/disk/by-path</path>\n" +
+                "  </target>\n" +
+                "</pool>";
+        PoolDefinition actual = PoolDefinition.parse(xml);
+        assertEquals("host0", actual.getSource().getAdapter().getName());
+    }
+
+    public void testParseIscsiDirect() {
+        String xml =
+                "<pool type='iscsi-direct'>\n" +
+                "  <name>virtimages</name>\n" +
+                "  <source>\n" +
+                "    <host name='iscsi.example.com'/>\n" +
+                "    <device path='iqn.2013-06.com.example:iscsi-pool'/>\n" +
+                "    <initiator>\n" +
+                "      <iqn name='iqn.2013-06.com.example:iscsi-initiator'/>\n" +
+                "    </initiator>\n" +
+                "    <auth type='chap' username='myname'>\n" +
+                "      <secret uuid='2ec115d7-3a88-3ceb-bc12-0ac909a6fd87'/>\n" +
+                "    </auth>\n" +
+                "  </source>\n" +
+                "</pool>";
+        PoolDefinition actual = PoolDefinition.parse(xml);
+        assertEquals("iqn.2013-06.com.example:iscsi-initiator", actual.getSource().getInitiator());
+        assertEquals("chap", actual.getSource().getAuth().getType());
+        assertEquals("myname", actual.getSource().getAuth().getUsername());
+        assertEquals("uuid", actual.getSource().getAuth().getSecretType());
+        assertEquals("2ec115d7-3a88-3ceb-bc12-0ac909a6fd87", actual.getSource().getAuth().getSecretValue());
+    }
+
+    public void testParseIscsiAddress() {
+        String xml =
+                "<pool type=\"iscsi\">\n" +
+                "  <name>virtimages</name>\n" +
+                "  <source>\n" +
+                "    <host name=\"iscsi.example.com\"/>\n" +
+                "    <device path=\"iqn.2013-06.com.example:iscsi-pool\"/>\n" +
+                "    <adapter type='scsi_host'>\n" +
+                "      <parentaddr unique_id='1'>\n" +
+                "        <address domain='0x0000' bus='0x00' slot='0x1f' function='0x2'/>\n" +
+                "      </parentaddr>\n" +
+                "    </adapter>\n" +
+                "  </source>\n" +
+                "  <target>\n" +
+                "    <path>/dev/disk/by-path</path>\n" +
+                "  </target>\n" +
+                "</pool>";
+        PoolDefinition actual = PoolDefinition.parse(xml);
+        assertEquals("scsi_host", actual.getSource().getAdapter().getType());
+        assertEquals("1", actual.getSource().getAdapter().getParentAddressUid());
+        assertEquals("0000:00:1f.2", actual.getSource().getAdapter().getParentAddress());
+    }
+
+    public void testParseIscsiWwnn() {
+        String xml =
+                "<pool type=\"iscsi\">\n" +
+                "  <name>virtimages</name>\n" +
+                "  <source>\n" +
+                "    <host name=\"iscsi.example.com\"/>\n" +
+                "    <device path=\"iqn.2013-06.com.example:iscsi-pool\"/>\n" +
+                "    <adapter type='fc_host' parent='scsi_host5' wwnn='20000000c9831b4b' wwpn='10000000c9831b4b'/>\n" +
+                "  </source>\n" +
+                "  <target>\n" +
+                "    <path>/dev/disk/by-path</path>\n" +
+                "  </target>\n" +
+                "</pool>";
+        PoolDefinition actual = PoolDefinition.parse(xml);
+        assertEquals("fc_host", actual.getSource().getAdapter().getType());
+        assertEquals("scsi_host5", actual.getSource().getAdapter().getParent());
+        assertEquals("20000000c9831b4b", actual.getSource().getAdapter().getWwnn());
+        assertEquals("10000000c9831b4b", actual.getSource().getAdapter().getWwpn());
+    }
+}

--- a/web/html/src/manager/virtualization/pools/virtualization-pool-definition-api.js
+++ b/web/html/src/manager/virtualization/pools/virtualization-pool-definition-api.js
@@ -1,0 +1,39 @@
+// @flow
+import * as React from 'react';
+import Network from 'utils/network';
+import * as Messages from 'components/messages';
+
+type Props = {
+  /** Virtual host server ID */
+  hostid: string,
+  /** Name of the pool for which to get the defintion*/
+  poolName: string,
+  /** Children function rendering the content depending on the request result */
+  children: ({definition: Object, messages: React.Node}) => React.Node,
+};
+
+/** Component calling the Uyuni REST API to get the XML definition of a virtual storage pool */
+export function VirtualizationPoolDefinitionApi(props: Props) {
+  const [messages, setMessages] = React.useState([]);
+  const [definition, setDefinition] = React.useState(null);
+
+  React.useEffect(() => {
+    Network.get(`/rhn/manager/api/systems/details/virtualization/pools/${props.hostid}/pool/${props.poolName}`,
+      'application/json').promise
+      .then((response) => {
+        setDefinition(response);
+      }, (xhr) => {
+        const errMessages = xhr.status === 0
+          ? [Messages.Utils.error(
+            t('Request interrupted or invalid response received from the server. Please try again.'),
+          )]
+          : [Messages.Utils.error(Network.errorMessageByStatus(xhr.status))];
+        setMessages(errMessages);
+      });
+  }, [props.hostid, props.poolName]);
+
+  return props.children({
+    definition: definition,
+    messages: messages,
+  });
+}


### PR DESCRIPTION
## What does this PR change?

Add REST API and ReactJS component to fetch the XML definition of a virtual storage pool.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal pieces

- [X] **DONE**

## Test coverage

- Unit tests were added

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
