### PR TITLE
Handle custom info values in image profiles

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -23,6 +23,7 @@ import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
 
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
@@ -1389,6 +1390,10 @@ public class SaltServerActionService {
 
                         }
                         pillar.put("repo", repocontent);
+
+                        // Add custom info values
+                        pillar.put("customvalues", profile.getCustomDataValues().stream()
+                                .collect(toMap(v -> v.getKey().getLabel(), v -> v.getValue())));
                     });
 
                     profile.asKiwiProfile().ifPresent(kiwiProfile -> {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Pass image profile custom info values as Docker buildargs during image build
 - Fix activation keys request error in image import page (bsc#1170046)
 - Fix custom info values input in image profile edit form (bsc#1169773)
 - Add check for non-existing formulas when assigning formulas to a system/group

--- a/susemanager-utils/susemanager-sls/salt/images/docker.sls
+++ b/susemanager-utils/susemanager-sls/salt/images/docker.sls
@@ -19,6 +19,11 @@ mgr_buildimage:
     - buildargs:
         repo: "{{ pillar.get('repo') }}"
         cert: "{{ pillar.get('cert') }}"
+{%- if pillar.get('customvalues') is defined %}
+{%- for key, value in pillar.get('customvalues').items() %}
+        {{key}}: "{{value}}"
+{%- endfor %}
+{%- endif %}
     - require:
       - module: mgr_registries_login
 
@@ -45,6 +50,11 @@ mgr_buildimage:
     - buildargs:
         repo: "{{ pillar.get('repo') }}"
         cert: "{{ pillar.get('cert') }}"
+{%- if pillar.get('customvalues') is defined %}
+{%- for key, value in pillar.get('customvalues').items() %}
+        {{key}}: "{{value}}"
+{%- endfor %}
+{%- endif %}
     - require:
       - module: mgr_registries_login
 

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Pass image profile custom info values as Docker buildargs during image build
 - Cluster Awareness: Introduce generic SLS files for Cluster Management
   and CaaSP Cluster Provider custom Salt module.
 - Add virtual volume delete action


### PR DESCRIPTION
Pass image profile custom info values as buildargs to Docker build command.

Related: https://github.com/uyuni-project/uyuni/pull/2151

## Documentation
- https://github.com/uyuni-project/uyuni-docs/pull/238

## Test coverage
- No tests: not feasible

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"  
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
