### PR TITLE
Page description as normal text, no external link

### DIFF
--- a/web/html/src/components/FormulaForm.js
+++ b/web/html/src/components/FormulaForm.js
@@ -28,8 +28,6 @@ class FormulaForm extends React.Component {
     constructor(props) {
         super(props);
 
-        const previewMessage = <p>On this page you can configure <a href="https://docs.saltstack.com/en/latest/topics/development/conventions/formulas.html" target="_blank" rel="noopener noreferrer">Salt Formulas</a> to automatically install and configure software.</p>;
-
         this.state = {
             formulaName: "",
             formulaList: [],
@@ -37,7 +35,7 @@ class FormulaForm extends React.Component {
             systemData: {},
             groupData: {},
             formulaChanged: false,
-            messages: [previewMessage],
+            messages: [],
             errors: []
         };
 
@@ -150,6 +148,8 @@ class FormulaForm extends React.Component {
     }
 
     render() {
+        const defaultMessage = <p>{t('On this page you can configure Salt Formulas to automatically install and configure software.')}</p>;
+
         let messageItems = this.state.messages.map((msg) => {
             return { severity: "info", text: msg };
         });
@@ -163,6 +163,7 @@ class FormulaForm extends React.Component {
                 this.props.addFormulaNavBar(get(this.state.formulaList, ["Not found"]), this.props.formulaId);
             return (
                 <div>
+                    {defaultMessage}
                     {messages}
                     <div className="panel panel-default">
                         <div className="panel-heading">
@@ -187,6 +188,7 @@ class FormulaForm extends React.Component {
                     groupData={this.state.groupData}
                     scope={this.props.scope}>
                         <div>
+                            {defaultMessage}
                             {messages}
                             <div className="form-horizontal">
                                 <SectionToolbar>

--- a/web/html/src/components/formula-selection.js
+++ b/web/html/src/components/formula-selection.js
@@ -206,11 +206,7 @@ class FormulaSelection extends React.Component {
     }
 
     render() {
-      var items = [{severity: "info", text:
-            <p>On this page you can select <a href="https://docs.saltstack.com/en/latest/topics/development/conventions/formulas.html">Salt Formulas</a> for
-            this group/system, which can then be configured on group and system level. This allows you to automatically install and configure software. 
-            </p>
-        }];
+      var items = [];
         if(this.props.warningMessage){
           items.push({severity: "warning", text: this.props.warningMessage});
         }
@@ -230,6 +226,9 @@ class FormulaSelection extends React.Component {
 
         return (
             <div>
+                <p>
+                    {t('On this page you can select Salt Formulas for this group/system, which can then be configured on group and system level. This allows you to automatically install and configure software.')} 
+                </p>
                 <Messages items={items}/>
                 <SectionToolbar>
                     <div className="action-button-wrapper">


### PR DESCRIPTION
## What does this PR change?

Get rid of external links (normally they do not work as product instances are offline).
Get rid of the blue box as the description of the page is a simple text descriptor.

## GUI diff

Before:

![Screenshot from 2020-03-31 19-08-57](https://user-images.githubusercontent.com/7080830/78054933-18ab2200-7383-11ea-9f36-77b584d92768.png)

After:
![Screenshot from 2020-03-31 19-08-34](https://user-images.githubusercontent.com/7080830/78054943-1b0d7c00-7383-11ea-9e62-270b31e2f03c.png)

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
