### PR TITLE
set susemanager-branding as optional on susemanager

### DIFF
--- a/susemanager/susemanager.spec
+++ b/susemanager/susemanager.spec
@@ -71,7 +71,7 @@ Requires:       spacewalk-schema
 Requires:       susemanager-tools
 # migration.sh need either sqlplus or psql
 Requires:       spacewalk-db-virtual
-Requires:       susemanager-branding
+Recommends:     susemanager-branding
 BuildRequires:  uyuni-base-server
 Requires(pre):  uyuni-base-server
 # yast module dependency


### PR DESCRIPTION
## What does this PR change?

On uyuni we don't use the branding jar, and that
jar is not packaged for that product.
For that reason the branding jar dependency needs
to be set as a week dependency: try to process it
but if fails to get, the instalation continues.

** Should it be backport to Manager versions? **
I don't think so since the branding jar is required there.


## GUI diff

No difference.


- [X] **DONE**

## Documentation
- No documentation needed: Change on packaging

- [X] **DONE**

## Test coverage
- No tests: change on packaging

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [X] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
