### PR TITLE
Install kickstart package only in case of traditional systems

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartData.java
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartData.java
@@ -102,6 +102,8 @@ public class KickstartData {
         {"partitions", "raids", "logvols", "volgroups", "include",
         "repo", "custom", "custom_partition"};
 
+    private final String DEFAULT_KICKSTART_PACKAGE_FOR_TRADITIONAL = "spacewalk-koan";
+
     private static final List<String> ADANCED_OPTIONS = Arrays.asList(advancedOptions);
 
     /**
@@ -1313,6 +1315,15 @@ public class KickstartData {
         return ConfigDefaults.get().getKickstartPackageNames();
 
     }
+
+    /**
+     * Get the kickstart package name for the traditional type system('management' entitlement)
+     * @return the kickstart package name for the traditional type system
+     */
+    public String getKickstartPackageNameForTraditional() {
+        return DEFAULT_KICKSTART_PACKAGE_FOR_TRADITIONAL;
+    }
+
 
     /**
      * @return Returns if the post scripts should be logged.

--- a/java/code/src/com/redhat/rhn/manager/kickstart/KickstartScheduleCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/KickstartScheduleCommand.java
@@ -1103,9 +1103,8 @@ public class KickstartScheduleCommand extends BaseSystemOperation {
     }
 
     /**
-     * Looks for the package name among the specified channels and, if it is found,
-     * it returns the highest available version in Map form.
-     *
+     * Looks for the kickstart package name for the traditional system ('management' entitlement) among the
+     * specified channels and, if it is found, it returns the highest available version in Map form.
      * @param channelIds channels the server could be subscribed to
      * @return a ValidationError or null
      */
@@ -1113,9 +1112,9 @@ public class KickstartScheduleCommand extends BaseSystemOperation {
         List<Map<String, Long>> results = new LinkedList<Map<String, Long>>();
 
         for (Long chnnelId : channelIds) {
-            log.debug("    Checking on:" + chnnelId + " for: " + getKickstartPackageNames());
+            log.debug("    Checking on:" + chnnelId + " for: " + this.ksdata.getKickstartPackageNameForTraditional());
             List<Map<String, Object>> packages = ChannelManager.listLatestPackagesEqual(
-                    chnnelId, getKickstartPackageNames());
+                    chnnelId, this.ksdata.getKickstartPackageNameForTraditional());
             log.debug("    size: " + packages.size());
 
             for (Map<String, Object> aPackage : packages) {


### PR DESCRIPTION
## What does this PR change?

In the case of salt-minion, there is no need to install any package. For the traditional system, only look for spacewalk-koan package for installation.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bugfix
- [x] **DONE**

## Test coverage
- No tests: **add explanation**

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

- [ ] Re-run test "java_lint_checkstyle" 