### PR TITLE
Virtualization pool actions schema upgrade scripts fix

### DIFF
--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- fix the place for the virtualization pool actions schema upgrade scripts
 - added an index to improve reposync performance
 - Update schema for virtual volume delete action
 

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.6-to-susemanager-schema-4.1.7/001-add_virt_pool_actions_rhnActionType.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.6-to-susemanager-schema-4.1.7/001-add_virt_pool_actions_rhnActionType.sql
@@ -13,6 +13,36 @@
 --
 
 insert into rhnActionType (id, label, name, trigger_snapshot, unlocked_only) (
+    select 509, 'virt.pool_refresh', 'Refresh a virtual storage pool', 'N', 'N'
+    from dual
+    where not exists (select 1 from rhnActionType where id = 509)
+);
+
+insert into rhnActionType (id, label, name, trigger_snapshot, unlocked_only) (
+    select 510, 'virt.pool_start', 'Starts a virtual storage pool', 'N', 'N'
+    from dual
+    where not exists (select 1 from rhnActionType where id = 510)
+);
+
+insert into rhnActionType (id, label, name, trigger_snapshot, unlocked_only) (
+    select 511, 'virt.pool_stop', 'Stops a virtual storage pool', 'N', 'N'
+    from dual
+    where not exists (select 1 from rhnActionType where id = 511)
+);
+
+insert into rhnActionType (id, label, name, trigger_snapshot, unlocked_only) (
+    select 512, 'virt.pool_delete', 'Deletes a virtual storage pool', 'N', 'N'
+    from dual
+    where not exists (select 1 from rhnActionType where id = 512)
+);
+
+insert into rhnActionType (id, label, name, trigger_snapshot, unlocked_only) (
+    select 513, 'virt.pool_create', 'Creates a virtual storage pool', 'N', 'N'
+    from dual
+    where not exists (select 1 from rhnActionType where id = 513)
+);
+
+insert into rhnActionType (id, label, name, trigger_snapshot, unlocked_only) (
     select 514, 'virt.volume_delete', 'Deletes a virtual storage volume', 'N', 'N'
     from dual
     where not exists (select 1 from rhnActionType where id = 514)

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.6-to-susemanager-schema-4.1.7/002-rhnActionVirtPoolRefresh.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.6-to-susemanager-schema-4.1.7/002-rhnActionVirtPoolRefresh.sql
@@ -1,0 +1,29 @@
+-- Copyright (c) 2020 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+CREATE TABLE IF NOT EXISTS rhnActionVirtPoolRefresh
+(
+    action_id            NUMERIC NOT NULL
+                             CONSTRAINT rhn_action_virt_pool_refresh_aid_fk
+                                 REFERENCES rhnAction (id)
+                                 ON DELETE CASCADE
+                             CONSTRAINT rhn_action_virt_pool_refresh_aid_pk
+                                 PRIMARY KEY,
+    pool_name            VARCHAR(256)
+)
+;
+
+CREATE UNIQUE INDEX IF NOT EXISTS rhn_action_virt_pool_refresh_aid_uq
+    ON rhnActionVirtPoolRefresh (action_id);
+

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.6-to-susemanager-schema-4.1.7/003-rhnActionVirtPoolStart.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.6-to-susemanager-schema-4.1.7/003-rhnActionVirtPoolStart.sql
@@ -1,0 +1,29 @@
+-- Copyright (c) 2020 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+CREATE TABLE IF NOT EXISTS rhnActionVirtPoolStart
+(
+    action_id            NUMERIC NOT NULL
+                             CONSTRAINT rhn_action_virt_pool_start_aid_fk
+                                 REFERENCES rhnAction (id)
+                                 ON DELETE CASCADE
+                             CONSTRAINT rhn_action_virt_pool_start_aid_pk
+                                 PRIMARY KEY,
+    pool_name            VARCHAR(256)
+)
+;
+
+CREATE UNIQUE INDEX IF NOT EXISTS rhn_action_virt_pool_start_aid_uq
+    ON rhnActionVirtPoolStart (action_id);
+

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.6-to-susemanager-schema-4.1.7/004-rhnActionVirtPoolStop.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.6-to-susemanager-schema-4.1.7/004-rhnActionVirtPoolStop.sql
@@ -1,0 +1,29 @@
+-- Copyright (c) 2020 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+CREATE TABLE IF NOT EXISTS rhnActionVirtPoolStop
+(
+    action_id            NUMERIC NOT NULL
+                             CONSTRAINT rhn_action_virt_pool_stop_aid_fk
+                                 REFERENCES rhnAction (id)
+                                 ON DELETE CASCADE
+                             CONSTRAINT rhn_action_virt_pool_stop_aid_pk
+                                 PRIMARY KEY,
+    pool_name            VARCHAR(256)
+)
+;
+
+CREATE UNIQUE INDEX IF NOT EXISTS rhn_action_virt_pool_stop_aid_uq
+    ON rhnActionVirtPoolStop (action_id);
+

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.6-to-susemanager-schema-4.1.7/005-rhnActionVirtPoolDelete.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.6-to-susemanager-schema-4.1.7/005-rhnActionVirtPoolDelete.sql
@@ -1,0 +1,32 @@
+-- Copyright (c) 2020 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+CREATE TABLE IF NOT EXISTS rhnActionVirtPoolDelete
+(
+    action_id            NUMERIC NOT NULL
+                             CONSTRAINT rhn_action_virt_pool_delete_aid_fk
+                                 REFERENCES rhnAction (id)
+                                 ON DELETE CASCADE
+                             CONSTRAINT rhn_action_virt_pool_delete_aid_pk
+                                 PRIMARY KEY,
+    pool_name            VARCHAR(256),
+    purge                CHAR(1)
+                            DEFAULT ('Y') NOT NULL
+                            CONSTRAINT rhn_avpdelete_purge_ck
+                                CHECK (purge in ('Y','N'))
+)
+;
+
+CREATE UNIQUE INDEX IF NOT EXISTS rhn_action_virt_pool_delete_aid_uq
+    ON rhnActionVirtPoolDelete (action_id);

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.6-to-susemanager-schema-4.1.7/006-rhnActionVirtPoolCreate.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.6-to-susemanager-schema-4.1.7/006-rhnActionVirtPoolCreate.sql
@@ -1,0 +1,41 @@
+-- Copyright (c) 2020 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+CREATE TABLE IF NOT EXISTS rhnActionVirtPoolCreate
+(
+    action_id            NUMERIC NOT NULL
+                             CONSTRAINT rhn_action_virt_pool_create_aid_fk
+                                 REFERENCES rhnAction (id)
+                                 ON DELETE CASCADE
+                             CONSTRAINT rhn_action_virt_pool_create_aid_pk
+                                 PRIMARY KEY,
+    pool_name            VARCHAR(256),
+    uuid                 VARCHAR(128),
+    type                 VARCHAR(25),
+    target               VARCHAR(256),
+    autostart            CHAR(1)
+                            DEFAULT ('Y') NOT NULL
+                            CONSTRAINT rhn_avpcreate_autostart_ck
+                                CHECK (autostart in ('Y','N')),
+    permission_mode      VARCHAR(4),
+    permission_owner     VARCHAR(10),
+    permission_group     VARCHAR(10),
+    permission_seclabel  VARCHAR(256),
+    source               VARCHAR(2048)
+)
+;
+
+CREATE UNIQUE INDEX IF NOT EXISTS rhn_action_virt_pool_create_aid_uq
+    ON rhnActionVirtPoolCreate (action_id);
+


### PR DESCRIPTION
## What does this PR change?

The virtualization pool action schema upgrade scripts mistakenly went
into 4.1.4 to 4.1.5 folder instead of 4.1.5 to 4.1.6. Adding them to
the latest folder will at least get the next releases right.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed:  upgrade fix

- [X] **DONE**

## Test coverage
- No tests: upgrade fix

- [X] **DONE**

## Links

Fixes https://lists.opensuse.org/uyuni-users/2020-04/msg00043.html

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
