### PR TITLE
fix xmlrpc doc generation

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ShortSystemInfoSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ShortSystemInfoSerializer.java
@@ -31,7 +31,7 @@ import java.util.Date;
  *
  * @xmlrpc.doc
  *
- * #struct("system")
+ * #struct_begin("system")
  *     #prop("int", "id")
  *     #prop("string", "name")
  *     #prop_desc("dateTime.iso8601",  "last_checkin", "Last time server


### PR DESCRIPTION
## What does this PR change?

Fix api doc generation

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [doc-susemanager](https://github.com/SUSE/doc-susemanager) PR or issue was created (GitHub automatic link expected below)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
