### PR TITLE
Testsuite: Decouple the minion from the Docker/Kiwi build host

### DIFF
--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -11,7 +11,7 @@ Apart from Cucumber, the testsuite relies on a number of [software components](d
 
 # Running the testsuite
 
-You can run the SUSE Manager testsuite [with sumaform](https://github.com/moio/sumaform/blob/master/README_ADVANCED.md#cucumber-testsuite).
+You can run the SUSE Manager testsuite [with sumaform](https://github.com/uyuni-project/sumaform/blob/master/README_ADVANCED.md#cucumber-testsuite).
 
 If you want to run the testsuite for [Uyuni](https://www.uyuni-project.org), nothing special needs to be done. The testuite will autodetect it.
 

--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -37,8 +37,9 @@ Possible values are currently:
 | SUSE Manager proxy | ```$proxy``` | ```$PROXY``` | ```"proxy"``` | ```"suse_manager_proxy"``` |
 | SLES traditional client | ```$client``` | ```$CLIENT``` | ```"sle_client"``` | ```"client"``` |
 | SLES Salt minion | ```$minion``` | ```$MINION``` | ```"sle_minion"``` or ```"sle_migrated_minion"``` | ```"minion"``` |
+| SLES Docker and Kiwi build host | ```$build_host``` | ```$BUILD_HOST``` | ```"build_host"``` | ```"minion"``` |
 | SLES Salt SSH minion | ```$ssh_minion``` | ```$SSHMINION``` | ```"ssh_minion"``` | ```"minion"``` |
-| CentOS Salt minion or traditional client | ```$ceos_minion``` | ```$CENTOSMINION``` | ```"ceos_minion"```, ```"ceos_traditional_client"```, or ``"ceos_ssh_minion"``` | ```"minion"``` |
+| CentOS Salt minion or traditional client | ```$ceos_minion``` | ```$CENTOSMINION``` | ```"ceos_minion"```, ```"ceos_traditional_client"```, or ```"ceos_ssh_minion"``` | ```"minion"``` |
 | Ubuntu minion | ```$ubuntu_minion``` | ```$UBUNTUMINION``` | ```"ubuntu_minion"``` or ```"ubuntu_ssh_minion"``` | ```"minion"``` |
 | PXE-Boot minion |  None | ```$PXEBOOT_MAC``` | ```"pxeboot_minion"``` | ```"pxeboot"``` |
 

--- a/testsuite/documentation/guidelines.md
+++ b/testsuite/documentation/guidelines.md
@@ -62,6 +62,7 @@ Avoid reinventing function names and variables. Cucumber is all about human-read
    * "proxy": feature testing proxy side
    * "min": feature testing SLES minions (not SSH)
    * "minssh": feature testing SSH SLES minions
+   * "buildhost": feature using Kiwi and Docker build host
    * "minkvm": feature testing KVM host SLES minions
    * "minxen": feature testing Xen host SLES minions
    * "ubuntu": feature testing Ubuntu

--- a/testsuite/documentation/optional.md
+++ b/testsuite/documentation/optional.md
@@ -56,6 +56,27 @@ Inside of the testsuite, the scenarios that are tagged with
 are executed only if the minion is available.
 
 
+### Testing with a Docker and Kiwi build host
+
+Using a Docker and Kiwi build host with the testsuite is not mandatory.
+
+If you do not want such a machine, do not define `BUILD_HOST` environment
+variable before you run the testsuite. That's all.
+
+If you want a Docker and Kiwi build host, make this variable point to the machine
+that will be the build host:
+```bash
+export BUILD_HOST=my_build_host.example.com
+```
+and then run the testsuite.
+
+Inside of the testsuite, the scenarios that are tagged with
+```
+@buildhost
+```
+are executed only if the Docker and Kiwi build host is available.
+
+
 ### Testing with a SSH minion
 
 Using a SSH minion with the testsuite is not mandatory.

--- a/testsuite/documentation/static-run.md
+++ b/testsuite/documentation/static-run.md
@@ -17,6 +17,7 @@ Set up the following environment variables:
 * `PROXY` the SUSE Manager proxy (don't declare this variable if there is no proxy)
 * `CLIENT` the traditional client
 * `MINION` the Salt minion
+* `BUILD_HOST` the Docker and Kiwi build host
 * `SSHMINION` the SSH-managed Salt minion
 * `CENTOSMINION` the CentOS Salt minion
 * `UBUNTUMINION` the Ubuntu Salt minion
@@ -26,9 +27,10 @@ To run all standard tests, from the controller:
 
 ```console
 export SERVER="${PREFIX}suma3pg.tf.local"
-export CLIENT="${PREFIX}clisles12sp3.tf.local"
-export MINION="${PREFIX}minsles12sp3.tf.local"
-export SSHMINION="${PREFIX}minsles12sp3ssh.tf.local"
+export CLIENT="${PREFIX}cli-sles15.tf.local"
+export MINION="${PREFIX}min-sles15.tf.local"
+export BUILD_HOST="${PREFIX}min-build.tf.local"
+export SSHMINION="${PREFIX}minssh-sles15.tf.local"
 export CENTOSMINION="${PREFIX}mincentos7.tf.local"
 export UBUNTUMINION="${PREFIX}min-ubuntu.tf.local"
 run-testsuite

--- a/testsuite/features/core/allcli_sanity.feature
+++ b/testsuite/features/core/allcli_sanity.feature
@@ -16,6 +16,11 @@ Feature: Sanity checks
     Then "sle_minion" should have a FQDN
     And "sle_minion" should communicate with the server
 
+@buildhost
+  Scenario: The build host is healthy
+    Then "build_host" should have a FQDN
+    And "build_host" should communicate with the server
+
 @ssh_minion
   Scenario: The SSH minion is healthy
     Then "ssh_minion" should have a FQDN

--- a/testsuite/features/init_clients/sle_buildhost.feature
+++ b/testsuite/features/init_clients/sle_buildhost.feature
@@ -1,0 +1,95 @@
+# Copyright (c) 2016-2020 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: Be able to bootstrap a Salt build host via the GUI
+
+@buildhost
+  Scenario: Create the bootstrap repository for a Salt client build host
+     Given I am authorized
+     When I create the "x86_64" bootstrap repository for "build_host" on the server
+
+@buildhost
+  Scenario: Bootstrap a SLES build host
+     Given I am authorized
+     When I go to the bootstrapping page
+     Then I should see a "Bootstrap Minions" text
+     When I enter the hostname of "build_host" as "hostname"
+     And I enter "22" as "port"
+     And I enter "root" as "user"
+     And I enter "linux" as "password"
+     And I select the hostname of "proxy" from "proxies"
+     And I click on "Bootstrap"
+     And I wait until I see "Successfully bootstrapped host!" text
+
+@buildhost
+  Scenario: Check the new bootstrapped build host in System Overview page
+    Given I am authorized
+    When I go to the minion onboarding page
+    Then I should see a "accepted" text
+    When I follow the left menu "Systems > Overview"
+    And I wait until I see the name of "build_host", refreshing the page
+    And I wait until onboarding is completed for "build_host"
+    Then the Salt master can reach "build_host"
+
+@proxy
+@buildhost
+  Scenario: Check connection from build host to proxy
+    Given I am on the Systems overview page of this "build_host"
+    When I follow "Details" in the content area
+    And I follow "Connection" in the content area
+    Then I should see "proxy" short hostname
+
+@proxy
+@buildhost
+  Scenario: Check registration on build host of minion
+    Given I am on the Systems overview page of this "proxy"
+    When I follow "Details" in the content area
+    And I follow "Proxy" in the content area
+    Then I should see "build_host" hostname
+
+@buildhost
+  Scenario: Detect latest Salt changes on the SLES build host
+    When I query latest Salt changes on "build_host"
+
+@buildhost
+  Scenario: Turn the SLES build host into a container build host
+    Given I am on the Systems overview page of this "build_host"
+    When I follow "Details" in the content area
+    And I follow "Properties" in the content area
+    And I check "container_build_host"
+    And I click on "Update Properties"
+    Then I should see a "Container Build Host type has been applied." text
+    And I should see a "Note: This action will not result in state application" text
+    And I should see a "To apply the state, either use the states page or run state.highstate from the command line." text
+    And I should see a "System properties changed" text
+
+@buildhost
+  Scenario: Turn the SLES build host into a OS image build host
+    Given I am on the Systems overview page of this "build_host"
+    When I follow "Details" in the content area
+    And I follow "Properties" in the content area
+    And I check "osimage_build_host"
+    And I click on "Update Properties"
+    Then I should see a "OS Image Build Host type has been applied." text
+    And I should see a "Note: This action will not result in state application" text
+    And I should see a "To apply the state, either use the states page or run state.highstate from the command line." text
+    And I should see a "System properties changed" text
+
+@buildhost
+  Scenario: Apply the highstate to the build host
+    Given I am on the Systems overview page of this "build_host"
+    When I wait until no Salt job is running on "build_host"
+    And I apply highstate on "build_host"
+    And I wait until "docker" service is active on "build_host"
+    And I wait until file "/var/lib/Kiwi/repo/rhn-org-trusted-ssl-cert-osimage-1.0-1.noarch.rpm" exists on "build_host"
+
+@buildhost
+  Scenario: Check that the build host is now a build host
+    Given I am on the Systems overview page of this "build_host"
+    Then I should see a "[Container Build Host]" text
+    Then I should see a "[OS Image Build Host]" text
+
+@buildhost
+  Scenario: Check events history for failures on SLES build host
+    Given I am on the Systems overview page of this "build_host"
+    Then I check for failed events on history event page

--- a/testsuite/features/init_clients/sle_minion.feature
+++ b/testsuite/features/init_clients/sle_minion.feature
@@ -62,43 +62,6 @@ Feature: Be able to bootstrap a Salt minion via the GUI
   Scenario: Detect latest Salt changes on the SLES minion
     When I query latest Salt changes on "sle_minion"
 
-
-  Scenario: Turn the SLES minion into a container build host
-    Given I am on the Systems overview page of this "sle_minion"
-    When I follow "Details" in the content area
-    And I follow "Properties" in the content area
-    And I check "container_build_host"
-    And I click on "Update Properties"
-    Then I should see a "Container Build Host type has been applied." text
-    And I should see a "Note: This action will not result in state application" text
-    And I should see a "To apply the state, either use the states page or run state.highstate from the command line." text
-    And I should see a "System properties changed" text
-
-  Scenario: Turn the SLES minion into a OS image build host
-    Given I am on the Systems overview page of this "sle_minion"
-    When I follow "Details" in the content area
-    And I follow "Properties" in the content area
-    And I check "osimage_build_host"
-    And I click on "Update Properties"
-    Then I should see a "OS Image Build Host type has been applied." text
-    And I should see a "Note: This action will not result in state application" text
-    And I should see a "To apply the state, either use the states page or run state.highstate from the command line." text
-    And I should see a "System properties changed" text
-
-  Scenario: Apply the highstate to build host
-    Given I am on the Systems overview page of this "sle_minion"
-    When I wait until no Salt job is running on "sle_minion"
-    And I enable repositories before installing Docker
-    And I apply highstate on "sle_minion"
-    And I wait until "docker" service is active on "sle_minion"
-    And I wait until file "/var/lib/Kiwi/repo/rhn-org-trusted-ssl-cert-osimage-1.0-1.noarch.rpm" exists on "sle_minion"
-    And I disable repositories after installing Docker
-
-  Scenario: Check that the minion is now a build host
-    Given I am on the Systems overview page of this "sle_minion"
-    Then I should see a "[Container Build Host]" text
-    Then I should see a "[OS Image Build Host]" text
-
   Scenario: Check events history for failures on SLES minion
     Given I am on the Systems overview page of this "sle_minion"
     Then I check for failed events on history event page

--- a/testsuite/features/secondary/buildhost_docker_auth_registry.feature
+++ b/testsuite/features/secondary/buildhost_docker_auth_registry.feature
@@ -1,6 +1,7 @@
-# Copyright (c) 2018 SUSE LLC
+# Copyright (c) 2018-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
+@buildhost
 Feature: Build image with authenticated registry
 
   Scenario: Create an authenticated image store as Docker admin
@@ -27,7 +28,7 @@ Feature: Build image with authenticated registry
     When I navigate to images build webpage
     And I select "portus_profile" from "profileId"
     And I enter "latest" as "version"
-    And I select the hostname of "sle_minion" from "buildHostId"
+    And I select the hostname of "build_host" from "buildHostId"
     And I click on "submit-btn"
     Then I wait until I see "portus_profile" text
     # Verify the status of images in the authenticated image store
@@ -54,4 +55,4 @@ Feature: Build image with authenticated registry
     When I delete the image "portus_profile" with version "latest" via XML-RPC calls
 
   Scenario: Cleanup: kill stale portus image build jobs
-    When I kill remaining Salt jobs on "sle_minion"
+    When I kill remaining Salt jobs on "build_host"

--- a/testsuite/features/secondary/buildhost_docker_build_image.feature
+++ b/testsuite/features/secondary/buildhost_docker_build_image.feature
@@ -4,6 +4,7 @@
 # Basic images do not contain zypper nor the name of the server,
 # so the inspect functionality is not tested here.
 
+@buildhost
 Feature: Build container images
 
   Scenario: Create a simple image profile without activation key
@@ -45,7 +46,7 @@ Feature: Build container images
     And I click on "create-btn"
 
   Scenario: Build the images with and without activation key
-    Given I am on the Systems overview page of this "sle_minion"
+    Given I am on the Systems overview page of this "build_host"
     When I schedule the build of image "suse_key" via XML-RPC calls
     And I wait at most 500 seconds until event "Image Build suse_key scheduled by admin" is completed
     And I schedule the build of image "suse_simple" via XML-RPC calls
@@ -77,7 +78,7 @@ Feature: Build container images
     When I navigate to images build webpage
     And I select "suse_real_key" from "profileId"
     And I enter "GUI_BUILT_IMAGE" as "version"
-    And I select the hostname of "sle_minion" from "buildHostId"
+    And I select the hostname of "build_host" from "buildHostId"
     And I click on "submit-btn"
     Then I wait until I see "GUI_BUILT_IMAGE" text
 
@@ -86,7 +87,7 @@ Feature: Build container images
     When I navigate to images build webpage
     And I select "suse_real_key" from "profileId"
     And I enter "GUI_DOCKERADMIN" as "version"
-    And I select the hostname of "sle_minion" from "buildHostId"
+    And I select the hostname of "build_host" from "buildHostId"
     And I click on "submit-btn"
     Then I wait until I see "GUI_DOCKERADMIN" text
 
@@ -99,7 +100,7 @@ Feature: Build container images
     And I delete the image "suse_real_key" with version "GUI_DOCKERADMIN" via XML-RPC calls
 
   Scenario: Cleanup: kill stale image build jobs
-    When I kill remaining Salt jobs on "sle_minion"
+    When I kill remaining Salt jobs on "build_host"
 
   Scenario: Cleanup: delete all profiles
     Given I am authorized as "admin" with password "admin"

--- a/testsuite/features/secondary/buildhost_osimage_build_image.feature
+++ b/testsuite/features/secondary/buildhost_osimage_build_image.feature
@@ -9,7 +9,7 @@
 #   java.kiwi_os_image_building_enabled = true
 # which means "Enable Kiwi OS Image building"
 
-@sle_minion
+@buildhost
 Feature: Build OS images
 
   Scenario: Create an OS image profile with activation key
@@ -31,11 +31,11 @@ Feature: Build OS images
     Given I am authorized as "kiwikiwi" with password "kiwikiwi"
     When I navigate to images build webpage
     And I select "suse_os_image" from "profileId"
-    And I select the hostname of "sle_minion" from "buildHostId"
+    And I select the hostname of "build_host" from "buildHostId"
     And I click on "submit-btn"
 
   Scenario: Check the OS image built as Kiwi image administrator
-    Given I am on the Systems overview page of this "sle_minion"
+    Given I am on the Systems overview page of this "build_host"
     Then I should see a "[OS Image Build Host]" text
     When I wait at most 3300 seconds until event "Image Build suse_os_image scheduled by kiwikiwi" is completed
     And I wait at most 300 seconds until event "Image Inspect 1//suse_os_image:latest scheduled by kiwikiwi" is completed

--- a/testsuite/features/secondary/min_activationkey.feature
+++ b/testsuite/features/secondary/min_activationkey.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2019 SUSE LLC
+# Copyright (c) 2018-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Bootstrap a Salt minion via the GUI with an activation key
@@ -123,38 +123,6 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
     And I follow "Delete Key"
     And I click on "Delete Activation Key"
     And I should see a "Activation key Minion testing has been deleted." text
-
-  Scenario: Cleanup: turn the SLES minion into a container build host after activation key tests
-    Given I am on the Systems overview page of this "sle_minion"
-    When I follow "Details" in the content area
-    And I follow "Properties" in the content area
-    And I check "container_build_host"
-    And I click on "Update Properties"
-
-  Scenario: Cleanup: turn the SLES minion into a OS image build host after activation key tests
-    Given I am on the Systems overview page of this "sle_minion"
-    When I follow "Details" in the content area
-    And I follow "Properties" in the content area
-    And I check "osimage_build_host"
-    And I click on "Update Properties"
-    Then I should see a "OS Image Build Host type has been applied." text
-    And I should see a "Note: This action will not result in state application" text
-    And I should see a "To apply the state, either use the states page or run state.highstate from the command line." text
-    And I should see a "System properties changed" text
-
-  Scenario: Cleanup: apply the highstate to build host after activation key tests
-    Given I am on the Systems overview page of this "sle_minion"
-    When I wait until no Salt job is running on "sle_minion"
-    And I enable repositories before installing Docker
-    And I apply highstate on "sle_minion"
-    And I wait until "docker" service is active on "sle_minion"
-    And I wait until file "/var/lib/Kiwi/repo/rhn-org-trusted-ssl-cert-osimage-1.0-1.noarch.rpm" exists on "sle_minion"
-    And I disable repositories after installing Docker
-
-  Scenario: Cleanup: check that the minion is now a build host after activation key tests
-    Given I am on the Systems overview page of this "sle_minion"
-    Then I should see a "[Container Build Host]" text
-    Then I should see a "[OS Image Build Host]" text
 
   Scenario: Check events history for failures on SLES minion with activation key
     Given I am on the Systems overview page of this "sle_minion"

--- a/testsuite/features/secondary/min_bootstrap_negative.feature
+++ b/testsuite/features/secondary/min_bootstrap_negative.feature
@@ -92,39 +92,3 @@ Feature: Negative tests for bootstrapping normal minions
     When I click on "Confirm"
     Then I should see a "Changing the channels has been scheduled." text
     And I wait until event "Subscribe channels scheduled by admin" is completed
-
-  Scenario: Cleanup: turn the SLES minion into a container build
-    Given I am on the Systems overview page of this "sle_minion"
-    When I follow "Details" in the content area
-    And I follow "Properties" in the content area
-    And I check "container_build_host"
-    And I click on "Update Properties"
-    Then I should see a "Container Build Host type has been applied." text
-    And I should see a "Note: This action will not result in state application" text
-    And I should see a "To apply the state, either use the states page or run state.highstate from the command line." text
-    And I should see a "System properties changed" text
-
-  Scenario: Cleanup: turn the SLES minion into a OS image build host
-    Given I am on the Systems overview page of this "sle_minion"
-    When I follow "Details" in the content area
-    And I follow "Properties" in the content area
-    And I check "osimage_build_host"
-    And I click on "Update Properties"
-    Then I should see a "OS Image Build Host type has been applied." text
-    And I should see a "Note: This action will not result in state application" text
-    And I should see a "To apply the state, either use the states page or run state.highstate from the command line." text
-    And I should see a "System properties changed" text
-
-  Scenario: Cleanup: apply the highstate to build host
-    Given I am on the Systems overview page of this "sle_minion"
-    When I wait until no Salt job is running on "sle_minion"
-    And I enable repositories before installing Docker
-    And I apply highstate on "sle_minion"
-    And I wait until "docker" service is active on "sle_minion"
-    And I wait until file "/var/lib/Kiwi/repo/rhn-org-trusted-ssl-cert-osimage-1.0-1.noarch.rpm" exists on "sle_minion"
-    And I disable repositories after installing Docker
-
-  Scenario: Cleanup: check that the minion is now a build host
-    Given I am on the Systems overview page of this "sle_minion"
-    Then I should see a "[Container Build Host]" text
-    Then I should see a "[OS Image Build Host]" text

--- a/testsuite/features/secondary/min_bootstrap_script.feature
+++ b/testsuite/features/secondary/min_bootstrap_script.feature
@@ -1,11 +1,10 @@
-# Copyright (c) 2019 SUSE LLC
+# Copyright (c) 2019-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 #
 # 1) delete SLES minion and register again with bootstrap script
 # 2) subscribe minion to a base channels
 # 3) install and remove a package
-# 4) cleanup: re-add build host entitlements
 
 @sle_minion
 Feature: Register a Salt minion via Bootstrap-script
@@ -82,39 +81,3 @@ Feature: Register a Salt minion via Bootstrap-script
   Scenario: Cleanup: remove package from script-bootstrapped SLES minion
    When I remove package "orion-dummy-1.1-1.1" from this "sle_minion"
    Then "orion-dummy-1.1-1.1" should not be installed on "sle_minion"
-
-  Scenario: Cleanup: turn the SLES minion into a container build host after script-bootstrap
-    Given I am on the Systems overview page of this "sle_minion"
-    When I follow "Details" in the content area
-    And I follow "Properties" in the content area
-    And I check "container_build_host"
-    And I click on "Update Properties"
-    Then I should see a "Container Build Host type has been applied." text
-    And I should see a "Note: This action will not result in state application" text
-    And I should see a "To apply the state, either use the states page or run state.highstate from the command line." text
-    And I should see a "System properties changed" text
-
-  Scenario: Cleanup: turn the SLES minion into a OS image build host after script-bootstrap
-    Given I am on the Systems overview page of this "sle_minion"
-    When I follow "Details" in the content area
-    And I follow "Properties" in the content area
-    And I check "osimage_build_host"
-    And I click on "Update Properties"
-    Then I should see a "OS Image Build Host type has been applied." text
-    And I should see a "Note: This action will not result in state application" text
-    And I should see a "To apply the state, either use the states page or run state.highstate from the command line." text
-    And I should see a "System properties changed" text
-
-  Scenario: Cleanup: apply the highstate to build host after script-bootstrap
-    Given I am on the Systems overview page of this "sle_minion"
-    When I wait until no Salt job is running on "sle_minion"
-    And I enable repositories before installing Docker
-    And I apply highstate on "sle_minion"
-    And I wait until "docker" service is active on "sle_minion"
-    And I wait until file "/var/lib/Kiwi/repo/rhn-org-trusted-ssl-cert-osimage-1.0-1.noarch.rpm" exists on "sle_minion"
-    And I disable repositories after installing Docker
-
-  Scenario: Cleanup: check that the minion is now a build host after script-bootstrap
-    Given I am on the Systems overview page of this "sle_minion"
-    Then I should see a "[Container Build Host]" text
-    And I should see a "[OS Image Build Host]" text

--- a/testsuite/features/secondary/min_bootstrap_ssh_key.feature
+++ b/testsuite/features/secondary/min_bootstrap_ssh_key.feature
@@ -58,35 +58,3 @@ Feature: Bootstrap a Salt minion via the GUI using SSH key
   
   Scenario: Cleanup: restore authorized keys
     When I restore the SSH authorized_keys file of host "sle_minion"
-
-  Scenario: Cleanup: turn the SLES minion into a container build host after bootstrap with SSH key
-    Given I am on the Systems overview page of this "sle_minion"
-    When I follow "Details" in the content area
-    And I follow "Properties" in the content area
-    And I check "container_build_host"
-    And I click on "Update Properties"
-
-  Scenario: Cleanup: turn the SLES minion into a OS image build host after bootstrap with SSH key
-    Given I am on the Systems overview page of this "sle_minion"
-    When I follow "Details" in the content area
-    And I follow "Properties" in the content area
-    And I check "osimage_build_host"
-    And I click on "Update Properties"
-    Then I should see a "OS Image Build Host type has been applied." text
-    And I should see a "Note: This action will not result in state application" text
-    And I should see a "To apply the state, either use the states page or run state.highstate from the command line." text
-    And I should see a "System properties changed" text
-
-  Scenario: Cleanup: apply the highstate to build host after bootstrap with SSH key
-    Given I am on the Systems overview page of this "sle_minion"
-    When I wait until no Salt job is running on "sle_minion"
-    And I enable repositories before installing Docker
-    And I apply highstate on "sle_minion"
-    And I wait until "docker" service is active on "sle_minion"
-    And I wait until file "/var/lib/Kiwi/repo/rhn-org-trusted-ssl-cert-osimage-1.0-1.noarch.rpm" exists on "sle_minion"
-    And I disable repositories after installing Docker
-
-  Scenario: Cleanup: check that the minion is now a build host after bootstrap with SSH key
-    Given I am on the Systems overview page of this "sle_minion"
-    Then I should see a "[Container Build Host]" text
-    And I should see a "[OS Image Build Host]" text

--- a/testsuite/features/secondary/min_bootstrap_xmlrpc.feature
+++ b/testsuite/features/secondary/min_bootstrap_xmlrpc.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2019 SUSE LLC
+# Copyright (c) 2017-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Register a Salt minion via XML-RPC API
@@ -67,35 +67,3 @@ Feature: Register a Salt minion via XML-RPC API
     Given I am logged in via XML-RPC system as user "admin" and password "admin"
     When I call system.bootstrap() on a salt minion with saltSSH = true, but with activation key with Default contact method, I should get an XML-RPC fault with code -1
     And I logout from XML-RPC system namespace
-
-  Scenario: Cleanup: turn the SLES minion into a container build host after XML bootstrap
-    Given I am on the Systems overview page of this "sle_minion"
-    When I follow "Details" in the content area
-    And I follow "Properties" in the content area
-    And I check "container_build_host"
-    And I click on "Update Properties"
-
-  Scenario: Cleanup: turn the SLES minion into a OS image build host after XML bootstrap
-    Given I am on the Systems overview page of this "sle_minion"
-    When I follow "Details" in the content area
-    And I follow "Properties" in the content area
-    And I check "osimage_build_host"
-    And I click on "Update Properties"
-    Then I should see a "OS Image Build Host type has been applied." text
-    And I should see a "Note: This action will not result in state application" text
-    And I should see a "To apply the state, either use the states page or run state.highstate from the command line." text
-    And I should see a "System properties changed" text
-
-  Scenario: Cleanup: apply the highstate to build host after XML bootstrap
-    Given I am on the Systems overview page of this "sle_minion"
-    When I wait until no Salt job is running on "sle_minion"
-    And I enable repositories before installing Docker
-    And I apply highstate on "sle_minion"
-    And I wait until "docker" service is active on "sle_minion"
-    And I wait until file "/var/lib/Kiwi/repo/rhn-org-trusted-ssl-cert-osimage-1.0-1.noarch.rpm" exists on "sle_minion"
-    And I disable repositories after installing Docker
-
-  Scenario: Cleanup: check that the minion is now a build host after XML bootstrap
-    Given I am on the Systems overview page of this "sle_minion"
-    Then I should see a "[Container Build Host]" text
-    Then I should see a "[OS Image Build Host]" text

--- a/testsuite/features/secondary/min_salt_minions_page.feature
+++ b/testsuite/features/secondary/min_salt_minions_page.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2019 SUSE LLC
+# Copyright (c) 2015-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Management of minion keys
@@ -94,35 +94,3 @@ Feature: Management of minion keys
     When I click on "Confirm"
     Then I should see a "Changing the channels has been scheduled." text
     And I wait until event "Subscribe channels scheduled by admin" is completed
-
-  Scenario: Cleanup: turn the SLES minion into a container build host after new bootstrap
-    Given I am on the Systems overview page of this "sle_minion"
-    When I follow "Details" in the content area
-    And I follow "Properties" in the content area
-    And I check "container_build_host"
-    And I click on "Update Properties"
-
-  Scenario: Cleanup: turn the SLES minion into a OS image build host after new bootstrap
-    Given I am on the Systems overview page of this "sle_minion"
-    When I follow "Details" in the content area
-    And I follow "Properties" in the content area
-    And I check "osimage_build_host"
-    And I click on "Update Properties"
-    Then I should see a "OS Image Build Host type has been applied." text
-    And I should see a "Note: This action will not result in state application" text
-    And I should see a "To apply the state, either use the states page or run state.highstate from the command line." text
-    And I should see a "System properties changed" text
-
-  Scenario: Cleanup: apply the highstate to build host after new bootstrap
-    Given I am on the Systems overview page of this "sle_minion"
-    When I wait until no Salt job is running on "sle_minion"
-    And I enable repositories before installing Docker
-    And I apply highstate on "sle_minion"
-    And I wait until "docker" service is active on "sle_minion"
-    And I wait until file "/var/lib/Kiwi/repo/rhn-org-trusted-ssl-cert-osimage-1.0-1.noarch.rpm" exists on "sle_minion"
-    And I disable repositories after installing Docker
-
-  Scenario: Cleanup: check that the minion is now a build host after new bootstrap
-    Given I am on the Systems overview page of this "sle_minion"
-    Then I should see a "[Container Build Host]" text
-    Then I should see a "[OS Image Build Host]" text

--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -3,7 +3,7 @@
 #
 # This feature depends on a JeOS image present on the proxy
 # Please make sure that the feature
-#     features/min_osimage_build_image.feature
+#     features/buildhost_osimage_build_image.feature
 # has been tested previously
 #
 # The scenarios in this feature are skipped:

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -150,7 +150,7 @@ When(/^I apply highstate on "([^"]*)"$/) do |host|
     cmd = 'runuser -u salt -- salt-ssh --priv=/srv/susemanager/salt/salt_ssh/mgr_ssh_id'
     extra_cmd = '-i --roster-file=/tmp/roster_tests -w -W'
     $server.run("printf '#{system_name}:\n  host: #{system_name}\n  user: root\n  passwd: linux\n' > /tmp/roster_tests")
-  elsif host.include? 'minion'
+  elsif host.include? 'minion' or host.include? 'build_host'
     cmd = 'salt'
     extra_cmd = ''
   end

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -281,7 +281,7 @@ When(/^I refresh the metadata for "([^"]*)"$/) do |host|
   if host.include?('client') or host.include?('ceos') or host.include?('ubuntu')
     node.run('rhn_check -vvv', true, 500, 'root')
     client_refresh_metadata
-  elsif host.include?('minion') or host.include?('server') or host.include?('proxy')
+  elsif host.include?('minion') or host.include?('server') or host.include?('proxy') or host.include?('build_host')
     node.run_until_ok('zypper --non-interactive refresh -s')
   else
     raise "The host #{host} has not yet a implementation for that step"
@@ -702,65 +702,6 @@ When(/^I enable SUSE Manager tools repositories on "([^"]*)"$/) do |host|
     repos.gsub(/\s/, ' ').split.each do |repo|
       node.run("sed -i 's/enabled=.*/enabled=1/g' /etc/yum.repos.d/#{repo}.repo")
     end
-  end
-end
-
-When(/^I enable repositories before installing Docker$/) do
-  os_version, os_family = get_os_version($minion)
-
-  # Distribution
-  repos = "os_pool_repo os_update_repo"
-  puts $minion.run("zypper mr --enable #{repos}")
-
-  # Tools
-  repos, _code = $minion.run('zypper lr | grep "tools" | cut -d"|" -f2')
-  puts $minion.run("zypper mr --enable #{repos.gsub(/\s/, ' ')}")
-
-  # Development
-  # (we do not install Python 2 repositories in this branch
-  #  because they are not needed anymore starting with version 4.1)
-  if os_family =~ /^sles/ && os_version =~ /^15/
-    repos = "devel_pool_repo devel_updates_repo"
-    puts $minion.run("zypper mr --enable #{repos}")
-  end
-
-  # Containers
-  unless os_family =~ /^opensuse/ || os_version =~ /^11/
-    repos = "containers_pool_repo containers_updates_repo"
-    puts $minion.run("zypper mr --enable #{repos}")
-  end
-
-  $minion.run('zypper -n --gpg-auto-import-keys ref')
-end
-
-When(/^I disable repositories after installing Docker$/) do
-  os_version, os_family = get_os_version($minion)
-
-  # Distribution
-  repos = "os_pool_repo os_update_repo"
-  puts $minion.run("zypper mr --disable #{repos}")
-
-  # Tools
-  repos, _code = $minion.run('zypper lr | grep "tools" | cut -d"|" -f2')
-  puts $minion.run("zypper mr --disable #{repos.gsub(/\s/, ' ')}")
-
-  # Development
-  # (we do not install Python 2 repositories in this branch
-  #  because they are not needed anymore starting with version 4.1)
-  if os_family =~ /^sles/ && os_version =~ /^15/
-    repos = "devel_pool_repo devel_updates_repo"
-    puts $minion.run("zypper mr --disable #{repos}")
-  end
-
-  # Containers
-  unless os_family =~ /^opensuse/ || os_version =~ /^11/
-    repos = "containers_pool_repo containers_updates_repo"
-    puts $minion.run("zypper mr --disable #{repos}")
-  end
-
-  # Refresh is only necessary when some repos are enabled
-  if $minion.run('zypper -x lr -E').include? '</repo>'
-    $minion.run('zypper -n --gpg-auto-import-keys ref')
   end
 end
 

--- a/testsuite/features/step_definitions/docker_steps.rb
+++ b/testsuite/features/step_definitions/docker_steps.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2019 SUSE LLC.
+# Copyright (c) 2017-2020 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'xmlrpc/client'
@@ -9,17 +9,17 @@ require 'timeout'
 # container operations
 cont_op = XMLRPCImageTest.new(ENV['SERVER'])
 
-# retrieve minion id, needed for scheduleImageBuild call
-def retrieve_minion_id
+# retrieve build host id, needed for scheduleImageBuild call
+def retrieve_build_host_id
   sysrpc = XMLRPCSystemTest.new(ENV['SERVER'])
   sysrpc.login('admin', 'admin')
   systems = sysrpc.list_systems
   refute_nil(systems)
-  minion_id = systems
-              .select { |s| s['name'] == $minion.full_hostname }
-              .map { |s| s['id'] }.first
-  refute_nil(minion_id, "Minion #{$minion.full_hostname} is not yet registered?")
-  minion_id
+  build_host_id = systems
+                  .select { |s| s['name'] == $build_host.full_hostname }
+                  .map { |s| s['id'] }.first
+  refute_nil(build_host_id, "Build host #{$build_host.full_hostname} is not yet registered?")
+  build_host_id
 end
 
 When(/^I navigate to images webpage$/) do
@@ -62,7 +62,7 @@ When(/^I wait at most (\d+) seconds until all "([^"]*)" container images are bui
     end
   end
   # don't run this for sles11 (docker feature is not there)
-  ck_container_imgs(timeout, count) unless sle11family?($minion)
+  ck_container_imgs(timeout, count) unless sle11family?($build_host)
 end
 
 When(/^I check the first image$/) do
@@ -73,20 +73,20 @@ When(/^I schedule the build of image "([^"]*)" via XML-RPC calls$/) do |image|
   cont_op.login('admin', 'admin')
   # empty by default
   version_build = ''
-  build_hostid = retrieve_minion_id
+  build_host_id = retrieve_build_host_id
   now = DateTime.now
   date_build = XMLRPC::DateTime.new(now.year, now.month, now.day, now.hour, now.min, now.sec)
-  cont_op.schedule_image_build(image, version_build, build_hostid, date_build)
+  cont_op.schedule_image_build(image, version_build, build_host_id, date_build)
 end
 
 When(/^I schedule the build of image "([^"]*)" with version "([^"]*)" via XML-RPC calls$/) do |image, version|
   cont_op.login('admin', 'admin')
   # empty by default
   version_build = version
-  build_hostid = retrieve_minion_id
+  build_host_id = retrieve_build_host_id
   now = DateTime.now
   date_build = XMLRPC::DateTime.new(now.year, now.month, now.day, now.hour, now.min, now.sec)
-  cont_op.schedule_image_build(image, version_build, build_hostid, date_build)
+  cont_op.schedule_image_build(image, version_build, build_host_id, date_build)
 end
 
 When(/^I delete the image "([^"]*)" with version "([^"]*)" via XML-RPC calls$/) do |image_name_todel, version|

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -360,6 +360,8 @@ When(/^I select the hostname of "([^"]*)" from "([^"]*)"$/) do |host, hostname|
     step %(I select "#{$proxy.full_hostname}" from "#{hostname}")
   when 'sle_minion'
     step %(I select "#{$minion.full_hostname}" from "#{hostname}")
+  when 'build_host'
+    step %(I select "#{$build_host.full_hostname}" from "#{hostname}")
   end
 end
 

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -63,7 +63,7 @@ end
 # this is a safety net only, the best thing to do is to not start the reposync at all
 def compute_list_to_leave_running
   do_not_kill = []
-  [$minion, $sshminion].each do |node|
+  [$minion, $build_host, $sshminion].each do |node|
     next if node.nil?
     os_version, os_family = get_os_version(node)
     if os_family == 'sles' && os_version == '12SP4'

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2019 SUSE LLC
+# Copyright (c) 2010-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 require 'English'
@@ -114,6 +114,10 @@ end
 
 Before('@ssh_minion') do
   skip_this_scenario unless $ssh_minion
+end
+
+Before('@buildhost') do
+  skip_this_scenario unless $build_host
 end
 
 Before('@virthost_kvm') do

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -8,6 +8,7 @@ raise 'Server IP address or domain name variable empty' if ENV['SERVER'].nil?
 warn 'Proxy IP address or domain name variable empty' if ENV['PROXY'].nil?
 warn 'Client IP address or domain name variable empty' if ENV['CLIENT'].nil?
 warn 'Minion IP address or domain name variable empty' if ENV['MINION'].nil?
+warn 'Buildhost IP address or domain name variable empty' if ENV['BUILD_HOST'].nil?
 warn 'CentOS minion IP address or domain name variable empty' if ENV['CENTOSMINION'].nil?
 warn 'SSH minion IP address or domain name variable empty' if ENV['SSHMINION'].nil?
 warn 'PXE boot MAC address variable empty' if ENV['PXEBOOT_MAC'].nil?
@@ -73,11 +74,12 @@ if $qam_test
 else
   # Define twopence objects for QA environment
   $minion = twopence_init("ssh:#{ENV['MINION']}") if ENV['MINION']
+  $build_host = twopence_init("ssh:#{ENV['BUILD_HOST']}") if ENV['BUILD_HOST']
   $ssh_minion = twopence_init("ssh:#{ENV['SSHMINION']}") if ENV['SSHMINION']
   $client = twopence_init("ssh:#{ENV['CLIENT']}") if ENV['CLIENT']
   $ceos_minion = twopence_init("ssh:#{ENV['CENTOSMINION']}") if ENV['CENTOSMINION']
   $ubuntu_minion = twopence_init("ssh:#{ENV['UBUNTUMINION']}") if ENV['UBUNTUMINION']
-  nodes += [$client, $minion, $ceos_minion, $ubuntu_minion, $ssh_minion]
+  nodes += [$client, $minion, $build_host, $ceos_minion, $ubuntu_minion, $ssh_minion]
 end
 
 # Lavanda library module extension
@@ -200,6 +202,7 @@ $node_by_host = { 'server'                => $server,
                   'ubuntu_ssh_minion'     => $ubuntu_minion,
                   'ssh_minion'            => $ssh_minion,
                   'sle_minion'            => $minion,
+                  'build_host'            => $build_host,
                   'sle_client'            => $client,
                   'kvm_server'            => $kvm_server,
                   'xen_server'            => $xen_server,

--- a/testsuite/run_sets/init_clients.yml
+++ b/testsuite/run_sets/init_clients.yml
@@ -11,5 +11,5 @@
 - features/init_clients/sle_ssh_minion.feature
 - features/init_clients/centos_ssh_minion.feature
 - features/init_clients/ubuntu_ssh_minion.feature
-
+- features/init_clients/sle_buildhost.feature
 ## Post run Core - Initialize clients END ##

--- a/testsuite/run_sets/refhost.yml
+++ b/testsuite/run_sets/refhost.yml
@@ -22,6 +22,7 @@
 - features/init_clients/sle_ssh_minion.feature
 - features/init_clients/centos_ssh_minion.feature
 - features/init_clients/ubuntu_ssh_minion.feature
+- features/init_clients/sle_buildhost.feature
 # these features sync real channels (last core features)
 - features/reposync/srv_sync_channels.feature
 - features/reposync/srv_sync_products.feature

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -9,7 +9,7 @@
 # IDEMPOTENT
 
 - features/secondary/srv_users.feature
-- features/secondary/min_osimage_build_image.feature
+- features/secondary/buildhost_osimage_build_image.feature
 - features/secondary/allcli_reboot.feature
 - features/secondary/trad_config_channel.feature
 - features/secondary/trad_lock_packages.feature
@@ -37,8 +37,8 @@
 - features/secondary/allcli_action_chain.feature
 - features/secondary/srv_delete_channel_from_ui.feature
 - features/secondary/srv_delete_channel_with_tool.feature
-- features/secondary/min_docker_build_image.feature
-- features/secondary/min_docker_auth_registry.feature
+- features/secondary/buildhost_docker_build_image.feature
+- features/secondary/buildhost_docker_auth_registry.feature
 - features/secondary/min_docker_xmlrpc.feature
 - features/secondary/min_recurring_action.feature
 - features/secondary/min_change_software_channel.feature

--- a/testsuite/run_sets/sle-updates.yml
+++ b/testsuite/run_sets/sle-updates.yml
@@ -20,6 +20,7 @@
 - features/init_clients/sle_client.feature
 - features/init_clients/sle_minion.feature
 - features/init_clients/ubuntu_ssh_minion.feature
+- features/init_clients/sle_buildhost.feature
 # these features sync real channels (last core features)
 - features/reposync/srv_sync_channels.feature
 - features/reposync/core_srv_setup_wizard.feature
@@ -46,7 +47,7 @@
 - features/secondary/min_docker_auth_registry.feature
 - features/secondary/srv_docker_advanced_content_management.feature
 - features/secondary/srv_docker_cve_audit.feature
-- features/secondary/min_osimage_build_image.feature
+- features/secondary/buildhost_osimage_build_image.feature
 - features/secondary/min_salt_install_package.feature
 - features/secondary/srv_power_management.feature
 - features/secondary/srv_datepicker.feature


### PR DESCRIPTION
## What does this PR change?

Do not turn the sle_minion into a container/build host.
Add the container/build host entitlements specifically to
a new host (build host).
Tag the scenarios for the new host with the tag `@buildhost`.

(See https://github.com/SUSE/spacewalk/issues/10680)

- testsuite/features/init_clients/sle_buildhost.feature: New file.
- testsuite/features/init_clients/sle_minion.feature: Do not
  turn the sle minion into neither container nor image build host.

- testsuite/features/secondary/buildhost_osimage_build_image.feature
- testsuite/features/secondary/buildhost_docker_build_image.feature
- testsuite/features/secondary/buildhost_docker_auth_registry.feature:
  Renamed with prefix 'buildhost_'.
  Use buildhost tag.

- testsuite/features/secondary/min_activationkey.feature
- testsuite/features/secondary/min_bootstrap_negative.feature
- testsuite/features/secondary/min_bootstrap_script.feature
- testsuite/features/secondary/min_bootstrap_xmlrpc.feature
- testsuite/features/secondary/min_salt_minions_page.feature
- testsuite/features/secondary/min_bootstrap_ssh_key.feature:
  Remove clean up scenarios for build host entitlements.

- testsuite/features/secondary/min_docker_build_image.feature:
  Use buildhost tag.

- testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature:
  Use the new file name (i.e. buildhost_osimage_build_image.feature)

- testsuite/features/step_definitions/common_steps.rb:
  Remove step definitions for enable/disable repos before/after install Docker.
  Take in account the new buildhost tag.

- testsuite/features/step_definitions/command_steps.rb
- testsuite/features/step_definitions/navigation_steps.rb
- testsuite/features/support/commonlib.rb:
  Take in account the new buildhost tag.

- testsuite/features/step_definitions/docker_steps.rb (retrieve_build_host_id):
  Renamed from `retrieve_minion_id`.  All callers updated.
  Take in account the new buildhost tag.

- testsuite/features/support/env.rb:
  Skip scenarios tagged with `@buildhost` when the build host VM is missing.

- testsuite/features/support/twopence_init.rb:
  Make the environment aware of the build host VM.

- testsuite/run_sets/init_clients.yml
- testsuite/run_sets/refhost.yml
- testsuite/run_sets/sle-updates.yml:
  List the new file (sle_buildhost.feature)

- testsuite/run_sets/secondary.yml
- testsuite/run_sets/sle-updates.yml:
  Adjust with the renamed file (buildhost_osimage_build_image.feature).

- testsuite/README.md: Use the URL of Uyuni project for the link.
- testsuite/documentation/guidelines.md (Rules for features)
  Document the new prefix 'buildhost'.

- testsuite/documentation/cucumber-steps.md
- testsuite/documentation/optional.md
- testsuite/documentation/static-run.md: Document buildhost VM.

- testsuite/features/core/allcli_sanity.feature: Add scenario for the build host.

## Links
### Ports
- Manager-3.2: https://github.com/SUSE/spacewalk/pull/11430
- Manager-4.0: https://github.com/SUSE/spacewalk/pull/11431

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
