### PR TITLE
Increase checks on metadata API endpoints and returned instance id (bsc#1171491)

### DIFF
--- a/susemanager-utils/susemanager-sls/src/grains/public_cloud.py
+++ b/susemanager-utils/susemanager-sls/src/grains/public_cloud.py
@@ -92,23 +92,47 @@ def __virtual__():
     for i in results:
         api_ret.update(i)
 
-    if api_ret['amazon'].get('status', 0) == 200 and "instance-id" in api_ret['amazon']['body']:
+    if _is_valid_endpoint(api_ret['amazon'], 'instance-id'):
         INSTANCE_ID = http.query(os.path.join(HOST, AMAZON_URL_PATH, 'instance-id'), raise_error=False)['body']
         return True
-    elif api_ret['azure'].get('status', 0) == 200 and "vmId" in api_ret['azure']['body']:
+    elif _is_valid_endpoint(api_ret['azure'], 'vmId'):
         INSTANCE_ID = http.query(os.path.join(HOST, AZURE_URL_PATH, 'vmId') + AZURE_API_ARGS, header_dict={"Metadata":"true"}, raise_error=False)['body']
         return True
-    elif api_ret['google'].get('status', 0) == 200 and "id" in api_ret['google']['body']:
+    elif _is_valid_endpoint(api_ret['google'], 'id'):
         INSTANCE_ID = http.query(os.path.join(HOST, GOOGLE_URL_PATH, 'id'), header_dict={"Metadata-Flavor": "Google"}, raise_error=False)['body']
         return True
 
     return False
 
 
+def _is_valid_endpoint(response, tag):
+    if not response.get('status', 0) == 200:
+        return False
+    elif not tag in response.get('body', ''):
+        return False
+    elif ' ' in response.get('body', ''):
+        return False
+    else:
+        return True
+
+
+def _is_valid_instance_id(id_str):
+    if not id_str:
+        return False
+    if os.linesep in id_str:
+        return False
+    elif ' ' in id_str:
+        return False
+    elif len(id_str) > 128:
+        return False
+    else:
+        return True
+
+
 def instance_id():
     global INSTANCE_ID
     ret = {}
-    if INSTANCE_ID:
+    if _is_valid_instance_id(INSTANCE_ID):
         ret['instance_id'] = INSTANCE_ID
     return ret
 

--- a/susemanager-utils/susemanager-sls/src/grains/public_cloud.py
+++ b/susemanager-utils/susemanager-sls/src/grains/public_cloud.py
@@ -47,6 +47,7 @@ log = logging.getLogger(__name__)
 
 def __virtual__():
     global INSTANCE_ID
+    log.debug("Checking if minion is running in the public cloud")
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.settimeout(0.1)
     result = sock.connect_ex((INTERNAL_API_IP, 80))
@@ -133,7 +134,11 @@ def instance_id():
     global INSTANCE_ID
     ret = {}
     if _is_valid_instance_id(INSTANCE_ID):
+        log.debug("This minion is running in the public cloud. Adding instance_id to grains: {}".format(INSTANCE_ID))
         ret['instance_id'] = INSTANCE_ID
+    else:
+        log.error("The obtained public cloud instance id doesn't seems correct: {}".format(INSTANCE_ID))
+        log.error("Skipping")
     return ret
 
 def is_payg_instance():

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- Fix failing "Hardware Refresh" actions because wrong "instance_id" reported
+  from minion due a captive portal on the network (bsc#1171491)
 - Remove suseRegisterInfo package only if it's plain client (bsc#1171262)
 - On Debian-like systems, install only required dependencies when installing salt
 - Enable support for bootstrapping Ubuntu 20.04 LTS


### PR DESCRIPTION
## What does this PR change?

This PR increases the checks on the custom `public_cloud` Salt grain module at the time of interacting with possible public cloud metadata API endpoints to collect the instance id.

It also increases the `DEBUG` and `ERROR` logging produced within this module.

Before this PR, we faced situations where a captive portal on the network can make the `public_cloud` module to assumes the minion is running in the public cloud and exposes a corrupted instance id grain. This situation makes the "Hardware Refresh" action to fail.

With the new checks introduced here, we should be safe on those situations where requests to `169.254.169.254` (metadata API) are returning valid HTTP responses which are not coming from the actual public cloud metadata API.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **bugfix**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/11460

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
