### PR TITLE
Testsuite - traditional clients bootstrapped by script

### DIFF
--- a/testsuite/features/core/proxy_register_as_minion_with_gui.feature
+++ b/testsuite/features/core/proxy_register_as_minion_with_gui.feature
@@ -36,7 +36,7 @@ Feature: Setup SUSE Manager proxy
   Scenario: Copy the keys and configure the proxy
     When I copy server's keys to the proxy
     And I configure the proxy
-    Then I should see "proxy" in spacewalk
+    Then I should see "proxy" via spacecmd
 
 @proxy
   Scenario: Check proxy system details

--- a/testsuite/features/core/proxy_register_as_minion_with_script.feature
+++ b/testsuite/features/core/proxy_register_as_minion_with_script.feature
@@ -39,7 +39,7 @@ Feature: Setup SUSE Manager proxy
   Scenario: Copy the keys and configure the proxy
     When I copy server's keys to the proxy
     And I configure the proxy
-    Then I should see "proxy" in spacewalk
+    Then I should see "proxy" via spacecmd
 
 @proxy
   Scenario: Check proxy system details

--- a/testsuite/features/core/proxy_register_as_trad_with_script.feature
+++ b/testsuite/features/core/proxy_register_as_trad_with_script.feature
@@ -23,7 +23,7 @@ Feature: Setup SUSE Manager proxy
   Scenario: Copy the keys and configure the proxy
     When I copy server's keys to the proxy
     And I configure the proxy
-    Then I should see "proxy" in spacewalk
+    Then I should see "proxy" via spacecmd
 
 @proxy
   Scenario: Check proxy system details

--- a/testsuite/features/init_clients/sle_client.feature
+++ b/testsuite/features/init_clients/sle_client.feature
@@ -3,12 +3,11 @@
 
 Feature: Register a traditional client
   In order to register a traditional client to the SUSE Manager server
-  As the root user
-  I want to call rhnreg_ks
+  I want to create, parametrize and run boostrap script from proxy
 
   Scenario: Register a traditional client
-    When I register using "1-SUSE-DEV-x86_64" key
-    Then I should see "sle_client" in spacewalk
+    When I bootstrap traditional client "sle_client" using bootstrap script with activation key "1-SUSE-DEV-x86_64" from the proxy
+    Then I should see "sle_client" via spacecmd
 
   Scenario: Check registration values
     Given I update the profile of this client

--- a/testsuite/features/qam/init_clients/proxy.feature
+++ b/testsuite/features/qam/init_clients/proxy.feature
@@ -34,7 +34,7 @@ Feature: Setup SUSE Manager proxy
   Scenario: Copy the keys and configure the proxy
     When I copy server's keys to the proxy
     And I configure the proxy
-    Then I should see "proxy" in spacewalk
+    Then I should see "proxy" via spacecmd
 
   Scenario: Check proxy system details
     When I am on the Systems overview page of this "proxy"

--- a/testsuite/features/qam/init_clients/sle11sp4_client.feature
+++ b/testsuite/features/qam/init_clients/sle11sp4_client.feature
@@ -10,7 +10,7 @@ Feature: Register a sle11sp4 traditional client
   Scenario: Register a sle11sp4 traditional client
     When I register "sle11sp4_client" as traditional client with activation key "1-sle11sp4_client_key"
     And I run "mgr-actions-control --enable-all" on "sle11sp4_client"
-    Then I should see "sle11sp4_client" in spacewalk
+    Then I should see "sle11sp4_client" via spacecmd
     And I wait until onboarding is completed for "sle11sp4_client"
 
   Scenario: Check registration values of sle11sp4 traditional

--- a/testsuite/features/qam/init_clients/sle12sp4_client.feature
+++ b/testsuite/features/qam/init_clients/sle12sp4_client.feature
@@ -10,7 +10,7 @@ Feature: Register a sle12sp4 traditional client
   Scenario: Register a sle12sp4 traditional client
     When I register "sle12sp4_client" as traditional client with activation key "1-sle12sp4_client_key"
     And I run "mgr-actions-control --enable-all" on "sle12sp4_client"
-    Then I should see "sle12sp4_client" in spacewalk
+    Then I should see "sle12sp4_client" via spacecmd
     And I wait until onboarding is completed for "sle12sp4_client"
 
   Scenario: Check registration values of sle12sp4 traditional client

--- a/testsuite/features/qam/init_clients/sle15_client.feature
+++ b/testsuite/features/qam/init_clients/sle15_client.feature
@@ -10,7 +10,7 @@ Feature: Register a sle15 traditional client
   Scenario: Register a traditional client
     When I register "sle15_client" as traditional client with activation key "1-sle15_client_key"
     And I run "mgr-actions-control --enable-all" on "sle15_client"
-    Then I should see "sle15_client" in spacewalk
+    Then I should see "sle15_client" via spacecmd
     And I wait until onboarding is completed for "sle15_client"
 
   Scenario: Check registration values

--- a/testsuite/features/qam/init_clients/sle15sp1_client.feature
+++ b/testsuite/features/qam/init_clients/sle15sp1_client.feature
@@ -10,7 +10,7 @@ Feature: Register a sle15sp1 traditional client
   Scenario: Register a sle15sp1 traditional client
     When I register "sle15sp1_client" as traditional client with activation key "1-sle15sp1_client_key"
     And I run "mgr-actions-control --enable-all" on "sle15sp1_client"
-    Then I should see "sle15sp1_client" in spacewalk
+    Then I should see "sle15sp1_client" via spacecmd
     And I wait until onboarding is completed for "sle15sp1_client"
 
   Scenario: Check registration values of sle15sp1 traditional

--- a/testsuite/features/secondary/trad_baremetal_discovery.feature
+++ b/testsuite/features/secondary/trad_baremetal_discovery.feature
@@ -23,8 +23,8 @@ Feature: Bare metal discovery
     And the PXE default profile should be enabled
 
   Scenario: Register a client for bare metal discovery
-    When I register using "1-spacewalk-bootstrap-activation-key" key
-    Then I should see "sle_client" in spacewalk
+    When I bootstrap traditional client "sle_client" using bootstrap script with activation key "1-spacewalk-bootstrap-activation-key" from the proxy
+    Then I should see "sle_client" via spacecmd
 
   Scenario: Check registration values of client
     Given I am on the Systems overview page of this "sle_client"
@@ -81,7 +81,7 @@ Feature: Bare metal discovery
     When I check the "sle_client" client
     And I wait for "30" seconds
     Then I am on System Set Manager Overview
-  
+
   Scenario: Check SSM page for bare metal system
     Given I am authorized as "admin" with password "admin"
     And I am on System Set Manager Overview
@@ -115,10 +115,10 @@ Feature: Bare metal discovery
     When I click on "Disable adding to this organization"
     Then I should see a "Automatic bare-metal system discovery has been successfully disabled" text
     And the PXE default profile should be disabled
-  
+
   Scenario: Cleanup: register a traditional client after bare metal tests
-    When I register using "1-SUSE-DEV-x86_64" key
-    Then I should see "sle_client" in spacewalk
+    When I bootstrap traditional client "sle_client" using bootstrap script with activation key "1-SUSE-DEV-x86_64" from the proxy
+    Then I should see "sle_client" via spacecmd
 
   Scenario: Cleanup: remove remaining systems from SSM after bare metal tests
     When I am authorized as "admin" with password "admin"

--- a/testsuite/features/secondary/trad_mgr_bootstrap.feature
+++ b/testsuite/features/secondary/trad_mgr_bootstrap.feature
@@ -11,7 +11,7 @@ Feature: Generate a bootstrap script and use it to register a client
   Scenario: Register this client using the bootstrap script
     When I fetch "pub/bootstrap/bootstrap-test.sh" to "sle_client"
     And I run "sh ./bootstrap-test.sh" on "sle_client"
-    Then I should see "sle_client" in spacewalk
+    Then I should see "sle_client" via spacecmd
     And "sed" should be installed on "sle_client"
     And config-actions are enabled
     And remote-commands are enabled

--- a/testsuite/features/secondary/trad_migrate_to_minion.feature
+++ b/testsuite/features/secondary/trad_migrate_to_minion.feature
@@ -96,7 +96,8 @@ Feature: Migrate a traditional client into a Salt minion
     When I enable SUSE Manager tools repositories on "sle_client"
     And I install package "spacewalk-client-setup spacewalk-oscap mgr-cfg-actions" on this "sle_client"
     And I remove package "salt-minion" from this "sle_client"
-    And I register using "1-SUSE-DEV-x86_64" key
+    And I bootstrap traditional client "sle_client" using bootstrap script with activation key "1-SUSE-DEV-x86_64" from the proxy
+    Then I should see "sle_client" via spacecmd
 
   Scenario: Cleanup: check that this is again a traditional client
     Given I am on the Systems overview page of this "sle_client"

--- a/testsuite/features/secondary/trad_migrate_to_sshminion.feature
+++ b/testsuite/features/secondary/trad_migrate_to_sshminion.feature
@@ -118,7 +118,8 @@ Feature: Migrate a traditional client into a Salt SSH minion
   Scenario: Cleanup: register SSH minion again as traditional client
     When I enable SUSE Manager tools repositories on "sle_client"
     And I install package "spacewalk-client-setup spacewalk-oscap mgr-cfg-actions" on this "sle_client"
-    And I register using "1-SUSE-DEV-x86_64" key
+    And I bootstrap traditional client "sle_client" using bootstrap script with activation key "1-SUSE-DEV-x86_64" from the proxy
+    Then I should see "sle_client" via spacecmd
 
   Scenario: Cleanup: change contact method of activation key back to default
     Given I am authorized as "admin" with password "admin"

--- a/testsuite/features/secondary/trad_ssh_push.feature
+++ b/testsuite/features/secondary/trad_ssh_push.feature
@@ -38,7 +38,7 @@ Feature: Register a traditional system to be managed via SSH push
 
   Scenario: Register this client for SSH push via tunnel
     When I register this client for SSH push via tunnel
-    Then I should see "sle_client" in spacewalk
+    Then I should see "sle_client" via spacecmd
 
   Scenario: Check this client's contact method
     Given I am on the Systems overview page of this "sle_client"
@@ -75,5 +75,5 @@ Feature: Register a traditional system to be managed via SSH push
     And I remove server hostname from hosts file on "sle_client"
  
   Scenario: Cleanup: register a traditional client after SSH push tests
-    When I register using "1-SUSE-DEV-x86_64" key
-    Then I should see "sle_client" in spacewalk
+    When I bootstrap traditional client "sle_client" using bootstrap script with activation key "1-SUSE-DEV-x86_64" from the proxy
+    Then I should see "sle_client" via spacecmd

--- a/testsuite/features/upload_files/bootstrap-traditional.exp
+++ b/testsuite/features/upload_files/bootstrap-traditional.exp
@@ -1,0 +1,19 @@
+set address [lindex $argv 0]
+
+spawn /usr/bin/scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null /srv/www/htdocs/pub/bootstrap/bootstrap.sh root@$address:/root/bootstrap.sh
+expect {
+	"*?assword:*" { send "linux\r"; interact }
+	eof { exit }
+}
+
+spawn /usr/bin/ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $address
+match_max 1000000
+expect "*?assword:*"
+send -- "linux\r"
+expect "#"
+send -- "chmod 750 /root/bootstrap.sh\r"
+expect "#"
+send -- "/root/bootstrap.sh\r"
+set timeout 180
+expect "?bootstrap complete?"
+puts "\r"


### PR DESCRIPTION
## What does this PR change?

This PR replaces current mechanism of traditional client registration (using `rhnreg_ks` command) with bootstrap script as it is supported and recommended way to register new traditional client.

## Links

https://github.com/SUSE/spacewalk/issues/10661

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle" (Test skipped, there are no changes to test)		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
