### PR TITLE
Refactoring the validation of a package installed

### DIFF
--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -404,7 +404,7 @@ The check box can be identified by name, id or label text.
   When I install package "virgo-dummy-1.0-1.1" on this "sle_minion"
   When I remove package "orion-dummy" from this "sle_minion"
   When I refresh packages list via spacecmd on "sle_minion"
-  When I wait for "virgo-dummy-1.0" to be installed on this "sle_minion"
+  When I wait for "virgo-dummy-1.0" to be installed on "sle_minion"
   When I wait for "milkyway-dummy" to be uninstalled on "sle_minion"
   When I wait until refresh package list on "sle_minion" is finished
   When I wait until package "virgo-dummy" is installed on "sle_minion" via spacecmd

--- a/testsuite/features/core/proxy_branch_network.feature
+++ b/testsuite/features/core/proxy_branch_network.feature
@@ -23,7 +23,7 @@ Feature: Setup SUSE Manager for Retail branch network
 @private_net
   Scenario: Install the Retail pattern on the server
     When I install pattern "suma_retail" on this "server"
-    And I wait for "patterns-suma_retail" to be installed on this "server"
+    And I wait for "patterns-suma_retail" to be installed on "server"
 
 @proxy
 @private_net

--- a/testsuite/features/secondary/min_action_chain.feature
+++ b/testsuite/features/secondary/min_action_chain.feature
@@ -165,7 +165,7 @@ Feature: Action chains on Salt minions
     And I follow "new action chain"
     And I click on "Save and Schedule"
     Then I should see a "Action Chain new action chain has been scheduled for execution." text
-    When I wait for "virgo-dummy" to be installed on this "sle_minion"
+    When I wait for "virgo-dummy" to be installed on "sle_minion"
     And I wait at most 300 seconds until file "/tmp/action_chain_one_system_done" exists on "sle_minion"
 
   Scenario: Add a remote command to the new action chain on Salt minion

--- a/testsuite/features/secondary/min_activationkey.feature
+++ b/testsuite/features/secondary/min_activationkey.feature
@@ -70,8 +70,8 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
     When I go to the minion onboarding page
     Then I should see a "accepted" text
     And the Salt master can reach "sle_minion"
-    When I wait for "orion-dummy" to be installed on this "sle_minion"
-    And I wait for "perseus-dummy" to be installed on this "sle_minion"
+    When I wait for "orion-dummy" to be installed on "sle_minion"
+    And I wait for "perseus-dummy" to be installed on "sle_minion"
 
   Scenario: Check system ID of bootstrapped minion
     Given I am on the Systems overview page of this "sle_minion"

--- a/testsuite/features/secondary/min_bootstrap_script.feature
+++ b/testsuite/features/secondary/min_bootstrap_script.feature
@@ -37,7 +37,6 @@ Feature: Register a Salt minion via Bootstrap-script
   Scenario: Bootstrap the minion using the script
     Given I am authorized as "admin" with password "admin"
     When I run "sh /root/bootstrap.sh" on "sle_minion"
-    And I wait for "5" seconds
     When I follow the left menu "Salt > Keys"
     And I wait until I see the name of "sle_minion", refreshing the page
     And I should see a "pending" text

--- a/testsuite/features/secondary/min_salt_install_package.feature
+++ b/testsuite/features/secondary/min_salt_install_package.feature
@@ -33,9 +33,8 @@ Feature: Install a patch on the client via Salt through the UI
     When I check "virgo-dummy-3456" in the list
     And I click on "Apply Patches"
     And I click on "Confirm"
-    And I wait for "5" seconds
     Then I should see a "1 patch update has been scheduled for" text
-    And I wait for "virgo-dummy-2.0-1.1" to be installed on this "sle_minion"
+    And I wait for "virgo-dummy-2.0-1.1" to be installed on "sle_minion"
 
   Scenario: Cleanup: remove virgo-dummy package from SLE minion
     When I disable repository "test_repo_rpm_pool" on this "sle_minion"

--- a/testsuite/features/secondary/min_salt_install_with_staging.feature
+++ b/testsuite/features/secondary/min_salt_install_with_staging.feature
@@ -52,7 +52,7 @@ Feature: Install a package on the SLES minion with staging enabled
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled for" text
     And I wait until the package "orion-dummy-1.1-1.1" has been cached on this "sle_minion"
-    And I wait for "orion-dummy-1.1-1.1" to be installed on this "sle_minion"
+    And I wait for "orion-dummy-1.1-1.1" to be installed on "sle_minion"
 
   Scenario: Install patch in the future and check for staging
     Given I am on the Systems overview page of this "sle_minion"
@@ -64,7 +64,7 @@ Feature: Install a package on the SLES minion with staging enabled
     And I click on "Confirm"
     Then I should see a "1 patch update has been scheduled for" text
     And I wait until the package "virgo-dummy-2.0-1.1.noarch" has been cached on this "sle_minion"
-    And I wait for "virgo-dummy-2.0-1.1" to be installed on this "sle_minion"
+    And I wait for "virgo-dummy-2.0-1.1" to be installed on "sle_minion"
 
   Scenario: Cleanup: remove virgo-dummy package from SLES minion
     Given I am on the Systems overview page of this "sle_minion"

--- a/testsuite/features/secondary/min_salt_software_states.feature
+++ b/testsuite/features/secondary/min_salt_software_states.feature
@@ -66,7 +66,7 @@ Feature: Salt package states
     And I click save
     Then I wait until I see "Package states have been saved." text
     And I click apply
-    And I wait for "milkyway-dummy" to be installed on this "sle_minion"
+    And I wait for "milkyway-dummy" to be installed on "sle_minion"
 
   Scenario: Install an already installed package through the UI
     Given I am on the Systems overview page of this "sle_minion"
@@ -82,7 +82,7 @@ Feature: Salt package states
     And I click save
     Then I wait until I see "Package states have been saved." text
     And I click apply
-    And I wait for "virgo-dummy-1.0" to be installed on this "sle_minion"
+    And I wait for "virgo-dummy-1.0" to be installed on "sle_minion"
 
   Scenario: Upgrade a package through the UI
     Given I am on the Systems overview page of this "sle_minion"
@@ -98,7 +98,7 @@ Feature: Salt package states
     And I click save
     Then I wait until I see "Package states have been saved." text
     And I click apply
-    And I wait for "andromeda-dummy-2.0-1.1" to be installed on this "sle_minion"
+    And I wait for "andromeda-dummy-2.0-1.1" to be installed on "sle_minion"
 
   Scenario: Verify the package states
     Given I am on the Systems overview page of this "sle_minion"

--- a/testsuite/features/secondary/minssh_action_chain.feature
+++ b/testsuite/features/secondary/minssh_action_chain.feature
@@ -164,7 +164,7 @@ Feature: Salt SSH action chain
     And I should see a "Action Chain new action chain has been scheduled for execution." text
 
   Scenario: Verify that the action chain was executed successfully
-    When I wait for "virgo-dummy" to be installed on this "ssh_minion"
+    When I wait for "virgo-dummy" to be installed on "ssh_minion"
     And I wait at most 300 seconds until file "/tmp/action_chain_one_system_done" exists on "ssh_minion"
 
   Scenario: Add a remote command to the new action chain on SSH minion

--- a/testsuite/features/secondary/minssh_centos_salt_install_package_and_patch.feature
+++ b/testsuite/features/secondary/minssh_centos_salt_install_package_and_patch.feature
@@ -51,9 +51,8 @@ Feature: Install a patch on the CentOS SSH minion via Salt through the UI
     When I check "virgo-dummy-3456" in the list
     And I click on "Apply Patches"
     And I click on "Confirm"
-    And I wait for "5" seconds
     Then I should see a "1 patch update has been scheduled for" text
-    And I wait for "virgo-dummy-2.0-1.1" to be installed on this "ceos_ssh_minion"
+    And I wait for "virgo-dummy-2.0-1.1" to be installed on "ceos_ssh_minion"
 
 @centos_minion
   Scenario: Install a package on the Centos SSH minion

--- a/testsuite/features/secondary/srv_distro_cobbler.feature
+++ b/testsuite/features/secondary/srv_distro_cobbler.feature
@@ -85,7 +85,6 @@ Feature: Cobbler and distribution autoinstallation
     And I follow "fedora_kickstart_profile"
     And I enter "kernel_option=a_value" as "kernel_options"
     And I click on "Update"
-    And I wait for "5" seconds
     And I wait until file "/srv/tftpboot/pxelinux.cfg/default" contains "kernel_option=a_value" on server
 
   Scenario: Add a kernel option to the uploaded profile
@@ -93,7 +92,6 @@ Feature: Cobbler and distribution autoinstallation
     And I follow "fedora_kickstart_profile_upload"
     And I enter "kernel_option2=a_value2" as "kernel_options"
     And I click on "Update"
-    And I wait for "5" seconds
     And I wait until file "/srv/tftpboot/pxelinux.cfg/default" contains "kernel_option2=a_value2" on server
 
   Scenario: Check default snippets

--- a/testsuite/features/secondary/trad_cve_audit.feature
+++ b/testsuite/features/secondary/trad_cve_audit.feature
@@ -98,7 +98,6 @@ Feature: CVE Audit on traditional clients
     And I check "milkyway-dummy-2345" in the list
     And I click on "Apply Patches"
     And I click on "Confirm"
-    And I wait for "5" seconds
     And I run "rhn_check -vvv" on "sle_client"
     Then I should see a "patch update has been scheduled" text
 

--- a/testsuite/features/secondary/trad_migrate_to_minion.feature
+++ b/testsuite/features/secondary/trad_migrate_to_minion.feature
@@ -66,7 +66,7 @@ Feature: Migrate a traditional client into a Salt minion
     And I click on "Install Selected Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled for" text
-    And I wait for "perseus-dummy-1.1-1.1" to be installed on this "sle_migrated_minion"
+    And I wait for "perseus-dummy-1.1-1.1" to be installed on "sle_migrated_minion"
 
   Scenario: Run a remote script on the migrated minion
     Given I am on the Systems overview page of this "sle_migrated_minion"

--- a/testsuite/features/secondary/trad_migrate_to_sshminion.feature
+++ b/testsuite/features/secondary/trad_migrate_to_sshminion.feature
@@ -88,7 +88,7 @@ Feature: Migrate a traditional client into a Salt SSH minion
     And I click on "Install Selected Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled for" text
-    And I wait for "perseus-dummy-1.1-1.1" to be installed on this "sle_migrated_minion"
+    And I wait for "perseus-dummy-1.1-1.1" to be installed on "sle_migrated_minion"
 
   Scenario: Run a remote script on the migrated SSH minion
     Given I am on the Systems overview page of this "sle_migrated_minion"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -60,6 +60,31 @@ Then(/^"([^"]*)" should not be installed on "([^"]*)"$/) do |package, host|
   node.run("rpm -q #{package}; test $? -ne 0")
 end
 
+When(/^I wait for "([^"]*)" to be (uninstalled|installed) on "([^"]*)"$/) do |package, status, host|
+  if package.include?("suma") && $product == "Uyuni"
+    package.gsub! "suma", "uyuni"
+  end
+  node = get_target(host)
+  if host.include? 'ubuntu'
+    node.wait_while_process_running('apt-get')
+    pkg_version = package.split('-')[-1]
+    pkg_name = package.delete_suffix("-#{pkg_version}")
+    pkg_version_regexp = pkg_version.gsub('.', '\\.')
+    if status == 'installed'
+      node.run_until_ok("dpkg -l | grep -E '^ii +#{pkg_name} +#{pkg_version_regexp} +'")
+    else
+      node.run_until_fail("dpkg -l | grep -E '^ii +#{pkg_name} +#{pkg_version_regexp} +'")
+    end
+  else
+    node.wait_while_process_running('zypper')
+    if status == 'installed'
+      node.run_until_ok("rpm -q #{package}")
+    else
+      node.run_until_fail("rpm -q #{package}")
+    end
+  end
+end
+
 When(/^I query latest Salt changes on "(.*?)"$/) do |host|
   node = get_target(host)
   result, return_code = node.run("LANG=en_US.UTF-8 rpm -q --changelog salt")
@@ -189,7 +214,6 @@ When(/^I fetch "([^"]*)" to "([^"]*)"$/) do |file, host|
 end
 
 When(/^I wait until file "([^"]*)" contains "([^"]*)" on server$/) do |file, content|
-  sleep(3)
   repeat_until_timeout(message: "#{content} not found in file #{file}", report_result: true) do
     output = sshcmd("grep #{content} #{file}", ignore_err: true)
     break if output[:stdout] =~ /#{content}/
@@ -220,7 +244,6 @@ end
 
 Then(/^I restart the spacewalk service$/) do
   $server.run('spacewalk-service restart')
-  sleep(5)
 end
 
 Then(/^I shutdown the spacewalk service$/) do

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -658,34 +658,6 @@ When(/^I change the state of "([^"]*)" to "([^"]*)" and "([^"]*)"$/) do |pkg, st
   end
 end
 
-Then(/^I wait for "([^"]*)" to be uninstalled on "([^"]*)"$/) do |package, host|
-  node = get_target(host)
-  repeat_until_timeout(message: "Package removal failed", report_result: true) do
-    output, code = node.run("rpm -q #{package}", false)
-    if code.nonzero?
-      uninstalled = true
-      break
-    end
-    sleep 1
-    "code #{code}, #{output}"
-  end
-end
-
-Then(/^I wait for "([^"]*)" to be installed on this "([^"]*)"$/) do |package, host|
-  if package.include?("suma") && $product == "Uyuni"
-    package.gsub! "suma", "uyuni"
-  end
-  node = get_target(host)
-  if host.include? 'ubuntu'
-    pkg_version = package.split('-')[-1]
-    pkg_name = package.delete_suffix("-#{pkg_version}")
-    pkg_version_regexp = pkg_version.gsub('.', '\\.')
-    node.run_until_ok("dpkg -l | grep -E '^ii +#{pkg_name} +#{pkg_version_regexp} +'")
-  else
-    node.run_until_ok("rpm -q #{package}")
-  end
-end
-
 When(/^I click undo for "(.*?)"$/) do |pkg|
   find("button##{pkg}-undo").click
 end

--- a/testsuite/features/support/lavanda.rb
+++ b/testsuite/features/support/lavanda.rb
@@ -65,4 +65,14 @@ module LavandaBasic
       result
     end
   end
+
+  def wait_while_process_running(process)
+    result = nil
+    repeat_until_timeout(report_result: true) do
+      result, code = run("pgrep -x #{process} >/dev/null", false)
+      break if code.nonzero?
+      sleep 2
+      result
+    end
+  end
 end


### PR DESCRIPTION
## What does this PR change?

That PR intends to fix an intermittent issue with the zypper command, which was running in the background at the moment we were executing another zypper command.

The whole conflict seems to be caused due to a check of the status of a salt-action, we only do it via command line, by testing if a package is installed, instead of checking the salt event status from webUI.

Here we had two solutions, either we change the validation from command line and we check it via webU as we do in other scenarios, either we assure during the command line steps that not only the package is installed but also the zypper/apt-get command has finished.

For now, as it is less disruptive, I went through the second option.

Note: 
You will notice also small changes, like a rename of a step to combine two opposite steps and removing unuseful sleep calls as just after it they have a wait command. 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Fixes # https://ci.suse.de/view/Manager/view/Uyuni/job/uyuni-master-cucumber-pipeline-NUE/1230/TestSuite_20Report/

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
