### PR TITLE
Add Springdale Linux

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -229,6 +229,75 @@ gpgkey_id = 2F86D6A1
 gpgkey_fingerprint = 94E2 79EB 8D8F 25B2 1810 ADF1 21EA 45AB 2F86 D6A1
 repo_url = http://mirrors.fedoraproject.org/mirrorlist?repo=epel-8&arch=%(arch)s
 
+[sdl8]
+archs    = x86_64
+name     = Springdale Linux 8 BaseOS (%(arch)s)
+gpgkey_url = http://springdale.princeton.edu/data/springdale/7/%(arch)s/os/RPM-GPG-KEY-springdale
+gpgkey_id = 41A40948
+gpgkey_fingerprint = 2266 6129 E0CD 0062 8D44 C6CF 16CF C333 41A4 094
+repo_url = http://springdale.princeton.edu/data/springdale/8/%(arch)s/os/BaseOS/mirrorlist
+dist_map_release = 8
+
+[sdl8-updates]
+label    = %(base_channel)s-updates
+archs    = x86_64
+name     = Springdale Linux 8 BaseOS Updates (%(arch)s)
+base_channels = sdl8-%(arch)s
+repo_url = http://springdale.princeton.edu/data/springdale/8/%(arch)s/os/Updates_BaseOS/mirrorlist
+
+[sdl8-appstream]
+label    = %(base_channel)s-appstream
+archs    = x86_64
+name     = Springdale Linux 8 AppStream (%(arch)s)
+base_channels = sdl8-%(arch)s
+repo_url = http://springdale.princeton.edu/data/springdale/8/%(arch)s/os/AppStream/mirrorlist
+
+[sdl8-appstream-updates]
+label    = %(base_channel)s-appstream-updates
+archs    = x86_64
+name     = Springdale Linux 8 AppStream Updates (%(arch)s)
+base_channels = sdl8-%(arch)s
+repo_url = http://springdale.princeton.edu/data/springdale/8/%(arch)s/os/Updates_AppStream/mirrorlist
+
+[sdl8-unsupported]
+label    = %(base_channel)s-unsupported
+archs    = x86_64
+name     = Springdale Linux 8 Unsupported (%(arch)s)
+base_channels = sdl8-%(arch)s
+repo_url = http://springdale.princeton.edu/data/puias/unsupported/8/%(arch)s/mirrorlist
+
+[sdl8-computational]
+label    = %(base_channel)s-computational
+archs    = x86_64
+name     = Springdale Linux 8 Computational (%(arch)s)
+base_channels = sdl8-%(arch)s
+repo_url = http://springdale.princeton.edu/data/puias/computational/8/%(arch)s/mirrorlist
+
+[sdl8-buildsys]
+label    = %(base_channel)s-buildsys
+archs    = x86_64
+name     = Springdale Linux 8 Build System (%(arch)s)
+base_channels = sdl8-%(arch)s
+repo_url = http://springdale.princeton.edu/data/puias/buildsys/8/os/%(arch)s/
+
+[sdl8-uyuni-client]
+name     = Uyuni Client Tools for %(base_channel_name)s
+archs    = %(_x86_archs)s
+base_channels = sdl8-%(arch)s
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8/
+
+[sdl8-uyuni-client-devel]
+name     = Uyuni Client Tools for %(base_channel_name)s (Development)
+archs    = %(_x86_archs)s
+base_channels = sdl8-%(arch)s
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS8-Uyuni-Client-Tools/CentOS_8/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS8-Uyuni-Client-Tools/CentOS_8/
+
 [centos7]
 archs    = x86_64
 name     = CentOS 7 (%(arch)s)
@@ -357,6 +426,89 @@ gpgkey_id = 352C64E5
 gpgkey_fingerprint = 91E9 7D7C 4A5E 96F1 7F3E  888F 6A2F AEA2 352C 64E5
 repo_url = http://mirrors.fedoraproject.org/mirrorlist?repo=epel-7&arch=%(arch)s
 
+[sdl7]
+archs    = %(_x86_archs)s
+name     = Springdale Linux 7 (%(arch)s)
+gpgkey_url = http://springdale.princeton.edu/data/springdale/7/%(arch)s/os/RPM-GPG-KEY-springdale
+gpgkey_id = 41A40948
+gpgkey_fingerprint = 2266 6129 E0CD 0062 8D44 C6CF 16CF C333 41A4 0948
+repo_url = http://springdale.princeton.edu/data/springdale/7/%(arch)s/os/mirrorlist
+dist_map_release = 7
+
+[sdl7-updates]
+label    = %(base_channel)s-updates
+archs    = %(_x86_archs)s
+name     = Springdale Linux 7 Updates (%(arch)s)
+base_channels = sdl7-%(arch)s
+repo_url = http://springdale.princeton.edu/data/springdale/updates/7/en/os/%(arch)s/mirrorlist
+
+[sdl7-addons]
+label    = %(base_channel)s-addons
+archs    = %(_x86_archs)s
+name     = Springdale Linux 7 Addons (%(arch)s)
+base_channels = sdl7-%(arch)s
+repo_url = http://springdale.princeton.edu/data/springdale/7/%(arch)s/os/Addons/mirrorlist
+
+[sdl7-addons-updates]
+label    = %(base_channel)s-addons-updates
+archs    = %(_x86_archs)s
+name     = Springdale Linux 7 Addons Updates (%(arch)s)
+base_channels = sdl7-addons-%(arch)s
+repo_url = http://springdale.princeton.edu/data/springdale/updates/7/en/Addons/%(arch)s/mirrorlist
+
+[sdl7-unsupported]
+label    = %(base_channel)s-unsupported
+archs    = %(_x86_archs)s
+name     = Springdale Linux 7 Unsupported (%(arch)s)
+base_channels = sdl7-%(arch)s
+repo_url = http://springdale.princeton.edu/data/springdale/unsupported/7/%(arch)s/mirrorlist
+
+[sdl7-computational]
+label    = %(base_channel)s-computational
+archs    = %(_x86_archs)s
+name     = Springdale Linux 7 Computational (%(arch)s)
+base_channels = sdl7-%(arch)s
+repo_url = http://springdale.princeton.edu/data/springdale/computational/7/%(arch)s/mirrorlist
+
+[sdl7-storage]
+label    = %(base_channel)s-storage
+archs    = %(_x86_archs)s
+name     = Springdale Linux 7 Storage (%(arch)s)
+base_channels = sdl7-%(arch)s
+repo_url = http://springdale.princeton.edu/data/springdale/storage/7/%(arch)s/mirrorlist
+
+[sdl7-scl]
+label    = %(base_channel)s-scl
+archs    = %(_x86_archs)s
+name     = Springdale Linux 7 Software Collections (%(arch)s)
+base_channels = sdl7-%(arch)s
+repo_url = http://springdale.princeton.edu/data/springdale/SCL/7/%(arch)s/
+
+[sdl7-buildsys]
+label    = %(base_channel)s-buildsys
+archs    = %(_x86_archs)s
+name     = Springdale Linux 7 Build System (%(arch)s)
+base_channels = sdl7-%(arch)s
+repo_url = http://springdale.princeton.edu/data/springdale/buildsys/7/os/%(arch)s/mirrorlist
+
+[sdl7-uyuni-client]
+name     = Uyuni Client Tools for %(base_channel_name)s
+archs    = %(_x86_archs)s
+base_channels = sdl7-%(arch)s
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7/
+
+[sdl7-uyuni-client-devel]
+name     = Uyuni Client Tools for %(base_channel_name)s (Development)
+archs    = %(_x86_archs)s
+base_channels = sdl7-%(arch)s
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS7-Uyuni-Client-Tools/CentOS_7/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS7-Uyuni-Client-Tools/CentOS_7/
+
 [scientific6]
 archs    = %(_x86_archs)s
 name     = Scientific Linux 6 (%(arch)s)
@@ -451,6 +603,117 @@ gpgkey_url = http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6
 gpgkey_id = 0608B895
 gpgkey_fingerprint = 8C3B E96A F230 9184 DA5C  0DAE 3B49 DF2A 0608 B895
 repo_url = http://mirrors.fedoraproject.org/mirrorlist?repo=epel-6&arch=%(arch)s
+
+[sdl6]
+archs    = %(_x86_archs)s
+name     = Springdale Linux 6 (%(arch)s)
+gpgkey_url = http://springdale.sprinceton.edu/data/puias/6/%(arch)s/os/RPM-GPG-KEY-puias
+gpgkey_id = 41A40948
+gpgkey_fingerprint = 2266 6129 E0CD 0062 8D44 C6CF 16CF C333 41A4 0948
+repo_url = http://puias.sprinceton.edu/data/puias/6/%(arch)s/os/mirrorlist
+dist_map_release = 6
+
+[sdl6-updates]
+label    = %(base_channel)s-updates
+archs    = %(_x86_archs)s
+name     = Springdale Linux 6 Updates (%(arch)s)
+base_channels = sdl6-%(arch)s
+repo_url = http://springdale.princeton.edu/data/puias/updates/6/en/os/%(arch)s/mirrorlist
+
+[sdl6-addons]
+label    = %(base_channel)s-addons
+archs    = %(_x86_archs)s
+name     = Springdale Linux 6 Addons (%(arch)s)
+base_channels = sdl6-%(arch)s
+repo_url = http://springdale.princeton.edu/data/puias/6/%(arch)s/os/Addons/mirrorlist
+
+[sdl6-addons-updates]
+label    = %(base_channel)s-addons-updates
+archs    = %(_x86_archs)s
+name     = Springdale Linux 6 Addons Updates (%(arch)s)
+base_channels = sdl6-addons-%(arch)s
+repo_url = http://springdale.princeton.edu/data/puias/6/%(arch)s/os/Addons/mirrorlist
+
+[sdl6-unsupported]
+label    = %(base_channel)s-unsupported
+archs    = %(_x86_archs)s
+name     = Springdale Linux 6 Unsupported (%(arch)s)
+base_channels = sdl6-%(arch)s
+repo_url = http://springdale.princeton.edu/data/puias/unsupported/6/%(arch)s/mirrorlist
+
+[sdl6-computational]
+label    = %(base_channel)s-computational
+archs    = %(_x86_archs)s
+name     = Springdale Linux 6 Computational (%(arch)s)
+base_channels = sdl6-%(arch)s
+repo_url = http://springdale.princeton.edu/data/puias/computational/6/%(arch)s/mirrorlist
+
+[sdl6-ssa]
+label    = %(base_channel)s-computational
+archs    = %(_x86_archs)s
+name     = Springdale Linux 6 SSA (%(arch)s)
+base_channels = sdl6-%(arch)s
+repo_url = http://springdale.princeton.edu/data/springdale/SSA/6/%(arch)s/
+
+[sdl6-scl]
+label    = %(base_channel)s-computational
+archs    = %(_x86_archs)s
+name     = Springdale Linux 6 Software Collections (%(arch)s)
+base_channels = sdl6-%(arch)s
+repo_url = http://springdale.princeton.edu/data/springdale/SCL/6/%(arch)s/
+
+[sdl6-rhs]
+label    = %(base_channel)s-rhs
+archs    = %(_x86_archs)s
+name     = Springdale Linux 6 RHS (%(arch)s)
+base_channels = sdl6-%(arch)s
+repo_url = http://springdale.princeton.edu/data/springdale/RHS/6/%(arch)s/
+
+[sdl6-ose]
+label    = %(base_channel)s-ose
+archs    = %(_x86_archs)s
+name     = Springdale Linux 6 OSE (%(arch)s)
+base_channels = sdl6-%(arch)s
+repo_url = http://springdale.princeton.edu/data/springdale/OSE/6/%(arch)s/
+
+[sdl6-devtoolset]
+label    = %(base_channel)s-devtoolset
+archs    = %(_x86_archs)s
+name     = Springdale Linux 6 DevToolSet (%(arch)s)
+base_channels = sdl6-%(arch)s
+repo_url = http://springdale.princeton.edu/data/springdale/DevToolset/6/%(arch)s/mirrorlist
+
+[sdl6-common]
+label    = %(base_channel)s-common
+archs    = %(_x86_archs)s
+name     = Springdale Linux 6 COMMON (%(arch)s)
+base_channels = sdl6-%(arch)s
+repo_url = http://springdale.princeton.edu/data/springdale/COMMON/6/%(arch)s/
+
+[sdl6-buildsys]
+label    = %(base_channel)s-buildsys
+archs    = %(_x86_archs)s
+name     = Springdale Linux 6 buildsys (%(arch)s)
+base_channels = sdl6-%(arch)s
+repo_url = http://springdale.princeton.edu/data/springdale/buildsys/6/os/%(arch)s/
+
+[sdl6-uyuni-client]
+name     = Uyuni Client Tools for %(base_channel_name)s
+archs    = %(_x86_archs)s
+base_channels = sdl6-%(arch)s
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS6-Uyuni-Client-Tools/CentOS_6/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS6-Uyuni-Client-Tools/CentOS_6/
+
+[sdl6-uyuni-client-devel]
+name     = Uyuni Client Tools for %(base_channel_name)s (Development)
+archs    = %(_x86_archs)s
+base_channels = sdl6-%(arch)s
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS6-Uyuni-Client-Tools/CentOS_6/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS6-Uyuni-Client-Tools/CentOS_6/
 
 [spacewalk28-client-scientific6]
 name     = Spacewalk Client 2.8 for %(base_channel_name)s

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,5 @@
+- Add Springdale Linux 6, 7 and 8 repositories
+
 -------------------------------------------------------------------
 Mon Feb 17 12:52:28 CET 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Add [Springdale Linux](http://springdale.princeton.edu/) 6, 7 and 8 to `spacewalk-common-channels`.

Springdale Linux is a RHEL clone which sticks to a single `modules.yaml` file, like RHEL does.

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: OSs in spacewalk-common channels are no listed or discussed in the docs

- [x] **DONE**

## Test coverage
- No tests: new entries in spacewalk-common channels do not need a test, OSs do need a test, if we deem them important enough (SDL is not at this point in time)
- Unit tests were added: no, see above
- Cucumber tests were added: no, see above

- [x] **DONE**

## Links

Fixes # => N/A, no bug
Tracks # => N/A

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
