### PR TITLE
Uyuni bootstrap repo without tools

### DIFF
--- a/susemanager/src/mgr-create-bootstrap-repo
+++ b/susemanager/src/mgr-create-bootstrap-repo
@@ -21,8 +21,9 @@ rhnSQL.initDB()
 
 basepath = CFG.MOUNT_POINT or '/var/spacewalk'
 logfile = '/var/log/rhn/mgr-create-bootstrap-repo.log'
-LOCK = None
-BETA = None
+LOCK  = None
+BETA  = None
+UYUNI = None
 
 _sql_synced_proucts = rhnSQL.Statement("""
    SELECT sp.product_id id, spsr.root_product_id
@@ -166,6 +167,13 @@ SELECT c.label, c.last_synced,
  WHERE (SELECT id FROM rhnchannel WHERE label = :basechannel) IN (c.parent_channel, c.id);
 """;
 
+_lookupToolsProductIds = """
+SELECT sp.product_id
+  FROM suseProducts sp
+  JOIN rhnChannelFamily cf ON sp.channel_family_id = cf.id
+ WHERE cf.label = 'SLE-M-T';
+""";
+
 def releaseLOCK():
     global LOCK
     if LOCK:
@@ -187,11 +195,23 @@ def log(msg, level=0):
 
 def isBeta():
     global BETA
+    global UYUNI
     if BETA is None:
         initCFG('java')
         BETA = CFG.PRODUCT_TREE_TAG == 'Beta'
+        UYUNI = CFG.PRODUCT_TREE_TAG == 'Uyuni'
         initCFG('server.susemanager')
     return BETA
+
+def isUyuni():
+    global BETA
+    global UYUNI
+    if UYUNI is None:
+        initCFG('java')
+        BETA = CFG.PRODUCT_TREE_TAG == 'Beta'
+        UYUNI = CFG.PRODUCT_TREE_TAG == 'Uyuni'
+        initCFG('server.susemanager')
+    return UYUNI
 
 def cli():
 
@@ -237,17 +257,22 @@ def cli():
     if isBeta():
         log("Is a Beta installation", 1)
 
+    blacklistedPids = []
+    if isUyuni():
+        log("Is a Uyuni installation", 1)
+        blacklistedPids = list_products_needs_tools_subscription()
+
     modulename = options.datamodule or CFG.BOOTSTRAP_REPO_DATAMODULE
     try:
         bootstrap_data = __import__(modulename)
         for label in bootstrap_data.DATA:
             if 'PDID' in bootstrap_data.DATA[label]:
                 if not isinstance(bootstrap_data.DATA[label]['PDID'], usix.ListType):
-                    bootstrap_data.DATA[label]['PDID'] = list(map(str, [int(bootstrap_data.DATA[label]['PDID'])]))
+                    bootstrap_data.DATA[label]['PDID'] = list(map(str, [x for x in [int(bootstrap_data.DATA[label]['PDID'])] if x not in blacklistedPids]))
                 else:
-                    bootstrap_data.DATA[label]['PDID'] = list(map(str, [int(pdid) for pdid in bootstrap_data.DATA[label]['PDID']]))
+                    bootstrap_data.DATA[label]['PDID'] = list(map(str, [x for x in [int(pdid) for pdid in bootstrap_data.DATA[label]['PDID']] if x not in blacklistedPids]))
                 if isBeta() and 'BETAPDID' in bootstrap_data.DATA[label]:
-                    bootstrap_data.DATA[label]['PDID'].extend(list(map(str, [int(pdid) for pdid in bootstrap_data.DATA[label]['BETAPDID']])))
+                    bootstrap_data.DATA[label]['PDID'].extend(list(map(str, [x for x in [int(pdid) for pdid in bootstrap_data.DATA[label]['BETAPDID']] if x not in blacklistedPids])))
 
     except ImportError as e:
         log_error("Unable to load module '%s'" % modulename)
@@ -258,6 +283,10 @@ def cli():
         options.interactive = True
 
     return options, args, bootstrap_data
+
+def list_products_needs_tools_subscription():
+    h = rhnSQL.Statement(_lookupToolsProductIds)
+    return [x['product_id'] for x in rhnSQL.fetchall_dict(h) or []]
 
 
 def find_root_channel_labels(pdids):
@@ -322,6 +351,12 @@ def create_repo(label, options, mgr_bootstrap_data, additional=[]):
         pdids = ', '.join(mgr_bootstrap_data.DATA[label]['PDID'])
         if (label.startswith('RES') or label.startswith('RHEL') or label.lower().startswith('ubuntu')):
             usecustomchannels = True
+        if isUyuni():
+            usecustomchannels = True
+            for label in find_root_channel_labels(pdids):
+                # we take the first one
+                parentchannel = label
+                break
     else:
         usecustomchannels = True
         parentchannel = mgr_bootstrap_data.DATA[label]['BASECHANNEL']

--- a/susemanager/src/mgr-create-bootstrap-repo
+++ b/susemanager/src/mgr-create-bootstrap-repo
@@ -355,9 +355,9 @@ def create_repo(label, options, mgr_bootstrap_data, additional=[]):
             usecustomchannels = True
         if isUyuni():
             usecustomchannels = True
-            for label in find_root_channel_labels(pdids):
+            for plabel in find_root_channel_labels(pdids):
                 # we take the first one
-                parentchannel = label
+                parentchannel = plabel
                 break
     else:
         usecustomchannels = True

--- a/susemanager/src/mgr-create-bootstrap-repo
+++ b/susemanager/src/mgr-create-bootstrap-repo
@@ -320,7 +320,9 @@ def list_labels(mgr_bootstrap_data, do_print=True):
     custom_parent_channels = find_custom_parent_channel_labels()
     label_index = 1
     for label in sorted(mgr_bootstrap_data.DATA.keys()):
-        if 'PDID' in mgr_bootstrap_data.DATA[label] and all(elem in synced_products for elem in mgr_bootstrap_data.DATA[label]['PDID']):
+        if ('PDID' in mgr_bootstrap_data.DATA[label] and mgr_bootstrap_data.DATA[label]['PDID'] and
+            all(elem in synced_products for elem in mgr_bootstrap_data.DATA[label]['PDID'])):
+
             if do_print:
                 print("{0}. {1}".format(label_index, label))
             label_map[label_index] = label

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- create bootstrap repos on Uyuni without SUSE Manager tools channels
 - Enable support for bootstrapping Debian 9 and 10
 
 -------------------------------------------------------------------

--- a/utils/spacewalk-common-channels
+++ b/utils/spacewalk-common-channels
@@ -116,7 +116,11 @@ def add_channels(channels, section, arch, client):
                 pass
             elif channel_base_server:
                 # If not, if cannel exists on the server, convert it
-                channels[channel['base_channel']] = {'name' : channel_base_server['label'],
+                channels[channel['base_channel']] = {'label': channel_base_server['label'],
+                                                     'name' : channel_base_server['name'],
+                                                     'summary': channel_base_server['summary'],
+                                                     'arch': channel_base_server['arch_name'],
+                                                     'checksum': channel_base_server['checksum_label'],
                                                      'gpgkey_url': channel_base_server['gpg_key_url'],
                                                      'gpgkey_id': channel_base_server['gpg_key_id'],
                                                      'gpgkey_fingerprint': channel_base_server['gpg_key_fp'],
@@ -250,7 +254,7 @@ Create everything as well as unlimited activation key for every channel:
                              if fnmatch.fnmatch(channels[n]['section'], pattern)]
         for name in matching_channels:
             attr = channels[name]
-            if attr['base_channel']:
+            if 'base_channel' in attr and attr['base_channel']:
                 if attr['base_channel'] not in base_channels:
                     base_channels[attr['base_channel']] = False
                 if attr['base_channel'] in child_channels:
@@ -290,8 +294,8 @@ Create everything as well as unlimited activation key for every channel:
                                                    base_info['summary'], CHANNEL_ARCH[base_info['arch']],
                                                    '', base_info['checksum'],
                                                    {'url': base_info['gpgkey_url'],
-                                                       'id': base_info['gpgkey_id'],
-                                                       'fingerprint': base_info['gpgkey_fingerprint']})
+                                                    'id': base_info['gpgkey_id'],
+                                                    'fingerprint': base_info['gpgkey_fingerprint']})
                     client.channel.software.createRepo(key,
                                                        base_info['yum_repo_label'], repo_type,
                                                        base_info['repo_url'])
@@ -299,8 +303,7 @@ Create everything as well as unlimited activation key for every channel:
                                                           base_info['label'], base_info['yum_repo_label'])
                 except xmlrpclib.Fault as e:
                     if e.faultCode == 1200:  # ignore if channel exists
-                        sys.stderr.write("WARNING: %s: %s\n" % (
-                            base_info['label'], e.faultString))
+                        sys.stdout.write("INFO: %s exists\n" % base_info['label'])
                     else:
                         sys.stderr.write("ERROR: %s: %s\n" % (
                             base_info['label'], e.faultString))

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,4 @@
+- fix spacewalk-common-channel when base channel exists
 - Add Springdale Linux 6, 7 and 8 repositories
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

In uyuni the customers typically do not have a SUSE Manager subscription which is required to access the SUSE Manager Tools Channel. These Tools channels are not even listed when a product gets synced.
This means we cannot use them in case of creating the bootstrap repo either.

On an Uyuni installation we blacklist the product ids which require a SUSE Manager Subscription.
Additionally we set "--with-custom-channels" as we expect they come from the uyuni tools channel.

It fixes also problems with spacewalk-common-channels when the base channel already exists.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/2007

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
