### PR TITLE
Manager bsc1165921

### DIFF
--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes
@@ -1,3 +1,5 @@
+- add workaround for uptime overflow to spacewalk-update-status as well (bsc#1165921)
+
 -------------------------------------------------------------------
 Mon Feb 17 12:49:18 CET 2020 - jgonzalez@suse.com
 

--- a/client/rhel/spacewalk-client-tools/src/bin/spacewalk-update-status.py
+++ b/client/rhel/spacewalk-client-tools/src/bin/spacewalk-update-status.py
@@ -44,6 +44,10 @@ class StatusCli(rhncli.RhnCli):
             except:
                 pass
 
+        # We need to fit into xmlrpc's integer limits
+        if status_report['uptime'][1] > long(2)**31-1:
+            status_report['uptime'][1] = -1
+
         return status_report
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What does this PR change?

add workaround for uptime overflow to spacewalk-update-status as well (bsc#1165921)

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: bugfix

- [X] **DONE**

## Test coverage
- No tests: Needs a server with extreme uptime to trigger

- [X]

## Links

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1165921

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed