### PR TITLE
Avoid multiple base channels when onboarding minions (bsc#1167871)

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
@@ -32,6 +32,7 @@ import com.redhat.rhn.domain.rhnpackage.Package;
 import com.redhat.rhn.domain.rhnpackage.PackageFactory;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerArch;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.state.PackageState;
 import com.redhat.rhn.domain.state.PackageStates;
@@ -278,21 +279,36 @@ public class RegistrationUtils {
                 )
         );
 
-        // this is needed for "special" cases like RES6 that has multiple architectures in one product, or in case an
-        // activation key specifies a base channel for an incorrect arch
-        Set<Channel> compatibleChannels = unfilteredChannels.stream()
-                .filter(c -> c.getChannelArch().getCompatibleServerArches().contains(server.getServerArch()))
-                .collect(toSet());
+        server.setChannels(
+                filterCompatibleChannelsForServerArch(server.getServerArch(), unfilteredChannels, activationKey));
+    }
 
-        Channel assignedBaseChannel = server.getBaseChannel();
-        if (assignedBaseChannel != null && compatibleChannels.stream()
-                .filter(channel -> channel.isBaseChannel())
-                .anyMatch(baseChannel -> !baseChannel.equals(assignedBaseChannel))) {
-            // if base channel is going to be changed, we reset all current assignments
-            server.getChannels().clear();
-        }
+    /**
+     * Given a set of channels, filter those channels that are compatible with the passed serverArch.
+     * If an activationKey is passed, the base channel of the activationKey is used if it's compatible with the passed
+     * serverArch.
+     *
+     * NOTE: this is needed for "special" cases like RES6 that has multiple architectures in one product, or in case an
+     * activation key specifies a base channel for an incorrect arch.
+     *
+     * @param serverArch the serverArch
+     * @param channels the channels to be filtered
+     * @param activationKey the activationKey
+     * @return a set of compatible channels
+     */
+    private static Set<Channel> filterCompatibleChannelsForServerArch(ServerArch serverArch, Set<Channel> channels,
+            Optional<ActivationKey> activationKey) {
+        Map<Boolean, List<Channel>> compatibleChannels =
+                channels.stream().filter(c -> c.getChannelArch().getCompatibleServerArches().contains(serverArch))
+                        .collect(partitioningBy(c -> c.isBaseChannel()));
 
-        server.setChannels(compatibleChannels);
+        Optional<Channel> activationKeyBaseChannel = activationKey.flatMap(ak -> ofNullable(ak.getBaseChannel()));
+
+        Stream<Channel> compatibleBaseChannels =
+                Opt.fold(activationKeyBaseChannel, () -> compatibleChannels.get(true).stream(),
+                        bc -> compatibleChannels.get(true).stream().filter(c -> bc.getId().equals(c.getId())));
+
+        return Stream.concat(compatibleBaseChannels, compatibleChannels.get(false).stream()).collect(toSet());
     }
 
     private static Set<Channel> findChannelsForProducts(Set<SUSEProduct> suseProducts, String minionId) {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,4 +1,11 @@
+- avoid multiple base channels when onboarding minions (bsc#1167871)
 - Remember settings after Service Pack Migration dry-run
+
+-------------------------------------------------------------------
+Thu Apr 23 10:25:13 CEST 2020 - jgonzalez@suse.com
+
+- version 4.0.32-1
+>>>>>>> 5baf21ad1dc... Avoid multiple base channels when onboarding minions (bsc#1167871)
 - hide message about changed Update Tag change (bsc#1169109)
 - Web UI: Implement bootstrapping minions using an SSH private key
 - add virtual volume delete action


### PR DESCRIPTION
## What does this PR change?

When onboarding a RES6 minion with activationKey, you can end up with 2 base channels. This fix that problem.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed:  only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11105
Tracks https://github.com/SUSE/spacewalk/pull/11314

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
