### PR TITLE
Testsuite - use correct method

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -753,7 +753,7 @@ When(/^I disable repositories after installing Docker$/) do
   end
 
   # Refresh is only necessary when some repos are enabled
-  if $minion.run('zypper lr').contains? 'Yes'
+  if $minion.run('zypper lr -E').include? '| Yes'
     $minion.run('zypper -n --gpg-auto-import-keys ref')
   end
 end

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -753,7 +753,7 @@ When(/^I disable repositories after installing Docker$/) do
   end
 
   # Refresh is only necessary when some repos are enabled
-  if $minion.run('zypper lr -E').include? '| Yes'
+  if $minion.run('zypper -x lr -E').include? '</repo>'
     $minion.run('zypper -n --gpg-auto-import-keys ref')
   end
 end


### PR DESCRIPTION
## What does this PR change?

PR changes proper method to check for string.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
