### PR TITLE
Manager bsc1168069

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -234,6 +234,7 @@ RES6 = [
     "yum",
     "python2-rhnlib",
     "rpm-python",
+    "redhat-rpm-config",
     "slang",
     "spacewalk-check",
     "python2-spacewalk-check",
@@ -283,6 +284,7 @@ RES7 = [
     "openssl",
     "openssl-libs",
     "python-ipaddress",
+    "redhat-rpm-config",
     "rpm-python",
     "spacewalk-check",
     "python2-spacewalk-check",
@@ -299,6 +301,7 @@ RES7 = [
 ]
 
 RES8 = [
+    "redhat-rpm-config",
     "salt",
     "salt-minion",
     "python3-salt",

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- add package redhat-rpm-config to bootstrap repo for RH and CentOS systems (bsc#1168069)
 - Add 'python-singledispatch' to SLE12 (all SPs) and RES7 bootstrap repos.
 - Enable support for bootstrapping Astra Linux CE "Orel"
 - add database 10 to 12 migration script


### PR DESCRIPTION
## What does this PR change?

At least with CentOS it seems possible to have an OS installed without the vital package redhat-rpm-config. This prevents bootstrapping because the salt package depends on it and it does not get copied to the bootstrap repo. While this can be easily worked around by explicitly adding the package, we can exclude this source of problems by simply adding the package to the bootstrap repo.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: Bugfix for implementation detail

- [X] **DONE**

## Test coverage
- No tests: Normally the package is already part of the OS

- [X] **DONE**

## Links

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1168069

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
