### PR TITLE
Pass primary minion ip to the salt runner

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -1268,7 +1268,7 @@ public class SaltService implements SystemQuery, SaltApi {
     public Optional<MgrUtilRunner.ExecResult> collectKiwiImage(MinionServer minion, String filepath,
             String imageStore) {
         RunnerCall<MgrUtilRunner.ExecResult> call =
-                MgrKiwiImageRunner.collectImage(minion.getMinionId(), filepath, imageStore);
+                MgrKiwiImageRunner.collectImage(minion.getMinionId(), minion.getIpAddress(), filepath, imageStore);
         return callSync(call);
     }
 }

--- a/java/code/src/com/suse/manager/webui/services/impl/runner/MgrKiwiImageRunner.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/runner/MgrKiwiImageRunner.java
@@ -33,15 +33,17 @@ public class MgrKiwiImageRunner {
     /**
      * Upload built Kiwi image to SUSE Manager
      *
-     * @param minionId the minion ID (hostname)
+     * @param minionId the minion ID
+     * @param minionIP the minion IP address
      * @param filepath      the filepath
      * @param imageStoreDir the image store location
      * @return the execution result
      */
-    public static RunnerCall<MgrUtilRunner.ExecResult> collectImage(String minionId, String filepath,
-            String imageStoreDir) {
+    public static RunnerCall<MgrUtilRunner.ExecResult> collectImage(String minionId, String minionIP,
+            String filepath, String imageStoreDir) {
         Map<String, Object> args = new LinkedHashMap<>();
         args.put("minion", minionId);
+        args.put("minion_ip", minionIP);
         args.put("filepath", filepath);
         args.put("image_store_dir", imageStoreDir);
 

--- a/java/code/src/com/suse/manager/webui/services/impl/runner/MgrUtilRunner.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/runner/MgrUtilRunner.java
@@ -35,7 +35,7 @@ public class MgrUtilRunner {
      */
     public static class ExecResult {
 
-        @SerializedName("returncode")
+        @SerializedName("retcode")
         private int returnCode;
         @SerializedName("stdout")
         private String stdout;

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Pass minion ip to the kiwi_collect_image runner as fallback instead
+  of fqdn if not present (bsc#1170737)
 - Fix software channel list coloring
 - apply highstate when add-on system types should be applied to the
   system on bootstrapping (bsc#1172190)

--- a/susemanager-utils/susemanager-sls/modules/runners/kiwi-image-collect.py
+++ b/susemanager-utils/susemanager-sls/modules/runners/kiwi-image-collect.py
@@ -1,37 +1,36 @@
 # SUSE Manager
-# Copyright (c) 2018,2019 SUSE LLC
+# Copyright (c) 2018--2020 SUSE LLC
 
 # runner to collect image from build host
 
 import os
-import salt.exceptions
 import logging
 
 log = logging.getLogger(__name__)
 
-def upload_file_from_minion(minion, filetoupload, targetdir):
-    src = 'root@' + minion + ':' + filetoupload
-    result = __salt__['salt.cmd'](
+def upload_file_from_minion(minion, minion_ip, filetoupload, targetdir):
+    fqdn = __salt__['cache.grains'](tgt=minion).get(minion, {}).get('fqdn')
+    log.info('Collecting image "{}" from minion {} (FQDN: {}, IP: {})'.format(filetoupload, minion, fqdn, minion_ip))
+    if not fqdn or fqdn == 'localhost':
+        fqdn = minion_ip
+    src = 'root@{}:{}'.format(fqdn, filetoupload)
+    return __salt__['salt.cmd'](
       'rsync.rsync',
       src, targetdir,
       rsh='ssh -o IdentityFile=/srv/susemanager/salt/salt_ssh/mgr_ssh_id -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
     )
-    if result['retcode'] != 0:
-      raise ConnectionError('Failed to transfer image from minion {}: {}'.format(minion, result['stderr']))
-    return result
 
 def move_file_from_minion_cache(minion, filetomove, targetdir):
     src = os.path.join(__opts__['cachedir'], 'minions', minion, 'files', filetomove.lstrip('/'))
+    log.info('Collecting image from minion cache "{}"'.format(src))
     # file.move throws an exception in case of error
-    return __salt__['salt.cmd']('file.move', src, targetdir);
+    return __salt__['salt.cmd']('file.move', src, targetdir)
 
-def kiwi_collect_image(minion, filepath, image_store_dir):
+def kiwi_collect_image(minion, minion_ip, filepath, image_store_dir):
     __salt__['salt.cmd']('file.mkdir', image_store_dir)
 
-    pillars = list(__salt__['cache.pillar'](tgt=minion).values())[0]
-    if pillars.get('use_salt_transport'):
-      log.info('Collecting image "{}" from minion cache'.format(filepath))
-      return move_file_from_minion_cache(minion, filepath, image_store_dir)
+    use_salt_transport = __salt__['cache.pillar'](tgt=minion).get(minion, {}).get('use_salt_transport')
+    if use_salt_transport:
+        return move_file_from_minion_cache(minion, filepath, image_store_dir)
 
-    log.info('Collecting image "{}" from minion using rsync'.format(filepath))
-    return upload_file_from_minion(minion, filepath, image_store_dir)
+    return upload_file_from_minion(minion, minion_ip, filepath, image_store_dir)

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,6 @@
+- Use minion fqdn instead of minion id as target in kiwi_collect_image
+  runner. If fqdn is not present or is localhost, use minion ip as
+  fallback (bsc#1170737)
 - trust customer gpg key when metadata signing is enabled
 - specify gpg key for RH systems in repo file (bsc#1172286)
 - Implement CaaSP cluster upgrade procedure in cluster provider module.


### PR DESCRIPTION
## What does this PR change?

collectKiwiImage wrongly assumed that minion id is the same as minion hostname. Now ask grains for primary fqdn.
To support scenarios where DNS system may not be configured, collectKiwiImage runner needs reachable IP address for rsync. Instead of parsing and evaluating all IPs from grains, rely on primary IP address passed from database.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: not user facing change

- [X] **DONE**

## Test coverage
- Unit tests already cowered.
- Cucumber tests Basic functionality already cowered.

- [X] **DONE**

## Links

Fixes bsc#1170737
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
