### PR TITLE
Fix Formula Form page not rendered because of javascript error (bsc#1171728)

### DIFF
--- a/web/html/src/components/formulas/FormulaComponentGenerator.js
+++ b/web/html/src/components/formulas/FormulaComponentGenerator.js
@@ -749,7 +749,7 @@ export class FormulaFormContextProvider extends React.Component {
 
         const recurOnVals = (value) => {
             return Object.entries(value)
-                .map(([nestedName, nestedVal]) => [nestedName, adjustNestedDefault(element.$prototype[nestedName], nestedVal)])
+                .map(([nestedName, nestedVal]) => [nestedName, this.adjustNestedDefault(element.$prototype[nestedName], nestedVal)])
                 .reduce((acc, entry) => {
                     acc[entry[0]] = entry[1];
                     return acc;

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fix Formula Form page not rendered because of javascript error (bsc#1171728)
 - Fix formula with form rendering with non-string values
 - auto select recommended and mandatory channels by default (bsc#1162843)
 - Add hint to edit formulas before applying state (bsc#1168805)


### PR DESCRIPTION
## What does this PR change?

Fix Formula Form page not rendered because of javascript error

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
- No tests: cucubmer tests already exist

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
