### PR TITLE
require to use postgresql 10 on SUSE

### DIFF
--- a/spacewalk/package/spacewalk.changes
+++ b/spacewalk/package/spacewalk.changes
@@ -1,3 +1,4 @@
+- explicitly require postgresql10 package
 - drop unused oracle subpackage
 
 -------------------------------------------------------------------

--- a/spacewalk/package/spacewalk.spec
+++ b/spacewalk/package/spacewalk.spec
@@ -44,7 +44,7 @@ Group:          Applications/Internet
 Obsoletes:      spacewalk < 0.7.0
 
 BuildRequires:  python
-Requires:       python >= 2.3
+Requires:       python >= 3
 Requires:       spacewalk-setup
 
 # Java

--- a/spacewalk/package/spacewalk.spec
+++ b/spacewalk/package/spacewalk.spec
@@ -19,7 +19,7 @@
 
 %define release_name Smile
 %if 0%{?suse_version}
-%global postgresql postgresql >= 8.4
+%global postgresql postgresql >= 10
 %else
 %global postgresql /usr/bin/psql
 %endif
@@ -125,15 +125,16 @@ Requires:       %{postgresql}
 Requires:       spacewalk-backend-sql-postgresql
 Requires:       spacewalk-java-postgresql
 Requires:       perl(DBD::Pg)
-%if 0%{?rhel} == 5
-Requires:       postgresql84-contrib
+%if 0%{?suse_version}
+Requires:       postgresql10
+Requires:       postgresql10-contrib
 %else
-Requires:       postgresql-contrib >= 8.4
-%endif
-Requires:       postgresql >= 9.6
+Requires:       postgresql >= 10
+Requires:       postgresql-contrib >= 10
 # we do not support postgresql versions > 10.x yet
 Conflicts:      postgresql >= 11
 Conflicts:      postgresql-contrib >= 11
+%endif
 
 %description postgresql
 Spacewalk is a systems management application that will 

--- a/spacewalk/package/spacewalk.spec
+++ b/spacewalk/package/spacewalk.spec
@@ -128,6 +128,8 @@ Requires:       perl(DBD::Pg)
 %if 0%{?suse_version}
 Requires:       postgresql10
 Requires:       postgresql10-contrib
+Conflicts:      postgresql12
+Conflicts:      postgresql12-contrib
 %else
 Requires:       postgresql >= 10
 Requires:       postgresql-contrib >= 10

--- a/spacewalk/package/spacewalk.spec
+++ b/spacewalk/package/spacewalk.spec
@@ -102,12 +102,8 @@ Requires:       jabberd-selinux
 Requires:       selinux-policy-base >= 3.7.19-93
 %endif
 
-%if 0%{?suse_version}
-Requires:       cobbler
+Requires:       cobbler >= 3
 Requires:       susemanager-jsp_en
-%else
-Requires:       cobbler20
-%endif
 
 %description common
 Spacewalk is a systems management application that will

--- a/spacewalk/package/spacewalk.spec
+++ b/spacewalk/package/spacewalk.spec
@@ -95,9 +95,6 @@ Requires:       spacewalk-selinux
 Obsoletes:      spacewalk-monitoring-selinux < 2.3
 %endif
 
-%if 0%{?rhel} == 5
-Requires:       jabberd-selinux
-%endif
 %if 0%{?rhel} == 6
 Requires:       selinux-policy-base >= 3.7.19-93
 %endif

--- a/spacewalk/package/spacewalk.spec
+++ b/spacewalk/package/spacewalk.spec
@@ -43,7 +43,7 @@ Summary:        Spacewalk Systems Management Application with postgresql databas
 Group:          Applications/Internet
 Obsoletes:      spacewalk < 0.7.0
 
-BuildRequires:  python
+BuildRequires:  python >= 3
 Requires:       python >= 3
 Requires:       spacewalk-setup
 


### PR DESCRIPTION
## What does this PR change?

For SUMA 4.1 Beta 2 we want to pin SUSE Manager to use postgresql 10 .
Version 12 will be available in the repos and we must prevent that they get installed.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **temp solution only**

- [x] **DONE**

## Test coverage
- No tests: **already covered**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/10920

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
