### PR TITLE
Adapt "mgractionchains" module to work with Salt 3000

### DIFF
--- a/susemanager-utils/susemanager-sls/src/modules/mgractionchains.py
+++ b/susemanager-utils/susemanager-sls/src/modules/mgractionchains.py
@@ -10,8 +10,13 @@ import os
 import sys
 import salt.config
 import salt.syspaths
-import salt.utils
 import yaml
+
+# Prevent issues due 'salt.utils.fopen' deprecation
+try:
+    from salt.utils import fopen
+except:
+    from salt.utils.files import fopen
 
 from salt.exceptions import CommandExecutionError
 
@@ -61,7 +66,7 @@ def _read_next_ac_chunk(clear=True):
         return None
     ret = None
     try:
-        with salt.utils.fopen(f_storage_filename, "r") as f_storage:
+        with fopen(f_storage_filename, "r") as f_storage:
             ret = yaml.load(f_storage.read())
         if clear:
             os.remove(f_storage_filename)
@@ -88,7 +93,7 @@ def _persist_next_ac_chunk(next_chunk):
         f_storage_dir = os.path.dirname(f_storage_filename);
         if not os.path.exists(f_storage_dir):
             os.makedirs(f_storage_dir)
-        with salt.utils.fopen(f_storage_filename, "w") as f_storage:
+        with fopen(f_storage_filename, "w") as f_storage:
             f_storage.write(yaml.dump(next_chunk))
     except (IOError, yaml.scanner.ScannerError) as exc:
         err_str = "Error writing YAML from '{0}': {1}".format(f_storage_filename, exc)

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- Adapt 'mgractionchains' module to work with Salt 3000
+
 -------------------------------------------------------------------
 Wed Mar 11 11:03:06 CET 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue in custom `mgractionchains` module of Salt that is caused due the deprecation of `salt.utils.fopen` in the new Salt 3000 (Neon), where this method has been moved to `salt.utils.files.fopen`.

The changes on this PR makes the `mgractionchains` module to work in both cases.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **tested on cucumber**
- [x] **DONE**

## Links


- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
