### PR TITLE
Add missing cleanup of bind formula

### DIFF
--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -340,7 +340,7 @@ Feature: PXE boot a Retail terminal
 @proxy
 @private_net
 @pxeboot_minion
-  Scenario: Apply the highstate to clear PXE formulas
+  Scenario: Cleanup: apply the highstate to clear PXE formulas
     Given I am on the Systems overview page of this "proxy"
     When I follow "States" in the content area
     And I enable repositories before installing branch server
@@ -378,12 +378,6 @@ Feature: PXE boot a Retail terminal
     Given I am on the Systems overview page of this "proxy"
     When I follow "Formulas" in the content area
     And I follow first "Bind" in the content area
-    # WORKAROUND to be removed when bsc#1150657 is fixed
-    # "empty-zones-enable" option is rewritten by retail_yaml command
-    And I press "Add Item" in config options section
-    And I enter "empty-zones-enable" in first option field
-    And I enter "no" in first value field
-    # end of WORKAROUND
     And I press "Add Item" in configured zones section
     And I enter "tf.local" in third configured zone name field
     And I press "Add Item" in available zones section
@@ -498,7 +492,25 @@ Feature: PXE boot a Retail terminal
 
 @proxy
 @private_net
-  Scenario: Cleanup: Disable the formulas needed for mass import
+  Scenario: Cleanup: remove DNS records added by mass import
+    Given I am on the Systems overview page of this "proxy"
+    When I follow "Formulas" in the content area
+    And I follow first "Bind" in the content area
+    # direct zone example.org:
+    And I press "Remove Item" in fifth CNAME section
+    And I press "Remove Item" in fourth CNAME section
+    And I press "Remove Item" in third CNAME section
+    And I press "Remove Item" in second CNAME section
+    And I press "Remove Item" in first CNAME section
+    # direct zone tf.local:
+    And I press minus sign in third configured zone section
+    And I press minus sign in third available zone section
+    And I click on "Save Formula"
+    Then I should see a "Formula saved" text
+
+@proxy
+@private_net
+  Scenario: Cleanup: disable the formulas needed for mass import
     Given I am on the Systems overview page of this "proxy"
     When I follow "Formulas" in the content area
     And I uncheck the "pxe" formula

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -495,9 +495,17 @@ end
 
 When(/^I press "Remove Item" in (.*) section$/) do |section|
   sectionids = { 'first CNAME'       => 'bind#available_zones#0#records#CNAME#0',
-                 'second CNAME'      => 'bind#available_zones#0#records#CNAME#0',
-                 'third CNAME'       => 'bind#available_zones#0#records#CNAME#0' }
+                 'second CNAME'      => 'bind#available_zones#0#records#CNAME#1',
+                 'third CNAME'       => 'bind#available_zones#0#records#CNAME#2',
+                 'fourth CNAME'      => 'bind#available_zones#0#records#CNAME#3',
+                 'fifth CNAME'       => 'bind#available_zones#0#records#CNAME#4' }
   find(:xpath, "//div[@id='#{sectionids[section]}']/button").click
+end
+
+When(/^I press minus sign in (.*) section$/) do |section|
+  sectionids = { 'third configured zone' => 'bind#configured_zones#2',
+                 'third available zone'  => 'bind#available_zones#2' }
+  find(:xpath, "//div[@id='#{sectionids[section]}']/div[1]/i[@class='fa fa-minus']").click
 end
 
 When(/^I check (.*) box$/) do |box|


### PR DESCRIPTION
## What does this PR change?

This PR adds missing cleanup of bind formula. This idempotency problem was that "local.tf" zone and "dns" and "dhcp" records were added, but not removed at the end

This PR also removes the workaround for bsc#1150657. This bug "option empty-zones-enable in bind formula is rewritten by retail_yaml command" has been fixed now.

@aplanas: the lines of interest for you in yomi feature are:
```cucumber
    And I press minus sign in third configured zone section
    And I press minus sign in third available zone section
```

## Links

Fixes #SUSE/spacewalk#11028

Ports:
* 3.2: SUSE/spacewalk#11050
* 4.0: SUSE/spacewalk#11048


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
