### PR TITLE
Get latest changes from upstream and adjust the spec for 1.0.15

### DIFF
--- a/client/debian/apt-spacewalk/apt-spacewalk.spec
+++ b/client/debian/apt-spacewalk/apt-spacewalk.spec
@@ -14,7 +14,7 @@ Summary: Spacewalk plugin for Advanced Packaging Tool
 Packager: Uyuni Project <uyuni-devel@opensuse.org>
 Group: admin
 %endif
-Version: 1.0.14
+Version: 1.0.15
 Release: 1%{?dist}
 License: GPLv2
 Source0: %{name}-%{version}.tar.gz
@@ -108,6 +108,18 @@ esac
 %endif
 
 %changelog
+* Thu Oct 25 2018 Tomas Kasparek <tkasparek@redhat.com> 1.0.15-1
+- client, usix: Rework how client packaging is done for Debian/Ubuntu
+- Move apt-spacewalk to the client/debian/ directory
+
+* Mon Jun 18 2018 Michael Mraka <michael.mraka@redhat.com> 1.0.14-1
+- client/debian: Port apt-spacewalk to be Python 3 ready
+
+* Mon Apr 16 2018 Tomas Kasparek <tkasparek@redhat.com> 1.0.13-1
+- apt-transport-spacewalk: missed part of patch within pre_invoke
+- further modifications on apt-transport-spacewalk
+- modify apt-transport-spacewalk to support signed repos
+
 * Fri Feb 09 2018 Michael Mraka <michael.mraka@redhat.com> 1.0.12-1
 - removed BuildRoot from specfiles
 

--- a/client/debian/apt-spacewalk/spacewalk
+++ b/client/debian/apt-spacewalk/spacewalk
@@ -19,6 +19,7 @@
 from __future__ import print_function
 
 import sys
+import os
 import re
 import hashlib
 
@@ -223,11 +224,25 @@ class spacewalk_method(pkg_acquire_method):
         self.__init_headers()
         self.__make_conn()
 
-        self.conn.request("GET", "/" + document, headers = self.http_headers)
+        hdrs = self.http_headers;
+        # check is partially downloaded file present
+        if os.path.isfile(self.filename):
+            fsize = os.stat(self.filename).st_size
+            if fsize > 0:
+                # resume aborted download by requesting tail of the file
+                # using Range HTTP header
+                hdrs['Range'] = 'bytes=' + str(fsize) + '-'
+
+        self.conn.request("GET", "/" + document, headers = hdrs)
         self.status(URI = self.uri, Message = 'Waiting for headers')
 
         res = self.conn.getresponse()
-        if res.status != 200:
+
+        if      res.status == 200:
+            f = open(self.filename, "wb")
+        elif    res.status == 206:
+            f = open(self.filename, "ab")
+        else:
             self.uri_failure({'URI': self.uri,
                               'Message': str(res.status) + '  ' + res.reason,
                               'FailReason': 'HttpError' + str(res.status)})
@@ -241,22 +256,30 @@ class spacewalk_method(pkg_acquire_method):
                         'Size': res.getheader('content-length'),
                         'Last-Modified': res.getheader('last-modified')})
 
-        f = open(self.filename, "w")
-        hash_sha256 = hashlib.sha256()
-        hash_md5 = hashlib.md5()
         while True:
             data = res.read(4096)
             if not len(data):
                 break
-            hash_sha256.update(bstr(data))
-            hash_md5.update(bstr(data))
             f.write(data)
         res.close()
         f.close()
 
+        f = open(self.filename, "r")
+        hash_sha256 = hashlib.sha256()
+        hash_md5 = hashlib.md5()
+        fsize = 0
+        while True:
+            data = f.read(4096)
+            if not len(data):
+                break
+            fsize += len(data)
+            hash_sha256.update(data)
+            hash_md5.update(data)
+        f.close()
+
         self.uri_done({'URI': self.uri,
                        'Filename': self.filename,
-                       'Size': res.getheader('content-length'),
+                       'Size': str(fsize),
                        'Last-Modified': res.getheader('last-modified'),
                        'MD5-Hash': hash_md5.hexdigest(),
                        'MD5Sum-Hash': hash_md5.hexdigest(),


### PR DESCRIPTION
## What does this PR change?

- Get latest changes from upstream and adjust the spec for 1.0.15 (the code was already 1.0.15, but the spec was not updated)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: No, unsupported for now.

- [x] **DONE**

## Test coverage
- No tests: No, not covered for now.

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
