### PR TITLE
fix small typos

### DIFF
--- a/tftpsync/susemanager-tftpsync/sync_post_tftpd_proxies.py
+++ b/tftpsync/susemanager-tftpsync/sync_post_tftpd_proxies.py
@@ -140,7 +140,7 @@ def find_delete_from_proxies(tftpbootdir, settings, lcache='/var/lib/cobbler', l
         if delete_from_proxies(relpath, settings, logger):
             changed = True
             del_paths.append(path)
-            logger.info("Delete successfull")
+            logger.info("Delete successful")
         else:
             logger.info("Delete failed")
 
@@ -208,7 +208,7 @@ def check_push(fn, tftpbootdir, settings, lcache='/var/lib/cobbler', logger=None
         if sync_to_proxies(fn, tftpbootdir, format, settings, logger):
             db[fn] = (mtime,key)
             simplejson.dump(db, open(dbfile,'w'))
-            logger.info("Push successfull")
+            logger.info("Push successful")
         else:
             logger.info("Push failed")
 


### PR DESCRIPTION
## What does this PR change?

"Push successfull" should read "Push successful", in the output of "cobbler sync". 

- [x] **DONE**

## GUI diff

Before:
CLI: Push successfull

After:
CLI: Push successful

- [x] **DONE**

## Documentation
- No documentation needed: typo

- [x] **DONE**

## Test coverage
- No tests: typo

- [x] **DONE**

## Links

Fixes # bsc#1169553

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
