### PR TITLE
Remove dead links

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Following links might be of value in case you are interested:
 
   * [Project home](https://www.uyuni-project.org/)
   * [OBS project](https://build.opensuse.org/project/show/systemsmanagement:Uyuni:Master)
-  * [IRC](https://www.uyuni-project.org/contact.html#irc) (#uyuni at irc.freenode.org)
-  * [Mailing lists](https://www.uyuni-project.org/contact.html#ml)
+  * [IRC] #uyuni at irc.freenode.org
+  * [Mailing lists]
   * [Bug reports](https://github.com/uyuni-project/uyuni/issues)
   * [SUSE Manager](https://www.suse.com/products/suse-manager/)


### PR DESCRIPTION
GSoC aspirant discovered these links are broken. I can't work out where they're supposed to go, so leaving them blank for now.

## What does this PR change?

**add description**

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
