### PR TITLE
remove TaskoRun entries which belong to mgr-register

### DIFF
--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.3-to-susemanager-schema-4.1.4/004-drop-mgr-register-task.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.3-to-susemanager-schema-4.1.4/004-drop-mgr-register-task.sql
@@ -1,3 +1,10 @@
+DELETE FROM rhnTaskoRun
+ WHERE template_id in (
+        SELECT id
+          FROM rhnTaskoTemplate
+         WHERE bunch_id = (SELECT id FROM rhnTaskoBunch WHERE name='mgr-register-bunch')
+           AND task_id = (SELECT id FROM rhnTaskoTask WHERE name='mgr-register')
+);
 DELETE FROM rhnTaskoTemplate
  WHERE bunch_id = (SELECT id FROM rhnTaskoBunch WHERE name='mgr-register-bunch')
    AND task_id = (SELECT id FROM rhnTaskoTask WHERE name='mgr-register');


### PR DESCRIPTION
## What does this PR change?

TaskoRun has a foreign key on TaskoTemplate which is not cleaned up automatically.
This change remove entries which belong to mgr-register template.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
