### PR TITLE
tftpsync: fix compat issues with Python3 at MultipartPostHandler and wsgi scripts (bsc#1164111)

### DIFF
--- a/tftpsync/susemanager-tftpsync-recv/delete.wsgi
+++ b/tftpsync/susemanager-tftpsync-recv/delete.wsgi
@@ -16,7 +16,10 @@ import os
 import re
 import logging
 import logging.handlers
-import urlparse
+try:
+    import urlparse
+except:
+    from urllib import parse as urlparse
 from spacewalk.common.rhnConfig import CFG, initCFG
 
 initCFG("tftpsync")
@@ -81,7 +84,7 @@ def application(environ, start_response):
                 os.remove(path)
                 status = '200 OK'
                 content = "removing file '%s', status: %s" % (path, status)
-            except Exception, e:
+            except Exception as e:
                 logger.debug("os.remove(%s) failed: %s" % (path, e))
                 content = "removing %s failed" % path
         else:
@@ -93,6 +96,6 @@ def application(environ, start_response):
                         ('Content-Length', str(len(content)))]
     start_response(status, response_headers)
 
-    return [content]
+    return [content.encode()]
 
 

--- a/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.changes
+++ b/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.changes
@@ -1,3 +1,5 @@
+- Make wsgi scripts compatible with Python3 (bsc#1164111)
+
 -------------------------------------------------------------------
 Wed Nov 27 16:53:45 CET 2019 - jgonzalez@suse.com
 

--- a/tftpsync/susemanager-tftpsync/MultipartPostHandler.py
+++ b/tftpsync/susemanager-tftpsync/MultipartPostHandler.py
@@ -63,7 +63,10 @@ class MultipartPostHandler(BaseHandler):
     handler_order = HTTPHandler.handler_order - 10 # needs to run first
 
     def http_request(self, request):
-        data = request.get_data()
+        try:
+            data = request.get_data()
+        except:
+            data = request.data
         if data is not None and type(data) != str:
             v_files = []
             v_vars = []

--- a/tftpsync/susemanager-tftpsync/MultipartPostHandler.py
+++ b/tftpsync/susemanager-tftpsync/MultipartPostHandler.py
@@ -41,9 +41,12 @@ Further Example:
 try:
     from urllib.parse import urlencode
     from urllib.request import build_opener, HTTPHandler, BaseHandler
+    from io import IOBase as file
+    from io import BytesIO as StringIO
 except ImportError:
     from urllib import urlencode
     from urllib2 import build_opener, HTTPHandler, BaseHandler
+    from cStringIO import StringIO
 
 import re
 import random
@@ -53,7 +56,10 @@ import sys
 
 class Callable:
     def __init__(self, anycallable):
-        self.__call__ = anycallable
+        self.call = anycallable
+
+    def __call__(self, *args, **kwargs):
+        return self.call(*args, **kwargs)
 
 # Controls how sequences are uncoded. If true, elements may be given multiple values by
 #  assigning a sequence.
@@ -72,7 +78,7 @@ class MultipartPostHandler(BaseHandler):
             v_vars = []
             try:
                 for(key, value) in list(data.items()):
-                    if type(value) == file:
+                    if isinstance(value, file):
                         v_files.append((key, value))
                     else:
                         v_vars.append((key, value))
@@ -91,29 +97,32 @@ class MultipartPostHandler(BaseHandler):
                     print("Replacing %s with %s" % (request.get_header('content-type'), 'multipart/form-data'))
                 request.add_unredirected_header('Content-Type', contenttype)
 
-            request.add_data(data)
+            try:
+                request.add_data(data)
+            except:
+                request.data = data
         return request
 
     def multipart_encode(vars, files, boundary=None, buffer=None):
         if boundary is None:
             boundary = _make_boundary()
         if buffer is None:
-            buffer = ''
+            buffer = b''
         for(key, value) in vars:
-            buffer += '--%s\r\n' % boundary
-            buffer += 'Content-Disposition: form-data; name="%s"' % key
-            buffer += '\r\n\r\n' + value + '\r\n'
+            buffer += ('--%s\r\n' % boundary).encode()
+            buffer += ('Content-Disposition: form-data; name="%s"' % key).encode()
+            buffer += ('\r\n\r\n' + value + '\r\n').encode()
         for(key, fd) in files:
             file_size = os.fstat(fd.fileno())[stat.ST_SIZE]
             filename = fd.name.split('/')[-1]
             contenttype = mimetypes.guess_type(filename)[0] or 'application/octet-stream'
-            buffer += '--%s\r\n' % boundary
-            buffer += 'Content-Disposition: form-data; name="%s"; filename="%s"\r\n' % (key, filename)
-            buffer += 'Content-Type: %s\r\n' % contenttype
+            buffer += ('--%s\r\n' % boundary).encode()
+            buffer += ('Content-Disposition: form-data; name="%s"; filename="%s"\r\n' % (key, filename)).encode()
+            buffer += ('Content-Type: %s\r\n' % contenttype).encode()
             # buffer += 'Content-Length: %s\r\n' % file_size
             fd.seek(0)
-            buffer += '\r\n' + fd.read() + '\r\n'
-        buffer += '--%s--\r\n\r\n' % boundary
+            buffer += ('\r\n').encode() + fd.read() + ('\r\n').encode()
+        buffer += ('--%s--\r\n\r\n' % boundary).encode()
         return boundary, buffer
     multipart_encode = Callable(multipart_encode)
 

--- a/tftpsync/susemanager-tftpsync/susemanager-tftpsync.changes
+++ b/tftpsync/susemanager-tftpsync/susemanager-tftpsync.changes
@@ -1,3 +1,5 @@
+- Use alternative method for deprecated 'Request.get_data' (bsc#1164111)
+
 -------------------------------------------------------------------
 Wed Nov 27 17:09:22 CET 2019 - jgonzalez@suse.com
 

--- a/tftpsync/susemanager-tftpsync/susemanager-tftpsync.changes
+++ b/tftpsync/susemanager-tftpsync/susemanager-tftpsync.changes
@@ -1,3 +1,4 @@
+- Fix few compat issues with Python3 at MultipartPostHandler
 - Use alternative method for deprecated 'Request.get_data' (bsc#1164111)
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

This PR fixes some issues at `susemanager-tftpsync` and `susemanager-tftpsync-recv` package due Python 3 compatibility:

- Wrong handling of binary content (string and files).
- Deprecation of `Request.get_data` and `Request.add_data` methods.
- Fix callable magic for `Callable` class.
- Syntax error due exceptions and import errors.

After this PR, the `susemanager-tftpsync` is able to sync with proxy instances running with Python 3 and also with old instances which are still running with Python 2.

## GUI diff

No difference.

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **tftpsync is not being automatically tested**

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/1200
Tracks https://github.com/SUSE/spacewalk/issues/10877

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
