### PR TITLE
Fix email option reposync

### DIFF
--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -111,10 +111,13 @@ def send_mail(sync_type="Repo"):
         headers = {
             'Subject': _("%s sync. report from %s") % (sync_type, host_label),
         }
+        comp = CFG.getComponent()
+        initCFG('web')
         sndr = "root@%s" % host_label
         if CFG.default_mail_from:
             sndr = CFG.default_mail_from
         rhnMail.send(headers, body, sender=sndr)
+        initCFG(comp)
     else:
         print((_("+++ email requested, but there is nothing to send +++")))
 

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- use default sender address from web namespace
 - Enable extra HTTP headers support for "spacewalk-repo-sync".
 - Add missing Zypper plugin to deal with ULN repositories.
 


### PR DESCRIPTION
## What does this PR change?

rhn.conf has defined `web.default_mail_from` which is not available in the config namespace we use in spacewalk-repo-sync. This PR switch the namespace to get the sender address.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/2142
Tracks https://github.com/SUSE/spacewalk/pull/11299

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle" (Test skipped, there are no changes to test)
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
