### PR TITLE
Enable monitoring for ppc64le and aarch64 (bsc#1166613)

### DIFF
--- a/schema/spacewalk/common/data/rhnServerServerGroupArchCompat.sql
+++ b/schema/spacewalk/common/data/rhnServerServerGroupArchCompat.sql
@@ -851,4 +851,12 @@ insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type)
     values (lookup_server_arch('amd64-debian-linux'),
             lookup_sg_type('monitoring_entitled'));
 
+insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type)
+    values (lookup_server_arch('ppc64le-redhat-linux'),
+            lookup_sg_type('monitoring_entitled'));
+
+insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type)
+    values (lookup_server_arch('aarch64-redhat-linux'),
+            lookup_sg_type('monitoring_entitled'));
+
 commit;

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,5 @@
+- Enable monitoring for ppc64le and aarch64 (bsc#1166613)
+
 -------------------------------------------------------------------
 Wed Mar 11 11:02:33 CET 2020 - jgonzalez@suse.com
 

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.4-to-susemanager-schema-4.1.5/002-monitoring-ppc64le-aarch64.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.4-to-susemanager-schema-4.1.5/002-monitoring-ppc64le-aarch64.sql
@@ -1,0 +1,17 @@
+insert into rhnServerServerGroupArchCompat (server_arch_id, server_group_type)
+    select lookup_server_arch('ppc64le-redhat-linux'),
+            lookup_sg_type('monitoring_entitled')
+    from dual where not exists (
+        select 1 from rhnServerServerGroupArchCompat where
+        server_arch_id=lookup_server_arch('ppc64le-redhat-linux') and
+        server_group_type=lookup_sg_type('monitoring_entitled')
+    );
+
+insert into rhnServerServerGroupArchCompat (server_arch_id, server_group_type)
+    select lookup_server_arch('aarch64-redhat-linux'),
+            lookup_sg_type('monitoring_entitled')
+    from dual where not exists (
+        select 1 from rhnServerServerGroupArchCompat where
+        server_arch_id=lookup_server_arch('aarch64-redhat-linux') and
+        server_group_type=lookup_sg_type('monitoring_entitled')
+    );


### PR DESCRIPTION
## What does this PR change?

This patch enables the monitoring entitlement to be used for `ppc64le` and `aarch64` systems. This was previously untested and therefore not enabled.

## GUI diff

No difference.

- [X] **DONE**

## Documentation

- No documentation needed, we don't specify architectures in the docs AFAIK.

- [X] **DONE**

## Test coverage

- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/10989.

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
