### PR TITLE
Fix unit test for CLM module filters

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/MockModulemdApi.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/MockModulemdApi.java
@@ -143,7 +143,7 @@ public class MockModulemdApi extends ModulemdApi {
         nevras.add(perlNevra);
 
         // 'modularitylabel' rpm tag determines that a package belongs to a module
-        PackageExtraTagsKeys modularityHeader = PackageManagerTest.createExtraTagKey("MODULARITYLABEL");
+        PackageExtraTagsKeys modularityHeader = PackageManagerTest.createExtraTagKey("modularitylabel");
 
         Pattern nevraPattern = Pattern.compile("^(.*)-(\\d+):(.*)-(.*)\\.(.*)$");
         for (String nevra : nevras) {


### PR DESCRIPTION
Fixes the failing unit test in `ContentManagerTest` suite.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
