### PR TITLE
Fix auto bootstrap repo with deb

### DIFF
--- a/backend/satellite_tools/repo_plugins/deb_src.py
+++ b/backend/satellite_tools/repo_plugins/deb_src.py
@@ -240,6 +240,7 @@ class ContentSource:
         else:
             self.org = "NULL"
 
+        comp = CFG.getComponent()
         # read the proxy configuration in /etc/rhn/rhn.conf
         initCFG('server.satellite')
 
@@ -258,6 +259,7 @@ class ContentSource:
         (_scheme, _netloc, _path, query, _fragid) = urlparse.urlsplit(url)
         if query:
             self.authtoken = query
+        initCFG(comp)
 
     def get_md_checksum_type(self):
         pass

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- restore config namespace in debian repo module to fix
+  autogeneration of bootstrap repos
 - send CreateBootstrapRepoFailed Notification
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

The debian repo module change the config namespace which remove the availability of the variable CFG.AUTO_GENERATE_BOOTSTRAP_REPO .
Restore the old namespace after usage fix this issue

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **already covered**

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/2087

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
