### PR TITLE
Virt pool create

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
@@ -49,6 +49,7 @@ import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationCreateAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationDeleteAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationDestroyAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolCreateAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolDeleteAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolRefreshAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolStartAction;
@@ -449,6 +450,9 @@ public class ActionFactory extends HibernateFactory {
         }
         else if (typeIn.equals(TYPE_VIRTUALIZATION_POOL_DELETE)) {
             retval = new VirtualizationPoolDeleteAction();
+        }
+        else if (typeIn.equals(TYPE_VIRTUALIZATION_POOL_CREATE)) {
+            retval = new VirtualizationPoolCreateAction();
         }
         else if (typeIn.equals(TYPE_SCAP_XCCDF_EVAL)) {
             retval = new ScapAction();
@@ -927,6 +931,7 @@ public class ActionFactory extends HibernateFactory {
                 actionType.equals(TYPE_VIRTUALIZATION_SHUTDOWN) ||
                 actionType.equals(TYPE_VIRTUALIZATION_START) ||
                 actionType.equals(TYPE_VIRTUALIZATION_SUSPEND) ||
+                actionType.equals(TYPE_VIRTUALIZATION_POOL_CREATE) ||
                 actionType.equals(TYPE_VIRTUALIZATION_POOL_DELETE) ||
                 actionType.equals(TYPE_VIRTUALIZATION_POOL_REFRESH) ||
                 actionType.equals(TYPE_VIRTUALIZATION_POOL_START) ||
@@ -1303,5 +1308,11 @@ public class ActionFactory extends HibernateFactory {
      */
     public static final ActionType TYPE_VIRTUALIZATION_POOL_DELETE =
             lookupActionTypeByLabel("virt.pool_delete");
+
+    /**
+     * The constant representing "Creates a virtual storage pool." [ID:513]
+     */
+    public static final ActionType TYPE_VIRTUALIZATION_POOL_CREATE =
+            lookupActionTypeByLabel("virt.pool_create");
 }
 

--- a/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
@@ -411,6 +411,23 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
           </join>
         </subclass>
 
+        <subclass name="com.redhat.rhn.domain.action.virtualization.VirtualizationPoolCreateAction"
+          discriminator-value="513" lazy="true">
+          <join table="rhnActionVirtPoolCreate">
+            <key column="action_id"/>
+            <property name="poolName" type="string" column="pool_name"/>
+            <property name="uuid" type="string" column="uuid"/>
+            <property name="type" type="string" column="type"/>
+            <property name="target" type="string" column="target"/>
+            <property name="autostart" type="yes_no" column="autostart"/>
+            <property name="mode" type="string" column="permission_mode"/>
+            <property name="owner" type="string" column="permission_owner"/>
+            <property name="group" type="string" column="permission_group"/>
+            <property name="seclabel" type="string" column="permission_seclabel"/>
+            <property name="sourceAsString" type="string" column="source"/>
+          </join>
+        </subclass>
+
         <!-- PackageActions: 1, 3, 4, 8, 13, 14, 33 -->
         <!-- PackageAction is abstract - the subclasses only get instantiated -->
         <subclass
@@ -539,7 +556,17 @@ select {ra.*}
     (select NULL as pool_name from dual) ra_13_,
     (select NULL as pool_name from dual) ra_14_,
     (select NULL as pool_name,
-            NULL as purge from dual) ra_15_
+            NULL as purge from dual) ra_15_,
+    (select NULL as pool_name,
+            NULL as uuid,
+            NULL as type,
+            NULL as target,
+            NULL as autostart,
+            NULL as permission_mode,
+            NULL as permission_owner,
+            NULL as permission_group,
+            NULL as permission_seclabel,
+            NULL as source from dual) ra_16_
    where
     ra.id = (SELECT max(rA.id)
                    FROM rhnAction rA
@@ -655,7 +682,17 @@ select sa.server_id
                      (select NULL as pool_name from dual) ra_13_,
                      (select NULL as pool_name from dual) ra_14_,
                      (select NULL as pool_name,
-                             NULL as purge from dual) ra_15_
+                             NULL as purge from dual) ra_15_,
+                     (select NULL as pool_name,
+                             NULL as uuid,
+                             NULL as type,
+                             NULL as target,
+                             NULL as autostart,
+                             NULL as permission_mode,
+                             NULL as permission_owner,
+                             NULL as permission_group,
+                             NULL as permission_seclabel,
+                             NULL as source from dual) ra_16_
                      where ra.id in (select distinct ac.id
                                    from rhnAction ac
                                       inner join rhnServerAction sa on ac.id = sa.action_id

--- a/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationPoolCreateAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationPoolCreateAction.java
@@ -1,0 +1,192 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.domain.action.virtualization;
+
+/**
+ * Represents a virtual storage creation action.
+ */
+public class VirtualizationPoolCreateAction extends BaseVirtualizationPoolAction {
+
+    private String uuid;
+    private String type;
+    private String target;
+    private boolean autostart = false;
+
+    // Permissions properties
+    private String mode;
+    private String owner;
+    private String group;
+    private String seclabel;
+
+    private VirtualizationPoolCreateActionSource source;
+
+
+    /**
+     * @return Returns the uuid.
+     */
+    public String getUuid() {
+        return uuid;
+    }
+
+
+    /**
+     * @param uuidIn The uuid to set.
+     */
+    public void setUuid(String uuidIn) {
+        uuid = uuidIn;
+    }
+
+    /**
+     * @return Returns the pool type.
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * @param typeIn The pool type to set.
+     */
+    public void setType(String typeIn) {
+        type = typeIn;
+    }
+
+    /**
+     * @return Returns the target.
+     */
+    public String getTarget() {
+        return target;
+    }
+
+    /**
+     * @param targetIn The target to set.
+     */
+    public void setTarget(String targetIn) {
+        target = targetIn;
+    }
+
+    /**
+     * @return Returns whether to autostart the pool.
+     */
+    public boolean isAutostart() {
+        return autostart;
+    }
+
+    /**
+     * @param autostartIn True if the pool needs to be automatically started.
+     */
+    public void setAutostart(boolean autostartIn) {
+        autostart = autostartIn;
+    }
+
+    /**
+     * @return Returns the permission mode.
+     */
+    public String getMode() {
+        return mode;
+    }
+
+    /**
+     * @param modeIn The permission mode to set.
+     */
+    public void setMode(String modeIn) {
+        mode = modeIn;
+    }
+
+    /**
+     * @return Returns the owner user.
+     */
+    public String getOwner() {
+        return owner;
+    }
+
+    /**
+     * @param ownerIn The owner user to set.
+     */
+    public void setOwner(String ownerIn) {
+        owner = ownerIn;
+    }
+
+
+    /**
+     * @return Returns the group.
+     */
+    public String getGroup() {
+        return group;
+    }
+
+    /**
+     * @param groupIn The group to set.
+     */
+    public void setGroup(String groupIn) {
+        group = groupIn;
+    }
+
+    /**
+     * @return Returns the SE Linux label.
+     */
+    public String getSeclabel() {
+        return seclabel;
+    }
+
+    /**
+     * @param seclabelIn The SE Linux label to set.
+     */
+    public void setSeclabel(String seclabelIn) {
+        seclabel = seclabelIn;
+    }
+
+    /**
+     * @return Returns the source.
+     */
+    public VirtualizationPoolCreateActionSource getSource() {
+        return source;
+    }
+
+    /**
+     * @return the source serialized into a String.
+     *
+     * This function should only be used by hibernate.
+     */
+    public String getSourceAsString() {
+        String string = null;
+        if (source != null) {
+            string = source.toString();
+        }
+        return string;
+    }
+
+    /**
+     * @param sourceIn The source to set.
+     */
+    public void setSource(VirtualizationPoolCreateActionSource sourceIn) {
+        source = sourceIn;
+    }
+
+    /**
+     * Set the source from its Serialized value.
+     *
+     * @param sourceString serialized value.
+     *
+     * This function should only be used by hibernate.
+     */
+    public void setSourceAsString(String sourceString) {
+        if (sourceString != null) {
+            source = VirtualizationPoolCreateActionSource.parse(sourceString);
+        }
+        else {
+            source = null;
+        }
+    }
+}

--- a/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationPoolCreateActionSource.java
+++ b/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationPoolCreateActionSource.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.domain.action.virtualization;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+import com.suse.manager.reactor.utils.OptionalTypeAdapterFactory;
+import com.suse.manager.virtualization.PoolSource;
+
+/**
+ * Represents the virtual storage source parameters for the storage pool creation action.
+ * Note that to save database fields this is stored as a json string in the database.
+ */
+public class VirtualizationPoolCreateActionSource extends PoolSource {
+
+    private static final Gson GSON = new GsonBuilder()
+            .registerTypeAdapterFactory(new OptionalTypeAdapterFactory())
+            .create();
+
+    /**
+     * Create from a serialized string.
+     *
+     * @param json the serialized string as output by toString()
+     * @return the parsed object
+     */
+    public static VirtualizationPoolCreateActionSource parse(String json) {
+        return GSON.fromJson(json, new TypeToken<VirtualizationPoolCreateActionSource>() { }.getType());
+    }
+
+    /**
+     * Serializes into a json string
+     * {@inheritDoc}
+     */
+    public String toString() {
+        return GSON.toJson(this);
+    }
+}

--- a/java/code/src/com/redhat/rhn/domain/action/virtualization/test/VirtualizationPoolCreateActionSourceTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/virtualization/test/VirtualizationPoolCreateActionSourceTest.java
@@ -1,0 +1,47 @@
+package com.redhat.rhn.domain.action.virtualization.test;
+
+import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolCreateActionSource;
+
+import com.suse.manager.virtualization.PoolSourceDevice;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import junit.framework.TestCase;
+
+public class VirtualizationPoolCreateActionSourceTest extends TestCase {
+
+    public void testNfsDir() {
+        VirtualizationPoolCreateActionSource src = new VirtualizationPoolCreateActionSource();
+        src.setDir("/var/lib/libvirt/images");
+        src.setFormat("nfs");
+        src.setHosts(Arrays.asList("localhost"));
+
+        String serialized = src.toString();
+        assertEquals(
+               "{\"dir\":\"/var/lib/libvirt/images\"," +
+               "\"hosts\":[\"localhost\"]," +
+               "\"format\":\"nfs\"" +
+               "}", serialized);
+
+        VirtualizationPoolCreateActionSource src2 = VirtualizationPoolCreateActionSource.parse(serialized);
+        assertEquals(src.getDir(), src2.getDir());
+        assertEquals(src.getFormat(), src2.getFormat());
+        assertEquals("localhost", src2.getHosts().get(0));
+    }
+
+    public void testDevice() {
+        VirtualizationPoolCreateActionSource src = new VirtualizationPoolCreateActionSource();
+        List<PoolSourceDevice> devices = new ArrayList<>();
+        devices.add(new PoolSourceDevice("/dev/mapper/dev0"));
+        devices.add(new PoolSourceDevice("/dev/mapper/dev1", Optional.of(true)));
+        src.setDevices(devices);
+
+        String serialized = src.toString();
+        assertEquals("{\"devices\":[" +
+                "{\"path\":\"/dev/mapper/dev0\"}," +
+                "{\"path\":\"/dev/mapper/dev1\",\"separator\":true}]}", serialized);
+    }
+}

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -7088,6 +7088,12 @@ Follow this url to see the full list of inactive systems:
           <context context-type="sourcefile">com.redhat.rhn.domain.action.ActionFormatter.getActionType</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="virt.pool_create">
+        <source>Virtual storage pool creation</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">com.redhat.rhn.domain.action.ActionFormatter.getActionType</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="channels.subscribers.updated">
         <source>{0} channel subscriber(s) successfully updated.</source>
         <context-group name="ctx">

--- a/java/code/src/com/suse/manager/webui/controllers/VirtualPoolsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/VirtualPoolsController.java
@@ -107,6 +107,8 @@ public class VirtualPoolsController {
     public void initRoutes(JadeTemplateEngine jade) {
         get("/manager/systems/details/virtualization/storage/:sid",
                 withUserPreferences(withCsrfToken(withUser(this::show))), jade);
+        get("/manager/systems/details/virtualization/storage/:sid/new",
+                withUserPreferences(withCsrfToken(withUser(this::createDialog))), jade);
         get("/manager/api/systems/details/virtualization/pools/:sid/data",
                 withUser(this::data));
         get("/manager/api/systems/details/virtualization/pools/:sid/capabilities",
@@ -135,6 +137,19 @@ public class VirtualPoolsController {
      */
     public ModelAndView show(Request request, Response response, User user) {
         return renderPage(request, response, user, "show", null);
+    }
+
+
+    /**
+     * Displays the virtual storage pool creation page.
+     *
+     * @param request the request
+     * @param response the response
+     * @param user the user
+     * @return the ModelAndView object to render the page
+     */
+    public ModelAndView createDialog(Request request, Response response, User user) {
+        return renderWithActionChains(request, response, user, "create", null);
     }
 
 
@@ -396,6 +411,31 @@ public class VirtualPoolsController {
         /* For the rest of the template */
 
         return new ModelAndView(data, String.format("templates/virtualization/pools/%s.jade", template));
+    }
+
+
+    /**
+     * Displays a virtual storage pool-relate page with actionChains in the model.
+     *
+     * @param request the request
+     * @param response the response
+     * @param user the user
+     * @param template the name to the Jade template of the page
+     * @param modelExtender provides additional properties to pass to the Jade template
+     * @return the ModelAndView object to render the page
+     */
+    private ModelAndView renderWithActionChains(Request request, Response response, User user,
+            String template, Supplier<Map<String, Object>> modelExtender) {
+        return renderPage(request, response, user, template,
+            () -> {
+                Map<String, Object> data = new HashMap<>();
+                MinionController.addActionChains(user, data);
+                if (modelExtender != null) {
+                    data.putAll(modelExtender.get());
+                }
+                return data;
+            }
+        );
     }
 
     private String poolAction(Request request, Response response, User user,

--- a/java/code/src/com/suse/manager/webui/templates/virtualization/pools/create.jade
+++ b/java/code/src/com/suse/manager/webui/templates/virtualization/pools/create.jade
@@ -1,0 +1,22 @@
+include ../../system-common.jade
+#virtualpools-create
+
+script(src='/javascript/momentjs/moment-with-langs.min.js?cb=#{webBuildtimestamp}', type='text/javascript')
+script(src='/javascript/validator/validator.min.js?cb=#{webBuildtimestamp}', type='text/javascript')
+
+script(type='text/javascript').
+    window.csrfToken = "#{csrf_token}";
++userPreferences
+
+script(type='text/javascript').
+    spaImportReactPage('virtualization/pools/create/pools-create')
+        .then(function(module) {
+            module.renderer(
+              'virtualpools-create',
+              {
+                  serverId: "#{server.id}",
+                  actionChains: !{actionChains},
+                  timezone: "#{h.renderTimezone()}",
+                  localTime: "#{h.renderLocalTime()}",
+              }
+        )});

--- a/java/code/src/com/suse/manager/webui/utils/gson/VirtualPoolCreateActionJson.java
+++ b/java/code/src/com/suse/manager/webui/utils/gson/VirtualPoolCreateActionJson.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.webui.utils.gson;
+
+import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolCreateActionSource;
+
+import com.suse.manager.virtualization.PoolTarget;
+
+/**
+*
+* represents the pool create action request body structure.
+*/
+public class VirtualPoolCreateActionJson extends VirtualPoolBaseActionJson {
+
+    private String uuid;
+    private String type;
+    private boolean autostart;
+    private VirtualizationPoolCreateActionSource source;
+    private PoolTarget target;
+
+
+    /**
+     * @return Returns the uuid.
+     */
+    public String getUuid() {
+        return uuid;
+    }
+
+
+    /**
+     * @param uuidIn The uuid to set.
+     */
+    public void setUuid(String uuidIn) {
+        uuid = uuidIn;
+    }
+
+    /**
+     * @return Returns the type.
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * @param typeIn The type to set.
+     */
+    public void setType(String typeIn) {
+        type = typeIn;
+    }
+
+    /**
+     * @return Returns whether the pool is to be autostarted.
+     */
+    public boolean isAutostart() {
+        return autostart;
+    }
+
+    /**
+     * @param autostartIn whether the pool is to be autostarted.
+     */
+    public void setAutostart(boolean autostartIn) {
+        autostart = autostartIn;
+    }
+
+    /**
+     * @return Returns the source.
+     */
+    public VirtualizationPoolCreateActionSource getSource() {
+        return source;
+    }
+
+    /**
+     * @param sourceIn The source to set.
+     */
+    public void setSource(VirtualizationPoolCreateActionSource sourceIn) {
+        source = sourceIn;
+    }
+
+    /**
+     * @return Returns the target.
+     */
+    public PoolTarget getTarget() {
+        return target;
+    }
+
+    /**
+     * @param targetIn The target to set.
+     */
+    public void setTarget(PoolTarget targetIn) {
+        target = targetIn;
+    }
+}

--- a/java/code/src/com/suse/manager/webui/websocket/VirtNotifications.java
+++ b/java/code/src/com/suse/manager/webui/websocket/VirtNotifications.java
@@ -20,6 +20,7 @@ import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.action.virtualization.BaseVirtualizationAction;
 import com.redhat.rhn.domain.action.virtualization.BaseVirtualizationPoolAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolCreateAction;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.domain.user.UserFactory;
@@ -91,8 +92,15 @@ public class VirtNotifications {
             },
             BaseVirtualizationPoolAction.class,
             (action) -> {
+                String id = "new-" + action.getId();
                 BaseVirtualizationPoolAction virtAction = (BaseVirtualizationPoolAction)action;
-                return String.format("pool-%s", virtAction.getPoolName());
+
+                if (action instanceof VirtualizationPoolCreateAction &&
+                        ((VirtualizationPoolCreateAction)action).getUuid() != null ||
+                        !(action instanceof VirtualizationPoolCreateAction)) {
+                    id = String.format("pool-%s", virtAction.getPoolName());
+                }
+                return id;
             }
         );
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add virtual storage pools actions
 - Remove no longer necessary check for retail TERMINALS group membership
 - change DB check before login
 - fix error when adding systems to ssm with 'add to ssm' button (bsc#1160246)

--- a/schema/spacewalk/common/data/rhnActionType.sql
+++ b/schema/spacewalk/common/data/rhnActionType.sql
@@ -83,6 +83,7 @@ insert into rhnActionType values (509, 'virt.pool_refresh', 'Refresh a virtual s
 insert into rhnActionType values (510, 'virt.pool_start', 'Starts a virtual storage pool', 'N', 'N');
 insert into rhnActionType values (511, 'virt.pool_stop', 'Stops a virtual storage pool', 'N', 'N');
 insert into rhnActionType values (512, 'virt.pool_delete', 'Deletes a virtual storage pool', 'N', 'N');
+insert into rhnActionType values (513, 'virt.pool_create', 'Creates a virtual storage pool', 'N', 'N');
 --
 --
 -- Revision 1.25  2004/10/29 05:07:52  pjones

--- a/schema/spacewalk/common/tables/rhnActionVirtPoolCreate.sql
+++ b/schema/spacewalk/common/tables/rhnActionVirtPoolCreate.sql
@@ -1,0 +1,42 @@
+--
+-- Copyright (c) 2020 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+CREATE TABLE rhnActionVirtPoolCreate
+(
+    action_id            NUMERIC NOT NULL
+                             CONSTRAINT rhn_action_virt_pool_create_aid_fk
+                                 REFERENCES rhnAction (id)
+                                 ON DELETE CASCADE
+                             CONSTRAINT rhn_action_virt_pool_create_aid_pk
+                                 PRIMARY KEY,
+    pool_name            VARCHAR(256),
+    uuid                 VARCHAR(128),
+    type                 VARCHAR(25),
+    target               VARCHAR(256),
+    autostart            CHAR(1)
+                            DEFAULT ('Y') NOT NULL
+                            CONSTRAINT rhn_avpcreate_autostart_ck
+                                CHECK (autostart in ('Y','N')),
+    permission_mode                 VARCHAR(4),
+    permission_owner                VARCHAR(10),
+    permission_group                VARCHAR(10),
+    permission_seclabel             VARCHAR(256),
+    source               VARCHAR(2048)
+)
+;
+
+CREATE UNIQUE INDEX rhn_action_virt_pool_create_aid_uq
+    ON rhnActionVirtPoolCreate (action_id);
+

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,5 @@
+- Update schema for virtualization pool actions
+
 -------------------------------------------------------------------
 Thu Mar 19 12:19:27 CET 2020 - jgonzalez@suse.com
 

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.4-to-susemanager-schema-4.1.5/001-add_virt_pool_actions_rhnActionType.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.4-to-susemanager-schema-4.1.5/001-add_virt_pool_actions_rhnActionType.sql
@@ -35,3 +35,9 @@ insert into rhnActionType (id, label, name, trigger_snapshot, unlocked_only) (
     from dual
     where not exists (select 1 from rhnActionType where id = 512)
 );
+
+insert into rhnActionType (id, label, name, trigger_snapshot, unlocked_only) (
+    select 513, 'virt.pool_create', 'Creates a virtual storage pool', 'N', 'N'
+    from dual
+    where not exists (select 1 from rhnActionType where id = 513)
+);

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.4-to-susemanager-schema-4.1.5/006-rhnActionVirtPoolCreate.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.4-to-susemanager-schema-4.1.5/006-rhnActionVirtPoolCreate.sql
@@ -1,0 +1,41 @@
+-- Copyright (c) 2020 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+CREATE TABLE IF NOT EXISTS rhnActionVirtPoolCreate
+(
+    action_id            NUMERIC NOT NULL
+                             CONSTRAINT rhn_action_virt_pool_create_aid_fk
+                                 REFERENCES rhnAction (id)
+                                 ON DELETE CASCADE
+                             CONSTRAINT rhn_action_virt_pool_create_aid_pk
+                                 PRIMARY KEY,
+    pool_name            VARCHAR(256),
+    uuid                 VARCHAR(128),
+    type                 VARCHAR(25),
+    target               VARCHAR(256),
+    autostart            CHAR(1)
+                            DEFAULT ('Y') NOT NULL
+                            CONSTRAINT rhn_avpcreate_autostart_ck
+                                CHECK (autostart in ('Y','N')),
+    permission_mode      VARCHAR(4),
+    permission_owner     VARCHAR(10),
+    permission_group     VARCHAR(10),
+    permission_seclabel  VARCHAR(256),
+    source               VARCHAR(2048)
+)
+;
+
+CREATE UNIQUE INDEX IF NOT EXISTS rhn_action_virt_pool_create_aid_uq
+    ON rhnActionVirtPoolCreate (action_id);
+

--- a/susemanager-utils/susemanager-sls/salt/virt/pool-create.sls
+++ b/susemanager-utils/susemanager-sls/salt/virt/pool-create.sls
@@ -1,0 +1,109 @@
+pool_running:
+  virt.pool_running:
+    - name: {{ pillar['pool_name'] }}
+    - ptype: {{ pillar['pool_type'] }}
+    {% if pillar['target']|default(none) %}
+    - target: {{ pillar['target'] }}
+    {% endif %}
+    - autostart: {{ pillar['autostart'] }}
+    {% if pillar['permissions']|default(none) %}
+    - permissions:
+      {% if pillar['permissions']['mode']|default(none) %}
+        mode: {{ pillar['permissions']['mode'] }}
+      {% endif %}
+      {% if pillar['permissions']['owner']|default(none) %}
+        owner: {{ pillar['permissions']['owner'] }}
+      {% endif %}
+      {% if pillar['permissions']['group']|default(none) %}
+        group: {{ pillar['permissions']['group'] }}
+      {% endif %}
+      {% if pillar['permissions']['label']|default(none) %}
+        label: {{ pillar['permissions']['label'] }}
+      {% endif %}
+    {% endif %}  {# pillar['permissions']['mode']|default(none) #}
+    {% if pillar['source']|default(none) %}
+    - source:
+      {% if pillar['source']['dir']|default(none) %}
+        dir: {{ pillar['source']['dir'] }}
+      {% endif %}
+      {% if pillar['source']['name']|default(none) %}
+        name: {{ pillar['source']['name'] }}
+      {% endif %}
+      {% if pillar['source']['format']|default(none) %}
+        format: {{ pillar['source']['format'] }}
+      {% endif %}
+      {% if pillar['source']['initiator']|default(none) %}
+        initiator: {{ pillar['source']['initiator'] }}
+      {% endif %}
+      {% if pillar['source']['hosts']|default(none) %}
+        hosts:
+        {% for host in pillar['source']['hosts'] %}
+          - {{ host }}
+        {% endfor %}
+      {% endif %}  {# pillar['source']['hosts']|default(none) #}
+      {% if pillar['source']['auth']|default(none) %}
+        auth:
+          username: {{ pillar['source']['auth']['username'] }}
+          password: {{ pillar['source']['auth']['password'] }}
+      {% endif %}  {# pillar['source']['auth']|default(none) #}
+      {% if pillar['source']['devices']|default(none) %}
+        - devices:
+        {% for device in pillar['source']['devices'] %}
+          - path: {{ device['path'] }}
+          {% if device['part_separator']|default(none) %}
+            part_separator: {{ device['part_separator'] }}
+          {% endif %}
+        {% endfor %}
+      {% endif %}  {# pillar['source']['devices']|default(none) #}
+      {% if pillar['source']['adapter']|default(none) %}
+        adapter:
+        {% if pillar['source']['adapter']['type']|default(none) %}
+          type: {{ pillar['source']['adapter']['type'] }}
+        {% endif %}
+        {% if pillar['source']['adapter']['name']|default(none) %}
+          name: {{ pillar['source']['adapter']['name'] }}
+        {% endif %}
+        {% if pillar['source']['adapter']['parent']|default(none) %}
+          parent: {{ pillar['source']['adapter']['parent'] }}
+        {% endif %}
+        {% if pillar['source']['adapter']['managed']|default(none) %}
+          managed: {{ pillar['source']['adapter']['managed'] }}
+        {% endif %}
+        {% if pillar['source']['adapter']['parent_wwnn']|default(none) %}
+          parent_wwnn: {{ pillar['source']['adapter']['parent_wwnn'] }}
+        {% endif %}
+        {% if pillar['source']['adapter']['parent_wwpn']|default(none) %}
+          parent_wwpn: {{ pillar['source']['adapter']['parent_wwpn'] }}
+        {% endif %}
+        {% if pillar['source']['adapter']['parent_fabric_wwn']|default(none) %}
+          parent_fabric_wwn: {{ pillar['source']['adapter']['parent_fabric_wwn'] }}
+        {% endif %}
+        {% if pillar['source']['adapter']['wwnn']|default(none) %}
+          wwnn: {{ pillar['source']['adapter']['wwnn'] }}
+        {% endif %}
+        {% if pillar['source']['adapter']['wwpn']|default(none) %}
+          wwpn: {{ pillar['source']['adapter']['wwpn'] }}
+        {% endif %}
+        {% if pillar['source']['adapter']['parent_address']|default(none) %}
+          parent_address:
+          {% if pillar['source']['adapter']['parent_address']['unique_id']|default(none) %}
+            unique_id: {{ pillar['source']['adapter']['parent_address']['unique_id'] }}
+          {% endif %}
+          {% if pillar['source']['adapter']['parent_address']['address']|default(none) %}
+            address:
+            {% if pillar['source']['adapter']['parent_address']['address']['domain']|default(none) %}
+              domain: {{ pillar['source']['adapter']['parent_address']['address']['domain'] }}
+            {% endif %}
+            {% if pillar['source']['adapter']['parent_address']['address']['bus']|default(none) %}
+              bus: {{ pillar['source']['adapter']['parent_address']['address']['bus'] }}
+            {% endif %}
+            {% if pillar['source']['adapter']['parent_address']['address']['slot']|default(none) %}
+              slot: {{ pillar['source']['adapter']['parent_address']['address']['slot'] }}
+            {% endif %}
+            {% if pillar['source']['adapter']['parent_address']['address']['function']|default(none) %}
+              function: {{ pillar['source']['adapter']['parent_address']['address']['function'] }}
+            {% endif %}
+          {% endif %}  {# pillar['source']['adapter']['parent_address']['address']|default(none) #}
+        {% endif %}  {# pillar['source']['adapter']['parent_address']|default(none) #}
+      {% endif %}  {# pillar['source']['adapter']|default(none) #}
+    {% endif %}  {# pillar['source']|default(none) #}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- Add virtual storage pool actions
+
 -------------------------------------------------------------------
 Thu Mar 19 12:17:47 CET 2020 - jgonzalez@suse.com
 

--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -445,6 +445,7 @@ The check box can be identified by name, id or label text.
   Then file "/srv/susemanager/salt/manager_org_1/mixedchannel/init.sls" should exist on server
   Then file "/srv/susemanager/salt/manager_org_1/s-mgr/config/init.sls" should not exist on server
   Then file "/var/lib/libvirt/images/test-pool0" should not exist on "kvm_server"
+  Then file "/var/lib/libvirt/images/test-pool1" should have 755 permissions on "kvm_server"
 ```
 
 * File contents

--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -226,6 +226,22 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And file "/var/lib/libvirt/images/test-pool0" should not exist on "kvm_server"
 
 @virthost_kvm
+  Scenario: Create a virtual storage pool for KVM
+    Given I am on the "Virtualization" page of this "kvm_server"
+    When I follow "Storage"
+    And I follow "Create Pool"
+    And I wait until I see "General" text
+    And I select "dir" from "type"
+    And I enter "test-pool1" as "name"
+    And I uncheck "autostart"
+    And I enter "/var/lib/libvirt/images/test-pool1" as "target_path"
+    And I enter "0755" as "target_mode"
+    And I click on "Create"
+    Then I should see a "Virtual Storage Pools and Volumes" text
+    And I wait until the tree item "test-pool1" contains "running" text
+    And file "/var/lib/libvirt/images/test-pool1" should have 755 permissions on "kvm_server"
+
+@virthost_kvm
   Scenario: Cleanup: Unregister the KVM virtualization host
     Given I am on the Systems overview page of this "kvm_server"
     When I follow "Delete System"
@@ -248,6 +264,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I delete test-net0 virtual network on "kvm_server" without error control
     And I delete test-net1 virtual network on "kvm_server" without error control
     And I delete test-pool0 virtual storage pool on "kvm_server" without error control
+    And I delete test-pool1 virtual storage pool on "kvm_server" without error control
     And I delete all "test-vm.*" volumes from "test-pool0" pool on "kvm_server" without error control
     # Remove the virtpoller cache to avoid problems
     And I run "rm /var/cache/virt_state.cache" on "kvm_server" without error control

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -591,6 +591,11 @@ Then(/^file "([^"]*)" should exist on "([^"]*)"$/) do |filename, host|
   node.run("test -f #{filename}", true)
 end
 
+Then(/^file "([^"]*)" should have ([0-9]+) permissions on "([^"]*)"$/) do |filename, permissions, host|
+  node = get_target(host)
+  node.run("test \"`stat -c '%a' #{filename}`\" = \"#{permissions}\"", true)
+end
+
 Then(/^file "([^"]*)" should not exist on server$/) do |filename|
   $server.run("test ! -f #{filename}")
 end

--- a/web/html/src/manager/virtualization/index.js
+++ b/web/html/src/manager/virtualization/index.js
@@ -4,5 +4,6 @@ export default {
   'virtualization/guests/create/guests-create': () => import('./guests/create/guests-create.renderer'),
   'virtualization/guests/console/guests-console': () => import('./guests/console/guests-console.renderer'),
   'virtualization/pools/list/pools-list': () => import('./pools/list/pools-list.renderer'),
+  'virtualization/pools/create/pools-create': () => import('./pools/create/pools-create.renderer'),
 }
 

--- a/web/html/src/manager/virtualization/pools/create/pools-create.js
+++ b/web/html/src/manager/virtualization/pools/create/pools-create.js
@@ -1,0 +1,49 @@
+// @flow
+import type { ActionChain } from 'components/action-schedule';
+
+import * as React from 'react';
+import { TopPanel } from 'components/panels/TopPanel';
+import { VirtualizationPoolsActionApi } from '../virtualization-pools-action-api';
+import { PoolProperties } from '../pool-properties';
+
+type Props = {
+  serverId: string,
+  localTime: string,
+  timezone: string,
+  actionChains: Array<ActionChain>,
+};
+
+export function PoolsCreate(props: Props) {
+  return (
+    <VirtualizationPoolsActionApi
+      hostid={props.serverId}
+      bounce={`/rhn/manager/systems/details/virtualization/storage/${props.serverId}`}
+    >
+    {
+      ({
+        onAction,
+        messages
+      }) => {
+        const onSubmit = (model: Object) => onAction('create', [model.name], model);
+
+        return (
+          <TopPanel
+            title={t('Create Virtual Storage Pool')}
+          >
+            <PoolProperties
+              serverId={props.serverId}
+              submitText={t('Create')}
+              submit={onSubmit}
+              initialModel={{}}
+              messages={messages}
+              timezone={props.timezone}
+              localTime={props.localTime}
+              actionChains={props.actionChains}
+            />
+          </TopPanel>
+        );
+      }
+    }
+    </VirtualizationPoolsActionApi>
+  );
+}

--- a/web/html/src/manager/virtualization/pools/create/pools-create.renderer.js
+++ b/web/html/src/manager/virtualization/pools/create/pools-create.renderer.js
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { PoolsCreate } from './pools-create';
+import SpaRenderer from "core/spa/spa-renderer";
+
+export const renderer = (id, { serverId, actionChains, timezone, localTime }) => {
+  SpaRenderer.renderNavigationReact(
+    <PoolsCreate
+      serverId={serverId}
+      actionChains={actionChains}
+      timezone={timezone}
+      localTime={localTime}
+    />,
+    document.getElementById(id),
+  );
+};

--- a/web/html/src/manager/virtualization/pools/list/pools-list.js
+++ b/web/html/src/manager/virtualization/pools/list/pools-list.js
@@ -6,6 +6,7 @@ import { CustomDiv } from 'components/custom-objects';
 import { ProgressBar } from 'components/progressbar';
 import { CustomDataHandler } from 'components/table/CustomDataHandler';
 import { SearchField } from 'components/table/SearchField';
+import { LinkButton } from 'components/buttons';
 import { AsyncButton } from 'components/buttons';
 import { Messages } from 'components/messages';
 import { Utils as MessagesUtils } from 'components/messages';
@@ -313,6 +314,15 @@ export function PoolsList(props: Props) {
 
               return (
                 <>
+                  <div className="pull-right btn-group">
+                    <LinkButton
+                      text={t('Create Pool')}
+                      title={t('Create Pool')}
+                      className="btn-default"
+                      icon="fa-plus"
+                      href={`/rhn/manager/systems/details/virtualization/storage/${props.serverId}/new`}
+                    />
+                  </div>
                   <h2>{t('Virtual Storage Pools and Volumes')}</h2>
                   <p>{t('This is the list of storage pools defined on this host containing virtual guests disks.')}</p>
                   <Messages items={[].concat(messages, refreshError || [], getCreationActionMessages())}/>

--- a/web/html/src/manager/virtualization/pools/pool-properties.js
+++ b/web/html/src/manager/virtualization/pools/pool-properties.js
@@ -1,0 +1,613 @@
+// @flow
+
+import type { ActionChain } from 'components/action-schedule';
+
+import * as React from 'react';
+import { Loading } from 'components/utils/Loading';
+import { Form } from 'components/input/Form';
+import { FormMultiInput } from 'components/input/FormMultiInput';
+import { Panel } from 'components/panels/Panel';
+import { PanelRow } from 'components/panels/PanelRow';
+import { Text } from 'components/input/Text';
+import { Password } from 'components/input/Password';
+import { Select } from 'components/input/Select';
+import { Check } from 'components/input/Check';
+import { unflattenModel, flattenModel } from 'components/input/form-utils';
+import Validation from 'components/validation';
+import { SubmitButton, Button } from 'components/buttons';
+import { Messages } from 'components/messages';
+import { ActionSchedule } from 'components/action-schedule';
+import Functions from 'utils/functions';
+import { VirtualizationPoolCapsApi } from './virtualization-pools-capabilities-api';
+import * as FieldsData from './properties/fields-data';
+
+type Props = {
+  serverId: string,
+  submitText: string,
+  submit: (Object) => void,
+  initialModel: ?Object,
+  messages: Array<String>,
+  localTime: string,
+  timezone: string,
+  actionChains: Array<ActionChain>,
+};
+
+export function PoolProperties(props: Props) {
+  const [model, setModel] = React.useState(props.initialModel ? flattenModel(props.initialModel) : {});
+  const [invalid, setInvalid] = React.useState(false);
+  const [actionChain, setActionChain] = React.useState(null);
+  const [earliest, setEarliest] = React.useState(Functions.Utils.dateWithTimezone(props.localTime));
+
+  React.useEffect(() => {
+    clearFields();
+  }, [props.initialModel]);
+
+  const clearFields = () => {
+    if (props.initialModel) {
+      // Split the hosts name and port
+      let initialModel = props.initialModel;
+      if ((props.initialModel.source || {}).hosts) {
+        const splitHosts = props.initialModel.source.hosts.map(
+          host => {
+            const [hostname, port] = host.split(':');
+            return {name: hostname, port};
+          }
+        );
+        initialModel.source.hosts = splitHosts;
+      }
+      // Flatten the model for the form
+      let flattened = flattenModel(initialModel);
+      // Set source_adapter_selection
+      if (flattened.type === "scsi") {
+        flattened[`source_adapter_selection`] = FieldsData.computeSourceAdapterSelection(flattened);
+      }
+      setModel(flattened);
+    } else {
+      setModel({});
+    }
+  };
+
+  const onValidate = (isValid: boolean) => {
+    setInvalid(!isValid);
+  };
+
+  const onChange = (newModel: Object) => {
+    setModel(Object.assign({}, newModel));
+  };
+
+  const onSubmit = () => {
+    // Prepare the model for the submit action
+    let data = unflattenModel(model);
+
+    // Merge hosts name and port
+    if (data.source != null && data.source.hosts != null) {
+      const hosts = data.source.hosts.map(host => {
+        const port = host.port ? `:${host.port}` : '';
+        return `${host.name}${port}`;
+      });
+      data.source.hosts = hosts;
+    }
+
+    data['actionChain'] = actionChain;
+    data['earliest'] = earliest;
+    if (data.source_adapter_selection != null) {
+      delete data['source_adapter_selection'];
+    }
+
+    props.submit(data);
+  };
+
+  const onDateTimeChanged = (date: Date) => {
+    setEarliest(date);
+  }
+
+  const onActionChainChanged = (newActionChain: ?ActionChain) => {
+    setActionChain(newActionChain);
+  }
+
+  const onPoolTypeChanged = () => {
+    model.source_format = undefined;
+    if (FieldsData.getValue(model.type, 'source_hosts.show', false)) {
+      model.source_hosts0_name = '';
+      model.source_hosts0_port = '';
+    }
+    if (FieldsData.getValue(model.type, 'source_devices.show', false)) {
+      model.source_devices0_path = '';
+      model.source_devices0_separator = '';
+    }
+  }
+
+  return (
+    <VirtualizationPoolCapsApi hostId={props.serverId}>
+    {
+      ({
+        capabilities,
+        messages: capsError,
+      }) => {
+        if (capabilities != null) {
+          const pool_types = capabilities['pool_types']
+            .filter(pool_type => pool_type.supported)
+            .map(pool_type => pool_type['name']);
+
+          const pool_type = capabilities['pool_types'].find(type => type.name === model.type);
+          const source_format_types = (((pool_type || {})['options'] || {})['pool'] || {})['sourceFormatType'];
+          const source_format_default = (((pool_type || {})['options'] || {})['pool'] || {})['default_format'];
+
+          const default_adapter_type = 'scsi_host';
+          const selected_adapter_type = model.source_adapter_type || default_adapter_type;
+
+          const default_adapter_selection = FieldsData.getValue(model.type,
+              `source_adapter.${selected_adapter_type}.default_selection`, '');
+
+          const selected_adapter_selection = model.source_adapter_selection || default_adapter_selection;
+
+          const adapter_selections = FieldsData.getValue(model.type,
+                        `source_adapter.${selected_adapter_type}.selection`, {});
+          const adapter_fields = FieldsData.getValue(model.type,
+              `source_adapter.${selected_adapter_type}.fields`, [])
+            .concat(FieldsData.getValue(model.type,
+              `source_adapter.${selected_adapter_type}.${selected_adapter_selection}`, []));
+
+          const renderDeviceFields = (index: number, in_list: boolean): React.Node => {
+            const has_separator = FieldsData.getValue(model.type, 'source_devices.allow_part', false);
+            const path_field = (
+              <Text
+                name={`source_devices${index}_path`}
+                label={t(FieldsData.getValue(model.type, 'source_devices.label', 'Path'))}
+                required
+                labelClass={has_separator ? "col-md-5" : "col-md-3"}
+                divClass={has_separator ? "col-md-7" : "col-md-6"}
+              />
+            );
+
+            // TODO Add link to doc for the part separator
+            const separator_field = has_separator && (
+              <div className={in_list ? "col-md-2" : "col-md-3"}>
+                <Select
+                  name={`source_devices${index}_separator`}
+                  label={t('Partition separator')}
+                  labelClass={in_list ? "col-md-8" : "col-md-5"}
+                  divClass={in_list ? "col-md-4" : "col-md-3"}
+                  defaultValue=''
+                >
+                  <option key='' value=''></option>
+                  <option key='yes' value='yes'>{t('Yes')}</option>
+                  <option key='no' value='no'>{t('No')}</option>
+                </Select>
+              </div>
+            );
+
+            if (has_separator) {
+              return (
+                <>
+                  <div className={"col-md-7"}>
+                    {path_field}
+                  </div>
+                  { separator_field }
+                </>
+              );
+            }
+
+            return path_field;
+          };
+
+          const renderHostFields = (index: number, in_list: boolean): React.Node => {
+            return (
+                <>
+                  <div className="col-md-7">
+                    <Text
+                      name={`source_hosts${index}_name`}
+                      label={t('Host name')}
+                      labelClass="col-md-5"
+                      divClass="col-md-7"
+                      required={FieldsData.getValue(model.type, 'source_hosts.required', false)}
+                    />
+                  </div>
+                  <div className={in_list ? "col-md-2" : "col-md-3"}>
+                    <Text
+                      name={`source_hosts${index}_port`}
+                      label={t('Port')}
+                      labelClass="col-md-3"
+                      divClass={in_list ? "col-md-9" : "col-md-5"}
+                    />
+                  </div>
+                </>
+            );
+          };
+
+          return (
+            <Form
+              className="form-horizontal"
+              model={model}
+              onValidate={onValidate}
+              onChange={onChange}
+              onSubmit={onSubmit}
+            >
+              <Messages items={props.messages} />
+              <Panel key="general" title={t('General')} headingLevel="h2">
+                { (props.initialModel || {}).name === undefined
+                  && (
+                  <Text
+                    name="name"
+                    label={t('Name')}
+                    required
+                    invalidHint={t('Can not contain the following characters: /\\')}
+                    labelClass="col-md-3"
+                    divClass="col-md-6"
+                    validators={[Validation.matches(/^[^/\\]+$/)]}
+                  />)
+                }
+                <Select
+                  labelClass="col-md-3"
+                  divClass="col-md-6"
+                  label={t('Pool Type')}
+                  name="type"
+                  required
+                  disabled={(props.initialModel || {}).type !== undefined}
+                  hint={t(FieldsData.getValue(model.type, 'description', ''))}
+                  defaultValue={pool_types[0]}
+                  onChange={onPoolTypeChanged}
+                >
+                  {
+                    pool_types.map(k => <option key={k} value={k}>{k}</option>)
+                  }
+                </Select>
+                <Check
+                  name="autostart"
+                  label={t('Start during virtual host boot')}
+                  divClass="col-md-6 col-md-offset-3"
+                />
+              </Panel>
+
+              { FieldsData.getValue(model.type, 'panels', []).includes('source') && (
+                <Panel
+                  key="source"
+                  title={t('Source')}
+                  headingLevel="h3"
+                >
+                {
+                  FieldsData.getValue(model.type, 'source_hosts.show', false) &&
+                  !FieldsData.getValue(model.type, 'source_hosts.list', false) &&
+                  <PanelRow>
+                    { renderHostFields(0, false) }
+                  </PanelRow>
+                }
+                {
+                  FieldsData.getValue(model.type, 'source_hosts.show', false) &&
+                  FieldsData.getValue(model.type, 'source_hosts.list', false) &&
+                  <FormMultiInput
+                    id="source_hosts"
+                    prefix="source_hosts"
+                    title={t('Hosts')}
+                    onAdd={(index: number) => {
+                      const newProperties = {
+                        [`source_hosts${index}_name`]: '',
+                        [`source_hosts${index}_port`]: '',
+                      };
+                      setModel(Object.assign({}, model, newProperties));
+                    }}
+                    onRemove={(index: number) => {
+                      setModel(Object.entries(model).reduce((res, entry) => {
+                        const property = !entry[0].startsWith(`source_hosts${index}_`) ? { [entry[0]]: entry[1] } : undefined;
+                        return Object.assign(res, property);
+                      }, {}));
+                    }}
+                    disabled={false}
+                  >
+                    {
+                      (index: number) => renderHostFields(index, true)
+                    }
+                  </FormMultiInput>
+                }
+                { FieldsData.getValue(model.type, 'source_devices.show', false) &&
+                  !FieldsData.getValue(model.type, 'source_devices.list', false) &&
+                  <PanelRow>
+                    { renderDeviceFields(0, false) }
+                  </PanelRow>
+                }
+                { FieldsData.getValue(model.type, 'source_devices.show', false) &&
+                  FieldsData.getValue(model.type, 'source_devices.list', true) &&
+                  <FormMultiInput
+                    id="source_devices"
+                    prefix="source_devices"
+                    title={t('Devices')}
+                    onAdd={(index: number) => {
+                      const newProperties = {
+                        [`source_devices${index}_path`]: '',
+                        [`source_devices${index}_separator`]: '',
+                      };
+                      setModel(Object.assign({}, model, newProperties));
+                    }}
+                    onRemove={(index: number) => {
+                      setModel(Object.entries(model).reduce((res, entry) => {
+                        const property = !entry[0].startsWith(`source_devices${index}_`) ? { [entry[0]]: entry[1] } : undefined;
+                        return Object.assign(res, property);
+                      }, {}));
+                    }}
+                    disabled={false}
+                  >
+                    {
+                      (index: number) => renderDeviceFields(index, true)
+                    }
+                  </FormMultiInput>
+                }
+                { FieldsData.getValue(model.type, 'source_dir.show', false) &&
+                  <Text
+                    name="source_dir"
+                    label={t(FieldsData.getValue(model.type, `source_dir.label.${model.source_format || 'auto'}`, 'Directory'))}
+                    required={FieldsData.getValue(model.type, 'source_dir.required', false)}
+                    labelClass="col-md-3"
+                    divClass="col-md-6"
+                  />
+                }
+                { FieldsData.getValue(model.type, 'source_initiator.show', false) &&
+                  <Text
+                    name="source_initiator"
+                    label={t('Initiator IQN')}
+                    required={FieldsData.getValue(model.type, 'source_initiator.required', false)}
+                    labelClass="col-md-3"
+                    divClass="col-md-6"
+                  />
+                }
+                {
+                  FieldsData.getValue(model.type, 'source_adapter', null) != null &&
+                  <>
+                    <Select
+                      name="source_adapter_type"
+                      label={t('Adapter type')}
+                      labelClass="col-md-3"
+                      divClass="col-md-6"
+                      defaultValue={default_adapter_type}
+                      onChange={() => model.source_adapter_selection = undefined}
+                    >
+                    {
+                      Object.keys(FieldsData.getValue(model.type, 'source_adapter', {}))
+                        .map(type => <option key={type} value={type}>{type}</option>)
+                    }
+                    </Select>
+                    <Select
+                      name="source_adapter_selection"
+                      label={t(FieldsData.getValue(model.type,
+                          `source_adapter.${selected_adapter_type}.selection_title`, ''))}
+                      labelClass="col-md-3"
+                      divClass="col-md-6"
+                      defaultValue={default_adapter_selection}
+                    >
+                      {
+                        Object.keys(adapter_selections)
+                          .map(item =>
+                            <option key={item} value={item}>{t(adapter_selections[item])}</option>
+                          )
+                      }
+                    </Select>
+                    { /* required one of name || parent_address && parent_address_uid */ }
+                    { adapter_fields.includes('name') &&
+                      <Text
+                        name="source_adapter_name"
+                        label={t('Adapter name')}
+                        required
+                        labelClass="col-md-3"
+                        divClass="col-md-6"
+                      />
+                    }
+                    { adapter_fields.includes('parent_address') &&
+                      <Text
+                        name="source_adapter_parentAddress"
+                        label={t('Adapter parent PCI address')}
+                        required
+                        labelClass="col-md-3"
+                        divClass="col-md-6"
+                        invalidHint={t('PCI address formatted like 0000:00:00.0')}
+                        validators={[Validation.matches(/^[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{1}.[0-9a-fA-F]$/)]}
+                      />
+                    }
+                    { adapter_fields.includes('parent_address_uid') &&
+                      <Text
+                        name="source_adapter_parentAddressUid"
+                        label={t('Adapter parent address unique ID')}
+                        required
+                        labelClass="col-md-3"
+                        divClass="col-md-6"
+                        invalidHint={t('PCI address formatted like 0000:00:00.0')}
+                        validators={[Validation.isInt]}
+                      />
+                    }
+                    { adapter_fields.includes('parent') &&
+                      <Text
+                        name="source_adapter_parent"
+                        label={t('Adapter parent name')}
+                        labelClass="col-md-3"
+                        divClass="col-md-6"
+                      />
+                    }
+                    { adapter_fields.includes('parent_wwnn') &&
+                      <Text
+                        name="source_adapter_parentWwnn"
+                        label={t('Adapter parent wwnn')}
+                        labelClass="col-md-3"
+                        divClass="col-md-6"
+                        invalidHint={t('16 characters long hexadecimal value. Example: 500277a4100c4e21')}
+                        validators={[Validation.matches(/^(0x)?[0-9a-fA-F]{16}$/)]}
+                      />
+                    }
+                    { adapter_fields.includes('parent_wwpn') &&
+                      <Text
+                        name="source_adapter_parentWwpn"
+                        label={t('Adapter parent wwpn')}
+                        labelClass="col-md-3"
+                        divClass="col-md-6"
+                        invalidHint={t('16 characters long hexadecimal value. Example: 500277a4100c4e21')}
+                        validators={[Validation.matches(/^(0x)?[0-9a-fA-F]{16}$/)]}
+                      />
+                    }
+                    { adapter_fields.includes('parent_fabric_wwn') &&
+                      <Text
+                        name="source_adapter_parentFabricWwn"
+                        label={t('Adapter parent fabric wwn')}
+                        labelClass="col-md-3"
+                        divClass="col-md-6"
+                        invalidHint={t('16 characters long hexadecimal value. Example: 500277a4100c4e21')}
+                        validators={[Validation.matches(/^(0x)?[0-9a-fA-F]{16}$/)]}
+                      />
+                    }
+                    { adapter_fields.includes('wwnn') &&
+                      <Text
+                        name="source_adapter_wwnn"
+                        label={t('Adapter wwnn')}
+                        required
+                        labelClass="col-md-3"
+                        divClass="col-md-6"
+                        invalidHint={t('16 characters long hexadecimal value. Example: 500277a4100c4e21')}
+                        validators={[Validation.matches(/^(0x)?[0-9a-fA-F]{16}$/)]}
+                      />
+                    }
+                    { adapter_fields.includes('wwpn') &&
+                      <Text
+                        name="source_adapter_wwpn"
+                        label={t('Adapter wwpn')}
+                        required
+                        labelClass="col-md-3"
+                        divClass="col-md-6"
+                        invalidHint={t('16 characters long hexadecimal value. Example: 500277a4100c4e21')}
+                        validators={[Validation.matches(/^(0x)?[0-9a-fA-F]{16}$/)]}
+                      />
+                    }
+                    { adapter_fields.includes('managed') &&
+                      <Check
+                        name="source_adapter_managed"
+                        label={t('Manage vHBA deletion')}
+                        divClass="col-md-6 col-md-offset-3"
+                      />
+                    }
+                  </>
+                }
+                { FieldsData.getValue(model.type, 'source_name.show', false) &&
+                  <Text
+                    name="source_name"
+                    label={t('Source name')}
+                    required={FieldsData.getValue(model.type, 'source_name.required', false)}
+                    labelClass="col-md-3"
+                    divClass="col-md-6"
+                  />
+                }
+                { source_format_types != null &&
+                  <Select
+                    name="source_format"
+                    label={t('Format')}
+                    labelClass="col-md-3"
+                    divClass="col-md-6"
+                    defaultValue={source_format_default}
+                  >
+                    {
+                      source_format_types.map(k => <option key={k} value={k}>{k}</option>)
+                    }
+                  </Select>
+                }
+                { FieldsData.getValue(model.type, 'has_auth', false) &&
+                  <>
+                    <Text
+                      name="source_auth_username"
+                      label={t('Username')}
+                      labelClass="col-md-3"
+                      divClass="col-md-6"
+                    />
+                    <Password
+                      name="source_auth_password"
+                      label={t('Passphrase')}
+                      labelClass="col-md-3"
+                      divClass="col-md-6"
+                    />
+                  </>
+                }
+                </Panel>
+              )}
+
+              { FieldsData.getValue(model.type, 'panels', []).includes('target') && (
+                  <Panel
+                    key="target"
+                    title={t('Target')}
+                    headingLevel="h3"
+                  >
+                    <Text
+                      name="target_path"
+                      label={t('Path')}
+                      hint={t(FieldsData.getValue(model.type, 'target_path.hint', undefined))}
+                      required={FieldsData.getValue(model.type, 'target_path.required', false)}
+                      labelClass="col-md-3"
+                      divClass="col-md-6"
+                    />
+                    <Text
+                      name="target_owner"
+                      label={t('Owner UID')}
+                      labelClass="col-md-3"
+                      divClass="col-md-6"
+                      validators={[Validation.isInt({min: 0})]}
+                      invalidHint={t('UID is a numeric value')}
+                    />
+                    <Text
+                      name="target_group"
+                      label={t('Group ID')}
+                      labelClass="col-md-3"
+                      divClass="col-md-6"
+                      validators={[Validation.isInt({min: 0})]}
+                      invalidHint={t('GID is a numeric value')}
+                    />
+                    <Text
+                      name="target_mode"
+                      label={t('Permission mode')}
+                      hint={t('target directory permissions in octal form, like 0775')}
+                      labelClass="col-md-3"
+                      divClass="col-md-6"
+                      validators={[Validation.isInt({gt: 0})]}
+                      invalidHint={t('GID is a numeric value')}
+                    />
+                    {/* TODO Add Link to the UI Reference */}
+                    <Text
+                      name="target_seclabel"
+                      label={t('SELinux label')}
+                      labelClass="col-md-3"
+                      divClass="col-md-6"
+                    />
+                  </Panel>
+                )
+              }
+
+              <Panel
+                key="schedule"
+                title={t('Schedule')}
+                headingLevel="h3"
+              >
+                <ActionSchedule
+                  timezone={props.timezone}
+                  localTime={props.localTime}
+                  earliest={earliest}
+                  actionChains={props.actionChains}
+                  actionChain={actionChain}
+                  onActionChainChanged={onActionChainChanged}
+                  onDateTimeChanged={onDateTimeChanged}
+                />
+              </Panel>
+              <div className="col-md-offset-3 col-md-6">
+                <SubmitButton
+                  id="submit-btn"
+                  className="btn-success"
+                  text={props.submitText}
+                  disabled={invalid}
+                />
+                <Button
+                  id="clear-btn"
+                  className="btn-default pull-right"
+                  icon="fa-eraser"
+                  text={t('Clear Fields')}
+                  handler={clearFields}
+                />
+              </div>
+            </Form>
+          )
+        }
+        return <Loading text={t('Loading...')} withBorders={false} />;
+      }
+    }
+    </VirtualizationPoolCapsApi>
+  );
+};

--- a/web/html/src/manager/virtualization/pools/properties/fields-data.js
+++ b/web/html/src/manager/virtualization/pools/properties/fields-data.js
@@ -1,0 +1,244 @@
+const mapping = {
+  dir: {
+    description: 'Manages files in a directory on the virtual host',
+    panels: ['target'],
+    target_path: {
+      hint: 'Absolute path where the pool will be mounted',
+      required: true,
+    }
+  },
+  fs: {
+    description: 'Manages files in a block device to be mounted',
+    panels: ['source', 'target'],
+    source_devices: {
+      show: true,
+      label: 'Device path',
+      required: true,
+      list: false,
+    },
+    target_path: {
+      hint: 'Absolute path where the pool will be mounted',
+      required: true,
+    }
+  },
+  netfs: {
+    description: 'Manages files in a network file system to be mounted',
+    panels: ['source', 'target'],
+    source_hosts: {
+      show: true,
+      required: true,
+    },
+    source_dir: {
+      show: true,
+      required: true,
+      label: {
+        auto: "Directory",
+        nfs: "Directory",
+        glusterfs: "Volume name",
+        cifs: "CIFS share"
+      }
+    },
+    target_path: {
+      hint: 'Absolute path where the pool will be mounted',
+      required: true,
+    }
+  },
+  disk: {
+    description: 'Manages volumes as partitions on a physical disk',
+    panels: ['source', 'target'],
+    source_devices: {
+      show: true,
+      label: 'Device path',
+      list: false,
+      required: true,
+      allow_part: true,
+    },
+    target_path: {
+      hint: 'Absolute path to the directory containing the devices nodes',
+      required: true,
+    }
+  },
+  iscsi: {
+    description: 'Manages pre-allocated volumes on a iSCSI server using iscsiadm',
+    panels: ['source', 'target'],
+    source_hosts: {
+      show: true,
+      required: true,
+    },
+    source_devices: {
+      show: true,
+      list: false,
+      required: true,
+      label: 'iSCSI Qualified Name'
+    },
+    source_initiator: {
+      show: true,
+    },
+    has_auth: true,
+    target_path: {
+      hint: 'Absolute path to the directory containing the devices nodes',
+      required: true,
+    }
+  },
+  logical: {
+    description: 'Manages volumes in a LVM Volume Group.',
+    panels: ['source'],
+    source_devices: {
+      show: true,
+      list: true,
+    },
+    source_name: {
+      show: true
+    }
+  },
+  scsi: {
+    description: 'Manages pre-existing LUNs on a SCSI HBA',
+    panels: ['source', 'target'],
+    source_adapter: {
+      scsi_host: {
+        selection_mode: true,
+        selection_title: 'Select device by',
+        default_selection: 'name',
+        selection: {
+          name: 'Name',
+          parent_address: 'Parent PCI Address'
+        },
+        name: ['name'],
+        parent_address: ['parent_address', 'parent_address_uid']
+      },
+      fc_host: {
+        fields: ['wwnn', 'wwpn', 'managed'],
+        parent_selection: true,
+        selection_title: 'Parent vHBA selection mode',
+        default_selection: 'automatic',
+        selection: {
+          automatic: 'Detect parent scsi_host',
+          name: 'Parent scsi_host name',
+          wwnn_wwpn: 'Parent WWNN/WWPN',
+          fabric_wwn: 'Parent Fabric WWN'
+        },
+        name: ['parent'],
+        wwnn_wwpn: ['parent_wwnn', 'parent_wwpn'],
+        fabric_wwn: ['parent_fabric_wwn'],
+      }
+    },
+    target_path: {
+      hint: 'Absolute path to the directory containing the devices nodes',
+      required: true,
+    }
+  },
+  mpath: {
+    description: 'Pool containing all the multipath devices on the host',
+  },
+  rbd: {
+    description: 'Pool containing all RBD images in a RADOS pool',
+    panels: ['source'],
+    source_hosts: {
+      show: true,
+      list: true,
+      required: true,
+    },
+    source_name: {
+      show: true,
+      required: true,
+    },
+    has_auth: true,
+  },
+  sheepdog: {
+    description: 'Pool based on an already formatted Sheepdog cluster',
+    panels: ['source'],
+    source_hosts: {
+      show: true,
+    },
+    source_name: {
+      show: true,
+      required: true,
+    }
+  },
+  gluster: {
+    description: 'Pool based on a Gluster volume using native access',
+    panels: ['source'],
+    source_hosts: {
+      show: true,
+      required: true,
+    },
+    source_dir: {
+      show: true,
+      label: {
+        auto: "Subdirectory"
+      }
+    },
+    source_name: {
+      show: true,
+      required: true,
+    }
+  },
+  zfs: {
+    description: 'Pool based on the ZFS filesystem',
+    panels: ['source'],
+    source_devices: {
+      show: true,
+      list: false,
+      required: false,
+      label: 'Device path',
+    },
+    source_name: {
+      show: true,
+      required: true,
+    }
+  },
+  'iscsi-direct': {
+    description: 'Manages pre-allocated volumes on a iSCSI server using libiscsi',
+    panels: ['source'],
+    source_hosts: {
+      show: true,
+      required: true,
+    },
+    source_devices: {
+      show: true,
+      list: false,
+      required: true,
+      label: 'iSCSI Qualified Name'
+    },
+    source_initiator: {
+      show: true,
+      required: true,
+    },
+    has_auth: true,
+  }
+};
+
+function getObjectValue(obj, path, defaultValue) {
+  const pos = path.indexOf('.');
+  if (pos > 0) {
+    const member_name = path.substring(0, pos);
+    const path_rest = path.substring(pos + 1);
+
+    return getObjectValue(obj[member_name] || {}, path_rest, defaultValue);
+  }
+  return obj[path] != null ? obj[path] : defaultValue;
+}
+
+export function getValue(type, path, defaultValue) {
+  return getObjectValue(mapping[type] || {}, path, defaultValue);
+}
+
+
+export function computeSourceAdapterSelection(model: Object) {
+  const adapter_type = model.source_adapter_type || 'scsi_host';
+  const selection_types = Object.keys(
+    getValue('scsi', `source_adapter.${adapter_type}.selection`, {}));
+  const possible_selections = selection_types.filter(selection => {
+    const fields = getValue('scsi', `source_adapter.${adapter_type}.${selection}`, []);
+    return fields.some(field => {
+      // CamelCase to get the property name
+      const name = field.split('_')
+        .map((item, idx) => idx > 0 ? `${item.substring(0, 1).toUpperCase()}${item.substring(1)}` : item)
+        .join('');
+      const property_name = `source_adapter_${name}`;
+      return model[property_name] != null;
+    });
+  }).filter(selection => selection !== 'automatic');
+
+  return possible_selections.length > 0 ? possible_selections[0] : undefined;
+}

--- a/web/html/src/manager/virtualization/pools/properties/fields-data.test.js
+++ b/web/html/src/manager/virtualization/pools/properties/fields-data.test.js
@@ -1,0 +1,57 @@
+import { computeSourceAdapterSelection } from './fields-data';
+
+describe('source_adapter_selection computing helper', () => {
+  test('automatic case', () => {
+    expect(computeSourceAdapterSelection({})).toEqual(undefined);
+  });
+
+  test('scsi_host name case', () => {
+    const model = {
+      source_adapter_type: 'scsi_host',
+      source_adapter_name: 'testname',
+    };
+    expect(computeSourceAdapterSelection(model)).toEqual('name');
+  });
+
+  test('scsi_host parent_address case', () => {
+    const model = {
+      source_adapter_parentAddress: 'someparentaddress',
+      source_adapter_parentAddressUid: 'someUid',
+    };
+    expect(computeSourceAdapterSelection(model)).toEqual('parent_address');
+    expect(computeSourceAdapterSelection({source_adapter_parentAddress: 'foo'})).toEqual('parent_address');
+    expect(computeSourceAdapterSelection({source_adapter_parentAddressUid: 'foo'})).toEqual('parent_address');
+  });
+
+  test('fc_host name case', () => {
+    expect(computeSourceAdapterSelection({
+      source_adapter_type: 'fc_host',
+      source_adapter_parent: 'foo',
+    })).toEqual('name');
+  });
+
+  test('fc_host wwnn_wwpn case', () => {
+    expect(computeSourceAdapterSelection({
+      source_adapter_type: 'fc_host',
+      source_adapter_parentWwnn: 'foo',
+      source_adapter_parentWwpn: 'bar',
+    })).toEqual('wwnn_wwpn');
+
+    expect(computeSourceAdapterSelection({
+      source_adapter_type: 'fc_host',
+      source_adapter_parentWwnn: 'foo',
+    })).toEqual('wwnn_wwpn');
+
+    expect(computeSourceAdapterSelection({
+      source_adapter_type: 'fc_host',
+      source_adapter_parentWwpn: 'foo',
+    })).toEqual('wwnn_wwpn');
+  });
+
+  test('fc_host fabric_wwn case', () => {
+    expect(computeSourceAdapterSelection({
+      source_adapter_type: 'fc_host',
+      source_adapter_parentFabricWwn: 'foo',
+    })).toEqual('fabric_wwn');
+  });
+});

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Add virtual storage pool actions
 - Rename Formula tab to Configuration
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Add the virtual pool create action

## GUI diff

After:

Add a Create button in the virtual pools list page. This buttons shows a dialog to fill all the properties of the new pool.

- [X] **DONE**

## Documentation
- [uyuni-docs](uyuni-project/uyuni-docs#52) PR or issue was created for all pool actions

- [X] **DONE**

## Test coverage
- Unit tests were added
- Cucumber tests were added

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

This PR contains the changelog entries for the other virtual pool actions

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
