### PR TITLE
Use utf8 encoding for files managed by "fileutils.decompress_open" (bsc#1158463)

### DIFF
--- a/uyuni/common-libs/common/fileutils.py
+++ b/uyuni/common-libs/common/fileutils.py
@@ -13,6 +13,7 @@
 # in this software or its documentation.
 #
 
+import codecs
 import os
 import sys
 import bz2
@@ -505,9 +506,9 @@ def decompress_open(filename):
             # uncompress, keep both, return uncompressed file
             subprocess.call(['xz', '-d', '-k', filename])
             uncompressed_path = filename.rsplit('.', 1)[0]
-            file_obj = open(uncompressed_path, 'rb')
+            file_obj = codecs.open(uncompressed_path, 'rb', encoding="utf8")
     else:
-        file_obj = open(filename, 'r')
+        file_obj = codecs.open(filename, 'r', encoding="utf8")
     if filename.endswith(('.gz', '.bz2', '.xz')):
-        return io.TextIOWrapper(file_obj)
+        return io.TextIOWrapper(file_obj, encoding="utf8")
     return file_obj

--- a/uyuni/common-libs/uyuni-common-libs.changes
+++ b/uyuni/common-libs/uyuni-common-libs.changes
@@ -1,3 +1,5 @@
+- Do not break when syncing Oracle 7 yum channel (bsc#1158463)
+
 -------------------------------------------------------------------
 Thu Mar 19 12:18:16 CET 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR forces to use `utf8` encoding for the instance returned by `fileutils.decompress_open` method. Currently, it might be cases where the default encoding is set to `ascii` while processing files with `utf8` content.

This situation, of course breaks, and it's currently causing issues when using `spacewalk-repo-sync` against some particular repositories (i.a. Oracle 7 yum):

```
2019/12/04 18:29:08 -00:00 Command: ['/usr/bin/spacewalk-repo-sync', '--channel', 'oraclelinux7-x86_64', '--type', 'yum', '--non-interactive']
2019/12/04 18:29:08 -00:00 Sync of channel started.
2019/12/04 18:30:06 -00:00 
2019/12/04 18:30:06 -00:00   Importing comps file 45064643ce9645744751e714d23f41106e89b5c0-comps.xml.
2019/12/04 18:30:06 -00:00   Renaming non-standard filename 45064643ce9645744751e714d23f41106e89b5c0-comps.xml to comps.xml.
2019/12/04 18:30:06 -00:00 Unexpected error: <class 'UnicodeDecodeError'>
2019/12/04 18:30:06 -00:00 Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/spacewalk/satellite_tools/reposync.py", line 565, in sync
    self.import_groups(plugin)
  File "/usr/lib/python3.6/site-packages/spacewalk/satellite_tools/reposync.py", line 785, in import_groups
    abspath = self.copy_metadata_file(plug, groupsfile, 'comps', relative_comps_dir)
  File "/usr/lib/python3.6/site-packages/spacewalk/satellite_tools/reposync.py", line 741, in copy_metadata_file
    shutil.copyfileobj(src, dst)
  File "/usr/lib64/python3.6/shutil.py", line 79, in copyfileobj
    buf = fsrc.read(length)
  File "/usr/lib64/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe0 in position 230: ordinal not in range(128)
```

After this PR, `spacewalk-repo-sync` won't break when dealing with such situations.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **no tests for Oracle 7**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/10254

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
