### PR TITLE
restore config component in downloader

### DIFF
--- a/backend/satellite_tools/download.py
+++ b/backend/satellite_tools/download.py
@@ -277,11 +277,15 @@ class DownloadThread(Thread):
 class ThreadedDownloader:
     def __init__(self, retries=3, log_obj=None, force=False):
         self.queues = {}
+        comp = CFG.getComponent()
         initCFG('server.satellite')
         try:
             self.threads = int(CFG.REPOSYNC_DOWNLOAD_THREADS)
         except ValueError:
+            initCFG(comp)
             raise ValueError("Number of threads expected, found: '%s'" % CFG.REPOSYNC_DOWNLOAD_THREADS)
+        else:
+            initCFG(comp)
         if self.threads < 1:
             raise ValueError("Invalid number of threads: %d" % self.threads)
         self.retries = retries


### PR DESCRIPTION
## What does this PR change?

Fix another regression of https://github.com/uyuni-project/uyuni/pull/1967

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **regression fix**

- [x] **DONE**

## Test coverage
- No tests: **already covered**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
