### PR TITLE
New YAML file for sanity check

### DIFF
--- a/testsuite/run_sets/core.yml
+++ b/testsuite/run_sets/core.yml
@@ -8,7 +8,6 @@
 
 # IMMUTABLE ORDER
 
-- features/core/allcli_sanity.feature
 - features/core/first_settings.feature
 
 # initialize SUSE Manager server

--- a/testsuite/run_sets/sanity_check.yml
+++ b/testsuite/run_sets/sanity_check.yml
@@ -1,0 +1,13 @@
+# This file describes the order of features in a normal testsuite run.
+#
+# If you create new features, please see conventions about naming of the
+# feature files in testsuite/docs/Guidelines.md in "Rules for features" chapter,
+# as well as guidelines about idempotency in "Idempotency" chapter.
+
+## Sanity Check BEGIN ###
+
+# IMMUTABLE ORDER
+
+- features/core/allcli_sanity.feature
+
+## Sanity Check END ###


### PR DESCRIPTION
## What does this PR change?

Card: https://github.com/SUSE/spacewalk/issues/10347

We want to have the sanity checks in a different stage of the testsuite, so if the sanity checks fails, the rest of the test suite is aborted.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/10347

Relevant branches (GitHub automatic links expected below):
 - Manager-3.2 https://github.com/SUSE/spacewalk/pull/11101
 - Manager-4.0 https://github.com/SUSE/spacewalk/pull/11099
 - Uyuni

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
