### PR TITLE
Enable monitoring for RHEL 8 Salt clients

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
@@ -155,7 +155,7 @@ public class MinionServer extends Server implements SaltConfigurable {
 
     @Override
     public boolean doesOsSupportsMonitoring() {
-        return isSLES12() || isSLES15() || isLeap15() || isUbuntu1804() || isRedHat6() || isRedHat7();
+        return isSLES12() || isSLES15() || isLeap15() || isUbuntu1804() || isRedHat6() || isRedHat7() || isRedHat8();
     }
 
     /**
@@ -203,6 +203,10 @@ public class MinionServer extends Server implements SaltConfigurable {
 
     private boolean isRedHat7() {
         return ServerConstants.REDHAT.equals(getOsFamily()) && getRelease().equals("7");
+    }
+
+    private boolean isRedHat8() {
+        return ServerConstants.REDHAT.equals(getOsFamily()) && getRelease().equals("8");
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerTest.java
@@ -213,6 +213,18 @@ public class ServerTest extends BaseTestCaseWithUser {
     }
 
     /**
+     * Test for {@link Server#doesOsSupportsMonitoring()} for RedHat 87.
+     */
+    public void testOsSupportsMonitoringRedHat8() throws Exception {
+        MinionServer s = (MinionServer) ServerFactoryTest.createTestServer(user, true,
+                ServerConstants.getServerGroupTypeSaltEntitled(),
+                ServerFactoryTest.TYPE_SERVER_MINION);
+        s.setOsFamily("RedHat");
+        s.setRelease("8");
+        assertTrue(s.doesOsSupportsMonitoring());
+    }
+
+    /**
      * Test for {@link Server#doesOsSupportsOSImageBuilding()}.
      */
     public void testOsDoesNotSupportsOSImageBuilding() throws Exception {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Enable monitoring for RHEL 8 Salt clients
 - Add recurring actions xmlrpc interface
 - Add StateApplyFailed and CreateBootstrapRepoFailed notifications
 - Add virtual storage pools actions


### PR DESCRIPTION
## What does this PR change?

Enable monitoring for RHEL 8 Salt clients

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- https://github.com/uyuni-project/uyuni-docs/pull/168

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/10709

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
