### PR TITLE
Use "saltutil" states if available on the minion (bsc#1167556)

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/actionchains/resumessh.sls
+++ b/susemanager-utils/susemanager-sls/salt/actionchains/resumessh.sls
@@ -2,7 +2,11 @@ resumessh:
     module.run:
     -   name: mgractionchains.resume
     - require:
+{%- if grains.get('__suse_reserved_saltutil_states_support', False) %}
+      - saltutil: sync_modules
+{%- else %}
       - module: sync_modules
+{%- endif %}
 
 include:
   - util.synccustomall

--- a/susemanager-utils/susemanager-sls/salt/actionchains/startssh.sls
+++ b/susemanager-utils/susemanager-sls/salt/actionchains/startssh.sls
@@ -3,7 +3,11 @@ startssh:
     -   name: mgractionchains.start
     -   actionchain_id: {{ pillar.get('actionchain_id')}}
     - require:
+{%- if grains.get('__suse_reserved_saltutil_states_support', False) %}
+      - saltutil: sync_modules
+{%- else %}
       - module: sync_modules
+{%- endif %}
 
 include:
   - util.synccustomall

--- a/susemanager-utils/susemanager-sls/salt/packages/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/packages/init.sls
@@ -4,7 +4,11 @@ mgr_install_products:
     - refresh: True
     - require:
       - file: mgrchannels_*
+{%- if grains.get('__suse_reserved_saltutil_states_support', False) %}
+      - saltutil: sync_states
+{%- else %}
       - module: sync_states
+{%- endif %}
 {%- endif %}
 
 include:

--- a/susemanager-utils/susemanager-sls/salt/packages/profileupdate.sls
+++ b/susemanager-utils/susemanager-sls/salt/packages/profileupdate.sls
@@ -31,12 +31,20 @@ grains_update:
   module.run:
     - name: grains.items
     - require:
+{%- if grains.get('__suse_reserved_saltutil_states_support', False) %}
+      - saltutil: sync_grains
+{%- else %}
       - module: sync_grains
+{%- endif %}
 
 {% if not pillar.get('imagename') %}
 kernel_live_version:
   module.run:
     - name: sumautil.get_kernel_live_version
     - require:
+{%- if grains.get('__suse_reserved_saltutil_states_support', False) %}
+      - saltutil: sync_modules
+{%- else %}
       - module: sync_modules
+{%- endif %}
 {% endif %}

--- a/susemanager-utils/susemanager-sls/salt/services/kiwi-image-server.sls
+++ b/susemanager-utils/susemanager-sls/salt/services/kiwi-image-server.sls
@@ -82,7 +82,11 @@ mgr_sshd_public_key_copied:
       - pkg: mgr_sshd_installed_enabled
 
 mgr_saltutil_synced:
+{%- if grains.get('__suse_reserved_saltutil_states_support', False) %}
+    saltutil.sync_all
+{%- else %}
   module.run:
     - name: saltutil.sync_all
+{%- endif %}
 
 {% endif %}

--- a/susemanager-utils/susemanager-sls/salt/util/syncbeacons.sls
+++ b/susemanager-utils/susemanager-sls/salt/util/syncbeacons.sls
@@ -1,3 +1,7 @@
 sync_beacons:
+{%- if grains.get('__suse_reserved_saltutil_states_support', False) %}
+  saltutil.sync_beacons
+{%- else %}
   module.run:
     - name: saltutil.sync_beacons
+{%- endif %}

--- a/susemanager-utils/susemanager-sls/salt/util/syncgrains.sls
+++ b/susemanager-utils/susemanager-sls/salt/util/syncgrains.sls
@@ -1,4 +1,8 @@
 sync_grains:
+{%- if grains.get('__suse_reserved_saltutil_states_support', False) %}
+  saltutil.sync_grains:
+{%- else %}
   module.run:
     - name: saltutil.sync_grains
+{%- endif %}
     - reload_grains: true

--- a/susemanager-utils/susemanager-sls/salt/util/syncmodules.sls
+++ b/susemanager-utils/susemanager-sls/salt/util/syncmodules.sls
@@ -1,3 +1,7 @@
 sync_modules:
+{%- if grains.get('__suse_reserved_saltutil_states_support', False) %}
+    saltutil.sync_modules
+{%- else %}
   module.run:
     - name: saltutil.sync_modules
+{%- endif %}

--- a/susemanager-utils/susemanager-sls/salt/util/syncstates.sls
+++ b/susemanager-utils/susemanager-sls/salt/util/syncstates.sls
@@ -1,4 +1,8 @@
 sync_states:
+{%- if grains.get('__suse_reserved_saltutil_states_support', False) %}
+  saltutil.sync_states
+{%- else %}
   module.run:
       - name: saltutil.sync_states
+{%- endif %}
 

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Use saltutil states if available on the minion (bsc#1167556)
 - Enable support for bootstrapping Astra Linux CE "Orel"
 - remove key grains only when file and grain exists (bsc#1167237)
 - Add virtual storage pool actions


### PR DESCRIPTION
## What does this PR change?

This PR modifies our SLS files in order to avoid calling `saltutil` execution module using `module.run` state when the new `saltutil` **state** module is available.

Old way:

```yaml
whatever:
  module.run:
    - name: saltutil.sync_XXXX
```

New way:

```yaml
whatever:
  saltutil.sync_XXXX
```

The problem with `module.run` is that it always returns the output from the executed module as "changes" from the `module.run` state execution. This is currently breaking the Salt states "change" detection, because it always wrongly assumes that something was synced even if not.

As a consequence of this, and considering that we call `util.syncstates` on every "highstate" [1], that means that every "highstate" execution will report changes even if there were not.

The `saltutil` state module  is new in Salt 3000 but has been already backported to our Salt 2019.2 codebase and 2016.11. We have added a hardcoded `__suse_reserved_saltutil_states_support` grain to the Salt packages that contains this new capability, that way we can detect and render the SLS accordingly.

[1] https://github.com/uyuni-project/uyuni/blob/master/susemanager-utils/susemanager-sls/salt/packages/init.sls#L11

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal changes**

- [x] **DONE**

## Test coverage
- No tests: **tested by cucumber**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/11055

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
