### PR TITLE
Reposync speedup part 2

### DIFF
--- a/backend/server/importlib/backend.py
+++ b/backend/server/importlib/backend.py
@@ -17,6 +17,7 @@
 #
 
 import copy
+from datetime import datetime
 import string
 import sys
 
@@ -141,33 +142,49 @@ class Backend:
     def processChangeLog(self, changelogHash):
         if CFG.has_key('package_import_skip_changelog') and CFG.package_import_skip_changelog:
             return
-        sql = "select id from rhnPackageChangeLogData where name = :name and time = :time and text = :text"
-        h = self.dbmodule.prepare(sql)
-        toinsert = [[], [], [], []]
-        for name, time, text in list(changelogHash.keys()):
-            val = {}
-            _buildExternalValue(val, {'name': name, 'time': time, 'text': text}, self.tables['rhnPackageChangeLogData'])
-            h.execute(name=val['name'], time=val['time'], text=val['text'])
-            row = h.fetchone_dict()
-            if row:
-                changelogHash[(name, time, text)] = row['id']
-                continue
 
-            id = self.sequences['rhnPackageChangeLogData'].next()
-            changelogHash[(name, time, text)] = id
-
-            toinsert[0].append(id)
-            toinsert[1].append(val['name'])
-            toinsert[2].append(val['time'])
-            toinsert[3].append(val['text'])
-
-        if not toinsert[0]:
-            # Nothing to do
+        if not changelogHash:
             return
 
-        sql = "insert into rhnPackageChangeLogData (id, name, time, text) values (:id, :name, :time, :text)"
+        sql = """
+            WITH wanted (name, time, text) AS (
+              VALUES %s
+            ),
+            missing AS (
+              SELECT nextval('rhn_pkg_cld_id_seq') AS id, wanted.*
+                FROM wanted
+                LEFT JOIN rhnPackageChangeLogData
+                    ON rhnPackageChangeLogData.name = wanted.name
+                      AND rhnPackageChangeLogData.time = wanted.time
+                      AND rhnPackageChangeLogData.text = wanted.text
+                WHERE rhnPackageChangeLogData.id IS NULL
+            )
+            INSERT INTO rhnPackageChangeLogData(id, name, time, text)
+              SELECT *
+                FROM missing
+              ON CONFLICT DO NOTHING
+        """
+        values = [(key[0], datetime.strptime(key[1], '%Y-%m-%d %H:%M:%S'), key[2]) for key in changelogHash.keys()]
         h = self.dbmodule.prepare(sql)
-        h.executemany(id=toinsert[0], name=toinsert[1], time=toinsert[2], text=toinsert[3])
+        h.execute_values(sql, values, fetch=False)
+
+        sql = """
+            WITH wanted (name, time, text) AS (
+              VALUES %s
+            )
+            SELECT wanted.*, rhnPackageChangeLogData.id
+              FROM wanted
+              JOIN rhnPackageChangeLogData
+                  ON rhnPackageChangeLogData.name = wanted.name
+                    AND rhnPackageChangeLogData.time = wanted.time
+                    AND rhnPackageChangeLogData.text = wanted.text
+        """
+        h = self.dbmodule.prepare(sql)
+        changelogs = h.execute_values(sql, values)
+
+        for changelog in changelogs:
+            changelogHash[(changelog[0], changelog[1].strftime('%Y-%m-%d %H:%M:%S'), changelog[2])] = changelog[3]
+
 
     def processSuseProductFiles(self, prodfileHash):
         sql = """

--- a/backend/server/importlib/backendOracle.py
+++ b/backend/server/importlib/backendOracle.py
@@ -692,32 +692,10 @@ class PostgresqlBackend(OracleBackend):
     # Postgres doesn't support autonomous transactions. We could use
     # dblink_exec like we do in other stored procedures to open a new
     # connection to the db and do our inserts there, but there are a lot of
-    # capabilities and opening several million connections to the db in the
+    # checksums and opening several million connections to the db in the
     # middle of a sat-sync is slow. Instead we keep open a secondary db
     # connection which we only use here, so we can directly commit to that
     # instead of opening a new connection for each insert.
-    def processCapabilities(self, capabilityHash):
-        # must lock the table to keep rhnpush or whomever from causing
-        # this transaction to fail
-        lock_sql = "lock table rhnPackageCapability in exclusive mode"
-        sql = "select lookup_package_capability_fast(:name, :version) as id from dual"
-        try:
-            self.dbmodule.execute_secondary(lock_sql)
-            h = self.dbmodule.prepare_secondary(sql)
-            for name, version in list(capabilityHash.keys()):
-                ver = version
-                if version == '':
-                    ver = None
-                h.execute(name=name, version=ver)
-                row = h.fetchone_dict()
-                capabilityHash[(name, version)] = row['id']
-            self.dbmodule.commit_secondary()  # commit also unlocks the table
-        except Exception:
-            e = sys.exc_info()[1]
-            self.dbmodule.execute_secondary("rollback")
-            raise e
-
-    # Same as processCapabilities
     def lookupChecksums(self, checksumHash):
         if not checksumHash:
             return

--- a/backend/server/rhnSQL/driver_postgresql.py
+++ b/backend/server/rhnSQL/driver_postgresql.py
@@ -21,6 +21,7 @@ import sys
 import string
 import re
 import psycopg2
+import psycopg2.extras
 
 # workaround for python-psycopg2 = 2.0.13 (RHEL6)
 # which does not import extensions by default
@@ -349,6 +350,11 @@ class Cursor(sql_base.Cursor):
         self.description = self._real_cursor.description
         rowcount = self._real_cursor.rowcount
         return rowcount
+
+    def _execute_values(self, sql, argslist, template=None, page_size=1000, fetch=True):
+        results = psycopg2.extras.execute_values(self._real_cursor, sql, argslist, template=template, page_size=page_size, fetch=fetch)
+        self.description = self._real_cursor.description
+        return results
 
     def update_blob(self, table_name, column_name, where_clause, data,
                     **kwargs):

--- a/backend/server/rhnSQL/sql_base.py
+++ b/backend/server/rhnSQL/sql_base.py
@@ -158,6 +158,13 @@ class Cursor:
         """
         return self._execute_wrapper(self._executemany, *p, **kw)
 
+    def execute_values(self, sql, argslist, template=None, page_size=1000, fetch=True):
+        """
+        Execute a query with a potentially-long VALUEs list. This method will split the query up in page_size
+        chunks. Use a %s placeholder where the VALUE list goes.
+        """
+        return self._execute_wrapper(self._execute_values, sql, argslist, template, page_size, fetch)
+
     def execute_bulk(self, dict, chunk_size=100):
         """
         Uses executemany but chops the incoming dict into chunks for each
@@ -204,6 +211,9 @@ class Cursor:
         return self._execute_(args, kwargs)
 
     def _executemany(self, *args, **kwargs):
+        raise NotImplementedError()
+
+    def _execute_values(self, *args, **kwargs):
         raise NotImplementedError()
 
     def _execute_(self, args, kwargs):

--- a/schema/spacewalk/postgres/tables/rhnPackageCapability_index.sql
+++ b/schema/spacewalk/postgres/tables/rhnPackageCapability_index.sql
@@ -20,3 +20,6 @@ CREATE UNIQUE INDEX rhn_pkg_cap_name_version_uq
 create unique index rhn_pkg_cap_name_uq
     on rhnPackageCapability (name)
  where version is null;
+
+CREATE INDEX rhn_pkg_cap_name_idx
+    ON rhnPackageCapability USING HASH (name);

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- added an index to improve reposync performance
 - Update schema for virtual volume delete action
 
 -------------------------------------------------------------------

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.6-to-susemanager-schema-4.1.7/003-rhnpackagecapability-name-index.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.6-to-susemanager-schema-4.1.7/003-rhnpackagecapability-name-index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS rhn_pkg_cap_name_idx
+    ON rhnPackageCapability USING HASH (name);


### PR DESCRIPTION
## What does this PR change?

It replaces the existing mechanism in `spacewalk-repo-sync` to insert package capabilities, changelogs and checksums with a more efficient one.

**Total speedup is ~25%**, individual contributions from relevant commits as measured in my setup (syncing `sles12-sp5-updates-x86_64` from a local mirror, robustly transferable to other channels) follow:


| Commit                                                | Speedup |
|-------------------------------------------------------|---------|
| reposync speedup: use execute_values for capabilities | 5.18%   |
| Add INDEX to rhnPackageCapability.name                | 8.16%   |
| reposync speedup: use execute_values for checksums    | 4.57%   |
| reposync speedup: use execute_values for changelogs   | 5.28%   |

## The old mechanism being replaced

Capabilities/checksums/changelogs were inserted one by one via a `lookup_` stored procedure. The stored procedure was coded in a way to avoid that inserting an already-existing object would cause a unique constraint error - it did so by opening a secondary Postgres connection that was dedicated to just those insertions.

## The new mechanism proposed in this PR

Main differences are:

 * normal `INSERT INTO` statements are used instead of stored procedures
 * insertions are batched (one statement for many `VALUE`s)
 * batching happens via the via the `psycopg2` [execute_many helper](https://www.psycopg.org/docs/extras.html#fast-execution-helpers#psycopg2.extras.execute_values). According to the library documentation and my tests [using such helper is much faster than simply looping over a statement or the previously-used `executemany` method](https://www.psycopg.org/docs/extras.html#fast-execution-helpers)
 * potential conflicts with concurrent insertions are resolved via the the `INSERT INTO ... ON CONFLICT DO NOTHING` [clause of PostgreSQL](https://www.postgresql.org/docs/12/sql-insert.html#SQL-ON-CONFLICT) instead of the secondary connection
 * code implementing the secondary connection is dropped

This requires the latest psycopg2 library in order to work. [This is being added to SLE as part of the addition of PostgreSQL 12](https://smelt.suse.de/request/215193/) and [we will add the package to Uyuni temporarily](https://build.opensuse.org/request/show/797156).

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal change only**
- [x] **DONE**

## Test coverage
- No tests: **Cucumber tests to be implemented after reposync is fast enough**

- [x] **DONE**

## Links

Fixes partially https://github.com/SUSE/spacewalk/issues/9275
- [x] **DONE**

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
