### PR TITLE
Install "python3" inside testing Docker images

### DIFF
--- a/testsuite/features/profiles/Docker/authprofile/add_packages.sh
+++ b/testsuite/features/profiles/Docker/authprofile/add_packages.sh
@@ -10,6 +10,9 @@ zypper --non-interactive in avahi
 cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 /usr/sbin/avahi-daemon -D
 
+# install python3 on the container
+zypper --non-interactive in python3 python3-xml
+
 # re-enable normal repo and remove helper repo
 zypper mr --enable Test-Channel-x86_64 || :
 zypper rr sles12sp4

--- a/testsuite/features/profiles/Docker/serverhost/add_packages.sh
+++ b/testsuite/features/profiles/Docker/serverhost/add_packages.sh
@@ -10,6 +10,9 @@ zypper --non-interactive in avahi
 cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 /usr/sbin/avahi-daemon -D
 
+# install python3 on the container
+zypper --non-interactive in python3 python3-xml
+
 # re-enable normal repo and remove helper repo
 zypper mr --enable Test-Channel-x86_64 || :
 zypper rr sles12sp4


### PR DESCRIPTION
## What does this PR change?

This PR follows-up https://github.com/uyuni-project/uyuni/pull/2049 and installs `python3` and `python3-xml` on the remaining profiles that were missing.

After the previous PR, we reduced from 4 to 2 the amount of errors in the `salt-events.txt` and hopefully this new PR will get rid of the remaining errors.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **testsuite fix**

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
