### PR TITLE
susemanager-tftpsync-recv: Do not produce 500 errors with empty and UTF files (bsc#1167265)

### DIFF
--- a/tftpsync/susemanager-tftpsync-recv/add.wsgi
+++ b/tftpsync/susemanager-tftpsync-recv/add.wsgi
@@ -22,6 +22,7 @@ try:
     from cStringIO import OutputType
 except:
     from io import StringIO as OutputType
+from io import BytesIO
 from spacewalk.common.rhnConfig import CFG, initCFG
 
 initCFG("tftpsync")
@@ -102,7 +103,7 @@ def application(environ, start_response):
                 tf.write(file_content)
                 tf.close()
                 os.rename(tfname, rfname)
-            elif isinstance(tfpointer, OutputType):
+            elif isinstance(tfpointer, OutputType) or isinstance(tfpointer, BytesIO):
                 tf = open(tfname, 'wb')
                 tf.write(form.getvalue('file'))
                 tf.close()

--- a/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.changes
+++ b/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.changes
@@ -1,3 +1,5 @@
+- Do not produce 500 errors with empty and UTF files (bsc#1167265)
+
 -------------------------------------------------------------------
 Mon Apr 13 09:30:48 CEST 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue in the `add` wsgi handler from `susemanager-tftpsync-recv` at the time of receiving an empty or UTF encoded files on the Proxy during `cobbler sync` execution.

Given a setup with a Server and a Proxy, with an "Autoinstallation" profile created, where I created empty or UTF encoded file:

```
ext-uyuni-srv:~ # file /srv/tftpboot/yaboot.conf 
/srv/tftpboot/yaboot.conf: empty
```

Then:

```
ext-uyuni-srv:~ # cobbler sync
...
sync_post_tftp_proxies started
uploading /srv/tftpboot/yaboot.conf to all known proxies. Timeout: 15
uploading /srv/tftpboot/yaboot.conf to proxy ext-uyuni-pxy.tf.local as yaboot.conf
uploading to proxy ext-uyuni-pxy.tf.local failed: HTTP Error 500: Server Error
Push failed
...
```

After this PR, the issue is fixed and all files are pushed successfully.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **bugfix**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/11240

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
