### PR TITLE
Virt pool delete

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
@@ -49,6 +49,7 @@ import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationCreateAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationDeleteAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationDestroyAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolDeleteAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolRefreshAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolStartAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolStopAction;
@@ -445,6 +446,9 @@ public class ActionFactory extends HibernateFactory {
         }
         else if (typeIn.equals(TYPE_VIRTUALIZATION_POOL_STOP)) {
             retval = new VirtualizationPoolStopAction();
+        }
+        else if (typeIn.equals(TYPE_VIRTUALIZATION_POOL_DELETE)) {
+            retval = new VirtualizationPoolDeleteAction();
         }
         else if (typeIn.equals(TYPE_SCAP_XCCDF_EVAL)) {
             retval = new ScapAction();
@@ -923,6 +927,7 @@ public class ActionFactory extends HibernateFactory {
                 actionType.equals(TYPE_VIRTUALIZATION_SHUTDOWN) ||
                 actionType.equals(TYPE_VIRTUALIZATION_START) ||
                 actionType.equals(TYPE_VIRTUALIZATION_SUSPEND) ||
+                actionType.equals(TYPE_VIRTUALIZATION_POOL_DELETE) ||
                 actionType.equals(TYPE_VIRTUALIZATION_POOL_REFRESH) ||
                 actionType.equals(TYPE_VIRTUALIZATION_POOL_START) ||
                 actionType.equals(TYPE_VIRTUALIZATION_POOL_STOP);
@@ -1292,5 +1297,11 @@ public class ActionFactory extends HibernateFactory {
      */
     public static final ActionType TYPE_VIRTUALIZATION_POOL_STOP =
             lookupActionTypeByLabel("virt.pool_stop");
+
+    /**
+     * The constant representing "Deletes a virtual storage pool." [ID:512]
+     */
+    public static final ActionType TYPE_VIRTUALIZATION_POOL_DELETE =
+            lookupActionTypeByLabel("virt.pool_delete");
 }
 

--- a/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
@@ -402,6 +402,14 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
           </join>
         </subclass>
 
+        <subclass name="com.redhat.rhn.domain.action.virtualization.VirtualizationPoolDeleteAction"
+          discriminator-value="512" lazy="true">
+          <join table="rhnActionVirtPoolDelete">
+            <key column="action_id"/>
+            <property name="poolName" type="string" column="pool_name"/>
+            <property name="purge" type="yes_no" column="purge"/>
+          </join>
+        </subclass>
 
         <!-- PackageActions: 1, 3, 4, 8, 13, 14, 33 -->
         <!-- PackageAction is abstract - the subclasses only get instantiated -->
@@ -530,6 +538,8 @@ select {ra.*}
     (select NULL as pool_name from dual) ra_12_,
     (select NULL as pool_name from dual) ra_13_,
     (select NULL as pool_name from dual) ra_14_,
+    (select NULL as pool_name,
+            NULL as purge from dual) ra_15_
    where
     ra.id = (SELECT max(rA.id)
                    FROM rhnAction rA
@@ -643,7 +653,9 @@ select sa.server_id
                              NULL as remove_interfaces from dual) ra_11_,
                      (select NULL as pool_name from dual) ra_12_,
                      (select NULL as pool_name from dual) ra_13_,
-                     (select NULL as pool_name from dual) ra_14_
+                     (select NULL as pool_name from dual) ra_14_,
+                     (select NULL as pool_name,
+                             NULL as purge from dual) ra_15_
                      where ra.id in (select distinct ac.id
                                    from rhnAction ac
                                       inner join rhnServerAction sa on ac.id = sa.action_id

--- a/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationPoolDeleteAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationPoolDeleteAction.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.domain.action.virtualization;
+
+/**
+ * Represents a virtual storage removal action.
+ */
+public class VirtualizationPoolDeleteAction extends BaseVirtualizationPoolAction {
+
+    private boolean purge = false;
+
+    /**
+     * Set whether the delete operation needs to also delete the data.
+     *
+     * @param purgeIn true to delete the pool and volumes, false otherwise
+     */
+    public void setPurge(boolean purgeIn) {
+        purge = purgeIn;
+    }
+
+    /**
+     * @return whether the delete operation needs to also delete the data.
+     *      Defaults to false.
+     */
+    public boolean isPurge() {
+        return purge;
+    }
+}

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -7082,6 +7082,12 @@ Follow this url to see the full list of inactive systems:
           <context context-type="sourcefile">com.redhat.rhn.domain.action.ActionFormatter.getActionType</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="virt.pool_delete">
+        <source>Virtual storage pool delete</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">com.redhat.rhn.domain.action.ActionFormatter.getActionType</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="channels.subscribers.updated">
         <source>{0} channel subscriber(s) successfully updated.</source>
         <context-group name="ctx">

--- a/java/code/src/com/suse/manager/webui/controllers/VirtualPoolsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/VirtualPoolsController.java
@@ -26,6 +26,7 @@ import com.redhat.rhn.domain.action.ActionChain;
 import com.redhat.rhn.domain.action.ActionChainFactory;
 import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.virtualization.BaseVirtualizationPoolAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolDeleteAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolRefreshAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolStartAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolStopAction;
@@ -48,6 +49,7 @@ import com.suse.manager.virtualization.VirtManager;
 import com.suse.manager.webui.errors.NotFoundException;
 import com.suse.manager.webui.utils.MinionActionUtils;
 import com.suse.manager.webui.utils.gson.VirtualPoolBaseActionJson;
+import com.suse.manager.webui.utils.gson.VirtualPoolDeleteActionJson;
 import com.suse.manager.webui.utils.gson.VirtualStoragePoolInfoJson;
 import com.suse.manager.webui.utils.gson.VirtualStorageVolumeInfoJson;
 
@@ -115,6 +117,8 @@ public class VirtualPoolsController {
                 withUser(this::poolStart));
         post("/manager/api/systems/details/virtualization/pools/:sid/stop",
                 withUser(this::poolStop));
+        post("/manager/api/systems/details/virtualization/pools/:sid/delete",
+                withUser(this::poolDelete));
     }
 
     /**
@@ -272,6 +276,28 @@ public class VirtualPoolsController {
             action.setName(action.getActionType().getName() + ": " + String.join(",", data.getPoolNames()));
             return action;
         });
+    }
+
+    /**
+     * Executes the POST query to delete a set of virtual pools.
+     *
+     * @param request the request
+     * @param response the response
+     * @param user the user
+     * @return JSON list of created action IDs
+     */
+    public String poolDelete(Request request, Response response, User user) {
+        return poolAction(request, response, user, (data) -> {
+            VirtualizationPoolDeleteAction action = (VirtualizationPoolDeleteAction)
+                    ActionFactory.createAction(ActionFactory.TYPE_VIRTUALIZATION_POOL_DELETE);
+            action.setName(action.getActionType().getName() + ": " + String.join(",", data.getPoolNames()));
+
+            VirtualPoolDeleteActionJson deleteData = (VirtualPoolDeleteActionJson)data;
+            if (deleteData.getPurge() != null) {
+                action.setPurge(deleteData.getPurge());
+            }
+            return action;
+        }, VirtualPoolDeleteActionJson.class);
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/utils/gson/VirtualPoolDeleteActionJson.java
+++ b/java/code/src/com/suse/manager/webui/utils/gson/VirtualPoolDeleteActionJson.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.webui.utils.gson;
+
+/**
+*
+* represents the pool delete action request body structure.
+*/
+public class VirtualPoolDeleteActionJson extends VirtualPoolBaseActionJson {
+
+    private Boolean purge;
+
+    /**
+     * @return Returns whether to remove all volumes or not.
+     */
+    public Boolean getPurge() {
+        return purge;
+    }
+
+    /**
+     * @param purgeIn whether to remove all volumes or not.
+     */
+    public void setPurge(Boolean purgeIn) {
+        purge = purgeIn;
+    }
+}

--- a/schema/spacewalk/common/data/rhnActionType.sql
+++ b/schema/spacewalk/common/data/rhnActionType.sql
@@ -82,6 +82,7 @@ insert into rhnActionType values (508, 'virt.create', 'Creates a virtual domain.
 insert into rhnActionType values (509, 'virt.pool_refresh', 'Refresh a virtual storage pool', 'N', 'N');
 insert into rhnActionType values (510, 'virt.pool_start', 'Starts a virtual storage pool', 'N', 'N');
 insert into rhnActionType values (511, 'virt.pool_stop', 'Stops a virtual storage pool', 'N', 'N');
+insert into rhnActionType values (512, 'virt.pool_delete', 'Deletes a virtual storage pool', 'N', 'N');
 --
 --
 -- Revision 1.25  2004/10/29 05:07:52  pjones

--- a/schema/spacewalk/common/tables/rhnActionVirtPoolDelete.sql
+++ b/schema/spacewalk/common/tables/rhnActionVirtPoolDelete.sql
@@ -1,0 +1,33 @@
+--
+-- Copyright (c) 2020 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+CREATE TABLE rhnActionVirtPoolDelete
+(
+    action_id            NUMERIC NOT NULL
+                             CONSTRAINT rhn_action_virt_pool_delete_aid_fk
+                                 REFERENCES rhnAction (id)
+                                 ON DELETE CASCADE
+                             CONSTRAINT rhn_action_virt_pool_delete_aid_pk
+                                 PRIMARY KEY,
+    pool_name            VARCHAR(256),
+    purge                CHAR(1)
+                            DEFAULT ('Y') NOT NULL
+                            CONSTRAINT rhn_avpdelete_purge_ck
+                                CHECK (purge in ('Y','N'))
+)
+;
+
+CREATE UNIQUE INDEX rhn_action_virt_pool_delete_aid_uq
+    ON rhnActionVirtPoolDelete (action_id);

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.4-to-susemanager-schema-4.1.5/001-add_virt_pool_actions_rhnActionType.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.4-to-susemanager-schema-4.1.5/001-add_virt_pool_actions_rhnActionType.sql
@@ -29,3 +29,9 @@ insert into rhnActionType (id, label, name, trigger_snapshot, unlocked_only) (
     from dual
     where not exists (select 1 from rhnActionType where id = 511)
 );
+
+insert into rhnActionType (id, label, name, trigger_snapshot, unlocked_only) (
+    select 512, 'virt.pool_delete', 'Deletes a virtual storage pool', 'N', 'N'
+    from dual
+    where not exists (select 1 from rhnActionType where id = 512)
+);

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.4-to-susemanager-schema-4.1.5/005-rhnActionVirtPoolDelete.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.4-to-susemanager-schema-4.1.5/005-rhnActionVirtPoolDelete.sql
@@ -1,0 +1,32 @@
+-- Copyright (c) 2020 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+CREATE TABLE IF NOT EXISTS rhnActionVirtPoolDelete
+(
+    action_id            NUMERIC NOT NULL
+                             CONSTRAINT rhn_action_virt_pool_delete_aid_fk
+                                 REFERENCES rhnAction (id)
+                                 ON DELETE CASCADE
+                             CONSTRAINT rhn_action_virt_pool_delete_aid_pk
+                                 PRIMARY KEY,
+    pool_name            VARCHAR(256),
+    purge                CHAR(1)
+                            DEFAULT ('Y') NOT NULL
+                            CONSTRAINT rhn_avpdelete_purge_ck
+                                CHECK (purge in ('Y','N'))
+)
+;
+
+CREATE UNIQUE INDEX IF NOT EXISTS rhn_action_virt_pool_delete_aid_uq
+    ON rhnActionVirtPoolDelete (action_id);

--- a/susemanager-utils/susemanager-sls/salt/virt/pool-deleted.sls
+++ b/susemanager-utils/susemanager-sls/salt/virt/pool-deleted.sls
@@ -1,0 +1,4 @@
+mgr_pool_deleted:
+  virt.pool_deleted:
+    - name: {{ pillar['pool_name'] }}
+    - purge: {{ pillar['pool_purge'] }}

--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -444,6 +444,7 @@ The check box can be identified by name, id or label text.
   When I wait until file "/srv/tftpboot/pxelinux.cfg/default" exists on server
   Then file "/srv/susemanager/salt/manager_org_1/mixedchannel/init.sls" should exist on server
   Then file "/srv/susemanager/salt/manager_org_1/s-mgr/config/init.sls" should not exist on server
+  Then file "/var/lib/libvirt/images/test-pool0" should not exist on "kvm_server"
 ```
 
 * File contents

--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -216,6 +216,16 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I wait until the tree item "test-pool0" contains "running" text
 
 @virthost_kvm
+  Scenario: Delete a virtual storage pool for KVM
+    Given I am on the "Virtualization" page of this "kvm_server"
+    When I follow "Storage"
+    And I click on "Delete" in tree item "test-pool0"
+    And I check "purge"
+    And I click on "Delete" in "Delete Virtual Storage Pool" modal
+    Then I wait until I do not see "test-pool0" text
+    And file "/var/lib/libvirt/images/test-pool0" should not exist on "kvm_server"
+
+@virthost_kvm
   Scenario: Cleanup: Unregister the KVM virtualization host
     Given I am on the Systems overview page of this "kvm_server"
     When I follow "Delete System"

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -479,7 +479,7 @@ When(/^I wait until the tree item "([^"]+)" contains "([^"]+)" text$/) do |item,
   end
 end
 
-And(/^I open the sub-list of the product "(.*?)"$/) do |product|
+When(/^I open the sub-list of the product "(.*?)"$/) do |product|
   xpath = "//span[contains(text(), '#{product}')]/ancestor::div[contains(@class, 'product-details-wrapper')]/div/i[contains(@class, 'fa-angle-right')]"
   # within(:xpath, xpath) do
   #   raise unless find('i.fa-angle-down').click
@@ -593,6 +593,11 @@ end
 
 Then(/^file "([^"]*)" should not exist on server$/) do |filename|
   $server.run("test ! -f #{filename}")
+end
+
+Then(/^file "([^"]*)" should not exist on "([^"]*)"$/) do |filename, host|
+  node = get_target(host)
+  node.run("test ! -f #{filename}")
 end
 
 When(/^I store "([^"]*)" into file "([^"]*)" on "([^"]*)"$/) do |content, filename, host|


### PR DESCRIPTION
## What does this PR change?

Add virtual pool delete action

## GUI diff

After:

A Delete button has been added to the virtual pool actions

- [X] **DONE**

## Documentation
- [uyuni-docs](uyuni-project/uyuni-docs#52) PR or issue was created for all pool actions

- [X] **DONE**

## Test coverage
- Unit tests were added
- Cucumber tests were added

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

To avoid cluttering the changelog there is one commit adding changelog entry for all storage pool actions coming in an upcoming PR.

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
