### PR TITLE
Configure tomcat ajp connector

### DIFF
--- a/spacewalk/setup/share/server.xml.xsl
+++ b/spacewalk/setup/share/server.xml.xsl
@@ -16,6 +16,7 @@
     <xsl:attribute name="address">127.0.0.1</xsl:attribute>
     <xsl:attribute name="maxThreads">150</xsl:attribute>
     <xsl:attribute name="connectionTimeout">20000</xsl:attribute>
+    <xsl:attribute name="secretRequired">false</xsl:attribute>
   </xsl:element>
   <xsl:if test="not(../Connector[@port='8009' and @address='::1'])">
   <xsl:copy-of select="preceding-sibling::node()[last()][self::text()]" />
@@ -25,6 +26,7 @@
     <xsl:attribute name="address">::1</xsl:attribute>
     <xsl:attribute name="maxThreads">150</xsl:attribute>
     <xsl:attribute name="connectionTimeout">20000</xsl:attribute>
+    <xsl:attribute name="secretRequired">false</xsl:attribute>
   </xsl:element>
   </xsl:if>
 </xsl:template>
@@ -36,7 +38,39 @@
     <xsl:attribute name="address">::1</xsl:attribute>
     <xsl:attribute name="maxThreads">150</xsl:attribute>
     <xsl:attribute name="connectionTimeout">20000</xsl:attribute>
+    <xsl:attribute name="secretRequired">false</xsl:attribute>
   </xsl:element>
+</xsl:template>
+
+<xsl:template match="/Server/Service[@name='Catalina'][not(Connector[@port='8009'])]">
+  <xsl:copy>
+    <xsl:apply-templates select="@*"/>
+    <xsl:text>
+    </xsl:text>
+    <xsl:element name="Connector">
+      <xsl:attribute name="port">8009</xsl:attribute>
+      <xsl:attribute name="protocol">AJP/1.3</xsl:attribute>
+      <xsl:attribute name="redirectPort">8443</xsl:attribute>
+      <xsl:attribute name="URIEncoding">UTF-8</xsl:attribute>
+      <xsl:attribute name="address">127.0.0.1</xsl:attribute>
+      <xsl:attribute name="maxThreads">150</xsl:attribute>
+      <xsl:attribute name="connectionTimeout">20000</xsl:attribute>
+      <xsl:attribute name="secretRequired">false</xsl:attribute>
+    </xsl:element>
+    <xsl:text>
+    </xsl:text>
+    <xsl:element name="Connector">
+      <xsl:attribute name="port">8009</xsl:attribute>
+      <xsl:attribute name="protocol">AJP/1.3</xsl:attribute>
+      <xsl:attribute name="redirectPort">8443</xsl:attribute>
+      <xsl:attribute name="URIEncoding">UTF-8</xsl:attribute>
+      <xsl:attribute name="address">::1</xsl:attribute>
+      <xsl:attribute name="maxThreads">150</xsl:attribute>
+      <xsl:attribute name="connectionTimeout">20000</xsl:attribute>
+      <xsl:attribute name="secretRequired">false</xsl:attribute>
+    </xsl:element>
+  <xsl:apply-templates select="node()"/>
+  </xsl:copy>
 </xsl:template>
 
 <xsl:template match="/Server/Service[@name='Catalina']/Connector[@port='8080']">

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,5 @@
+- create AJP connector for tomcat if it does not exist
+
 -------------------------------------------------------------------
 Mon Feb 17 12:51:58 CET 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

In new tomcat versions the AJP connector might be commented out.
Create it, if it does not exist.

Additionally set secretRequired to false

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **already covered**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
