### PR TITLE
Uyuni issue 10893 supportconfig speedup

### DIFF
--- a/backend/satellite_tools/spacewalk-debug
+++ b/backend/satellite_tools/spacewalk-debug
@@ -62,7 +62,6 @@ while [ ${#} -ne 0 ]; do
             MAX_LOG_AGE=$1
             ;;
         --no-reports)
-            shift
             NO_REPORTS=1
             ;;
         --*)

--- a/backend/satellite_tools/spacewalk-debug
+++ b/backend/satellite_tools/spacewalk-debug
@@ -26,6 +26,7 @@ fi
 BASE_DIR=/tmp
 IS_SUSE=0
 NO_REPORTS=0
+NO_COMPRESSION=0
 MAX_LOG_AGE=10
 if [ -f /etc/SuSE-release ]; then
     IS_SUSE=1
@@ -41,9 +42,10 @@ usage() {
     echo
     echo "  OPTIONS:"
     echo "    --help                Display usage and exit"
-    echo "    --dir                 Destination directory for the tarball ($BASE_DIR)"
+    echo "    --dir                 Destination directory ($BASE_DIR)"
     echo "    --log-age             Set the maximum age (in days) for extracted logs ($MAX_LOG_AGE)"
     echo "    --no-reports          Do not run spacewalk-report. Useful if spacewalk-debug takes too long"
+    echo "    --no-compression      Do not compress spacewalk-debug destination folder"
     exit $1
 }
 
@@ -64,6 +66,9 @@ while [ ${#} -ne 0 ]; do
         --no-reports)
             NO_REPORTS=1
             ;;
+        --no-compression)
+            NO_COMPRESSION=1
+            ;;
         --*)
             echo "Unknown option $arg (use --help)"
             exit 1
@@ -81,10 +86,13 @@ if [ ! -d "$BASE_DIR" ]; then
     [ $? != 0 ] && echo "Unable to create directory $BASE_DIR" && exit 1
 fi
 
+# clean any previous run
+rm -rf $BASE_DIR/spacewalk-debug/*
+
 # Make sure BASE_DIR is not relative
 BASE_DIR=$(cd $BASE_DIR && pwd)
 
-DIR=$BASE_DIR/spacewalk-debug-$$/spacewalk-debug
+DIR=$BASE_DIR/spacewalk-debug
 TARBALL=$BASE_DIR/spacewalk-debug.tar.bz2
 
 /bin/mkdir -p $DIR
@@ -129,6 +137,8 @@ elif [ -d /etc/apache2 ]; then
 fi
 cp -fapRd /etc/rhn $DIR/conf/rhn
 cp -fapRd /etc/sysconfig/rhn $DIR/conf/rhn/sysconfig
+# exclude schema upgrade files, as they are packaged
+rm -r $DIR/conf/rhn/sysconfig/rhn/schema-upgrade
 
 # there might be backups of rhn.conf so clean them up as well (bsc#1146419)
 find $DIR/conf/rhn -name rhn.conf -exec sed -i 's/^server.susemanager.mirrcred_pass.*/server.susemanager.mirrcred_pass = <replaced_by_debug_tool>/' {} \;
@@ -438,21 +448,27 @@ if [ "$MAX_LOG_AGE" -eq "$MAX_LOG_AGE" 2>/dev/null ]; then
         done
 fi
 
-echo "    * creating tarball (may take some time): $TARBALL"
-# 209620 - satellite-debug creates world readable output
-# set tarball premissions *before* writing data
 # exclude private keys
-install -m 600 /dev/null $TARBALL
-tar -cjf $TARBALL \
-    -C $(dirname $DIR) \
-    --exclude "*PRIVATE*" \
-    --exclude "server.key*" \
-    --exclude "server.pem*" \
-    --exclude "rhn-org-httpd-ssl*" \
-    $(basename $DIR)
+find $DIR -name "*PRIVATE*" -delete
+find $DIR -name "server.key*" -delete
+find $DIR -name "server.pem*" -delete
+find $DIR -name "rhn-org-httpd-ssl*" -delete
 
-echo "    * removing temporary debug tree"
-rm -Rf $(echo $DIR | sed -e 's/\/[^\/]*$//g')
+# fix permissions
+chmod -R 700 $DIR
 
-echo
-echo "Debug dump created, stored in $TARBALL"
+if [ $NO_COMPRESSION -eq 1 ] ; then
+  echo
+  echo "Debug dump created, stored in $DIR"
+else
+  echo "    * creating tarball (may take some time): $TARBALL"
+  # set tarball premissions *before* writing data
+  install -m 600 /dev/null $TARBALL
+  tar -cjf $TARBALL \
+      -C $(dirname $DIR) \
+      $(basename $DIR)
+
+  echo "    * removing temporary debug tree"
+  rm -Rf echo $DIR
+  echo "Debug dump created, stored in $TARBALL"
+fi

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- supportconfig speedup fixes, add option to not compress spacewalk-debug output dir
 - Prevent failure when syncing from RHEL CDN due extra params (bsc#1171885)
 
 -------------------------------------------------------------------

--- a/susemanager-utils/supportutils-plugin-susemanager/supportconfig-sumalog
+++ b/susemanager-utils/supportutils-plugin-susemanager/supportconfig-sumalog
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-/usr/bin/spacewalk-debug --dir $1
+/usr/bin/spacewalk-debug --no-compression --dir $1
 echo "Done, SUSE Manager logs can now be found in the supportconfig directory."
 


### PR DESCRIPTION
## What does this PR change?

Optimization on spacewalk-debug which will reflect also in optimizations on supportconfig generation.

Main changes on spacewalk-debug:
- Clean "spacewalk-debug" working dir before start.
- Exclude schema upgrade files
- Add flag to not compress output folder

The default behavior will be kept and the output will be a tar file with all the data.

Supportconfig sets the property --no-compression to true and avoid double compression execution on spacewalk-debug.

**Manual test:**
Log directory with 1 Gb.

Times before:
```
real	10m56.993s
user	9m34.576s
sys	0m20.524s
```
Times after:
```
real	9m20.605s
user	8m2.152s
sys	0m20.248s
```

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: internal tool changes only.

- [X] **DONE**

## Test coverage
- No tests: this tool doesn't have automatic tests

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/10893
Tracks https://github.com/SUSE/spacewalk/pull/10798
Needs downstream PR or Manager 4.0 and maybe 3.2

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
