### PR TITLE
Uyuni hide updatetag message

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -1561,7 +1561,7 @@ public class ContentSyncManager {
 
                                 if (!entry.getUpdateTag()
                                         .equals(Optional.ofNullable(prodRepoLink.getUpdateTag()))) {
-                                    log.error("updatetag changed from '" +
+                                    log.debug("updatetag changed from '" +
                                             prodRepoLink.getUpdateTag() +
                                             "' to '" + entry.getUpdateTag() +
                                             "' but its not allowed to change.");

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- hide message about changed Update Tag change (bsc#1169109)
 - Web UI: Implement bootstrapping minions using an SSH private key
 - add virtual volume delete action
 - refresh pillar after channel change


### PR DESCRIPTION
## What does this PR change?

Hide message about changed update tag from log.
It cannot be fixed and such error messages just create confusions.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **just a logmessage**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/11265

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
