### PR TITLE
Use salt for registration in kickstart for selected install types

### DIFF
--- a/backend/rhn-conf/rhn.conf
+++ b/backend/rhn-conf/rhn.conf
@@ -34,3 +34,6 @@ db_port =
 
 # If set to 1 all generated repository metadata will be signed
 sign_metadata = 0
+
+# install types for which salt should be used for registration
+salt_enabled_kickstart_install_types=rhel_8

--- a/backend/rhn-conf/rhn.conf
+++ b/backend/rhn-conf/rhn.conf
@@ -37,3 +37,6 @@ sign_metadata = 0
 
 # install types for which salt should be used for registration
 salt_enabled_kickstart_install_types=rhel_8
+
+# possible auto kick start package names(comma separated)
+kickstart_packages = spacewalk-koan,salt

--- a/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -313,6 +313,12 @@ public class ConfigDefaults {
      */
     public static final String SINGLE_SIGN_ON_ENABLED = "java.sso";
 
+    /**
+     * List of distributions for which use salt for registration in kickstart
+     */
+    public static final String SALT_ENABLED_KICKSTART_INSTALL_TYPES = "salt_enabled_kickstart_install_types";
+
+
     private ConfigDefaults() {
     }
 
@@ -976,5 +982,15 @@ public class ConfigDefaults {
     public boolean isSingleSignOnEnabled() {
         return Config.get().getBoolean(SINGLE_SIGN_ON_ENABLED);
     }
+
+    /**
+     * Returns list of install type labels for which use salt for registration in kickstart profile.
+     * @return list of distributions
+     */
+    public List<String> getUserSelectedSaltInstallTypeLabels() {
+        return Config.get().getList(SALT_ENABLED_KICKSTART_INSTALL_TYPES);
+    }
+
+
 
 }

--- a/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -115,6 +115,10 @@ public class ConfigDefaults {
 
 
     private static final String DEFAULT_KICKSTART_PACKAGE_NAME = "spacewalk-koan";
+
+    //Comma separated names of possible kickstart packages
+    private static final String POSSIBLE_KICKSTART_PACKAGE_NAMES = "spacewalk-koan,salt";
+
     private static final String KICKSTART_PACKAGE_NAME = "kickstart_package";
 
     public static final String MOUNT_POINT = "mount_point";
@@ -403,6 +407,15 @@ public class ConfigDefaults {
     public String getKickstartPackageName() {
         return StringUtils.defaultIfEmpty(Config.get().getString(KICKSTART_PACKAGE_NAME),
                 DEFAULT_KICKSTART_PACKAGE_NAME).trim();
+    }
+
+    /**
+     * Returns the list of default kickstart packages names
+     * @return the list of default kickstart packages names
+     */
+    public List<String> getKickstartPackageNames() {
+        List<String> packageNames = Config.get().getList(KICKSTART_PACKAGE_NAME);
+        return packageNames.isEmpty() ?  Arrays.asList(POSSIBLE_KICKSTART_PACKAGE_NAMES.split(",")) : packageNames;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -113,13 +113,10 @@ public class ConfigDefaults {
 
     public static final String REPOMD_CACHE_MOUNT_POINT = "repomd_cache_mount_point";
 
-
-    private static final String DEFAULT_KICKSTART_PACKAGE_NAME = "spacewalk-koan";
-
     //Comma separated names of possible kickstart packages
     private static final String POSSIBLE_KICKSTART_PACKAGE_NAMES = "spacewalk-koan,salt";
 
-    private static final String KICKSTART_PACKAGE_NAME = "kickstart_package";
+    private static final String KICKSTART_PACKAGE_NAMES = "kickstart_packages";
 
     public static final String MOUNT_POINT = "mount_point";
     public static final String KICKSTART_MOUNT_POINT = "kickstart_mount_point";
@@ -399,22 +396,12 @@ public class ConfigDefaults {
         return mount;
     }
 
-
-    /**
-     * Returns the default kickstart package name
-     * @return the default kickstart package name
-     */
-    public String getKickstartPackageName() {
-        return StringUtils.defaultIfEmpty(Config.get().getString(KICKSTART_PACKAGE_NAME),
-                DEFAULT_KICKSTART_PACKAGE_NAME).trim();
-    }
-
     /**
      * Returns the list of default kickstart packages names
      * @return the list of default kickstart packages names
      */
     public List<String> getKickstartPackageNames() {
-        List<String> packageNames = Config.get().getList(KICKSTART_PACKAGE_NAME);
+        List<String> packageNames = Config.get().getList(KICKSTART_PACKAGE_NAMES);
         return packageNames.isEmpty() ?  Arrays.asList(POSSIBLE_KICKSTART_PACKAGE_NAMES.split(",")) : packageNames;
     }
 

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Channel_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Channel_queries.xml
@@ -811,6 +811,16 @@ SELECT CP.package_id, CP.name_id, CP.evr_id, CP.package_arch_id
     </query>
 </mode>
 
+<mode name="latest_packages_equal">
+        <query params="cid, names">
+            SELECT CP.package_id, CP.name_id, CP.evr_id, CP.package_arch_id
+            FROM rhnPackageName PN, rhnChannelNewestPackage CP
+            WHERE CP.channel_id = :cid
+            AND CP.name_id = PN.id
+            AND PN.name SIMILAR TO :names
+        </query>
+</mode>
+
 <mode name="contentsrc_for_org" class="com.redhat.rhn.frontend.dto.ContentSourceDto">
   <query params="org_id">
     SELECT CS.id, CS.label,
@@ -847,6 +857,17 @@ SELECT CP.package_id, CP.name_id, CP.evr_id
    AND PN.name like :name
     </query>
 </mode>
+
+<mode name="latest_packages_similar_to">
+        <query params="cid, names">
+            SELECT CP.package_id, CP.name_id, CP.evr_id
+            FROM rhnPackageName PN, rhnChannelNewestPackage CP
+            WHERE CP.channel_id = :cid
+            AND CP.name_id = PN.id
+            AND PN.name SIMILAR TO :names
+       </query>
+</mode>
+
 
 <mode name="channel_with_package">
     <query params="parent, package, org_id">

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Channel_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Channel_queries.xml
@@ -811,16 +811,6 @@ SELECT CP.package_id, CP.name_id, CP.evr_id, CP.package_arch_id
     </query>
 </mode>
 
-<mode name="latest_packages_equal">
-        <query params="cid, names">
-            SELECT CP.package_id, CP.name_id, CP.evr_id, CP.package_arch_id
-            FROM rhnPackageName PN, rhnChannelNewestPackage CP
-            WHERE CP.channel_id = :cid
-            AND CP.name_id = PN.id
-            AND PN.name SIMILAR TO :names
-        </query>
-</mode>
-
 <mode name="contentsrc_for_org" class="com.redhat.rhn.frontend.dto.ContentSourceDto">
   <query params="org_id">
     SELECT CS.id, CS.label,
@@ -860,7 +850,7 @@ SELECT CP.package_id, CP.name_id, CP.evr_id
 
 <mode name="latest_packages_similar_to">
         <query params="cid, names">
-            SELECT CP.package_id, CP.name_id, CP.evr_id
+            SELECT CP.package_id, CP.name_id, CP.evr_id, CP.package_arch_id
             FROM rhnPackageName PN, rhnChannelNewestPackage CP
             WHERE CP.channel_id = :cid
             AND CP.name_id = PN.id

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartData.java
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartData.java
@@ -1315,6 +1315,15 @@ public class KickstartData {
     }
 
     /**
+     * Get the list of possible name of the kickstart packages this KS could use.
+     * @return List of kickstart packages like auto-kickstart-ks-rhel-i386-as-4
+     */
+    public List<String> getKickstartPackageNames() {
+        return ConfigDefaults.get().getKickstartPackageNames();
+
+    }
+
+    /**
      * @return Returns if the post scripts should be logged.
      */
     public Boolean getPostLog() {

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartData.java
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartData.java
@@ -1306,15 +1306,6 @@ public class KickstartData {
     }
 
     /**
-     * Get the name of the kickstart package this KS will use.
-     * @return String kickstart package like auto-kickstart-ks-rhel-i386-as-4
-     */
-    public String getKickstartPackageName() {
-        return ConfigDefaults.get().getKickstartPackageName();
-
-    }
-
-    /**
      * Get the list of possible name of the kickstart packages this KS could use.
      * @return List of kickstart packages like auto-kickstart-ks-rhel-i386-as-4
      */

--- a/java/code/src/com/redhat/rhn/domain/kickstart/test/KickstartDataTest.java
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/test/KickstartDataTest.java
@@ -394,7 +394,7 @@ public class KickstartDataTest extends BaseTestCaseWithUser {
            addPackages(c, KickstartFormatter.FRESH_PKG_NAMES_RHEL34);
        }
        PackageManagerTest.addPackageToChannel(
-               ConfigDefaults.get().getKickstartPackageName() + "testy", c);
+               ConfigDefaults.get().getKickstartPackageNames().get(0) + "testy", c);
        PackageManagerTest.addPackageToChannel(
                KickstartData.LEGACY_KICKSTART_PACKAGE_NAME +
                    KickstartableTreeTest.TEST_BOOT_PATH, c);

--- a/java/code/src/com/redhat/rhn/frontend/action/kickstart/KickstartHelper.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/kickstart/KickstartHelper.java
@@ -245,7 +245,7 @@ public class KickstartHelper {
 
     /**
      *
-     * @param orgIdIn Org Id
+     * @param orgIn Org Id
      * @return Default Kickstart Data for Org
      */
     private KickstartData getOrgDefaultProfile(Org orgIn) {
@@ -468,7 +468,7 @@ public class KickstartHelper {
             List<Map<String, Object>> kspackages =
                     ChannelManager.listLatestPackagesLike(
                     current.getId(),
-                    ksdata.getKickstartPackageName());
+                    ksdata.getKickstartPackageNames());
             //found it, this channel is good.
             if (kspackages.size() > 0) {
                 return true;

--- a/java/code/src/com/redhat/rhn/frontend/action/kickstart/KickstartHelper.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/kickstart/KickstartHelper.java
@@ -47,6 +47,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -521,10 +522,9 @@ public class KickstartHelper {
         if (ksdata.isRhel3() || ksdata.isRhel4()) {
             packages.addAll(Arrays.asList(KickstartFormatter.FRESH_PKG_NAMES_RHEL34));
         }
-        // TODO: do we actually need this?
-        //add a '*' at the end because the auto kickstart is a prefix
-        packages.add(ksdata.getKickstartPackageName() + "*");
-
+        String autoKickStartPackages = ksdata.getKickstartPackageNames().stream().map(String::trim)
+                .collect(Collectors.joining("|"));
+        packages.add(autoKickStartPackages);
         //Now convert the list to a delimited string.
         String delimiter = LocalizationService.getInstance().getMessage("list delimiter");
         return StringUtils.join(packages.toArray(), delimiter);

--- a/java/code/src/com/redhat/rhn/frontend/action/kickstart/test/ScheduleKickstartWizardTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/kickstart/test/ScheduleKickstartWizardTest.java
@@ -74,7 +74,7 @@ public class ScheduleKickstartWizardTest extends RhnMockStrutsTestCase {
         s.addChannel(c);
 
         PackageManagerTest.addPackageToSystemAndChannel(
-                ConfigDefaults.get().getKickstartPackageName(), s, c);
+                ConfigDefaults.get().getKickstartPackageNames().get(0), s, c);
 
         PackageManagerTest.
             addUp2dateToSystemAndChannel(user, s,

--- a/java/code/src/com/redhat/rhn/frontend/action/kickstart/tree/test/TreeActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/kickstart/tree/test/TreeActionTest.java
@@ -117,7 +117,7 @@ public class TreeActionTest extends RhnPostMockStrutsTestCase {
         Channel rhel5BaseChan = ChannelTestUtils.createTestChannel(user);
         Channel rhel5ToolsChan = ChannelTestUtils.createChildChannel(user, rhel5BaseChan);
         PackageManagerTest.addKickstartPackageToChannel(
-                ConfigDefaults.get().getKickstartPackageName(), rhel5ToolsChan);
+                ConfigDefaults.get().getKickstartPackageNames().get(0), rhel5ToolsChan);
         return rhel5BaseChan;
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/virtualization/test/ProvisionVirtualizationWizardActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/virtualization/test/ProvisionVirtualizationWizardActionTest.java
@@ -81,7 +81,7 @@ public class ProvisionVirtualizationWizardActionTest extends RhnMockStrutsTestCa
         s.addChannel(c);
 
         PackageManagerTest.addPackageToSystemAndChannel(
-                ConfigDefaults.get().getKickstartPackageName(), s, c);
+                ConfigDefaults.get().getKickstartPackageNames().get(0), s, c);
         TestUtils.saveAndFlush(s);
         TestUtils.saveAndFlush(c);
 

--- a/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
@@ -1275,6 +1275,33 @@ public class ChannelManager extends BaseManager {
     }
 
     /**
+     * List the latest packages equal in the passed in Channel and names of packages
+     *
+     * @param channelId to lookup package against
+     * @param packageNames list of package names to check
+     * @return List containing Maps of "CP.package_id, CP.name_id, CP.evr_id"
+     */
+    public static List<Map<String, Object>> listLatestPackagesEqual(Long channelId,
+                                                                    List<String> packageNames) {
+        if (log.isDebugEnabled()) {
+            log.debug("listLatestPackagesEqual: " +
+                    channelId + " pn: " + packageNames);
+        }
+        SelectMode m = ModeFactory.getMode("Channel_queries",
+                "latest_packages_equal");
+
+        StringBuilder pnames = new StringBuilder();
+        pnames.append("(");
+        pnames.append(packageNames.stream().map(String::trim).collect(Collectors.joining("|")));
+        pnames.append(")");
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("cid", channelId);
+        params.put("names", pnames.toString());
+        return m.execute(params);
+
+    }
+
+    /**
      * List the latest packages in a channel *like* the given package name.
      *
      * @param channelId to lookup package against
@@ -1298,6 +1325,30 @@ public class ChannelManager extends BaseManager {
         params.put("name", pname.toString());
         return m.execute(params);
 
+    }
+    /**
+     * List the latest packages in a channel *like* the given list of package names.
+     *
+     * @param channelId to lookup package against
+     * @param packageNames List of packageName to check
+     * @return List containing Maps of "CP.package_id, CP.name_id, CP.evr_id"
+     */
+    public static List<Map<String, Object>> listLatestPackagesLike(Long channelId,
+                                                                   List<String> packageNames) {
+        if (log.isDebugEnabled()) {
+            log.debug("listLatestPackagesLike() cid: " +
+                    channelId + " packageNames : " + packageNames);
+        }
+        SelectMode m = ModeFactory.getMode("Channel_queries",
+                "latest_packages_similar_to");
+        StringBuilder pnames = new StringBuilder();
+        pnames.append("%(");
+        pnames.append(packageNames.stream().map(String::trim).collect(Collectors.joining("|")));
+        pnames.append(")%");
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("cid", channelId);
+        params.put("names", pnames.toString());
+        return m.execute(params);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
@@ -1288,7 +1288,7 @@ public class ChannelManager extends BaseManager {
                     channelId + " pn: " + packageNames);
         }
         SelectMode m = ModeFactory.getMode("Channel_queries",
-                "latest_packages_equal");
+                "latest_packages_similar_to");
 
         StringBuilder pnames = new StringBuilder();
         pnames.append("(");

--- a/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
@@ -1707,7 +1707,7 @@ public class ChannelManager extends BaseManager {
 
             // Search for rhn-kickstart package name:
             kspackages = ChannelManager.listLatestPackagesEqual(child.getId(),
-                    ConfigDefaults.get().getKickstartPackageName());
+                    ConfigDefaults.get().getKickstartPackageNames());
             if (kspackages.size() > 0) {
                 return child;
             }
@@ -1719,7 +1719,7 @@ public class ChannelManager extends BaseManager {
             return baseChannel;
         }
         kspackages = ChannelManager.listLatestPackagesEqual(baseChannel.getId(),
-                ConfigDefaults.get().getKickstartPackageName());
+                ConfigDefaults.get().getKickstartPackageNames());
         if (kspackages.size() > 0) {
             return baseChannel;
         }

--- a/java/code/src/com/redhat/rhn/manager/channel/test/ChannelManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/test/ChannelManagerTest.java
@@ -590,7 +590,7 @@ public class ChannelManagerTest extends BaseTestCaseWithUser {
         Channel base = ChannelTestUtils.createTestChannel(user);
         Channel tools = ChannelTestUtils.createChildChannel(user, base);
         PackageManagerTest.addKickstartPackageToChannel(
-                ConfigDefaults.get().getKickstartPackageName(), tools);
+                ConfigDefaults.get().getKickstartPackageNames().get(0), tools);
 
         Channel lookup = ChannelManager.getToolsChannel(base, user);
         assertEquals(tools.getId(), lookup.getId());

--- a/java/code/src/com/redhat/rhn/manager/kickstart/KickstartFormatter.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/KickstartFormatter.java
@@ -60,10 +60,9 @@ public class KickstartFormatter {
 
 
     private static final String REDHAT_REGISTER_SNIPPET = "spacewalk/redhat_register";
-    private static final String POST_REACTIVATION_SNIPPET =
-                                                    "spacewalk/post_reactivation_key";
-    private static final String POST_DELETION_SNIPPET =
-                                        "spacewalk/post_delete_system";
+    private static final String REDHAT_REGISTER_USING_SALT_SNIPPET = "spacewalk/redhat_register_using_salt";
+    private static final String POST_REACTIVATION_SNIPPET = "spacewalk/post_reactivation_key";
+    private static final String POST_DELETION_SNIPPET = "spacewalk/post_delete_system";
     private static final String KEEP_SYSTEM_ID_SNIPPET = "spacewalk/keep_system_id";
     private static final String DEFAULT_MOTD = "spacewalk/default_motd";
 
@@ -798,11 +797,18 @@ public class KickstartFormatter {
         }
 
         addCobblerSnippet(retval, DEFAULT_MOTD);
-        addCobblerSnippet(retval, REDHAT_REGISTER_SNIPPET);
+
+        if (ConfigDefaults.get().getUserSelectedSaltInstallTypeLabels().contains(ksdata.getInstallType().getLabel())) {
+            addCobblerSnippet(retval, REDHAT_REGISTER_USING_SALT_SNIPPET);
+        }
+        else {
+            addCobblerSnippet(retval, REDHAT_REGISTER_SNIPPET);
+            retval.append(NEWLINE);
+            retval.append(RHNCHECK + NEWLINE);
+        }
+
         retval.append("# end cobbler snippet" + NEWLINE);
 
-        retval.append(NEWLINE);
-        retval.append(RHNCHECK + NEWLINE);
         addLogEnd(retval, RHN_LOG_FILE, "");
 
         addEnd(retval);

--- a/java/code/src/com/redhat/rhn/manager/kickstart/KickstartScheduleCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/KickstartScheduleCommand.java
@@ -1065,8 +1065,7 @@ public class KickstartScheduleCommand extends BaseSystemOperation {
 
         // check for package among channels the server is subscribed to.
         // If one is found, return
-        Map<String, Long> pkgToInstall = findKickstartPackageToInstall(
-                hostServer, serverChannelIds);
+        Map<String, Long> pkgToInstall = findKickstartPackageToInstall(serverChannelIds);
         if (pkgToInstall != null) {
             this.packagesToInstall.add(pkgToInstall);
             log.debug("    packagesToInstall: " + packagesToInstall);
@@ -1077,7 +1076,7 @@ public class KickstartScheduleCommand extends BaseSystemOperation {
         // If one is found, subscribe channel and return
         Set<Long> subscribableChannelIds = SystemManager.subscribableChannelIds(
                 hostServer.getId(), this.user.getId(), hostServer.getBaseChannel().getId());
-        pkgToInstall = findKickstartPackageToInstall(hostServer, subscribableChannelIds);
+        pkgToInstall = findKickstartPackageToInstall(subscribableChannelIds);
 
         if (pkgToInstall != null) {
             this.packagesToInstall.add(pkgToInstall);
@@ -1107,18 +1106,16 @@ public class KickstartScheduleCommand extends BaseSystemOperation {
      * Looks for the package name among the specified channels and, if it is found,
      * it returns the highest available version in Map form.
      *
-     * @param server the server
      * @param channelIds channels the server could be subscribed to
      * @return a ValidationError or null
      */
-    public Map<String, Long> findKickstartPackageToInstall(Server server,
-            Collection<Long> channelIds) {
+    public Map<String, Long> findKickstartPackageToInstall(Collection<Long> channelIds) {
         List<Map<String, Long>> results = new LinkedList<Map<String, Long>>();
 
         for (Long chnnelId : channelIds) {
-            log.debug("    Checking on:" + chnnelId + " for: " + getKickstartPackageName());
+            log.debug("    Checking on:" + chnnelId + " for: " + getKickstartPackageNames());
             List<Map<String, Object>> packages = ChannelManager.listLatestPackagesEqual(
-                    chnnelId, getKickstartPackageName());
+                    chnnelId, getKickstartPackageNames());
             log.debug("    size: " + packages.size());
 
             for (Map<String, Object> aPackage : packages) {
@@ -1151,11 +1148,11 @@ public class KickstartScheduleCommand extends BaseSystemOperation {
     }
 
     /**
-     * Return the kickstart package name for this kickstart action.
-     * @return kickstart package name
+     * Return the list of possible kickstart packages names for this kickstart action.
+     * @return list of kickstart packages names
      */
-    public String getKickstartPackageName() {
-        return this.ksdata.getKickstartPackageName();
+    public List<String> getKickstartPackageNames() {
+        return this.ksdata.getKickstartPackageNames();
     }
 
     // Check to make sure up2date is 2.9.0

--- a/java/code/src/com/redhat/rhn/manager/kickstart/test/KickstartScheduleCommandTest.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/test/KickstartScheduleCommandTest.java
@@ -231,13 +231,11 @@ public class KickstartScheduleCommandTest extends BaseKickstartCommandTestCase {
         ksdata.getKickstartDefaults().getKstree().setInstallType(KickstartFactory.
                 lookupKickstartInstallTypeByLabel(KickstartInstallType.RHEL_4));
 
-        assertEquals("spacewalk-koan",
-                ksdata.getKickstartPackageName());
+        assertContains(ksdata.getKickstartPackageNames(), "spacewalk-koan");
         ksdata.getKickstartDefaults().getKstree().setInstallType(KickstartFactory.
                 lookupKickstartInstallTypeByLabel(KickstartInstallType.RHEL_5));
 
-        assertEquals("spacewalk-koan",
-                ksdata.getKickstartPackageName());
+        assertContains(ksdata.getKickstartPackageNames(),"spacewalk-koan");
 
     }
 
@@ -339,7 +337,7 @@ public class KickstartScheduleCommandTest extends BaseKickstartCommandTestCase {
                         user, new Date(), "rhn.webdev.redhat.com");
 
         PackageManagerTest.addPackageToSystemAndChannel(
-                ConfigDefaults.get().getKickstartPackageName(), server, c);
+                ConfigDefaults.get().getKickstartPackageNames().get(0), server, c);
         // ksdata.getKsdefault().getKstree().setChannel(c);
         cmd.setProfileType(profileType);
         cmd.setServerProfileId(otherServerId);

--- a/java/code/src/com/redhat/rhn/manager/kickstart/test/ProvisionVirtualInstanceCommandTest.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/test/ProvisionVirtualInstanceCommandTest.java
@@ -36,7 +36,7 @@ public class ProvisionVirtualInstanceCommandTest extends BaseKickstartCommandTes
         ProvisionVirtualInstanceCommand cmd = new
             ProvisionVirtualInstanceCommand(server.getId(), this.ksdata.getId(), user,
                     new Date(), "localhost");
-        assertEquals(cmd.getKickstartPackageName(), "spacewalk-koan");
+        assertContains(cmd.getKickstartPackageNames(), "spacewalk-koan");
     }
 
 }

--- a/java/code/src/com/redhat/rhn/testing/ChannelTestUtils.java
+++ b/java/code/src/com/redhat/rhn/testing/ChannelTestUtils.java
@@ -102,7 +102,7 @@ public class ChannelTestUtils {
         PackageManagerTest.addPackageToChannel(
                 ChannelManager.RHN_VIRT_HOST_PACKAGE_NAME, rhnTools);
         PackageManagerTest.addPackageToChannel(
-                ConfigDefaults.get().getKickstartPackageName(), rhnTools);
+                ConfigDefaults.get().getKickstartPackageNames().get(0), rhnTools);
 
 
         Channel rhelVirt =

--- a/java/conf/cobbler/snippets/redhat_register_using_salt
+++ b/java/conf/cobbler/snippets/redhat_register_using_salt
@@ -1,9 +1,56 @@
-# begin Red Hat management server registration
-wget http://$redhat_management_server/pub/bootstrap/bootstrap.sh
-key=$redhat_management_key
-if [ -f /tmp/key ]; then
-    key=`cat /tmp/key`,\$key
+# begin SUSE Manager registration
+<script>
+    <filename>uyuni-minion.sh</filename>
+    <source>
+        <![CDATA[
+cat <<EOF >"/etc/salt/minion.d/susemanager.conf"
+master: $redhat_management_server
+
+EOF
+#if $varExists('registration_key') or $varExists('redhat_management_key')
+cat <<EOF >>"/etc/salt/minion.d/susemanager.conf"
+grains:
+    susemanager:
+EOF
+#end if
+#if $varExists('redhat_management_key')
+cat <<EOF >>"/etc/salt/minion.d/susemanager.conf"
+        management_key: "$redhat_management_key"
+EOF
+#end if
+#if $varExists('registration_key')
+cat <<EOF >>"/etc/salt/minion.d/susemanager.conf"
+        activation_key: "$registration_key"
+EOF
+#end if
+
+#if not $varExists('dont_register')
+# if you don't want to register, set the 'dont_register' variable
+
+systemctl restart salt-minion
+systemctl enable salt-minion
+#end if
+
+#if not $varExists('dont_disable_automatic_onlineupdate')
+YAOU_SYSCFGFILE="/etc/sysconfig/automatic_online_update"
+if [ -f "$YAOU_SYSCFGFILE" ]; then
+  echo "* Disable YAST automatic online update."
+  sed -i 's/^ *AOU_ENABLE_CRONJOB.*/AOU_ENABLE_CRONJOB="false"/' "$YAOU_SYSCFGFILE"
+  for D in /etc/cron.*; do
+    test -L $D/opensuse.org-online_update && rm $D/opensuse.org-online_update
+  done
 fi
-sed -i '/^ACTIVATION_KEYS=/c\\ACTIVATION_KEYS=\$key' bootstrap.sh
-sh bootstrap.sh
-# end Red Hat management server registration
+#end if
+
+#if not $varExists('dont_disable_local_repos')
+echo "* Disable all repos not provided by SUSE Manager Server."
+zypper ms -d --all
+zypper ms -e --medium-type plugin
+zypper mr -d --all
+zypper mr -e --medium-type plugin
+#end if
+
+        ]]>
+    </source>
+</script>
+# end SUSE Manager registration

--- a/java/conf/cobbler/snippets/redhat_register_using_salt
+++ b/java/conf/cobbler/snippets/redhat_register_using_salt
@@ -1,0 +1,9 @@
+# begin Red Hat management server registration
+wget http://$redhat_management_server/pub/bootstrap/bootstrap.sh
+key=$redhat_management_key
+if [ -f /tmp/key ]; then
+    key=`cat /tmp/key`,\$key
+fi
+sed -i '/^ACTIVATION_KEYS=/c\\ACTIVATION_KEYS=\$key' bootstrap.sh
+sh bootstrap.sh
+# end Red Hat management server registration

--- a/java/conf/cobbler/snippets/redhat_register_using_salt
+++ b/java/conf/cobbler/snippets/redhat_register_using_salt
@@ -5,6 +5,10 @@
         <![CDATA[
 cat <<EOF >"/etc/salt/minion.d/susemanager.conf"
 master: $redhat_management_server
+server_id_use_crc: adler32
+enable_legacy_startup_events: False
+enable_fqdns_grains: False
+mine_enabled: False
 
 EOF
 #if $varExists('registration_key') or $varExists('redhat_management_key')

--- a/java/conf/cobbler/snippets/redhat_register_using_salt
+++ b/java/conf/cobbler/snippets/redhat_register_using_salt
@@ -1,8 +1,4 @@
 # begin SUSE Manager registration
-<script>
-    <filename>uyuni-minion.sh</filename>
-    <source>
-        <![CDATA[
 cat <<EOF >"/etc/salt/minion.d/susemanager.conf"
 master: $redhat_management_server
 server_id_use_crc: adler32
@@ -54,7 +50,4 @@ zypper mr -d --all
 zypper mr -e --medium-type plugin
 #end if
 
-        ]]>
-    </source>
-</script>
 # end SUSE Manager registration

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Use salt for registration for selected install types (bsc#1164836)
 - Added a new API end point to manage package state (bsc#1169520)
 - avoid multiple base channels when onboarding minions (bsc#1167871)
 - Remember settings after Service Pack Migration dry-run

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -543,6 +543,7 @@ install -m 644 conf/cobbler/snippets/keep_system_id  $RPM_BUILD_ROOT%{spacewalks
 install -m 644 conf/cobbler/snippets/post_reactivation_key  $RPM_BUILD_ROOT%{spacewalksnippetsdir}/post_reactivation_key
 install -m 644 conf/cobbler/snippets/post_delete_system  $RPM_BUILD_ROOT%{spacewalksnippetsdir}/post_delete_system
 install -m 644 conf/cobbler/snippets/redhat_register  $RPM_BUILD_ROOT%{spacewalksnippetsdir}/redhat_register
+install -m 644 conf/cobbler/snippets/redhat_register_using_salt    $RPM_BUILD_ROOT%{spacewalksnippetsdir}/redhat_register_using_salt
 install -m 644 conf/cobbler/snippets/minion_script    $RPM_BUILD_ROOT%{spacewalksnippetsdir}/minion_script
 install -m 644 conf/cobbler/snippets/sles_register    $RPM_BUILD_ROOT%{spacewalksnippetsdir}/sles_register
 install -m 644 conf/cobbler/snippets/sles_register_script $RPM_BUILD_ROOT%{spacewalksnippetsdir}/sles_register_script
@@ -746,6 +747,7 @@ chown tomcat:%{apache_group} /var/log/rhn/gatherer.log
 %config %{spacewalksnippetsdir}/post_reactivation_key
 %config %{spacewalksnippetsdir}/post_delete_system
 %config %{spacewalksnippetsdir}/redhat_register
+%config %{spacewalksnippetsdir}/redhat_register_using_salt
 %config %{spacewalksnippetsdir}/minion_script
 %config %{spacewalksnippetsdir}/sles_register
 %config %{spacewalksnippetsdir}/sles_register_script


### PR DESCRIPTION
## What does this PR change?

## Re-run a test
Port of https://github.com/SUSE/spacewalk/pull/11222
If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
