### PR TITLE
use shared SaltService instance jobs and workers (bsc#1168696)

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionChainExecutor.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionChainExecutor.java
@@ -38,7 +38,7 @@ public class MinionActionChainExecutor extends RhnJavaJob {
     private static final int ACTION_DATABASE_GRACE_TIME = 10000;
     private static final long MAXIMUM_TIMEDELTA_FOR_SCHEDULED_ACTIONS = 24; // hours
 
-    private SaltServerActionService saltServerActionService = new SaltServerActionService(new SaltService());
+    private SaltServerActionService saltServerActionService = new SaltServerActionService(SaltService.INSTANCE);
 
     /**
      * @param context the job execution context

--- a/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionExecutor.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionExecutor.java
@@ -44,7 +44,7 @@ public class MinionActionExecutor extends RhnJavaJob {
     private static final int ACTION_DATABASE_POLL_TIME = 100;
     private static final long MAXIMUM_TIMEDELTA_FOR_SCHEDULED_ACTIONS = 24; // hours
 
-    private SaltServerActionService saltServerActionService = new SaltServerActionService(new SaltService());
+    private SaltServerActionService saltServerActionService = new SaltServerActionService(SaltService.INSTANCE);
 
     /**
      * @param context the job execution context

--- a/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/SSHPushWorkerSalt.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/SSHPushWorkerSalt.java
@@ -69,7 +69,7 @@ public class SSHPushWorkerSalt implements QueueWorker {
         system = systemIn;
         systemQuery = SaltService.INSTANCE;
         saltSSHService = SaltService.INSTANCE.getSaltSSHService();
-        saltServerActionService = new SaltServerActionService(new SaltService());
+        saltServerActionService = new SaltServerActionService(systemQuery);
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- fix resource leak in taskomatic (bsc#1168696)
 - XMLRPC: Implement bootstrapping minions using an SSH private key
 - Fix: unable to be redirected to the IdP when SSO is enabled (bsc#1167667)
 - improve performance of cleanup-data-bunch


### PR DESCRIPTION
## What does this PR change?

Temporary solution to avoid continuously creating new `SaltService` instances which leak a http client thread every time.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests" 		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
