### PR TITLE
temporary hack to pass accessible url check

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -997,6 +997,9 @@ public class ContentSyncManager {
      * @throws URISyntaxException in case of an error
      */
     public String buildRepoFileUrl(String url, SCCRepository repo) throws URISyntaxException {
+        if (url.contains("mirrorlist")) {
+            return url;
+        }
         URI uri = new URI(url);
         String relFile = "/repodata/repomd.xml";
 


### PR DESCRIPTION
## What does this PR change?

This makes sure that for mirrorlist urls we check the original url instread of looking for repo metadata.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
