### PR TITLE
Add support for extra HTTP headers for "spacewalk-repo-sync" on RPM repos

### DIFF
--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -68,7 +68,7 @@ ZYPP_SOLV_CACHE_PATH = os.path.join(ZYPP_CACHE_PATH, 'solv')
 REPOSYNC_ZYPPER_ROOT = os.path.join(SPACEWALK_LIB, "reposync/root")
 REPOSYNC_ZYPPER_RPMDB_PATH = os.path.join(REPOSYNC_ZYPPER_ROOT, 'var/lib/rpm')
 REPOSYNC_ZYPPER_CONF = '/etc/rhn/spacewalk-repo-sync/zypper.conf'
-REPOSYNC_HTTP_HEADERS_CONF = '/etc/rhn/spacewalk-repo-sync/headers.conf'
+REPOSYNC_EXTRA_HTTP_HEADERS_CONF = '/etc/rhn/spacewalk-repo-sync/extra_headers.conf'
 
 RPM_PUBKEY_VERSION_RELEASE_RE = re.compile(r'^gpg-pubkey-([0-9a-fA-F]+)-([0-9a-fA-F]+)')
 
@@ -451,10 +451,10 @@ class ContentSource:
                 if zypper_cfg.has_option(section_name, 'proxy_password'):
                     self.proxy_pass = zypper_cfg.get(section_name, 'proxy_password')
 
-        # Get custom HTTP Headers configuration from /etc/rhn/spacewalk-repo-sync/headers.conf
-        if os.path.isfile(REPOSYNC_HTTP_HEADERS_CONF):
+        # Get extra HTTP headers configuration from /etc/rhn/spacewalk-repo-sync/extra_headers.conf
+        if os.path.isfile(REPOSYNC_EXTRA_HTTP_HEADERS_CONF):
             http_headers_cfg = configparser.ConfigParser()
-            http_headers_cfg.read_file(open(REPOSYNC_HTTP_HEADERS_CONF))
+            http_headers_cfg.read_file(open(REPOSYNC_EXTRA_HTTP_HEADERS_CONF))
             section_name = None
 
             if http_headers_cfg.has_section(self.name):

--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -37,10 +37,10 @@ import types
 import urlgrabber
 
 try:
-    from urllib import urlencode, unquote
+    from urllib import urlencode, unquote, quote
     from urlparse import urlsplit, urlparse, urlunparse
 except:
-    from urllib.parse import urlsplit, urlencode, urlparse, urlunparse, unquote
+    from urllib.parse import urlsplit, urlencode, urlparse, urlunparse, unquote, quote
 
 import xml.etree.ElementTree as etree
 
@@ -68,6 +68,7 @@ ZYPP_SOLV_CACHE_PATH = os.path.join(ZYPP_CACHE_PATH, 'solv')
 REPOSYNC_ZYPPER_ROOT = os.path.join(SPACEWALK_LIB, "reposync/root")
 REPOSYNC_ZYPPER_RPMDB_PATH = os.path.join(REPOSYNC_ZYPPER_ROOT, 'var/lib/rpm')
 REPOSYNC_ZYPPER_CONF = '/etc/rhn/spacewalk-repo-sync/zypper.conf'
+REPOSYNC_HTTP_HEADERS_CONF = '/etc/rhn/spacewalk-repo-sync/headers.conf'
 
 RPM_PUBKEY_VERSION_RELEASE_RE = re.compile(r'^gpg-pubkey-([0-9a-fA-F]+)-([0-9a-fA-F]+)')
 
@@ -450,6 +451,23 @@ class ContentSource:
                 if zypper_cfg.has_option(section_name, 'proxy_password'):
                     self.proxy_pass = zypper_cfg.get(section_name, 'proxy_password')
 
+        # Get custom HTTP Headers configuration from /etc/rhn/spacewalk-repo-sync/headers.conf
+        if os.path.isfile(REPOSYNC_HTTP_HEADERS_CONF):
+            http_headers_cfg = configparser.ConfigParser()
+            http_headers_cfg.read_file(open(REPOSYNC_HTTP_HEADERS_CONF))
+            section_name = None
+
+            if http_headers_cfg.has_section(self.name):
+                section_name = self.name
+            elif http_headers_cfg.has_section(channel_label):
+                section_name = channel_label
+            elif http_headers_cfg.has_section('main'):
+                section_name = 'main'
+
+            if section_name:
+                for hdr in http_headers_cfg[section_name]:
+                    self.http_headers[hdr] = http_headers_cfg.get(section_name, option=hdr)
+
         self._authenticate(url)
 
         # Make sure baseurl ends with / and urljoin will work correctly
@@ -567,7 +585,9 @@ repo_gpgcheck={gpgcheck}
 type=rpm-md
 '''
         if uln_repo:
-           _url = 'plugin:spacewalk-uln-resolver?url={}'.format(self._url_orig)
+           _url = 'plugin:spacewalk-uln-resolver?url={}'.format(zypp_repo_url)
+        elif self.http_headers:
+           _url = 'plugin:spacewalk-extra-http-headers?url={}&repo_name={}&channel_label={}'.format(quote(zypp_repo_url), self.name, self.channel_label)
         else:
            _url = zypp_repo_url if not mirrorlist else os.path.join(repo.root, 'mirrorlist.txt')
 

--- a/backend/satellite_tools/spacewalk-extra-http-headers
+++ b/backend/satellite_tools/spacewalk-extra-http-headers
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import sys
 import os

--- a/backend/satellite_tools/spacewalk-extra-http-headers
+++ b/backend/satellite_tools/spacewalk-extra-http-headers
@@ -13,7 +13,7 @@ except:
 
 from zypp_plugin import Plugin
 
-REPOSYNC_HTTP_HEADERS_CONF = '/etc/rhn/spacewalk-repo-sync/headers.conf'
+REPOSYNC_EXTRA_HTTP_HEADERS_CONF = '/etc/rhn/spacewalk-repo-sync/extra_headers.conf'
 
 
 class SpacewalkExtraHTTPHeaders(Plugin):
@@ -28,10 +28,10 @@ class SpacewalkExtraHTTPHeaders(Plugin):
         """
         try:
             self.http_headers = {}
-            # Get custom HTTP Headers configuration from /etc/rhn/spacewalk-repo-sync/headers.conf
-            if os.path.isfile(REPOSYNC_HTTP_HEADERS_CONF):
+            # Get extra HTTP headers configuration from /etc/rhn/spacewalk-repo-sync/extra_headers.conf
+            if os.path.isfile(REPOSYNC_EXTRA_HTTP_HEADERS_CONF):
                 http_headers_cfg = configparser.ConfigParser()
-                http_headers_cfg.read_file(open(REPOSYNC_HTTP_HEADERS_CONF))
+                http_headers_cfg.read_file(open(REPOSYNC_EXTRA_HTTP_HEADERS_CONF))
                 section_name = None
 
                 if http_headers_cfg.has_section(headers['repo_name']):

--- a/backend/satellite_tools/spacewalk-extra-http-headers
+++ b/backend/satellite_tools/spacewalk-extra-http-headers
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+import re
+import traceback
+import configparser
+
+try:
+    from urllib import unquote
+except:
+    from urllib.parse import unquote
+
+from zypp_plugin import Plugin
+
+REPOSYNC_HTTP_HEADERS_CONF = '/etc/rhn/spacewalk-repo-sync/headers.conf'
+
+
+class SpacewalkExtraHTTPHeaders(Plugin):
+    """
+    Plugin to add extra HTTP Headers to Zypper requests
+    """
+    def RESOLVEURL(self, headers, body):
+        """
+        Resolve URL.
+
+        :returns: None
+        """
+        try:
+            self.http_headers = {}
+            # Get custom HTTP Headers configuration from /etc/rhn/spacewalk-repo-sync/headers.conf
+            if os.path.isfile(REPOSYNC_HTTP_HEADERS_CONF):
+                http_headers_cfg = configparser.ConfigParser()
+                http_headers_cfg.read_file(open(REPOSYNC_HTTP_HEADERS_CONF))
+                section_name = None
+
+                if http_headers_cfg.has_section(headers['repo_name']):
+                    section_name = headers['repo_name']
+                elif http_headers_cfg.has_section(headers['channel_label']):
+                    section_name = headers['channel_label']
+                elif http_headers_cfg.has_section('main'):
+                    section_name = 'main'
+
+                if section_name:
+                    for hdr in http_headers_cfg[section_name]:
+                        self.http_headers[hdr] = http_headers_cfg.get(section_name, option=hdr)
+
+        except Exception as exc:
+            self.answer("ERROR", {}, str(exc))
+        self.answer("RESOLVEDURL", self.http_headers, unquote(headers['url']))
+
+plugin = SpacewalkExtraHTTPHeaders()
+plugin.main()

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,6 @@
+- Enable extra HTTP headers support for "spacewalk-repo-sync".
+- Add missing Zypper plugin to deal with ULN repositories.
+
 -------------------------------------------------------------------
 Mon Apr 13 09:32:22 CEST 2020 - jgonzalez@suse.com
 

--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -235,6 +235,8 @@ Requires:       spacewalk-admin >= 0.1.1-0
 Requires:       spacewalk-certs-tools
 Requires:       susemanager-tools
 %if 0%{?suse_version}
+Requires(pre):  libzypp(plugin:system) >= 0
+Requires:       zypp-plugin-python
 Requires:       apache2-prefork
 %endif
 %if 0%{?fedora} || 0%{?rhel}
@@ -328,6 +330,13 @@ sed -i 's/#DOCUMENTROOT#/\/srv\/www\/htdocs/' $RPM_BUILD_ROOT%{rhnconfigdefaults
 %endif
 
 install -m 755 satellite_tools/mgr-update-pkg-extra-tags $RPM_BUILD_ROOT%{_prefix}/lib/susemanager/bin/
+
+## Install Zypper plugins only on SUSE machines
+%if 0%{?suse_version}
+install -Dd -m 0750 % $RPM_BUILD_ROOT%{_prefix}/lib/zypp/plugins/urlresolver
+%{__install} satellite_tools/spacewalk-uln-resolver $RPM_BUILD_ROOT%{_prefix}/lib/zypp/plugins/urlresolver/spacewalk-uln-resolver
+%{__install} satellite_tools/spacewalk-extra-http-headers $RPM_BUILD_ROOT%{_prefix}/lib/zypp/plugins/urlresolver/spacewalk-extra-http-headers
+%endif
 
 %check
 make -f Makefile.backend PYTHONPATH=$RPM_BUILD_ROOT%{python3_sitelib}:$RPM_BUILD_ROOT%{python3_sitelib}/uyuni/common-libs PYTHON_BIN=python3 test
@@ -639,6 +648,8 @@ fi
 %attr(755,root,root) %{_bindir}/mgr-sign-metadata-ctl
 %attr(755,root,root) %{_bindir}/spacewalk-diskcheck
 %attr(755,root,root) %{_prefix}/lib/susemanager/bin/mgr-update-pkg-extra-tags
+%{_prefix}/lib/zypp/plugins/urlresolver/spacewalk-uln-resolver
+%{_prefix}/lib/zypp/plugins/urlresolver/spacewalk-extra-http-headers
 %{python3rhnroot}/satellite_tools/contentRemove.py*
 %{python3rhnroot}/satellite_tools/SequenceServer.py*
 %{python3rhnroot}/satellite_tools/messages.py*

--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -312,6 +312,8 @@ install -m 644 rhn-conf/signing.cnf $RPM_BUILD_ROOT%{rhnconf}/signing.conf
 install -m 644 satellite_tools/spacewalk-diskcheck.service $RPM_BUILD_ROOT/%{_unitdir}
 install -m 644 satellite_tools/spacewalk-diskcheck.timer $RPM_BUILD_ROOT/%{_unitdir}
 
+install -m 644 satellite_tools/ulnauth.py $RPM_BUILD_ROOT/%{python3rhnroot}/satellite_tools
+
 %find_lang %{name}-server
 
 %if 0%{?is_opensuse}
@@ -667,6 +669,7 @@ fi
 %{python3rhnroot}/satellite_tools/reposync.py*
 %{python3rhnroot}/satellite_tools/constants.py*
 %{python3rhnroot}/satellite_tools/download.py*
+%{python3rhnroot}/satellite_tools/ulnauth.py*
 %dir %{python3rhnroot}/satellite_tools/disk_dumper
 %{python3rhnroot}/satellite_tools/disk_dumper/__init__.py*
 %{python3rhnroot}/satellite_tools/disk_dumper/iss.py*


### PR DESCRIPTION
## What does this PR change?

This PR enables `spacewalk-repo-sync` to use extra HTTP headers when dealing with RPM repositories:

- Extra HTTP headers can be now defined at `/etc/rhn/spacewalk-repo-sync/extra_headers.conf` file, in a similar way as you can set HTTP proxy settings:

```yaml
# You can define extra headers per channel label
[channel_label]
header1=value1
header2=value2

# Or by repository name
[repository_name]
another_header1=value
another_header2=value

# Or globally for all respositories and channels
[main]
a_global_header=value
```
- A new Zypper plugin called `spacewalk-extra-http-headers` has been also introduced in order to allow injecting the customer headers into the requests made by Zypper to retrieve the repository metadata.

This is particularly useful to deal with RHUI repositories within the public clouds.

**NOTE:** This PR also adds missing `ulnauth` and `spacewalk-uln-resolver` files to `spacewalk-backend-tools` package.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls) (will be linked shortly)

- [x] **DONE**

## Test coverage
- No tests: **no tests for reposync with extra headers**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/10936

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
