### PR TITLE
Manager bsc1169535

### DIFF
--- a/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.changes
+++ b/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.changes
@@ -1,3 +1,4 @@
+- ensure correct /etc/apache2/conf.d/susemanager-tftpsync-recv.conf after upgrade (bsc#1169535)
 - Do not produce 500 errors with empty and UTF files (bsc#1167265)
 
 -------------------------------------------------------------------

--- a/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.spec
+++ b/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.spec
@@ -70,6 +70,20 @@ if [ -d /srv/tftpboot ]; then
     chmod 750 /srv/tftpboot
     chown wwwrun:tftp /srv/tftpboot
 fi
+if [ -f /etc/apache2/conf.d/susemanager-tftpsync-recv.conf.rpmnew ]; then
+    PARENT_FQDN=$( egrep -m1 "^proxy.rhn_parent[[:space:]]*=" /etc/rhn/rhn.conf | sed 's/^proxy.rhn_parent[[:space:]]*=[[:space:]]*\(.*\)/\1/' || echo "" )
+    if [ -z "$PARENT_FQDN" ]; then
+            echo "Could not determine SUSE Manager Parent Hostname! Got /etc/rhn/rhn.conf vanished?" >&2;
+            exit 1;
+    fi;
+
+    SUMA_IP=$( host $PARENT_FQDN | awk '{ print $4 }' )
+
+    sed -i "s/^[[:space:]]*Allow from[[:space:]].*$/        Allow from $SUMA_IP/" /etc/apache2/conf.d/susemanager-tftpsync-recv.conf.rpmnew
+    sed -i "s/^[[:space:]#]*Require ip[[:space:]].*$/        Require ip $SUMA_IP/" /etc/apache2/conf.d/susemanager-tftpsync-recv.conf.rpmnew
+
+    mv /etc/apache2/conf.d/susemanager-tftpsync-recv.conf.rpmnew /etc/apache2/conf.d/susemanager-tftpsync-recv.conf
+fi
 
 %files
 %defattr(-,wwwrun,root,-)


### PR DESCRIPTION
## What does this PR change?

When a proxy gets migrated from 3.2 to 4.0, a new apache configuration file gets installed at /etc/apache2/conf.d/susemanager-tftpsync-recv.conf because the syntax has changed with the newer apache version. However this file is just a template that gets filled by configure-tftpsync.sh so the new template gets installed as /etc/apache2/conf.d/susemanager-tftpsync-recv.conf.rpmnew and apache will complain as it only finds the syntax of the old version. So we need to detect this condition and install and configure the new template during postinstall.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: Bugfix

- [X] **DONE**

## Test coverage
- No tests: Happens only when upgrading a proxy where tftpsync had already been configured

- [X] **DONE**

## Links

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1169535

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
