### PR TITLE
Fix race on metadata caching

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
@@ -1916,6 +1916,7 @@ ORDER BY P.package_arch_id DESC
                 (select cp.package_id as id from rhnChannelPackage cp left join rhnPackageRepoData rd on cp.package_id = rd.package_id
                         where cp.channel_id = :cid
                           and rd.package_id is null)
+        ON CONFLICT DO NOTHING
    </query>
 </write-mode>
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- prevent race condition on metadata generation (bsc#1170197)
 - Make automatic system locking for cluster node (CaaSP) user configurable
 - Assign Activation Key channels only (bsc#1166516)
 - Pass image profile custom info values as Docker buildargs during image build


### PR DESCRIPTION
## What does this PR change?

When generating metadata in parallel it can happen that 2 channels share the same packages (e.g. noarch).
At the beginning of the generation all packages with its ID are [inserted](https://github.com/uyuni-project/uyuni/blob/master/java/code/src/com/redhat/rhn/taskomatic/task/repomd/RpmRepositoryWriter.java#L112) but the commit happens later.

The generated XML snippets are added via `update` statement which should hopefully do not cause conflicts.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **already covered (happen in cucumber testsuite**

- [x] **DONE**

## Links

Bug  https://bugzilla.suse.com/show_bug.cgi?id=1170197
Fixes https://github.com/SUSE/spacewalk/issues/11326
Tracks 

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
