### PR TITLE
Testsuite - avoid mandatory proxy for client boostrapping

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -643,25 +643,31 @@ When(/^I accept key of pxeboot minion in the Salt master$/) do
   $server.run("salt-key -y --accept=pxeboot.example.org")
 end
 
-When(/^I bootstrap (traditional|minion) client "([^"]*)" using bootstrap script with activation key "([^"]*)" from the proxy$/) do |client_type, host, key|
+When(/^I bootstrap (traditional|minion) client "([^"]*)" using bootstrap script with activation key "([^"]*)" from the (server|proxy)$/) do |client_type, host, key, target_type|
   # Preparation of bootstrap script for different types of clients
   client = client_type == 'traditional' ? '--traditional' : ''
+  # Use server if proxy is not defined as proxy is not mandatory
+  target = $proxy
+  if target_type.include? 'server' or $proxy.nil?
+    puts 'WARN: Bootstrapping to server, because proxy is not defined.' unless target_type.include? 'server'
+    target = $server
+  end
   cmd = "mgr-bootstrap #{client} &&
   sed -i s\'/^exit 1//\' /srv/www/htdocs/pub/bootstrap/bootstrap.sh &&
   sed -i '/^ACTIVATION_KEYS=/c\\ACTIVATION_KEYS=#{key}' /srv/www/htdocs/pub/bootstrap/bootstrap.sh &&
   chmod 644 /srv/www/htdocs/pub/RHN-ORG-TRUSTED-SSL-CERT &&
   sed -i '/^ORG_GPG_KEY=/c\\ORG_GPG_KEY=RHN-ORG-TRUSTED-SSL-CERT' /srv/www/htdocs/pub/bootstrap/bootstrap.sh &&
   cat /srv/www/htdocs/pub/bootstrap/bootstrap.sh"
-  output, code = $proxy.run(cmd)
+  output, = target.run(cmd)
   raise "Key: #{key} not included" unless output.include? key
   # Run bootstrap script and check for result
   boostrap_script = 'bootstrap-general.exp'
   source = File.dirname(__FILE__) + '/../upload_files/' + boostrap_script
   dest = '/tmp/' + boostrap_script
-  return_code = file_inject($proxy, source, dest)
+  return_code = file_inject(target, source, dest)
   raise 'File injection failed' unless return_code.zero?
   system_name = get_system_name(host)
-  output, code = $proxy.run("expect -f /tmp/#{boostrap_script} #{system_name}")
+  output, = target.run("expect -f /tmp/#{boostrap_script} #{system_name}")
   raise 'Bootstrapp didn\'t finish properly' unless output.include? '-bootstrap complete-'
 end
 


### PR DESCRIPTION
## What does this PR change?

Current status of step for bootstrapping via script allows us only to bootstrap via proxy, but proxy is not (and must not be) mandatory. This PR changes step definition so it is also possible to specify server to be used for bootstrap. PR also adds fallback mechanism, so server is used automatically in the case proxy is not defined in `.bashrc` file on controller.

@moio It should solve the problem you reported.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
