### PR TITLE
Virt pool refresh

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
@@ -14,6 +14,8 @@
  */
 package com.redhat.rhn.domain.action;
 
+import static java.util.stream.Collectors.toSet;
+
 import com.redhat.rhn.common.db.datasource.CallableMode;
 import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.common.db.datasource.ModeFactory;
@@ -47,6 +49,7 @@ import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationCreateAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationDeleteAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationDestroyAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolRefreshAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationRebootAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationResumeAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationSchedulePollerAction;
@@ -68,10 +71,11 @@ import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.rhnset.RhnSetManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
+
 import org.apache.log4j.Logger;
 import org.hibernate.HibernateException;
-import org.hibernate.query.Query;
 import org.hibernate.Session;
+import org.hibernate.query.Query;
 
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
@@ -85,8 +89,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
-
-import static java.util.stream.Collectors.toSet;
 
 /**
  * ActionFactory - the singleton class used to fetch and store
@@ -432,6 +434,9 @@ public class ActionFactory extends HibernateFactory {
         }
         else if (typeIn.equals(TYPE_VIRTUALIZATION_CREATE)) {
             retval = new VirtualizationCreateAction();
+        }
+        else if (typeIn.equals(TYPE_VIRTUALIZATION_POOL_REFRESH)) {
+            retval = new VirtualizationPoolRefreshAction();
         }
         else if (typeIn.equals(TYPE_SCAP_XCCDF_EVAL)) {
             retval = new ScapAction();
@@ -909,7 +914,8 @@ public class ActionFactory extends HibernateFactory {
                 actionType.equals(TYPE_VIRTUALIZATION_SET_VCPUS) ||
                 actionType.equals(TYPE_VIRTUALIZATION_SHUTDOWN) ||
                 actionType.equals(TYPE_VIRTUALIZATION_START) ||
-                actionType.equals(TYPE_VIRTUALIZATION_SUSPEND);
+                actionType.equals(TYPE_VIRTUALIZATION_SUSPEND) ||
+                actionType.equals(TYPE_VIRTUALIZATION_POOL_REFRESH);
     }
 
     /**
@@ -1258,5 +1264,11 @@ public class ActionFactory extends HibernateFactory {
      */
     public static final ActionType TYPE_VIRTUALIZATION_CREATE =
             lookupActionTypeByLabel("virt.create");
+
+    /**
+     * The constant representing "Refresh a virtual storage pool." [ID:509]
+     */
+    public static final ActionType TYPE_VIRTUALIZATION_POOL_REFRESH =
+            lookupActionTypeByLabel("virt.pool_refresh");
 }
 

--- a/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
@@ -378,6 +378,14 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
           </join>
         </subclass>
 
+        <subclass name="com.redhat.rhn.domain.action.virtualization.VirtualizationPoolRefreshAction"
+          discriminator-value="509" lazy="true">
+          <join table="rhnActionVirtPoolRefresh">
+            <key column="action_id"/>
+            <property name="poolName" type="string" column="pool_name"/>
+          </join>
+        </subclass>
+
 
         <!-- PackageActions: 1, 3, 4, 8, 13, 14, 33 -->
         <!-- PackageAction is abstract - the subclasses only get instantiated -->
@@ -502,7 +510,8 @@ select {ra.*}
             NULL as arch,
             NULL as graphics_type,
             NULL as remove_disks,
-            NULL as remove_interfaces from dual) ra_11_
+            NULL as remove_interfaces from dual) ra_11_,
+    (select NULL as pool_name from dual) ra_12_
    where
     ra.id = (SELECT max(rA.id)
                    FROM rhnAction rA
@@ -613,7 +622,8 @@ select sa.server_id
                              NULL as arch,
                              NULL as graphics_type,
                              NULL as remove_disks,
-                             NULL as remove_interfaces from dual) ra_11_
+                             NULL as remove_interfaces from dual) ra_11_,
+                     (select NULL as pool_name from dual) ra_12_
                      where ra.id in (select distinct ac.id
                                    from rhnAction ac
                                       inner join rhnServerAction sa on ac.id = sa.action_id

--- a/java/code/src/com/redhat/rhn/domain/action/virtualization/BaseVirtualizationPoolAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/virtualization/BaseVirtualizationPoolAction.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.domain.action.virtualization;
+
+import com.redhat.rhn.domain.action.Action;
+
+/**
+ * Represents the common pieces of virtual storage actions.
+ */
+public class BaseVirtualizationPoolAction extends Action {
+
+    private String poolName;
+
+    /**
+     * @return Returns the name of the storage pool to apply the action on.
+     */
+    public String getPoolName() {
+        return poolName;
+    }
+
+    /**
+     * @param poolNameIn The name of the storage pool name to set.
+     */
+    public void setPoolName(String poolNameIn) {
+        poolName = poolNameIn;
+    }
+}

--- a/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationPoolRefreshAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationPoolRefreshAction.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.domain.action.virtualization;
+
+/**
+ * Represents a virtual storage refresh action.
+ */
+public class VirtualizationPoolRefreshAction extends BaseVirtualizationPoolAction {
+
+}

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -7070,6 +7070,12 @@ Follow this url to see the full list of inactive systems:
           <context context-type="sourcefile">com.redhat.rhn.domain.action.ActionFormatter.getActionType</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="virt.pool_refresh">
+        <source>Virtual storage pool refresh</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">com.redhat.rhn.domain.action.ActionFormatter.getActionType</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="channels.subscribers.updated">
         <source>{0} channel subscriber(s) successfully updated.</source>
         <context-group name="ctx">

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -42,6 +42,7 @@ import com.redhat.rhn.domain.action.script.ScriptResult;
 import com.redhat.rhn.domain.action.script.ScriptRunAction;
 import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.action.virtualization.BaseVirtualizationAction;
+import com.redhat.rhn.domain.action.virtualization.BaseVirtualizationPoolAction;
 import com.redhat.rhn.domain.channel.AccessToken;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.config.ConfigRevision;
@@ -659,6 +660,12 @@ public class SaltUtils {
             JsonObject result = jsonResult.getAsJsonObject();
             String key = result.keySet().iterator().next();
             serverAction.setResultMsg(result.get(key).getAsJsonObject().get("comment").getAsString());
+        }
+        else if (action instanceof BaseVirtualizationPoolAction) {
+            // Tell VirtNotifications that we got a pool action change, passing action
+            VirtNotifications.spreadActionUpdate(action);
+            // Intentionally don't get only the comment since the changes value could be interesting
+            serverAction.setResultMsg(getJsonResultWithPrettyPrint(jsonResult));
         }
         else {
            serverAction.setResultMsg(getJsonResultWithPrettyPrint(jsonResult));

--- a/java/code/src/com/suse/manager/webui/utils/gson/VirtualPoolBaseActionJson.java
+++ b/java/code/src/com/suse/manager/webui/utils/gson/VirtualPoolBaseActionJson.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.webui.utils.gson;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ *
+ * VirtualPoolBaseAction represents the generic pool action request body structure.
+ */
+public class VirtualPoolBaseActionJson {
+    private List<String> poolNames;
+    private LocalDateTime earliest;
+    private Optional<String> actionChain = Optional.empty();
+
+    /**
+     * @return the names of the pools to action on
+     */
+    public List<String> getPoolNames() {
+        return poolNames;
+    }
+
+    /**
+     * @param poolNamesIn The poolNames to set.
+     */
+    public void setPoolNames(List<String> poolNamesIn) {
+        poolNames = poolNamesIn;
+    }
+
+    /**
+     * @return the earliest
+     */
+    public LocalDateTime getEarliest() {
+        return earliest;
+    }
+
+    /**
+     * @param earliestIn The earliest to set.
+     */
+    public void setEarliest(LocalDateTime earliestIn) {
+        earliest = earliestIn;
+    }
+
+    /**
+     * @return actionChain to get
+     */
+    public Optional<String> getActionChain() {
+        return actionChain;
+    }
+
+    /**
+     * @param actionChainIn The actionChain to set.
+     */
+    public void setActionChain(Optional<String> actionChainIn) {
+        actionChain = actionChainIn;
+    }
+}

--- a/java/code/src/com/suse/manager/webui/websocket/VirtNotifications.java
+++ b/java/code/src/com/suse/manager/webui/websocket/VirtNotifications.java
@@ -19,6 +19,7 @@ import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.action.virtualization.BaseVirtualizationAction;
+import com.redhat.rhn.domain.action.virtualization.BaseVirtualizationPoolAction;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.domain.user.UserFactory;
@@ -87,6 +88,11 @@ public class VirtNotifications {
                     id = uuid;
                 }
                 return id;
+            },
+            BaseVirtualizationPoolAction.class,
+            (action) -> {
+                BaseVirtualizationPoolAction virtAction = (BaseVirtualizationPoolAction)action;
+                return String.format("pool-%s", virtAction.getPoolName());
             }
         );
 

--- a/schema/spacewalk/common/data/rhnActionType.sql
+++ b/schema/spacewalk/common/data/rhnActionType.sql
@@ -79,6 +79,7 @@ insert into rhnActionType values (505, 'image.inspect', 'Inspect an Image', 'N',
 insert into rhnActionType values (506, 'channels.subscribe', 'Subscribe to channels', 'N', 'N');
 insert into rhnActionType values (507, 'virt.delete', 'Deletes a virtual domain.', 'N', 'N');
 insert into rhnActionType values (508, 'virt.create', 'Creates a virtual domain.', 'N', 'N');
+insert into rhnActionType values (509, 'virt.pool_refresh', 'Refresh a virtual storage pool', 'N', 'N');
 --
 --
 -- Revision 1.25  2004/10/29 05:07:52  pjones

--- a/schema/spacewalk/common/tables/rhnActionVirtPoolRefresh.sql
+++ b/schema/spacewalk/common/tables/rhnActionVirtPoolRefresh.sql
@@ -1,0 +1,30 @@
+--
+-- Copyright (c) 2020 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+CREATE TABLE rhnActionVirtPoolRefresh
+(
+    action_id            NUMERIC NOT NULL
+                             CONSTRAINT rhn_action_virt_pool_refresh_aid_fk
+                                 REFERENCES rhnAction (id)
+                                 ON DELETE CASCADE
+                             CONSTRAINT rhn_action_virt_pool_refresh_aid_pk
+                                 PRIMARY KEY,
+    pool_name            VARCHAR(256)
+)
+;
+
+CREATE UNIQUE INDEX rhn_action_virt_pool_refresh_aid_uq
+    ON rhnActionVirtPoolRefresh (action_id)
+    ;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.4-to-susemanager-schema-4.1.5/001-add_virt_pool_actions_rhnActionType.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.4-to-susemanager-schema-4.1.5/001-add_virt_pool_actions_rhnActionType.sql
@@ -1,0 +1,19 @@
+-- Copyright (c) 2020 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+insert into rhnActionType (id, label, name, trigger_snapshot, unlocked_only) (
+    select 509, 'virt.pool_refresh', 'Refresh a virtual storage pool', 'N', 'N'
+    from dual
+    where not exists (select 1 from rhnActionType where id = 509)
+);

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.4-to-susemanager-schema-4.1.5/002-rhnActionVirtPoolRefresh.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.4-to-susemanager-schema-4.1.5/002-rhnActionVirtPoolRefresh.sql
@@ -1,0 +1,29 @@
+-- Copyright (c) 2020 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+CREATE TABLE IF NOT EXISTS rhnActionVirtPoolRefresh
+(
+    action_id            NUMERIC NOT NULL
+                             CONSTRAINT rhn_action_virt_pool_refresh_aid_fk
+                                 REFERENCES rhnAction (id)
+                                 ON DELETE CASCADE
+                             CONSTRAINT rhn_action_virt_pool_refresh_aid_pk
+                                 PRIMARY KEY,
+    pool_name            VARCHAR(256)
+)
+;
+
+CREATE UNIQUE INDEX IF NOT EXISTS rhn_action_virt_pool_refresh_aid_uq
+    ON rhnActionVirtPoolRefresh (action_id);
+

--- a/susemanager-utils/susemanager-sls/salt/virt/pool-refreshed.sls
+++ b/susemanager-utils/susemanager-sls/salt/virt/pool-refreshed.sls
@@ -1,0 +1,4 @@
+mgr_pool_refreshed:
+  module.run:
+    - name: virt.pool_refresh
+    - m_name: {{ pillar['pool_name'] }}

--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -246,6 +246,11 @@ For a test with a regular expression, there is ```I should see a text like "..."
 
 (last one should probably be renamed - it looks in the contents area of the page)
 
+* Wait until a tree item has no sub list
+
+```cucumber
+  When I wait until the tree item "test-pool0" has no sub-list
+```
 
 <a name="b4" />
 
@@ -277,6 +282,7 @@ For a test with a regular expression, there is ```I should see a text like "..."
 
 ```cucumber
   When I click on "Schedule"
+  When I click on "Refresh" in tree item "test-pool0"
 ```
 
 The button can be identified by id, value, title, text content, or alt of image.

--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -195,6 +195,13 @@ Feature: Be able to manage KVM virtual machines via the GUI
     Then I should not see a "test-vm2" virtual machine on "kvm_server"
 
 @virthost_kvm
+  Scenario: Refresh a virtual storage pool for KVM
+    Given I am on the "Virtualization" page of this "kvm_server"
+    When I follow "Storage"
+    And I click on "Refresh" in tree item "test-pool0"
+    And I wait until the tree item "test-pool0" has no sub-list
+
+@virthost_kvm
   Scenario: Cleanup: Unregister the KVM virtualization host
     Given I am on the Systems overview page of this "kvm_server"
     When I follow "Delete System"

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -461,6 +461,18 @@ When(/^I select "([^\"]*)" as a product$/) do |product|
   raise "xpath: #{xpath} not found" unless find(:xpath, xpath).set(true)
 end
 
+When(/I wait until the tree item "([^"]+)" has no sub-list/) do |item|
+  repeat_until_timeout(message: "could still find a sub list for tree item #{item}") do
+    xpath = "//span[contains(text(), '#{item}')]/ancestor::div[contains(@class, 'product-details-wrapper')]/div/i[contains(@class, 'fa-angle-')]"
+    begin
+      find(:xpath, xpath)
+      sleep 1
+    rescue Capybara::ElementNotFound
+      break
+    end
+  end
+end
+
 And(/^I open the sub-list of the product "(.*?)"$/) do |product|
   xpath = "//span[contains(text(), '#{product}')]/ancestor::div[contains(@class, 'product-details-wrapper')]/div/i[contains(@class, 'fa-angle-right')]"
   # within(:xpath, xpath) do

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -23,6 +23,12 @@ When(/^I click on "([^"]+)" in row "([^"]+)"$/) do |link, item|
   end
 end
 
+When(/^I click on "([^"]+)" in tree item "(.*?)"$/) do |button, item|
+  within(:xpath, "//span[contains(text(), '#{item}')]/ancestor::div[contains(@class, 'product-details-wrapper')]") do
+    click_link_or_button_and_wait(button)
+  end
+end
+
 Then(/^the current path is "([^"]*)"$/) do |arg1|
   raise "Path #{current_path} different than #{arg1}" unless current_path == arg1
 end

--- a/web/html/src/manager/virtualization/pools/list/pools-list.js
+++ b/web/html/src/manager/virtualization/pools/list/pools-list.js
@@ -6,7 +6,9 @@ import { CustomDiv } from 'components/custom-objects';
 import { ProgressBar } from 'components/progressbar';
 import { CustomDataHandler } from 'components/table/CustomDataHandler';
 import { SearchField } from 'components/table/SearchField';
+import { AsyncButton } from 'components/buttons';
 import { VirtualizationPoolsListRefreshApi } from '../virtualization-pools-list-refresh-api';
+import { VirtualizationPoolsActionApi } from '../virtualization-pools-action-api';
 
 type Props = {
   serverId: string,
@@ -92,124 +94,148 @@ function FilteredTree(props: FilteredTreeProps) {
 
 export function PoolsList(props: Props) {
   return (
-    <VirtualizationPoolsListRefreshApi
-      serverId={props.serverId}
-      refreshInterval={props.refreshInterval}
+    <VirtualizationPoolsActionApi
+      hostid={props.serverId}
     >
-      {
-        ({
-          pools,
-          refreshError,
-        }) => {
-          function renderPool(pool: Object, renderNameColumn: Function): React.Node {
-            return [
-              <CustomDiv key="name" className="col" width="30" um="%">
-                {renderNameColumn(pool.name)}
-              </CustomDiv>,
-              <CustomDiv key="state" className="col text-center" width="5" um="%">{pool.state}</CustomDiv>,
-              <CustomDiv key="autostart" className="col text-center" width="5" um="%">
-                {
-                  pool.autostart &&
-                  <i className="fa fa-check-square fa-1-5x" title={t(`${pool.name} is started automatically`)}/>
-                }
-              </CustomDiv>,
-              <CustomDiv key="persistent" className="col text-center" width="5" um="%">
-                {
-                  pool.persistent &&
-                  <i className="fa fa-check-square fa-1-5x" title={t(`${pool.name} is persistent`)}/>
-                }
-              </CustomDiv>,
-              <CustomDiv key="target" className="col" width="30" um="%">{pool.targetPath}</CustomDiv>,
-              <CustomDiv key="usage" className="col" width="10" um="%">
-                { pool.capacity !== 0 &&
-                  <ProgressBar
-                    progress={Math.round(100 * pool.allocation / pool.capacity)}
-                    title={t(`${pool.allocation / (1024 * 1024)} GiB / ${pool.capacity / (1024 * 1024)} GiB in use`)}
-                  />
-                }
-                { pool.capacity === 0 &&
-                  <span>{t("Unknown")}</span>
-                }
-              </CustomDiv>,
-              <CustomDiv key="actions" className="col text-right" width="10" um="%">
-              </CustomDiv>,
-            ];
-          }
-
-          function renderVolume (volume: Object, renderNameColumn: Function): React.Node {
-            return [
-              <CustomDiv key="name" className="col" width="calc((100% + 3em) * 0.3 - 3em)" um="">
-                {renderNameColumn(volume.name)}
-              </CustomDiv>,
-              <CustomDiv key="usedBy" className="col" width="calc((100% + 3em) * 0.45)" um="">{volume.usedBy != null ? volume.usedBy.join(", ") : ''}</CustomDiv>,
-              <CustomDiv key="usage" className="col" width="calc((100% + 3em) * 0.1)" um="">
-                { volume.capacity !== 0 &&
-                  <ProgressBar
-                    progress={Math.min(100, Math.round(100 * volume.allocation / volume.capacity))}
-                    title={t(`${volume.allocation / (1024 * 1024)} GiB / ${volume.capacity / (1024 * 1024)} GiB in use`)}
-                  />
-                }
-                { volume.capacity === 0 &&
-                  <span>{t("Unknown")}</span>
-                }
-              </CustomDiv>,
-              <CustomDiv key="actions" className="col text-right" width="calc((100% + 3em) * 0.1)" um="">
-                <div className="btn-group">
-                </div>
-              </CustomDiv>,
-            ];
-          }
-
-          function renderItem (item: TreeItem, renderNameColumn: Function): React.Node {
-            const itemRenderers = {
-              pool: renderPool,
-              volume: renderVolume,
-            };
-            if (item.data != null) {
-              return itemRenderers[item.data.itemType](item.data, renderNameColumn);
-            } else {
-              return null;
-            }
-          }
-
-          const tree = poolsInfoToTree(pools);
-          const header = [
-            <CustomDiv key="name" className="col col-class-calc-width" width="30" um="%">{t('Name')}</CustomDiv>,
-            <CustomDiv key="state" className="col text-center" width="5" um="%">{t('State')}</CustomDiv>,
-            <CustomDiv key="autostart" className="col text-center" width="5" um="%">{t('Autostart')}</CustomDiv>,
-            <CustomDiv key="persistent" className="col text-center" width="5" um="%">{t('Persistent')}</CustomDiv>,
-            <CustomDiv key="target" className="col" width="30" um="%">{t('Location')}</CustomDiv>,
-            <CustomDiv key="usage" className="col" width="10" um="%">{t('Usage')}</CustomDiv>,
-            <CustomDiv key="actions" className="col text-right" width="10" um="%">{t('Actions')}</CustomDiv>,
-          ];
-
-          return (
-            <CustomDataHandler
-              data={getPoolsAndVolumes(tree)}
-              identifier={(raw) => raw.id}
-              initialItemsPerPage={Number(props.pageSize)}
-              loading={tree == null}
-              additionalFilters={[]}
-              searchField={
-                  <SearchField filter={searchData}
-                      criteria={''}
-                      placeholder={t('Filter by pool or volume name')}
-                  />
+    {
+      ({
+        onAction,
+        messages
+      }) => {
+        return (
+          <VirtualizationPoolsListRefreshApi
+            serverId={props.serverId}
+            refreshInterval={props.refreshInterval}
+          >
+          {
+            ({
+              pools,
+              refreshError,
+            }) => {
+              function renderPool(pool: Object, renderNameColumn: Function): React.Node {
+                return [
+                  <CustomDiv key="name" className="col" width="30" um="%">
+                    {renderNameColumn(pool.name)}
+                  </CustomDiv>,
+                  <CustomDiv key="state" className="col text-center" width="5" um="%">{pool.state}</CustomDiv>,
+                  <CustomDiv key="autostart" className="col text-center" width="5" um="%">
+                    {
+                      pool.autostart &&
+                      <i className="fa fa-check-square fa-1-5x" title={t(`${pool.name} is started automatically`)}/>
+                    }
+                  </CustomDiv>,
+                  <CustomDiv key="persistent" className="col text-center" width="5" um="%">
+                    {
+                      pool.persistent &&
+                      <i className="fa fa-check-square fa-1-5x" title={t(`${pool.name} is persistent`)}/>
+                    }
+                  </CustomDiv>,
+                  <CustomDiv key="target" className="col" width="30" um="%">{pool.targetPath}</CustomDiv>,
+                  <CustomDiv key="usage" className="col" width="10" um="%">
+                    { pool.capacity !== 0 &&
+                      <ProgressBar
+                        progress={Math.round(100 * pool.allocation / pool.capacity)}
+                        title={t(`${pool.allocation / (1024 * 1024)} GiB / ${pool.capacity / (1024 * 1024)} GiB in use`)}
+                      />
+                    }
+                    { pool.capacity === 0 &&
+                      <span>{t("Unknown")}</span>
+                    }
+                  </CustomDiv>,
+                  <CustomDiv key="actions" className="col text-right" width="10" um="%">
+                    <div className="btn-group">
+                      { pool.state === 'running' &&
+                        <AsyncButton
+                          defaultType="btn-default btn-sm"
+                          title={t("Refresh")}
+                          icon="fa-refresh"
+                          action={() => onAction('refresh', [pool.name], {})}
+                        />
+                      }
+                    </div>
+                  </CustomDiv>,
+                ];
               }
-            >
-            {
-              tree != null &&
-              <FilteredTree tree={tree}>
-                <Tree
-                  header={header}
-                  renderItem={renderItem}
-                />
-              </FilteredTree>
+
+              function renderVolume (volume: Object, renderNameColumn: Function): React.Node {
+                return [
+                  <CustomDiv key="name" className="col" width="calc((100% + 3em) * 0.3 - 3em)" um="">
+                    {renderNameColumn(volume.name)}
+                  </CustomDiv>,
+                  <CustomDiv key="usedBy" className="col" width="calc((100% + 3em) * 0.45)" um="">{volume.usedBy != null ? volume.usedBy.join(", ") : ''}</CustomDiv>,
+                  <CustomDiv key="usage" className="col" width="calc((100% + 3em) * 0.1)" um="">
+                    { volume.capacity !== 0 &&
+                      <ProgressBar
+                        progress={Math.min(100, Math.round(100 * volume.allocation / volume.capacity))}
+                        title={t(`${volume.allocation / (1024 * 1024)} GiB / ${volume.capacity / (1024 * 1024)} GiB in use`)}
+                      />
+                    }
+                    { volume.capacity === 0 &&
+                      <span>{t("Unknown")}</span>
+                    }
+                  </CustomDiv>,
+                  <CustomDiv key="actions" className="col text-right" width="calc((100% + 3em) * 0.1)" um="">
+                    <div className="btn-group">
+                    </div>
+                  </CustomDiv>,
+                ];
+              }
+
+              function renderItem (item: TreeItem, renderNameColumn: Function): React.Node {
+                const itemRenderers = {
+                  pool: renderPool,
+                  volume: renderVolume,
+                };
+                if (item.data != null) {
+                  return itemRenderers[item.data.itemType](item.data, renderNameColumn);
+                } else {
+                  return null;
+                }
+              }
+
+              const tree = poolsInfoToTree(pools);
+              const header = [
+                <CustomDiv key="name" className="col col-class-calc-width" width="30" um="%">{t('Name')}</CustomDiv>,
+                <CustomDiv key="state" className="col text-center" width="5" um="%">{t('State')}</CustomDiv>,
+                <CustomDiv key="autostart" className="col text-center" width="5" um="%">{t('Autostart')}</CustomDiv>,
+                <CustomDiv key="persistent" className="col text-center" width="5" um="%">{t('Persistent')}</CustomDiv>,
+                <CustomDiv key="target" className="col" width="30" um="%">{t('Location')}</CustomDiv>,
+                <CustomDiv key="usage" className="col" width="10" um="%">{t('Usage')}</CustomDiv>,
+                <CustomDiv key="actions" className="col text-right" width="10" um="%">{t('Actions')}</CustomDiv>,
+              ];
+
+              return (
+                <CustomDataHandler
+                  data={getPoolsAndVolumes(tree)}
+                  identifier={(raw) => raw.id}
+                  initialItemsPerPage={Number(props.pageSize)}
+                  loading={tree == null}
+                  additionalFilters={[]}
+                  searchField={
+                      <SearchField filter={searchData}
+                          criteria={''}
+                          placeholder={t('Filter by pool or volume name')}
+                          name='pool-name-filter'
+                      />
+                  }
+                >
+                {
+                  tree != null &&
+                  <FilteredTree tree={tree}>
+                    <Tree
+                      header={header}
+                      renderItem={renderItem}
+                    />
+                  </FilteredTree>
+                }
+                </CustomDataHandler>
+              );
             }
-            </CustomDataHandler>
-          );
-        }
+          }
+          </VirtualizationPoolsListRefreshApi>
+        );
       }
-    </VirtualizationPoolsListRefreshApi>
+    }
+    </VirtualizationPoolsActionApi>
   );
 }

--- a/web/html/src/manager/virtualization/pools/virtualization-pools-action-api.js
+++ b/web/html/src/manager/virtualization/pools/virtualization-pools-action-api.js
@@ -1,0 +1,37 @@
+// @flow
+import * as React from 'react';
+import { ActionApi } from '../ActionApi';
+
+type Props = {
+  hostid: string,
+  children: Function,
+  bounce?: string,
+  callback?: Function,
+};
+
+export function VirtualizationPoolsActionApi(props: Props) {
+  return (
+    <ActionApi
+      urlTemplate={ `/rhn/manager/api/systems/details/virtualization/pools/${props.hostid}/@ACTION@`}
+      bounce={props.bounce}
+      callback={props.callback}
+    >
+    {
+      ({
+        onAction: apiAction,
+        messages,
+      }) => {
+        const onAction = (action: string, poolNames: Array<string>, parameters: Object) => {
+          const messageData = Object.assign({ }, parameters, { poolNames });
+          apiAction(action, messageData);
+        }
+        return props.children({onAction, messages});
+      }
+    }
+    </ActionApi>
+  );
+}
+VirtualizationPoolsActionApi.defaultProps = {
+  bounce: undefined,
+  callback: undefined,
+};


### PR DESCRIPTION
## What does this PR change?

Add virtual pool refresh action

## GUI diff

Before:

No action was possible for virtual pools

After:

The refresh action is possible for virtual pools

- [X] **DONE**

## Documentation
- [uyuni-docs](uyuni-project/uyuni-docs#52) PR or issue was created for all pool actions

- [X] **DONE**

## Test coverage
- Unit tests were added
- Cucumber tests were added

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

To avoid cluttering the changelog there is one commit adding changelog entry for all storage pool actions coming in an upcoming PR.

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
