### PR TITLE
Testsuite: Choose repo name according with the product

### DIFF
--- a/testsuite/features/secondary/min_monitoring.feature
+++ b/testsuite/features/secondary/min_monitoring.feature
@@ -8,7 +8,7 @@ Feature: Monitor SUMA environment with Prometheus on a normal minion
   I want to enable Prometheus exporters
 
   Scenario: Pre-requisite: enable Prometheus exporters repository on the minion
-    When I enable repository "tools_pool_repo" on this "sle_minion"
+    When I "enable" Prometheus exporter repository on this "sle_minion"
     And I run "zypper -n ref" on "sle_minion"
 
   Scenario: Apply Prometheus and Prometheus exporter formulas
@@ -70,4 +70,4 @@ Feature: Monitor SUMA environment with Prometheus on a normal minion
     And I wait until event "Apply highstate scheduled by admin" is completed
 
   Scenario: Cleanup: disable Prometheus exporters repository
-    And I disable repository "tools_additional_repo" on this "sle_minion" without error control
+    And I "disable" Prometheus exporter repository on this "sle_minion" without error control

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1254,3 +1254,12 @@ Then(/^the "([^"]*)" on "([^"]*)" grains does not exist$/) do |key, client|
   _result, code = node.run("grep #{key} /etc/salt/minion.d/susemanager.conf", fatal = false)
   raise if code.zero?
 end
+
+# Enable/disable repository for monitoring exporters
+When(/^I "([^"]*)" Prometheus exporter repository on this "([^"]*)"((?: without error control)?)$/) do |action, host, error_control|
+  repo_name = 'tools_additional_repo'
+  if $product == 'Uyuni'
+    repo_name = 'tools_pool_repo'
+  end
+  step %(I #{action} repository "#{repo_name}" on this "#{host}"#{error_control})
+end


### PR DESCRIPTION
## What does this PR change?

- Choose the repository name according to the product.
  (This is a follow up of https://github.com/uyuni-project/uyuni/pull/2119)

## Links
### Ports

- Manager-4.0: https://github.com/SUSE/spacewalk/pull/11256

## Changelogs

- [x] No changelog needed
