### PR TITLE
refresh pillar data on the minion after generating new channel pillar data

### DIFF
--- a/java/code/src/com/redhat/rhn/common/messaging/MessageQueue.java
+++ b/java/code/src/com/redhat/rhn/common/messaging/MessageQueue.java
@@ -54,8 +54,6 @@ import com.redhat.rhn.frontend.events.UpdateErrataCacheAction;
 import com.redhat.rhn.frontend.events.UpdateErrataCacheEvent;
 
 import com.redhat.rhn.frontend.events.AlignSoftwareTargetMsg;
-import com.suse.manager.reactor.messaging.ChannelsChangedEventMessage;
-import com.suse.manager.reactor.messaging.ChannelsChangedEventMessageAction;
 import org.apache.log4j.Logger;
 
 import java.util.ArrayList;
@@ -331,9 +329,5 @@ public class MessageQueue {
         // Deploy configuration files
         MessageQueue.registerAction(new SsmConfigFilesAction(),
                                     SsmConfigFilesEvent.class);
-
-        // Handle changes of channel assignments on minions
-        MessageQueue.registerAction(new ChannelsChangedEventMessageAction(),
-                ChannelsChangedEventMessage.class);
     }
 }

--- a/java/code/src/com/suse/manager/reactor/SaltReactor.java
+++ b/java/code/src/com/suse/manager/reactor/SaltReactor.java
@@ -28,6 +28,8 @@ import com.suse.manager.reactor.messaging.ApplyStatesEventMessage;
 import com.suse.manager.reactor.messaging.ApplyStatesEventMessageAction;
 import com.suse.manager.reactor.messaging.BatchStartedEventMessage;
 import com.suse.manager.reactor.messaging.BatchStartedEventMessageAction;
+import com.suse.manager.reactor.messaging.ChannelsChangedEventMessage;
+import com.suse.manager.reactor.messaging.ChannelsChangedEventMessageAction;
 import com.suse.manager.reactor.messaging.ImageDeployedEventMessage;
 import com.suse.manager.reactor.messaging.ImageDeployedEventMessageAction;
 import com.suse.manager.reactor.messaging.JobReturnEventMessage;
@@ -128,6 +130,9 @@ public class SaltReactor {
                 LibvirtEngineDomainLifecycleMessage.class);
         MessageQueue.registerAction(new BatchStartedEventMessageAction(),
                 BatchStartedEventMessage.class);
+        // Handle changes of channel assignments on minions
+        MessageQueue.registerAction(new ChannelsChangedEventMessageAction(systemQuery),
+                ChannelsChangedEventMessage.class);
 
         MessageQueue.publish(new RefreshGeneratedSaltFilesEventMessage());
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- refresh pillar after channel change
+
 -------------------------------------------------------------------
 Wed Apr 15 17:12:31 CEST 2020 - jgonzalez@suse.com
 

--- a/testsuite/features/secondary/min_change_software_channel.feature
+++ b/testsuite/features/secondary/min_change_software_channel.feature
@@ -1,0 +1,79 @@
+# Copyright (c) 2020 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: Assign child channel to system
+
+@sle_minion
+  Scenario: Check SLES minion is still subscribed to old channels before channel change completes
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Software" in the content area
+    And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
+    Then radio button "Test-Channel-x86_64" is checked
+    And I wait until I do not see "Loading..." text
+    And I should see "Test-Channel-x86_64 Child Channel" as unchecked
+
+
+@sle_minion
+  Scenario: Check old channels are still enabled on SLES minion before channel change completes
+    When I refresh the metadata for "sle_minion"
+    Then "1" channels should be enabled on "sle_minion"
+    And channel "Test-Channel-x86_64" should be enabled on "sle_minion"
+
+@sle_minion
+  Scenario: Assign a child channel to system
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Software" in the content area
+    And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
+    Then radio button "Test-Channel-x86_64" is checked
+    And I wait until I do not see "Loading..." text
+    And I check "Test-Channel-x86_64 Child Channel"
+    And I click on "Next"
+    Then I should see a "Confirm Software Channel Change" text
+    And I click on "Confirm"
+    Then I should see a "Changing the channels has been scheduled." text
+    When I follow "scheduled" in the content area
+    And I wait until I see "1 system successfully completed this action." text, refreshing the page
+    Then channel "Test-Channel-x86_64 Child Channel" should be enabled on "sle_minion"
+
+@sle_minion
+  Scenario: Check channel change has completed for the SLES minion
+    Given I am on the Systems overview page of this "sle_minion"
+    When I wait until event "Subscribe channels scheduled by admin" is completed
+    Then I should see a "The client completed this action on" text
+
+@sle_minion
+  Scenario: Check the SLES minion is subscribed to the new channels
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Software" in the content area
+    And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
+    Then radio button "Test-Channel-x86_64" is checked
+    And I wait until I do not see "Loading..." text
+    And I should see "Test-Channel-x86_64 Child Channel" as checked
+
+@sle_minion
+  Scenario: Check the new channels are enabled on the SLES minion
+    When I refresh the metadata for "sle_minion"
+    Then "2" channels should be enabled on "sle_minion"
+    And channel "Test-Channel-x86_64" should be enabled on "sle_minion"
+    And channel "Test-Channel-x86_64 Child Channel" should be enabled on "sle_minion"
+
+@sle_minion
+  Scenario: Cleanup: subscribe the SLES minion back to previous channels
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Software" in the content area
+    And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
+    Then radio button "Test-Channel-x86_64" is checked
+    And I wait until I do not see "Loading..." text
+    And I wait until I see "Test-Channel-x86_64 Child Channel" text
+    And I uncheck "Test-Channel-x86_64 Child Channel"
+    And I click on "Next"
+    Then I should see a "Confirm Software Channel Change" text
+    When I click on "Confirm"
+    Then I should see a "Changing the channels has been scheduled." text
+    When I follow "scheduled" in the content area
+    And I wait until I see "1 system successfully completed this action." text, refreshing the page
+    Then channel "Test-Channel-x86_64 Child Channel" should not be enabled on "sle_minion"

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -40,5 +40,6 @@
 - features/secondary/min_docker_auth_registry.feature
 - features/secondary/min_docker_xmlrpc.feature
 - features/secondary/min_recurring_action.feature
+- features/secondary/min_change_software_channel.feature
 
 ## Secondary features END ##


### PR DESCRIPTION
## What does this PR change?

After changing channels on a minion it happens very otften, that a "zypper refresh" called on that minion failed as it cannot access the repositories.
It turns out that the tokens are still old in the repo file and looking at the pillar data on the minon show, that it still has the old tokens while on the server the pillar files has already the new tokens.

Take care to call a pillar_refresh after changing the tokens.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/11234

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests" 		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
