### PR TITLE
Formual tab rename

### DIFF
--- a/web/html/src/manager/minion/formula/minion-formula-selection.renderer.js
+++ b/web/html/src/manager/minion/formula/minion-formula-selection.renderer.js
@@ -53,7 +53,7 @@ export const renderer = (renderId, {serverId, warningMessage}) => {
     $("#formula-nav-bar").remove();
 
     var navBar = "<ul class='nav nav-tabs nav-tabs-pf' id='formula-nav-bar'>\n"
-    navBar += "<li class='active'><a href='/rhn/manager/systems/details/formulas?sid=" + serverId + "'>" + t("Formulas") + "</a></li>\n";
+    navBar += "<li class='active'><a href='/rhn/manager/systems/details/formulas?sid=" + serverId + "'><i class='fa fa-pencil-square-o'></i>" + t("Configuration") + "</a></li>\n";
     for (var i in formulaList)
       navBar += "<li><a href='/rhn/manager/systems/details/formula/" + i + "?sid=" + serverId + "'>" + capitalize(formulaList[i]) + "</a></li>\n";
     navBar += "</ul>"

--- a/web/html/src/manager/minion/formula/minion-formula.renderer.js
+++ b/web/html/src/manager/minion/formula/minion-formula.renderer.js
@@ -25,7 +25,7 @@ export const renderer = (renderId, {serverId, formulaId}) => {
     $("#formula-nav-bar").remove();
 
     var navBar = "<ul class='nav nav-tabs nav-tabs-pf' id='formula-nav-bar'>\n"
-    navBar += "<li><a href='/rhn/manager/systems/details/formulas?sid=" + serverId + "'>" + t("Formulas") + "</a></li>\n";
+    navBar += "<li><a href='/rhn/manager/systems/details/formulas?sid=" + serverId + "'><i class='fa fa-pencil-square-o'></i>" + t("Configuration") + "</a></li>\n";
     for (var i in formulaList)
       navBar += "<li" + (i == activeId ? " class='active'>" : ">") + "<a href='/rhn/manager/systems/details/formula/" + i + "?sid=" + serverId + "'>" + capitalize(formulaList[i]) + "</a></li>\n";
     navBar += "</ul>"

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- Rename Formula tab to Configuration
+
 -------------------------------------------------------------------
 Wed Mar 11 10:59:39 CET 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?
This changes the Formula tab text to Configuration 

## GUI diff

No difference.

Before:
![formula_tab_before](https://user-images.githubusercontent.com/729087/76623333-9376df00-6533-11ea-8947-16dcfe18f275.png)

After:
![formula_tab_after](https://user-images.githubusercontent.com/729087/76623352-9bcf1a00-6533-11ea-80c1-36bcf20f977a.png)

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests:   I don't think we need to change the cucumber tests

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
