### PR TITLE
Add child product channel sync status visibility at parent level

### DIFF
--- a/branding/css/susemanager-setup-wizard.less
+++ b/branding/css/susemanager-setup-wizard.less
@@ -220,7 +220,7 @@ ul.product-list {
       background-color: #ededed;
     }
     .product-installed {
-      .product-description, i {
+      .product-description {
         color: @spacewalk-green-dark;
       }
       .recommended-tag {

--- a/branding/css/susemanager-setup-wizard.less
+++ b/branding/css/susemanager-setup-wizard.less
@@ -184,7 +184,7 @@ ul.subscriptions-list {
 }
 
 .row-odd {
-  background-color: #fff;
+  background-color: #fafafa;
 }
 .row-even {
   background-color: @spacewalk-background;

--- a/branding/spacewalk-branding.changes
+++ b/branding/spacewalk-branding.changes
@@ -1,3 +1,5 @@
+- Show separate info for syncing product channels and children
+
 -------------------------------------------------------------------
 Mon Feb 17 12:48:21 CET 2020 - jgonzalez@suse.com
 

--- a/java/code/src/com/suse/manager/model/products/ChannelJson.java
+++ b/java/code/src/com/suse/manager/model/products/ChannelJson.java
@@ -23,6 +23,7 @@ import com.redhat.rhn.frontend.dto.SetupWizardProductDto.SyncStatus.SyncStage;
  */
 public class ChannelJson {
 
+    private final Long id;
     private final String name;
     private final String label;
     private final String summary;
@@ -32,15 +33,17 @@ public class ChannelJson {
     /**
      * Constructor
      *
+     * @param idIn the id of the channel, if present
      * @param nameIn the name of the channel
      * @param labelIn the label of the channel
      * @param summaryIn the summary of the channel
      * @param optionalIn if the channel is mandatory or optional
      * @param statusIn the status of the channel
      */
-    public ChannelJson(String nameIn, String labelIn,
+    public ChannelJson(Long idIn, String nameIn, String labelIn,
                        String summaryIn, boolean optionalIn,
                        SetupWizardProductDto.SyncStatus.SyncStage statusIn) {
+        this.id = idIn;
         this.name = nameIn;
         this.label = labelIn;
         this.summary = summaryIn;
@@ -54,6 +57,11 @@ public class ChannelJson {
     public SetupWizardProductDto.SyncStatus.SyncStage getStatus() {
         return status;
     }
+
+    /**
+     * @return the id of the channel
+     */
+    public Long getId() { return id; }
 
     /**
      * @return the label of the channel

--- a/java/code/src/com/suse/manager/model/products/ChannelJson.java
+++ b/java/code/src/com/suse/manager/model/products/ChannelJson.java
@@ -61,7 +61,9 @@ public class ChannelJson {
     /**
      * @return the id of the channel
      */
-    public Long getId() { return id; }
+    public Long getId() {
+        return id;
+    }
 
     /**
      * @return the label of the channel

--- a/java/code/src/com/suse/manager/webui/controllers/ProductsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/ProductsController.java
@@ -16,7 +16,6 @@
 package com.suse.manager.webui.controllers;
 
 import com.google.gson.reflect.TypeToken;
-
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.util.SCCRefreshLock;
@@ -33,17 +32,12 @@ import com.redhat.rhn.manager.content.MgrSyncProductDto;
 import com.redhat.rhn.manager.setup.ProductSyncManager;
 import com.redhat.rhn.taskomatic.TaskoFactory;
 import com.redhat.rhn.taskomatic.domain.TaskoRun;
-import com.suse.manager.model.products.Extension;
 import com.suse.manager.model.products.ChannelJson;
+import com.suse.manager.model.products.Extension;
 import com.suse.manager.model.products.Product;
 import com.suse.manager.webui.utils.gson.ResultJson;
+import com.suse.mgrsync.MgrSyncStatus;
 import com.suse.utils.Json;
-import org.apache.log4j.Logger;
-import spark.ModelAndView;
-import spark.Request;
-import spark.Response;
-import spark.template.jade.JadeTemplateEngine;
-
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -51,6 +45,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import org.apache.log4j.Logger;
+import spark.ModelAndView;
+import spark.Request;
+import spark.Response;
+import spark.template.jade.JadeTemplateEngine;
 
 import static com.suse.manager.webui.utils.SparkApplicationHelper.json;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.withCsrfToken;
@@ -319,6 +318,10 @@ public class ProductsController {
                                             s.getStatus(),
                                             s.getChannels().stream().map(c ->
                                                     new ChannelJson(
+                                                            s.getStatus().equals(MgrSyncStatus.INSTALLED) &&
+                                                                    ChannelFactory.lookupByLabel(c.getLabel()) != null ?
+                                                                    ChannelFactory.lookupByLabel(c.getLabel()).getId()
+                                                                    : -1L,
                                                             c.getName(),
                                                             c.getLabel(),
                                                             c.getSummary(),
@@ -365,6 +368,10 @@ public class ProductsController {
                         rootExtensions,
                         syncProduct.getChannels().stream().map(c ->
                                 new ChannelJson(
+                                        syncProduct.getStatus().equals(MgrSyncStatus.INSTALLED) &&
+                                                ChannelFactory.lookupByLabel(c.getLabel()) != null ?
+                                                ChannelFactory.lookupByLabel(c.getLabel()).getId()
+                                                : -1L,
                                         c.getName(),
                                         c.getLabel(),
                                         c.getSummary(),

--- a/java/code/src/com/suse/manager/webui/controllers/ProductsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/ProductsController.java
@@ -320,8 +320,8 @@ public class ProductsController {
                                                     new ChannelJson(
                                                             s.getStatus().equals(MgrSyncStatus.INSTALLED) &&
                                                                     ChannelFactory.lookupByLabel(c.getLabel()) != null ?
-                                                                    ChannelFactory.lookupByLabel(c.getLabel()).getId()
-                                                                    : -1L,
+                                                                    ChannelFactory.lookupByLabel(c.getLabel()).getId() :
+                                                                    -1L,
                                                             c.getName(),
                                                             c.getLabel(),
                                                             c.getSummary(),
@@ -370,8 +370,8 @@ public class ProductsController {
                                 new ChannelJson(
                                         syncProduct.getStatus().equals(MgrSyncStatus.INSTALLED) &&
                                                 ChannelFactory.lookupByLabel(c.getLabel()) != null ?
-                                                ChannelFactory.lookupByLabel(c.getLabel()).getId()
-                                                : -1L,
+                                                ChannelFactory.lookupByLabel(c.getLabel()).getId() :
+                                                -1L,
                                         c.getName(),
                                         c.getLabel(),
                                         c.getSummary(),

--- a/java/code/src/com/suse/manager/webui/controllers/ProductsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/ProductsController.java
@@ -36,7 +36,6 @@ import com.suse.manager.model.products.ChannelJson;
 import com.suse.manager.model.products.Extension;
 import com.suse.manager.model.products.Product;
 import com.suse.manager.webui.utils.gson.ResultJson;
-import com.suse.mgrsync.MgrSyncStatus;
 import com.suse.utils.Json;
 import java.util.Collection;
 import java.util.HashMap;
@@ -318,10 +317,8 @@ public class ProductsController {
                                             s.getStatus(),
                                             s.getChannels().stream().map(c ->
                                                     new ChannelJson(
-                                                            s.getStatus().equals(MgrSyncStatus.INSTALLED) &&
-                                                                    ChannelFactory.lookupByLabel(c.getLabel()) != null ?
-                                                                    ChannelFactory.lookupByLabel(c.getLabel()).getId() :
-                                                                    -1L,
+                                                            Optional.ofNullable(channelByLabel.get(c.getLabel()))
+                                                                    .map(x -> x.getId()).orElse(-1L),
                                                             c.getName(),
                                                             c.getLabel(),
                                                             c.getSummary(),
@@ -368,10 +365,8 @@ public class ProductsController {
                         rootExtensions,
                         syncProduct.getChannels().stream().map(c ->
                                 new ChannelJson(
-                                        syncProduct.getStatus().equals(MgrSyncStatus.INSTALLED) &&
-                                                ChannelFactory.lookupByLabel(c.getLabel()) != null ?
-                                                ChannelFactory.lookupByLabel(c.getLabel()).getId() :
-                                                -1L,
+                                        Optional.ofNullable(channelByLabel.get(c.getLabel()))
+                                                .map(x -> x.getId()).orElse(-1L),
                                         c.getName(),
                                         c.getLabel(),
                                         c.getSummary(),

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Show separate info for syncing product channels and children
 - add XMLRPC API method: proxy.listProxyClients (bsc#1166408)
 - Enable monitoring for RHEL 8 Salt clients
 - Add recurring actions xmlrpc interface

--- a/web/html/src/manager/admin/setup/products/products-scc-dialog.js
+++ b/web/html/src/manager/admin/setup/products/products-scc-dialog.js
@@ -157,7 +157,7 @@ class SCCDialog extends React.Component {
           <Button
               id='scc-refresh-button'
               className='btn btn-default'
-              disabled={this.isSyncRunning() ? 'disabled' : ''}
+              disabled={this.isSyncRunning()}
               handler={this.startSync}
               icon={'fa-refresh ' + (this.isSyncRunning() ? 'fa-spin' : '')}
               text={t('Refresh')}

--- a/web/html/src/manager/admin/setup/products/products.js
+++ b/web/html/src/manager/admin/setup/products/products.js
@@ -887,7 +887,10 @@ class ChannelList extends React.Component {
             this.props.items
               .map(c =>
                   <li key={c.label}>
-                    <div><strong>{c.summary}</strong>&nbsp;{this.decodeChannelStatus(c.status)}</div>
+                    <div>
+                      <strong>{c.name}</strong>
+                      &nbsp;{this.decodeChannelStatus(c.status)}
+                    </div>
                     <div>{c.label}</div>
                   </li>
               )

--- a/web/html/src/manager/admin/setup/products/products.js
+++ b/web/html/src/manager/admin/setup/products/products.js
@@ -23,6 +23,7 @@ const ProgressBar = require("components/progressbar").ProgressBar;
 const CustomDiv = require("components/custom-objects").CustomDiv;
 const {Toggler} = require("components/toggler");
 const {HelpLink} = require('components/utils/HelpLink');
+const ChannelLink = require('components/links').ChannelLink;
 const SpaRenderer  = require("core/spa/spa-renderer").default;
 
 const _DATA_ROOT_ID = 'baseProducts';
@@ -882,7 +883,11 @@ const ChannelList = (props) => {
                 <strong>{c.name}</strong>
                 &nbsp;{decodeChannelStatus(c.status)}
                 <br/>
-                {c.label}
+                {
+                  c.id != -1 ?
+                    <ChannelLink id={c.id} newWindow={true}>{c.label}</ChannelLink>
+                    : c.label
+                }
               </li>
             )
         }

--- a/web/html/src/manager/admin/setup/products/products.js
+++ b/web/html/src/manager/admin/setup/products/products.js
@@ -64,7 +64,7 @@ const _CHANNEL_STATUS = {
 const _COLS = {
   selector: { width: 2, um: 'em' },
   showSubList: { width: 2, um: 'em'},
-  description: { width: undefined, um: 'px'},
+  description: { width: 'auto', um: ''},
   arch: { width: 6, um: 'em' },
   channels: { width: 5, um: 'em' },
   mix: { width: 13, um: 'em'}
@@ -454,7 +454,7 @@ class Products extends React.Component {
     const archFilter =
       <div className='multiple-select-wrapper'>
         <select id='product-arch-filter' name='product-arch-filter' className='form-control d-inline-block apply-select2js-on-this' multiple='multiple'>
-          { this.getDistinctArchsFromData(this.props.data).map(a => <option key={a} value={a}>{a}</option>) }
+          { this.getDistinctArchsFromData(this.props.data).map((a, i) => <option key={a + i} value={a}>{a}</option>) }
         </select>
       </div>;
     return (
@@ -518,7 +518,7 @@ class CheckList extends React.Component {
               <li className='list-header'>
                 <CustomDiv className='col text-center' width={this.props.bypassProps.cols.selector.width} um={this.props.bypassProps.cols.selector.um}></CustomDiv>
                 <CustomDiv className='col text-center' width={this.props.bypassProps.cols.showSubList.width} um={this.props.bypassProps.cols.showSubList.um}></CustomDiv>
-                <CustomDiv className='col col-class-calc-width'>{t('Product Description')}</CustomDiv>
+                <CustomDiv className='col col-class-calc-width' width={this.props.bypassProps.cols.description.width} um={this.props.bypassProps.cols.description.um}>{t('Product Description')}</CustomDiv>
                 <CustomDiv className='col' width={this.props.bypassProps.cols.arch.width} um={this.props.bypassProps.cols.arch.um} title={t('Architecture')}>{t('Arch')}</CustomDiv>
                 <CustomDiv className='col text-center' width={this.props.bypassProps.cols.channels.width} um={this.props.bypassProps.cols.channels.um}>{t('Channels')}</CustomDiv>
                 <CustomDiv className='col text-right' width={this.props.bypassProps.cols.mix.width} um={this.props.bypassProps.cols.mix.um}></CustomDiv>
@@ -791,7 +791,7 @@ class CheckListItem extends React.Component {
           <CustomDiv className='col text-center' width={this.props.bypassProps.cols.showSubList.width} um={this.props.bypassProps.cols.showSubList.um}>
             {showNestedDataIconContent}
           </CustomDiv>
-          <CustomDiv className='col col-class-calc-width'>
+          <CustomDiv className='col col-class-calc-width' width={this.props.bypassProps.cols.description.width} um={this.props.bypassProps.cols.description.um}>
             {productDescriptionContent}
           </CustomDiv>
           <CustomDiv className='col' width={this.props.bypassProps.cols.arch.width} um={this.props.bypassProps.cols.arch.um} title={t('Architecture')}>

--- a/web/html/src/manager/admin/setup/products/products.js
+++ b/web/html/src/manager/admin/setup/products/products.js
@@ -655,7 +655,14 @@ class CheckListItem extends React.Component {
         />;
     }
     else if (this.isInstalled()) {
-      selectorContent = <i className='fa fa-check-square-o fa-1-5x product-installed' title={t('This product is mirrored.')} />
+      selectorContent =
+        <input type='checkbox'
+            id={'checkbox-for-' + currentItem.identifier}
+            value={currentItem.identifier}
+            checked='checked'
+            disabled='disabled'
+            title={t('This product is mirrored.')}
+        />;
     }
     /*****/
 

--- a/web/html/src/manager/admin/setup/products/products.js
+++ b/web/html/src/manager/admin/setup/products/products.js
@@ -678,6 +678,31 @@ class CheckListItem extends React.Component {
     return [];
   };
 
+  channelsStatusSync = (channelList, isRootProduct) => {
+    const iconSize = isRootProduct ? "fa-1-5x" : "";
+    const wrapPrefix = isRootProduct ? null : "(";
+    const wrapSuffix = isRootProduct ? null : ")";
+    const testPrefix = isRootProduct ? "Product" : "Child products";
+    if (channelList.filter(c => c.status == _CHANNEL_STATUS.failed).length > 0) {
+      return (
+        <span className="text-danger" title={t(testPrefix + ' channels sync failed')}>
+          {wrapPrefix}<i className={"fa fa-exclamation-circle " + iconSize}></i>{wrapSuffix}
+        </span>);
+    }
+    else if (channelList.filter(c => c.status == _CHANNEL_STATUS.syncing).length > 0) {
+      return (
+        <span className="text-info" title={t(testPrefix + ' channels sync in progress')}>
+          {wrapPrefix}<i className={"fa fa-spinner fa-spin " + iconSize}></i>{wrapSuffix}
+        </span>);
+    }
+    else if (channelList.filter(c => c.status == _CHANNEL_STATUS.synced).length > 0) {
+      return (
+        <span className="text-success" title={t(testPrefix + ' channels synced')}>
+          {wrapPrefix}<i className={"fa fa-check-circle " + iconSize}></i>{wrapSuffix}
+        </span>);
+    }
+  };
+
   render() {
     const currentItem = this.props.item;
     /** generate item selector content **/
@@ -749,57 +774,22 @@ class CheckListItem extends React.Component {
     let channelSyncContent;
     if (this.isInstalled()) {
       let currentProductChannels = currentItem.channels.filter(c => c.status != _CHANNEL_STATUS.notSynced);
-
-      // if the product sync has just been scheduled
-      if (currentProductChannels.filter(c => c.status == _CHANNEL_STATUS.failed).length > 0) {
-        channelSyncContent =
-          <span className="text-danger" title={t('Product channels sync failed')}>
-            <i className="fa fa-exclamation-circle fa-1-5x"></i>
-          </span>;
-      }
-      else if (currentProductChannels.filter(c => c.status == _CHANNEL_STATUS.syncing).length > 0) {
-        channelSyncContent =
-          <span className="text-info" title={t('Product channels sync in progress')}>
-            <i className="fa fa-spinner fa-spin fa-1-5x"></i>
-          </span>;
-      }
-      else if (currentProductChannels.filter(c => c.status == _CHANNEL_STATUS.synced).length > 0) {
-        channelSyncContent =
-          <span className="text-success" title={t('Product channels synced')}>
-            <i className="fa fa-check-circle fa-1-5x"></i>
-          </span>;
-      }
+      channelSyncContent = this.channelsStatusSync(currentProductChannels, true);
     }
 
     let childProductChannelSyncContent;
     if (this.isInstalled()) {
-      // add all channels of the subtree
       let childProductChannels = [];
 
+      // add all channels of the subtree
       this.getChildrenTree(currentItem)
         .filter(product => product.status == _PRODUCT_STATUS.installed)
         .forEach(prod => {
           prod.channels.filter(channel => channel.status != _CHANNEL_STATUS.notSynced)
             .forEach(chan => { childProductChannels.push(chan) })
         });
-      if (childProductChannels.filter(c => c.status == _CHANNEL_STATUS.failed).length > 0) {
-        childProductChannelSyncContent =
-          <span className="text-danger" title={t('Child products channels sync failed')}>
-            (<i className="fa fa-exclamation-circle"></i>)
-          </span>;
-      }
-      else if (childProductChannels.filter(c => c.status == _CHANNEL_STATUS.syncing).length > 0) {
-        childProductChannelSyncContent =
-          <span className="text-info" title={t('Child products channels in progress')}>
-            (<i className="fa fa-spinner fa-spin"></i>)
-          </span>;
-      }
-      else if (childProductChannels.filter(c => c.status == _CHANNEL_STATUS.synced).length > 0) {
-        childProductChannelSyncContent =
-          <span className="text-success" title={t('Child products channels synced')}>
-            (<i className="fa fa-check-circle"></i>)
-          </span>;
-      }
+
+      childProductChannelSyncContent = this.channelsStatusSync(childProductChannels, false);
     }
     /*****/
 

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Show separate info for syncing product channels and children
 - sort notifications by type
 - Add StateApplyFailed and CreateBootstrapRepoFailed notifications
 - Add virtual storage pool actions


### PR DESCRIPTION
## What does this PR change?

In the Product page a children product channel sync fails, we need to report to the collapsed parent tree this information.
No reason to keep the `progress bar` percentage indicator as it was not really reporting a sync progress, but just a percentage of *how many channels finished on how many channels it is syncing*


@hustodemon [this is the commit](https://github.com/uyuni-project/uyuni/pull/2020/commits/048de8f77fe0a57a54fd10e2eaeba440a346e7ef) where I really need a review, because I am not sure about performances and if it is the correct way of doing it. The scope of that commit is just to add the `channelId` to each channel of products when the channel exists. I am not sure if it is better to do as I did or just iterating on the complete tree at the very end just once and add finally.

## GUI diff

Before:
![Screenshot from 2020-03-16 14-54-54](https://user-images.githubusercontent.com/7080830/76765172-45ade100-6796-11ea-8afb-6f98814ad082.png)


After:
![Screenshot from 2020-03-20 23-36-44](https://user-images.githubusercontent.com/7080830/77211294-d290cb80-6b03-11ea-8857-a4beb0686642.png)

![Screenshot from 2020-03-20 22-42-42](https://user-images.githubusercontent.com/7080830/77211352-0ff55900-6b04-11ea-9062-44aba262280d.png)


- [x] **DONE**

## Documentation
- No documentation needed: @Loquacity do you think we need to document this somehow? Screenshots?

- [x] **DONE**

## Test coverage
- No tests: @srbarrios ?

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/9884
Tracks # 

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
