### PR TITLE
Testsuite: Remove workaround for bsc#1138952

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -861,7 +861,6 @@ Then(/^name resolution should work on terminal "([^"]*)"$/) do |host|
   end
 end
 
-# rubocop:disable Metrics/BlockLength
 When(/^I configure the proxy$/) do
   # prepare the settings file
   settings = "RHN_PARENT=#{$server.ip}\n" \
@@ -890,17 +889,8 @@ When(/^I configure the proxy$/) do
   filename = File.basename(path)
   cmd = "configure-proxy.sh --non-interactive --rhn-user=admin --rhn-password=admin --answer-file=#{filename}"
   proxy_timeout = 600
-  return_code = 0
-  # WORKAROUND bsc#1138952
-  # Wrap the shell command inside a begin block to catch the exception
-  begin
-    return_code = $proxy.run(cmd, true, proxy_timeout, 'root')
-  rescue StandardError => e
-    puts "Catched exception (see bsc#1138952): #{e}"
-    return_code
-  end
+  $proxy.run(cmd, true, proxy_timeout, 'root')
 end
-# rubocop:enable Metrics/BlockLength
 
 Then(/^The metadata buildtime from package "(.*?)" match the one in the rpm on "(.*?)"$/) do |pkg, host|
   # for testing buildtime of generated metadata - See bsc#1078056


### PR DESCRIPTION
## What does this PR change?
Remove a workaround for bsc#1138952 after this bug has been fixed.
## Links
### Ports
- Manager-4.0: https://github.com/SUSE/spacewalk/pull/11384
- Manager 3.2: https://github.com/SUSE/spacewalk/pull/11383


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
