### PR TITLE
Port changes from master, including tagging

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -202,6 +202,53 @@ ENHANCE12SP1 = [
     "python-setuptools",
 ]
 
+# This is in fact only required for now for AWS SLE12SP5 x86_64 images,
+# as they do not have dbus-1-glib installed
+ENHANCE12SP5_X86 = [
+    "dbus-1-glib",
+    "girepository-1_0",
+    "libcairo2",
+    "libdatrie1",
+    "libdrm2",
+    "libdrm_amdgpu1",
+    "libdrm_intel1",
+    "libdrm_nouveau2",
+    "libdrm_radeon1",
+    "libgbm1",
+    "libgirepository-1_0-1",
+    "libgobject-2_0-0",
+    "libgraphite2-3",
+    "libharfbuzz0",
+    "libLLVM7",
+    "libpango-1_0-0",
+    "libpciaccess0",
+    "libpixman-1-0",
+    "libthai0",
+    "libthai-data",
+    "libX11-xcb1",
+    "libxcb-dri2-0",
+    "libxcb-dri3-0",
+    "libxcb-glx0",
+    "libxcb-present0",
+    "libxcb-render0",
+    "libxcb-shm0",
+    "libxcb-sync1",
+    "libxcb-xfixes0",
+    "libXdamage1",
+    "libXfixes3",
+    "libXft2",
+    "libXrender1",
+    "libxshmfence1",
+    "libXxf86vm1",
+    "Mesa",
+    "Mesa-dri",
+    "Mesa-libEGL1",
+    "Mesa-libGL1",
+    "Mesa-libglapi0",
+    "python-gobject",
+    "typelib-1_0-Pango-1_0",
+]
+
 RES6 = [
     "salt",
     "salt-minion",
@@ -336,10 +383,10 @@ PKGLIST15_SALT = [
     "python3-idna",
     "python3-Jinja2",
     "python3-MarkupSafe",
+    "python3-M2Crypto",
     "python3-msgpack",
     "python3-psutil",
     "python3-py",
-    "python3-pycrypto|python3-M2Crypto",
     "python3-pytz",
     "python3-PyYAML",
     "python3-pyzmq",
@@ -352,6 +399,10 @@ PKGLIST15_SALT = [
     "salt",
     "python3-salt",
     "salt-minion",
+]
+
+PKGLIST15SP0SP1_SALT = [
+    "python3-tornado",
 ]
 
 PKGLIST15SP0SP1_SALT = [
@@ -944,11 +995,11 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/5/bootstrap/'
     },
     'SLE-12-SP5-x86_64' : {
-        'PDID' : [1878], 'BETAPDID' : [1747], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
+        'PDID' : [1878], 'BETAPDID' : [1747], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + ENHANCE12SP5_X86 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/5/bootstrap/'
     },
     'SLES4SAP-12-SP5-x86_64' : {
-        'PDID' : [1880], 'BETAPDID' : [1747], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
+        'PDID' : [1880], 'BETAPDID' : [1747], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + ENHANCE12SP5_X86 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/5/bootstrap/'
     },
     'SLES4SAP-12-SP5-ppc64le' : {
@@ -956,7 +1007,7 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/5/bootstrap/'
     },
     'SLE4HPC-12-SP5-x86_64' : {
-        'PDID' : [1873], 'BETAPDID' : [1747], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
+        'PDID' : [1873], 'BETAPDID' : [1747], 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + ENHANCE12SP5_X86 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/5/bootstrap/'
     },
     'SLE4HPC-12-SP5-aarch64' : {
@@ -968,7 +1019,7 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/2/bootstrap/'
     },
     'OES2018-SP1-x86_64' : {
-        'PDID' : 46, 'PKGLIST' : PKGLIST12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
+        'PDID' : 46, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/3/bootstrap/'
     },
     'OES2018-SP2-x86_64' : {

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,4 +1,23 @@
+-------------------------------------------------------------------
+Mon Apr 20 14:11:37 CEST 2020 - jgonzalez@suse.com
+
+- version 4.1.11-1
 - Require python3-tornado only for SLE15/SLE15SP1/openSUSE Leap 15.1 (bsc#1169865)
+- add missing packages to OES2018-SP1-x86_64 target for bootstrap data (bsc#1169144)
+
+-------------------------------------------------------------------
+Thu Apr 16 11:39:54 CEST 2020 - jgonzalez@suse.com
+
+- version 4.1.10-1
+- Use python3-M2Crypto for all SLE15 versions and openSUSE Leap 15.1
+  bootstrap repositories
+
+-------------------------------------------------------------------
+Thu Apr 16 00:35:45 CEST 2020 - jgonzalez@suse.com
+
+- version 4.1.9-1
+- Add dbus-1-glib to SLE12SP5 x86_64 to allow onboarding of AWS Cloud SLE12SP5
+  clients (they do not have it by default anymore)
 
 -------------------------------------------------------------------
 Mon Apr 13 09:37:12 CEST 2020 - jgonzalez@suse.com

--- a/susemanager/susemanager.spec
+++ b/susemanager/susemanager.spec
@@ -23,7 +23,7 @@
 %define pythonX %{?build_py3:python3}%{!?build_py3:python2}
 
 Name:           susemanager
-Version:        4.1.8
+Version:        4.1.11
 Release:        1%{?dist}
 Summary:        SUSE Manager specific scripts
 License:        GPL-2.0-only


### PR DESCRIPTION
## What does this PR change?

Port changes from master, including tagging:
* add missing packages to OES2018-SP1-x86_64 target for bootstrap data (bsc#1169144)
* Use python3-M2Crypto for all SLE15 versions and openSUSE Leap 15.1 bootstrap repositories
* Add dbus-1-glib to SLE12SP5 x86_64 to allow onboarding of AWS Cloud SLE12SP5 clients (they do not have it by default anymore)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Bugfixing

- [x] **DONE**

## Test coverage
- No tests: Cucumber should be testing this, but we are not there yet.

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
