### PR TITLE
Fix saving image profile custom info values with XMLRPC (bsc#1171526)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/profile/ImageProfileHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/profile/ImageProfileHandler.java
@@ -371,10 +371,9 @@ public class ImageProfileHandler extends BaseHandler {
             // Create or update the key
             profileVal.setValue(val);
             profileVal.setLastModifier(loggedInUser);
+            ImageProfileFactory.save(profileVal);
         });
 
-        // Save changes
-        ImageProfileFactory.save(profile);
         return 1;
     }
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix saving image profile custom info values with XMLRPC (bsc#1171526)
 - New API endpoint for retrieving combined formula data for a list of systems
 - New API endpoint for retrieving network information for a list of system
 - New API endpoint for retrieving system groups information for systems with a given entitlement


### PR DESCRIPTION
Fix the saving of image profile custom data values with the `image.profile.set_custom_values` XMLRPC endpoint.

**Problem:** Custom info values are not saved anymore since Hibernate "cascade" option was removed in `ImageProfile` recently.

https://bugzilla.suse.com/1171526

## Test coverage
- Tested in Cucumber tests

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11492

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"  
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
