### PR TITLE
Temporarily disable CentOS reboots

### DIFF
--- a/testsuite/features/secondary/allcli_reboot.feature
+++ b/testsuite/features/secondary/allcli_reboot.feature
@@ -37,16 +37,19 @@ Feature: Reboot systems managed by SUSE Manager
     And I run "rhn_check -vvv" on "sle_client"
     Then I wait and check that "sle_client" has rebooted
 
-@centos_minion
-  Scenario: Reboot the CentOS minion and wait until reboot is completed
-    Given I am on the Systems overview page of this "ceos_ssh_minion"
-    When I follow first "Schedule System Reboot"
-    Then I should see a "System Reboot Confirmation" text
-    And I should see a "Reboot system" button
-    When I click on "Reboot system"
-    Then I should see a "Reboot scheduled for system" text
-    When I wait at most 600 seconds until event "System reboot scheduled by admin" is completed
-    Then I should see a "Reboot completed." text
+# WORKAROUND
+#    This scenario is disabled as long as we have failures during CentOS reboots
+#
+#@centos_minion
+#  Scenario: Reboot the CentOS minion and wait until reboot is completed
+#    Given I am on the Systems overview page of this "ceos_ssh_minion"
+#    When I follow first "Schedule System Reboot"
+#    Then I should see a "System Reboot Confirmation" text
+#    And I should see a "Reboot system" button
+#    When I click on "Reboot system"
+#    Then I should see a "Reboot scheduled for system" text
+#    When I wait at most 600 seconds until event "System reboot scheduled by admin" is completed
+#    Then I should see a "Reboot completed." text
 
 @ubuntu_minion
   Scenario: Reboot the Ubuntu minion and wait until reboot is completed


### PR DESCRIPTION
## What does this PR change?

There's something fishy with our initrd on CentOS. Disabling reboot test as long as it is not solved.

## Links

I can't check on 4.0 whether that branch is affected, as the test suite fails to deploy for other reasons. I will not port it to 4.0 as long as I'm not sure it's needed.

No port to 3.2 as far as I know.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
