### PR TITLE
Reposync speedup

### DIFF
--- a/backend/satellite_tools/contentRemove.py
+++ b/backend/satellite_tools/contentRemove.py
@@ -483,11 +483,7 @@ def _delete_srpms(srcPackageIds):
         from rhnPackageSource
         where id = :id
     """)
-    count = h.executemany(id=srcPackageIds)
-    if not count:
-        count = 0
-    log_debug(2, "Successfully deleted %s/%s source package ids" % (
-        count, len(srcPackageIds)))
+    h.executemany(id=srcPackageIds)
 
 
 def _delete_rpms(packageIds):
@@ -532,15 +528,10 @@ def _delete_rpm_group(packageIds):
     deleteStatement = "delete from %s where package_id = :package_id"
     for table in references:
         h = rhnSQL.prepare(deleteStatement % table)
-        count = h.executemany(package_id=packageIds)
-        log_debug(3, "Deleted from %s: %d rows" % (table, count))
+        h.executemany(package_id=packageIds)
     deleteStatement = "delete from rhnPackage where id = :package_id"
     h = rhnSQL.prepare(deleteStatement)
-    count = h.executemany(package_id=packageIds)
-    if count:
-        log_debug(2, "DELETED package id %s" % str(packageIds))
-    else:
-        log_error("No such package id %s" % str(packageIds))
+    h.executemany(package_id=packageIds)
     rhnSQL.commit()
 
 

--- a/backend/server/action_extra_data/configfiles.py
+++ b/backend/server/action_extra_data/configfiles.py
@@ -54,7 +54,7 @@ def upload(server_id, action_id, data={}):
 
     failure_table = rhnSQL.Table('rhnConfigFileFailure', 'label')
     h = rhnSQL.prepare(_query_mark_upload_files)
-    # We don't do execute_bulk here, since we want to know if each update has
+    # We don't do executemany here, since we want to know if each update has
     # actually touched a row
 
     reason_map = {'missing_files': 'missing',
@@ -124,7 +124,7 @@ def mtime_upload(server_id, action_id, data={}):
     num_paths = len(paths)
 
     h = rhnSQL.prepare(_query_create_action_config_filename)
-    h.execute_bulk({
+    h.executemany(**{
         'action_id': [action_id] * num_paths,
         'server_id': [server_id] * num_paths,
         'path': paths,
@@ -227,7 +227,7 @@ def _mark_missing_diff_files(server_id, action_id, missing_files):
     failure_ids = [failure_id] * len(ids)
 
     h = rhnSQL.prepare(_query_mark_failed_diff_files)
-    h.execute_bulk({
+    h.executemany(**{
         'action_config_revision_id': ids,
         'failure_id': failure_ids,
     })
@@ -307,4 +307,4 @@ def _disable_old_diffs(server_id):
         return
 
     h = rhnSQL.prepare(_query_delete_old_diffs)
-    h.execute_bulk({'action_config_revision_id': old_acr_ids})
+    h.executemany(**{'action_config_revision_id': old_acr_ids})

--- a/backend/server/action_extra_data/packages.py
+++ b/backend/server/action_extra_data/packages.py
@@ -407,7 +407,7 @@ def _mark_dep_failures(server_id, action_id, data):
 
     h = rhnSQL.prepare(_query_insert_dep_failures)
 
-    h.execute_bulk(inserts)
+    h.executemany(**inserts)
 
 
 def _check_dep(server_id, action_id, failed_dep):

--- a/backend/server/action_extra_data/packages.py
+++ b/backend/server/action_extra_data/packages.py
@@ -407,8 +407,7 @@ def _mark_dep_failures(server_id, action_id, data):
 
     h = rhnSQL.prepare(_query_insert_dep_failures)
 
-    rowcount = h.execute_bulk(inserts)
-    log_debug(5, "Inserted rows", rowcount)
+    h.execute_bulk(inserts)
 
 
 def _check_dep(server_id, action_id, failed_dep):

--- a/backend/server/action_extra_data/scap.py
+++ b/backend/server/action_extra_data/scap.py
@@ -116,9 +116,7 @@ def _create_rresult(testresult_id, result_label):
 
 def _store_idents(data):
     h = rhnSQL.prepare(_query_insert_identmap)
-    rowcount = h.execute_bulk(data)
-    log_debug(5, "Inserted xccdf_ruleresults rows:", rowcount)
-
+    h.execute_bulk(data)
 
 def _get_text(node):
     rc = []

--- a/backend/server/action_extra_data/scap.py
+++ b/backend/server/action_extra_data/scap.py
@@ -116,7 +116,7 @@ def _create_rresult(testresult_id, result_label):
 
 def _store_idents(data):
     h = rhnSQL.prepare(_query_insert_identmap)
-    h.execute_bulk(data)
+    h.executemany(**data)
 
 def _get_text(node):
     rc = []

--- a/backend/server/importlib/backend.py
+++ b/backend/server/importlib/backend.py
@@ -2141,16 +2141,17 @@ class Backend:
                     entry_list = object[tbl.getAttribute()]
                     if entry_list is None:
                         continue
-                    for entry in entry_list:
+                    seq_col = tbl.sequenceColumn
+                    new_ids = self.sequences[tbl.name].next_many(len(entry_list)) if seq_col else []
+                    for i, entry in enumerate(entry_list):
                         extObject = {childTables[tname]: id}
-                        seq_col = tbl.sequenceColumn
                         if seq_col:
                             # This table has to insert values in a sequenced
                             # column; since it's a child table and the entry
                             # in the master table is not created yet, there
                             # shouldn't be a problem with uniqueness
                             # constraints
-                            new_id = self.sequences[tbl.name].next()
+                            new_id = new_ids[i]
                             extObject[seq_col] = new_id
                             # Make sure we initialize the object's sequenced
                             # column as well

--- a/backend/server/importlib/backendLib.py
+++ b/backend/server/importlib/backendLib.py
@@ -464,7 +464,6 @@ def executeStatement(statement, valuesHash, chunksize):
     if not valuesHash:
         # Empty hash
         return
-    count = 0
     while 1:
         tempdict = {}
         for k, vals in list(valuesHash.items()):
@@ -481,10 +480,9 @@ def executeStatement(statement, valuesHash, chunksize):
             break
         # Now execute it
         if chunksize > 1:
-            count += statement.executemany(**tempdict)
+            statement.executemany(**tempdict)
         else:
-            count += statement.execute(**tempdict)
-    return count
+            statement.execute(**tempdict)
 
 
 def sanitizeValue(value, datatype):

--- a/backend/server/importlib/backendOracle.py
+++ b/backend/server/importlib/backendOracle.py
@@ -692,32 +692,10 @@ class PostgresqlBackend(OracleBackend):
     # Postgres doesn't support autonomous transactions. We could use
     # dblink_exec like we do in other stored procedures to open a new
     # connection to the db and do our inserts there, but there are a lot of
-    # capabilities and opening several million connections to the db in the
+    # checksums and opening several million connections to the db in the
     # middle of a sat-sync is slow. Instead we keep open a secondary db
     # connection which we only use here, so we can directly commit to that
     # instead of opening a new connection for each insert.
-    def processCapabilities(self, capabilityHash):
-        # must lock the table to keep rhnpush or whomever from causing
-        # this transaction to fail
-        lock_sql = "lock table rhnPackageCapability in exclusive mode"
-        sql = "select lookup_package_capability_fast(:name, :version) as id from dual"
-        try:
-            self.dbmodule.execute_secondary(lock_sql)
-            h = self.dbmodule.prepare_secondary(sql)
-            for name, version in list(capabilityHash.keys()):
-                ver = version
-                if version == '':
-                    ver = None
-                h.execute(name=name, version=ver)
-                row = h.fetchone_dict()
-                capabilityHash[(name, version)] = row['id']
-            self.dbmodule.commit_secondary()  # commit also unlocks the table
-        except Exception:
-            e = sys.exc_info()[1]
-            self.dbmodule.execute_secondary("rollback")
-            raise e
-
-    # Same as processCapabilities
     def lookupChecksums(self, checksumHash):
         if not checksumHash:
             return

--- a/backend/server/importlib/importLib.py
+++ b/backend/server/importlib/importLib.py
@@ -39,14 +39,14 @@ class DateType:
 
 
 # An Item is just an extension for a dictionary
-class Item(UserDict):
+class Item(dict):
 
     """
     First level object, that stores information in a hash-like structure
     """
 
     def __init__(self, attributes=None):
-        UserDict.__init__(self, attributes)
+        dict.__init__(self, attributes)
 
     def populate(self, hash):
         self.update(hash)

--- a/backend/server/rhnSQL/driver_postgresql.py
+++ b/backend/server/rhnSQL/driver_postgresql.py
@@ -21,6 +21,7 @@ import sys
 import string
 import re
 import psycopg2
+import psycopg2.extras
 
 # workaround for python-psycopg2 = 2.0.13 (RHEL6)
 # which does not import extensions by default
@@ -349,6 +350,11 @@ class Cursor(sql_base.Cursor):
         self.description = self._real_cursor.description
         rowcount = self._real_cursor.rowcount
         return rowcount
+
+    def _execute_values(self, sql, argslist, template=None, page_size=100, fetch=True):
+        results = psycopg2.extras.execute_values(self._real_cursor, sql, argslist, template=template, page_size=page_size, fetch=fetch)
+        self.description = self._real_cursor.description
+        return results
 
     def update_blob(self, table_name, column_name, where_clause, data,
                     **kwargs):

--- a/backend/server/rhnSQL/driver_postgresql.py
+++ b/backend/server/rhnSQL/driver_postgresql.py
@@ -346,7 +346,7 @@ class Cursor(sql_base.Cursor):
                 all_kwargs[i][key] = val
                 i = i + 1
 
-        self._real_cursor.executemany(self.sql, all_kwargs)
+        psycopg2.extras.execute_batch(self._real_cursor, self.sql, all_kwargs, page_size=10_000)
         self.description = self._real_cursor.description
 
     def _execute_values(self, sql, argslist, template=None, page_size=100, fetch=True):

--- a/backend/server/rhnSQL/driver_postgresql.py
+++ b/backend/server/rhnSQL/driver_postgresql.py
@@ -348,8 +348,6 @@ class Cursor(sql_base.Cursor):
 
         self._real_cursor.executemany(self.sql, all_kwargs)
         self.description = self._real_cursor.description
-        rowcount = self._real_cursor.rowcount
-        return rowcount
 
     def _execute_values(self, sql, argslist, template=None, page_size=100, fetch=True):
         results = psycopg2.extras.execute_values(self._real_cursor, sql, argslist, template=template, page_size=page_size, fetch=fetch)

--- a/backend/server/rhnSQL/sql_base.py
+++ b/backend/server/rhnSQL/sql_base.py
@@ -156,7 +156,7 @@ class Cursor:
         Call with keyword arguments mapping to ordered lists.
         i.e. cursor.executemany(id=[1, 2], name=["Bill", "Mary"])
         """
-        return self._execute_wrapper(self._executemany, *p, **kw)
+        self._execute_wrapper(self._executemany, *p, **kw)
 
     def execute_values(self, sql, argslist, template=None, page_size=100, fetch=True):
         """
@@ -178,7 +178,6 @@ class Cursor:
         dict is supposed to be the dictionary that we normally apply to
         statement.execute.
         """
-        ret = 0
         start_chunk = 0
         while 1:
             subdict = {}
@@ -186,13 +185,13 @@ class Cursor:
                 subarr = arr[start_chunk:start_chunk + chunk_size]
                 if not subarr:
                     # Nothing more to do here - we exhausted the array(s)
-                    return ret
+                    return
                 subdict[k] = subarr
-            ret = ret + self.executemany(**subdict)
+            self.executemany(**subdict)
             start_chunk = start_chunk + chunk_size
 
         # Should never reach this point
-        return ret
+
 
     def _execute_wrapper(self, function, *p, **kw):
         """

--- a/backend/server/rhnSQL/sql_base.py
+++ b/backend/server/rhnSQL/sql_base.py
@@ -165,34 +165,6 @@ class Cursor:
         """
         return self._execute_wrapper(self._execute_values, sql, argslist, template, page_size, fetch)
 
-    def execute_bulk(self, dict, chunk_size=100):
-        """
-        Uses executemany but chops the incoming dict into chunks for each
-        call.
-
-        When attempting to execute bulk operations with a lot of rows in the
-        arrays,
-        Oracle may occasionally lock (probably the oracle client library).
-        I noticed this previously with the import code. -- misa
-        This function executes bulk operations in smaller chunks
-        dict is supposed to be the dictionary that we normally apply to
-        statement.execute.
-        """
-        start_chunk = 0
-        while 1:
-            subdict = {}
-            for k, arr in list(dict.items()):
-                subarr = arr[start_chunk:start_chunk + chunk_size]
-                if not subarr:
-                    # Nothing more to do here - we exhausted the array(s)
-                    return
-                subdict[k] = subarr
-            self.executemany(**subdict)
-            start_chunk = start_chunk + chunk_size
-
-        # Should never reach this point
-
-
     def _execute_wrapper(self, function, *p, **kw):
         """
         Database specific execute wrapper. Mostly used just to catch DB

--- a/backend/server/rhnSQL/sql_base.py
+++ b/backend/server/rhnSQL/sql_base.py
@@ -158,6 +158,13 @@ class Cursor:
         """
         return self._execute_wrapper(self._executemany, *p, **kw)
 
+    def execute_values(self, sql, argslist, template=None, page_size=100, fetch=True):
+        """
+        Execute a query with a potentially-long VALUEs list. This method will split the query up in page_size
+        chunks. Use a %s placeholder where the VALUE list goes.
+        """
+        return self._execute_wrapper(self._execute_values, sql, argslist, template, page_size, fetch)
+
     def execute_bulk(self, dict, chunk_size=100):
         """
         Uses executemany but chops the incoming dict into chunks for each
@@ -204,6 +211,9 @@ class Cursor:
         return self._execute_(args, kwargs)
 
     def _executemany(self, *args, **kwargs):
+        raise NotImplementedError()
+
+    def _execute_values(self, *args, **kwargs):
         raise NotImplementedError()
 
     def _execute_(self, args, kwargs):

--- a/backend/server/rhnSQL/sql_sequence.py
+++ b/backend/server/rhnSQL/sql_sequence.py
@@ -41,6 +41,13 @@ class Sequence:
             return ret
         return int(ret['id'])
 
+    def next_many(self, n):
+        sql = "SELECT sequence_nextval('%s') FROM generate_series(1, %s)" % (self.__seq, n)
+        cursor = self.__db.prepare(sql)
+        cursor.execute()
+        result = cursor.fetchall()
+        return [r[0] for r in result]
+
     def __call__(self):
         return self.next()
 

--- a/backend/server/rhnServer/server_hardware.py
+++ b/backend/server/rhnServer/server_hardware.py
@@ -527,7 +527,7 @@ class NetIfaceInformation(Device):
         columns.sort()
         bind_params = ", ".join([':' + x for x in columns])
         h = rhnSQL.prepare(q % (", ".join(columns), bind_params))
-        return _dml(h, params)
+        _dml(h, params)
 
     def _delete(self, params):
         q = """delete from rhnServerNetInterface
@@ -536,7 +536,7 @@ class NetIfaceInformation(Device):
         columns = ['server_id', 'name']
         wheres = ['%s = :%s' % (x, x) for x in columns]
         h = rhnSQL.prepare(q % " and ".join(wheres))
-        return _dml(h, params)
+        _dml(h, params)
 
     def _update(self, params):
         q = """update rhnServerNetInterface
@@ -554,7 +554,7 @@ class NetIfaceInformation(Device):
         updates = ", ".join(updates)
 
         h = rhnSQL.prepare(q % (updates, wheres))
-        return _dml(h, params)
+        _dml(h, params)
 
     def reload(self, server_id):
         h = rhnSQL.prepare("""
@@ -694,7 +694,7 @@ class NetIfaceAddress(Device):
         columns.sort()
         bind_params = ", ".join([':' + x for x in columns])
         h = rhnSQL.prepare(q % (self.table, ", ".join(columns), bind_params))
-        return _dml(h, params)
+        _dml(h, params)
 
     def _delete(self, params):
         q = """delete from %s
@@ -703,7 +703,7 @@ class NetIfaceAddress(Device):
         columns = self.unique
         wheres = ['%s = :%s' % (x, x) for x in columns]
         h = rhnSQL.prepare(q % (self.table, " and ".join(wheres)))
-        return _dml(h, params)
+        _dml(h, params)
 
     def _update(self, params):
         q = """update %s
@@ -721,7 +721,7 @@ class NetIfaceAddress(Device):
         updates = ", ".join(updates)
 
         h = rhnSQL.prepare(q % (self.table, updates, wheres))
-        return _dml(h, params)
+        _dml(h, params)
 
     def reload(self, interface_id):
         h = rhnSQL.prepare("""
@@ -796,10 +796,7 @@ def _dml(statement, params):
     if not params:
         return 0
     params = _transpose(params)
-    rowcount = statement.executemany(**params)
-    log_debug(5, "Affected rows", rowcount)
-    return rowcount
-
+    statement.executemany(**params)
 
 def _transpose(hasharr):
     """ Transpose the array of hashes into a hash of arrays """

--- a/backend/server/rhnServer/server_kickstart.py
+++ b/backend/server/rhnServer/server_kickstart.py
@@ -672,7 +672,7 @@ def terminate_kickstart_sessions(server_id):
     }
     # Terminate pending actions
     log_debug(4, "Terminating sessions", params)
-    h.execute_bulk(params)
+    h.executemany(**params)
 
     # Invalidate pending actions
     for action_id in action_ids:

--- a/backend/server/rhnServer/server_packages.py
+++ b/backend/server/rhnServer/server_packages.py
@@ -195,7 +195,7 @@ class Packages:
             and ((:package_arch_id is null and package_arch_id is null)
                 or package_arch_id = :package_arch_id)
             """)
-            h.execute_bulk({
+            h.executemany(**{
                 'sysid': [sysid] * len(dlist),
                 'name_id': [a.name_id for a in dlist],
                 'evr_id': [a.evr_id for a in dlist],
@@ -232,7 +232,7 @@ class Packages:
                 'instime': [self.__expand_installtime(a.installtime) for a in alist],
             }
             try:
-                h.execute_bulk(package_data)
+                h.executemany(**package_data)
                 rhnSQL.commit()
             except rhnSQL.SQLSchemaError:
                 e = sys.exc_info()[1]

--- a/backend/server/rhnServer/server_token.py
+++ b/backend/server/rhnServer/server_token.py
@@ -319,7 +319,7 @@ def deploy_configs_if_needed(server):
     log_debug(4, "scheduled activation key config deploy")
 
     h = rhnSQL.prepare(_query_add_revision_to_action)
-    # XXX should use executemany() or execute_bulk
+    # XXX should use executemany()
     for revision_id in list(revisions.values()):
         log_debug(5, action_id, revision_id)
         h.execute(server_id=server_id,
@@ -413,7 +413,7 @@ def token_config_channels(server, tokens_obj):
     if config_channels:
         h = rhnSQL.prepare(_query_set_server_config_channels)
 
-        h.execute_bulk({
+        h.executemany(**{
             'server_id': [server_id] * len(config_channels),
             'config_channel_id': [c['config_channel_id'] for c in config_channels],
             'position': [c['position'] for c in config_channels],

--- a/backend/test/non-unit/server/rhnSQL/dbtests.py
+++ b/backend/test/non-unit/server/rhnSQL/dbtests.py
@@ -127,7 +127,7 @@ class RhnSQLDatabaseTests(unittest.TestCase):
             'id': ids,
             'name': names,
         }
-        cursor.execute_bulk(d)
+        cursor.executemany(**d)
 
         query = rhnSQL.prepare("SELECT * FROM %s WHERE id >= 1000 ORDER BY ID"
                                % self.temp_table)

--- a/schema/spacewalk/postgres/tables/rhnPackageCapability_index.sql
+++ b/schema/spacewalk/postgres/tables/rhnPackageCapability_index.sql
@@ -20,3 +20,6 @@ CREATE UNIQUE INDEX rhn_pkg_cap_name_version_uq
 create unique index rhn_pkg_cap_name_uq
     on rhnPackageCapability (name)
  where version is null;
+
+CREATE INDEX rhn_pkg_cap_name
+    ON rhnPackageCapability USING HASH (name);

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.4-to-susemanager-schema-4.1.5/003-rhnpackagecapability-name-index.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.4-to-susemanager-schema-4.1.5/003-rhnpackagecapability-name-index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX rhn_pkg_cap_name
+    ON rhnPackageCapability USING HASH (name);

--- a/uyuni/common-libs/common/rhn_pkg.py
+++ b/uyuni/common-libs/common/rhn_pkg.py
@@ -67,7 +67,7 @@ def package_from_filename(filename):
     stream = open(filename, mode='rb')
     return package_from_stream(stream, packaging)
 
-BUFFER_SIZE = 16384
+BUFFER_SIZE = 8388608
 DEFAULT_CHECKSUM_TYPE = 'md5'
 
 


### PR DESCRIPTION
## What does this PR change?

It optimizes code paths in `spacewalk-repo-sync`.

* "reposync speedup: get sequence numbers in batches": ~7% speedup
* "reposync speedup: stream with bigger buffer": ~4% additional speedup
* "WIP: use execute_values for capabilities": 9x speedup of the `processCapabilities` method, but slower overall, investigating. Requires a [patch](https://gist.github.com/moio/1569cf72a8efda7bef43dfe738e39d8b) to backport [psycopg2 PR 813](https://github.com/psycopg/psycopg2/pull/813/files), apply with `patch -d /usr/lib64/python3.6/site-packages/psycopg2 -p2 </path/to/patch.patch`

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **only internal changes**

- [x] **DONE**

## Test coverage
- No tests: **covered**

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
