### PR TITLE
Fix sanity checks for Uyuni

### DIFF
--- a/testsuite/features/core/allcli_sanity.feature
+++ b/testsuite/features/core/allcli_sanity.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 SUSE LLC
+# Copyright (c) 2019-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Sanity checks
@@ -47,9 +47,8 @@ Feature: Sanity checks
     And "xen_server" should communicate with the server
 
   Scenario: The external resources can be reached
-    Then it should be possible to download the file "http://download.suse.de/ibs/SUSE/Products/SLE-SERVER/12-SP4/x86_64/product/media.1/products.key"
-    And it should be possible to download the file "https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Updates/rpm/repodata/repomd.xml"
-    And it should be possible to download the file "https://gitlab.suse.de/galaxy/suse-manager-containers/blob/master/test-profile/Dockerfile"
-    And it should be possible to download the file "https://github.com/uyuni-project/uyuni/blob/master/README.md"
+    Then it should be possible to reach the download site
+    And it should be possible to reach the container profiles
+    And it should be possible to reach the test suite profiles
     And it should be possible to reach the portus registry
     And it should be possible to reach the other registry

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -21,14 +21,46 @@ Then(/^"([^"]*)" should communicate with the server$/) do |host|
   $server.run("ping -c1 #{node.full_hostname}")
 end
 
-Then(/^it should be possible to download the file "([^"]*)"$/) do |file|
-  $server.run("curl -k #{file} -o /dev/null")
+# rubocop:disable Metrics/BlockLength
+Then(/^it should be possible to reach the (.*)$/) do |resource|
+  url = case resource
+        when 'download site'
+    if $product == 'Uyuni'
+      'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Updates/rpm/repodata/repomd.xml'
+    else
+      'http://download.suse.de/ibs/SUSE/Products/SLE-SERVER/12-SP4/x86_64/product/media.1/products.key'
+    end
+        when 'container profiles'
+    # TODO: move that resource to next location ("test suite profiles")
+    if $product == 'Uyuni'
+      ''
+    else
+      'https://gitlab.suse.de/galaxy/suse-manager-containers/blob/master/test-profile/Dockerfile'
+    end
+        when 'test suite profiles'
+    'https://github.com/uyuni-project/uyuni/blob/master/testsuite/features/profiles/Docker/Dockerfile'
+        when 'portus registry'
+    if $product == 'Uyuni'
+      # TODO: move that internal resource to some other external location
+      ''
+    else
+      'https://portus.mgr.suse.de:5000'
+    end
+        when 'other registry'
+    if $product == 'Uyuni'
+      # TODO: move that internal resource to some other external location
+      ''
+    else
+      'https://registry.mgr.suse.de:443'
+    end
+        end
+  if url.empty?
+    STDERR.puts 'Sanity check not implemented, move resource to external network first'
+  else
+    $server.run("curl -k #{url} -o /dev/null") # --fail option does not work as expected
+  end
 end
-
-Then(/^it should be possible to reach the (.*) registry$/) do |registry|
-  url = registry == 'portus' ? 'https://portus.mgr.suse.de:5000' : 'https://registry.mgr.suse.de:443'
-  $server.run("curl -k --fail #{url}")
-end
+# rubocop:enable Metrics/BlockLength
 
 # Channels
 


### PR DESCRIPTION
## What does this PR change?

The sanity checks were not written with the fact that some people would need to run them from outside our internal network in mind.

This PR checks the existing resources are available with no access to internal network.

**Important** : in case the resource has not been transported to the external network yet, it displays an error message, but does not fail. This way, we can go past the core features in Uyuni.

Also: I removed `--fail`option from `curl`. I tested it manually and it did not seem satisfactory to me.


## Links

Fixes SUSE/spacewalk#10976
Ports:
 * 4.0: SUSE/spacewalk#11015
 * 3.2: SUSE/spacewalk#11016

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
