### PR TITLE
1791111 - improve performance of cleanup-data-bunch

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Task_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Task_queries.xml
@@ -278,7 +278,8 @@ SELECT id, channel_label, client, reason, force, bypass_filters, next_action
    <query params="">
 <!-- DISTINCT makes the DELETE faster for postgresql (no difference for oracle) -->
     DELETE FROM rhnPackageChangeLogData
-        WHERE id NOT IN ( SELECT DISTINCT changelog_data_id FROM rhnPackageChangeLogRec )
+        WHERE NOT EXISTS ( SELECT DISTINCT 1 FROM rhnPackageChangeLogRec
+                            WHERE rhnPackageChangeLogRec.changelog_data_id = rhnPackageChangeLogData.id )
    </query>
 </write-mode>
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- improve performance of cleanup-data-bunch
 - Show separate info for syncing product channels and children
 - add XMLRPC API method: proxy.listProxyClients (bsc#1166408)
 - Enable monitoring for RHEL 8 Salt clients


### PR DESCRIPTION
## What does this PR change?

Improves performance in the changelog cleanup Taskomatic Task (patch picked from Spacewalk).

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal change**

- [x] **DONE**

## Test coverage
- No tests: **covered**

- [x] **DONE**

## Links

https://github.com/spacewalkproject/spacewalk/commit/0e7249a4260d0a460c7bde85b69170d81655d8d5

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
