### PR TITLE
Add Ubuntu 20.04 channels for Uyuni

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -1566,6 +1566,80 @@ checksum = sha256
 base_channels = ubuntu-18.04-pool-amd64-uyuni
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/Ubuntu1804-Uyuni-Client-Tools/xUbuntu_18.04/
 
+[ubuntu-2004-pool-amd64-uyuni]
+label    = ubuntu-20.04-pool-amd64-uyuni
+checksum = sha256
+archs    = amd64-deb
+repo_type = deb
+name     = Ubuntu 20.04 LTS AMD64 Base for Uyuni
+gpgkey_url =
+gpgkey_id =
+gpgkey_fingerprint =
+repo_url = http://localhost/pub/repositories/empty-deb/?uniquekey=2004-uyuni
+
+[ubuntu-2004-amd64-main-uyuni]
+label    = ubuntu-2004-amd64-main-uyuni
+checksum = sha256
+archs    = amd64-deb
+repo_type = deb
+name     = Ubuntu 20.04 LTS AMD64 Main for Uyuni
+base_channels = ubuntu-20.04-pool-amd64-uyuni
+repo_url = http://archive.ubuntu.com/ubuntu/dists/focal/main/binary-amd64/
+
+[ubuntu-2004-amd64-main-updates-uyuni]
+label    = ubuntu-2004-amd64-main-updates-uyuni
+name     = Ubuntu 20.04 LTS AMD64 Main Updates for Uyuni
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = ubuntu-20.04-pool-amd64-uyuni
+repo_url = http://archive.ubuntu.com/ubuntu/dists/focal-updates/main/binary-amd64/
+
+[ubuntu-2004-amd64-main-security-uyuni]
+label    = ubuntu-2004-amd64-main-security-uyuni
+name     = Ubuntu 20.04 LTS AMD64 Main Security for Uyuni
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = ubuntu-20.04-pool-amd64-uyuni
+repo_url = http://archive.ubuntu.com/ubuntu/dists/focal-security/main/binary-amd64/
+
+[ubuntu-2004-amd64-universe-uyuni]
+label    = ubuntu-2004-amd64-universe-uyuni
+name     = Ubuntu 20.04 LTS AMD64 Universe for Uyuni
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = ubuntu-20.04-pool-amd64-uyuni
+repo_url = http://archive.ubuntu.com/ubuntu/dists/focal/universe/binary-amd64/
+
+[ubuntu-2004-amd64-universe-updates-uyuni]
+label    = ubuntu-2004-amd64-universe-updates-uyuni
+name     = Ubuntu 20.04 LTS AMD64 Universe Updates for Uyuni
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = ubuntu-20.04-pool-amd64-uyuni
+repo_url = http://archive.ubuntu.com/ubuntu/dists/focal-updates/universe/binary-amd64/
+
+[ubuntu-2004-amd64-uyuni-client]
+label    = ubuntu-2004-amd64-uyuni-client
+name     = Uyuni Client Tools for Ubuntu 20.04 AMD64
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = ubuntu-20.04-pool-amd64-uyuni
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/Ubuntu2004-Uyuni-Client-Tools/xUbuntu_20.04/
+
+[ubuntu-2004-amd64-uyuni-client-devel]
+label    = ubuntu-2004-amd64-uyuni-client-devel
+name     = Uyuni Client Tools for Ubuntu 20.04 AMD64 (Development)
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = ubuntu-20.04-pool-amd64-uyuni
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/Ubuntu2004-Uyuni-Client-Tools/xUbuntu_20.04/
+
 [debian-9-pool-amd64]
 label    = debian-9-pool-amd64
 checksum = sha256

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,5 @@
+- Add Ubuntu 20.04 channels to spacewalk-common-channels
+
 -------------------------------------------------------------------
 Mon Apr 13 09:34:52 CEST 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Add Ubuntu 20.04 repositories to spacewalk-common-channels with the "-uyuni" suffix

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: none
- Documentation issue was created: not needed
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
- No tests: just adds repositories
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11367
Tracks https://github.com/SUSE/spacewalk/issues/11325

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
