### PR TITLE
Add hint to edit formulas before applying state

### DIFF
--- a/web/html/src/manager/groups/formula/group-formula-selection.renderer.js
+++ b/web/html/src/manager/groups/formula/group-formula-selection.renderer.js
@@ -12,7 +12,8 @@ const SpaRenderer  = require("core/spa/spa-renderer").default;
 export const renderer = (renderId, {groupId, warningMessage}) => {
 
   const messageTexts = {
-    "formulas_saved": <p>{t("Formula saved. Apply the ")}<a
+    "formulas_saved": <p>{t("Formula saved. Edit configuration options " +
+      "in the enabled formulas and apply the ")}<a
       href={'/rhn/manager/groups/details/highstate?sgid=' +
         groupId}>{t("Highstate")}</a>{t(" for the changes to take effect.")}
     </p>,

--- a/web/html/src/manager/minion/formula/minion-formula-selection.renderer.js
+++ b/web/html/src/manager/minion/formula/minion-formula-selection.renderer.js
@@ -13,7 +13,11 @@ export const renderer = (renderId, {serverId, warningMessage}) => {
 
 
   const messageTexts = {
-    "formulas_saved" : <p>{t("Formula saved. Apply the ")}<a href={'/rhn/manager/systems/details/highstate?sid=' + serverId}>{t("Highstate")}</a>{t(" for the changes to take effect.")}</p>,
+    "formulas_saved" : <p>{t("Formula saved. Edit configuration options " +
+      "in the enabled formulas and apply the ")}<a
+      href={'/rhn/manager/systems/details/highstate?sid=' +
+        serverId}>{t("Highstate")}</a>{t(" for the changes to take effect.")}
+    </p>,
     "error_invalid_target" : t("Invalid target type.")
   }
 


### PR DESCRIPTION
## What does this PR change?

In most cases users should review and edit configuration details of the
newly enabled formulas before applying the highstate.

This change adds a hint to the displayed message to execute this step.

## GUI diff

Before: _Formula saved. Apply the Highstate for the changes to take effect._

After: _Formula saved. Edit configuration options in the enabled formulas and apply the Highstate for the changes to take effect._

- [x] **DONE**

## Documentation
- No documentation needed: Documentation is [clear about it already](https://www.uyuni-project.org/uyuni-docs/uyuni/administration/monitoring.html#_install_prometheus).
- [x] **DONE**

## Test coverage
- No tests: 
- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11190

- [x] **DONE**

## Changelogs

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
