### PR TITLE
Virt pool stop

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
@@ -51,6 +51,7 @@ import com.redhat.rhn.domain.action.virtualization.VirtualizationDeleteAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationDestroyAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolRefreshAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolStartAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolStopAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationRebootAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationResumeAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationSchedulePollerAction;
@@ -441,6 +442,9 @@ public class ActionFactory extends HibernateFactory {
         }
         else if (typeIn.equals(TYPE_VIRTUALIZATION_POOL_START)) {
             retval = new VirtualizationPoolStartAction();
+        }
+        else if (typeIn.equals(TYPE_VIRTUALIZATION_POOL_STOP)) {
+            retval = new VirtualizationPoolStopAction();
         }
         else if (typeIn.equals(TYPE_SCAP_XCCDF_EVAL)) {
             retval = new ScapAction();
@@ -920,7 +924,8 @@ public class ActionFactory extends HibernateFactory {
                 actionType.equals(TYPE_VIRTUALIZATION_START) ||
                 actionType.equals(TYPE_VIRTUALIZATION_SUSPEND) ||
                 actionType.equals(TYPE_VIRTUALIZATION_POOL_REFRESH) ||
-                actionType.equals(TYPE_VIRTUALIZATION_POOL_START);
+                actionType.equals(TYPE_VIRTUALIZATION_POOL_START) ||
+                actionType.equals(TYPE_VIRTUALIZATION_POOL_STOP);
     }
 
     /**
@@ -1281,5 +1286,11 @@ public class ActionFactory extends HibernateFactory {
      */
     public static final ActionType TYPE_VIRTUALIZATION_POOL_START =
             lookupActionTypeByLabel("virt.pool_start");
+
+    /**
+     * The constant representing "Stops a virtual storage pool." [ID:511]
+     */
+    public static final ActionType TYPE_VIRTUALIZATION_POOL_STOP =
+            lookupActionTypeByLabel("virt.pool_stop");
 }
 

--- a/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
@@ -394,6 +394,14 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
           </join>
         </subclass>
 
+        <subclass name="com.redhat.rhn.domain.action.virtualization.VirtualizationPoolStopAction"
+          discriminator-value="511" lazy="true">
+          <join table="rhnActionVirtPoolStop">
+            <key column="action_id"/>
+            <property name="poolName" type="string" column="pool_name"/>
+          </join>
+        </subclass>
+
 
         <!-- PackageActions: 1, 3, 4, 8, 13, 14, 33 -->
         <!-- PackageAction is abstract - the subclasses only get instantiated -->
@@ -520,7 +528,8 @@ select {ra.*}
             NULL as remove_disks,
             NULL as remove_interfaces from dual) ra_11_,
     (select NULL as pool_name from dual) ra_12_,
-    (select NULL as pool_name from dual) ra_13_
+    (select NULL as pool_name from dual) ra_13_,
+    (select NULL as pool_name from dual) ra_14_,
    where
     ra.id = (SELECT max(rA.id)
                    FROM rhnAction rA
@@ -633,7 +642,8 @@ select sa.server_id
                              NULL as remove_disks,
                              NULL as remove_interfaces from dual) ra_11_,
                      (select NULL as pool_name from dual) ra_12_,
-                     (select NULL as pool_name from dual) ra_13_
+                     (select NULL as pool_name from dual) ra_13_,
+                     (select NULL as pool_name from dual) ra_14_
                      where ra.id in (select distinct ac.id
                                    from rhnAction ac
                                       inner join rhnServerAction sa on ac.id = sa.action_id

--- a/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationPoolStopAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationPoolStopAction.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.domain.action.virtualization;
+
+
+/**
+ * Represents a virtual storage stop action.
+ */
+public class VirtualizationPoolStopAction extends BaseVirtualizationPoolAction {
+
+}

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -7076,6 +7076,12 @@ Follow this url to see the full list of inactive systems:
           <context context-type="sourcefile">com.redhat.rhn.domain.action.ActionFormatter.getActionType</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="virt.pool_stop">
+        <source>Virtual storage pool stop</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">com.redhat.rhn.domain.action.ActionFormatter.getActionType</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="channels.subscribers.updated">
         <source>{0} channel subscriber(s) successfully updated.</source>
         <context-group name="ctx">

--- a/java/code/src/com/suse/manager/webui/controllers/VirtualPoolsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/VirtualPoolsController.java
@@ -28,6 +28,7 @@ import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.virtualization.BaseVirtualizationPoolAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolRefreshAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolStartAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolStopAction;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.rhnset.RhnSetDecl;
@@ -112,6 +113,8 @@ public class VirtualPoolsController {
                 withUser(this::poolRefresh));
         post("/manager/api/systems/details/virtualization/pools/:sid/start",
                 withUser(this::poolStart));
+        post("/manager/api/systems/details/virtualization/pools/:sid/stop",
+                withUser(this::poolStop));
     }
 
     /**
@@ -249,6 +252,23 @@ public class VirtualPoolsController {
         return poolAction(request, response, user, (data) -> {
             VirtualizationPoolStartAction action = (VirtualizationPoolStartAction)
                     ActionFactory.createAction(ActionFactory.TYPE_VIRTUALIZATION_POOL_START);
+            action.setName(action.getActionType().getName() + ": " + String.join(",", data.getPoolNames()));
+            return action;
+        });
+    }
+
+    /**
+     * Executes the POST query to stop a set of virtual pools.
+     *
+     * @param request the request
+     * @param response the response
+     * @param user the user
+     * @return JSON list of created action IDs
+     */
+    public String poolStop(Request request, Response response, User user) {
+        return poolAction(request, response, user, (data) -> {
+            VirtualizationPoolStopAction action = (VirtualizationPoolStopAction)
+                    ActionFactory.createAction(ActionFactory.TYPE_VIRTUALIZATION_POOL_STOP);
             action.setName(action.getActionType().getName() + ": " + String.join(",", data.getPoolNames()));
             return action;
         });

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -56,6 +56,7 @@ import com.redhat.rhn.domain.action.virtualization.VirtualizationCreateActionInt
 import com.redhat.rhn.domain.action.virtualization.VirtualizationDeleteAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolRefreshAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolStartAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolStopAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationRebootAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationResumeAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationSetMemoryAction;
@@ -372,6 +373,11 @@ public class SaltServerActionService {
             VirtualizationPoolStartAction startAction =
                     (VirtualizationPoolStartAction)actionIn;
             return virtPoolStateChangeAction(minions, startAction.getPoolName(), "start");
+        }
+        else if (ActionFactory.TYPE_VIRTUALIZATION_POOL_STOP.equals(actionType)) {
+            VirtualizationPoolStopAction stopAction =
+                    (VirtualizationPoolStopAction)actionIn;
+            return virtPoolStateChangeAction(minions, stopAction.getPoolName(), "stop");
         }
         else {
             if (LOG.isDebugEnabled()) {

--- a/schema/spacewalk/common/data/rhnActionType.sql
+++ b/schema/spacewalk/common/data/rhnActionType.sql
@@ -81,6 +81,7 @@ insert into rhnActionType values (507, 'virt.delete', 'Deletes a virtual domain.
 insert into rhnActionType values (508, 'virt.create', 'Creates a virtual domain.', 'N', 'N');
 insert into rhnActionType values (509, 'virt.pool_refresh', 'Refresh a virtual storage pool', 'N', 'N');
 insert into rhnActionType values (510, 'virt.pool_start', 'Starts a virtual storage pool', 'N', 'N');
+insert into rhnActionType values (511, 'virt.pool_stop', 'Stops a virtual storage pool', 'N', 'N');
 --
 --
 -- Revision 1.25  2004/10/29 05:07:52  pjones

--- a/schema/spacewalk/common/tables/rhnActionVirtPoolStop.sql
+++ b/schema/spacewalk/common/tables/rhnActionVirtPoolStop.sql
@@ -1,0 +1,29 @@
+--
+-- Copyright (c) 2020 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+CREATE TABLE rhnActionVirtPoolStop
+(
+    action_id            NUMERIC NOT NULL
+                             CONSTRAINT rhn_action_virt_pool_stop_aid_fk
+                                 REFERENCES rhnAction (id)
+                                 ON DELETE CASCADE
+                             CONSTRAINT rhn_action_virt_pool_stop_aid_pk
+                                 PRIMARY KEY,
+    pool_name            VARCHAR(256)
+)
+;
+
+CREATE UNIQUE INDEX rhn_action_virt_pool_stop_aid_uq
+    ON rhnActionVirtPoolStop (action_id);

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.4-to-susemanager-schema-4.1.5/001-add_virt_pool_actions_rhnActionType.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.4-to-susemanager-schema-4.1.5/001-add_virt_pool_actions_rhnActionType.sql
@@ -23,3 +23,9 @@ insert into rhnActionType (id, label, name, trigger_snapshot, unlocked_only) (
     from dual
     where not exists (select 1 from rhnActionType where id = 510)
 );
+
+insert into rhnActionType (id, label, name, trigger_snapshot, unlocked_only) (
+    select 511, 'virt.pool_stop', 'Stops a virtual storage pool', 'N', 'N'
+    from dual
+    where not exists (select 1 from rhnActionType where id = 511)
+);

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.4-to-susemanager-schema-4.1.5/004-rhnActionVirtPoolStop.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.4-to-susemanager-schema-4.1.5/004-rhnActionVirtPoolStop.sql
@@ -1,0 +1,29 @@
+-- Copyright (c) 2020 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+CREATE TABLE IF NOT EXISTS rhnActionVirtPoolStop
+(
+    action_id            NUMERIC NOT NULL
+                             CONSTRAINT rhn_action_virt_pool_stop_aid_fk
+                                 REFERENCES rhnAction (id)
+                                 ON DELETE CASCADE
+                             CONSTRAINT rhn_action_virt_pool_stop_aid_pk
+                                 PRIMARY KEY,
+    pool_name            VARCHAR(256)
+)
+;
+
+CREATE UNIQUE INDEX IF NOT EXISTS rhn_action_virt_pool_stop_aid_uq
+    ON rhnActionVirtPoolStop (action_id);
+

--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -231,6 +231,7 @@ For a test with a regular expression, there is ```I should see a text like "..."
   When I wait until I see "Successfully bootstrapped host!" text
   When I wait until I do not see "Loading..." text
   When I wait at most 360 seconds until I see "Product Description" text
+  When I wait until the tree item "test-pool0" contains "inactive" text
 ```
 
 * Same, but re-issue HTTP requests to refresh the page

--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -202,6 +202,13 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I wait until the tree item "test-pool0" has no sub-list
 
 @virthost_kvm
+  Scenario: Stop a virtual storage pool for KVM
+    Given I am on the "Virtualization" page of this "kvm_server"
+    When I follow "Storage"
+    And I click on "Stop" in tree item "test-pool0"
+    And I wait until the tree item "test-pool0" contains "inactive" text
+
+@virthost_kvm
   Scenario: Start a virtual storage pool for KVM
     Given I am on the "Virtualization" page of this "kvm_server"
     When I follow "Storage"

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -473,6 +473,12 @@ When(/I wait until the tree item "([^"]+)" has no sub-list/) do |item|
   end
 end
 
+When(/^I wait until the tree item "([^"]+)" contains "([^"]+)" text$/) do |item, text|
+  within(:xpath, "//span[contains(text(), '#{item}')]/ancestor::div[contains(@class, 'product-details-wrapper')]") do
+    raise "could not find text #{text} for tree item #{item}" unless has_text?(text, wait: DEFAULT_TIMEOUT)
+  end
+end
+
 And(/^I open the sub-list of the product "(.*?)"$/) do |product|
   xpath = "//span[contains(text(), '#{product}')]/ancestor::div[contains(@class, 'product-details-wrapper')]/div/i[contains(@class, 'fa-angle-right')]"
   # within(:xpath, xpath) do

--- a/web/html/src/manager/virtualization/pools/list/pools-list.js
+++ b/web/html/src/manager/virtualization/pools/list/pools-list.js
@@ -202,6 +202,16 @@ export function PoolsList(props: Props) {
                           />
                         )
                       }
+                      { pool.state === 'running'
+                        && (
+                          <AsyncButton
+                              defaultType="btn-default btn-sm"
+                              title={t("Stop")}
+                              icon="fa-stop"
+                              action={() => onAction('stop', [pool.name], {})}
+                          />
+                        )
+                      }
                     </div>
                   </CustomDiv>,
                 ];


### PR DESCRIPTION
## What does this PR change?

Add virtual pool stop action

## GUI diff

After:

A Stop button has been added to the virtual pool actions

- [X] **DONE**

## Documentation
- [uyuni-docs](uyuni-project/uyuni-docs#52) PR or issue was created for all pool actions

- [X] **DONE**

## Test coverage
- Unit tests were added
- Cucumber tests were added

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

To avoid cluttering the changelog there is one commit adding changelog entry for all storage pool actions coming in an upcoming PR.

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
