### PR TITLE
Check that reposync works as expected

### DIFF
--- a/testsuite/features/reposync/srv_check_reposync.feature
+++ b/testsuite/features/reposync/srv_check_reposync.feature
@@ -1,0 +1,8 @@
+# Copyright (c) 2020 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: Reposync works as expected
+
+  Scenario: Check reposync of custom channel
+    Then "orion-dummy-1.1-1.1.x86_64.rpm" package should have been stored
+    And solver file for "test-channel-x86_64" should reference "orion-dummy-1.1-1.1.x86_64.rpm"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -244,6 +244,14 @@ When(/^I make sure no spacewalk\-repo\-sync is executing, excepted the ones need
   end
 end
 
+Then(/^"([^"]*)" package should have been stored$/) do |pkg|
+  $server.run("find /var/spacewalk/packages -name #{pkg}")
+end
+
+Then(/^solver file for "([^"]*)" should reference "([^"]*)"$/) do |channel, pkg|
+  $server.run("dumpsolv /var/cache/rhn/repodata/#{channel}/solv | grep #{pkg}")
+end
+
 When(/^I execute mgr\-bootstrap "([^"]*)"$/) do |arg1|
   arch = 'x86_64'
   $command_output = sshcmd("mgr-bootstrap --activation-keys=1-SUSE-PKG-#{arch} #{arg1}")[:stdout]

--- a/testsuite/run_sets/refhost.yml
+++ b/testsuite/run_sets/refhost.yml
@@ -28,6 +28,7 @@
 - features/reposync/srv_enable_sync_products.feature
   # we let the synchronization run
   # - features/reposync/srv_abort_all_sync.feature
+- features/reposync/srv_check_reposync.feature
 
 ## Core features END ###
 

--- a/testsuite/run_sets/reposync.yml
+++ b/testsuite/run_sets/reposync.yml
@@ -13,5 +13,6 @@
 - features/reposync/srv_sync_products.feature
 - features/reposync/srv_enable_sync_products.feature
 - features/reposync/srv_abort_all_sync.feature
+- features/reposync/srv_check_reposync.feature
 
 ## Channels and Product synchronization features END ###

--- a/testsuite/run_sets/virtualization.yml
+++ b/testsuite/run_sets/virtualization.yml
@@ -22,6 +22,7 @@
 - features/reposync/srv_sync_products.feature
 - features/reposync/srv_enable_sync_products.feature
 - features/reposync/srv_abort_all_sync.feature
+- features/reposync/srv_check_reposync.feature
 
 ## Core features END ###
 


### PR DESCRIPTION
## What does this PR change?

We currently do reposyncs, but never test that they succeeded.

This PR introduces a new feature that:
* checks that one of the test packages was copied into `/var/spacewalk/packages`
* checks that the `solv` file references the test package

This first version does the tests with test packages where the solver part currently fails from time to time on head. It could be extended later for more comprehensive tests.


## Links

Bug: https://bugzilla.suse.com/show_bug.cgi?id=1170197

Backports:
* 4.0: SUSE/spacewalk#11312
* 3.2: SUSE/spacewalk#11313

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
