### PR TITLE
fix nullpointer by handling base channels with no parent channel (bsc…

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/proxy/ProxyHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/proxy/ProxyHandler.java
@@ -38,6 +38,7 @@ import com.redhat.rhn.manager.system.SystemManager;
 import org.apache.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -173,24 +174,22 @@ public class ProxyHandler extends BaseHandler {
                 .PROXY_CHANNEL_FAMILY_LABEL,
                 null);
 
-        List<String> returnList = new ArrayList<String>();
 
         if (proxyFamily == null ||
                 proxyFamily.getChannels() == null ||
                 proxyFamily.getChannels().isEmpty()) {
-            return returnList;
+            return Collections.emptyList();
         }
 
         /* We search for a proxy channel whose parent channel is our server's basechannel.
          * This will be the channel we attempt to subscribe the server to.
          */
-        for (Channel proxyChan : proxyFamily.getChannels()) {
-            if (proxyChan.getProduct() != null &&
-                proxyChan.getParentChannel().equals(server.getBaseChannel())) {
-                returnList.add(proxyChan.getProduct().getVersion());
-            }
-        }
-        return returnList;
+        Channel baseChannel = server.getBaseChannel();
+        return proxyFamily.getChannels().stream()
+                .filter(p -> p.getProduct() != null)
+                .filter(p -> baseChannel.equals(p.getParentChannel()) || baseChannel.equals(p))
+                .map(p -> p.getProduct().getVersion())
+                .collect(toList());
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix nullpointer exception during proxy registration (bsc#1171287)
 - improve Content Lifecycle Management build and promotion performance (bsc#1159226)
 - fix info text about package installation on channel change (bsc#1171684)
 - Clarify the behavior of the checkbox system list, when it adds systems to ssm


### PR DESCRIPTION
## What does this PR change?

Fixes a null pointer exception that happens since proxy 4.0 products are base products and have a base channel which shows up in proxy channel familys channel list. Since base channel have no parent channel getParentChannel is null and causes a null pointer.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11451


- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"  
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
