### PR TITLE
Reposync speedup part 3

### DIFF
--- a/backend/satellite_tools/contentRemove.py
+++ b/backend/satellite_tools/contentRemove.py
@@ -483,11 +483,7 @@ def _delete_srpms(srcPackageIds):
         from rhnPackageSource
         where id = :id
     """)
-    count = h.executemany(id=srcPackageIds)
-    if not count:
-        count = 0
-    log_debug(2, "Successfully deleted %s/%s source package ids" % (
-        count, len(srcPackageIds)))
+    h.executemany(id=srcPackageIds)
 
 
 def _delete_rpms(packageIds):
@@ -532,15 +528,10 @@ def _delete_rpm_group(packageIds):
     deleteStatement = "delete from %s where package_id = :package_id"
     for table in references:
         h = rhnSQL.prepare(deleteStatement % table)
-        count = h.executemany(package_id=packageIds)
-        log_debug(3, "Deleted from %s: %d rows" % (table, count))
+        h.executemany(package_id=packageIds)
     deleteStatement = "delete from rhnPackage where id = :package_id"
     h = rhnSQL.prepare(deleteStatement)
-    count = h.executemany(package_id=packageIds)
-    if count:
-        log_debug(2, "DELETED package id %s" % str(packageIds))
-    else:
-        log_error("No such package id %s" % str(packageIds))
+    h.executemany(package_id=packageIds)
     rhnSQL.commit()
 
 

--- a/backend/server/action_extra_data/configfiles.py
+++ b/backend/server/action_extra_data/configfiles.py
@@ -54,7 +54,7 @@ def upload(server_id, action_id, data={}):
 
     failure_table = rhnSQL.Table('rhnConfigFileFailure', 'label')
     h = rhnSQL.prepare(_query_mark_upload_files)
-    # We don't do execute_bulk here, since we want to know if each update has
+    # We don't do executemany here, since we want to know if each update has
     # actually touched a row
 
     reason_map = {'missing_files': 'missing',
@@ -124,7 +124,7 @@ def mtime_upload(server_id, action_id, data={}):
     num_paths = len(paths)
 
     h = rhnSQL.prepare(_query_create_action_config_filename)
-    h.execute_bulk({
+    h.executemany(**{
         'action_id': [action_id] * num_paths,
         'server_id': [server_id] * num_paths,
         'path': paths,
@@ -227,7 +227,7 @@ def _mark_missing_diff_files(server_id, action_id, missing_files):
     failure_ids = [failure_id] * len(ids)
 
     h = rhnSQL.prepare(_query_mark_failed_diff_files)
-    h.execute_bulk({
+    h.executemany(**{
         'action_config_revision_id': ids,
         'failure_id': failure_ids,
     })
@@ -307,4 +307,4 @@ def _disable_old_diffs(server_id):
         return
 
     h = rhnSQL.prepare(_query_delete_old_diffs)
-    h.execute_bulk({'action_config_revision_id': old_acr_ids})
+    h.executemany(**{'action_config_revision_id': old_acr_ids})

--- a/backend/server/action_extra_data/packages.py
+++ b/backend/server/action_extra_data/packages.py
@@ -407,7 +407,7 @@ def _mark_dep_failures(server_id, action_id, data):
 
     h = rhnSQL.prepare(_query_insert_dep_failures)
 
-    h.execute_bulk(inserts)
+    h.executemany(**inserts)
 
 
 def _check_dep(server_id, action_id, failed_dep):

--- a/backend/server/action_extra_data/packages.py
+++ b/backend/server/action_extra_data/packages.py
@@ -407,8 +407,7 @@ def _mark_dep_failures(server_id, action_id, data):
 
     h = rhnSQL.prepare(_query_insert_dep_failures)
 
-    rowcount = h.execute_bulk(inserts)
-    log_debug(5, "Inserted rows", rowcount)
+    h.execute_bulk(inserts)
 
 
 def _check_dep(server_id, action_id, failed_dep):

--- a/backend/server/action_extra_data/scap.py
+++ b/backend/server/action_extra_data/scap.py
@@ -116,9 +116,7 @@ def _create_rresult(testresult_id, result_label):
 
 def _store_idents(data):
     h = rhnSQL.prepare(_query_insert_identmap)
-    rowcount = h.execute_bulk(data)
-    log_debug(5, "Inserted xccdf_ruleresults rows:", rowcount)
-
+    h.execute_bulk(data)
 
 def _get_text(node):
     rc = []

--- a/backend/server/action_extra_data/scap.py
+++ b/backend/server/action_extra_data/scap.py
@@ -116,7 +116,7 @@ def _create_rresult(testresult_id, result_label):
 
 def _store_idents(data):
     h = rhnSQL.prepare(_query_insert_identmap)
-    h.execute_bulk(data)
+    h.executemany(**data)
 
 def _get_text(node):
     rc = []

--- a/backend/server/importlib/backendLib.py
+++ b/backend/server/importlib/backendLib.py
@@ -464,7 +464,6 @@ def executeStatement(statement, valuesHash, chunksize):
     if not valuesHash:
         # Empty hash
         return
-    count = 0
     while 1:
         tempdict = {}
         for k, vals in list(valuesHash.items()):
@@ -481,10 +480,9 @@ def executeStatement(statement, valuesHash, chunksize):
             break
         # Now execute it
         if chunksize > 1:
-            count += statement.executemany(**tempdict)
+            statement.executemany(**tempdict)
         else:
-            count += statement.execute(**tempdict)
-    return count
+            statement.execute(**tempdict)
 
 
 def sanitizeValue(value, datatype):

--- a/backend/server/rhnSQL/driver_postgresql.py
+++ b/backend/server/rhnSQL/driver_postgresql.py
@@ -348,8 +348,6 @@ class Cursor(sql_base.Cursor):
 
         self._real_cursor.executemany(self.sql, all_kwargs)
         self.description = self._real_cursor.description
-        rowcount = self._real_cursor.rowcount
-        return rowcount
 
     def _execute_values(self, sql, argslist, template=None, page_size=1000, fetch=True):
         results = psycopg2.extras.execute_values(self._real_cursor, sql, argslist, template=template, page_size=page_size, fetch=fetch)

--- a/backend/server/rhnSQL/driver_postgresql.py
+++ b/backend/server/rhnSQL/driver_postgresql.py
@@ -346,7 +346,7 @@ class Cursor(sql_base.Cursor):
                 all_kwargs[i][key] = val
                 i = i + 1
 
-        self._real_cursor.executemany(self.sql, all_kwargs)
+        psycopg2.extras.execute_batch(self._real_cursor, self.sql, all_kwargs)
         self.description = self._real_cursor.description
 
     def _execute_values(self, sql, argslist, template=None, page_size=1000, fetch=True):

--- a/backend/server/rhnSQL/sql_base.py
+++ b/backend/server/rhnSQL/sql_base.py
@@ -165,34 +165,6 @@ class Cursor:
         """
         return self._execute_wrapper(self._execute_values, sql, argslist, template, page_size, fetch)
 
-    def execute_bulk(self, dict, chunk_size=100):
-        """
-        Uses executemany but chops the incoming dict into chunks for each
-        call.
-
-        When attempting to execute bulk operations with a lot of rows in the
-        arrays,
-        Oracle may occasionally lock (probably the oracle client library).
-        I noticed this previously with the import code. -- misa
-        This function executes bulk operations in smaller chunks
-        dict is supposed to be the dictionary that we normally apply to
-        statement.execute.
-        """
-        start_chunk = 0
-        while 1:
-            subdict = {}
-            for k, arr in list(dict.items()):
-                subarr = arr[start_chunk:start_chunk + chunk_size]
-                if not subarr:
-                    # Nothing more to do here - we exhausted the array(s)
-                    return
-                subdict[k] = subarr
-            self.executemany(**subdict)
-            start_chunk = start_chunk + chunk_size
-
-        # Should never reach this point
-
-
     def _execute_wrapper(self, function, *p, **kw):
         """
         Database specific execute wrapper. Mostly used just to catch DB

--- a/backend/server/rhnSQL/sql_base.py
+++ b/backend/server/rhnSQL/sql_base.py
@@ -156,7 +156,7 @@ class Cursor:
         Call with keyword arguments mapping to ordered lists.
         i.e. cursor.executemany(id=[1, 2], name=["Bill", "Mary"])
         """
-        return self._execute_wrapper(self._executemany, *p, **kw)
+        self._execute_wrapper(self._executemany, *p, **kw)
 
     def execute_values(self, sql, argslist, template=None, page_size=1000, fetch=True):
         """
@@ -178,7 +178,6 @@ class Cursor:
         dict is supposed to be the dictionary that we normally apply to
         statement.execute.
         """
-        ret = 0
         start_chunk = 0
         while 1:
             subdict = {}
@@ -186,13 +185,13 @@ class Cursor:
                 subarr = arr[start_chunk:start_chunk + chunk_size]
                 if not subarr:
                     # Nothing more to do here - we exhausted the array(s)
-                    return ret
+                    return
                 subdict[k] = subarr
-            ret = ret + self.executemany(**subdict)
+            self.executemany(**subdict)
             start_chunk = start_chunk + chunk_size
 
         # Should never reach this point
-        return ret
+
 
     def _execute_wrapper(self, function, *p, **kw):
         """

--- a/backend/server/rhnServer/server_hardware.py
+++ b/backend/server/rhnServer/server_hardware.py
@@ -527,7 +527,7 @@ class NetIfaceInformation(Device):
         columns.sort()
         bind_params = ", ".join([':' + x for x in columns])
         h = rhnSQL.prepare(q % (", ".join(columns), bind_params))
-        return _dml(h, params)
+        _dml(h, params)
 
     def _delete(self, params):
         q = """delete from rhnServerNetInterface
@@ -536,7 +536,7 @@ class NetIfaceInformation(Device):
         columns = ['server_id', 'name']
         wheres = ['%s = :%s' % (x, x) for x in columns]
         h = rhnSQL.prepare(q % " and ".join(wheres))
-        return _dml(h, params)
+        _dml(h, params)
 
     def _update(self, params):
         q = """update rhnServerNetInterface
@@ -554,7 +554,7 @@ class NetIfaceInformation(Device):
         updates = ", ".join(updates)
 
         h = rhnSQL.prepare(q % (updates, wheres))
-        return _dml(h, params)
+        _dml(h, params)
 
     def reload(self, server_id):
         h = rhnSQL.prepare("""
@@ -694,7 +694,7 @@ class NetIfaceAddress(Device):
         columns.sort()
         bind_params = ", ".join([':' + x for x in columns])
         h = rhnSQL.prepare(q % (self.table, ", ".join(columns), bind_params))
-        return _dml(h, params)
+        _dml(h, params)
 
     def _delete(self, params):
         q = """delete from %s
@@ -703,7 +703,7 @@ class NetIfaceAddress(Device):
         columns = self.unique
         wheres = ['%s = :%s' % (x, x) for x in columns]
         h = rhnSQL.prepare(q % (self.table, " and ".join(wheres)))
-        return _dml(h, params)
+        _dml(h, params)
 
     def _update(self, params):
         q = """update %s
@@ -721,7 +721,7 @@ class NetIfaceAddress(Device):
         updates = ", ".join(updates)
 
         h = rhnSQL.prepare(q % (self.table, updates, wheres))
-        return _dml(h, params)
+        _dml(h, params)
 
     def reload(self, interface_id):
         h = rhnSQL.prepare("""
@@ -796,10 +796,7 @@ def _dml(statement, params):
     if not params:
         return 0
     params = _transpose(params)
-    rowcount = statement.executemany(**params)
-    log_debug(5, "Affected rows", rowcount)
-    return rowcount
-
+    statement.executemany(**params)
 
 def _transpose(hasharr):
     """ Transpose the array of hashes into a hash of arrays """

--- a/backend/server/rhnServer/server_kickstart.py
+++ b/backend/server/rhnServer/server_kickstart.py
@@ -672,7 +672,7 @@ def terminate_kickstart_sessions(server_id):
     }
     # Terminate pending actions
     log_debug(4, "Terminating sessions", params)
-    h.execute_bulk(params)
+    h.executemany(**params)
 
     # Invalidate pending actions
     for action_id in action_ids:

--- a/backend/server/rhnServer/server_packages.py
+++ b/backend/server/rhnServer/server_packages.py
@@ -195,7 +195,7 @@ class Packages:
             and ((:package_arch_id is null and package_arch_id is null)
                 or package_arch_id = :package_arch_id)
             """)
-            h.execute_bulk({
+            h.executemany(**{
                 'sysid': [sysid] * len(dlist),
                 'name_id': [a.name_id for a in dlist],
                 'evr_id': [a.evr_id for a in dlist],
@@ -232,7 +232,7 @@ class Packages:
                 'instime': [self.__expand_installtime(a.installtime) for a in alist],
             }
             try:
-                h.execute_bulk(package_data)
+                h.executemany(**package_data)
                 rhnSQL.commit()
             except rhnSQL.SQLSchemaError:
                 e = sys.exc_info()[1]

--- a/backend/server/rhnServer/server_token.py
+++ b/backend/server/rhnServer/server_token.py
@@ -319,7 +319,7 @@ def deploy_configs_if_needed(server):
     log_debug(4, "scheduled activation key config deploy")
 
     h = rhnSQL.prepare(_query_add_revision_to_action)
-    # XXX should use executemany() or execute_bulk
+    # XXX should use executemany()
     for revision_id in list(revisions.values()):
         log_debug(5, action_id, revision_id)
         h.execute(server_id=server_id,
@@ -413,7 +413,7 @@ def token_config_channels(server, tokens_obj):
     if config_channels:
         h = rhnSQL.prepare(_query_set_server_config_channels)
 
-        h.execute_bulk({
+        h.executemany(**{
             'server_id': [server_id] * len(config_channels),
             'config_channel_id': [c['config_channel_id'] for c in config_channels],
             'position': [c['position'] for c in config_channels],

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,4 +1,4 @@
-- reposync speedup fixes
+- reposync speedup fixes, which require psycopg2 to be at least version 2.8.4
 - use default sender address from web namespace
 - Enable extra HTTP headers support for "spacewalk-repo-sync".
 - Add missing Zypper plugin to deal with ULN repositories.

--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -101,7 +101,7 @@ the Spacewalk backend modules.
 %package sql-postgresql
 Summary:        Postgresql backend for Spacewalk
 Group:          System/Management
-Requires:       python3-psycopg2 >= 2.0.14-2
+Requires:       python3-psycopg2 >= 2.8.4
 Provides:       %{name}-sql-virtual = %{version}-%{release}
 
 %description sql-postgresql

--- a/backend/test/non-unit/server/rhnSQL/dbtests.py
+++ b/backend/test/non-unit/server/rhnSQL/dbtests.py
@@ -127,7 +127,7 @@ class RhnSQLDatabaseTests(unittest.TestCase):
             'id': ids,
             'name': names,
         }
-        cursor.execute_bulk(d)
+        cursor.executemany(**d)
 
         query = rhnSQL.prepare("SELECT * FROM %s WHERE id >= 1000 ORDER BY ID"
                                % self.temp_table)


### PR DESCRIPTION
## What does this PR change?

It replaces the existing mechanism in `spacewalk-repo-sync` to insert "non-special" per-package table rows (anything other than capabilities, changelogs and checksums) with a more efficient one.

**Total speedup is ~140%**, individual contributions from relevant commits as measured in my setup (syncing `sles11-sp4-updates-x86_64` from a local mirror, robustly transferable to other channels) follow:

| Commit                                                             | Speedup |
|--------------------------------------------------------------------|---------|
| reposync speedup: use execute_values for INSERTS of generic tables | 77.58%  |
| reposync speedup: use fast execution helper in executemany         | 64.02%  |

## Change details

Insert batches before this patch used the `executemany` method from `psycopg2`, which is notoriously slow, and this PR refactors code to use the faster `execute_values` and `execute_batch` instead. Per the library documentation:

> The current implementation of executemany() is (using an extremely charitable understatement) not particularly performing. [The alternative execute_values and execute_batch methods] can be used to speed up the repeated execution of a statement against a set of parameters. By reducing the number of server roundtrips the performance can be orders of magnitude better than using executemany()."

Source: https://www.psycopg.org/docs/extras.html#fast-execution-helpers

## Dependencies

This change requires the latest psycopg2 library in order to work, and builds on top of #2157 for this reason.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal change only**
- [x] **DONE**

## Test coverage
- No tests: **Cucumber tests to be implemented after reposync is fast enough**

- [x] **DONE**

## Links

Fixes partially https://github.com/SUSE/spacewalk/issues/9275
- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
