### PR TITLE
Do not build susemanager-branding-oss on SLE aarch64

### DIFF
--- a/susemanager-branding-oss/susemanager-branding-oss.spec
+++ b/susemanager-branding-oss/susemanager-branding-oss.spec
@@ -29,6 +29,8 @@ BuildArch:      noarch
 %if 0%{?is_opensuse}
 ExcludeArch:    i586 x86_64 ppc64le s390x aarch64
 %else
+# SUSE Manager does not support aarch64 for the server
+ExcludeArch:    aarch64
 BuildRequires:  SUSE-Manager-Server-release
 %endif
 Provides:       susemanager-branding = %{version}


### PR DESCRIPTION
## What does this PR change?

Do not build susemanager-branding-oss on SLE aarch64.

This a change only valid the downstream SUSE Manager, as it doesn't provide aarch64 for server and therefore the package fails to build.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: No support for aarch64 server, so no need to ducment anything.

- [x] **DONE**

## Test coverage
- No tests: SPEC already covered by OBS.

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
