### PR TITLE
Prevent "Check salt event log for failures on server" testsuite failure

### DIFF
--- a/testsuite/features/profiles/Docker/add_packages.sh
+++ b/testsuite/features/profiles/Docker/add_packages.sh
@@ -16,4 +16,4 @@ zypper rr sles12sp4
 
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref
-zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar python python-xml
+zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar python python-xml python3 python3-xml


### PR DESCRIPTION
## What does this PR change?

This PR modifies Dockerfile for testing image in order to install `python3` and avoid a current testsuite failure:

```
 Scenario: Check salt event log for failures on server
```

As discussed today with @mcalmer , we should make use of different base images in order to do not depend on internal Docker registry: https://github.com/SUSE/spacewalk/issues/11038

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **testsuite issue**
- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
