### PR TITLE
Adds ssm text to header

### DIFF
--- a/branding/css/spacewalk-tables.less
+++ b/branding/css/spacewalk-tables.less
@@ -105,7 +105,6 @@
 	}
 }
 
-
 .table thead > tr > td{
 	padding: 0
 }
@@ -210,4 +209,8 @@ th.descSort a:after {
 
 .table-striped > tbody > tr.tree-row-child-odd:hover > td {
   background-color: #d9d9d9;
+}
+
+.span-ssm-marg {
+  margin-left: 7px;
 }

--- a/branding/spacewalk-branding.changes
+++ b/branding/spacewalk-branding.changes
@@ -1,3 +1,5 @@
+- Clarify the behavior of the checkbox system list, when it adds systems to ssm
+
 -------------------------------------------------------------------
 Mon Apr 13 09:32:49 CEST 2020 - jgonzalez@suse.com
 

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/list/SelectableColumnTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/list/SelectableColumnTag.java
@@ -54,6 +54,7 @@ public class SelectableColumnTag extends TagSupport {
     private String listName;
     private String rhnSet;
     private String hideDisabled;
+    private String checkboxText;
 
     /**
      * Sets the column width
@@ -119,6 +120,13 @@ public class SelectableColumnTag extends TagSupport {
         hideDisabled = expr;
     }
 
+    /**
+     * setter for checkboxTextIn
+     * @param checkboxTextIn "true" if we should hide disabled checkboxes, else we show them
+     */
+    public void setCheckboxText(String checkboxTextIn) {
+        checkboxText = checkboxTextIn;
+    }
 
     /**
      * {@inheritDoc}
@@ -223,6 +231,9 @@ public class SelectableColumnTag extends TagSupport {
                                 getIgnorableParentIds());
         ListTagUtil.write(pageContext, script);
         ListTagUtil.write(pageContext, "\" />");
+        if (checkboxText != null) {
+            ListTagUtil.write(pageContext, checkboxText);
+        }
     }
     private void renderCheckbox() throws JspException {
         render(valueExpr);

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/rhn-list.tld
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/rhn-list.tld
@@ -282,6 +282,11 @@
       <required>false</required>
       <rtexprvalue>true</rtexprvalue>
     </attribute>
+    <attribute>
+      <name>checkboxText</name>
+      <required>false</required>
+      <rtexprvalue>true</rtexprvalue>
+    </attribute>
   </tag>
   <tag>
     <name>radiocolumn</name>

--- a/java/code/webapp/WEB-INF/pages/common/fragments/systems/system_listdisplay.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/systems/system_listdisplay.jspf
@@ -26,8 +26,12 @@
     <c:if test = "${empty notSelectable}">
         <rl:decorator name="SelectableDecorator"/>
         <rl:selectablecolumn value="${current.id}"
+                width="75"
+                checkboxText="<span class='span-ssm-marg'>SSM</spank>"
                 selected="${current.selected}"
-                disabled="${not current.selectable}"/>
+                disabled="${not current.selectable}"
+                />
+                
         <c:if test="${empty noAddToSsm}">
             <rl:decorator name="AddToSsmDecorator"/>
         </c:if>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Clarify the behavior of the checkbox system list, when it adds systems to ssm
 - Implement module picker controls for CLM AppStream filters
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?
Some system list pages have an automagic adding/removing from the SSM by selecting/deselecting the checkbox.  This pr adds the "SSM" text to the table header to make it clear that it's an SSM checkbox. 

## GUI diff

No difference.

Before:
![image](https://user-images.githubusercontent.com/729087/81541718-da3a5700-9373-11ea-9f84-c1657e8a4da9.png)

After:
![image](https://user-images.githubusercontent.com/729087/81541775-f0e0ae00-9373-11ea-9d1a-83babf8d8822.png)

No header text on pages with the add to ssm button

![image](https://user-images.githubusercontent.com/729087/81541930-2ab1b480-9374-11ea-8ac5-cee8ed2bbe58.png)

- [ ] **DONE**

## Documentation
- No documentation needed: I will ping @Loquacity about updating screen shots. 

- [x] **DONE**

## Test coverage
- No tests: not needed 

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle" 
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
