### PR TITLE
Refactor Formula Form component to make it reusable outside Formulas UI

### DIFF
--- a/web/html/src/components/FormulaForm.js
+++ b/web/html/src/components/FormulaForm.js
@@ -110,7 +110,6 @@ class FormulaForm extends React.Component {
                     errors: messages
             });
         } else {
-            console.log("saveFormula");
           let formData = {
                 type: formType,
                 id: this.props.systemId,

--- a/web/html/src/components/FormulaForm.js
+++ b/web/html/src/components/FormulaForm.js
@@ -1,12 +1,12 @@
 /* eslint-disable */
 import * as React from 'react';
-import Network from "../utils/network";
+import * as Network from 'utils/network';
 import {Utils, Formulas} from 'utils/functions';
 import {default as Jexl} from 'jexl';
-import {Button} from "../components/buttons";
-import {Messages} from "../components/messages";
-import {generateFormulaComponent, checkVisibilityCondition, evalExpression} from "./formulas/FormulaComponentGenerator";
-import {SectionToolbar} from "components/section-toolbar/section-toolbar";
+import {Button} from 'components/buttons';
+import {Messages} from 'components/messages';
+import {FormulaFormContext, FormulaFormContextProvider, FormulaFormRenderer, text, get} from './formulas/FormulaComponentGenerator';
+import {SectionToolbar} from 'components/section-toolbar/section-toolbar';
 
 const getEditGroupSubtype = Formulas.getEditGroupSubtype;
 const EditGroupSubtype = Formulas.EditGroupSubtype;
@@ -16,8 +16,6 @@ const capitalize = Utils.capitalize;
 const defaultMessageTexts = {
     "pillar_only_formula_saved": <p>{t("Formula saved. Applying the highstate is not needed for this formula.")}</p>
 }
-
-const productName = Utils.getProductName();
 
 //props:
 //dataUrl = url to get the server data
@@ -30,15 +28,14 @@ class FormulaForm extends React.Component {
     constructor(props) {
         super(props);
 
-        ["saveFormula", "handleChange", "clearValues", "getMessageText", "getEmptyValues"].forEach(method => this[method] = this[method].bind(this));
-
         const previewMessage = <p>On this page you can configure <a href="https://docs.saltstack.com/en/latest/topics/development/conventions/formulas.html" target="_blank" rel="noopener noreferrer">Salt Formulas</a> to automatically install and configure software.</p>;
 
         this.state = {
             formulaName: "",
             formulaList: [],
-            formulaLayout: {},
-            formulaValues: {},
+            formulaRawLayout: {},
+            systemData: {},
+            groupData: {},
             formulaChanged: false,
             messages: [previewMessage],
             errors: []
@@ -58,28 +55,33 @@ class FormulaForm extends React.Component {
         this.init();
     }
 
-    init() {
-        Network.get(this.props.dataUrl).promise.then(data => {
+    init = () => {
+        var dataPromise;
+        if (this.props.getDataPromise) {
+            dataPromise = this.props.getDataPromise()
+        } else {
+            dataPromise = Network.get(this.props.dataUrl).promise;
+        }
+
+        dataPromise.then(data => {
             if (data === null)
                 this.setState({
                     formulaName: "",
                     formulaList: [],
-                    formulaLayout: {},
-                    formulaValues: {},
+                    formulaRawLayout: {},
+                    systemData: {},
+                    groupData: {},
                     formulaChanged: false,
                     metadata: {}
                 });
             else {
-                const layout = preprocessLayout(data.layout);
-                preprocessData(layout, get(data.system_data, {}));
-                preprocessData(layout, get(data.group_data, {}));
-                const values = generateValues(layout, get(data.group_data, {}), get(data.system_data, {}));
-
+                const rawLayout = data.layout;
                 this.setState({
                     formulaName: data.formula_name,
                     formulaList: data.formula_list,
-                    formulaLayout: layout,
-                    formulaValues: values,
+                    formulaRawLayout: rawLayout,
+                    systemData: get(data.system_data, {}),
+                    groupData: get(data.group_data, {}),
                     formulaChanged: false,
                     formulaMetadata: data.metadata
                 });
@@ -87,114 +89,35 @@ class FormulaForm extends React.Component {
         });
     }
 
-    walkValueTree(value, formulaForm, formulaValues, validationFunc) {
-        if (value instanceof Object) {
-            for (let key in value) {
-                if (!key.startsWith("$meta$")) {
-                    if (("$meta$" + key) in value) {
-                        const meta = value["$meta$" + key];
-                        const keepWalking = validationFunc(value, key, meta, formulaForm, formulaValues);
-                        console.log("walkValueTree keepWalking: " + keepWalking);
-                        if (keepWalking) {
-                            this.walkValueTree(value[key], formulaForm, formulaValues, validationFunc);
-                        }
-                    } else {
-                        this.walkValueTree(value[key], formulaForm, formulaValues, validationFunc);
-                    }
-                }
-            }
-        }
-    }    
-
-    getEmptyValues() {
-        let requiredErrors = []
-        this.walkValueTree(this.state.formulaValues, this, this.state.formulaValues, 
-            (parentVal, key, meta, formulaForm, formulaValues) => {
-                const val = parentVal[key];
-                if (meta["visibleIf"]) {
-                    const visibleIf = checkVisibilityCondition(meta["id"], meta["visibleIf"], formulaForm);
-                    if (!visibleIf) {
-                        return false;
-                    }
-                } else if (meta["visible"]) {
-                    const visible = evalExpression(meta["id"], meta["visible"], formulaForm);
-                    if (!visible) {
-                        return false;
-                    }
-                }
-                if(meta["required"]) {
-                    const required = evalExpression(meta["id"], meta["required"] + "", formulaForm);
-                    if (required) {
-                        if (Array.isArray(val) && val.some(v => !v)) {
-                            requiredErrors.push(meta["name"]);
-                        } else if (!val) {
-                            requiredErrors.push(meta["name"]);
-                        }
-                    }
-                }
-                return true;
-            });
-        return requiredErrors;
-    }
-
-    checkFieldsFormat() {
-        const errors = [];
-        this.walkValueTree(this.state.formulaValues, this, this.state.formulaValues, 
-            (parentVal, key, meta, formulaForm, formulaValues) => {
-                const value = parentVal[key];
-                if(meta["match"]) {
-                    try {
-                        const re = new RegExp(meta["match"]);
-                        if (Array.isArray(value)) {
-                            // match each value
-                            if (!value.every(v => re.test(v))) {
-                                errors.push(meta["name"]);
-                            }
-                        } else {
-                            if (!re.test(value)) {
-                                errors.push(meta["name"]);
-                            }
-                        }
-                    } catch (err) {
-                        console.log("Error matching regex: '" + meta["match"] + "':" + err);
-                    }
-                }
-                return true;
-            });
-        return errors;
-    }
-
-    saveFormula(event) {
-        event.preventDefault();
+    saveFormula = (data) => {
         this.setState({ formulaChanged: false });
         let scope = this.props.scope;
         let formType = scope.toUpperCase();
         if (formType === 'SYSTEM') {
             formType = 'SERVER';
         }
-        let formData = {
-            type: formType,
-            id: this.props.systemId,
-            formula_name: this.state.formulaName,
-            content: this.getValuesClean(preprocessCleanValues(this.state.formulaValues, this.state.formulaLayout))
-        };
 
-        const emptyRequiredFields = [...new Set(this.getEmptyValues())];
-        const checkFieldsFormat = [...new Set(this.checkFieldsFormat())];
-
-        if(emptyRequiredFields.length > 0 || checkFieldsFormat.length > 0) {
+        if(data.errors) {
             const messages = [];
-            if (emptyRequiredFields.length > 0) {
-                messages.push(t("Please input required fields: {0}", emptyRequiredFields.join(', ')));
+            if (data.errors.required && data.errors.required.length > 0) {
+                messages.push(t("Please input required fields: {0}", data.errors.required.join(', ')));
             }
-            if (checkFieldsFormat.length > 0) {
-                messages.push(t("Invalid format of fields: {0}", checkFieldsFormat.join(', ')));
+            if (data.errors.invalid && data.errors.invalid.length > 0) {
+                messages.push(t("Invalid format of fields: {0}", data.errors.invalid.join(', ')));
             }
             this.setState({
                     messages: [],
                     errors: messages
             });
         } else {
+            console.log("saveFormula");
+          let formData = {
+                type: formType,
+                id: this.props.systemId,
+                formula_name: this.state.formulaName,
+                content: data.values
+          };
+
           Network.post(
             this.props.saveUrl,
             JSON.stringify(formData),
@@ -215,138 +138,16 @@ class FormulaForm extends React.Component {
                     });
                 }
             }.bind(this));
-        }
-        window.scrollTo(0, 0);
-    }
-
-    getValuesClean(values = this.state.formulaValues, layout = this.state.formulaLayout) {
-        let result = {};
-        for (let key in values) {
-            if (key.startsWith("$meta")) {
-                continue;
-            }
-            let value = values[key];
-            let element = layout[key];
-            if (element.$type === "group" || element.$type === "namespace") {
-                value = this.getValuesClean(value, element);
-                if (!$.isEmptyObject(value))
-                    result[key] = value;
-            }
-            else if ((element.$scope === this.props.currentScope || element.$scope === "system") && !(value && value.length === 0)) {
-                value = this.checkIfEmptyValueAttrExists(value, element, values);
-                result[key] = this.cleanMeta(value);
-            }
-        }
-        return result;
-    }
-
-    /**
-    * Remove $meta element from all form values.
-    */
-    cleanMeta(value) {
-        let result = {};
-        if (value instanceof Object && !Array.isArray(value)) {
-            for (let key in value) {
-                if (key.startsWith("$meta")) {
-                    continue;
-                }
-                result[key] = this.cleanMeta(value[key]);
-            }
-        } else {
-            result = value;
-        }
-        return result;
-    }
-
-    checkIfEmptyValueAttrExists(value, element, formulaValues) {
-         if((value == null || value.length == 0) && !element.$optional && (element.$ifEmpty || element.$ifEmpty === null)) {
-            value = element.$ifEmpty;
-            formulaValues[element.$id] = value;
-         }
-         return value;
-    }
-
-    clearValues() {
-        if (window.confirm("Are you sure you want to clear all values?")) {
-            if (this.props.scope === "system") {
-                Network.get(this.props.dataUrl).promise.then(data => {
-                    this.setState({
-                        formulaValues: generateValues(this.state.formulaLayout, get((data === null ? undefined : data.group_data), {}), {}),
-                        formulaChanged: false
-                    });
-                });
-            }
-            else {
-                this.setState({
-                    formulaValues: generateValues(this.state.formulaLayout, {}, {}),
-                    formulaChanged: false
-                });
-            }
-        }
-    }
-
-    handleChange(event) {
-        let id, value;
-        if (event.id) {
-            id = event.id;
-            value = event.value;
-        }
-        else {
-            id = event.target.id;
-
-            if (event.target.type === "checkbox")
-                value = event.target.checked;
-            else if (event.target.type === "number")
-                value = isNaN(event.target.valueAsNumber) ? "" : event.target.valueAsNumber;
-            else
-                value = event.target.value;
+            window.scrollTo(0, 0);
         }
 
-        this.setState((state) => {
-            let values = state.formulaValues;
-            let parents = id.split("#");
-            for (var i in parents.slice(0, -1)) {
-                if (values[parents[i]] === undefined)
-                    values[parents[i]] = {};
-                values = values[parents[i]];
-            }
-            values[parents[parents.length - 1]] = value;
-            return {
-                formulaValues: state.formulaValues,
-                formulaChanged: true
-            }
-        });
     }
 
-    getValueById(id) {
-        let parents = id.split("#");
-        let value = this.state.formulaValues;
-        for (let i in parents) {
-            if (value[parents[i]] === undefined)
-                return null;
-            value = value[parents[i]];
-        }
-        return value;
-    }
-
-    renderForm() {
-        let form = [];
-        const layout = this.state.formulaLayout;
-        const values = this.state.formulaValues;
-        for (let key in layout)
-            form.push(generateFormulaComponent(layout[key], values[key], this));
-        return form;
-    }
-
-    getMessageText(msg) {
+    getMessageText = (msg) => {
       if (!this.props.messageTexts[msg] && defaultMessageTexts[msg]) {
           return t(defaultMessageTexts[msg]);
       }
       return this.props.messageTexts[msg] ? t(this.props.messageTexts[msg]) : msg;
-    }
-
-    getFormulaValues() {
-        return this.state.formulaValues;
     }
 
     render() {
@@ -358,7 +159,7 @@ class FormulaForm extends React.Component {
         }));
         const messages = <Messages items={messageItems} />;
 
-        if (this.state.formulaLayout === undefined || this.state.formulaLayout === null || $.isEmptyObject(this.state.formulaLayout)) {
+        if (this.state.formulaRawLayout === undefined || this.state.formulaRawLayout === null || $.isEmptyObject(this.state.formulaRawLayout)) {
             if (this.props.addFormulaNavBar !== undefined)
                 this.props.addFormulaNavBar(get(this.state.formulaList, ["Not found"]), this.props.formulaId);
             return (
@@ -376,388 +177,55 @@ class FormulaForm extends React.Component {
             );
         }
         else {
-            if (this.props.addFormulaNavBar !== undefined)
+            if (this.props.addFormulaNavBar !== undefined) {
                 this.props.addFormulaNavBar(this.state.formulaList, this.props.formulaId);
+            }
             const nextHref = this.props.getFormulaUrl(this.props.formulaId + 1);
             const prevHref = this.props.getFormulaUrl(this.props.formulaId - 1);
             return (
-                <div>
-                    {messages}
-                    <form id="formula-form" className="form-horizontal" onSubmit={this.saveFormula}>
-                        <SectionToolbar>
-                            <div className="btn-group">
-                                <button id="prev-btn" type="button" onClick={() => window.location.href = prevHref} disabled={this.props.formulaId === 0} className="btn btn-default"><i className="fa fa-arrow-left" /> Prev</button>
-                                <button id="next-btn" type="button" onClick={() => window.location.href = nextHref} disabled={this.props.formulaId >= this.state.formulaList.length - 1} className="btn btn-default">Next <i className="fa fa-arrow-right fa-right" /></button>
-                            </div>
-                            <div className="action-button-wrapper">
-                                <div className="btn-group">
-                                    <Button id="save-btn" icon="fa-floppy-o" text="Save Formula" className={"btn btn-success"} handler={() => $('<input type="submit">').hide().appendTo($("#formula-form")).click().remove()} />
-                                    <Button id="reset-btn" icon="fa-eraser" text="Clear values" className="btn btn-default" handler={this.clearValues} />
-                                </div>
-                            </div>
-                        </SectionToolbar>
-                        <div className="panel panel-default">
-                            <div className="panel-heading">
-                                <h3>{capitalize(get(this.state.formulaName, "Unnamed"))}</h3>
-                            </div>
-                            <div className="panel-body">
-                                <div className="formula-content">
-                                <p>{text(this.state.formulaMetadata.description)}</p>
-                                <hr/>
-                                {this.renderForm()}
+                <FormulaFormContextProvider layout={this.state.formulaRawLayout}
+                    systemData={this.state.systemData}
+                    groupData={this.state.groupData}
+                    scope={this.props.scope}>
+                        <div>
+                            {messages}
+                            <div className="form-horizontal">
+                                <SectionToolbar>
+                                    <div className="btn-group">
+                                        <button id="prev-btn" type="button" onClick={() => window.location.href = prevHref} disabled={this.props.formulaId === 0} className="btn btn-default"><i className="fa fa-arrow-left" /> Prev</button>
+                                        <button id="next-btn" type="button" onClick={() => window.location.href = nextHref} disabled={this.props.formulaId >= this.state.formulaList.length - 1} className="btn btn-default">Next <i className="fa fa-arrow-right fa-right" /></button>
+                                    </div>
+                                    <div className="action-button-wrapper">
+                                            <FormulaFormContext.Consumer>
+                                                {({validate, clearValues}) =>
+                                                    <div className="btn-group">
+                                                        <Button id="save-btn" icon="fa-floppy-o" text="Save Formula" className={"btn btn-success"} handler={() => this.saveFormula(validate())} />
+                                                        <Button id="reset-btn" icon="fa-eraser" text="Clear values" className="btn btn-default" handler={() => clearValues(() => window.confirm("Are you sure you want to clear all values?"))} />
+                                                    </div>
+                                                }
+                                            </FormulaFormContext.Consumer>
+                                    </div>
+                                </SectionToolbar>
+                                <div className="panel panel-default">
+                                    <div className="panel-heading">
+                                        <h3>{capitalize(get(this.state.formulaName, "Unnamed"))}</h3>
+                                    </div>
+                                    <div className="panel-body">
+                                        <div className="formula-content">
+                                        <p>{text(this.state.formulaMetadata.description)}</p>
+                                        <hr/>
+                                            <FormulaFormRenderer />
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
                         </div>
-                    </form>
-                </div>
+                </FormulaFormContextProvider>
             );
         }
     }
 }
 
-/*
- * Set missing attributes ($type, $scope) to default values,
- * set $default values,
- * set $newItemValues for edit-groups.
- */
-function preprocessLayout(layout, scope = "system") {
-    Object.entries(layout)
-        .filter(([name, element]) => !name.startsWith("$") || name === "$key")
-        .forEach(([name, element]) => {
-            adjustElementBasicAttrs([name, element], scope);
 
-            // groups are processed recursively
-            if (element.$type === "group" || element.$type === "namespace") {
-                preprocessLayout(element, element.$scope)
-            }
-            // edit-groups too
-            else if (element.$type === "edit-group") {
-                element.$prototype = preprocessLayout(element.$prototype, element.$scope);
-                adjustEditGroup(element);
-            }
-        });
-
-    return layout;
-}
-
-// consumes an element entry: [element name, element]
-function adjustElementBasicAttrs([elementName, element], scope) {
-    if (!("$scope" in element)) {
-        element.$scope = scope;
-    }
-
-    if (element.$type === "hidden-group") {
-        element.$type = "namespace";
-    }
-
-    if (!("$type" in element)) {
-        element.$type = "text"
-    }
-
-    if (element.$name === undefined && elementName === "$key") {
-        element.$name = "Key";
-    }
-
-    if (elementName === "$key") {
-        element["$required"] = true;
-    }
-
-    element.$id = elementName;
-    element.$name = text(get(element.$name, capitalize(elementName)));
-    element.$help = text(get(element.$help, element.$name));
-    element.$placeholder = text(get(element.$placeholder, ""));
-
-    if (isPrimitiveElement(element)) {
-        element.$default = defaultValueForElement(element);
-    };
-}
-
-function defaultValue(type, defValue, selectValues) {
-    if (type === "boolean")
-        return get(defValue, false);
-    else if (type === "select")
-        return get(defValue, selectValues[0]);
-    else if (type === "color")
-        return get(defValue, "#000000");
-    else if (type === "password")
-        return get(defValue, "");
-
-    return get(defValue, "");
-}
-
-function defaultValueForElement(element) {
-    return defaultValue(element.$type, element.$default, element.$values);
-}
-
-function isPrimitiveElement(element) {
-    return element.$type !== "group" &&
-        element.$type !== "namespace" &&
-        element.$type !== "edit-group";
-}
-
-function text(txt) {
-    // replace variables
-    txt = txt.replace(/\${productName}/g, productName);
-    return txt;
-}
-
-/*
- * Adjust edit group default and 'new item' value of edit-group
- * Some subtypes of edit-group need special handling (e.g. nested dictionary
- * needs to be converted to lists).
- */
-function adjustEditGroup(element) {
-    // Adjust common edit-group attributes
-    if (element.$prototype.$type === undefined) {
-        element.$prototype.$type = "group";
-    }
-    else if (element.$prototype.$scope === undefined) {
-        element.$prototype.$scope = "system";
-    }
-
-    if (element.$itemName === undefined) {
-        element.$itemName = "Item ${i}";
-    }
-
-    // Adjust defaults && new values
-    element.$default = adjustNestedDefault(element, element.$default);
-    const editGroupSubType = getEditGroupSubtype(element);
-    if (editGroupSubType === EditGroupSubtype.DICTIONARY_OF_DICTIONARIES
-            || editGroupSubType === EditGroupSubtype.LIST_OF_DICTIONARIES)
-    {
-        element.$newItemValue = generateValues(element.$prototype, {}, {}, element);
-    }
-    else if (editGroupSubType === EditGroupSubtype.PRIMITIVE_DICTIONARY) {
-        element.$newItemValue = [
-            defaultValue(element.$prototype.$key.$type, element.$prototype.$key.$default),
-            defaultValue(element.$prototype.$type, element.$prototype.$default)
-        ];
-    }
-    else if (editGroupSubType === EditGroupSubtype.PRIMITIVE_LIST) {
-        element.$newItemValue = defaultValue(element.$prototype.$type, element.$prototype.$default);
-    }
-
-    // if we don't have minimum number of items, let's create some
-    // todo handle the edit groups where their key must be unique
-    element.$default = get(element.$default, [])
-    while (element.$default.length < element.$minItems) {
-        element.$default.push(deepCopy(element.$newItemValue));
-    }
-}
-
-/*
- * This needs to be recursive as the element.$default can be a complex nested
- * structure of edit-groups/groups which we need to adjust.
- */
-function adjustNestedDefault(element, defVal) {
-    // helper function for setting values from the prototype
-    const setMissingValues = (value) => {
-        Object.keys(element.$prototype)
-            .filter(att => !att.startsWith("$") && !Object.keys(value).includes(att))
-            .forEach(att => value[att] = element.$prototype[att].$default)
-    }
-
-    const recurOnVals = (value) => {
-        return Object.entries(value)
-            .map(([nestedName, nestedVal]) => [nestedName, adjustNestedDefault(element.$prototype[nestedName], nestedVal)])
-            .reduce((acc, entry) => {
-                acc[entry[0]] = entry[1];
-                return acc;
-            }, {})
-    };
-
-    const editGroupSubType = getEditGroupSubtype(element);
-    if (editGroupSubType === EditGroupSubtype.DICTIONARY_OF_DICTIONARIES) {
-        // normalize the default (convert from an object to array)
-        return Object.entries(defVal || {})
-            .map(([name, value]) => {
-                value = recurOnVals(value);
-                value['$key'] = name;
-                setMissingValues(value);
-                return value;
-            });
-    }
-    else if (editGroupSubType === EditGroupSubtype.LIST_OF_DICTIONARIES) {
-        return (defVal || [])
-            .map(defEntry => {
-                defEntry = recurOnVals(defEntry);
-                setMissingValues(defEntry);
-                return defEntry;
-            });
-    }
-    else if (editGroupSubType === EditGroupSubtype.PRIMITIVE_DICTIONARY) {
-        return Object.entries(defVal || {});
-    }
-
-    return defVal;
-}
-
-/*
- * Goes through the layout and adjusts data for certain structures
- * (edit-group in a form of nested dictionary needs to be converted to lists, etc.)
- */
-function preprocessData(layout, data) {
-    Object.entries(layout)
-        .filter(([name, element]) => !(data[name] === undefined || name.startsWith("$") && name !== "$key"))
-        .forEach(([name, element]) => {
-            const editGroupSubType = getEditGroupSubtype(element);
-            // other edit-group as-a-dictionary needs to be converted to an array
-            if (editGroupSubType === EditGroupSubtype.DICTIONARY_OF_DICTIONARIES) {
-                data[name] = Object.entries(data[name] || {})
-                    .map(e => {
-                        e[1]['$key'] = e[0];
-                        preprocessData(element.$prototype, e[1]);
-                        return e[1];
-                    });
-            }
-            // edit-group as-a-primitive-dictionary too
-            else if (editGroupSubType === EditGroupSubtype.PRIMITIVE_DICTIONARY) {
-                data[name] = Object.entries(data[name] || {});
-            }
-            // the last form of a recursive edit-group needs to be processed recursively
-            else if (editGroupSubType === EditGroupSubtype.LIST_OF_DICTIONARIES) {
-                Object.entries(data[name] || {})
-                    .forEach(([name, value]) => preprocessData(element.$prototype, value));
-            }
-            // group elements also must be processed as they can contain edit-groups
-            else if (!isPrimitiveElement(element)) {
-                preprocessData(element, data[name]);
-            }
-        });
-}
-
-/*
- * Traverses the form values and adjusts certain elements.
- * (e.g. converts arrays to dictionaries in case of edit-group as a dictionary)
- */
-function preprocessCleanValues(values, layout) {
-    const result = {};
-    Object.entries(values)
-        .forEach(([key, value]) => {
-            if (key === "$required") {
-                return;
-            }
-
-            const element = layout[key];
-            const editGroupSubType = getEditGroupSubtype(element);
-
-            if (editGroupSubType === EditGroupSubtype.DICTIONARY_OF_DICTIONARIES) {
-                result[key] = value
-                    .map(entry => preprocessCleanValues(entry, element.$prototype))
-                    .filter(entry => entry["$key"] !== '')
-                    .reduce((acc, entry) => {
-                        acc[entry["$key"]] = entry;
-                        delete entry["$key"];
-                        return acc;
-                    }, {});
-            } else if (editGroupSubType === EditGroupSubtype.PRIMITIVE_DICTIONARY) {
-                result[key] = value
-                    .filter(entry => entry[0] !== '')
-                    .reduce((acc, entry) => {
-                        acc[entry[0]] = entry[1];
-                        return acc;
-                    }, {});
-            } else if (editGroupSubType === EditGroupSubtype.LIST_OF_DICTIONARIES) {
-                result[key] = value
-                    .map(entry => preprocessCleanValues(entry, element.$prototype));
-            } else if (editGroupSubType === EditGroupSubtype.PRIMITIVE_LIST) {
-                result[key] = value.filter(entry => entry !== '');
-            // we need to recur to groups as they can contain edit-groups that need an adjustment
-            } else if (element !== undefined && (element.$type === "group" || element.$type === "namespace")) {
-                result[key] = preprocessCleanValues(value, element);
-            } else {
-                result[key] = value;
-            }
-        });
-    return result;
-}
-
-/*
- * For each key in the layout, generate and return a defensive copy of an
- * object that follows the structure of the layout and has values populated
- * based on the system data, group data and layout default.
- */
-function generateValues(layout, group_data, system_data) {
-    const generateValuesInternal = (layout, group_data, system_data, prototypeParentId, elementIndex) => {
-        let result = {};
-        for (let key in layout) {
-            if (key.startsWith("$") && key !== "$key") continue;
-
-            let value = null;
-            let element = layout[key];
-            let elementId;
-            if (prototypeParentId && (elementIndex != undefined && elementIndex != null)) {
-                elementId = prototypeParentId+ "#" + elementIndex + "#" + element.$id;
-            } else {
-                elementId = (layout.$id ? layout.$id + "#" : "") + element.$id;
-            }
-
-            if (element.$type === "group" || element.$type === "namespace") {
-                value = generateValuesInternal(element, get(group_data[key], {}), get(system_data[key], {}));
-            } else if (element.$scope === "system") {
-                value = get(system_data[key], get(group_data[key], element.$default));
-            } else if (element.$scope === "group") {
-                value = get(group_data[key], element.$default);
-            } else if (element.$scope === "readonly") {
-                value = element.$default;
-            }
-
-            if (element.$type === "edit-group") {
-                if (!Array.isArray(value)) {
-                    // array is expected here
-                    // we can get other types if the saved data are incomplete or outdated
-                    value = [];
-                }
-                const editGroupSubType = getEditGroupSubtype(element);
-                if (editGroupSubType === EditGroupSubtype.LIST_OF_DICTIONARIES ||
-                    editGroupSubType === EditGroupSubtype.DICTIONARY_OF_DICTIONARIES) {
-                    // do not do merging of edit-group values,
-                    // take either system or group value based on the logic above
-                    // and process it recursively (hack: pass it always as "system" scope)
-                    value = value.map((entry, index) => generateValuesInternal(element.$prototype, entry, {}, elementId, index));
-                }
-            }
-
-            if (value === null) {
-                value = "";
-            }
-
-            result[key] = value
-
-            if ((element.$type === "edit-group") && 
-                !(getEditGroupSubtype(element) === EditGroupSubtype.LIST_OF_DICTIONARIES ||
-                    getEditGroupSubtype(element) === EditGroupSubtype.DICTIONARY_OF_DICTIONARIES)) {
-                result["$meta$"+ key] = {
-                    id: elementId,
-                    required: key == "$key" ? true : element.$prototype["$required"],
-                    disabled: element.$prototype["$disabled"],
-                    name: element["$name"],
-                    match: element.$prototype["$match"],
-                    visibleIf: element["$visibleIf"],
-                    visible: element["$visible"]                    
-                };
-            } else {
-                result["$meta$"+ key] = {
-                    id: elementId,
-                    required: key == "$key" ? true : element["$required"],
-                    disabled: element["$disabled"],
-                    name: element["$name"],
-                    match: element["$match"],
-                    visibleIf: element["$visibleIf"],
-                    visible: element["$visible"]
-                };
-            }
-        }
-        return result;
-    }
-
-    return deepCopy(generateValuesInternal(layout, group_data, system_data));
-}
-
-function get(value, def) {
-    if (value === undefined)
-        return def;
-    return value;
-}
 
 export default FormulaForm;

--- a/web/html/src/components/formulas/FormulaComponentGenerator.js
+++ b/web/html/src/components/formulas/FormulaComponentGenerator.js
@@ -5,9 +5,20 @@ import Group from './Group';
 import PasswordInput from './PasswordInput';
 import {default as Jexl} from 'jexl';
 import HelpIcon from 'components/utils/HelpIcon';
+import {Utils, Formulas} from 'utils/functions';
+const {capitalize, deepCopy} = Utils;
+const {getEditGroupSubtype, EditGroupSubtype} = Formulas;
 
 const BASIC_INPUT_TYPES = ["text", "email", "url", "date", "time"];
 
+export const FormulaFormContext = React.createContext({
+        scope: null,
+        layout: {},
+        values: {},
+        onFormulaChange: null,
+        getCleanValues: null,
+        clearValues: null,
+    });
 
 export function generateFormulaComponent(element, value, formulaForm, parents, wrapper, disabled = false) {
     const id = (parents ? parents + "#" : "") + element.$id;
@@ -177,14 +188,14 @@ function getConditionId(element_id, path) {
  * @param {*} formulaForm
  * @deprecated 
  */
-export function checkVisibilityCondition(id, condition, formulaForm) {
+function checkVisibilityCondition(id, condition, formulaForm) {
     if (condition.includes("!=")) {
         condition = condition.split("!=");
-        return String(formulaForm.getValueById(getConditionId(id, condition[0]))) !== getConditionValue(condition[1]);
+        return String(getValueById(formulaForm.getFormulaValues(), getConditionId(id, condition[0]))) !== getConditionValue(condition[1]);
     }
     else if (condition.includes("==")) {
         condition = condition.split("==");
-        return String(formulaForm.getValueById(getConditionId(id, condition[0]))) === getConditionValue(condition[1]);
+        return String(getValueById(formulaForm.getFormulaValues(), getConditionId(id, condition[0]))) === getConditionValue(condition[1]);
     }
     return false;
 }
@@ -201,7 +212,7 @@ function generateChildrenFormItems(element, value, formulaForm, id, disabled = f
 function generateSelectList(data) {
     var options = [];
     for (var key in data)
-        options.push(<option value={data[key]}>{data[key]}</option>);
+        options.push(<option key={key} value={data[key]}>{data[key]}</option>);
     return options;
 }
 
@@ -235,8 +246,687 @@ function wrapLabel(text, required, label_for) {
     );
 }
 
-function get(value, def) {
+function getValueById(values, id) {
+    let parents = id.split("#");
+    let value = values;
+    for (let i in parents) {
+        if (value[parents[i]] === undefined) {
+            return null;
+        }
+        value = value[parents[i]];
+    }
+    return value;
+}
+
+export function get(value, def) {
     if (value === undefined)
         return def;
     return value;
+}
+
+export function text(txt) {
+    if (!txt) {
+        return "";
+    }
+    // replace variables
+    txt = txt.replace(/\${productName}/g, Utils.getProductName());
+    return txt;
+}
+
+export const FormulaFormRenderer = () => (
+    <FormulaFormContext.Consumer>
+        {context => 
+            <UnwrappedFormulaFormRenderer {...context}/>}
+    </FormulaFormContext.Consumer>
+);
+
+// layout
+// values
+// onValuesChanged
+class UnwrappedFormulaFormRenderer extends React.Component {
+
+    constructor(props) {
+        super(props);
+        this.submitButton = React.createRef();
+    }
+
+    handleChange = (event) => {
+        let id, value;
+        if (event.id) {
+            id = event.id;
+            value = event.value;
+        }
+        else {
+            id = event.target.id;
+
+            if (event.target.type === "checkbox") {
+                value = event.target.checked;
+            } else if (event.target.type === "number") {
+                value = isNaN(event.target.valueAsNumber) ? "" : event.target.valueAsNumber;
+            } else {
+                value = event.target.value;
+            }
+        }
+
+        // notify the context provider about the values change
+        this.props.onChange(id, value);
+    }
+
+    componentDidMount() {
+        this.props.registerValidationTrigger(this.triggerValidation);
+    }
+
+    triggerValidation = () => {
+        this.submitButton.current.click();
+    }
+
+    dontSubmitForm = (event) => {
+        // TODO checkValidity must be called on each form input, not on the entire form
+        // this.form.current.checkValidity();
+        event.preventDefault();
+        // return false; // form if submitted via ajax
+    }
+
+    getFormulaValues = () => {
+        return this.props.values;
+    }
+
+    render() {
+        const {layout, values} = this.props;
+        if (!values) {
+            return null;
+        }
+        
+        let form = [];
+        for (const key in layout) {
+            form.push(generateFormulaComponent(layout[key], values[key], this));
+        }
+        return <form id="formula-form" className="form-horizontal" onSubmit={(event) => {event.preventDefault(); console.log("submitted"); return false;}}>
+            <input ref={this.submitButton} type="submit" hidden/>
+            {form}
+            </form>;
+    }
+
+}
+
+
+/*
+ * Remove $meta attrs and add $ifEmpty values if needed.
+ */
+function getValuesClean(values, layout) {
+    let result = {};
+    for (let key in values) {
+        if (key.startsWith("$meta")) {
+            continue;
+        }
+        let value = values[key];
+        let element = layout[key];
+        if (element.$type === "group" || element.$type === "namespace") {
+            value = getValuesClean(value, element);
+            if (!$.isEmptyObject(value))
+                result[key] = value;
+        }
+        else if ((element.$scope === "system") && !(value && value.length === 0)) {
+            value = checkIfEmptyValueAttrExists(value, element, values);
+            result[key] = cleanMeta(value);
+        }
+    }
+    return result;
+}
+
+/*
+ * Remove $meta element from all form values.
+ */
+function cleanMeta(value) {
+    let result = {};
+    if (value instanceof Object && !Array.isArray(value)) {
+        for (let key in value) {
+            if (key.startsWith("$meta")) {
+                continue;
+            }
+            result[key] = cleanMeta(value[key]);
+        }
+    } else {
+        result = value;
+    }
+    return result;
+}
+
+function checkIfEmptyValueAttrExists(value, element, formulaValues) {
+    if((value == null || value.length == 0) && !element.$optional && (element.$ifEmpty || element.$ifEmpty === null)) {
+        value = element.$ifEmpty;
+        formulaValues[element.$id] = value;
+    }
+    return value;
+}
+
+function isPrimitiveElement(element) {
+    return element.$type !== "group" &&
+        element.$type !== "namespace" &&
+        element.$type !== "edit-group";
+}
+
+/*
+ * Traverses the form values and adjusts certain elements.
+ * (e.g. converts arrays to dictionaries in case of edit-group as a dictionary)
+ */
+function preprocessCleanValues(values, layout) {
+    const result = {};
+    Object.entries(values)
+        .forEach(([key, value]) => {
+            if (key === "$required") {
+                return;
+            }
+
+            const element = layout[key];
+            const editGroupSubType = getEditGroupSubtype(element);
+
+            if (editGroupSubType === EditGroupSubtype.DICTIONARY_OF_DICTIONARIES) {
+                result[key] = value
+                    .map(entry => preprocessCleanValues(entry, element.$prototype))
+                    .filter(entry => entry["$key"] !== '')
+                    .reduce((acc, entry) => {
+                        acc[entry["$key"]] = entry;
+                        delete entry["$key"];
+                        return acc;
+                    }, {});
+            } else if (editGroupSubType === EditGroupSubtype.PRIMITIVE_DICTIONARY) {
+                result[key] = value
+                    .filter(entry => entry[0] !== '')
+                    .reduce((acc, entry) => {
+                        acc[entry[0]] = entry[1];
+                        return acc;
+                    }, {});
+            } else if (editGroupSubType === EditGroupSubtype.LIST_OF_DICTIONARIES) {
+                result[key] = value
+                    .map(entry => preprocessCleanValues(entry, element.$prototype));
+            } else if (editGroupSubType === EditGroupSubtype.PRIMITIVE_LIST) {
+                result[key] = value.filter(entry => entry !== '');
+            // we need to recur to groups as they can contain edit-groups that need an adjustment
+            } else if (element !== undefined && (element.$type === "group" || element.$type === "namespace")) {
+                result[key] = preprocessCleanValues(value, element);
+            } else {
+                result[key] = value;
+            }
+        });
+    return result;
+}
+
+
+// layout
+// systemData
+// groupData
+// scope
+export class FormulaFormContextProvider extends React.Component {
+
+    constructor(props) {
+        super(props);
+        const layout = this.preprocessLayout(props.layout);
+        this.preprocessData(layout, get(props.systemData, {}));
+        this.preprocessData(layout, get(props.groupData, {}));
+        const values = this.generateValues(layout, props.groupData, props.systemData);
+
+        this.state = {
+            formulaLayout: layout,
+            formulaValues: values,
+            formulaChanged: false
+        };
+
+    }
+
+    render() {
+        const layout = this.state.formulaLayout;
+        const values = this.state.formulaValues;
+        
+        const contextValue = {
+            scope: this.props.scope,
+            layout: this.state.formulaLayout,
+            values: this.state.formulaValues,
+            onChange: this.onFormulaChange,
+            clearValues: this.clearValues,
+            validate: this.validate,
+            registerValidationTrigger: this.registerValidationTrigger
+        };
+
+        return (
+            <FormulaFormContext.Provider value={contextValue}>
+                {this.props.children}
+            </FormulaFormContext.Provider>);
+    }
+
+    getFormulaValues = () => {
+        return this.state.formulaValues;
+    }
+
+    onFormulaChange = (id, value) => {
+        let values = this.state.formulaValues;
+        let parents = id.split("#");
+        for (var i in parents.slice(0, -1)) {
+            if (values[parents[i]] === undefined)
+                values[parents[i]] = {};
+            values = values[parents[i]];
+        }
+        values[parents[parents.length - 1]] = value;
+
+        this.setFormulaValues(this.state.formulaValues);
+    }
+
+    registerValidationTrigger = (validationTrigger) => {
+        this.setState({
+            validationTrigger: validationTrigger
+        })
+    }
+
+    setFormulaValues = (values) => {
+        this.setState({
+            formulaValues: values,
+            formulaChanged: true
+        });
+    }
+
+    getCleanValues = () => {
+        return getValuesClean(
+            preprocessCleanValues(this.state.formulaValues, this.state.formulaLayout),
+            this.state.formulaLayout);
+    }
+
+    walkValueTree = (value, formulaForm, formulaValues, validationFunc) => {
+        if (value instanceof Object) {
+            for (let key in value) {
+                if (!key.startsWith("$meta$")) {
+                    if (("$meta$" + key) in value) {
+                        const meta = value["$meta$" + key];
+                        const keepWalking = validationFunc(value, key, meta, formulaForm, formulaValues);
+                        if (keepWalking) {
+                            this.walkValueTree(value[key], formulaForm, formulaValues, validationFunc);
+                        }
+                    } else {
+                        this.walkValueTree(value[key], formulaForm, formulaValues, validationFunc);
+                    }
+                }
+            }
+        }
+    }       
+
+    getEmptyValues = () => {
+        let requiredErrors = []
+        this.walkValueTree(this.state.formulaValues, this, this.state.formulaValues, 
+            (parentVal, key, meta, formulaForm, formulaValues) => {
+                const val = parentVal[key];
+                if (meta["visibleIf"]) {
+                    const visibleIf = checkVisibilityCondition(meta["id"], meta["visibleIf"], formulaForm);
+                    if (!visibleIf) {
+                        return false;
+                    }
+                } else if (meta["visible"]) {
+                    const visible = evalExpression(meta["id"], meta["visible"], formulaForm);
+                    if (!visible) {
+                        return false;
+                    }
+                }
+                if(meta["required"]) {
+                    const required = evalExpression(meta["id"], meta["required"] + "", formulaForm);
+                    if (required) {
+                        if (Array.isArray(val) && val.some(v => !v)) {
+                            requiredErrors.push(meta["name"]);
+                        } else if (!val) {
+                            requiredErrors.push(meta["name"]);
+                        }
+                    }
+                }
+                return true;
+            });
+        return requiredErrors;
+    }
+
+    checkFieldsFormat = () => {
+        const errors = [];
+        this.walkValueTree(this.state.formulaValues, this, this.state.formulaValues, 
+            (parentVal, key, meta, formulaForm, formulaValues) => {
+                const value = parentVal[key];
+                if(meta["match"]) {
+                    try {
+                        let regex = meta["match"].startsWith("^") ? meta["match"] : "^" + meta["match"];
+                        regex = regex.endsWith("$") ? regex : regex + "$";
+                        const re = new RegExp(regex, "u");
+                        if (Array.isArray(value)) {
+                            // match each value
+                            if (!value.every(v => re.test(v))) {
+                                errors.push(meta["name"]);
+                            }
+                        } else {
+                            if (!re.test(value)) {
+                                errors.push(meta["name"]);
+                            }
+                        }
+                    } catch (err) {
+                        console.log("Error matching regex: '" + meta["match"] + "':" + err);
+                    }
+                }
+                return true;
+            });
+        return errors;
+    }
+
+    /**
+     * Validate and return errors (if any) + clean values
+     */
+    validate = () => {
+        if (this.state.validationTrigger) {
+            this.state.validationTrigger();
+        }
+        const emptyRequiredFields = [...new Set(this.getEmptyValues())];
+        const invalidFields = [...new Set(this.checkFieldsFormat())];
+
+        let errors;
+        if(emptyRequiredFields.length > 0 || invalidFields.length > 0) {
+            errors = {
+                required: emptyRequiredFields,
+                invalid: invalidFields
+            }
+        }
+
+        return {
+            errors: errors,
+            values: this.getCleanValues()
+        };
+    }
+
+    /*
+     * Set missing attributes ($type, $scope) to default values,
+     * set $default values,
+     * set $newItemValues for edit-groups.
+     */
+    preprocessLayout = (layout, scope = "system") => {
+        Object.entries(layout)
+            .filter(([name, element]) => !name.startsWith("$") || name === "$key")
+            .forEach(([name, element]) => {
+                this.adjustElementBasicAttrs([name, element], scope);
+
+                // groups are processed recursively
+                if (element.$type === "group" || element.$type === "namespace") {
+                    this.preprocessLayout(element, element.$scope)
+                }
+                // edit-groups too
+                else if (element.$type === "edit-group") {
+                    element.$prototype = this.preprocessLayout(element.$prototype, element.$scope);
+                    this.adjustEditGroup(element);
+                }
+            });
+
+        return layout;
+    }
+
+    /*
+     * Goes through the layout and adjusts data for certain structures
+     * (edit-group in a form of nested dictionary needs to be converted to lists, etc.)
+     */
+    preprocessData = (layout, data) => {
+        Object.entries(layout)
+            .filter(([name, element]) => !(data[name] === undefined || name.startsWith("$") && name !== "$key"))
+            .forEach(([name, element]) => {
+                const editGroupSubType = getEditGroupSubtype(element);
+                // other edit-group as-a-dictionary needs to be converted to an array
+                if (editGroupSubType === EditGroupSubtype.DICTIONARY_OF_DICTIONARIES) {
+                    data[name] = Object.entries(data[name] || {})
+                        .map(e => {
+                            e[1]['$key'] = e[0];
+                            this.preprocessData(element.$prototype, e[1]);
+                            return e[1];
+                        });
+                }
+                // edit-group as-a-primitive-dictionary too
+                else if (editGroupSubType === EditGroupSubtype.PRIMITIVE_DICTIONARY) {
+                    data[name] = Object.entries(data[name] || {});
+                }
+                // the last form of a recursive edit-group needs to be processed recursively
+                else if (editGroupSubType === EditGroupSubtype.LIST_OF_DICTIONARIES) {
+                    Object.entries(data[name] || {})
+                        .forEach(([name, value]) => this.preprocessData(element.$prototype, value));
+                }
+                // group elements also must be processed as they can contain edit-groups
+                else if (!isPrimitiveElement(element)) {
+                    this.preprocessData(element, data[name]);
+                }
+            });
+    }
+    
+
+    /*
+     * Adjust edit group default and 'new item' value of edit-group
+     * Some subtypes of edit-group need special handling (e.g. nested dictionary
+     * needs to be converted to lists).
+     */
+    adjustEditGroup = (element) => {
+        // Adjust common edit-group attributes
+        if (element.$prototype.$type === undefined) {
+            element.$prototype.$type = "group";
+        }
+        else if (element.$prototype.$scope === undefined) {
+            element.$prototype.$scope = "system";
+        }
+
+        if (element.$itemName === undefined) {
+            element.$itemName = "Item ${i}";
+        }
+
+        // Adjust defaults && new values
+        element.$default = this.adjustNestedDefault(element, element.$default);
+        const editGroupSubType = getEditGroupSubtype(element);
+        if (editGroupSubType === EditGroupSubtype.DICTIONARY_OF_DICTIONARIES
+                || editGroupSubType === EditGroupSubtype.LIST_OF_DICTIONARIES)
+        {
+            element.$newItemValue = this.generateValues(element.$prototype, {}, {}, element);
+        }
+        else if (editGroupSubType === EditGroupSubtype.PRIMITIVE_DICTIONARY) {
+            element.$newItemValue = [
+                this.defaultValue(element.$prototype.$key.$type, element.$prototype.$key.$default),
+                this.defaultValue(element.$prototype.$type, element.$prototype.$default)
+            ];
+        }
+        else if (editGroupSubType === EditGroupSubtype.PRIMITIVE_LIST) {
+            element.$newItemValue = this.defaultValue(element.$prototype.$type, element.$prototype.$default);
+        }
+
+        // if we don't have minimum number of items, let's create some
+        // todo handle the edit groups where their key must be unique
+        element.$default = get(element.$default, [])
+        while (element.$default.length < element.$minItems) {
+            element.$default.push(deepCopy(element.$newItemValue));
+        }
+    }
+
+    /*
+     * This needs to be recursive as the element.$default can be a complex nested
+     * structure of edit-groups/groups which we need to adjust.
+     */
+    adjustNestedDefault = (element, defVal) => {
+        // helper function for setting values from the prototype
+        const setMissingValues = (value) => {
+            Object.keys(element.$prototype)
+                .filter(att => !att.startsWith("$") && !Object.keys(value).includes(att))
+                .forEach(att => value[att] = element.$prototype[att].$default)
+        }
+
+        const recurOnVals = (value) => {
+            return Object.entries(value)
+                .map(([nestedName, nestedVal]) => [nestedName, adjustNestedDefault(element.$prototype[nestedName], nestedVal)])
+                .reduce((acc, entry) => {
+                    acc[entry[0]] = entry[1];
+                    return acc;
+                }, {})
+        };
+
+        const editGroupSubType = getEditGroupSubtype(element);
+        if (editGroupSubType === EditGroupSubtype.DICTIONARY_OF_DICTIONARIES) {
+            // normalize the default (convert from an object to array)
+            return Object.entries(defVal || {})
+                .map(([name, value]) => {
+                    value = recurOnVals(value);
+                    value['$key'] = name;
+                    setMissingValues(value);
+                    return value;
+                });
+        }
+        else if (editGroupSubType === EditGroupSubtype.LIST_OF_DICTIONARIES) {
+            return (defVal || [])
+                .map(defEntry => {
+                    defEntry = recurOnVals(defEntry);
+                    setMissingValues(defEntry);
+                    return defEntry;
+                });
+        }
+        else if (editGroupSubType === EditGroupSubtype.PRIMITIVE_DICTIONARY) {
+            return Object.entries(defVal || {});
+        }
+
+        return defVal;
+    }    
+
+    // consumes an element entry: [element name, element]
+    adjustElementBasicAttrs = ([elementName, element], scope) => {
+        if (!("$scope" in element)) {
+            element.$scope = scope;
+        }
+
+        if (element.$type === "hidden-group") {
+            element.$type = "namespace";
+        }
+
+        if (!("$type" in element)) {
+            element.$type = "text"
+        }
+
+        if (element.$name === undefined && elementName === "$key") {
+            element.$name = "Key";
+        }
+
+        if (elementName === "$key") {
+            element["$required"] = true;
+        }
+
+        element.$id = elementName;
+        element.$name = text(get(element.$name, capitalize(elementName)));
+        element.$help = text(get(element.$help, element.$name));
+        element.$placeholder = text(get(element.$placeholder, ""));
+
+        if (isPrimitiveElement(element)) {
+            element.$default = this.defaultValueForElement(element);
+        };
+    }
+
+    defaultValue = (type, defValue, selectValues) => {
+        if (type === "boolean")
+            return get(defValue, false);
+        else if (type === "select")
+            return get(defValue, selectValues[0]);
+        else if (type === "color")
+            return get(defValue, "#000000");
+        else if (type === "password")
+            return get(defValue, "");
+
+        return get(defValue, "");
+    }
+
+    defaultValueForElement = (element) => {
+        return this.defaultValue(element.$type, element.$default, element.$values);
+    }
+
+    /*
+     * For each key in the layout, generate and return a defensive copy of an
+     * object that follows the structure of the layout and has values populated
+     * based on the system data, group data and layout default.
+     */
+    generateValues = (layout, group_data, system_data) => {
+        const generateValuesInternal = (layout, group_data, system_data, prototypeParentId, elementIndex) => {
+            let result = {};
+            for (let key in layout) {
+                if (key.startsWith("$") && key !== "$key") continue;
+
+                let value = null;
+                let element = layout[key];
+                let elementId;
+                if (prototypeParentId && (elementIndex != undefined && elementIndex != null)) {
+                    elementId = prototypeParentId+ "#" + elementIndex + "#" + element.$id;
+                } else {
+                    elementId = (layout.$id ? layout.$id + "#" : "") + element.$id;
+                }
+
+                if (element.$type === "group" || element.$type === "namespace") {
+                    value = generateValuesInternal(element, get(group_data[key], {}), get(system_data[key], {}));
+                } else if (element.$scope === "system") {
+                    value = get(system_data[key], get(group_data[key], element.$default));
+                } else if (element.$scope === "group") {
+                    value = get(group_data[key], element.$default);
+                } else if (element.$scope === "readonly") {
+                    value = element.$default;
+                }
+
+                if (element.$type === "edit-group") {
+                    if (!Array.isArray(value)) {
+                        // array is expected here
+                        // we can get other types if the saved data are incomplete or outdated
+                        value = [];
+                    }
+                    const editGroupSubType = getEditGroupSubtype(element);
+                    if (editGroupSubType === EditGroupSubtype.LIST_OF_DICTIONARIES ||
+                        editGroupSubType === EditGroupSubtype.DICTIONARY_OF_DICTIONARIES) {
+                        // do not do merging of edit-group values,
+                        // take either system or group value based on the logic above
+                        // and process it recursively (hack: pass it always as "system" scope)
+                        value = value.map((entry, index) => generateValuesInternal(element.$prototype, entry, {}, elementId, index));
+                    }
+                }
+
+                if (value === null) {
+                    value = "";
+                }
+
+                result[key] = value
+
+                if ((element.$type === "edit-group") && 
+                    !(getEditGroupSubtype(element) === EditGroupSubtype.LIST_OF_DICTIONARIES ||
+                        getEditGroupSubtype(element) === EditGroupSubtype.DICTIONARY_OF_DICTIONARIES)) {
+                    result["$meta$"+ key] = {
+                        id: elementId,
+                        required: key == "$key" ? true : element.$prototype["$required"],
+                        disabled: element.$prototype["$disabled"],
+                        name: element["$name"],
+                        match: element.$prototype["$match"],
+                        visibleIf: element["$visibleIf"],
+                        visible: element["$visible"]                    
+                    };
+                } else {
+                    result["$meta$"+ key] = {
+                        id: elementId,
+                        required: key == "$key" ? true : element["$required"],
+                        disabled: element["$disabled"],
+                        name: element["$name"],
+                        match: element["$match"],
+                        visibleIf: element["$visibleIf"],
+                        visible: element["$visible"]
+                    };
+                }
+            }
+            return result;
+        }
+
+        return deepCopy(generateValuesInternal(layout, group_data, system_data));
+    }
+
+    clearValues = (clearValuesConfirmation) => {
+        const layout = this.state.formulaLayout;
+        const values = this.state.formulaValues;
+        if (clearValuesConfirmation()) {
+            let clearValues = {};
+            if (this.props.scope === "system") {
+                clearValues = this.generateValues(layout, get(this.props.groupData, {}), {});
+            } else {
+                clearValues = this.generateValues(layout, {}, {});
+            }
+          
+            this.setFormulaValues(clearValues);
+        }
+    }
+
 }

--- a/web/html/src/components/formulas/FormulaComponentGenerator.js
+++ b/web/html/src/components/formulas/FormulaComponentGenerator.js
@@ -321,10 +321,7 @@ class UnwrappedFormulaFormRenderer extends React.Component {
     }
 
     dontSubmitForm = (event) => {
-        // TODO checkValidity must be called on each form input, not on the entire form
-        // this.form.current.checkValidity();
         event.preventDefault();
-        // return false; // form if submitted via ajax
     }
 
     getFormulaValues = () => {
@@ -341,7 +338,7 @@ class UnwrappedFormulaFormRenderer extends React.Component {
         for (const key in layout) {
             form.push(generateFormulaComponent(layout[key], values[key], this));
         }
-        return <form id="formula-form" className="form-horizontal" onSubmit={(event) => {event.preventDefault(); console.log("submitted"); return false;}}>
+        return <form id="formula-form" className="form-horizontal" onSubmit={(event) => {event.preventDefault(); return false;}}>
             <input ref={this.submitButton} type="submit" hidden/>
             {form}
             </form>;

--- a/web/html/src/components/formulas/formula-form.css
+++ b/web/html/src/components/formulas/formula-form.css
@@ -52,7 +52,7 @@
     color: #8e8e90;
 }
 
-:global(.formula-content :invalid) {
+:global(input:invalid) {
     background-color: #fcf8e3;
 }
 


### PR DESCRIPTION
## What does this PR change?

Refactoring of the Formula Forms code to make it usable also outside of the Formulas UI. This is needed for the [clustering awerness UI](https://github.com/uyuni-project/uyuni/pull/2070) :

* separate the rendering of the formula form from the other UI elements like Save,Clear button, etc.
* use React Contexts for the nested component
* fix bug in `match` attribute validation

The rendering and validation logic was not changed.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: refactoring

- [x] **DONE**

## Test coverage
- No tests: cucumber tests exist

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
