### PR TITLE
Reposync speedup part 4

### DIFF
--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -71,7 +71,7 @@ default_log_location = '/var/log/rhn/'
 relative_comps_dir = 'rhn/comps'
 relative_modules_dir = 'rhn/modules'
 checksum_cache_filename = 'reposync/checksum_cache'
-default_import_batch_size = 50
+default_import_batch_size = 20
 
 errata_typemap = {
     'security': 'Security Advisory',

--- a/backend/server/rhnSQL/__init__.py
+++ b/backend/server/rhnSQL/__init__.py
@@ -129,7 +129,7 @@ def initDB(backend=None, host=None, port=None, username=None,
 # close the database
 
 
-def closeDB():
+def closeDB(committing=True, closing=True):
     global __DB
     try:
         my_db = __DB
@@ -137,8 +137,10 @@ def closeDB():
         return
     else:
         del my_db
-    __DB.commit()
-    __DB.close()
+    if committing:
+        __DB.commit()
+    if closing:
+        __DB.close()
     del __DB
     return
 

--- a/backend/server/rhnSQL/driver_postgresql.py
+++ b/backend/server/rhnSQL/driver_postgresql.py
@@ -306,7 +306,7 @@ class Cursor(sql_base.Cursor):
             raise sql_base.SQLSchemaError(error_code, e.pgerror, e)
         except psycopg2.ProgrammingError:
             e = sys.exc_info()[1]
-            raise sql_base.SQLStatementPrepareError(self.dbh, e.pgerror, self.sql)
+            raise sql_base.SQLStatementPrepareError(str(self.dbh), e.pgerror, self.sql)
         except KeyError:
             e = sys.exc_info()[1]
             raise sql_base.SQLError("Unable to bound the following variable(s): %s"


### PR DESCRIPTION
## What does this PR change?

It makes most of the CPU-bound code in `spacewalk-repo-sync` to run in multiple parallel processes. This allows to avoid the GIL and use multiple Postgres processes for the bulk of insertions, considerably speeding up the process.

**Speedup is ~325%**, bringing the total speedup of the four PRs (#2154, #2157, #2162 and this) to **more than 6x** in my setup (syncing `sles11-sp4-updates-x86_64` from a local mirror, robustly transferable to other channels). I tested with 6 vCPUs at most, adding more is expected to make numbers even better.

This also makes `spacewalk-repo-sync` consume more memory - the more vCPUs, the more the consumed memory. In my tests, it could take up to 6 GiB extra memory compared with current `master`.

## Change details

Implementation uses `multiprocessing.Pool` to dispatch function calls on multiple processes. Each process opens and closes its own Postgres connection for the duration of the processing of its batch of packages.

Parameters and return values are automatically pickled and unpickled, with the limitation that native objects (such as native connections) cannot cross the boundary. This had the side effect that the current progress bar implementation had to be dropped in favor of plain logging.

The degree of parallelism (number of processes) is auto-tuned on the number of available CPUs (according to my tests, two processes per CPU are sufficient to keep them busy).

Initially, many deadlocks were observed, but they all solved by INSERTing rows in a definite order across processes. I tested the resulting code extensively and believe none are left.

One additional mechanism was added to distribute different "varieties" of packages to all processes, to avoid the situation where one process is completely hogged by the heaviest ones (eg. kernel) and others are relatively less busy with simpler ones. Given alphabetically-ordered packages usually pack packages with the same name in order, the algorithm picks at equal "distances" from the list (see last commit).

Best reviewed commit-by-commit.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal change only**
- [x] **DONE**

## Test coverage
- No tests: **Cucumber tests to be implemented after reposync is fast enough**

- [x] **DONE**

## Links

Fixes partially https://github.com/SUSE/spacewalk/issues/9275
- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
