### PR TITLE
Update Software Channel list coloring

### DIFF
--- a/branding/css/susemanager-tables.less
+++ b/branding/css/susemanager-tables.less
@@ -19,6 +19,10 @@ background-color: @table-bg-accent !important;
   vertical-align: middle !important;
 }
 
+.list-row-odd {
+  background-color: @table-bg-accent;
+}
+
 td {
   overflow: hidden;
 }

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/UnpagedListDisplayTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/UnpagedListDisplayTag.java
@@ -276,10 +276,10 @@ public class UnpagedListDisplayTag extends ListDisplayTagBase {
              * it shouldn't matter
              */
             if (getType().equals("list")) {
-                out.print("<table class=\"table table-striped\"");
+                out.print("<table class=\"table\"");
             }
  else if (getType().equals("treeview")) {
-                out.print("<table class=\"table table-striped\" id=\"channel-list\"");
+                out.print("<table class=\"table\" id=\"channel-list\"");
             }
             else {
                 out.print("<table class=\"" + getType() + "\"");

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix software channel list coloring
 - apply highstate when add-on system types should be applied to the
   system on bootstrapping (bsc#1172190)
 - configure HTTP timeouts via rhn.conf


### PR DESCRIPTION
## What does this PR change?

Change coloring of the software channel list to not look random while collapsed.
New behavior is to have the same background coloring for each parent/child group.

## GUI diff

Before:

![channel_list_colors](https://user-images.githubusercontent.com/729087/77622090-ef7f3180-6f3d-11ea-8693-78c7db481f31.png)

After:

**Collapsed:**
![SofwareChannelListCollapsed](https://user-images.githubusercontent.com/31698054/81789623-8a3eca00-9504-11ea-8e85-6211d87abc0a.png)

**Expanded:**
![SoftwareChannelListExpanded](https://user-images.githubusercontent.com/31698054/81789645-932f9b80-9504-11ea-8f16-c7f0d3b21c49.png)


- [x] **DONE**

## Documentation
- No documentation needed: **Only cosmetic change. Use behavior does not change.**

- [x] **DONE**

## Test coverage
- No tests: **Only cosmetic change**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11067

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
