### PR TITLE
XMLRPC: Assign/retract mantenance schedules to/from systems  

### DIFF
--- a/java/code/src/com/redhat/rhn/common/hibernate/HibernateFactory.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/HibernateFactory.java
@@ -436,8 +436,9 @@ public abstract class HibernateFactory {
      * @param obj to be reloaded
      * @return Object found if not, null
      * @throws HibernateException if something bad happens.
+     * @param <T> the entity type
      */
-    public static Object reload(Object obj) throws HibernateException {
+    public static <T> T reload(T obj) throws HibernateException {
         // assertNotNull(obj);
         ClassMetadata cmd = connectionManager.getMetadata(obj);
         Serializable id = cmd.getIdentifier(obj, (SessionImplementor) getSession());
@@ -452,7 +453,7 @@ public abstract class HibernateFactory {
          * session.get is set to not return the proxy class, so that is what we'll use.
          */
         // assertNotSame(obj, result);
-        return session.get(obj.getClass(), id);
+        return (T) session.get(obj.getClass(), id);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
@@ -317,7 +317,7 @@ public class ActionFactory extends HibernateFactory {
     public static boolean doesServerHaveKickstartScheduled(Long serverId) {
         Session session = HibernateFactory.getSession();
         Query query =
-                session.getNamedQuery("ServerAction.findPendingKickstartsForServer");
+                session.getNamedQuery("ServerAction.findPendingActionsForServer");
         query.setParameter("serverId", serverId);
         query.setParameter("label", "kickstart.initiate");
         List retval = query.list();
@@ -333,7 +333,7 @@ public class ActionFactory extends HibernateFactory {
     public static Action isMigrationScheduledForServer(Long serverId) {
         Action ret = null;
         Query query = HibernateFactory.getSession().getNamedQuery(
-                "ServerAction.findPendingKickstartsForServer");
+                "ServerAction.findPendingActionsForServer");
         query.setParameter("serverId", serverId);
         query.setParameter("label", "distupgrade.upgrade");
         List<ServerAction> list = query.list();

--- a/java/code/src/com/redhat/rhn/domain/action/server/ServerAction.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/server/ServerAction.hbm.xml
@@ -33,7 +33,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
             column="server_id" insert="false" update="false"/>
 
         </class>
-        <query name="ServerAction.findPendingKickstartsForServer">
+        <query name="ServerAction.findPendingActionsForServer">
            <![CDATA[from com.redhat.rhn.domain.action.server.ServerAction as sa where sa.server.id = :serverId and sa.parentAction.actionType.label = :label
                         and status in ( 0, 1 )]]>
         </query>

--- a/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
@@ -38,6 +38,8 @@ import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.rhnset.RhnSetDecl;
 import com.redhat.rhn.manager.system.UpdateBaseChannelCommand;
 
+import com.suse.manager.model.maintenance.MaintenanceSchedule;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.hibernate.Criteria;
@@ -1355,5 +1357,33 @@ public class ServerFactory extends HibernateFactory {
         params.put("orgId", orgId);
         return singleton.listObjectsByNamedQuery(
                 "Server.listOrgSystems", params);
+    }
+
+    /**
+     * Filter systems with pending maintenance-only actions
+     *
+     * @param systemIds the system IDs
+     * @return only the IDs if systems with pending maintenance-only actions
+     */
+    public static Set<Long> filterSystemsWithPendingMaintOnlyActions(Set<Long> systemIds) {
+        return new HashSet<>(HibernateFactory.getSession()
+                .getNamedQuery("Server.filterSystemsWithPendingMaintenanceOnlyActions")
+                .setParameter("systemIds", systemIds)
+                .list());
+    }
+
+    /**
+     * Assign the given {@link MaintenanceSchedule} to set of {@link Server}s
+     *
+     * @param schedule the {@link MaintenanceSchedule}
+     * @param systemIds the set of {@link Server} IDs
+     * @return number of involved {@link Server}s
+     */
+    public static int setMaintenanceScheduleToSystems(MaintenanceSchedule schedule, Set<Long> systemIds) {
+        return HibernateFactory.getSession()
+                .getNamedQuery("Server.setMaintenanceScheduleToSystems")
+                .setParameter("schedule", schedule)
+                .setParameter("systemIds", systemIds)
+                .executeUpdate();
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
@@ -576,4 +576,17 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         ]]>
     </sql-query>
 
+    <query name="Server.filterSystemsWithPendingMaintenanceOnlyActions">
+        <![CDATA[SELECT sa.server.id FROM ServerAction sa
+                        WHERE sa.server.id IN (:systemIds)
+                          AND sa.parentAction.actionType.maintenancemodeonly = true
+                          AND status in ( 0, 1 )]]>
+    </query>
+
+    <query name="Server.setMaintenanceScheduleToSystems">
+        <![CDATA[UPDATE Server s
+                    SET s.maintenanceSchedule = :schedule
+                  WHERE s.id IN (:systemIds)]]>
+    </query>
+
 </hibernate-mapping>

--- a/java/code/src/com/suse/manager/maintenance/RescheduleStrategy.java
+++ b/java/code/src/com/suse/manager/maintenance/RescheduleStrategy.java
@@ -40,5 +40,5 @@ public interface RescheduleStrategy {
      * @param schedule the schedule where the server actions needs to apply to
      * @return true on success, otherwise false
      */
-    public boolean reschedule(User user, Map<Action, List<Server>> actionServer, MaintenanceSchedule schedule);
+    boolean reschedule(User user, Map<Action, List<Server>> actionServer, MaintenanceSchedule schedule);
 }

--- a/java/code/src/com/suse/manager/maintenance/test/MaintenanceManagerTest.java
+++ b/java/code/src/com/suse/manager/maintenance/test/MaintenanceManagerTest.java
@@ -14,9 +14,21 @@
  */
 package com.suse.manager.maintenance.test;
 
+import static com.redhat.rhn.domain.role.RoleFactory.ORG_ADMIN;
+
+import com.redhat.rhn.common.security.PermissionException;
 import com.redhat.rhn.common.util.FileUtils;
+import com.redhat.rhn.domain.action.Action;
+import com.redhat.rhn.domain.action.ActionFactory;
+import com.redhat.rhn.domain.action.server.test.ServerActionTest;
+import com.redhat.rhn.domain.action.test.ActionFactoryTest;
+import com.redhat.rhn.domain.org.Org;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
+import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.TestUtils;
+import com.redhat.rhn.testing.UserTestUtils;
 
 import com.suse.manager.maintenance.MaintenanceManager;
 import com.suse.manager.model.maintenance.MaintenanceCalendar;
@@ -28,6 +40,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 
 public class MaintenanceManagerTest extends BaseTestCaseWithUser {
@@ -155,5 +168,128 @@ public class MaintenanceManagerTest extends BaseTestCaseWithUser {
         assertEquals("test server", dbSchedule.getName());
         assertEquals(ScheduleType.MULTI, dbSchedule.getScheduleType());
         assertEquals(dbCal, dbSchedule.getCalendarOpt().orElse(null));
+    }
+
+    /**
+     * Test assigning a {@link MaintenanceSchedule} to {@link Server}s and listing it.
+     *
+     * @throws Exception
+     */
+    public void testListSystemsWithSchedule() throws Exception {
+        user.addPermanentRole(ORG_ADMIN);
+        MaintenanceManager mm = MaintenanceManager.instance();
+        MaintenanceSchedule schedule = mm.createMaintenanceSchedule(
+                user, "test-schedule-1", MaintenanceSchedule.ScheduleType.SINGLE, Optional.empty());
+
+        Server withSchedule = MinionServerFactoryTest.createTestMinionServer(user);
+        Server withoutSchedule = MinionServerFactoryTest.createTestMinionServer(user);
+
+        mm.assignScheduleToSystems(user, schedule, Set.of(withSchedule.getId()));
+
+        assertEquals(
+                List.of(withSchedule.getId()),
+                mm.listSystemIdsWithSchedule(user, schedule)
+        );
+    }
+
+    /**
+     * Test retracting a {@link MaintenanceSchedule} from {@link Server}
+     *
+     * @throws Exception
+     */
+    public void testRetractScheduleFromSystems() throws Exception {
+        user.addPermanentRole(ORG_ADMIN);
+        MaintenanceManager mm = MaintenanceManager.instance();
+        MaintenanceSchedule schedule = MaintenanceManager.instance().createMaintenanceSchedule(
+                user, "test-schedule-1", MaintenanceSchedule.ScheduleType.SINGLE, Optional.empty());
+
+        // assign the schedule to both systems
+        Server system1 = MinionServerFactoryTest.createTestMinionServer(user);
+        Server system2 = MinionServerFactoryTest.createTestMinionServer(user);
+        mm.assignScheduleToSystems(user, schedule, Set.of(system1.getId(), system2.getId()));
+
+        // retract it from one system
+        mm.retractScheduleFromSystems(user, Set.of(system1.getId()));
+
+        // check, that the other system still has it
+        assertEquals(
+                List.of(system2.getId()),
+                mm.listSystemIdsWithSchedule(user, schedule)
+        );
+    }
+
+    /**
+     * Test the behavior when user tries to assign a schedule to a system, that has already some offending actions
+     * pending.
+     *
+     * @throws Exception
+     */
+    public void testAssignScheduleToSystemWithPendingActions() throws Exception {
+        user.addPermanentRole(ORG_ADMIN);
+        MaintenanceManager mm = MaintenanceManager.instance();
+        MaintenanceSchedule schedule = MaintenanceManager.instance().createMaintenanceSchedule(
+                user, "test-schedule-1", MaintenanceSchedule.ScheduleType.SINGLE, Optional.empty());
+
+        Server sys1 = MinionServerFactoryTest.createTestMinionServer(user);
+        Server sys2 = MinionServerFactoryTest.createTestMinionServer(user);
+
+        // assign an offending action to one system
+        Action disallowedAction = ActionFactoryTest.createAction(user, ActionFactory.TYPE_APPLY_STATES);
+        ServerActionTest.createServerAction(sys1, disallowedAction);
+
+        assertExceptionThrown(
+                () -> mm.assignScheduleToSystems(user, schedule, Set.of(sys1.getId(), sys2.getId())),
+                IllegalArgumentException.class);
+    }
+
+    /**
+     * Test schedules assigning in a cross-organization context.
+     *
+     * @throws Exception
+     */
+    public void testAssignScheduleCrossOrg() throws Exception {
+        MaintenanceManager mm = MaintenanceManager.instance();
+        user.addPermanentRole(ORG_ADMIN);
+        Org acmeOrg = UserTestUtils.createNewOrgFull("acme-123");
+        User user2 = UserTestUtils.createUser("user-321", acmeOrg.getId());
+        user2.addPermanentRole(ORG_ADMIN);
+
+        MaintenanceSchedule schedule1 = MaintenanceManager.instance().createMaintenanceSchedule(
+                user, "test-schedule-1", MaintenanceSchedule.ScheduleType.SINGLE, Optional.empty());
+        MaintenanceSchedule schedule2 = MaintenanceManager.instance().createMaintenanceSchedule(
+                user2, "test-schedule-2", MaintenanceSchedule.ScheduleType.SINGLE, Optional.empty());
+
+        Server system1 = MinionServerFactoryTest.createTestMinionServer(user);
+        Server system2 = MinionServerFactoryTest.createTestMinionServer(user2);
+
+        // user 2 assigns schedule 1
+        assertExceptionThrown(
+                () -> mm.assignScheduleToSystems(user2, schedule1, Set.of(system2.getId())),
+                PermissionException.class);
+
+        // user 2 retracts from system1
+        assertExceptionThrown(
+                () -> mm.retractScheduleFromSystems(user2, Set.of(system1.getId())),
+                PermissionException.class);
+
+        // user 2 assigns to system 1
+        assertExceptionThrown(
+                () -> mm.assignScheduleToSystems(user2, schedule2, Set.of(system1.getId())),
+                PermissionException.class);
+
+        // user 2 lists systems with schedule 1
+        assertExceptionThrown(
+                () -> mm.listSystemIdsWithSchedule(user2, schedule1),
+                PermissionException.class);
+    }
+
+    private void assertExceptionThrown(Runnable body, Class exceptionClass) {
+        try {
+            body.run();
+            fail("An exceptions should have been thrown.");
+        }
+        catch (Exception e) {
+            assertEquals("The exception should be of class: " + exceptionClass, exceptionClass, e.getClass());
+        }
     }
 }

--- a/java/code/src/com/suse/manager/xmlrpc/maintenance/MaintenanceHandler.java
+++ b/java/code/src/com/suse/manager/xmlrpc/maintenance/MaintenanceHandler.java
@@ -287,6 +287,7 @@ public class MaintenanceHandler extends BaseHandler {
      * Refresh the calendar data using the configured URL
      * @param loggedInUser user
      * @param label the calendar label
+     * @return 1 on success
      *
      * @xmlrpc.doc Refresh Maintenance Calendar Data using the configured URL
      * @xmlrpc.param #session_key()

--- a/java/code/src/com/suse/manager/xmlrpc/maintenance/MaintenanceHandler.java
+++ b/java/code/src/com/suse/manager/xmlrpc/maintenance/MaintenanceHandler.java
@@ -14,9 +14,12 @@
  */
 package com.suse.manager.xmlrpc.maintenance;
 
+import com.redhat.rhn.common.security.PermissionException;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.xmlrpc.BaseHandler;
 import com.redhat.rhn.frontend.xmlrpc.EntityNotExistsFaultException;
+import com.redhat.rhn.frontend.xmlrpc.InvalidParameterException;
+import com.redhat.rhn.frontend.xmlrpc.PermissionCheckFailureException;
 
 import com.suse.manager.maintenance.MaintenanceManager;
 import com.suse.manager.model.maintenance.MaintenanceCalendar;
@@ -28,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Maintenance Schedule XMLRPC Handler
@@ -323,5 +327,92 @@ public class MaintenanceHandler extends BaseHandler {
         Optional<MaintenanceCalendar> calendar = mm.lookupCalendarByUserAndLabel(loggedInUser, label);
         mm.remove(calendar.orElseThrow(() -> new EntityNotExistsFaultException(label)));
         return 1;
+    }
+
+    /**
+     * Assign schedule with given name to systems with given IDs
+     *
+     * @param loggedInUser the user
+     * @param scheduleName the schedule name
+     * @param systemIds the system IDs
+     * @return the number of involved systems
+     *
+     * @xmlrpc.doc Assign schedule with given name to systems with given IDs.
+     * Throws a PermissionCheckFailureException when some of the systems are not accessible by the user.
+     * Throws a InvalidParameterException when some of the systems have pending actions that are not allowed in the
+     * maintenance mode.
+     * @xmlrpc.param #session_key()
+     * @xmlrpc.param #param_desc("string", "scheduleName", "The schedule name")
+     * @xmlrpc.param #array_single("int", "system IDs")
+     * @xmlrpc.returntype #array_single("int", "number of involved systems")
+     */
+    public Integer assignScheduleToSystems(User loggedInUser, String scheduleName, List<Integer> systemIds) {
+        ensureOrgAdmin(loggedInUser);
+        MaintenanceSchedule schedule = mm
+                .lookupMaintenanceScheduleByUserAndName(loggedInUser, scheduleName)
+                .orElseThrow(() -> new EntityNotExistsFaultException(scheduleName));
+
+        Set<Long> longIds = systemIds.stream().map(id -> id.longValue()).collect(Collectors.toSet());
+        try {
+            return mm.assignScheduleToSystems(loggedInUser, schedule, longIds);
+        }
+        catch (PermissionException e) {
+            throw new PermissionCheckFailureException(e);
+        }
+        catch (IllegalArgumentException e) {
+            throw new InvalidParameterException(e.getMessage());
+        }
+    }
+
+    /**
+     * Retract schedule with given name from systems with given IDs
+     *
+     * @param loggedInUser the user
+     * @param systemIds the system IDs
+     * @return the number of involved systems
+     *
+     * @xmlrpc.doc Retract schedule with given name from systems with given IDs
+     * Throws a PermissionCheckFailureException when some of the systems are not accessible by the user.
+     * @xmlrpc.param #session_key()
+     * @xmlrpc.param #array_single("int", "system IDs")
+     * @xmlrpc.returntype #array_single("int", "number of involved systems")
+     */
+    public Integer retractScheduleFromSystems(User loggedInUser, List<Integer> systemIds) {
+        ensureOrgAdmin(loggedInUser);
+
+        Set<Long> longIds = systemIds.stream().map(id -> id.longValue()).collect(Collectors.toSet());
+        try {
+            return mm.retractScheduleFromSystems(loggedInUser, longIds);
+        }
+        catch (PermissionException e) {
+            throw new PermissionCheckFailureException(e);
+        }
+    }
+
+    /**
+     * List IDs of systems that have given schedule assigned
+     *
+     * @param loggedInUser the user
+     * @param scheduleName the schedule name
+     * @return the IDs of systems that have given schedule assigned
+     *
+     * @xmlrpc.doc List IDs of systems that have given schedule assigned
+     * Throws a PermissionCheckFailureException when some of the systems are not accessible by the user.
+     * @xmlrpc.param #session_key()
+     * @xmlrpc.param #param_desc("string", "scheduleName", "The schedule name")
+     * @xmlrpc.returntype #array_single("int", "system IDs")
+    */
+    public List<Long> listSystemsWithSchedule(User loggedInUser, String scheduleName) {
+        ensureOrgAdmin(loggedInUser);
+        MaintenanceSchedule schedule = mm
+                .lookupMaintenanceScheduleByUserAndName(loggedInUser, scheduleName)
+                .orElseThrow(() -> new EntityNotExistsFaultException(scheduleName));
+
+        try {
+            return mm.listSystemIdsWithSchedule(loggedInUser, schedule);
+        }
+        catch (PermissionException e) {
+            throw new PermissionCheckFailureException(e);
+        }
     }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- XMLRPC: Assign/retract maintenance schedule to/from systems
 - Pass image profile custom info values as Docker buildargs during image build
 - Fix activation keys request error in image import page (bsc#1170046)
 - Fix custom info values input in image profile edit form (bsc#1169773)


### PR DESCRIPTION
## What does this PR change?

$subj

The assignment/retracting is implemented as a bulk operation for performance reasons.

Implemented operations so far:
- list systems with given schedule
- assign schedule to systems
- retract schedule from systems

When user does not have permissions to involved systems -> an exception is thrown.

Review commit-by-commit.

TODO
- [x] Perf tests on high number of systems (see below)
- [x] Check the permissions checking again
- [x] use faults in xmlrpc
- [x] more tests

## Perf tests
Tested for 10k systems.

### Current implementation (bulk JPQL operations):
  - assign/retract/list: 4s (all three operations together))

### 1-by-1 naive implementation (loop)
Just assign schedule takes ~20 seconds.
```java
// naive assignment via loop (takes ~20 seconds)
longIds.stream()
    .map(id -> ServerFactory.lookupById(id))
    .forEach(s -> s.setMaintenanceSchedule(schedule));
```


## GUI diff

No difference.

- [x] **DONE**

## Documentation
Covered in API docs.

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/11273

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
