### PR TITLE
Check for maintenance windows when scheduling actions

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/server/ServerAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/server/ServerAction.java
@@ -20,11 +20,14 @@ import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.ActionStatus;
 import com.redhat.rhn.domain.server.Server;
 
+import com.suse.manager.maintenance.MaintenanceManager;
+
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.io.Serializable;
 import java.util.Date;
+import java.util.Set;
 
 /**
  * Class representation of the table rhnServerAction.
@@ -149,11 +152,35 @@ public class ServerAction extends ActionChild implements Serializable {
 
     /**
      * Sets the Server associated with this ServerAction record
+     * Checks if the Action scheduled date fits in Maintenance windows, if system has any Maintenance schedule assigned.
+     *
      * @param serverIn The server to set.
      */
     public void setServer(Server serverIn) {
+        Action parentAction = getParentAction();
+        if (parentAction != null) {
+            MaintenanceManager.instance().checkMaintenanceWindows(Set.of(serverIn.getId()),
+                    parentAction.getEarliestAction(), parentAction.getActionType());
+        }
         this.server = serverIn;
         this.setServerId(serverIn.getId());
+    }
+
+    /**
+     *
+     * Sets the parent Action associated with this ServerAction record.
+     * Checks if the Action scheduled date fits in Maintenance windows, if system has any Maintenance schedule assigned.
+     *
+     * @param parentActionIn The parentAction to set.
+     */
+    @Override
+    public void setParentAction(Action parentActionIn) {
+        if (server != null) {
+            MaintenanceManager.instance().checkMaintenanceWindows(Set.of(server.getId()),
+                    parentActionIn.getEarliestAction(), parentActionIn.getActionType());
+        }
+
+        super.setParentAction(parentActionIn);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/action/server/ServerAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/server/ServerAction.java
@@ -159,8 +159,7 @@ public class ServerAction extends ActionChild implements Serializable {
     public void setServer(Server serverIn) {
         Action parentAction = getParentAction();
         if (parentAction != null) {
-            MaintenanceManager.instance().checkMaintenanceWindows(Set.of(serverIn.getId()),
-                    parentAction.getEarliestAction(), parentAction.getActionType());
+            MaintenanceManager.instance().checkMaintenanceWindows(Set.of(serverIn.getId()), parentAction);
         }
         this.server = serverIn;
         this.setServerId(serverIn.getId());
@@ -176,8 +175,7 @@ public class ServerAction extends ActionChild implements Serializable {
     @Override
     public void setParentAction(Action parentActionIn) {
         if (server != null) {
-            MaintenanceManager.instance().checkMaintenanceWindows(Set.of(server.getId()),
-                    parentActionIn.getEarliestAction(), parentActionIn.getActionType());
+            MaintenanceManager.instance().checkMaintenanceWindows(Set.of(server.getId()), parentActionIn);
         }
 
         super.setParentAction(parentActionIn);

--- a/java/code/src/com/redhat/rhn/domain/action/server/test/ServerActionTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/server/test/ServerActionTest.java
@@ -62,11 +62,14 @@ public class ServerActionTest extends RhnBaseTestCase {
         assertTrue(sa.equals(sa2));
 
         Server one = ServerFactory.createServer();
+        one.setId(10001L);
         sa.setServer(one);
         assertFalse(sa.equals(sa2));
         assertFalse(sa2.equals(sa));
 
-        sa2.setServer(ServerFactory.createServer());
+        Server two = ServerFactory.createServer();
+        two.setId(10001L); // same ID
+        sa2.setServer(two);
         assertTrue(sa.equals(sa2));
 
         one.setName("foo");
@@ -77,6 +80,7 @@ public class ServerActionTest extends RhnBaseTestCase {
 
         Action parent = new Action();
         parent.setId(243L);
+        parent.setActionType(ActionFactory.TYPE_APPLY_STATES);
         sa.setParentAction(parent);
         assertFalse(sa.equals(sa2));
 

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
@@ -1453,6 +1453,7 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
      * @throws Exception
      */
     public void testSetMaintenanceWindowToSystems() throws Exception {
+        user.addPermanentRole(RoleFactory.ORG_ADMIN);
         MaintenanceSchedule schedule = MaintenanceManager.instance().createMaintenanceSchedule(
                 user, "test-schedule-1", MaintenanceSchedule.ScheduleType.SINGLE, Optional.empty());
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/BaseHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/BaseHandler.java
@@ -55,6 +55,8 @@ import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.session.SessionManager;
 import com.redhat.rhn.manager.system.SystemManager;
 
+import com.suse.manager.maintenance.NotInMaintenanceModeException;
+
 /**
  * A basic xmlrpc handler class.  Uses reflection + an arbitrary algorithm
  * to call the appropriate method on a subclass.  So, an xmlrpc call to
@@ -175,6 +177,9 @@ public class BaseHandler implements XmlRpcInvocationHandler {
             }
             else if (t instanceof OverlappingFileLockException) {
                 throw new XmlRpcFault(-1, "Operation already running. Please try later again.");
+            }
+            else if (t instanceof NotInMaintenanceModeException) {
+                throw new XmlRpcFault(11334, t.getMessage());
             }
 
             // If it isn't a FaultException that caused this, we still need to

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/ExceptionTranslator.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/ExceptionTranslator.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.frontend.xmlrpc;
+
+import com.redhat.rhn.FaultException;
+
+import com.suse.manager.maintenance.NotInMaintenanceModeException;
+
+import java.nio.channels.OverlappingFileLockException;
+
+import redstone.xmlrpc.XmlRpcFault;
+
+/**
+ * Translation between backend exceptions and XMLRPC faults.
+ */
+public class ExceptionTranslator {
+
+    // forbid instantiation
+    private ExceptionTranslator() { }
+
+    /**
+     * Check given exception and re-return appropriate {@link FaultException}.
+     *
+     * @param t the exception
+     * @return XmlRpcFault the {@link FaultException}
+     */
+    public static XmlRpcFault translateException(Throwable t) {
+        // Generic fault exception
+        if (t instanceof FaultException) {
+            FaultException fe = (FaultException) t;
+            return new XmlRpcFault(fe.getErrorCode(), fe.getMessage());
+        }
+
+        if (t instanceof OverlappingFileLockException) {
+            return new XmlRpcFault(-1, "Operation already running. Please try later again.");
+        }
+
+        if (t instanceof NotInMaintenanceModeException) {
+            return new XmlRpcFault(11334, t.getMessage());
+        }
+
+        // For any other unhandled exception, we still need to send something to the client.
+        // If we can get the cause of the exception, then display the message
+        if (t != null) {
+            return new XmlRpcFault(-1, "unhandled internal exception: " + t.getLocalizedMessage());
+        }
+
+        // Otherwise, return the generic unhandled internal exception
+        return new XmlRpcFault(-1, "unhandled internal exception");
+    }
+}

--- a/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
@@ -1484,8 +1484,7 @@ public class ActionManager extends BaseManager {
      * @param serverIds server IDs
      */
     public static void scheduleForExecution(Action action, Set<Long> serverIds) {
-        MaintenanceManager.instance()
-                .checkMaintenanceWindows(serverIds, action.getEarliestAction(), action.getActionType());
+        MaintenanceManager.instance().checkMaintenanceWindows(serverIds, action);
 
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("status_id", ActionFactory.STATUS_QUEUED.getId());

--- a/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
@@ -86,6 +86,7 @@ import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
+import com.suse.manager.maintenance.MaintenanceManager;
 import com.suse.utils.Opt;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;
@@ -1476,10 +1477,16 @@ public class ActionManager extends BaseManager {
     /**
      * Schedules an action for execution on one or more servers (adding rows to
      * rhnServerAction)
+     *
+     * Also checks if the action scheduled date/time fit in systems maintenance schedules, if there are any assigned.
+     *
      * @param action the action
      * @param serverIds server IDs
      */
     public static void scheduleForExecution(Action action, Set<Long> serverIds) {
+        MaintenanceManager.instance()
+                .checkMaintenanceWindows(serverIds, action.getEarliestAction(), action.getActionType());
+
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("status_id", ActionFactory.STATUS_QUEUED.getId());
         params.put("tries", REMAINING_TRIES);

--- a/java/code/src/com/suse/manager/maintenance/MaintenanceManager.java
+++ b/java/code/src/com/suse/manager/maintenance/MaintenanceManager.java
@@ -127,8 +127,8 @@ public class MaintenanceManager {
     private Set<MaintenanceSchedule> listSystemSchedulesNotMachingDate(Set<Long> systemIds, Date date) {
         return listSchedulesOfSystems(systemIds).stream()
                 .filter(schedule -> {
-                    Collection<CalendarComponent> events = getScheduleEventsAtDate(date, schedule, schedule.getCalendarOpt()
-                            .flatMap(c -> parseCalendar(c)));
+                    Collection<CalendarComponent> events = getScheduleEventsAtDate(date, schedule, schedule
+                            .getCalendarOpt().flatMap(c -> parseCalendar(c)));
                     return events.isEmpty();
                 })
                 .collect(toSet());
@@ -515,7 +515,8 @@ public class MaintenanceManager {
      */
     public boolean isActionInMaintenanceWindow(Action action, MaintenanceSchedule schedule,
             Optional<Calendar> calendarOpt) {
-        Collection<CalendarComponent> events = getScheduleEventsAtDate(action.getEarliestAction(), schedule, calendarOpt);
+        Collection<CalendarComponent> events = getScheduleEventsAtDate(action.getEarliestAction(), schedule,
+                calendarOpt);
 
         if (!events.isEmpty()) {
             if (log.isDebugEnabled()) {
@@ -683,7 +684,7 @@ public class MaintenanceManager {
      * Ensures that the Maintenance Calendar does not exists yet
      *
      * @param user the user
-     * @param name the calendar label
+     * @param label the calendar label
      * @throws EntityExistsException if a calendar with this label already exists
      */
     private void ensureCalendarNotExists(User user, String label) {

--- a/java/code/src/com/suse/manager/maintenance/MaintenanceManager.java
+++ b/java/code/src/com/suse/manager/maintenance/MaintenanceManager.java
@@ -575,7 +575,7 @@ public class MaintenanceManager {
      * Ensures that given user has access to given {@link MaintenanceCalendar}
      *
      * @param user the user
-     * @param schedule the {@link MaintenanceCalendar}
+     * @param calendar the {@link MaintenanceCalendar}
      * @throws PermissionException if the user does not have access
      */
     private void ensureCalendarAccessible(User user, MaintenanceCalendar calendar) {

--- a/java/code/src/com/suse/manager/maintenance/MaintenanceManager.java
+++ b/java/code/src/com/suse/manager/maintenance/MaintenanceManager.java
@@ -127,7 +127,7 @@ public class MaintenanceManager {
     private Set<MaintenanceSchedule> listSystemSchedulesNotMachingDate(Set<Long> systemIds, Date date) {
         return listSchedulesOfSystems(systemIds).stream()
                 .filter(schedule -> {
-                    Collection<CalendarComponent> events = getEventsInTime(date, schedule, schedule.getCalendarOpt()
+                    Collection<CalendarComponent> events = getScheduleEventsAtDate(date, schedule, schedule.getCalendarOpt()
                             .flatMap(c -> parseCalendar(c)));
                     return events.isEmpty();
                 })
@@ -515,7 +515,7 @@ public class MaintenanceManager {
      */
     public boolean isActionInMaintenanceWindow(Action action, MaintenanceSchedule schedule,
             Optional<Calendar> calendarOpt) {
-        Collection<CalendarComponent> events = getEventsInTime(action.getEarliestAction(), schedule, calendarOpt);
+        Collection<CalendarComponent> events = getScheduleEventsAtDate(action.getEarliestAction(), schedule, calendarOpt);
 
         if (!events.isEmpty()) {
             if (log.isDebugEnabled()) {
@@ -529,7 +529,7 @@ public class MaintenanceManager {
         return false;
     }
 
-    private Collection<CalendarComponent> getEventsInTime(
+    private Collection<CalendarComponent> getScheduleEventsAtDate(
             Date date, MaintenanceSchedule schedule, Optional<Calendar> calendarOpt) {
         if (calendarOpt.isEmpty()) {
             return emptySet();

--- a/java/code/src/com/suse/manager/maintenance/NotInMaintenanceModeException.java
+++ b/java/code/src/com/suse/manager/maintenance/NotInMaintenanceModeException.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.manager.maintenance;
+
+import com.redhat.rhn.FaultException;
+
+import com.suse.manager.model.maintenance.MaintenanceSchedule;
+
+import java.util.Date;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * An {@link RuntimeException} bearing a set of {@link MaintenanceSchedule}s.
+ *
+ * Typically thrown, when scheduling an action at the date that doesn't fit to Maintenance window of
+ * some systems.
+ *
+ * This exception also serves as a XMLRPC Fault
+ */
+public class NotInMaintenanceModeException extends FaultException {
+
+    /**
+     * Standard constructor
+     *
+     * @param schedules the {@link MaintenanceSchedule}s
+     * @param date the scheduling date
+     */
+    public NotInMaintenanceModeException(Set<MaintenanceSchedule> schedules, Date date) {
+        super(1334,
+                "not_in_maintenance",
+                String.format("Schedules '%s' are not matching date %s ",
+                        scheduleNames(schedules), date));
+    }
+
+    private static String scheduleNames(Set<MaintenanceSchedule> schedulesIn) {
+        return schedulesIn.stream().map(s -> s.getName()).collect(Collectors.joining(","));
+    }
+}

--- a/java/code/src/com/suse/manager/maintenance/NotInMaintenanceModeException.java
+++ b/java/code/src/com/suse/manager/maintenance/NotInMaintenanceModeException.java
@@ -40,9 +40,9 @@ public class NotInMaintenanceModeException extends FaultException {
      * @param date the scheduling date
      */
     public NotInMaintenanceModeException(Set<MaintenanceSchedule> schedules, Date date) {
-        super(1334,
-                "not_in_maintenance",
-                String.format("Schedules '%s' are not matching date %s ",
+        super(11334,
+                "notInMaintenance",
+                String.format("Systems assigned to these schedules (%s) do not have a maintenance window at %s" ,
                         scheduleNames(schedules), date));
     }
 

--- a/java/code/src/com/suse/manager/maintenance/NotInMaintenanceModeException.java
+++ b/java/code/src/com/suse/manager/maintenance/NotInMaintenanceModeException.java
@@ -15,8 +15,6 @@
 
 package com.suse.manager.maintenance;
 
-import com.redhat.rhn.FaultException;
-
 import com.suse.manager.model.maintenance.MaintenanceSchedule;
 
 import java.util.Date;
@@ -31,7 +29,7 @@ import java.util.stream.Collectors;
  *
  * This exception also serves as a XMLRPC Fault
  */
-public class NotInMaintenanceModeException extends FaultException {
+public class NotInMaintenanceModeException extends RuntimeException {
 
     /**
      * Standard constructor
@@ -40,10 +38,8 @@ public class NotInMaintenanceModeException extends FaultException {
      * @param date the scheduling date
      */
     public NotInMaintenanceModeException(Set<MaintenanceSchedule> schedules, Date date) {
-        super(11334,
-                "notInMaintenance",
-                String.format("Systems assigned to these schedules (%s) do not have a maintenance window at %s" ,
-                        scheduleNames(schedules), date));
+        super(String.format("Systems assigned to these schedules (%s) do not have a maintenance window at %s" ,
+                scheduleNames(schedules), date));
     }
 
     private static String scheduleNames(Set<MaintenanceSchedule> schedulesIn) {

--- a/java/code/src/com/suse/manager/maintenance/test/MaintenanceManagerScheduleActionsTest.java
+++ b/java/code/src/com/suse/manager/maintenance/test/MaintenanceManagerScheduleActionsTest.java
@@ -1,0 +1,163 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.manager.maintenance.test;
+
+import static com.redhat.rhn.domain.role.RoleFactory.ORG_ADMIN;
+import static com.suse.manager.model.maintenance.MaintenanceSchedule.ScheduleType.SINGLE;
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+
+import com.redhat.rhn.common.util.FileUtils;
+import com.redhat.rhn.domain.action.Action;
+import com.redhat.rhn.domain.action.ActionChainFactory;
+import com.redhat.rhn.domain.action.ActionFactory;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
+import com.redhat.rhn.manager.action.ActionChainManager;
+import com.redhat.rhn.manager.action.ActionManager;
+import com.redhat.rhn.taskomatic.TaskomaticApi;
+import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
+import com.redhat.rhn.testing.TestUtils;
+
+import com.suse.manager.maintenance.MaintenanceManager;
+import com.suse.manager.maintenance.NotInMaintenanceModeException;
+import com.suse.manager.model.maintenance.MaintenanceCalendar;
+import com.suse.manager.model.maintenance.MaintenanceSchedule;
+
+import org.jmock.Expectations;
+import org.jmock.lib.legacy.ClassImposteriser;
+
+import java.io.File;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Tests
+ */
+public class MaintenanceManagerScheduleActionsTest extends JMockBaseTestCaseWithUser {
+
+    private String calString;
+
+    private TaskomaticApi taskomaticMock;
+
+    private static final String TESTDATAPATH = "/com/suse/manager/maintenance/test/testdata";
+    private static final String KDE_ICS = "maintenance-windows-kde.ics";
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        setImposteriser(ClassImposteriser.INSTANCE);
+
+        user.addPermanentRole(ORG_ADMIN);
+
+        taskomaticMock = mock(TaskomaticApi.class);
+        ActionManager.setTaskomaticApi(taskomaticMock);
+        ActionChainManager.setTaskomaticApi(taskomaticMock);
+        ActionChainFactory.setTaskomaticApi(taskomaticMock);
+
+        File ical = new File(TestUtils.findTestData(new File(TESTDATAPATH,  KDE_ICS).getAbsolutePath()).getPath());
+        calString = FileUtils.readStringFromFile(ical.getAbsolutePath());
+    }
+
+    /**
+     * Tests scheduling a state apply when a system is assigned to a schedule with maintenance windows
+     * (= it's not in the maintenance mode)
+     *
+     */
+    public void testScheduleHighstateNoMaintWindow() throws Exception {
+        // this tests assumes that APPLY STATES is a maintenance-mode-only action
+        assertTrue(ActionFactory.TYPE_APPLY_STATES.isMaintenancemodeOnly());
+
+        context().checking(new Expectations() {{
+            allowing(taskomaticMock).scheduleActionExecution(with(any(Action.class)));
+        }});
+
+        MaintenanceManager mm = MaintenanceManager.instance();
+        MaintenanceSchedule schedule = mm.createMaintenanceSchedule(user, "test-schedule-2", SINGLE, empty());
+
+        Server sys1 = MinionServerFactoryTest.createTestMinionServer(user);
+        Server sys2 = MinionServerFactoryTest.createTestMinionServer(user);
+
+        mm.assignScheduleToSystems(user, schedule, Set.of(sys1.getId()));
+
+        try {
+            ActionChainManager.scheduleApplyStates(user, List.of(sys1.getId(), sys2.getId()), empty(), new Date(12345), null);
+            fail("NoMaintenanceWindowException should have been thrown.");
+        }
+        catch (NotInMaintenanceModeException e) {
+            // this should happen
+        }
+
+        // no exception should happen here:
+        ActionChainManager.scheduleApplyStates(user, List.of(sys2.getId()), empty(), new Date(12345), null);
+    }
+
+    /**
+     * Tests scheduling a state apply outside maintenance window (= not in maintenance mode)
+     */
+    public void testScheduleHighstateOutsideMaintWindow() throws Exception {
+        // this tests assumes that APPLY STATES is a maintenance-mode-only action
+        assertTrue(ActionFactory.TYPE_APPLY_STATES.isMaintenancemodeOnly());
+
+        context().checking(new Expectations() {{
+            allowing(taskomaticMock).scheduleActionExecution(with(any(Action.class)));
+        }});
+
+        MaintenanceManager mm = MaintenanceManager.instance();
+        MaintenanceCalendar mc = mm.createMaintenanceCalendar(user, "testcalendar", calString);
+        MaintenanceSchedule schedule = mm.createMaintenanceSchedule(user, "test-schedule-2", SINGLE, of(mc));
+
+        Server sys1 = MinionServerFactoryTest.createTestMinionServer(user);
+        mm.assignScheduleToSystems(user, schedule, Set.of(sys1.getId()));
+
+        try {
+            ActionChainManager.scheduleApplyStates(user, List.of(sys1.getId()), empty(), new Date(12345), null);
+            fail("NoMaintenanceWindowException should have been thrown.");
+        }
+        catch (NotInMaintenanceModeException e) {
+            // this should happen
+        }
+
+        ZonedDateTime start = ZonedDateTime.parse("2020-04-30T09:15:00+02:00", ISO_OFFSET_DATE_TIME);
+        Date date = Date.from(start.toInstant());
+        ActionChainManager.scheduleApplyStates(user, List.of(sys1.getId()), empty(), date, null);
+    }
+
+    /**
+     * Tests scheduling a hardware refresh with no maintenance window (= system not in maintenance mode)
+     */
+    public void testScheduleHwRefreshNoMaintWindow() throws Exception {
+        // this tests assumes that HW refresh is not a maintenance-mode-only action
+        assertFalse(ActionFactory.TYPE_HARDWARE_REFRESH_LIST.isMaintenancemodeOnly());
+
+        MaintenanceManager mm = MaintenanceManager.instance();
+        MaintenanceSchedule schedule = mm.createMaintenanceSchedule(user, "test-schedule-3", SINGLE, empty());
+
+        Server sys1 = MinionServerFactoryTest.createTestMinionServer(user);
+
+        mm.assignScheduleToSystems(user, schedule, Set.of(sys1.getId()));
+
+        try {
+            ActionManager.scheduleHardwareRefreshAction(user, sys1, new Date(12345));
+        }
+        catch (NotInMaintenanceModeException e) {
+            fail("NoMaintenanceWindowException should NOT have been thrown.");
+        }
+    }
+}

--- a/java/code/src/com/suse/manager/maintenance/test/MaintenanceManagerTest.java
+++ b/java/code/src/com/suse/manager/maintenance/test/MaintenanceManagerTest.java
@@ -381,17 +381,15 @@ public class MaintenanceManagerTest extends BaseTestCaseWithUser {
         Action sapAction1 = createActionForServerAt(ActionFactory.TYPE_ERRATA, sapServer, "2020-04-13T08:15:00+02:00"); //moved
         Action sapActionEx = createActionForServerAt(ActionFactory.TYPE_VIRTUALIZATION_START, sapServer, "2020-04-13T08:15:00+02:00"); //moved
         Action sapAction2 = createActionForServerAt(ActionFactory.TYPE_ERRATA, sapServer, "2020-04-27T08:15:00+02:00"); //stay
-        Action sapAction3 = createActionForServerAt(ActionFactory.TYPE_ERRATA, sapServer, "2020-04-30T09:15:00+02:00"); //wrong window (Core)
         Action coreAction1 = createActionForServerAt(ActionFactory.TYPE_ERRATA, coreServer, "2020-04-30T09:15:00+02:00"); //stay
         Action coreActionEx = createActionForServerAt(ActionFactory.TYPE_VIRTUALIZATION_START, coreServer, "2020-05-21T09:15:00+02:00"); //moved
         Action coreAction2 = createActionForServerAt(ActionFactory.TYPE_ERRATA, coreServer, "2020-05-21T09:15:00+02:00"); //moved
-        Action coreAction3 = createActionForServerAt(ActionFactory.TYPE_ERRATA, coreServer, "2020-04-27T08:15:00+02:00"); //wrong window (SAP)
 
         List sapActionsBefore = ActionFactory.listActionsForServer(user, sapServer);
         List coreActionsBefore = ActionFactory.listActionsForServer(user, coreServer);
 
-        assertEquals(4, sapActionsBefore.size());
-        assertEquals(4, coreActionsBefore.size());
+        assertEquals(3, sapActionsBefore.size());
+        assertEquals(3, coreActionsBefore.size());
 
         /* update the calendar */
         Map<String, String> details = new HashMap<>();
@@ -481,7 +479,6 @@ public class MaintenanceManagerTest extends BaseTestCaseWithUser {
         assertContains(coreActionsAfter, coreAction3);
         assertContains(coreActionsAfter, coreAction4);
         assertEquals(2, coreActionsAfter.size()); // First chain should be canceled, second stay
-
     }
 
     /**

--- a/java/code/src/com/suse/manager/maintenance/test/MaintenanceManagerTest.java
+++ b/java/code/src/com/suse/manager/maintenance/test/MaintenanceManagerTest.java
@@ -245,7 +245,7 @@ public class MaintenanceManagerTest extends BaseTestCaseWithUser {
     }
 
     /**
-     * Test the behavior when user tries to assign a schedule to a system, that has already some offending actions
+     * Test the behavior when user tries to assign a schedule to a system, that has already some maintenance actions
      * pending.
      *
      * @throws Exception
@@ -519,6 +519,23 @@ public class MaintenanceManagerTest extends BaseTestCaseWithUser {
      */
     private Action createActionForServerAt(ActionType type, Server server, String datetime) throws Exception {
         return createActionForServerAt(type, server, datetime, null);
+    }
+
+    public void testListSystemsSchedules() throws Exception {
+        user.addPermanentRole(ORG_ADMIN);
+        MaintenanceManager mm = MaintenanceManager.instance();
+        MaintenanceSchedule schedule = mm.createMaintenanceSchedule(
+                user, "test-schedule-1", MaintenanceSchedule.ScheduleType.SINGLE, Optional.empty());
+
+        Server withSchedule = MinionServerFactoryTest.createTestMinionServer(user);
+        Server withoutSchedule = MinionServerFactoryTest.createTestMinionServer(user);
+
+        mm.assignScheduleToSystems(user, schedule, Set.of(withSchedule.getId()));
+
+        assertEquals(
+                Set.of(schedule),
+                mm.listSchedulesOfSystems(Set.of(withSchedule.getId(), withoutSchedule.getId()))
+        );
     }
 
     private void assertExceptionThrown(Runnable body, Class exceptionClass) {


### PR DESCRIPTION
## What does this PR change?

Before scheduling an Action on a system, SUMA now performs a check, if the
scheduling date/time is within maintenance windows. The check is only done for
systems that have some maint. schedule assigned and for actions that undergo
maintenance mode (e.g. salt states apply, not HW refresh).

Review commit-by-commit is suggested.

### Behavior in the XMLRPC:
A fault 13334 is thrown, offending schedules are reported

### Behavior in the UI

Internal server error. This is expected, since in the (near) future, user will
only be able to schedule an action inside a maint. window, therefore
out-of-maint-window situations are not expected in the UI.

If we need a graceful handling after all, I have some WIP code that handles
this in a sane way (both for Struts and React).


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/11273

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "java_lint_checkstyle"  
- [ ] Re-run test "java_pgsql_tests"  
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests" (Test skipped, there are no changes to test)
- [ ] Re-run test "javascript_lint" (Test skipped, there are no changes to test)
- [ ] Re-run test "spacecmd_unittests"