### PR TITLE
Fix Salt require error in virt.deleted

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/virt/deleted.sls
+++ b/susemanager-utils/susemanager-sls/salt/virt/deleted.sls
@@ -6,5 +6,5 @@ mgr_virt_destroy:
   module.run:
     - name: virt.purge
     - vm_: {{ pillar['domain_name'] }}
-    - requires:
+    - require:
       - virt: vm_stopped

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Fix virt.deleted state dependency
 - Make 'product' state module only available for minions with zypper >= 1.8.13 (bsc#1166699)
 - Use saltutil states if available on the minion (bsc#1167556)
 - Enable support for bootstrapping Astra Linux CE "Orel"


### PR DESCRIPTION
## What does this PR change?

Fix a typo in `virt.deleted` state require

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed:typo fix

- [X] **DONE**

## Test coverage
- No tests: typo fix

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
