### PR TITLE
Manager bsc1168310

### DIFF
--- a/suseRegisterInfo/suseRegisterInfo.changes
+++ b/suseRegisterInfo/suseRegisterInfo.changes
@@ -1,3 +1,5 @@
+- suseRegisterInfo only needs perl-base, not full perl (bsc#1168310)
+
 -------------------------------------------------------------------
 Wed Nov 27 16:52:31 CET 2019 - jgonzalez@suse.com
 

--- a/suseRegisterInfo/suseRegisterInfo.spec
+++ b/suseRegisterInfo/suseRegisterInfo.spec
@@ -37,7 +37,7 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 %endif
 Requires:       %{pythonX}-%{name} = %{version}-%{release}
-Requires:       perl
+Requires:       perl-base
 %if  0%{?rhel} && 0%{?rhel} < 6
 Requires:       e2fsprogs
 %endif

--- a/suseRegisterInfo/suseRegisterInfo.spec
+++ b/suseRegisterInfo/suseRegisterInfo.spec
@@ -37,7 +37,11 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 %endif
 Requires:       %{pythonX}-%{name} = %{version}-%{release}
+%if 0%{?suse_version}
 Requires:       perl-base
+%else
+Requires:       perl
+%endif
 %if  0%{?rhel} && 0%{?rhel} < 6
 Requires:       e2fsprogs
 %endif


### PR DESCRIPTION
## What does this PR change?

Some minimal installations only have perl-base but not perl installed. Such systems cannot be bootstrapped as traditional clients when the OS media is not available because perl is not part of the bootstrap repos. Since suseRegisterInfo in fact only needs perl-base, relax the requirement.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: internal

- [X] **DONE**

## Test coverage
- No tests: Can only be triggered in very special scenarios

- [X] **DONE**

## Links

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1168310

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
