### PR TITLE
Virt pool start

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
@@ -50,6 +50,7 @@ import com.redhat.rhn.domain.action.virtualization.VirtualizationCreateAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationDeleteAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationDestroyAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolRefreshAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolStartAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationRebootAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationResumeAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationSchedulePollerAction;
@@ -437,6 +438,9 @@ public class ActionFactory extends HibernateFactory {
         }
         else if (typeIn.equals(TYPE_VIRTUALIZATION_POOL_REFRESH)) {
             retval = new VirtualizationPoolRefreshAction();
+        }
+        else if (typeIn.equals(TYPE_VIRTUALIZATION_POOL_START)) {
+            retval = new VirtualizationPoolStartAction();
         }
         else if (typeIn.equals(TYPE_SCAP_XCCDF_EVAL)) {
             retval = new ScapAction();
@@ -915,7 +919,8 @@ public class ActionFactory extends HibernateFactory {
                 actionType.equals(TYPE_VIRTUALIZATION_SHUTDOWN) ||
                 actionType.equals(TYPE_VIRTUALIZATION_START) ||
                 actionType.equals(TYPE_VIRTUALIZATION_SUSPEND) ||
-                actionType.equals(TYPE_VIRTUALIZATION_POOL_REFRESH);
+                actionType.equals(TYPE_VIRTUALIZATION_POOL_REFRESH) ||
+                actionType.equals(TYPE_VIRTUALIZATION_POOL_START);
     }
 
     /**
@@ -1270,5 +1275,11 @@ public class ActionFactory extends HibernateFactory {
      */
     public static final ActionType TYPE_VIRTUALIZATION_POOL_REFRESH =
             lookupActionTypeByLabel("virt.pool_refresh");
+
+    /**
+     * The constant representing "Start a virtual storage pool." [ID:510]
+     */
+    public static final ActionType TYPE_VIRTUALIZATION_POOL_START =
+            lookupActionTypeByLabel("virt.pool_start");
 }
 

--- a/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
@@ -386,6 +386,14 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
           </join>
         </subclass>
 
+        <subclass name="com.redhat.rhn.domain.action.virtualization.VirtualizationPoolStartAction"
+          discriminator-value="510" lazy="true">
+          <join table="rhnActionVirtPoolStart">
+            <key column="action_id"/>
+            <property name="poolName" type="string" column="pool_name"/>
+          </join>
+        </subclass>
+
 
         <!-- PackageActions: 1, 3, 4, 8, 13, 14, 33 -->
         <!-- PackageAction is abstract - the subclasses only get instantiated -->
@@ -511,7 +519,8 @@ select {ra.*}
             NULL as graphics_type,
             NULL as remove_disks,
             NULL as remove_interfaces from dual) ra_11_,
-    (select NULL as pool_name from dual) ra_12_
+    (select NULL as pool_name from dual) ra_12_,
+    (select NULL as pool_name from dual) ra_13_
    where
     ra.id = (SELECT max(rA.id)
                    FROM rhnAction rA
@@ -623,7 +632,8 @@ select sa.server_id
                              NULL as graphics_type,
                              NULL as remove_disks,
                              NULL as remove_interfaces from dual) ra_11_,
-                     (select NULL as pool_name from dual) ra_12_
+                     (select NULL as pool_name from dual) ra_12_,
+                     (select NULL as pool_name from dual) ra_13_
                      where ra.id in (select distinct ac.id
                                    from rhnAction ac
                                       inner join rhnServerAction sa on ac.id = sa.action_id

--- a/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationPoolStartAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationPoolStartAction.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.domain.action.virtualization;
+
+
+/**
+ * Represents a virtual storage start action.
+ */
+public class VirtualizationPoolStartAction extends BaseVirtualizationPoolAction {
+
+}

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -7076,6 +7076,12 @@ Follow this url to see the full list of inactive systems:
           <context context-type="sourcefile">com.redhat.rhn.domain.action.ActionFormatter.getActionType</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="virt.pool_start">
+        <source>Virtual storage pool start</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">com.redhat.rhn.domain.action.ActionFormatter.getActionType</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="channels.subscribers.updated">
         <source>{0} channel subscriber(s) successfully updated.</source>
         <context-group name="ctx">

--- a/java/code/src/com/suse/manager/webui/controllers/VirtualPoolsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/VirtualPoolsController.java
@@ -27,6 +27,7 @@ import com.redhat.rhn.domain.action.ActionChainFactory;
 import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.virtualization.BaseVirtualizationPoolAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolRefreshAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolStartAction;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.rhnset.RhnSetDecl;
@@ -109,6 +110,8 @@ public class VirtualPoolsController {
                 withUser(this::getPool));
         post("/manager/api/systems/details/virtualization/pools/:sid/refresh",
                 withUser(this::poolRefresh));
+        post("/manager/api/systems/details/virtualization/pools/:sid/start",
+                withUser(this::poolStart));
     }
 
     /**
@@ -229,6 +232,23 @@ public class VirtualPoolsController {
         return poolAction(request, response, user, (data) -> {
             VirtualizationPoolRefreshAction action = (VirtualizationPoolRefreshAction)
                     ActionFactory.createAction(ActionFactory.TYPE_VIRTUALIZATION_POOL_REFRESH);
+            action.setName(action.getActionType().getName() + ": " + String.join(",", data.getPoolNames()));
+            return action;
+        });
+    }
+
+    /**
+     * Executes the POST query to start a set of virtual pools.
+     *
+     * @param request the request
+     * @param response the response
+     * @param user the user
+     * @return JSON list of created action IDs
+     */
+    public String poolStart(Request request, Response response, User user) {
+        return poolAction(request, response, user, (data) -> {
+            VirtualizationPoolStartAction action = (VirtualizationPoolStartAction)
+                    ActionFactory.createAction(ActionFactory.TYPE_VIRTUALIZATION_POOL_START);
             action.setName(action.getActionType().getName() + ": " + String.join(",", data.getPoolNames()));
             return action;
         });

--- a/schema/spacewalk/common/data/rhnActionType.sql
+++ b/schema/spacewalk/common/data/rhnActionType.sql
@@ -80,6 +80,7 @@ insert into rhnActionType values (506, 'channels.subscribe', 'Subscribe to chann
 insert into rhnActionType values (507, 'virt.delete', 'Deletes a virtual domain.', 'N', 'N');
 insert into rhnActionType values (508, 'virt.create', 'Creates a virtual domain.', 'N', 'N');
 insert into rhnActionType values (509, 'virt.pool_refresh', 'Refresh a virtual storage pool', 'N', 'N');
+insert into rhnActionType values (510, 'virt.pool_start', 'Starts a virtual storage pool', 'N', 'N');
 --
 --
 -- Revision 1.25  2004/10/29 05:07:52  pjones

--- a/schema/spacewalk/common/tables/rhnActionVirtPoolStart.sql
+++ b/schema/spacewalk/common/tables/rhnActionVirtPoolStart.sql
@@ -1,3 +1,4 @@
+--
 -- Copyright (c) 2020 SUSE LLC
 --
 -- This software is licensed to you under the GNU General Public License,
@@ -12,14 +13,17 @@
 -- in this software or its documentation.
 --
 
-insert into rhnActionType (id, label, name, trigger_snapshot, unlocked_only) (
-    select 509, 'virt.pool_refresh', 'Refresh a virtual storage pool', 'N', 'N'
-    from dual
-    where not exists (select 1 from rhnActionType where id = 509)
-);
+CREATE TABLE rhnActionVirtPoolStart
+(
+    action_id            NUMERIC NOT NULL
+                             CONSTRAINT rhn_action_virt_pool_start_aid_fk
+                                 REFERENCES rhnAction (id)
+                                 ON DELETE CASCADE
+                             CONSTRAINT rhn_action_virt_pool_start_aid_pk
+                                 PRIMARY KEY,
+    pool_name            VARCHAR(256)
+)
+;
 
-insert into rhnActionType (id, label, name, trigger_snapshot, unlocked_only) (
-    select 510, 'virt.pool_start', 'Starts a virtual storage pool', 'N', 'N'
-    from dual
-    where not exists (select 1 from rhnActionType where id = 510)
-);
+CREATE UNIQUE INDEX rhn_action_virt_pool_start_aid_uq
+    ON rhnActionVirtPoolStart (action_id);

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.4-to-susemanager-schema-4.1.5/003-rhnActionVirtPoolStart.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.4-to-susemanager-schema-4.1.5/003-rhnActionVirtPoolStart.sql
@@ -12,14 +12,18 @@
 -- in this software or its documentation.
 --
 
-insert into rhnActionType (id, label, name, trigger_snapshot, unlocked_only) (
-    select 509, 'virt.pool_refresh', 'Refresh a virtual storage pool', 'N', 'N'
-    from dual
-    where not exists (select 1 from rhnActionType where id = 509)
-);
+CREATE TABLE IF NOT EXISTS rhnActionVirtPoolStart
+(
+    action_id            NUMERIC NOT NULL
+                             CONSTRAINT rhn_action_virt_pool_start_aid_fk
+                                 REFERENCES rhnAction (id)
+                                 ON DELETE CASCADE
+                             CONSTRAINT rhn_action_virt_pool_start_aid_pk
+                                 PRIMARY KEY,
+    pool_name            VARCHAR(256)
+)
+;
 
-insert into rhnActionType (id, label, name, trigger_snapshot, unlocked_only) (
-    select 510, 'virt.pool_start', 'Starts a virtual storage pool', 'N', 'N'
-    from dual
-    where not exists (select 1 from rhnActionType where id = 510)
-);
+CREATE UNIQUE INDEX IF NOT EXISTS rhn_action_virt_pool_start_aid_uq
+    ON rhnActionVirtPoolStart (action_id);
+

--- a/susemanager-utils/susemanager-sls/salt/virt/pool-statechange.sls
+++ b/susemanager-utils/susemanager-sls/salt/virt/pool-statechange.sls
@@ -1,0 +1,4 @@
+mgr_pool_{{ pillar['pool_state'] }}:
+  module.run:
+    - name: virt.pool_{{ pillar['pool_state'] }}
+    - m_name: {{ pillar['pool_name'] }}

--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -202,6 +202,13 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I wait until the tree item "test-pool0" has no sub-list
 
 @virthost_kvm
+  Scenario: Start a virtual storage pool for KVM
+    Given I am on the "Virtualization" page of this "kvm_server"
+    When I follow "Storage"
+    And I click on "Start" in tree item "test-pool0"
+    And I wait until the tree item "test-pool0" contains "running" text
+
+@virthost_kvm
   Scenario: Cleanup: Unregister the KVM virtualization host
     Given I am on the Systems overview page of this "kvm_server"
     When I follow "Delete System"

--- a/web/html/src/manager/virtualization/pools/list/pools-list.js
+++ b/web/html/src/manager/virtualization/pools/list/pools-list.js
@@ -192,6 +192,16 @@ export function PoolsList(props: Props) {
                           action={() => onAction('refresh', [pool.name], {})}
                         />
                       }
+                      { pool.state !== 'running'
+                        && (
+                          <AsyncButton
+                              defaultType="btn-default btn-sm"
+                              title={t("Start")}
+                              icon="fa-play"
+                              action={() => onAction('start', [pool.name], {})}
+                          />
+                        )
+                      }
                     </div>
                   </CustomDiv>,
                 ];


### PR DESCRIPTION
## What does this PR change?

Add virtual pool start action

## GUI diff

After:

A Start button has been added to the virtual pool actions

- [X] **DONE**

## Documentation
- [uyuni-docs](uyuni-project/uyuni-docs#52) PR or issue was created for all pool actions

- [X] **DONE**

## Test coverage
- Unit tests were added
- Cucumber tests were added

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

To avoid cluttering the changelog there is one commit adding changelog entry for all storage pool actions coming in an upcoming PR.

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
