### PR TITLE
Use "int" instead of "long" on "rhn_check" for either Python 2 or 3

### DIFF
--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes
@@ -1,3 +1,5 @@
+- Use 'int' instead of 'long' on rhn_check for both Python 2 and 3
+
 -------------------------------------------------------------------
 Thu Mar 19 12:08:36 CET 2020 - jgonzalez@suse.com
 

--- a/client/rhel/spacewalk-client-tools/src/bin/rhn_check.py
+++ b/client/rhel/spacewalk-client-tools/src/bin/rhn_check.py
@@ -67,7 +67,6 @@ try: # python2
     import xmlrpclib
 except ImportError: # python3
     import xmlrpc.client as xmlrpclib
-    long = int
 
 if 'sgmlop' in sys.modules:
     del sys.modules['sgmlop']
@@ -359,7 +358,7 @@ class CheckCli(rhncli.RhnCli):
                 pass
 
         # We need to fit into xmlrpc's integer limits
-        if status_report['uptime'][1] > long(2)**31-1:
+        if status_report['uptime'][1] > int(2)**31-1:
             status_report['uptime'][1] = -1
 
         return status_report


### PR DESCRIPTION
## What does this PR change?

This PR just make `rhn_check` to always use `int` for both Python 2 and 3. That way we align this code with the changes made by https://github.com/uyuni-project/uyuni/pull/2025

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal changes**

- [x] **DONE**

## Test coverage
- No tests: **tested by cucumber**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
