### PR TITLE
Notification sort by type

### DIFF
--- a/web/html/src/manager/notifications/notification-messages.js
+++ b/web/html/src/manager/notifications/notification-messages.js
@@ -196,6 +196,11 @@ class NotificationMessages extends React.Component {
     return (result || Utils.sortById(aRaw, bRaw)) * sortDirection;
   };
 
+  sortByType = (aRaw, bRaw, columnKey, sortDirection) => {
+    var result = this.decodeTypeText(aRaw[columnKey]).toLowerCase().localeCompare(this.decodeTypeText(bRaw[columnKey]).toLowerCase());
+    return (result || Utils.sortById(aRaw, bRaw)) * sortDirection;
+  };
+
   buildSummaryText = (row) => {
     var div = document.createElement("div");
     div.innerHTML = row['summary']
@@ -352,6 +357,7 @@ class NotificationMessages extends React.Component {
             />
             <Column
               columnKey="type"
+              comparator={this.sortByType}
               header={t("Type")}
               cell={ (row) => this.decodeTypeText(row['type'])}
             />

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- sort notifications by type
 - Add StateApplyFailed and CreateBootstrapRepoFailed notifications
 - Add virtual storage pool actions
 - Rename Formula tab to Configuration


### PR DESCRIPTION
## What does this PR change?

https://github.com/SUSE/spacewalk/issues/3945 brought up the wish to sort by type as well.

## GUI diff

![Screenshot_20200323_160129](https://user-images.githubusercontent.com/1038917/77330386-96d24d80-6d1f-11ea-9de5-310f56e56c51.png)

- [x] **DONE**

## Documentation
- No documentation needed: **minimal ui change only**

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
