### PR TITLE
set config components back to original value

### DIFF
--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -413,6 +413,7 @@ class ContentSource:
         self.sslclientkey = client_key_file
         self.http_headers = {}
 
+        comp = CFG.getComponent()
         # read the proxy configuration in /etc/rhn/rhn.conf
         initCFG('server.satellite')
 
@@ -469,6 +470,8 @@ class ContentSource:
         self.num_excluded = 0
         self.gpgkey_autotrust = None
         self.groupsfile = None
+        # set config component back to original
+        initCFG(comp)
 
     def _get_mirror_list(self, repo, url):
         mirrorlist_path = os.path.join(repo.root, 'mirrorlist.txt')


### PR DESCRIPTION
## What does this PR change?

Fix a regression introduced with https://github.com/uyuni-project/uyuni/pull/1967 .
Our new config values are defined in component `server.susemanager`. 
The yum plugin change this to `server.satellite` which prevent reposync later to find the
config value for AUTO_GENERATE_BOOTSTRAP_REPO .

Take care the value is set back to the original component.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **follow up on an earlier PR**

- [x] **DONE**

## Test coverage
- No tests: **already covered**

- [x] **DONE**

## Links

Follow up on https://github.com/uyuni-project/uyuni/pull/1967

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
