### PR TITLE
Reduce SaltService.INSTANCE usage

### DIFF
--- a/java/code/src/com/redhat/rhn/common/security/acl/test/AccessTest.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/test/AccessTest.java
@@ -323,7 +323,7 @@ public class AccessTest extends BaseTestCaseWithUser {
     public void testIsVirtual() throws Exception {
         SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
                 new SystemUnentitler(),
-                new SystemEntitler(SaltService.INSTANCE)
+                new SystemEntitler(new SaltService())
         );
         Server host = ServerTestUtils.createVirtHostWithGuests(user, 1, systemEntitlementManager);
         Server guest = host.getGuests().iterator().next().getGuestSystem();

--- a/java/code/src/com/redhat/rhn/domain/entitlement/test/VirtualizationEntitlementTest.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/test/VirtualizationEntitlementTest.java
@@ -46,7 +46,7 @@ public class VirtualizationEntitlementTest extends BaseEntitlementTestCase {
     public void testIsAllowedOnServer() throws Exception {
         SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
                 new SystemUnentitler(),
-                new SystemEntitler(SaltService.INSTANCE)
+                new SystemEntitler(new SaltService())
         );
         Server host = ServerTestUtils.createVirtHostWithGuests(1, systemEntitlementManager);
         Server guest = host.getGuests().iterator().next().getGuestSystem();

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
@@ -84,6 +84,7 @@ import com.redhat.rhn.testing.ServerTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 import com.suse.manager.webui.services.SaltServerActionService;
+import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.salt.netapi.calls.LocalCall;
 
 import java.util.ArrayList;
@@ -113,6 +114,7 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
     public static final String HOSTNAME = "foo.bar.com";
 
     private static SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
+    private SaltServerActionService saltServerActionService = new SaltServerActionService(new SaltService());
 
     @Override
     public void setUp() throws Exception {
@@ -1099,7 +1101,7 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
         List<MinionSummary> minionSummaries = minions.stream().map(MinionSummary::new).collect(Collectors.toList());
 
         Map<LocalCall<?>, List<MinionSummary>> localCallListMap =
-                SaltServerActionService.INSTANCE.errataAction(minionSummaries, Collections.singleton(e1.getId()));
+                saltServerActionService.errataAction(minionSummaries, Collections.singleton(e1.getId()));
 
         assertEquals(1, localCallListMap.size());
         localCallListMap.entrySet().forEach(result -> {

--- a/java/code/src/com/redhat/rhn/domain/server/test/VirtualInstanceFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/VirtualInstanceFactoryTest.java
@@ -57,7 +57,7 @@ public class VirtualInstanceFactoryTest extends RhnBaseTestCase {
         builder = new GuestBuilder(user);
         systemEntitlementManager = new SystemEntitlementManager(
                 new SystemUnentitler(),
-                new SystemEntitler(SaltService.INSTANCE)
+                new SystemEntitler(new SaltService())
         );
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/test/SystemEntitlementsSubmitActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/test/SystemEntitlementsSubmitActionTest.java
@@ -159,7 +159,7 @@ public class SystemEntitlementsSubmitActionTest extends RhnPostMockStrutsTestCas
 
         SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
                 new SystemUnentitler(),
-                new SystemEntitler(SaltService.INSTANCE)
+                new SystemEntitler(new SaltService())
         );
         Server server = ServerTestUtils.createVirtHostWithGuests(user, 1, systemEntitlementManager);
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -1862,7 +1862,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
     public void testAddEntitlements() throws Exception {
         SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
                 new SystemUnentitler(),
-                new SystemEntitler(SaltService.INSTANCE)
+                new SystemEntitler(new SaltService())
         );
         Server server = ServerTestUtils.createVirtHostWithGuests(admin, 0, systemEntitlementManager);
 
@@ -1891,7 +1891,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
     public void testAddEntitlementSystemAlreadyHas() throws Exception {
         SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
                 new SystemUnentitler(),
-                new SystemEntitler(SaltService.INSTANCE)
+                new SystemEntitler(new SaltService())
         );
         Server server = ServerTestUtils.createVirtHostWithGuests(admin, 0, systemEntitlementManager);
 

--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -172,7 +172,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         });
         systemEntitlementManager = new SystemEntitlementManager(
                 new SystemUnentitler(),
-                new SystemEntitler(SaltService.INSTANCE)
+                new SystemEntitler(new SaltService())
         );
     }
 

--- a/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionChainExecutor.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionChainExecutor.java
@@ -24,6 +24,7 @@ import java.time.Duration;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
+import com.suse.manager.webui.services.impl.SaltService;
 import org.apache.log4j.Logger;
 import org.quartz.JobExecutionContext;
 
@@ -37,7 +38,7 @@ public class MinionActionChainExecutor extends RhnJavaJob {
     private static final int ACTION_DATABASE_GRACE_TIME = 10000;
     private static final long MAXIMUM_TIMEDELTA_FOR_SCHEDULED_ACTIONS = 24; // hours
 
-    private SaltServerActionService saltServerActionService = SaltServerActionService.INSTANCE;
+    private SaltServerActionService saltServerActionService = new SaltServerActionService(new SaltService());
 
     /**
      * @param context the job execution context

--- a/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionExecutor.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionExecutor.java
@@ -25,6 +25,7 @@ import com.redhat.rhn.domain.user.UserFactory;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.suse.manager.webui.services.SaltServerActionService;
 
+import com.suse.manager.webui.services.impl.SaltService;
 import org.quartz.JobExecutionContext;
 
 import java.time.Duration;
@@ -43,7 +44,7 @@ public class MinionActionExecutor extends RhnJavaJob {
     private static final int ACTION_DATABASE_POLL_TIME = 100;
     private static final long MAXIMUM_TIMEDELTA_FOR_SCHEDULED_ACTIONS = 24; // hours
 
-    private SaltServerActionService saltServerActionService = SaltServerActionService.INSTANCE;
+    private SaltServerActionService saltServerActionService = new SaltServerActionService(new SaltService());
 
     /**
      * @param context the job execution context

--- a/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/SSHPushWorkerSalt.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/SSHPushWorkerSalt.java
@@ -69,7 +69,7 @@ public class SSHPushWorkerSalt implements QueueWorker {
         system = systemIn;
         systemQuery = SaltService.INSTANCE;
         saltSSHService = SaltService.INSTANCE.getSaltSSHService();
-        saltServerActionService = SaltServerActionService.INSTANCE;
+        saltServerActionService = new SaltServerActionService(new SaltService());
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/test/SSHPushWorkerSaltTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/test/SSHPushWorkerSaltTest.java
@@ -308,7 +308,7 @@ public class SSHPushWorkerSaltTest extends JMockBaseTestCaseWithUser {
                 sshPushSystemMock,
                 saltServiceMock,
                 saltSSHServiceMock,
-                SaltServerActionService.INSTANCE
+                new SaltServerActionService(new SaltService())
         );
     }
 }

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -1692,6 +1692,8 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
             allowing(taskomaticMock).scheduleSubscribeChannels(with(any(User.class)), with(any(SubscribeChannelsAction.class)));
         } });
 
+        SaltServerActionService saltServerActionService = new SaltServerActionService(new SaltService());
+
         MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
         minion.setMinionId("dev-minsles12sp2.test.local");
 
@@ -1718,8 +1720,8 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         ServerAction sa = ActionFactoryTest.createServerAction(minion, action);
         action.addServerAction(sa);
 
-        SaltServerActionService.INSTANCE.setCommitTransaction(false);
-        Map<LocalCall<?>, List<MinionSummary>> calls = SaltServerActionService.INSTANCE.callsForAction(action);
+        saltServerActionService.setCommitTransaction(false);
+        Map<LocalCall<?>, List<MinionSummary>> calls = saltServerActionService.callsForAction(action);
 
         HibernateFactory.getSession().flush();
 
@@ -1752,6 +1754,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
             allowing(taskomaticMock).scheduleSubscribeChannels(with(any(User.class)),
                     with(any(SubscribeChannelsAction.class)));
         } });
+        SaltServerActionService saltServerActionService = new SaltServerActionService(new SaltService());
 
         MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
         minion.setMinionId("dev-minsles12sp2.test.local");
@@ -1779,8 +1782,8 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         ServerAction sa = ActionFactoryTest.createServerAction(minion, action);
         action.addServerAction(sa);
 
-        SaltServerActionService.INSTANCE.setCommitTransaction(false);
-        Map<LocalCall<?>, List<MinionSummary>> calls = SaltServerActionService.INSTANCE.callsForAction(action);
+        saltServerActionService.setCommitTransaction(false);
+        Map<LocalCall<?>, List<MinionSummary>> calls = saltServerActionService.callsForAction(action);
 
         // artifically expire tokens
         action.getDetails().getAccessTokens().stream().forEach(t -> t.setMinion(null));

--- a/java/code/src/com/suse/manager/webui/Router.java
+++ b/java/code/src/com/suse/manager/webui/Router.java
@@ -21,6 +21,7 @@ import static spark.Spark.get;
 import static spark.Spark.notFound;
 import static spark.Spark.post;
 
+import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.suse.manager.kubernetes.KubernetesManager;
 import com.suse.manager.virtualization.VirtManager;
 import com.suse.manager.webui.controllers.ActivationKeysController;
@@ -82,6 +83,7 @@ public class Router implements SparkApplication {
 
         initNotFoundRoutes(jade);
 
+        TaskomaticApi taskomaticApi = new TaskomaticApi();
         SystemQuery systemQuery = SaltService.INSTANCE;
         KubernetesManager kubernetesManager = new KubernetesManager(systemQuery);
         VirtManager virtManager = new VirtManager(systemQuery);
@@ -90,6 +92,7 @@ public class Router implements SparkApplication {
         SaltSSHController saltSSHController = new SaltSSHController(systemQuery);
         NotificationMessageController notificationMessageController = new NotificationMessageController(systemQuery);
         MinionsAPI minionsAPI = new MinionsAPI(systemQuery);
+        StatesAPI statesAPI = new StatesAPI(systemQuery, taskomaticApi);
 
         post("/manager/frontend-log", withUser(FrontendLogController::log));
 
@@ -133,7 +136,7 @@ public class Router implements SparkApplication {
         SsmController.initRoutes();
 
         // States API
-        StatesAPI.initRoutes();
+        statesAPI.initRoutes();
 
         // Recurring Action
         RecurringActionController.initRoutes(jade);

--- a/java/code/src/com/suse/manager/webui/Router.java
+++ b/java/code/src/com/suse/manager/webui/Router.java
@@ -89,6 +89,7 @@ public class Router implements SparkApplication {
         SystemsController systemsController = new SystemsController(systemQuery);
         SaltSSHController saltSSHController = new SaltSSHController(systemQuery);
         NotificationMessageController notificationMessageController = new NotificationMessageController(systemQuery);
+        MinionsAPI minionsAPI = new MinionsAPI(systemQuery);
 
         post("/manager/frontend-log", withUser(FrontendLogController::log));
 
@@ -121,7 +122,7 @@ public class Router implements SparkApplication {
         MinionController.initRoutes(jade);
 
         // Minions API
-        MinionsAPI.initRoutes();
+        minionsAPI.initRoutes();
 
         // Systems API
         SystemsController.initRoutes(systemsController);

--- a/java/code/src/com/suse/manager/webui/Router.java
+++ b/java/code/src/com/suse/manager/webui/Router.java
@@ -93,6 +93,7 @@ public class Router implements SparkApplication {
         NotificationMessageController notificationMessageController = new NotificationMessageController(systemQuery);
         MinionsAPI minionsAPI = new MinionsAPI(systemQuery);
         StatesAPI statesAPI = new StatesAPI(systemQuery, taskomaticApi);
+        FormulaController formulaController = new FormulaController(systemQuery);
 
         post("/manager/frontend-log", withUser(FrontendLogController::log));
 
@@ -154,7 +155,7 @@ public class Router implements SparkApplication {
         FormulaCatalogController.initRoutes(jade);
 
         // Formulas
-        FormulaController.initRoutes(jade);
+        formulaController.initRoutes(jade);
 
         // Visualization
         VisualizationController.initRoutes(jade);

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -179,9 +179,6 @@ import java.util.stream.Stream;
  */
 public class SaltServerActionService {
 
-    /* Singleton instance of this class */
-    public static final SaltServerActionService INSTANCE = new SaltServerActionService(SaltService.INSTANCE);
-
     /* Logger for this class */
     private static final Logger LOG = Logger.getLogger(SaltServerActionService.class);
     public static final String PACKAGES_PKGINSTALL = "packages.pkginstall";

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -1977,7 +1977,7 @@ public class SaltServerActionService {
         }
 
         try {
-            List<String> results = SaltService.INSTANCE
+            List<String> results = systemQuery
                     .callAsync(call, new MinionList(minionIds),
                             Optional.of(ScheduleMetadata.getDefaultMetadata().withActionChain())).get().getMinions();
 

--- a/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
@@ -168,7 +168,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         TestUtils.flushAndEvict(action);
         Action updateAction = ActionFactory.lookupById(action.getId());
 
-        Map<LocalCall<?>, List<MinionSummary>> result = SaltServerActionService.INSTANCE.callsForAction(updateAction, minionSummaries);
+        Map<LocalCall<?>, List<MinionSummary>> result = saltServerActionService.callsForAction(updateAction, minionSummaries);
         RhnBaseTestCase.assertNotEmpty(result.values());
     }
 
@@ -200,7 +200,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         TestUtils.flushAndEvict(action);
         Action updateAction = ActionFactory.lookupById(action.getId());
 
-        Map<LocalCall<?>, List<MinionSummary>> result = SaltServerActionService.INSTANCE.callsForAction(updateAction,
+        Map<LocalCall<?>, List<MinionSummary>> result = saltServerActionService.callsForAction(updateAction,
                 minionSummaries);
         assertEquals(1, result.size());
         LocalCall<?> resultCall = result.keySet().iterator().next();
@@ -253,7 +253,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         TestUtils.flushAndEvict(action);
         Action updateAction = ActionFactory.lookupById(action.getId());
 
-        Map<LocalCall<?>, List<MinionSummary>> result = SaltServerActionService.INSTANCE.callsForAction(updateAction,
+        Map<LocalCall<?>, List<MinionSummary>> result = saltServerActionService.callsForAction(updateAction,
                 minionSummaries);
         assertEquals(1, result.size());
         LocalCall<?> resultCall = result.keySet().iterator().next();
@@ -307,7 +307,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         TestUtils.saveAndReload(configAction);
 
         Map<LocalCall<?>, List<MinionSummary>> result =
-                SaltServerActionService.INSTANCE.callsForAction(configAction);
+                saltServerActionService.callsForAction(configAction);
         assertEquals(result.size(), 3);
     }
 
@@ -330,7 +330,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
             va.setUuid(minionHost.getGuests().iterator().next().getUuid());
             ActionFactory.addServerToAction(minionHost, action);
 
-            Map<LocalCall<?>, List<MinionSummary>> result = SaltServerActionService.INSTANCE.callsForAction(action, minions);
+            Map<LocalCall<?>, List<MinionSummary>> result = saltServerActionService.callsForAction(action, minions);
             assertEquals(1, result.size());
         }
     }
@@ -345,7 +345,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         va.setForce(true);
         ActionFactory.addServerToAction(minionHost, action);
 
-        Map<LocalCall<?>, List<MinionSummary>> result = SaltServerActionService.INSTANCE.callsForAction(action, minions);
+        Map<LocalCall<?>, List<MinionSummary>> result = saltServerActionService.callsForAction(action, minions);
         LocalCall<?> saltCall = result.keySet().iterator().next();
         assertStateApplyWithPillar("virt.statechange", "domain_state", "powered_off", saltCall);
     }
@@ -360,7 +360,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         va.setForce(true);
         ActionFactory.addServerToAction(minionHost, action);
 
-        Map<LocalCall<?>, List<MinionSummary>> result = SaltServerActionService.INSTANCE.callsForAction(action, minions);
+        Map<LocalCall<?>, List<MinionSummary>> result = saltServerActionService.callsForAction(action, minions);
         LocalCall<?> saltCall = result.keySet().iterator().next();
         assertStateApply("virt.reset", saltCall);
     }
@@ -485,8 +485,8 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
 
         ActionFactory.addServerToAction(minion1, action);
 
-        SaltServerActionService.INSTANCE.setCommitTransaction(false);
-        Map<LocalCall<?>, List<MinionSummary>> calls = SaltServerActionService.INSTANCE.callsForAction(action);
+        saltServerActionService.setCommitTransaction(false);
+        Map<LocalCall<?>, List<MinionSummary>> calls = saltServerActionService.callsForAction(action);
 
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().clear();


### PR DESCRIPTION
## What does this PR change?

further reduce the use of the `SaltService.INSTANCE`.

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: no user visible change

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
