### PR TITLE
Fix bootstrap repo md caching

### DIFF
--- a/proxy/installer/spacewalk-proxy-installer.changes
+++ b/proxy/installer/spacewalk-proxy-installer.changes
@@ -1,3 +1,5 @@
+- do not cache metadata of the bootstrap repositories (bsc#1171169)
+
 -------------------------------------------------------------------
 Mon Apr 13 09:34:15 CEST 2020 - jgonzalez@suse.com
 

--- a/proxy/installer/spacewalk-proxy-installer.spec
+++ b/proxy/installer/spacewalk-proxy-installer.spec
@@ -106,6 +106,9 @@ if [ -f /etc/sysconfig/apache2 ]; then
     sysconf_addword /etc/sysconfig/apache2 APACHE_MODULES proxy_http
 fi
 sed -i -e"s/^range_offset_limit -1 KB/range_offset_limit none/" /etc/squid/squid.conf
+if ! grep pub\/repositories /etc/squid/squid.conf >/dev/null; then
+    sed -i 's;\(refresh_pattern /rhn/manager/download.*\);\1\nrefresh_pattern /pub/repositories/.*/repodata/.*$ 0 1% 1440 ignore-no-cache reload-into-ims refresh-ims;' /etc/squid/squid.conf
+fi
 if [ -f %{apacheconfdir}/conf.d/cobbler-proxy.conf ]; then
     sed -i -e "s;download//cobbler_api;download/cobbler_api;g" %{apacheconfdir}/conf.d/cobbler-proxy.conf
 fi

--- a/proxy/installer/squid.conf
+++ b/proxy/installer/squid.conf
@@ -26,6 +26,8 @@ memory_replacement_policy heap GDSF
 refresh_pattern /XMLRPC/GET-REQ/.*/repodata/.*$ 0 1% 1440 ignore-no-cache reload-into-ims refresh-ims
 # salt minions get the repodata via a different URL
 refresh_pattern /rhn/manager/download/.*/repodata/.*$ 0 1% 1440 ignore-no-cache reload-into-ims refresh-ims
+# bootstrap repos needs to be handled as well
+refresh_pattern /pub/repositories/.*/repodata/.*$ 0 1% 1440 ignore-no-cache reload-into-ims refresh-ims
 # rpm will hardly ever change, force to cache it for very long time
 refresh_pattern  \.rpm$  10080 100% 525960 override-expire override-lastmod ignore-reload reload-into-ims
 refresh_pattern  \.deb$  10080 100% 525960 override-expire override-lastmod ignore-reload reload-into-ims


### PR DESCRIPTION
## What does this PR change?

A proxy should not cache the metadata. At least not for a long time.
We did this for repositories using traditional and salt download endpoints, but forgot
the bootstrap repositories.

This add a pattern to squid.conf which prevent caching of the metadata for a long time.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **manually**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11405
Tracks #

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
