### PR TITLE
Fix rendering of formula with form components with non-string values

### DIFF
--- a/web/html/src/components/formulas/FormulaComponentGenerator.js
+++ b/web/html/src/components/formulas/FormulaComponentGenerator.js
@@ -269,7 +269,9 @@ export function text(txt) {
         return "";
     }
     // replace variables
-    txt = txt.replace(/\${productName}/g, Utils.getProductName());
+    if (typeof txt === 'string' || txt instanceof String) {
+      txt = txt.replace(/\${productName}/g, Utils.getProductName());
+    }
     return txt;
 }
 

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fix formula with form rendering with non-string values
 - auto select recommended and mandatory channels by default (bsc#1162843)
 - Add hint to edit formulas before applying state (bsc#1168805)
 - Fix custom info values input in image profile edit form (bsc#1169773)


### PR DESCRIPTION
## What does this PR change?

If a form has a placeholder or value that is not a string but an integer
for example, the rendering of the page would fail with such an error:

TypeError: e.replace is not a function

Don't try to replace variables in non string values of forms.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: display bug fix

- [X] **DONE**

## Test coverage
- No tests: will come soon when KVM cucumber tests will be switched to Salt formula

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
