### PR TITLE
fix-yum-based-distros-repo_gpgcheck-state

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
@@ -135,7 +135,7 @@ public class MinionGeneralPillarGenerator implements MinionPillarGenerator {
         if (ConfigDefaults.get().isMetadataSigningEnabled()) {
             chanProps.put("gpgcheck", chan.isGPGCheck() ? "1" : "0");
             // three state field. yes, no or default
-            chanProps.put("repo_gpgcheck", "default");
+            chanProps.put("repo_gpgcheck", "0");
             chanProps.put("pkg_gpgcheck", "default");
         }
         else {


### PR DESCRIPTION
## What does this PR change?

Try to fix the problem that yum based systems (like CentOS) can not update if GPG signed channel used. See this issue: https://github.com/uyuni-project/uyuni/issues/2156

Becuse repo_gpgcheck is not imlemented yet, i set the state to "0".

I don't know, it possible causes a problem with .deb based system. Need to investigate it.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
