### PR TITLE
Content Lifecycle Management: speedup

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/CachedStatement.java
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/CachedStatement.java
@@ -46,6 +46,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import javax.persistence.FlushModeType;
 
 /**
  * A cached set of query/elaborator strings and the parameterMap hash maps.
@@ -908,7 +909,9 @@ public class CachedStatement implements Serializable {
      */
     private <T> T doWithStolenConnection(ReturningWork<T> work) throws HibernateException {
         Session session = HibernateFactory.getSession();
-        session.flush();
+        if (session.getFlushMode().equals(FlushModeType.AUTO)) {
+            session.flush();
+        }
         return session.doReturningWork(work);
     }
 

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Channel_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Channel_queries.xml
@@ -1200,4 +1200,11 @@ ORDER BY CC.modified DESC
         VALUES(:original_id, :channel_id)
     </query>
 </write-mode>
+
+<callable-mode name="analyze_channel_packages">
+    <query>
+    ANALYZE rhnChannelPackage
+    </query>
+</callable-mode>
+
 </datasource_modes>

--- a/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
@@ -1274,7 +1274,7 @@ public class ChannelFactory extends HibernateFactory {
      * @param eids List of eids to add mappings for
      * @param cid channel id we're cloning into
      */
-    public static void addClonedErrataToChannel(Set<Long> eids, Long cid) {
+    public static void addErrataToChannel(Set<Long> eids, Long cid) {
         WriteMode m = ModeFactory.getWriteMode("Channel_queries",
                 "add_cloned_erratum_to_channel");
         Map<String, Object> params = new HashMap<String, Object>();

--- a/java/code/src/com/redhat/rhn/domain/errata/AbstractErrata.java
+++ b/java/code/src/com/redhat/rhn/domain/errata/AbstractErrata.java
@@ -624,16 +624,16 @@ public abstract class AbstractErrata extends BaseDomainHelper implements
     public void addNotification(Date dateIn) {
         ErrataManager.clearErrataNotifications(this);
         for (Channel chan : getChannels()) {
-            ErrataManager.addErrataNotification(this, chan, dateIn);
+            ErrataManager.addErrataNotification(id, chan.getId(), dateIn);
         }
     }
 
     /**
      * {@inheritDoc}
      */
-    public void addChannelNotification(Channel channelIn, Date dateIn) {
-        ErrataManager.clearErrataChannelNotifications(this, channelIn);
-        ErrataManager.addErrataNotification(this, channelIn, dateIn);
+    public void addChannelNotification(long channelId, Date dateIn) {
+        ErrataManager.clearErrataChannelNotifications(id, channelId);
+        ErrataManager.addErrataNotification(id, channelId, dateIn);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/errata/AbstractErrata.java
+++ b/java/code/src/com/redhat/rhn/domain/errata/AbstractErrata.java
@@ -631,14 +631,6 @@ public abstract class AbstractErrata extends BaseDomainHelper implements
     /**
      * {@inheritDoc}
      */
-    public void replaceChannelNotifications(long channelId, Date dateIn) {
-        ErrataManager.clearErrataChannelNotifications(id, channelId);
-        ErrataManager.addErrataNotification(id, channelId, dateIn);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public List getNotificationQueue() {
         return ErrataManager.listErrataNotifications(this);
     }

--- a/java/code/src/com/redhat/rhn/domain/errata/AbstractErrata.java
+++ b/java/code/src/com/redhat/rhn/domain/errata/AbstractErrata.java
@@ -631,7 +631,7 @@ public abstract class AbstractErrata extends BaseDomainHelper implements
     /**
      * {@inheritDoc}
      */
-    public void addChannelNotification(long channelId, Date dateIn) {
+    public void replaceChannelNotifications(long channelId, Date dateIn) {
         ErrataManager.clearErrataChannelNotifications(id, channelId);
         ErrataManager.addErrataNotification(id, channelId, dateIn);
     }

--- a/java/code/src/com/redhat/rhn/domain/errata/Errata.java
+++ b/java/code/src/com/redhat/rhn/domain/errata/Errata.java
@@ -398,10 +398,10 @@ public interface Errata {
     /**
      * Add a new notification for this errata
      * in specified channel
-     * @param channelIn affected channel
+     * @param channelId affected channel ID
      * @param dateIn The notify date
      */
-    void addChannelNotification(Channel channelIn, Date dateIn);
+    void addChannelNotification(long channelId, Date dateIn);
 
     /**
      * List errata notifications that are queued

--- a/java/code/src/com/redhat/rhn/domain/errata/Errata.java
+++ b/java/code/src/com/redhat/rhn/domain/errata/Errata.java
@@ -396,12 +396,12 @@ public interface Errata {
     void addNotification(Date dateIn);
 
     /**
-     * Add a new notification for this errata
-     * in specified channel
+     * Replaces any existing notifications pending for this errata and channel with
+     * a new one for the specified channel
      * @param channelId affected channel ID
      * @param dateIn The notify date
      */
-    void addChannelNotification(long channelId, Date dateIn);
+    void replaceChannelNotifications(long channelId, Date dateIn);
 
     /**
      * List errata notifications that are queued

--- a/java/code/src/com/redhat/rhn/domain/errata/Errata.java
+++ b/java/code/src/com/redhat/rhn/domain/errata/Errata.java
@@ -396,14 +396,6 @@ public interface Errata {
     void addNotification(Date dateIn);
 
     /**
-     * Replaces any existing notifications pending for this errata and channel with
-     * a new one for the specified channel
-     * @param channelId affected channel ID
-     * @param dateIn The notify date
-     */
-    void replaceChannelNotifications(long channelId, Date dateIn);
-
-    /**
      * List errata notifications that are queued
      * @return list of maps with channel_id and time
      */

--- a/java/code/src/com/redhat/rhn/domain/errata/ErrataFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/errata/ErrataFactory.java
@@ -280,7 +280,7 @@ public class ErrataFactory extends HibernateFactory {
                 errata = publish(errata);
             }
             errata.addChannel(chan);
-            errata.addChannelNotification(chan, new Date());
+            errata.addChannelNotification(chan.getId(), new Date());
 
             Set<Package> packagesToPush = new HashSet<Package>();
             DataResult<PackageOverview> packs;

--- a/java/code/src/com/redhat/rhn/domain/errata/ErrataFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/errata/ErrataFactory.java
@@ -280,7 +280,7 @@ public class ErrataFactory extends HibernateFactory {
                 errata = publish(errata);
             }
             errata.addChannel(chan);
-            errata.addChannelNotification(chan.getId(), new Date());
+            errata.replaceChannelNotifications(chan.getId(), new Date());
 
             Set<Package> packagesToPush = new HashSet<Package>();
             DataResult<PackageOverview> packs;

--- a/java/code/src/com/redhat/rhn/domain/errata/ErrataFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/errata/ErrataFactory.java
@@ -280,7 +280,7 @@ public class ErrataFactory extends HibernateFactory {
                 errata = publish(errata);
             }
             errata.addChannel(chan);
-            errata.replaceChannelNotifications(chan.getId(), new Date());
+            ErrataManager.replaceChannelNotifications(errata.getId(), chan.getId(), new Date());
 
             Set<Package> packagesToPush = new HashSet<Package>();
             DataResult<PackageOverview> packs;

--- a/java/code/src/com/redhat/rhn/domain/errata/impl/UnpublishedErrata.java
+++ b/java/code/src/com/redhat/rhn/domain/errata/impl/UnpublishedErrata.java
@@ -26,8 +26,7 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Errata - Class representation of the table rhnErrata.
- * @version $Rev: 51306 $
+ * Errata - Class representation of the table rhnErrataTmp.
  */
 public class UnpublishedErrata extends AbstractErrata {
 

--- a/java/code/src/com/redhat/rhn/frontend/events/test/CloneErrataActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/test/CloneErrataActionTest.java
@@ -84,7 +84,7 @@ public class CloneErrataActionTest extends BaseTestCaseWithUser {
 
         // run CloneErrataAction
         Collection<Long> errataIds = new LinkedList<Long>() { { add(errata.getId()); } };
-        CloneErrataEvent event = new CloneErrataEvent(cloned, errataIds, user);
+        CloneErrataEvent event = new CloneErrataEvent(cloned, errataIds, admin);
         new CloneErrataAction().execute(event);
 
         // new errata should be in cloned channel, new repository metadata

--- a/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
@@ -14,6 +14,10 @@
  */
 package com.redhat.rhn.manager.channel;
 
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+import static java.util.Optional.ofNullable;
+
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.db.datasource.CallableMode;
@@ -102,10 +106,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static java.util.Optional.empty;
-import static java.util.Optional.of;
-import static java.util.Optional.ofNullable;
 
 /**
  * ChannelManager
@@ -2930,5 +2930,13 @@ public class ChannelManager extends BaseManager {
             break;
         }
         return cType;
+    }
+
+    /**
+     * Analyzes the rhnChannelPackage table, useful to update statistics after massive changes.
+     */
+    public static void analyzeChannelPackages() {
+        var m = ModeFactory.getCallableMode("Channel_queries", "analyze_channel_packages");
+        m.execute(new HashMap<>(), new HashMap<>());
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -15,6 +15,23 @@
 
 package com.redhat.rhn.manager.contentmgmt;
 
+import static com.redhat.rhn.domain.contentmgmt.ContentProjectFactory.lookupClonesInProject;
+import static com.redhat.rhn.domain.contentmgmt.ProjectSource.State.ATTACHED;
+import static com.redhat.rhn.domain.contentmgmt.ProjectSource.State.BUILT;
+import static com.redhat.rhn.domain.contentmgmt.ProjectSource.State.DETACHED;
+import static com.redhat.rhn.domain.contentmgmt.ProjectSource.Type.SW_CHANNEL;
+import static com.redhat.rhn.domain.role.RoleFactory.ORG_ADMIN;
+import static com.redhat.rhn.manager.channel.CloneChannelCommand.CloneBehavior.EMPTY;
+import static com.suse.utils.Opt.stream;
+import static java.util.Collections.emptyList;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+import static java.util.Optional.ofNullable;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.partitioningBy;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.hibernate.LookupException;
 import com.redhat.rhn.common.messaging.MessageQueue;
@@ -32,12 +49,12 @@ import com.redhat.rhn.domain.contentmgmt.ContentProjectHistoryEntry;
 import com.redhat.rhn.domain.contentmgmt.EnvironmentTarget;
 import com.redhat.rhn.domain.contentmgmt.ErrataFilter;
 import com.redhat.rhn.domain.contentmgmt.FilterCriteria;
-import com.redhat.rhn.domain.contentmgmt.modulemd.ModulemdApi;
 import com.redhat.rhn.domain.contentmgmt.PackageFilter;
 import com.redhat.rhn.domain.contentmgmt.ProjectSource;
 import com.redhat.rhn.domain.contentmgmt.ProjectSource.Type;
 import com.redhat.rhn.domain.contentmgmt.SoftwareEnvironmentTarget;
 import com.redhat.rhn.domain.contentmgmt.SoftwareProjectSource;
+import com.redhat.rhn.domain.contentmgmt.modulemd.ModulemdApi;
 import com.redhat.rhn.domain.errata.Errata;
 import com.redhat.rhn.domain.rhnpackage.Package;
 import com.redhat.rhn.domain.user.User;
@@ -63,23 +80,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
-
-import static com.redhat.rhn.domain.contentmgmt.ContentProjectFactory.lookupClonesInProject;
-import static com.redhat.rhn.domain.contentmgmt.ProjectSource.State.ATTACHED;
-import static com.redhat.rhn.domain.contentmgmt.ProjectSource.State.BUILT;
-import static com.redhat.rhn.domain.contentmgmt.ProjectSource.State.DETACHED;
-import static com.redhat.rhn.domain.contentmgmt.ProjectSource.Type.SW_CHANNEL;
-import static com.redhat.rhn.domain.role.RoleFactory.ORG_ADMIN;
-import static com.redhat.rhn.manager.channel.CloneChannelCommand.CloneBehavior.EMPTY;
-import static com.suse.utils.Opt.stream;
-import static java.util.Collections.emptyList;
-import static java.util.Optional.empty;
-import static java.util.Optional.of;
-import static java.util.Optional.ofNullable;
-import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.partitioningBy;
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toSet;
 
 /**
  * Content Management functionality
@@ -890,6 +890,9 @@ public class ContentManager {
 
         // align errata and the cache (rhnServerNeededCache)
         alignErrata(src, tgt, errataFilters, user);
+
+        // a lot was inserted into rhnChannelPackage at this point. Make sure stats are up-to-date before continuing
+        ChannelManager.analyzeChannelPackages();
 
         // update the channel newest packages cache
         ChannelFactory.refreshNewestPackageCache(tgt, "java::alignPackages");

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -235,7 +235,7 @@ public class ErrataManager extends BaseManager {
         //if we're publishing the errata but not pushing packages
         //  We need to add cache entries for ones that are already in the channel
         //  and associated to the errata
-        ErrataCacheManager.insertCacheForChannelErrata(channelIds, errata.getId());
+        ErrataCacheManager.addErrataRefreshing(channelIds, errata.getId());
 
 
         //Save the errata
@@ -2281,20 +2281,20 @@ public class ErrataManager extends BaseManager {
             Errata errata = ErrataFactory.lookupById(eid);
             // we merge custom errata directly (non Redhat and cloned)
             if (errata.getOrg() != null) {
-                ErrataCacheManager.insertCacheForChannelErrata(cids, eid);
+                ErrataCacheManager.addErrataRefreshing(cids, eid);
             }
             else {
                 List<Errata> clones = lookupPublishedByOriginal(user, errata);
                 if (clones.size() == 0) {
                     log.debug("Cloning errata");
                     var publishedId = HibernateFactory.doWithoutAutoFlushing(() -> PublishErrataHelper.cloneErrataFaster(eid, user.getOrg()));
-                    ErrataCacheManager.insertCacheForChannelErrata(cids, publishedId);
+                    ErrataCacheManager.addErrataRefreshing(cids, publishedId);
                 }
                 else {
                     log.debug("Re-publishing clone");
                     Errata firstClone = clones.get(0);
 
-                    ErrataCacheManager.insertCacheForChannelErrata(cids, firstClone.getId());
+                    ErrataCacheManager.addErrataRefreshing(cids, firstClone.getId());
                 }
             }
         }

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -230,10 +230,8 @@ public class ErrataManager extends BaseManager {
         while (itr.hasNext()) {
             Long channelId = (Long) itr.next();
             Channel channel = ChannelManager.lookupByIdAndUser(channelId, user);
-            if (channel != null) {
-                errata.addChannel(channel);
-                errata.addChannelNotification(channel, new Date());
-            }
+            errata.addChannel(channel);
+            errata.addChannelNotification(channel, new Date());
         }
 
         //if we're publishing the errata but not pushing packages

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -1642,7 +1642,7 @@ public class ErrataManager extends BaseManager {
             }
         }
 
-        ChannelFactory.addClonedErrataToChannel(eids, toCid);
+        ChannelFactory.addErrataToChannel(eids, toCid);
 
         // for things like errata email and auto errata updates
         for (Long eid : eids) {

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -230,7 +230,7 @@ public class ErrataManager extends BaseManager {
         while (itr.hasNext()) {
             Long channelId = (Long) itr.next();
             ChannelManager.lookupByIdAndUser(channelId, user);
-            errata.replaceChannelNotifications(channelId, new Date());
+            ErrataManager.replaceChannelNotifications(errata.getId(), channelId, new Date());
         }
 
         //if we're publishing the errata but not pushing packages
@@ -1743,6 +1743,18 @@ public class ErrataManager extends BaseManager {
     }
 
     /**
+     * Replaces any existing notifications pending for an errata and channel with
+     * a new one for the specified channel
+     * @param errataId the errata ID
+     * @param channelId affected channel ID
+     * @param dateIn The notify date
+     */
+    public static void replaceChannelNotifications(long errataId, long channelId, Date dateIn) {
+        clearErrataChannelNotifications(errataId, channelId);
+        addErrataNotification(errataId, channelId, dateIn);
+    }
+
+    /**
      * List queued errata notifications
      * @param e the errata
      * @return list of maps
@@ -2275,7 +2287,7 @@ public class ErrataManager extends BaseManager {
             // we merge custom errata directly (non Redhat and cloned)
             if (errata.getOrg() != null) {
                 ErrataCacheManager.insertCacheForChannelErrata(cids, eid);
-                errata.replaceChannelNotifications(channelId, new Date());
+                ErrataManager.replaceChannelNotifications(eid, channelId, new Date());
             }
             else {
                 Set<Channel> channelSet = new HashSet<>();
@@ -2287,7 +2299,7 @@ public class ErrataManager extends BaseManager {
                     var publishedId = HibernateFactory.doWithoutAutoFlushing(() -> PublishErrataHelper.cloneErrataFaster(eid, user.getOrg()));
                     Errata published = ErrataFactory.lookupById(publishedId);
                     ErrataCacheManager.insertCacheForChannelErrata(cids, publishedId);
-                    published.replaceChannelNotifications(channelId, new Date());
+                    ErrataManager.replaceChannelNotifications(publishedId, channelId, new Date());
                 }
                 else {
                     log.debug("Re-publishing clone");

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -230,7 +230,6 @@ public class ErrataManager extends BaseManager {
         while (itr.hasNext()) {
             Long channelId = (Long) itr.next();
             ChannelManager.lookupByIdAndUser(channelId, user);
-            ErrataManager.replaceChannelNotifications(errata.getId(), channelId, new Date());
         }
 
         //if we're publishing the errata but not pushing packages
@@ -2287,7 +2286,6 @@ public class ErrataManager extends BaseManager {
             // we merge custom errata directly (non Redhat and cloned)
             if (errata.getOrg() != null) {
                 ErrataCacheManager.insertCacheForChannelErrata(cids, eid);
-                ErrataManager.replaceChannelNotifications(eid, channelId, new Date());
             }
             else {
                 Set<Channel> channelSet = new HashSet<>();
@@ -2299,7 +2297,6 @@ public class ErrataManager extends BaseManager {
                     var publishedId = HibernateFactory.doWithoutAutoFlushing(() -> PublishErrataHelper.cloneErrataFaster(eid, user.getOrg()));
                     Errata published = ErrataFactory.lookupById(publishedId);
                     ErrataCacheManager.insertCacheForChannelErrata(cids, publishedId);
-                    ErrataManager.replaceChannelNotifications(publishedId, channelId, new Date());
                 }
                 else {
                     log.debug("Re-publishing clone");

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -241,7 +241,7 @@ public class ErrataManager extends BaseManager {
         //  and associated to the errata
         List<Long> list = new ArrayList<Long>();
         list.addAll(channelIds);
-        ErrataCacheManager.insertCacheForChannelErrata(list, errata);
+        ErrataCacheManager.insertCacheForChannelErrata(list, errata.getId());
 
 
         //Save the errata
@@ -2280,7 +2280,7 @@ public class ErrataManager extends BaseManager {
             // we merge custom errata directly (non Redhat and cloned)
             if (errata.getOrg() != null) {
                 errata.addChannel(channel);
-                ErrataCacheManager.insertCacheForChannelErrata(cids, errata);
+                ErrataCacheManager.insertCacheForChannelErrata(cids, eid);
                 errata.addChannelNotification(channel, new Date());
             }
             else {
@@ -2293,7 +2293,7 @@ public class ErrataManager extends BaseManager {
                     var publishedId = HibernateFactory.doWithoutAutoFlushing(() -> PublishErrataHelper.cloneErrataFaster(eid, user.getOrg()));
                     Errata published = ErrataFactory.lookupById(publishedId);
                     published.setChannels(channelSet);
-                    ErrataCacheManager.insertCacheForChannelErrata(cids, published);
+                    ErrataCacheManager.insertCacheForChannelErrata(cids, publishedId);
                     published.addChannelNotification(channel, new Date());
                 }
                 else {

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -2288,7 +2288,6 @@ public class ErrataManager extends BaseManager {
                 if (clones.size() == 0) {
                     log.debug("Cloning errata");
                     var publishedId = HibernateFactory.doWithoutAutoFlushing(() -> PublishErrataHelper.cloneErrataFaster(eid, user.getOrg()));
-                    Errata published = ErrataFactory.lookupById(publishedId);
                     ErrataCacheManager.insertCacheForChannelErrata(cids, publishedId);
                 }
                 else {

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -2296,8 +2296,6 @@ public class ErrataManager extends BaseManager {
                     Errata firstClone = clones.get(0);
 
                     ErrataCacheManager.insertCacheForChannelErrata(cids, firstClone.getId());
-
-                    updateSearchIndex();
                 }
             }
         }
@@ -2307,5 +2305,8 @@ public class ErrataManager extends BaseManager {
             ChannelFactory.save(channel);
             ChannelManager.queueChannelChange(channel.getLabel(), "java::cloneErrata", "Errata cloned");
         }
+
+        // update search index via XMLRPC
+        updateSearchIndex();
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -230,7 +230,7 @@ public class ErrataManager extends BaseManager {
         while (itr.hasNext()) {
             Long channelId = (Long) itr.next();
             ChannelManager.lookupByIdAndUser(channelId, user);
-            errata.addChannelNotification(channelId, new Date());
+            errata.replaceChannelNotifications(channelId, new Date());
         }
 
         //if we're publishing the errata but not pushing packages
@@ -2275,7 +2275,7 @@ public class ErrataManager extends BaseManager {
             // we merge custom errata directly (non Redhat and cloned)
             if (errata.getOrg() != null) {
                 ErrataCacheManager.insertCacheForChannelErrata(cids, eid);
-                errata.addChannelNotification(channelId, new Date());
+                errata.replaceChannelNotifications(channelId, new Date());
             }
             else {
                 Set<Channel> channelSet = new HashSet<>();
@@ -2287,7 +2287,7 @@ public class ErrataManager extends BaseManager {
                     var publishedId = HibernateFactory.doWithoutAutoFlushing(() -> PublishErrataHelper.cloneErrataFaster(eid, user.getOrg()));
                     Errata published = ErrataFactory.lookupById(publishedId);
                     ErrataCacheManager.insertCacheForChannelErrata(cids, publishedId);
-                    published.addChannelNotification(channelId, new Date());
+                    published.replaceChannelNotifications(channelId, new Date());
                 }
                 else {
                     log.debug("Re-publishing clone");

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -2269,12 +2269,8 @@ public class ErrataManager extends BaseManager {
      */
     public static void cloneErrata(Long channelId, Collection<Long> errataToClone, boolean requestRepodataRegen,
             User user) {
-        Channel channel = ChannelFactory.lookupById(channelId);
-        if (channel == null) {
-            log.error("Failed to clone errata " + errataToClone + " Didn't find channel with id: " +
-                    channelId.toString());
-            return;
-        }
+        Channel channel = ChannelManager.lookupByIdAndUser(channelId, user);
+
         Collection<Long> list = errataToClone;
         List<Long> cids = new ArrayList<Long>();
         cids.add(channel.getId());
@@ -2288,9 +2284,6 @@ public class ErrataManager extends BaseManager {
                 ErrataCacheManager.insertCacheForChannelErrata(cids, eid);
             }
             else {
-                Set<Channel> channelSet = new HashSet<>();
-                channelSet.add(channel);
-
                 List<Errata> clones = lookupPublishedByOriginal(user, errata);
                 if (clones.size() == 0) {
                     log.debug("Cloning errata");
@@ -2300,7 +2293,11 @@ public class ErrataManager extends BaseManager {
                 }
                 else {
                     log.debug("Re-publishing clone");
-                    publish(clones.get(0), cids, user);
+                    Errata firstClone = clones.get(0);
+
+                    ErrataCacheManager.insertCacheForChannelErrata(cids, firstClone.getId());
+
+                    updateSearchIndex();
                 }
             }
         }

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -229,8 +229,8 @@ public class ErrataManager extends BaseManager {
 
         while (itr.hasNext()) {
             Long channelId = (Long) itr.next();
-            Channel channel = ChannelManager.lookupByIdAndUser(channelId, user);
-            errata.addChannelNotification(channel, new Date());
+            ChannelManager.lookupByIdAndUser(channelId, user);
+            errata.addChannelNotification(channelId, new Date());
         }
 
         //if we're publishing the errata but not pushing packages
@@ -1680,15 +1680,15 @@ public class ErrataManager extends BaseManager {
 
     /**
      * Send errata notifications for a particular errata and channel
-     * @param e the errata to send notifications about
-     * @param chan the channel with which to decide which systems
+     * @param errataId the errata ID to send notifications about
+     * @param channelId the channel ID with which to decide which systems
      *       and users to send errata for
      * @param date  the date
      */
-    public static void addErrataNotification(Errata e, Channel chan, Date date) {
+    public static void addErrataNotification(long errataId, long channelId, Date date) {
         Map<String, Object> params = new HashMap<String, Object>();
-        params.put("cid", chan.getId());
-        params.put("eid", e.getId());
+        params.put("cid", channelId);
+        params.put("eid", errataId);
         java.sql.Date newDate = new java.sql.Date(date.getTime());
         params.put("datetime", newDate);
         WriteMode m = ModeFactory.getWriteMode(
@@ -1730,13 +1730,13 @@ public class ErrataManager extends BaseManager {
 
     /**
      * Delete all errata notifications for an errata in specified channel
-     * @param e the errata to clear notifications for
-     * @param c affected channel
+     * @param errataId the errata ID to clear notifications for
+     * @param channelId affected channel ID
      */
-    public static void clearErrataChannelNotifications(Errata e, Channel c) {
+    public static void clearErrataChannelNotifications(long errataId, long channelId) {
         Map<String, Object> params = new HashMap<String, Object>();
-        params.put("eid", e.getId());
-        params.put("cid", c.getId());
+        params.put("eid", errataId);
+        params.put("cid", channelId);
         WriteMode m = ModeFactory.getWriteMode(
                 "Errata_queries",  "clear_errata_channel_notification");
         m.executeUpdate(params);
@@ -2275,7 +2275,7 @@ public class ErrataManager extends BaseManager {
             // we merge custom errata directly (non Redhat and cloned)
             if (errata.getOrg() != null) {
                 ErrataCacheManager.insertCacheForChannelErrata(cids, eid);
-                errata.addChannelNotification(channel, new Date());
+                errata.addChannelNotification(channelId, new Date());
             }
             else {
                 Set<Channel> channelSet = new HashSet<>();
@@ -2287,7 +2287,7 @@ public class ErrataManager extends BaseManager {
                     var publishedId = HibernateFactory.doWithoutAutoFlushing(() -> PublishErrataHelper.cloneErrataFaster(eid, user.getOrg()));
                     Errata published = ErrataFactory.lookupById(publishedId);
                     ErrataCacheManager.insertCacheForChannelErrata(cids, publishedId);
-                    published.addChannelNotification(channel, new Date());
+                    published.addChannelNotification(channelId, new Date());
                 }
                 else {
                     log.debug("Re-publishing clone");

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -239,9 +239,7 @@ public class ErrataManager extends BaseManager {
         //if we're publishing the errata but not pushing packages
         //  We need to add cache entries for ones that are already in the channel
         //  and associated to the errata
-        List<Long> list = new ArrayList<Long>();
-        list.addAll(channelIds);
-        ErrataCacheManager.insertCacheForChannelErrata(list, errata.getId());
+        ErrataCacheManager.insertCacheForChannelErrata(channelIds, errata.getId());
 
 
         //Save the errata

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -230,7 +230,6 @@ public class ErrataManager extends BaseManager {
         while (itr.hasNext()) {
             Long channelId = (Long) itr.next();
             Channel channel = ChannelManager.lookupByIdAndUser(channelId, user);
-            errata.addChannel(channel);
             errata.addChannelNotification(channel, new Date());
         }
 
@@ -2275,7 +2274,6 @@ public class ErrataManager extends BaseManager {
             Errata errata = ErrataFactory.lookupById(eid);
             // we merge custom errata directly (non Redhat and cloned)
             if (errata.getOrg() != null) {
-                errata.addChannel(channel);
                 ErrataCacheManager.insertCacheForChannelErrata(cids, eid);
                 errata.addChannelNotification(channel, new Date());
             }
@@ -2288,7 +2286,6 @@ public class ErrataManager extends BaseManager {
                     log.debug("Cloning errata");
                     var publishedId = HibernateFactory.doWithoutAutoFlushing(() -> PublishErrataHelper.cloneErrataFaster(eid, user.getOrg()));
                     Errata published = ErrataFactory.lookupById(publishedId);
-                    published.setChannels(channelSet);
                     ErrataCacheManager.insertCacheForChannelErrata(cids, publishedId);
                     published.addChannelNotification(channel, new Date());
                 }

--- a/java/code/src/com/redhat/rhn/manager/errata/cache/ErrataCacheManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/cache/ErrataCacheManager.java
@@ -26,10 +26,12 @@ import com.redhat.rhn.domain.errata.Errata;
 import com.redhat.rhn.domain.errata.ErrataFactory;
 import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.frontend.events.UpdateErrataCacheEvent;
+import com.redhat.rhn.manager.errata.ErrataManager;
 
 import org.apache.log4j.Logger;
 
 import java.util.Collection;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -274,6 +276,7 @@ public class ErrataCacheManager extends HibernateFactory {
             ChannelFactory.addErrataToChannel(new HashSet<Long>() {{ add(errataId); }}, cid);
             List<Long> pids = ErrataFactory.listErrataChannelPackages(cid, errataId);
             ErrataCacheManager.insertCacheForChannelPackages(cid, errataId, pids);
+            ErrataManager.replaceChannelNotifications(errataId, cid, new Date());
         }
     }
 

--- a/java/code/src/com/redhat/rhn/manager/errata/cache/ErrataCacheManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/cache/ErrataCacheManager.java
@@ -266,12 +266,13 @@ public class ErrataCacheManager extends HibernateFactory {
     }
 
     /**
-     *updates the errata caches for the channels passed in.
+     * Adds specified errata to a set of channels, inserting appropriate cache entries and replacing channel
+     * notifications.
      * @param channelIdsToUpdate - channel IDs (Long) that need their errata
      * caches updated
      * @param errataId ID of the errata to update the cache for. Assumes the errata is published
      */
-    public static void insertCacheForChannelErrata(Collection<Long> channelIdsToUpdate, Long errataId) {
+    public static void addErrataRefreshing(Collection<Long> channelIdsToUpdate, Long errataId) {
         for (Long cid : channelIdsToUpdate) {
             ChannelFactory.addErrataToChannel(new HashSet<Long>() {{ add(errataId); }}, cid);
             List<Long> pids = ErrataFactory.listErrataChannelPackages(cid, errataId);

--- a/java/code/src/com/redhat/rhn/manager/errata/cache/ErrataCacheManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/cache/ErrataCacheManager.java
@@ -264,13 +264,12 @@ public class ErrataCacheManager extends HibernateFactory {
      *updates the errata caches for the channels passed in.
      * @param channelIdsToUpdate - channel IDs (Long) that need their errata
      * caches updated
-     * @param errata the errata to update the cache for
+     * @param errataId ID of the errata to update the cache for. Assumes the errata is published
      */
-    public static void insertCacheForChannelErrata(
-            List<Long> channelIdsToUpdate, Errata errata) {
+    public static void insertCacheForChannelErrata(List<Long> channelIdsToUpdate, Long errataId) {
         for (Long cid : channelIdsToUpdate) {
-            List<Long> pids = ErrataFactory.listErrataChannelPackages(cid, errata.getId());
-            ErrataCacheManager.insertCacheForChannelPackages(cid, errata.getId(), pids);
+            List<Long> pids = ErrataFactory.listErrataChannelPackages(cid, errataId);
+            ErrataCacheManager.insertCacheForChannelPackages(cid, errataId, pids);
         }
     }
 

--- a/java/code/src/com/redhat/rhn/manager/errata/cache/ErrataCacheManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/cache/ErrataCacheManager.java
@@ -28,6 +28,7 @@ import com.redhat.rhn.frontend.events.UpdateErrataCacheEvent;
 
 import org.apache.log4j.Logger;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -266,7 +267,7 @@ public class ErrataCacheManager extends HibernateFactory {
      * caches updated
      * @param errataId ID of the errata to update the cache for. Assumes the errata is published
      */
-    public static void insertCacheForChannelErrata(List<Long> channelIdsToUpdate, Long errataId) {
+    public static void insertCacheForChannelErrata(Collection<Long> channelIdsToUpdate, Long errataId) {
         for (Long cid : channelIdsToUpdate) {
             List<Long> pids = ErrataFactory.listErrataChannelPackages(cid, errataId);
             ErrataCacheManager.insertCacheForChannelPackages(cid, errataId, pids);

--- a/java/code/src/com/redhat/rhn/manager/errata/cache/ErrataCacheManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/cache/ErrataCacheManager.java
@@ -33,7 +33,6 @@ import org.apache.log4j.Logger;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -274,7 +273,7 @@ public class ErrataCacheManager extends HibernateFactory {
      */
     public static void addErrataRefreshing(Collection<Long> channelIdsToUpdate, Long errataId) {
         for (Long cid : channelIdsToUpdate) {
-            ChannelFactory.addErrataToChannel(new HashSet<Long>() {{ add(errataId); }}, cid);
+            ChannelFactory.addErrataToChannel(Set.of(errataId), cid);
             List<Long> pids = ErrataFactory.listErrataChannelPackages(cid, errataId);
             ErrataCacheManager.insertCacheForChannelPackages(cid, errataId, pids);
             ErrataManager.replaceChannelNotifications(errataId, cid, new Date());

--- a/java/code/src/com/redhat/rhn/manager/errata/cache/ErrataCacheManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/cache/ErrataCacheManager.java
@@ -21,6 +21,7 @@ import com.redhat.rhn.common.db.datasource.WriteMode;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.messaging.MessageQueue;
 import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.channel.ChannelFactory;
 import com.redhat.rhn.domain.errata.Errata;
 import com.redhat.rhn.domain.errata.ErrataFactory;
 import com.redhat.rhn.domain.org.Org;
@@ -30,6 +31,7 @@ import org.apache.log4j.Logger;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -269,6 +271,7 @@ public class ErrataCacheManager extends HibernateFactory {
      */
     public static void insertCacheForChannelErrata(Collection<Long> channelIdsToUpdate, Long errataId) {
         for (Long cid : channelIdsToUpdate) {
+            ChannelFactory.addErrataToChannel(new HashSet<Long>() {{ add(errataId); }}, cid);
             List<Long> pids = ErrataFactory.listErrataChannelPackages(cid, errataId);
             ErrataCacheManager.insertCacheForChannelPackages(cid, errataId, pids);
         }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- improve Content Lifecycle Management build and promotion performance (bsc#1159226)
 - Fix saving image profile custom info values with XMLRPC (bsc#1171526)
 - New API endpoint for retrieving combined formula data for a list of systems
 - New API endpoint for retrieving network information for a list of system


### PR DESCRIPTION
## What does this PR change?

It makes typical operations in CLM (build and promote) faster.

Measured speedups follow:

|         | SLES 12 SP3               | RES 7                        |
|---------|---------------------------|------------------------------|
| build   | **~9x** (35 min → 4 min)  | **~91x** (2003 min → 22 min) |
| promote | **~10x** (30 min → 3 min) | **~223x** (2010 min → 9 min) |

This was tested on my laptop building a SLES 12 SP3 or RES 7 project without filters or with a simple date filter on patches.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **no user visible change**

- [x] **DONE**

## Test coverage
- Unit tests were adapted

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/10361
Tracks https://github.com/SUSE/spacewalk/pull/11473

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle" 
- [ ] Re-run test "java_pgsql_tests"  
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint" (Test skipped, there are no changes to test)
- [ ] Re-run test "spacecmd_unittests"
