### PR TITLE
Automatic db schema upgrade

### DIFF
--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- run DB schema upgrade automatically on package update
 - change notification data type to TEXT
 - Update schema for virtualization pool actions
 

--- a/schema/spacewalk/susemanager-schema.spec
+++ b/schema/spacewalk/susemanager-schema.spec
@@ -103,6 +103,9 @@ else
 fi
 %endif
 
+%posttrans
+systemctl try-restart uyuni-check-database.service ||:
+
 %files
 %defattr(-,root,root)
 %dir %{rhnroot}

--- a/schema/spacewalk/update-messages.txt
+++ b/schema/spacewalk/update-messages.txt
@@ -2,19 +2,16 @@
 SUSE Manager Database Schema Update
 
 This patch updates the database schema.
-Additional configuration steps are required.
+The changes will be applied automatically at the end
+of the update.
+In case of a failure, some services are stopped or cannot
+be started util the issue was fixed.
 
-1. Stop the Spacewalk service before you apply this patch:
-spacewalk-service stop
+For more information about the failure call:
 
-2. Apply the patch.
+systemctl status uyuni-check-database.service
 
-3. If the SUSE Manager database is running on the same machine as
-your SUSE Manager Server, take care that the database instance is
-running
+When the schema update was applied successfully, start the
+services again with:
 
-4. Upgrade the database schema with:
-spacewalk-schema-upgrade
-
-5. Start the Spacewalk service:
 spacewalk-service start

--- a/schema/spacewalk/update-messages.txt
+++ b/schema/spacewalk/update-messages.txt
@@ -2,16 +2,16 @@
 SUSE Manager Database Schema Update
 
 This patch updates the database schema.
-The changes will be applied automatically at the end
+The patch will be applied automatically at the end
 of the update.
-In case of a failure, some services are stopped or cannot
-be started util the issue was fixed.
+In case of a failure, spacewalk services are stopped and cannot
+be started until the issue is fixed.
 
-For more information about the failure call:
+For more information about the failure, enter:
 
 systemctl status uyuni-check-database.service
 
-When the schema update was applied successfully, start the
+When the schema update is applied successfully, start the
 services again with:
 
 spacewalk-service start

--- a/spacewalk/admin/spacewalk-admin.changes
+++ b/spacewalk/admin/spacewalk-admin.changes
@@ -1,3 +1,4 @@
+- run DB schema upgrade automatically on startup
 - add DB check service and prevent service start with wrong DB version
 
 -------------------------------------------------------------------

--- a/spacewalk/admin/spacewalk-admin.spec
+++ b/spacewalk/admin/spacewalk-admin.spec
@@ -86,6 +86,12 @@ ln -s spacewalk-service $RPM_BUILD_ROOT%{_sbindir}/rhn-satellite
 sed -i 's|#!/usr/bin/python|#!/usr/bin/python3|' $RPM_BUILD_ROOT/usr/bin/mgr-events-config.py
 %endif
 
+%post
+if [ -x /usr/bin/systemctl ]; then
+    /usr/bin/systemctl daemon-reload || :
+fi
+
+
 %files
 %doc LICENSE
 %dir %{rhnroot}

--- a/spacewalk/admin/spacewalk-startup-helper
+++ b/spacewalk/admin/spacewalk-startup-helper
@@ -5,6 +5,15 @@ if [ -x "/usr/bin/lsof" ]; then
     LSOF="/usr/bin/lsof"
 fi
 
+perform_db_schema_upgrade() {
+    /usr/bin/spacewalk-schema-upgrade -y
+
+    if [ $? -ne 0 ]; then
+        echo "Database schema upgrade failed. Please check the logs."
+        exit 1
+    fi
+}
+
 check_database() {
     RETRIES=10;
     source /etc/os-release
@@ -17,6 +26,7 @@ check_database() {
                 echo "Database version '${VARR[0]}' is not supported for SUSE Manager/Uyuni on $PRETTY_NAME. Perform database migration."
                 exit 1
             fi
+            perform_db_schema_upgrade
             exit 0 # db is running
         fi
 


### PR DESCRIPTION
## What does this PR change?

To prevent people forgetting to update the database schema, apply it when the services start.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Part of https://github.com/SUSE/spacewalk/issues/10993

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/10574

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql" 		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
