### PR TITLE
Manager bsc1170684

### DIFF
--- a/uyuni/common-libs/uyuni-common-libs.changes
+++ b/uyuni/common-libs/uyuni-common-libs.changes
@@ -1,3 +1,4 @@
+- uyuni-common-libs obsoletes python3-spacewalk-usix (bsc#1170684)
 - reposync speedup fixes
 
 -------------------------------------------------------------------

--- a/uyuni/common-libs/uyuni-common-libs.changes
+++ b/uyuni/common-libs/uyuni-common-libs.changes
@@ -1,4 +1,5 @@
-- uyuni-common-libs obsoletes python3-spacewalk-usix (bsc#1170684)
+- uyuni-common-libs obsoletes python3-spacewalk-usix and
+  python3-spacewalk-backend-libs (bsc#1170684)
 - reposync speedup fixes
 
 -------------------------------------------------------------------

--- a/uyuni/common-libs/uyuni-common-libs.spec
+++ b/uyuni/common-libs/uyuni-common-libs.spec
@@ -83,6 +83,7 @@ Requires:       python3-libs
 %endif
 
 Obsoletes:      python3-spacewalk-usix
+Obsoletes:      python3-spacewalk-backend-libs
 
 %description -n python3-%{name}
 Python 3 libraries required by both Uyuni server and client tools.

--- a/uyuni/common-libs/uyuni-common-libs.spec
+++ b/uyuni/common-libs/uyuni-common-libs.spec
@@ -82,6 +82,7 @@ Requires:       python3-base
 Requires:       python3-libs
 %endif
 
+Obsoletes:      python3-spacewalk-usix
 
 %description -n python3-%{name}
 Python 3 libraries required by both Uyuni server and client tools.


### PR DESCRIPTION
## What does this PR change?

uyuni-common-libs needs to obsolete python3-spacewalk-usix or migrations from 4.0.x to 4.1 will fail:

Detected 1 file conflict:
File /usr/lib/python3.6/site-packages/spacewalk/common/__init__.py
  from install of
     spacewalk-backend-4.1.7-3.33.8.noarch (SLE-Module-SUSE-Manager-Server-4.1-Pool)
  conflicts with file from package
     python3-spacewalk-usix-4.0.9-1.2.noarch (@System)

File conflicts happen when two packages attempt to install files with the same name but different contents. If you continue, conflicting files will be replaced losing the previous content.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: bugfix

- [X] **DONE**

## Test coverage
- No tests: No automatic migration testing

- [X] **DONE**

## Links

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1170684

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
