### PR TITLE
validate cached package

### DIFF
--- a/backend/satellite_tools/satsync.py
+++ b/backend/satellite_tools/satsync.py
@@ -1110,8 +1110,9 @@ class Syncer:
                 # XXX Catch errors
                 if (not package_collection.has_package(pid) or not package_collection.get_package(pid)
                         or package_collection.get_package(pid)['last_modified']
-                        != short_package_collection.get_package(pid)['last_modified']):
-                    # not in the cache
+                        != short_package_collection.get_package(pid)['last_modified']
+                        or 'extra_tags' not in package_collection.get_package(pid)):
+                    # not in the cache or cache outdated
                     mp.append(pid)
 
         return missing_packages

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- validate cached package entries on ISS slave (bsc#1159184)
 - restore config namespace in debian repo module to fix
   autogeneration of bootstrap repos
 - send CreateBootstrapRepoFailed Notification


### PR DESCRIPTION
## What does this PR change?

When loading package entries on the slave from the cache, better check for the new extra_tags entry. In case it is not there, declare this cache entry as outdated and re-load it from the master.

Port of https://github.com/SUSE/spacewalk/pull/11192

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/11192

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
