### PR TITLE
Servicepack Migration: Remember Settings

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemHistoryEventAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemHistoryEventAction.java
@@ -18,6 +18,7 @@ import com.redhat.rhn.common.hibernate.LookupException;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.ActionFormatter;
+import com.redhat.rhn.domain.action.dup.DistUpgradeAction;
 import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerHistoryEvent;
@@ -93,6 +94,11 @@ public class SystemHistoryEventAction extends RhnAction {
                 serverAction.getStatus().equals(ActionFactory.STATUS_FAILED));
         request.setAttribute("pickedup",
                 serverAction.getStatus().equals(ActionFactory.STATUS_PICKEDUP));
+        request.setAttribute("completed",
+                serverAction.getStatus().equals(ActionFactory.STATUS_COMPLETED));
+        request.setAttribute("typedistupgradedryrun",
+                action.getActionType().equals(ActionFactory.TYPE_DIST_UPGRADE) &&
+                        ((DistUpgradeAction) action).getDetails().isDryRun());
         if (!serverAction.getStatus().equals(ActionFactory.STATUS_COMPLETED) &&
                 !serverAction.getStatus().equals(ActionFactory.STATUS_FAILED)) {
             request.setAttribute("referrerLink", "Pending.do");
@@ -100,6 +106,9 @@ public class SystemHistoryEventAction extends RhnAction {
             request.setAttribute("headerLabel", "system.event.pendingHeader");
         }
         if (isSubmitted((DynaActionForm)formIn)) {
+            if (serverAction.getStatus().equals(ActionFactory.STATUS_COMPLETED)) {
+                return mapping.findForward("confirm");
+            }
             createMessage(request, "system.event.rescheduled", action.getName(),
                     action.getId().toString());
             ActionFactory.rescheduleSingleServerAction(action, 5L, server.getId());

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemHistoryEventAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemHistoryEventAction.java
@@ -96,9 +96,9 @@ public class SystemHistoryEventAction extends RhnAction {
                 serverAction.getStatus().equals(ActionFactory.STATUS_PICKEDUP));
         request.setAttribute("completed",
                 serverAction.getStatus().equals(ActionFactory.STATUS_COMPLETED));
-        request.setAttribute("typedistupgradedryrun",
-                action.getActionType().equals(ActionFactory.TYPE_DIST_UPGRADE) &&
-                        ((DistUpgradeAction) action).getDetails().isDryRun());
+        boolean typeDistUpgradeDryRun = action.getActionType().equals(ActionFactory.TYPE_DIST_UPGRADE) &&
+                        ((DistUpgradeAction) action).getDetails().isDryRun();
+        request.setAttribute("typeDistUpgradeDryRun", typeDistUpgradeDryRun);
         if (!serverAction.getStatus().equals(ActionFactory.STATUS_COMPLETED) &&
                 !serverAction.getStatus().equals(ActionFactory.STATUS_FAILED)) {
             request.setAttribute("referrerLink", "Pending.do");
@@ -106,8 +106,8 @@ public class SystemHistoryEventAction extends RhnAction {
             request.setAttribute("headerLabel", "system.event.pendingHeader");
         }
         if (isSubmitted((DynaActionForm)formIn)) {
-            if (serverAction.getStatus().equals(ActionFactory.STATUS_COMPLETED)) {
-                return mapping.findForward("confirm");
+            if (serverAction.getStatus().equals(ActionFactory.STATUS_COMPLETED) && typeDistUpgradeDryRun) {
+                return mapping.findForward("spmigration");
             }
             createMessage(request, "system.event.rescheduled", action.getName(),
                     action.getId().toString());

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -8505,7 +8505,7 @@ Alternatively, you will want to download &lt;strong&gt;Incremental Channel Conte
         <source>This system is &lt;a href="/rhn/systems/details/history/Event.do?sid={0}&amp;aid={1}"&gt;scheduled&lt;/a&gt; to be migrated to &lt;strong&gt;{2}&lt;/strong&gt;.</source>
       </trans-unit>
       <trans-unit id="spmigration.message.scheduled.dry-run">
-        <source>This system is &lt;a href="/rhn/systems/details/history/Event.do?sid={0}&amp;aid={1}"&gt;scheduled&lt;/a&gt; for a dry run of the migration to &lt;strong&gt;{2}&lt;/strong&gt;.</source>
+        <source>This system is scheduled for a dry run of the migration to &lt;strong&gt;{2}&lt;/strong&gt;. Once the action completed successfully you can schedule the full migration &lt;a href="/rhn/systems/details/history/Event.do?sid={0}&amp;aid={1}"&gt;here&lt;/a&gt;</source>
       </trans-unit>
       <trans-unit id="task.status.mgr-register">
         <source>Run mgr-register</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -11515,6 +11515,9 @@ the &lt;strong&gt;@@ENTERPRISE_LINUX_NAME@@ System Administration Guide.&lt;/str
         <trans-unit id="system.event.pending.canceled">
           <source>{0} system event(s) canceled.</source>
         </trans-unit>
+        <trans-unit id="system.event.spmigration.notification">
+            <source>&lt;strong&gt;Reload&lt;/strong&gt; the page after the action completed successfully to schedule the full migration.</source>
+        </trans-unit>
         <trans-unit id="system.event.spmigration.rescheduleDryRun">
           <source>Run migration</source>
         </trans-unit>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -11515,6 +11515,9 @@ the &lt;strong&gt;@@ENTERPRISE_LINUX_NAME@@ System Administration Guide.&lt;/str
         <trans-unit id="system.event.pending.canceled">
           <source>{0} system event(s) canceled.</source>
         </trans-unit>
+        <trans-unit id="system.event.spmigration.rescheduleDryRun">
+          <source>Run migration</source>
+        </trans-unit>
       </group>
       <!-- System events legend -->
       <group>

--- a/java/code/webapp/WEB-INF/pages/systems/sdc/history_event.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/sdc/history_event.jsp
@@ -91,7 +91,17 @@
   </div>
 </c:if>
 
-<rhn:icon type="nav-up" title="system.event.returnIcon"/><a href="${referrerLink}?sid=${system.id}"><bean:message key="${linkLabel}" arg0="${fn:escapeXml(system.name)}" /></a>
+  <c:if test="${requestScope.completed == true && requestScope.typedistupgradedryrun == true}">
+    <div align="right">
+      <hr/>
+      <rhn:hidden name="aid" value="${requestScope.aid}" />
+      <html:submit styleClass="btn btn-success">
+        <bean:message key="system.event.spmigration.rescheduleDryRun"/>
+      </html:submit>
+    </div>
+  </c:if>
+
+  <rhn:icon type="nav-up" title="system.event.returnIcon"/><a href="${referrerLink}?sid=${system.id}"><bean:message key="${linkLabel}" arg0="${fn:escapeXml(system.name)}" /></a>
 
 </html:form>
 

--- a/java/code/webapp/WEB-INF/pages/systems/sdc/history_event.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/sdc/history_event.jsp
@@ -46,6 +46,9 @@
         </div>
         <div class="col-sm-10">
           <c:out value="${requestScope.actionnotes}" escapeXml="false"/><!-- already html-escaped in backend -->
+          <c:if test="${!requestScope.completed && requestScope.typeDistUpgradeDryRun}">
+            <bean:message key="system.event.spmigration.notification"/><br>
+          </c:if>
         </div>
       </div>
     </li>
@@ -91,7 +94,7 @@
   </div>
 </c:if>
 
-  <c:if test="${requestScope.completed == true && requestScope.typedistupgradedryrun == true}">
+  <c:if test="${requestScope.completed == true && requestScope.typeDistUpgradeDryRun == true}">
     <div align="right">
       <hr/>
       <rhn:hidden name="aid" value="${requestScope.aid}" />

--- a/java/code/webapp/WEB-INF/pages/systems/spmigration/spmigration-confirm.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/spmigration/spmigration-confirm.jsp
@@ -60,7 +60,7 @@
       </div>
     </div>
     <hr />
-    <c:if test="${!requestScope.completed == true}">
+    <c:if test="${!requestScope.completed}">
       <div class="alert alert-danger">
         <rhn:icon type="system-crit" />
         <bean:message key="spmigration.jsp.confirm.note" />
@@ -73,7 +73,7 @@
         </html:submit>
       </div>
       <div class="pull-right">
-        <c:if test="${!requestScope.completed == true}">
+        <c:if test="${!requestScope.completed}">
           <html:submit styleClass="btn btn-success" property="dispatch">
             <bean:message key="spmigration.jsp.confirm.submit.dry-run" />
           </html:submit>

--- a/java/code/webapp/WEB-INF/pages/systems/spmigration/spmigration-confirm.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/spmigration/spmigration-confirm.jsp
@@ -60,10 +60,12 @@
       </div>
     </div>
     <hr />
-    <div class="alert alert-danger">
-      <rhn:icon type="system-crit" />
-      <bean:message key="spmigration.jsp.confirm.note" />
-    </div>
+    <c:if test="${!requestScope.completed == true}">
+      <div class="alert alert-danger">
+        <rhn:icon type="system-crit" />
+        <bean:message key="spmigration.jsp.confirm.note" />
+      </div>
+    </c:if>
     <div>
       <div class="pull-left">
         <html:submit styleClass="btn btn-default" property="dispatch">
@@ -71,9 +73,11 @@
         </html:submit>
       </div>
       <div class="pull-right">
-        <html:submit styleClass="btn btn-success" property="dispatch">
-          <bean:message key="spmigration.jsp.confirm.submit.dry-run" />
-        </html:submit>
+        <c:if test="${!requestScope.completed == true}">
+          <html:submit styleClass="btn btn-success" property="dispatch">
+            <bean:message key="spmigration.jsp.confirm.submit.dry-run" />
+          </html:submit>
+        </c:if>
         <html:submit styleClass="btn btn-danger" property="dispatch">
           <bean:message key="spmigration.jsp.confirm.submit" />
         </html:submit>

--- a/java/code/webapp/WEB-INF/struts-config.xml
+++ b/java/code/webapp/WEB-INF/struts-config.xml
@@ -3232,7 +3232,7 @@
                  path="/WEB-INF/pages/systems/sdc/history_event.jsp"/>
         <forward name="continue"
                  path="/systems/details/history/History.do"/>
-        <forward name="confirm"
+        <forward name="spmigration"
                  path="/systems/details/SPMigration.do"/>
     </action>
 

--- a/java/code/webapp/WEB-INF/struts-config.xml
+++ b/java/code/webapp/WEB-INF/struts-config.xml
@@ -3232,6 +3232,8 @@
                  path="/WEB-INF/pages/systems/sdc/history_event.jsp"/>
         <forward name="continue"
                  path="/systems/details/history/History.do"/>
+        <forward name="confirm"
+                 path="/systems/details/SPMigration.do"/>
     </action>
 
     <action path="/systems/details/history/History"

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Remember settings after Service Pack Migration dry-run
 - hide message about changed Update Tag change (bsc#1169109)
 - Web UI: Implement bootstrapping minions using an SSH private key
 - add virtual volume delete action


### PR DESCRIPTION
## What does this PR change?

Remember ServigePack migration settings after performing a dry run.

## GUI diff

`Run migration` button added
Button is shown in the event log after successful SPMigration dryrun

![SPmigration_runmigration](https://user-images.githubusercontent.com/31698054/78537398-ba04fe80-77ef-11ea-8810-61be038b2040.png)

Warning and `Dry run` button removed after redirect from `Run migration` button

![SPmigration_remembersettings](https://user-images.githubusercontent.com/31698054/78537474-d43edc80-77ef-11ea-93bf-e6d887b8b6f9.png)


- [x] **DONE**

## Documentation

- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)
https://github.com/SUSE/spacewalk/issues/11162

- [x] **DONE**

## Test coverage

- No tests: Cucumber testing reposync not possible

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/2574

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"    		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"