### PR TITLE
Fix: unable to be redirected to the IdP when SSO is enabled (bsc#1167667)

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/login/LoginController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/login/LoginController.java
@@ -79,7 +79,8 @@ public class LoginController {
             catch (SettingsException | IOException e) {
                 log.error(e.getMessage());
             }
-            return null; // we forward the request to IdP via `auth.login`
+            return new ModelAndView(new HashMap<>(), "controllers/login/templates/login.jade");
+            // the return above is dummy, we already sent a redirect to the IdP login page via `auth.login`
         }
         else {
             // Redirect to user creation if needed

--- a/java/code/src/com/suse/manager/webui/controllers/test/LoginControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/LoginControllerTest.java
@@ -3,13 +3,13 @@ package com.suse.manager.webui.controllers.test;
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.domain.user.User;
-import com.suse.manager.webui.utils.LoginHelper;
 import com.redhat.rhn.manager.user.UserManager;
 import com.redhat.rhn.testing.RhnMockHttpServletRequest;
 import com.redhat.rhn.testing.RhnMockHttpServletResponse;
 import com.redhat.rhn.testing.RhnMockHttpSession;
 import com.redhat.rhn.testing.UserTestUtils;
 import com.suse.manager.webui.controllers.login.LoginController;
+import com.suse.manager.webui.utils.LoginHelper;
 import com.suse.manager.webui.utils.SparkTestUtils;
 import com.suse.utils.Json;
 
@@ -17,6 +17,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
+
 import spark.ModelAndView;
 import spark.Request;
 import spark.RequestResponseFactory;
@@ -70,7 +71,7 @@ public class LoginControllerTest extends BaseControllerTestCase {
 
         response = RequestResponseFactory.create(new RhnMockHttpServletResponse());
         ModelAndView result = LoginController.loginView(RequestResponseFactory.create(match, mockRequest), response);
-        assertNull(result); // redirect to the SSO login page
+        assertNotNull(result); // redirect to the SSO login page
     }
 
     public void testUrlBounceNotAuthenticated() throws UnsupportedEncodingException {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix: unable to be redirected to the IdP when SSO is enabled (bsc#1167667)
 - improve performance of cleanup-data-bunch
 - Show separate info for syncing product channels and children
 - add XMLRPC API method: proxy.listProxyClients (bsc#1166408)


### PR DESCRIPTION
## What does this PR change?

Add a dummy Spark ModelView to avoid a NPE

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: bugfix

- [X] **DONE**

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
