### PR TITLE
Do not crash 'mgr-update-status' because 'long' type is not defined in Python 3

### DIFF
--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes
@@ -1,3 +1,5 @@
+- Do not crash 'mgr-update-status' because 'long' type is not defined in Python 3
+
 -------------------------------------------------------------------
 Wed Mar 11 10:51:46 CET 2020 - jgonzalez@suse.com
 

--- a/client/rhel/spacewalk-client-tools/src/bin/spacewalk-update-status.py
+++ b/client/rhel/spacewalk-client-tools/src/bin/spacewalk-update-status.py
@@ -45,7 +45,7 @@ class StatusCli(rhncli.RhnCli):
                 pass
 
         # We need to fit into xmlrpc's integer limits
-        if status_report['uptime'][1] > long(2)**31-1:
+        if status_report['uptime'][1] > int(2)**31-1:
             status_report['uptime'][1] = -1
 
         return status_report


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue in `mgr-update-status` because of the use of type `long` which is not longer existing in Python 3:

```[Tue Mar 17 07:04:27 2020] up2date 
Traceback (most recent call last):
  File "/usr/sbin/mgr-update-status", line 55, in <module>
    cli.run()
  File "/usr/lib/python3.6/site-packages/up2date_client/rhncli.py", line 94, in run
    sys.exit(self.main() or 0)
  File "/usr/sbin/mgr-update-status", line 29, in main
    status_report = StatusCli.__build_status_report()
  File "/usr/sbin/mgr-update-status", line 48, in __build_status_report
    if status_report['uptime'][1] > long(2)**31-1:
<class 'NameError'>: name 'long' is not defined
```

This issue is currently making our cucumber testsuite to fail at `Scenario: Check spacewalk upd2date logs on client`

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **this is actually fixing a test failure**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
