### PR TITLE
Read modularity tag

### DIFF
--- a/backend/server/importlib/headerSource.py
+++ b/backend/server/importlib/headerSource.py
@@ -170,7 +170,7 @@ class rpmBinaryPackage(Package, rpmPackage):
         """
         Populate extra tags. Currently only "modularitylabel".
         """
-        mlabel = header.modularitylabel()
+        mlabel = header.modularity_label()
         if mlabel is not None:
             self["extra_tags"] = [
                 {"name": "modularitylabel", "value": mlabel}

--- a/backend/server/importlib/headerSource.py
+++ b/backend/server/importlib/headerSource.py
@@ -98,7 +98,20 @@ class rpmPackage(IncompletePackage):
             self['payload_format'] = 'cpio'
         if self['payload_size'] is None:
             self['payload_size'] = 0
+        # Extra tags
+        self._populateExtraTags(header)
+
         return self
+
+    def _populateExtraTags(self, header):
+        """
+        Populate extra tags. Currently only "modularitylabel".
+        """
+        mlabel = header.modularity_label()
+        if mlabel is not None:
+            self["extra_tags"] = [
+                {"name": "modularitylabel", "value": mlabel}
+            ]
 
 
 class rpmBinaryPackage(Package, rpmPackage):
@@ -163,18 +176,6 @@ class rpmBinaryPackage(Package, rpmPackage):
         self._populateChangeLog(header)
         # Channels
         self._populateChannels(channels)
-        # Extra tags
-        self._populateExtraTags(header)
-
-    def _populateExtraTags(self, header):
-        """
-        Populate extra tags. Currently only "modularitylabel".
-        """
-        mlabel = header.modularity_label()
-        if mlabel is not None:
-            self["extra_tags"] = [
-                {"name": "modularitylabel", "value": mlabel}
-            ]
 
     def _populateFiles(self, header):
         self._populateTag(header, 'files', rpmFile)

--- a/backend/server/importlib/headerSource.py
+++ b/backend/server/importlib/headerSource.py
@@ -306,6 +306,7 @@ class rpmSourcePackage(SourcePackage, rpmPackage):
         'payload_format': None,
         'channels': None,
         'package_id': None,
+        'extra_tags': None,
     })
 
     def populate(self, header, size, checksum_type, checksum, path=None, org_id=None,

--- a/backend/server/importlib/headerSource.py
+++ b/backend/server/importlib/headerSource.py
@@ -163,6 +163,18 @@ class rpmBinaryPackage(Package, rpmPackage):
         self._populateChangeLog(header)
         # Channels
         self._populateChannels(channels)
+        # Extra tags
+        self._populateExtraTags(header)
+
+    def _populateExtraTags(self, header):
+        """
+        Populate extra tags. Currently only "modularitylabel".
+        """
+        mlabel = header.modularitylabel()
+        if mlabel is not None:
+            self["extra_tags"] = [
+                {"name": "modularitylabel", "value": mlabel}
+            ]
 
     def _populateFiles(self, header):
         self._populateTag(header, 'files', rpmFile)

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- Read MODULARITYLABEL tag from RPM packages
+
 -------------------------------------------------------------------
 Wed Mar 11 10:49:22 CET 2020 - jgonzalez@suse.com
 

--- a/uyuni/common-libs/common/rhn_rpm.py
+++ b/uyuni/common-libs/common/rhn_rpm.py
@@ -118,7 +118,10 @@ class RPM_Header:
         Get modularity label tag.
         Returns string of modularity label or None if tag is not there.
         """
-        return self.hdr.get(rpm.RPMTAG_MODULARITYLABEL)
+        mtag = None
+        if rpm.RPMTAG_MODULARITYLABEL in self.hdr.keys():
+            mtag = self.hdr[rpm.RPMTAG_MODULARITYLABEL]
+        return mtag
 
     def checksum_type(self):
         if self.hdr[rpm.RPMTAG_FILEDIGESTALGO] \

--- a/uyuni/common-libs/common/rhn_rpm.py
+++ b/uyuni/common-libs/common/rhn_rpm.py
@@ -47,6 +47,7 @@ del sym, val
 
 # need this for rpm-pyhon < 4.6 (e.g. on RHEL5)
 rpm.RPMTAG_FILEDIGESTALGO = 5011
+rpm.RPMTAG_MODULARITYLABEL = 5096
 
 # these values are taken from /usr/include/rpm/rpmpgp.h
 # PGPHASHALGO_MD5             =  1,   /*!< MD5 */
@@ -111,6 +112,13 @@ class RPM_Header:
         return bool(self.hdr)
 
     __bool__ = __nonzero__
+
+    def modularity_label(self):
+        """
+        Get modularity label tag.
+        Returns string of modularity label or None if tag is not there.
+        """
+        return self.hdr.get(rpm.RPMTAG_MODULARITYLABEL)
 
     def checksum_type(self):
         if self.hdr[rpm.RPMTAG_FILEDIGESTALGO] \

--- a/uyuni/common-libs/uyuni-common-libs.changes
+++ b/uyuni/common-libs/uyuni-common-libs.changes
@@ -1,3 +1,5 @@
+- Add MODULARITYLABEL tag support
+
 -------------------------------------------------------------------
 Wed Jan 22 12:26:04 CET 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Implements modularity tag reading as per https://github.com/SUSE/spacewalk/issues/10897

- [x] **DONE**

## Documentation
- No documentation needed: this change is a part of above mentioned project.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
