### PR TITLE
Fix virtual pool creation with devices

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -1864,7 +1864,7 @@ public class SaltServerActionService {
                                 deviceParam.put("path", device.getPath());
                                 device.isSeparator().ifPresent(sep -> deviceParam.put("part_separator", sep));
                                 return deviceParam;
-                            }));
+                            }).collect(Collectors.toList()));
                         }
                         pillar.put("source", source);
                     }

--- a/susemanager-utils/susemanager-sls/salt/virt/pool-create.sls
+++ b/susemanager-utils/susemanager-sls/salt/virt/pool-create.sls
@@ -50,7 +50,7 @@ pool_{{ state }}:
           password: {{ pillar['source']['auth']['password'] }}
       {% endif %}  {# pillar['source']['auth']|default(none) #}
       {% if pillar['source']['devices']|default(none) %}
-        - devices:
+        devices:
         {% for device in pillar['source']['devices'] %}
           - path: {{ device['path'] }}
           {% if device['part_separator']|default(none) %}

--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -342,6 +342,12 @@ The check box can be identified by name, id or label text.
   When I select the hostname of "proxy" from "proxies"
 ```
 
+* Wait for a selection box to contain an item
+
+```cucumber
+  When I wait until option "dir" appears in list "type"
+```
+
 * Make sure an item in a selection box is selected
 
 ```cucumber

--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -230,7 +230,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
     Given I am on the "Virtualization" page of this "kvm_server"
     When I follow "Storage"
     And I follow "Create Pool"
-    And I wait until I see "General" text
+    And I wait until option "dir" appears in list "type"
     And I select "dir" from "type"
     And I enter "test-pool1" as "name"
     And I uncheck "autostart"

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -768,6 +768,15 @@ Then(/^option "([^"]*)" is selected as "([^"]*)"$/) do |arg1, arg2|
 end
 
 #
+# Wait for an option to appear in a list
+#
+When(/^I wait until option "([^"]*)" appears in list "([^"]*)"$/) do |arg1, arg2|
+  repeat_until_timeout(message: "#{arg1} has not been listed in #{arg2}") do
+    break if has_select?(arg2, with_options: [arg1])
+  end
+end
+
+#
 # Test if a radio button is checked
 #
 Then(/^radio button "([^"]*)" is checked$/) do |arg1|

--- a/web/html/src/manager/virtualization/pools/pool-properties.js
+++ b/web/html/src/manager/virtualization/pools/pool-properties.js
@@ -106,15 +106,20 @@ export function PoolProperties(props: Props) {
   }
 
   const onPoolTypeChanged = () => {
-    model.source_format = undefined;
-    if (FieldsData.getValue(model.type, 'source_hosts.show', false)) {
-      model.source_hosts0_name = '';
-      model.source_hosts0_port = '';
-    }
-    if (FieldsData.getValue(model.type, 'source_devices.show', false)) {
-      model.source_devices0_path = '';
-      model.source_devices0_separator = '';
-    }
+    const hostsProps =
+      FieldsData.getValue(model.type, 'source_hosts.show', false) ?
+      { source_hosts0_name: '', source_host0_port: '' } :
+      {};
+    const devicesProps =
+      FieldsData.getValue(model.type, 'source_devices.show', false) &&
+      FieldsData.getValue(model.type, 'source_devices.min', 1) ?
+      { source_devices0_path: '', source_devices0_separator: '' } :
+      {};
+    setModel(Object.assign({},
+      {
+        name: model.name,
+        type: model.type,
+      }, hostsProps, devicesProps));
   }
 
   return (

--- a/web/html/src/manager/virtualization/pools/properties/fields-data.js
+++ b/web/html/src/manager/virtualization/pools/properties/fields-data.js
@@ -86,6 +86,7 @@ const mapping = {
     source_devices: {
       show: true,
       list: true,
+      min: 0,
     },
     source_name: {
       show: true


### PR DESCRIPTION
## What does this PR change?

Fixes the creation of virtual storage pools using devices like disk ones.

Also enhances the cucumber testsuite for pool creation to really wait for the form to be ready.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: no UI change

- [X] **DONE**

## Test coverage
- No tests: automated testing of all the disk pool types would be long, complex and incomplete.

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
