### PR TITLE
Cleanup keys on minions part2

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/services/salt-minion.sls
+++ b/susemanager-utils/susemanager-sls/salt/services/salt-minion.sls
@@ -10,6 +10,7 @@ mgr_remove_management_key_grains:
     - name: /etc/salt/minion.d/susemanager.conf
     - pattern: '^\s*management_key:.*$'
     - repl: ''
+    - onlyif: grep 'management_key:' /etc/salt/minion.d/susemanager.conf
 
 {# activation keys are only usefull on first registration #}
 {# removed to prevent trouble on the next regular minion restart #}
@@ -18,6 +19,7 @@ mgr_remove_activation_key_grains:
     - name: /etc/salt/minion.d/susemanager.conf
     - pattern: '^\s*activation_key:.*$'
     - repl: ''
+    - onlyif: grep 'activation_key:' /etc/salt/minion.d/susemanager.conf
 
 mgr_salt_minion:
   pkg.installed:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- remove key grains only when file and grain exists (bsc#1167237)
 - Add virtual storage pool actions
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

When not suse manager / uyuni did the onboarding of a system, it may happen that the activation key grain is not specified in `/etc/salt/minion.d/susemanager.conf`. In this case ignore the state
and do not produce an error.
It is up to the user to cleanup the keys in such a case.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **already covered**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11032
Tracks https://github.com/SUSE/spacewalk/pull/11035

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
