### PR TITLE
Reposync bugfixes

### DIFF
--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -1059,7 +1059,7 @@ class RepoSync(object):
         to_process_batches = [[to_process[twisted_index] for twisted_index in twisted_batch] for twisted_batch in twisted_batch_indexes]
 
         affected_channels = []
-        with multiprocessing.Pool(processes=max(os.cpu_count() * 2, 32), maxtasksperchild=1) as pool:
+        with multiprocessing.Pool(processes=min(os.cpu_count() * 2, 32), maxtasksperchild=1) as pool:
             results = [pool.apply_async(self.import_package_batch, args=[to_process_batch, to_disassociate, is_non_local_repo, i, len(to_process_batches)])
                        for i, to_process_batch in enumerate(to_process_batches)]
 

--- a/backend/server/importlib/backend.py
+++ b/backend/server/importlib/backend.py
@@ -119,7 +119,8 @@ class Backend:
                   ORDER BY ordering
                 ON CONFLICT DO NOTHING
         """
-        wanted = [(i, key[0], None if key[1] == '' else key[1]) for i, key in enumerate(sorted(capabilityHash.keys()))]
+        sorted_capabilities = sorted(capabilityHash.keys(), key=lambda k:(k[0], k[1] or ''))
+        wanted = [(i, key[0], None if key[1] == '' else key[1]) for i, key in enumerate(sorted_capabilities)]
         h = self.dbmodule.prepare(sql)
         h.execute_values(sql, wanted, fetch=False)
 
@@ -668,7 +669,7 @@ class Backend:
     def lookupEVRs(self, evrHash):
         sql = "select LOOKUP_EVR(:epoch, :version, :release) id from dual"
         h = self.dbmodule.prepare(sql)
-        for evr in sorted(evrHash.keys(), key=lambda x: (x[0] if x[0] != '' else None, x[1], x[2])):
+        for evr in sorted(evrHash.keys(), key=lambda k: (str(k[0] or 0), k[1], k[2])):
             epoch, version, release = evr
             if epoch == '' or epoch is None:
                 epoch = None
@@ -702,7 +703,8 @@ class Backend:
                 ORDER BY ordering
               ON CONFLICT DO NOTHING
         """
-        values = [(i, key[0], key[1]) for i, key in enumerate(sorted(checksumHash.keys())) if key[1] != '']
+        sorted_checksums = sorted(checksumHash.keys(), key=lambda k:(k[0], k[1] or ''))
+        values = [(i, key[0], key[1]) for i, key in enumerate(sorted_checksums) if key[1] != '']
 
         if not values:
             return


### PR DESCRIPTION
## What does this PR change?

Bugfixes to regressions introduced by reposync speedups: #2154 #2157 #2162 #2164 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfixes**

- [x] **DONE**

## Test coverage
- No tests: **will be covered in upcoming integration tests**

- [x] **DONE**

## Links

See also #2154 #2157 #2162 #2164 

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed



## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
