### PR TITLE
Add notification messages filter by type

### DIFF
--- a/web/html/src/components/table/Table.js
+++ b/web/html/src/components/table/Table.js
@@ -33,6 +33,8 @@ type TableProps = {
   loadingText?: string,
   /** Children node in the table */
   children: React.Node,
+  /** Other filter fields */
+  additionalFilters?: Array<React.Node>,
 };
 
 export function Table(props: TableProps): React.Node {

--- a/web/html/src/manager/notifications/notification-messages.js
+++ b/web/html/src/manager/notifications/notification-messages.js
@@ -20,23 +20,23 @@ const {showDialog} = require("components/dialog/util");
 const _MESSAGE_TYPE = {
   OnboardingFailed: {
     id: "OnboardingFailed",
-    text: "Onboarding failed",
+    text: t("Onboarding failed"),
   },
   ChannelSyncFailed: {
     id: "ChannelSyncFailed",
-    text: "Channel sync failed",
+    text: t("Channel sync failed"),
   },
   ChannelSyncFinished: {
     id: "ChannelSyncFinished",
-    text: "Channel sync finished",
+    text: t("Channel sync finished"),
   },
   CreateBootstrapRepoFailed: {
     id: "CreateBootstrapRepoFailed",
-    text: "Creating Bootstrap Repository failed",
+    text: t("Creating Bootstrap Repository failed"),
   },
   StateApplyFailed: {
     id: "StateApplyFailed",
-    text: "State apply failed",
+    text: t("State apply failed"),
   },
 }
 
@@ -201,7 +201,7 @@ class NotificationMessages extends React.Component {
   };
 
   decodeTypeText = (rawType) => {
-    return t(_MESSAGE_TYPE[rawType].text);
+    return _MESSAGE_TYPE[rawType].text;
   };
 
   decodeIconBySeverity = (severity) => {

--- a/web/html/src/manager/notifications/notification-messages.js
+++ b/web/html/src/manager/notifications/notification-messages.js
@@ -351,7 +351,6 @@ class NotificationMessages extends React.Component {
 
 
     const panelButtons = <SectionToolbar>
-        {typeFilter}
         <div className='action-button-wrapper'>
           <div className='btn-group'>
             <AsyncButton id="reload" icon="fa-refresh" text={t('Refresh')} action={this.refreshServerData} />
@@ -397,7 +396,8 @@ class NotificationMessages extends React.Component {
                 <SearchField filter={this.searchData}
                     criteria={""}
                     placeholder={t("Filter by summary")} />
-            }>
+            }
+            additionalFilters={[typeFilter]}>
             <Column
               columnKey="severity"
               comparator={this.sortBySeverity}

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Add notification messages type filter
 - Show separate info for syncing product channels and children
 - sort notifications by type
 - Add StateApplyFailed and CreateBootstrapRepoFailed notifications


### PR DESCRIPTION
## What does this PR change?

https://github.com/SUSE/spacewalk/issues/3945 - "add type filter"

## GUI diff

Before:
![Screenshot from 2020-03-28 00-00-07](https://user-images.githubusercontent.com/7080830/77807119-1b59fe80-7087-11ea-84ac-ec1015f871f7.png)

After:
![Screenshot from 2020-03-27 23-56-21](https://user-images.githubusercontent.com/7080830/77807078-fb2a3f80-7086-11ea-8b0c-4c07de39fe05.png)


- [x] **DONE**

## Documentation
- Documentation needed: looking at [the docs](https://documentation.suse.com/external-tree/en-us/suma/4.0/suse-manager/reference/home/home-notification-messages.html) there is more to update. The screenshot for this new filter for sure, but also we have more `Types` now, and the default `java.notifications_type_disabled` includes the `ChannelSyncFinished` type. @mcalmer did you create already a doc issue for these changes? 
- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/3945
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
