### PR TITLE
Add calancha as test reviewer in the github action

### DIFF
--- a/.github/workflows/add_pr_reviewer.yml
+++ b/.github/workflows/add_pr_reviewer.yml
@@ -23,28 +23,34 @@ jobs:
       uses: kunihiko-t/review-request-action@v0.1.3
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        reviewers: "lkotek,ktsamis,Bischoff"
+        reviewers: "lkotek,ktsamis,Bischoff,calancha"
     - name: "Send Review Request to QA Squad"
       if: steps.review_step.outputs.review == 'true' && github.actor == 'lkotek'
       uses: kunihiko-t/review-request-action@v0.1.3
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        reviewers: "srbarrios,ktsamis,Bischoff"
+        reviewers: "srbarrios,ktsamis,Bischoff,calancha"
     - name: "Send Review Request to QA Squad"
       if: steps.review_step.outputs.review == 'true' && github.actor == 'Bischoff'
       uses: kunihiko-t/review-request-action@v0.1.3
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        reviewers: "lkotek,ktsamis,srbarrios"
+        reviewers: "lkotek,ktsamis,srbarrios,calancha"
     - name: "Send Review Request to QA Squad"
       if: steps.review_step.outputs.review == 'true' && github.actor == 'ktsamis'
       uses: kunihiko-t/review-request-action@v0.1.3
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        reviewers: "lkotek,srbarrios,Bischoff"
+        reviewers: "lkotek,srbarrios,Bischoff,calancha"
     - name: "Send Review Request to QA Squad"
-      if: steps.review_step.outputs.review == 'true' && github.actor != 'ktsamis' && github.actor != 'Bischoff' && github.actor != 'lkotek' && github.actor != 'srbarrios'
+      if: steps.review_step.outputs.review == 'true' && github.actor == 'calancha'
       uses: kunihiko-t/review-request-action@v0.1.3
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         reviewers: "lkotek,srbarrios,Bischoff,ktsamis"
+    - name: "Send Review Request to QA Squad"
+      if: steps.review_step.outputs.review == 'true' && github.actor != 'ktsamis' && github.actor != 'Bischoff' && github.actor != 'lkotek' && github.actor != 'srbarrios' && github.actor != 'calancha'
+      uses: kunihiko-t/review-request-action@v0.1.3
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        reviewers: "lkotek,srbarrios,Bischoff,ktsamis,calancha"


### PR DESCRIPTION
## What does this PR change?

Adding @calancha as Test Reviewer in our GitHub Action for new PR on testsuite folder

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
