### PR TITLE
Reposync speedup part 1

### DIFF
--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -70,7 +70,7 @@ default_log_location = '/var/log/rhn/'
 relative_comps_dir = 'rhn/comps'
 relative_modules_dir = 'rhn/modules'
 checksum_cache_filename = 'reposync/checksum_cache'
-default_import_batch_size = 10
+default_import_batch_size = 50
 
 errata_typemap = {
     'security': 'Security Advisory',

--- a/backend/server/importlib/backend.py
+++ b/backend/server/importlib/backend.py
@@ -2141,16 +2141,17 @@ class Backend:
                     entry_list = object[tbl.getAttribute()]
                     if entry_list is None:
                         continue
-                    for entry in entry_list:
+                    seq_col = tbl.sequenceColumn
+                    new_ids = self.sequences[tbl.name].next_many(len(entry_list)) if seq_col else []
+                    for i, entry in enumerate(entry_list):
                         extObject = {childTables[tname]: id}
-                        seq_col = tbl.sequenceColumn
                         if seq_col:
                             # This table has to insert values in a sequenced
                             # column; since it's a child table and the entry
                             # in the master table is not created yet, there
                             # shouldn't be a problem with uniqueness
                             # constraints
-                            new_id = self.sequences[tbl.name].next()
+                            new_id = new_ids[i]
                             extObject[seq_col] = new_id
                             # Make sure we initialize the object's sequenced
                             # column as well

--- a/backend/server/importlib/importLib.py
+++ b/backend/server/importlib/importLib.py
@@ -39,14 +39,14 @@ class DateType:
 
 
 # An Item is just an extension for a dictionary
-class Item(UserDict):
+class Item(dict):
 
     """
     First level object, that stores information in a hash-like structure
     """
 
     def __init__(self, attributes=None):
-        UserDict.__init__(self, attributes)
+        dict.__init__(self, attributes)
 
     def populate(self, hash):
         self.update(hash)
@@ -54,7 +54,7 @@ class Item(UserDict):
 
     def __repr__(self):
         return "[<%s instance; attributes=%s]" % (str(self.__class__),
-                                                  str(self.data))
+                                                  dict.__repr__(self))
 
 # BaseInformation is an Item with a couple of other features (an id, an ignored
 # flag, diff information)

--- a/backend/server/rhnSQL/sql_sequence.py
+++ b/backend/server/rhnSQL/sql_sequence.py
@@ -41,6 +41,13 @@ class Sequence:
             return ret
         return int(ret['id'])
 
+    def next_many(self, n):
+        sql = "SELECT sequence_nextval('%s') FROM generate_series(1, %s)" % (self.__seq, n)
+        cursor = self.__db.prepare(sql)
+        cursor.execute()
+        result = cursor.fetchall()
+        return [r[0] for r in result]
+
     def __call__(self):
         return self.next()
 

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- reposync speedup fixes
 - use default sender address from web namespace
 - Enable extra HTTP headers support for "spacewalk-repo-sync".
 - Add missing Zypper plugin to deal with ULN repositories.

--- a/uyuni/common-libs/common/rhn_pkg.py
+++ b/uyuni/common-libs/common/rhn_pkg.py
@@ -67,7 +67,7 @@ def package_from_filename(filename):
     stream = open(filename, mode='rb')
     return package_from_stream(stream, packaging)
 
-BUFFER_SIZE = 16384
+BUFFER_SIZE = 8388608
 DEFAULT_CHECKSUM_TYPE = 'md5'
 
 

--- a/uyuni/common-libs/uyuni-common-libs.changes
+++ b/uyuni/common-libs/uyuni-common-libs.changes
@@ -1,3 +1,5 @@
+- reposync speedup fixes
+
 -------------------------------------------------------------------
 Mon Apr 13 09:38:18 CEST 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

It adds some relatively safe fixes to speed up repository syncing.

**Total speedup is ~30%**, individual contributions from commits as measured in my setup (syncing `sles11-sp4-updates-x86_64` from a local mirror, robustly transferrable to other channels) follow:

| Commit                                                  | Speedup |
|---------------------------------------------------------|---------|
| reposync speedup: stream with bigger buffer             | 2.53%   |
| reposync speedup: process more packages between commits | 2.59%   |
| reposync speedup: get sequence numbers in batches       | 16.97%  |
| reposync speedup: avoid wrapper class                   | 4.43%   |


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal change only**
- [x] **DONE**

## Test coverage
- No tests: **Cucumber tests to be implemented after reposync is fast enough**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/9275
- [x] **DONE**

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
