### PR TITLE
Fix sp migration without target product

### DIFF
--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -186,7 +186,7 @@ artifacts:
   - artifact: postgresql-jdbc
     repository: Uyuni_Other
   - artifact: quartz
-    repository: Uyuni
+    repository: Uyuni_Other
   - artifact: redstone-xmlrpc
     jar: redstone-xmlrpc-[0-9.]+
     repository: Uyuni_Other

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -21369,6 +21369,9 @@ given channel.</source>
       <trans-unit id="spmigration.jsp.error.update-salt-package-needed">
         <source>The installed &lt;strong&gt;Salt&lt;/strong&gt; package version on this system is out of date. Please update the package to the latest version before you start a Service Pack migration.</source>
       </trans-unit>
+      <trans-unit id="spmigration.jsp.error.missing-successor-extensions">
+        <source>There is no migration available for this system. For some of the installed extensions no successor could be found:</source>
+      </trans-unit>
       <trans-unit id="spmigration.jsp.confirm.title">
         <source>Service Pack Migration - Confirm</source>
       </trans-unit>

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -6625,6 +6625,10 @@ public class SystemHandler extends BaseHandler {
         ChannelArch arch = server.getServerArch().getCompatibleChannelArch();
         List<SUSEProductSet> migrationTargets = DistUpgradeManager.
                 getTargetProductSets(installedProducts, arch, loggedInUser);
+
+        migrationTargets = DistUpgradeManager.removeIncompatibleTargets(
+                installedProducts, migrationTargets, Optional.empty());
+
         for (SUSEProductSet ps : migrationTargets) {
             if (!ps.getIsEveryChannelSynced()) {
                 continue;
@@ -6735,6 +6739,7 @@ public class SystemHandler extends BaseHandler {
         ChannelArch arch = server.getServerArch().getCompatibleChannelArch();
         List<SUSEProductSet> targets = DistUpgradeManager.getTargetProductSets(
                 installedProducts, arch, loggedInUser);
+        targets = DistUpgradeManager.removeIncompatibleTargets(installedProducts, targets, Optional.empty());
         if (targets.size() > 0) {
             SUSEProductSet targetProducts = null;
             if (StringUtils.isBlank(targetIdent)) {

--- a/java/code/webapp/WEB-INF/pages/systems/spmigration/spmigration-target.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/spmigration/spmigration-target.jsp
@@ -24,6 +24,16 @@
                     arg1="${migrationScheduled.id}" />
             </div>
         </c:when>
+        <c:when test="${not empty latestServicePack and not empty missingSuccessorExtensions}">
+            <div class="alert alert-warning">
+                <bean:message key="spmigration.jsp.error.missing-successor-extensions" /><br/>
+                <ul>
+                    <c:forEach items="${missingSuccessorExtensions}" var="missing">
+                        <li><c:out value="${missing}" /></li>
+                    </c:forEach>
+                </ul>
+            </div>
+        </c:when>
         <c:when test="${not empty latestServicePack}">
             <div class="alert alert-warning">
                 <bean:message key="spmigration.jsp.error.up-to-date" />

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- skip and show migration targets which do not have a successor
+  for all installed extension products (bsc#1168227)
 - fix resource leak in taskomatic (bsc#1168696)
 - XMLRPC: Implement bootstrapping minions using an SSH private key
 - Fix: unable to be redirected to the IdP when SSO is enabled (bsc#1167667)


### PR DESCRIPTION
## What does this PR change?

Test every installed extension if a successor could be found in the migration target set.
If not show them in UI to give a hint whats wrong.
For XMLRPC skip them.

This improve the situation for typical cases:

- LTSS product installed but not available in the migration target
- HA product installed on SLES for SAP
- unknown extension installed

## GUI diff

![Screenshot_20200404_163223](https://user-images.githubusercontent.com/1038917/78453422-e571d700-7691-11ea-98fe-ec218e37eb22.png)


- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11135
Fixes https://github.com/SUSE/spacewalk/issues/10560
Tracks

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
