### PR TITLE
CLM AppStream filters: module picker controls

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/modulemd/ListModulesResponse.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/modulemd/ListModulesResponse.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.domain.contentmgmt.modulemd;
+
+import java.util.Map;
+
+/**
+ * modulemd API response from 'list_modules' call
+ */
+public class ListModulesResponse {
+
+    private Map<String, ModuleStreams> modules;
+
+    public Map<String, ModuleStreams> getModules() {
+        return modules;
+    }
+}

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/modulemd/ModuleStreams.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/modulemd/ModuleStreams.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.domain.contentmgmt.modulemd;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+/**
+ * Represents a module's available streams in a modular repository
+ */
+public class ModuleStreams {
+
+    @SerializedName("default")
+    private String defaultStream;
+    private List<String> streams;
+
+    /**
+     * Initialize a new ModuleStreams instance
+     * @param defaultStreamIn the name of the default stream
+     * @param streamsIn the list of stream names
+     */
+    public ModuleStreams(String defaultStreamIn, List<String> streamsIn) {
+        this.defaultStream = defaultStreamIn;
+        this.streams = streamsIn;
+    }
+
+    public String getDefaultStream() {
+        return defaultStream;
+    }
+
+    public List<String> getStreams() {
+        return streams;
+    }
+}

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/modulemd/ModulemdApi.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/modulemd/ModulemdApi.java
@@ -49,10 +49,11 @@ public class ModulemdApi {
      * Get all defined modules in a channel's metadata
      *
      * @param channel the modular channel
-     * @return a map of module name to module/stream objects
+     * @return a map of module name to stream lists
      */
-    public Map<String, List<Module>> getAllModulesInChannel(Channel channel) {
-        throw new UnsupportedOperationException();
+    public Map<String, ModuleStreams> getAllModulesInChannel(Channel channel) {
+        ModulemdApiResponse res = callSync(ModulemdApiRequest.listModulesRequest(getMetadataPath(channel)));
+        return res.getListModules().getModules();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/modulemd/ModulemdApiRequest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/modulemd/ModulemdApiRequest.java
@@ -15,6 +15,7 @@
 
 package com.redhat.rhn.domain.contentmgmt.modulemd;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -59,11 +60,11 @@ public class ModulemdApiRequest {
     /**
      * Instantiate payload for a 'list_modules' call
      *
-     * @param paths module metadata paths
+     * @param path a single module metadata path
      * @return the request payload to call the API with
      */
-    public static ModulemdApiRequest listModulesRequest(List<String> paths) {
-        return new ModulemdApiRequest(LIST_MODULES, paths, null);
+    public static ModulemdApiRequest listModulesRequest(String path) {
+        return new ModulemdApiRequest(LIST_MODULES, Collections.singletonList(path), null);
     }
 
     public String getFunction() {

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/modulemd/ModulemdApiResponse.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/modulemd/ModulemdApiResponse.java
@@ -30,6 +30,7 @@ public class ModulemdApiResponse {
     private String exception;
     private ModulePackagesResponse modulePackages;
     private ListPackagesResponse listPackages;
+    private ListModulesResponse listModules;
     private ModulemdExceptionDataResponse data;
 
     public int getErrorCode() {
@@ -46,6 +47,10 @@ public class ModulemdApiResponse {
 
     public ListPackagesResponse getListPackages() {
         return listPackages;
+    }
+
+    public ListModulesResponse getListModules() {
+        return listModules;
     }
 
     public ModulemdExceptionDataResponse getData() {

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/MockModulemdApi.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/MockModulemdApi.java
@@ -25,6 +25,7 @@ import com.redhat.rhn.domain.contentmgmt.modulemd.ConflictingStreamsException;
 import com.redhat.rhn.domain.contentmgmt.modulemd.Module;
 import com.redhat.rhn.domain.contentmgmt.modulemd.ModuleNotFoundException;
 import com.redhat.rhn.domain.contentmgmt.modulemd.ModulePackagesResponse;
+import com.redhat.rhn.domain.contentmgmt.modulemd.ModuleStreams;
 import com.redhat.rhn.domain.contentmgmt.modulemd.ModulemdApi;
 import com.redhat.rhn.domain.contentmgmt.modulemd.RepositoryNotModularException;
 import com.redhat.rhn.domain.rhnpackage.Package;
@@ -39,14 +40,15 @@ import com.redhat.rhn.testing.TestUtils;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -59,17 +61,15 @@ public class MockModulemdApi extends ModulemdApi {
     private static final String MOUNT_POINT_PATH = Config.get().getString(ConfigDefaults.MOUNT_POINT);
 
     @Override
-    public Map<String, List<Module>> getAllModulesInChannel(Channel channel)
+    public Map<String, ModuleStreams> getAllModulesInChannel(Channel channel)
             throws RepositoryNotModularException {
         // Dummy call to trigger RepositoryNotModular exception:
         getMetadataPath(channel);
-        // Mock list
-        return Stream.of(
-                new Module("postgresql", "9.6"),
-                new Module("postgresql",  "10"),
-                new Module("perl", "5.26"),
-                new Module("perl", "5.24")
-        ).collect(Collectors.groupingBy(Module::getName));
+        // Mock map
+        Map<String, ModuleStreams> moduleStreamsMap = new HashMap<>();
+        moduleStreamsMap.put("postgresql", new ModuleStreams("10", Arrays.asList("10", "9.6")));
+        moduleStreamsMap.put("perl", new ModuleStreams("5.26", Arrays.asList("5.26", "5.24")));
+        return moduleStreamsMap;
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/controllers/channels/ChannelsApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/channels/ChannelsApiController.java
@@ -20,6 +20,7 @@ import static com.suse.manager.webui.utils.SparkApplicationHelper.json;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.withUser;
 import static spark.Spark.get;
 
+import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.contentmgmt.ContentProjectFactory;
 import com.redhat.rhn.domain.user.User;
 
@@ -46,6 +47,8 @@ public class ChannelsApiController {
     public static void initRoutes() {
         get("/manager/api/channels",
                 withUser(ChannelsApiController::getAllChannels));
+        get("/manager/api/channels/modular",
+                withUser(ChannelsApiController::getModularChannels));
     }
 
     /**
@@ -74,5 +77,21 @@ public class ChannelsApiController {
         return json(res, ResultJson.success(jsonChannelsFiltered));
     }
 
+    /**
+     * Get existing modular channels for a user in a channel id to channel label map
+     *
+     * @param req the request
+     * @param res the response
+     * @param user the current user
+     * @return the json response
+     */
+    public static String getModularChannels(Request req, Response res, User user) {
+        List<ChannelsJson.ChannelJson> jsonChannels = user.getOrg().getAccessibleChannels().stream()
+                .filter(Channel::isModular)
+                .map(ChannelsJson.ChannelJson::new)
+                .collect(Collectors.toList());
+
+        return json(res, ResultJson.success(jsonChannels));
+    }
 
 }

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/ContentManagementApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/ContentManagementApiController.java
@@ -14,6 +14,7 @@
  */
 package com.suse.manager.webui.controllers.contentmanagement;
 
+import com.suse.manager.webui.controllers.contentmanagement.handlers.AppStreamsApiController;
 import com.suse.manager.webui.controllers.contentmanagement.handlers.EnvironmentApiController;
 import com.suse.manager.webui.controllers.contentmanagement.handlers.FilterApiController;
 import com.suse.manager.webui.controllers.contentmanagement.handlers.ProjectActionsApiController;
@@ -36,6 +37,7 @@ public class ContentManagementApiController {
         FilterApiController.initRoutes();
         EnvironmentApiController.initRoutes();
         ProjectActionsApiController.initRoutes();
+        AppStreamsApiController.initRoutes();
     }
 
 }

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/AppStreamsApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/AppStreamsApiController.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.webui.controllers.contentmanagement.handlers;
+
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.contentmgmt.modulemd.ModulemdApi;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.manager.channel.ChannelManager;
+import com.suse.manager.webui.utils.gson.ResultJson;
+import org.apache.http.HttpStatus;
+import spark.Request;
+import spark.Response;
+import spark.Spark;
+
+import static com.suse.manager.webui.utils.SparkApplicationHelper.json;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withUser;
+import static spark.Spark.get;
+
+/**
+ * Spark controller ContentManagement AppStreams API
+ */
+public class AppStreamsApiController {
+
+    private static ModulemdApi api = new ModulemdApi();
+
+    private AppStreamsApiController() { }
+
+    /** Init routes for ContentManagement AppStreams Api.*/
+    public static void initRoutes() {
+        get("/manager/api/contentmanagement/appstreams/:channelId",
+                withUser(AppStreamsApiController::getModulesInChannel));
+    }
+
+    /**
+     * Return the JSON with all the available module streams for a specified modular channel
+     *
+     * @param req the http request
+     * @param res the http response
+     * @param user the current user
+     * @return the JSON data
+     */
+    public static String getModulesInChannel(Request req, Response res, User user) {
+        try {
+            Channel channel = ChannelManager.lookupByIdAndUser(Long.parseLong(req.params("channelId")), user);
+            return json(res, ResultJson.success(api.getAllModulesInChannel(channel)));
+        }
+        catch (NumberFormatException e) {
+            throw Spark.halt(HttpStatus.SC_BAD_REQUEST);
+        }
+    }
+
+}

--- a/java/code/src/com/suse/manager/webui/utils/gson/ChannelsJson.java
+++ b/java/code/src/com/suse/manager/webui/utils/gson/ChannelsJson.java
@@ -93,6 +93,16 @@ public class ChannelsJson {
         }
 
         /**
+         * Instantiates a new Channel json from a Channel object
+         *
+         * @param channel the channel object
+         */
+        public ChannelJson(Channel channel) {
+            this(channel.getId(), channel.getLabel(), channel.getName(), channel.isCustom(), false,
+                    channel.isCloned(), channel.getChannelArch().getLabel());
+        }
+
+        /**
          * @return the id
          */
         public Long getId() {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Implement module picker controls for CLM AppStream filters
+
 -------------------------------------------------------------------
 Wed May 20 10:55:24 CEST 2020 - jgonzalez@suse.com
 

--- a/susemanager-utils/mgr-libmod/mgr-libmod.changes
+++ b/susemanager-utils/mgr-libmod/mgr-libmod.changes
@@ -1,3 +1,5 @@
+- Reformat 'list_modules' response JSON object
+
 -------------------------------------------------------------------
 Wed Apr 15 17:11:04 CEST 2020 - jgonzalez@suse.com
 

--- a/susemanager-utils/mgr-libmod/mgrlibmod/mllib.py
+++ b/susemanager-utils/mgr-libmod/mgrlibmod/mllib.py
@@ -430,8 +430,8 @@ class MLLibmodAPI:
             "modules": []
         }
         self._proc.index_modules()
+        mobj: Dict = {}
         for m_name in self._proc._mod_index.get_module_names():
-            mobj: Dict = {}
             mod = self._proc._mod_index.get_module(m_name)
             d_mod = mod.get_defaults()
             if d_mod is not None:
@@ -439,7 +439,8 @@ class MLLibmodAPI:
                     "default": d_mod.get_default_stream(),
                     "streams": d_mod.get_streams_with_default_profiles(),
                 }
-                modules["modules"].append(mobj)
+
+        modules["modules"].append(mobj)
         return modules
 
     def _function__list_packages(self) -> Dict[str, List[str]]:

--- a/web/html/src/components/input/Combo.js
+++ b/web/html/src/components/input/Combo.js
@@ -1,0 +1,131 @@
+// @flow
+
+import * as React from 'react';
+import Select from 'react-select';
+import {InputBase} from './InputBase';
+import {FormContext} from './Form';
+
+export type OptionType = {
+  value: number | string,
+  label: string
+};
+
+type Props = {
+  /** options to display */
+  options: Array<OptionType>,
+  /** Value placeholder to display when no value is entered */
+  placeholder?: string,
+  /** whether the component's data is loading or not (async) */
+  isLoading?: boolean,
+  /** text to display when there are no options to list */
+  emptyText: string | null,
+  /** CSS class for the <input> element */
+  inputClass?: string,
+  /** name of the field to map in the form model */
+  name: string,
+  /** default value if none is set */
+  defaultValue?: string,
+  /** Label to display for the field */
+  label?: string,
+  /** hint string to display */
+  hint?: string,
+  /** CSS class to use for the label */
+  labelClass?: string,
+  /** CSS class to use for the <div> element wrapping the field input part */
+  divClass?: string,
+  /** Indicates whether the field is required in the form */
+  required?: boolean,
+  /** Indicates whether the field is disabled */
+  disabled?: boolean,
+  /** Hint to display on a validation error */
+  invalidHint?: string,
+  /** Function to call when the data model needs to be changed.
+   *  Takes a name and a value parameter.
+   */
+  onChange?: (name: string, value: string) => void,
+};
+
+/** A simple, single select combo-box implementation using 'react-select' */
+export default function Combo(props: Props) {
+
+  const bootstrapStyles = {
+    control: (styles: {}) => ({
+      ...styles,
+      minHeight: '34px',
+      display: 'flex'
+    }),
+    clearIndicator: (styles: {}) => ({
+      ...styles,
+      padding: '2px 8px',
+    }),
+    dropdownIndicator: (styles: {}) => ({
+      ...styles,
+      padding: '2px 8px',
+    }),
+    loadingIndicator: (styles: {}) => ({
+      ...styles,
+      padding: '2px 8px',
+    }),
+    menu: (styles: {}) => ({
+      ...styles,
+      zIndex: 3,
+    }),
+  };
+
+  const {
+    options,
+    placeholder,
+    isLoading,
+    emptyText,
+    inputClass,
+    ...propsToPass
+  } = props;
+
+  const formContext = React.useContext(FormContext);
+  return (
+    <InputBase {...propsToPass}>
+      {
+        ({
+          setValue,
+          onBlur,
+        }) => {
+          const onChange = (option: any, action: any) => {
+            setValue(props.name, option.value);
+          };
+          const fieldValue = (formContext.model || {})[props.name] || props.defaultValue || '';
+          return (
+            <Select
+              className={inputClass}
+              name={props.name}
+              options={props.options}
+              isLoading={isLoading}
+              isDisabled={props.disabled}
+              value={props.options.find(o => o.value === fieldValue)}
+              noOptionsMessage={() => emptyText}
+              onBlur={onBlur}
+              onChange={onChange}
+              placeholder={placeholder}
+              styles={bootstrapStyles}
+            />
+          );
+        }
+      }
+    </InputBase>
+  );
+}
+
+Combo.defaultProps = {
+  placeholder: undefined,
+  isLoading: false,
+  emptyText: "No options",
+  inputClass: undefined,
+  defaultValue: undefined,
+  label: undefined,
+  hint: undefined,
+  labelClass: undefined,
+  divClass: undefined,
+  required: false,
+  disabled: false,
+  invalidHint: undefined,
+  onChange: undefined,
+};

--- a/web/html/src/components/input/Combo.stories.js
+++ b/web/html/src/components/input/Combo.stories.js
@@ -1,0 +1,43 @@
+import React, {useState} from 'react';
+import {Form} from './Form';
+import Combo from './Combo';
+
+export default {
+  component: Combo,
+  title: 'Forms/Combo'
+};
+
+export const Example = () => {
+  const [model, setModel] = useState({});
+
+  const options = [
+    { value: 'chocolate', label: 'Chocolate' },
+    { value: 'strawberry', label: 'Strawberry' },
+    { value: 'vanilla', label: 'Vanilla' }
+  ];
+
+  return (
+    <div className="panel panel-default">
+      <div className="panel-body">
+        <Form
+          model={model}
+          onChange={setModel}
+          divClass="col-md-12"
+          formDirection="form-horizontal"
+        >
+          <Combo
+            name="flavor"
+            label={t("Flavor")}
+            options={options}
+            placeholder={t("Start typing...")}
+            emptyText={t("No flavors")}
+            labelClass="col-md-3"
+            divClass="col-md-6"
+            required
+          />
+        </Form>
+      </div>
+    </div>
+  );
+}
+

--- a/web/html/src/manager/content-management/list-filters/appstreams/appstreams.js
+++ b/web/html/src/manager/content-management/list-filters/appstreams/appstreams.js
@@ -1,0 +1,39 @@
+// @flow
+
+import React, {useState} from 'react';
+import {showErrorToastr} from 'components/toastr/toastr';
+import TextInput from './text-input';
+import SelectInput from './select-input';
+import Network from 'utils/network';
+
+export default function AppStreams() {
+  const [channels, setChannels] = useState([]);
+  const [isBrowse, setBrowse] = useState(false);
+  const [isLoading, setLoading] = useState(false);
+
+  const enableBrowse = () => {
+    setLoading(true);
+    Network.get("/rhn/manager/api/channels/modular", "application/json").promise
+      .then((channels) => {
+        setChannels(channels.data);
+        setLoading(false);
+        setBrowse(true);
+      }).catch(xhr => showErrorToastr(Network.responseErrorMessage(xhr)));
+  }
+
+  return (
+    isBrowse ?
+      <SelectInput channels={channels}/>
+    :
+      <>
+        <div className="form-group">
+          <div className="col-md-offset-3 col-md-6">
+            <a href="#" onClick={enableBrowse}>
+              {isLoading ? <i className="fa fa-refresh fa-spin fa-fw"/> : <i className="fa fa-search fa-fw"/>}
+              Browse available modules</a>
+          </div>
+        </div>
+        <TextInput/>
+      </>
+  );
+}

--- a/web/html/src/manager/content-management/list-filters/appstreams/module-selector.js
+++ b/web/html/src/manager/content-management/list-filters/appstreams/module-selector.js
@@ -1,0 +1,52 @@
+// @flow
+
+import React, {useContext} from 'react';
+import Combo from 'components/input/Combo';
+import {FormContext} from 'components/input/Form';
+
+type ModuleSelectorProps = {
+  modules: {
+    [name: string]: {
+      default: string,
+      streams: Array<string>
+    }
+  },
+  isLoading: boolean
+}
+
+export default function ModuleSelector(props: ModuleSelectorProps) {
+  const formContext = useContext(FormContext);
+  const createOption = value => ({value: value, label: value});
+  const moduleOptions = Object.keys(props.modules).map(createOption);
+  const getModuleName = ctx => ctx.model['moduleName'];
+  const getStreamOptions = ctx =>
+    ((props.modules[getModuleName(ctx)] || {}).streams || []).map(createOption);
+  const getDefaultStream = module => (props.modules[module] || {}).default;
+
+  return (
+    <>
+      <Combo
+        name="moduleName"
+        label={t("Module")}
+        isLoading={props.isLoading}
+        options={moduleOptions}
+        labelClass="col-md-3"
+        divClass="col-md-6"
+        placeholder={t("Select a module...")}
+        emptyText={t("No modules available")}
+        onChange={(name, module) => {formContext.model['moduleStream'] = getDefaultStream(module)}}
+        required
+      />
+      <Combo
+        name="moduleStream"
+        label={t("Stream")}
+        options={getStreamOptions(formContext)}
+        labelClass="col-md-3"
+        divClass="col-md-6"
+        disabled={!getModuleName(formContext)}
+        placeholder={t("Select a stream...")}
+        emptyText={t("No streams available")}
+      />
+    </>
+  );
+}

--- a/web/html/src/manager/content-management/list-filters/appstreams/select-input.js
+++ b/web/html/src/manager/content-management/list-filters/appstreams/select-input.js
@@ -1,0 +1,46 @@
+// @flow
+
+import React, {useState} from 'react';
+import {Select} from 'components/input/Select';
+import {showErrorToastr} from 'components/toastr/toastr';
+import useLifecycleActionsApi from '../../shared/api/use-lifecycle-actions-api';
+import ModuleSelector from './module-selector';
+
+type SelectInputProps = {
+  channels: Array<{id: string, name: string}>
+}
+
+export default function SelectInput(props: SelectInputProps) {
+  const [modules, setModules] = useState({});
+  const [isShowInputs, setShowInputs] = useState(false);
+  const {onAction, isLoading} = useLifecycleActionsApi({resource: "appstreams"});
+
+  const onChannelChange = (name, value) => {
+    if (value) {
+      setShowInputs(true);
+      onAction(null, "get", value)
+        .then(setModules)
+        .catch(showErrorToastr);
+    } else {
+      setModules({});
+    }
+  }
+
+  return (
+    <>
+      <Select
+        name="moduleChannel"
+        label={t("Channel")}
+        labelClass="col-md-3"
+        divClass="col-md-6"
+        onChange={onChannelChange}
+      >
+        <option disabled value="">{t("Select a channel to browse available modules")}</option>
+        {props.channels.map(c => <option key={c.id} value={c.id}>{c.name}</option>)}
+      </Select>
+      { isShowInputs &&
+          <ModuleSelector modules={modules} isLoading={isLoading}/>
+      }
+    </>
+  );
+}

--- a/web/html/src/manager/content-management/list-filters/appstreams/text-input.js
+++ b/web/html/src/manager/content-management/list-filters/appstreams/text-input.js
@@ -1,0 +1,24 @@
+// @flow
+
+import React from 'react';
+import {Text} from 'components/input/Text';
+
+export default function TextInput() {
+  return (
+    <>
+      <Text
+        name="moduleName"
+        label={t("Module Name")}
+        labelClass="col-md-3"
+        divClass="col-md-6"
+        required
+      />
+      <Text
+        name="moduleStream"
+        label={t("Stream")}
+        labelClass="col-md-3"
+        divClass="col-md-6"
+      />
+    </>
+  );
+}

--- a/web/html/src/manager/content-management/list-filters/filter-form.js
+++ b/web/html/src/manager/content-management/list-filters/filter-form.js
@@ -5,6 +5,7 @@ import {DateTime} from "components/input/DateTime";
 import {Radio} from "components/input/Radio";
 import {Select} from "components/input/Select";
 import {Form} from "components/input/Form";
+import AppStreamsForm from "./appstreams/appstreams";
 import type {FilterFormType} from "../shared/type/filter.type";
 import type {ClmFilterOptionType, FilterMatcherType} from "../shared/business/filters.enum";
 import {clmFilterOptions, findClmFilterByKey, getClmFiltersOptions} from "../shared/business/filters.enum";
@@ -279,19 +280,7 @@ const FilterForm = (props: Props) => {
         {
           clmFilterOptions.STREAM.key === props.filter.type &&
           <>
-            <Text
-              name={'moduleName'}
-              label={t("Module Name")}
-              labelClass="col-md-3"
-              divClass="col-md-6"
-              required
-            />
-            <Text
-              name={'moduleStream'}
-              label={t("Stream")}
-              labelClass="col-md-3"
-              divClass="col-md-6"
-            />
+            <AppStreamsForm/>
             <input type="hidden" name="rule" value="deny"/>
           </>
         }

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- Implement module picker controls for CLM AppStream filters
+
 -------------------------------------------------------------------
 Wed May 20 10:58:46 CEST 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
Add module picker controls for CLM AppStreams filter form.

## GUI diff
Before:
![combo-before](https://user-images.githubusercontent.com/1103552/81350057-7a1c8a00-90c1-11ea-82ec-bf3dac2c0eb6.png)

After (in order of flow):
![combo-browse](https://user-images.githubusercontent.com/1103552/81349856-2316b500-90c1-11ea-9d25-1e220020bfed.png)
![combo-channel](https://user-images.githubusercontent.com/1103552/81349861-24e07880-90c1-11ea-95a5-dbe448625a6a.png)
![combo-module](https://user-images.githubusercontent.com/1103552/81349862-24e07880-90c1-11ea-8f11-3db748498213.png)
![combo-stream](https://user-images.githubusercontent.com/1103552/81349863-25790f00-90c1-11ea-8f30-518f553480e5.png)

## Documentation
- https://github.com/SUSE/spacewalk/issues/11486

## Test coverage
- No tests: Not testable

## Links

Fixes https://github.com/SUSE/spacewalk/issues/10097

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"  
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
