### PR TITLE
Testsuite - run zypper refresh only when repos are enabled

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -752,7 +752,10 @@ When(/^I disable repositories after installing Docker$/) do
     puts $minion.run("zypper mr --disable #{repos}")
   end
 
-  $minion.run('zypper -n --gpg-auto-import-keys ref')
+  # Refresh is only necessary when some repos are enabled
+  if $minion.run('zypper lr').contains? 'Yes'
+    $minion.run('zypper -n --gpg-auto-import-keys ref')
+  end
 end
 
 When(/^I enable repositories before installing branch server$/) do


### PR DESCRIPTION
## What does this PR change?

This PR fixes failure in cleanup step `I disable repositories after installing Docker` in scenario `Bootstrap a Salt minion via the GUI using SSH key`. 

There is no need to run zypper refresh, when no repositories are enabled.

## Links

Related CI [run](https://ci.suse.de/view/Manager/view/Manager-Head/job/manager-Head-cucumber-NUE/90/TestSuite_20Report/)

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
