### PR TITLE
Manager bsc1166284

### DIFF
--- a/proxy/installer/configure-proxy.sh
+++ b/proxy/installer/configure-proxy.sh
@@ -348,7 +348,7 @@ fi
 
 SYSTEM_ID=$(/usr/bin/xsltproc /usr/share/rhn/get_system_id.xslt $SYSTEMID_PATH | cut -d- -f2)
 
-DIR=/usr/share/doc/proxy/conf-template
+DIR=/usr/share/rhn/proxy-template
 HOSTNAME=$(hostname -f)
 
 default_or_input "SUSE Manager Parent" RHN_PARENT $PROPOSED_PARENT

--- a/proxy/installer/spacewalk-proxy-installer.changes
+++ b/proxy/installer/spacewalk-proxy-installer.changes
@@ -1,3 +1,5 @@
+- move vital proxy templates to a safe place outside of docu (bsc#1166284)
+
 -------------------------------------------------------------------
 Mon Feb 17 12:51:37 CET 2020 - jgonzalez@suse.com
 

--- a/proxy/installer/spacewalk-proxy-installer.spec
+++ b/proxy/installer/spacewalk-proxy-installer.spec
@@ -80,7 +80,7 @@ Requires:       rhnlib
 Obsoletes:      proxy-installer < 5.3.0
 Provides:       proxy-installer = 5.3.0
 
-%define defaultdir %{_usr}/share/doc/proxy/conf-template/
+%define defaultdir %{_usr}/share/rhn/proxy-template
 
 %description
 The Spacewalk Proxy Server allows package proxying/caching
@@ -163,7 +163,7 @@ spacewalk-%{pythonX}-pylint .
 %{_usr}/sbin/rhn-proxy-activate
 %{_usr}/sbin/fetch-certificate
 %doc LICENSE answers.txt
-%dir %{_usr}/share/doc/proxy
+%dir %{_usr}/share/rhn/proxy-template
 %dir %{_usr}/share/rhn
 %dir %{_usr}/share/rhn/installer/jabberd
 %if 0%{?suse_version} > 1320


### PR DESCRIPTION
## What does this PR change?

In order to correctly configure a proxy, some templates are needed. Currently these templates live in /usr/share/doc/proxy/conf-template and as JeOS will not install any documentation, they are missing which results in an invalid setup.

So moving these templates into some save location; they are not documentation files anyway, but in fact needed for proper functionality.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: Bugfix

- [X] **DONE**

## Test coverage
- No tests: Issue can only be triggered by trying to configure a proxy based on JeOS

- [X] **DONE**

## Links

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1166284

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
