### PR TITLE
Recurring Actions XMLRPC API

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/HandlerFactory.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/HandlerFactory.java
@@ -49,6 +49,7 @@ import com.redhat.rhn.frontend.xmlrpc.packages.provider.PackagesProviderHandler;
 import com.redhat.rhn.frontend.xmlrpc.packages.search.PackagesSearchHandler;
 import com.redhat.rhn.frontend.xmlrpc.preferences.locale.PreferencesLocaleHandler;
 import com.redhat.rhn.frontend.xmlrpc.proxy.ProxyHandler;
+import com.redhat.rhn.frontend.xmlrpc.recurringaction.RecurringActionHandler;
 import com.redhat.rhn.frontend.xmlrpc.satellite.SatelliteHandler;
 import com.redhat.rhn.frontend.xmlrpc.schedule.ScheduleHandler;
 import com.redhat.rhn.frontend.xmlrpc.subscriptionmatching.PinnedSubscriptionHandler;
@@ -139,6 +140,7 @@ public class HandlerFactory {
         factory.addHandler("packages.search", new PackagesSearchHandler());
         factory.addHandler("preferences.locale", new PreferencesLocaleHandler());
         factory.addHandler("proxy", new ProxyHandler());
+        factory.addHandler("recurringaction", new RecurringActionHandler());
         factory.addHandler("satellite", new SatelliteHandler());
         factory.addHandler("schedule", new ScheduleHandler());
         factory.addHandler("subscriptionmatching.pinnedsubscription", new PinnedSubscriptionHandler());

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/recurringaction/RecurringActionHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/recurringaction/RecurringActionHandler.java
@@ -128,7 +128,7 @@ public class RecurringActionHandler extends BaseHandler {
      *  #struct_end()
      * @xmlrpc.returntype The id of the recurring action
      */
-    public Long create(User loggedInUser, Map<String, Object> actionProps) {
+    public int create(User loggedInUser, Map<String, Object> actionProps) {
         RecurringAction action = createAction(actionProps, loggedInUser);
         return save(loggedInUser, action);
     }
@@ -178,7 +178,7 @@ public class RecurringActionHandler extends BaseHandler {
      *  #struct_end()
      * @xmlrpc.returntype The id of the recurring action
      */
-    public Long update(User loggedInUser, Map<String, Object> actionProps) {
+    public int update(User loggedInUser, Map<String, Object> actionProps) {
         RecurringAction action = updateAction(actionProps, loggedInUser);
         return save(loggedInUser, action);
     }
@@ -206,9 +206,11 @@ public class RecurringActionHandler extends BaseHandler {
     }
 
     /* Helper method */
-    private Long save(User loggedInUser, RecurringAction action) {
+    private int save(User loggedInUser, RecurringAction action) {
         try {
-            RecurringActionManager.saveAndSchedule(action, loggedInUser);
+            RecurringAction saved = RecurringActionManager.saveAndSchedule(action, loggedInUser);
+            // let's throw an exeption on integer overflow
+            return Math.toIntExact(saved.getId());
         }
         catch (ValidatorException e) {
             throw new ValidationException(e.getMessage());
@@ -216,7 +218,6 @@ public class RecurringActionHandler extends BaseHandler {
         catch (com.redhat.rhn.taskomatic.TaskomaticApiException e) {
             throw new TaskomaticApiException(e.getMessage());
         }
-        return action.getId();
     }
 
     /**
@@ -231,7 +232,7 @@ public class RecurringActionHandler extends BaseHandler {
      * @xmlrpc.param #param_desc("int", "actionId", "Id of the action")
      * @xmlrpc.returntype The id of the recurring action
      */
-    public Long delete(User loggedInUser, Integer actionId) {
+    public int delete(User loggedInUser, Integer actionId) {
         RecurringAction action = lookupById(loggedInUser, actionId);
         try {
             RecurringActionManager.deleteAndUnschedule(action, loggedInUser);
@@ -239,6 +240,6 @@ public class RecurringActionHandler extends BaseHandler {
         catch (com.redhat.rhn.taskomatic.TaskomaticApiException e) {
             throw new TaskomaticApiException(e.getMessage());
         }
-        return Long.valueOf(actionId);
+        return actionId;
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/recurringaction/RecurringActionHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/recurringaction/RecurringActionHandler.java
@@ -15,6 +15,72 @@
 
 package com.redhat.rhn.frontend.xmlrpc.recurringaction;
 
+import com.redhat.rhn.common.security.PermissionException;
+import com.redhat.rhn.domain.recurringactions.RecurringAction;
+import com.redhat.rhn.domain.recurringactions.RecurringActionFactory;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.xmlrpc.BaseHandler;
+import com.redhat.rhn.frontend.xmlrpc.EntityExistsFaultException;
+import com.redhat.rhn.frontend.xmlrpc.EntityNotExistsFaultException;
+import com.redhat.rhn.frontend.xmlrpc.InvalidArgsException;
+import com.redhat.rhn.frontend.xmlrpc.TaskomaticApiException;
+import com.redhat.rhn.manager.EntityExistsException;
+import com.redhat.rhn.manager.recurringactions.RecurringActionManager;
+
+import org.hibernate.HibernateException;
+
+import java.util.List;
+import java.util.Map;
+
 public class RecurringActionHandler extends BaseHandler {
 
+    /* helper method */
+    private RecurringAction.Type getEntityType(String entityType) {
+        try {
+            return RecurringAction.Type.valueOf(entityType.toUpperCase());
+        }
+        catch (IllegalArgumentException e) {
+            throw new InvalidArgsException("Type \"" + entityType + "\" does not exist");
+        }
+    }
+
+    /**
+     * Return a list of recurring actions for a given entity.
+     *
+     * @param loggedInUser The current user
+     * @param entityId the id of the entity
+     * @param entityType type of the entity
+     * @return the list of recurring actions
+     *
+     * @xmlrpc.doc Return a list of recurring actions for a given entity.
+     * @xmlrpc.param #session_key()
+     * @xmlrpc.param #param_desc("string", "entityType", "Type of the target entity")
+     * @xmlrpc.param #param_desc("int", "entityId", "Id of the target entity")
+     * @xmlrpc.returntype
+     *      #array()
+     *          $RecurringActionSerializer
+     *      #array_end()
+     */
+    public List<? extends RecurringAction> listByEntity(User loggedInUser, String entityType, Integer entityId) {
+        List<? extends RecurringAction> schedules;
+        try {
+            switch (getEntityType(entityType)) {
+                case MINION:
+                    schedules = RecurringActionManager.listMinionRecurringActions(entityId, loggedInUser);
+                    break;
+                case GROUP:
+                    schedules = RecurringActionManager.listGroupRecurringActions(entityId, loggedInUser);
+                    break;
+                case ORG:
+                    schedules = RecurringActionManager.listOrgRecurringActions(entityId, loggedInUser);
+                    break;
+                default:
+                    throw new IllegalStateException("Unsupported type " + entityType);
+            }
+            return schedules;
+        }
+        catch (PermissionException e) {
+            throw new PermissionCheckFailureException(e.getMessage());
+        }
+    }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/recurringaction/RecurringActionHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/recurringaction/RecurringActionHandler.java
@@ -34,6 +34,9 @@ import java.util.Map;
 
 /**
  * Handler for Recurring Actions ({@link RecurringAction})
+
+ * @xmlrpc.namespace recurringaction
+ * @xmlrpc.doc Provides methods to handle Recurring Actions for Minions, Groups and Organizations.
  */
 public class RecurringActionHandler extends BaseHandler {
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/recurringaction/RecurringActionHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/recurringaction/RecurringActionHandler.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.frontend.xmlrpc.recurringaction;
+
+public class RecurringActionHandler extends BaseHandler {
+
+}

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/recurringaction/RecurringActionHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/recurringaction/RecurringActionHandler.java
@@ -189,6 +189,8 @@ public class RecurringActionHandler extends BaseHandler {
             throw new InvalidArgsException("No action id provided");
         }
         RecurringAction action = lookupById(user, ((Integer) actionProps.get("id")));
+        // detach the object and prevent hibernate from auto flushing when fields become dirty
+        RecurringActionFactory.getSession().evict(action);
 
         if (actionProps.containsKey("name")) {
             action.setName((String) actionProps.get("name"));
@@ -202,7 +204,8 @@ public class RecurringActionHandler extends BaseHandler {
         if (actionProps.containsKey("active")) {
             action.setActive(Boolean.parseBoolean(actionProps.get("active").toString()));
         }
-        return action;
+
+        return action; // return "detached" action
     }
 
     /* Helper method */

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/recurringaction/RecurringActionHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/recurringaction/RecurringActionHandler.java
@@ -32,6 +32,9 @@ import com.redhat.rhn.manager.recurringactions.RecurringActionManager;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Handler for Recurring Actions ({@link RecurringAction})
+ */
 public class RecurringActionHandler extends BaseHandler {
 
     /* helper method */
@@ -112,7 +115,12 @@ public class RecurringActionHandler extends BaseHandler {
      * @xmlrpc.param #session_key()
      * @xmlrpc.param
      *  #struct("actionProps")
-     *      #prop_desc("string", "entity_type", "The type of the target entity. Can be MINION, GROUP or ORG.")
+     *      #prop_desc("string", "entity_type", "The type of the target entity. One of the following:")
+     *        #options()
+     *          #item("MINION")
+     *          #item("GROUP")
+     *          #item("ORG")
+     *        #options_end()
      *      #prop_desc("int", "entity_id", "The id of the target entity")
      *      #prop_desc("string", "name", "The name of the action")
      *      #prop_desc("string", "cron_expr", "The execution frequency of the action")

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/recurringaction/test/RecurringActionHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/recurringaction/test/RecurringActionHandlerTest.java
@@ -1,0 +1,266 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.frontend.xmlrpc.recurringaction.test;
+
+import com.redhat.rhn.domain.org.OrgFactory;
+import com.redhat.rhn.domain.recurringactions.RecurringAction;
+import com.redhat.rhn.domain.recurringactions.RecurringActionFactory;
+import com.redhat.rhn.domain.role.RoleFactory;
+import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.xmlrpc.EntityNotExistsFaultException;
+import com.redhat.rhn.frontend.xmlrpc.InvalidArgsException;
+import com.redhat.rhn.frontend.xmlrpc.ValidationException;
+import com.redhat.rhn.frontend.xmlrpc.recurringaction.RecurringActionHandler;
+import com.redhat.rhn.manager.recurringactions.RecurringActionManager;
+import com.redhat.rhn.taskomatic.TaskomaticApi;
+import com.redhat.rhn.taskomatic.TaskomaticApiException;
+import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
+import com.redhat.rhn.testing.TestUtils;
+
+import org.jmock.Expectations;
+import org.jmock.lib.legacy.ClassImposteriser;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * Test for {@link RecurringActionHandler}
+ */
+public class RecurringActionHandlerTest extends JMockBaseTestCaseWithUser {
+
+    private RecurringActionHandler handler;
+
+    // common props for creating action
+    private Map<String, Object> testActionProps;
+
+    private TaskomaticApi taskomaticMock;
+
+    {
+        context().setImposteriser(ClassImposteriser.INSTANCE);
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        user.addPermanentRole(RoleFactory.ORG_ADMIN);
+        handler = new RecurringActionHandler();
+        testActionProps = Map.of(
+                "entity_id", user.getOrg().getId().intValue(),
+                "entity_type", "ORG",
+                "name", "test-action-123",
+                "cron_expr", "0 * * * * ?"
+        );
+
+        // mocking
+        taskomaticMock = context().mock(TaskomaticApi.class);
+        RecurringActionManager.setTaskomaticApi(taskomaticMock);
+
+        context().checking(new Expectations() { {
+            allowing(taskomaticMock).scheduleRecurringAction(with(any(RecurringAction.class)), with(any(User.class)));
+            allowing(taskomaticMock).unscheduleRecurringAction(with(any(RecurringAction.class)), with(any(User.class)));
+        } });
+    }
+
+    public void testCreateAndLookupOrgAction() {
+        var actionId = handler.create(user, testActionProps);
+
+        var createdAction = handler.lookupById(user, actionId);
+        var dbAction = RecurringActionFactory.lookupById(actionId).get();
+
+        assertEquals(dbAction, createdAction);
+        assertEquals(RecurringAction.Type.ORG, createdAction.getType());
+    }
+
+    public void testCreateAndLookupMinionAction() throws Exception {
+        var minionId = MinionServerFactoryTest.createTestMinionServer(user).getId().intValue();
+        var props = new HashMap<>(testActionProps);
+        props.put("entity_id", minionId);
+        props.put("entity_type", "MINION");
+        var actionId = handler.create(user, props);
+
+        var createdAction = handler.lookupById(user, actionId);
+        var dbAction = RecurringActionFactory.lookupById(actionId).get();
+
+        assertEquals(dbAction, createdAction);
+        assertEquals(RecurringAction.Type.MINION, createdAction.getType());
+    }
+
+    public void testCreateActionInvalidData() {
+        try {
+            handler.create(user, Map.of());
+            fail("An exception should have been thrown");
+        }
+        catch (InvalidArgsException e) {
+            // no-op
+        }
+    }
+
+    public void testCreateExistingAction() {
+        handler.create(user, testActionProps);
+        try {
+            handler.create(user, testActionProps);
+            fail("An exception should have been thrown");
+        }
+        catch (ValidationException e) {
+            // no-op
+        }
+    }
+
+    public void testCreateActionWithNonExistingEntity() {
+        var props = new HashMap<>(testActionProps);
+        props.put("entity_id", -12345);
+        try {
+            handler.create(user, props);
+            fail("An exception should have been thrown");
+        }
+        catch (EntityNotExistsFaultException e) {
+            // no-op
+        }
+    }
+
+    public void testCreateNonAccessibleEntity() {
+        var org = OrgFactory.createOrg();
+        org.setName("test org: " + TestUtils.randomString());
+        org = OrgFactory.save(org);
+
+        var props = Map.<String, Object>of(
+                "entity_id", org.getId().intValue(),
+                "entity_type", "ORG",
+                "name", "test-action-123",
+                "cron_expr", "0 * * * * ?"
+        );
+
+        try {
+            handler.create(user, props);
+            fail("An exception should have been thrown");
+        }
+        catch (ValidationException e) {
+            // no-op
+        }
+    }
+
+    public void testUpdateAction() {
+        int actionId = handler.create(user, testActionProps);
+
+        var updateProps = Map.<String, Object>of(
+                "id", actionId,
+                "name", "new-test-action-123",
+                "active", false
+        );
+        handler.update(user, updateProps);
+
+        var updatedAction = handler.lookupById(user, actionId);
+        assertEquals("new-test-action-123", updatedAction.getName());
+        assertFalse(updatedAction.isActive());
+    }
+
+    public void testUpdateActionSetExistingName() {
+        handler.create(user, testActionProps);
+        var otherActionProps = new HashMap<>(testActionProps);
+        otherActionProps.put("name", "new-test-action-123");
+        int otherAction = handler.create(user, otherActionProps);
+
+        var updateProps = Map.<String, Object>of(
+                "id", otherAction,
+                "name", "test-action-123" // try to set the name to the name of the first action
+        );
+        try {
+            handler.update(user, updateProps);
+            fail("An exception should have been thrown");
+        }
+        catch (ValidationException e) {
+            // no-op
+        }
+    }
+
+    public void testUpdateActionSetInvalidCronExpr() {
+        var actionId = handler.create(user, testActionProps);
+
+        var updateProps = Map.<String, Object>of(
+                "id", actionId,
+                "cron_expr", "THIS IS NOT CRON, THIS IS A STRING!"
+        );
+
+        try {
+            handler.update(user, updateProps);
+            fail("An exception should have been thrown");
+        }
+        catch (ValidationException e) {
+            // no-op
+        }
+    }
+
+    public void testUpdateNonexistingAction() {
+        var updateProps = Map.<String, Object>of(
+                "id", -123456,
+                "name", "test-name"
+        );
+        try {
+            handler.update(user, updateProps);
+            fail("An exception should have been thrown");
+        }
+        catch (EntityNotExistsFaultException e) {
+            // no-op
+        }
+    }
+
+    public void testCreateActionTaskomaticDown() throws Exception {
+        // mock taskomatic down
+        TaskomaticApi taskomaticMock2 = context().mock(TaskomaticApi.class, "taskomaticApi2");
+        context().checking(new Expectations() { {
+            allowing(taskomaticMock2).scheduleRecurringAction(with(any(RecurringAction.class)), with(any(User.class)));
+            will(throwException(new TaskomaticApiException(new RuntimeException())));
+            allowing(taskomaticMock2).unscheduleRecurringAction(with(any(RecurringAction.class)), with(any(User.class)));
+            will(throwException(new TaskomaticApiException(new RuntimeException())));
+        } });
+        RecurringActionManager.setTaskomaticApi(taskomaticMock2);
+
+        // create a minion with no recurring actions
+        var minionId = MinionServerFactoryTest.createTestMinionServer(user).getId();
+        var props = new HashMap<>(testActionProps);
+        props.put("entity_id", minionId.intValue());
+        props.put("entity_type", "MINION");
+
+        try {
+            handler.create(user, props);
+            fail("An exception should have been thrown");
+        }
+        catch (com.redhat.rhn.frontend.xmlrpc.TaskomaticApiException e) {
+            // no-op
+        }
+    }
+
+    public void testDeleteAction() {
+        int actionId = handler.create(user, testActionProps);
+
+        handler.delete(user, actionId);
+
+        assertTrue(RecurringActionFactory.lookupById(actionId).isEmpty());
+    }
+
+    public void testDeleteNonexistingAction() {
+        try {
+            handler.delete(user, -12345);
+            fail("An exception should have been thrown");
+        }
+        catch (EntityNotExistsFaultException e) {
+            // no-op
+        }
+    }
+}

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/RecurringActionSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/RecurringActionSerializer.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.frontend.xmlrpc.serializer;
+
+import com.redhat.rhn.domain.recurringactions.RecurringAction;
+import com.redhat.rhn.frontend.xmlrpc.serializer.util.SerializerHelper;
+
+import java.io.IOException;
+import java.io.Writer;
+
+import redstone.xmlrpc.XmlRpcException;
+import redstone.xmlrpc.XmlRpcSerializer;
+
+/**
+ * Serializer for {@link com.redhat.rhn.domain.recurringactions.RecurringAction} class and subclasses
+ *
+ * @xmlrpc.doc
+ * #struct("Recurring Action information")
+ *   #prop("int", "id")
+ *   #prop("string", "name")
+ *   #prop("int", "entity_id")
+ *   #prop("string", "entity_type")
+ *   #prop("string", "cron_expr")
+ *   #prop("string", "created")
+ *   #prop("string", "creator")
+ *   #prop("boolean", "test")
+ *   #prop("boolean", "active")
+ * #struct_end()
+ */
+public class RecurringActionSerializer extends RhnXmlRpcCustomSerializer {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Class getSupportedClass() {
+        return RecurringAction.class;
+    }
+
+    @Override
+    protected void doSerialize(Object obj, Writer writer, XmlRpcSerializer serializer)
+            throws XmlRpcException, IOException {
+        RecurringAction action = (RecurringAction) obj;
+        SerializerHelper helper = new SerializerHelper(serializer);
+
+        helper.add("id", action.getId());
+        helper.add("name", action.getName());
+        helper.add("entity_id", action.getEntityId());
+        helper.add("entity_type", action.getType().toString());
+        helper.add("cron_expr", action.getCronExpr());
+        helper.add("created", action.getCreated());
+        helper.add("creator", action.getCreator().getLogin());
+        helper.add("test", action.isTestMode());
+        helper.add("active", action.isActive());
+
+        helper.writeTo(writer);
+    }
+}

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/RecurringActionSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/RecurringActionSerializer.java
@@ -34,7 +34,7 @@ import redstone.xmlrpc.XmlRpcSerializer;
  *   #prop("int", "entity_id")
  *   #prop("string", "entity_type")
  *   #prop("string", "cron_expr")
- *   #prop("string", "created")
+ *   #prop($date, "created")
  *   #prop("string", "creator")
  *   #prop("boolean", "test")
  *   #prop("boolean", "active")

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/SerializerRegistry.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/SerializerRegistry.java
@@ -137,6 +137,7 @@ public class SerializerRegistry {
         SERIALIZER_CLASSES.add(ContentProjectSourceSerializer.class);
         SERIALIZER_CLASSES.add(ContentFilterSerializer.class);
         SERIALIZER_CLASSES.add(ContentProjectFilterSerializer.class);
+        SERIALIZER_CLASSES.add(RecurringActionSerializer.class);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/recurringactions/RecurringActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/recurringactions/RecurringActionManager.java
@@ -41,7 +41,6 @@ import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
 import org.apache.commons.lang3.StringUtils;
-import org.hibernate.HibernateException;
 
 import java.util.List;
 
@@ -126,14 +125,11 @@ public class RecurringActionManager {
      * @return
      */
     private static OrgRecurringAction createOrgRecurringAction(long orgId, User user) {
-        try {
-            Org org = OrgFactory.lookupById(orgId);
-            OrgRecurringAction action = new OrgRecurringAction(false, true, org, user);
-            return action;
-        }
-        catch (HibernateException e) {
+        Org org = OrgFactory.lookupById(orgId);
+        if (org == null) {
             throw new EntityNotExistsException(Org.class, orgId);
         }
+        return new OrgRecurringAction(false, true, org, user);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/recurringactions/RecurringActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/recurringactions/RecurringActionManager.java
@@ -18,7 +18,6 @@ package com.redhat.rhn.manager.recurringactions;
 import com.redhat.rhn.common.hibernate.LookupException;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.common.security.PermissionException;
-import com.redhat.rhn.common.util.StringUtil;
 import com.redhat.rhn.common.validator.ValidatorException;
 import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.org.OrgFactory;

--- a/java/code/src/com/redhat/rhn/manager/recurringactions/RecurringActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/recurringactions/RecurringActionManager.java
@@ -229,7 +229,8 @@ public class RecurringActionManager {
                     new PermissionException(String.format("%s not accessible to user %s", action, user)));
         }
 
-        if (!TaskoQuartzHelper.isValidCronExpression(action.getCronExpr())) {
+        String cronExpr = action.getCronExpr();
+        if (StringUtils.isBlank(cronExpr) || !TaskoQuartzHelper.isValidCronExpression(cronExpr)) {
             throw new ValidatorException(getLocalization().getMessage("recurring_action.invalid_cron"));
         }
 

--- a/java/code/src/com/redhat/rhn/manager/recurringactions/test/RecurringActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/recurringactions/test/RecurringActionManagerTest.java
@@ -17,6 +17,7 @@ import com.redhat.rhn.domain.server.ManagedServerGroup;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.EntityExistsException;
+import com.redhat.rhn.manager.EntityNotExistsException;
 import com.redhat.rhn.manager.recurringactions.RecurringActionManager;
 import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
@@ -157,6 +158,17 @@ public class RecurringActionManagerTest extends BaseTestCaseWithUser {
             fail("ValidatorException should have been thrown");
         }
         catch (ValidatorException e) {
+            // no-op
+        }
+    }
+
+    public void testCreateOrgActionNoOrg() {
+        try {
+            // let's try to create an action for a nonexisting org
+            RecurringActionManager.createRecurringAction(ORG, -123456L, user);
+            fail("An exception should have been thrown");
+        }
+        catch (EntityNotExistsException e) {
             // no-op
         }
     }

--- a/java/code/src/com/redhat/rhn/manager/recurringactions/test/RecurringActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/recurringactions/test/RecurringActionManagerTest.java
@@ -243,7 +243,7 @@ public class RecurringActionManagerTest extends BaseTestCaseWithUser {
         var recurringAction = RecurringActionManager.createRecurringAction(MINION, minion.getId(), user);
         recurringAction.setCronExpr(CRON_EXPR);
         recurringAction.setName("test-recurring-action-1");
-        RecurringActionManager.saveAndSchedule(recurringAction, user);
+        recurringAction = RecurringActionManager.saveAndSchedule(recurringAction, user);
 
         var sameAction = RecurringActionFactory.lookupById(recurringAction.getId()).get();
         var newName = "testname";

--- a/java/code/src/com/suse/manager/webui/controllers/test/RecurringActionControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/RecurringActionControllerTest.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.manager.webui.controllers.test ;
+
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+
+import com.redhat.rhn.domain.org.OrgFactory;
+import com.redhat.rhn.domain.recurringactions.RecurringAction;
+import com.redhat.rhn.domain.recurringactions.RecurringActionFactory;
+import com.redhat.rhn.domain.role.RoleFactory;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.manager.recurringactions.RecurringActionManager;
+import com.redhat.rhn.taskomatic.TaskomaticApi;
+import com.redhat.rhn.testing.RhnMockHttpServletResponse;
+import com.redhat.rhn.testing.TestUtils;
+
+import com.suse.manager.webui.controllers.RecurringActionController;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import org.jmock.Expectations;
+import org.jmock.lib.legacy.ClassImposteriser;
+
+import java.io.UnsupportedEncodingException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import spark.HaltException;
+import spark.RequestResponseFactory;
+import spark.Response;
+
+/**
+ * Test for {@link RecurringActionController}
+ */
+public class RecurringActionControllerTest extends BaseControllerTestCase {
+
+    private Response response;
+
+    private static final Gson GSON = new GsonBuilder().create();
+
+    private TaskomaticApi taskomaticMock;
+
+    {
+        context().setImposteriser(ClassImposteriser.INSTANCE);
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        user.addPermanentRole(RoleFactory.ORG_ADMIN);
+
+        response = RequestResponseFactory.create(new RhnMockHttpServletResponse());
+
+        // mocking
+        taskomaticMock = context().mock(TaskomaticApi.class);
+        RecurringActionManager.setTaskomaticApi(taskomaticMock);
+
+        context().checking(new Expectations() { {
+            allowing(taskomaticMock).scheduleRecurringAction(with(any(RecurringAction.class)), with(any(User.class)));
+            allowing(taskomaticMock).unscheduleRecurringAction(with(any(RecurringAction.class)), with(any(User.class)));
+        } });
+    }
+
+    public void testCreateAction() throws UnsupportedEncodingException {
+        Long orgId = user.getOrg().getId();
+
+        var actionJsonString = createActionJsonString(empty(), "test-schedule-123", of(orgId));
+        var saveRequest = getPostRequestWithCsrfAndBody("/manager/api/recurringactions/save", actionJsonString);
+        RecurringActionController.save(saveRequest, response, user);
+
+        var listRequest = getRequestWithCsrf("/manager/api/recurringactions/:type/:id", "ORG", orgId);
+
+        var list = GSON.fromJson(RecurringActionController.listByEntity(listRequest, response, user), List.class);
+        assertEquals(1, list.size());
+        Map<String, Object> action = (Map<String, Object>) list.iterator().next();
+        assertNotNull(action.get("targetId"));
+        assertEquals("test-schedule-123", action.get("scheduleName"));
+        assertEquals(user.getLogin(), action.get("creatorLogin"));
+    }
+
+    public void testCreateActionSameName() throws UnsupportedEncodingException {
+        Long orgId = user.getOrg().getId();
+
+        var actionJsonString = createActionJsonString(empty(), "test-schedule-123", of(orgId));
+        var saveRequest = getPostRequestWithCsrfAndBody("/manager/api/recurringactions/save", actionJsonString);
+        RecurringActionController.save(saveRequest, response, user);
+
+        try {
+            RecurringActionController.save(saveRequest, response, user);
+            fail("An exception should have been thrown");
+        }
+        catch (HaltException e) {
+            assertEquals(400, e.statusCode());
+        }
+    }
+
+    public void testUpdateAction() throws UnsupportedEncodingException {
+        var org = OrgFactory.createOrg();
+        org.setName("test org: " + TestUtils.randomString());
+        org = OrgFactory.save(org);
+        user.addPermanentRole(RoleFactory.SAT_ADMIN);
+
+        var orgId = org.getId();
+        var actionJsonString = createActionJsonString(empty(), "test-schedule-123", of(orgId));
+        var createRequest = getPostRequestWithCsrfAndBody("/manager/api/recurringactions/save", actionJsonString);
+        RecurringActionController.save(createRequest, response, user);
+
+        var actionId = RecurringActionFactory.listOrgRecurringActions(orgId).iterator().next().getId();
+
+        var updateJsonStr = createActionJsonString(of(actionId), "new-name-123", empty());
+        var updateRequest = getPostRequestWithCsrfAndBody("/manager/api/recurringactions/save", updateJsonStr);
+        RecurringActionController.save(updateRequest, response, user);
+
+        var updated = RecurringActionFactory.listOrgRecurringActions(orgId).iterator().next();
+        assertEquals("new-name-123", updated.getName());
+    }
+
+    private static String createActionJsonString(Optional<Long> actionId, String scheduleName, Optional<Long> targetId) {
+        return "{" +
+                actionId.map(id -> "'recurringActionId': " + id + ",").orElse("") +
+                "'scheduleName': '" + scheduleName + "'," +
+                targetId.map(id -> "'targetId': " + id + ",").orElse("") +
+                "'targetType': 'org'," +
+                "'type': 'hourly'," +
+                "'cronTimes': " +
+                "  {'minute': '0'," +
+                "   'hour': '0'," +
+                "   'dayOfWeek': '0'," +
+                "   'dayOfMonth': '0'" +
+                "  }" +
+                "}";
+    }
+}

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add recurring actions xmlrpc interface
 - Add StateApplyFailed and CreateBootstrapRepoFailed notifications
 - Add virtual storage pools actions
 - Remove no longer necessary check for retail TERMINALS group membership


### PR DESCRIPTION
## What does this PR change?

Add Recurring Action functionality to the XMLRPC API

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: xmlrpc doc strings added

- [x] **DONE**

## Test coverage

- Unit tests were added

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/8260

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"    		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
