### PR TITLE
Fix bug with vhm refresh and orgadmins 

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/TaskomaticApi.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskomaticApi.java
@@ -221,6 +221,18 @@ public class TaskomaticApi {
         return (Date) invoke("tasko.scheduleSingleSatBunchRun", bunchName, params);
     }
 
+        /**
+     * Creates a new single gatherer schedule
+     * @param user shall be org admin
+     * @param params parameters for the bunch
+     * @return date of the first schedule
+     * @throws TaskomaticApiException if there was an error
+     */
+    public Date scheduleGathererRefresh(User user, Map<String, String> params) throws TaskomaticApiException {
+        ensureOrgAdminRole(user);
+        return (Date) invoke("tasko.scheduleSingleSatBunchRun", "gatherer-matcher-bunch", params);
+    }
+
     /**
      * Validates user has sat admin role
      * @param user shall be sat admin

--- a/java/code/src/com/suse/manager/webui/controllers/VirtualHostManagerController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/VirtualHostManagerController.java
@@ -616,8 +616,7 @@ public class VirtualHostManagerController {
             Map<String, String> params = new HashMap<>();
             params.put(GathererJob.VHM_LABEL, label);
             try {
-                new TaskomaticApi()
-                        .scheduleSingleSatBunch(user, "gatherer-matcher-bunch", params);
+                new TaskomaticApi().scheduleGathererRefresh(user, params);
             }
             catch (TaskomaticApiException e) {
                 message  = "Problem when message Taskomatic job: " + e.getMessage();

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- fixed bug where in scheduling a vhm refresh would result in a permission error for org admins
 - Validate CLM projects on build/promote with XMLRPC
 - Fix nullpointer exception during proxy registration (bsc#1171287)
 - improve Content Lifecycle Management build and promotion performance (bsc#1159226)


### PR DESCRIPTION
## What does this PR change?
The SparkApplicationHelper checks for org admin rights but when scheduling it via TaskomaticAPI it checks for satadmin rights. So I made a new function that checks for org admin rights for this case. 

Should be ported to 4.0 also
## GUI diff

No difference.



- [ ] **DONE**

## Documentation
- No documentation needed:

- [ ] **DONE**

## Test coverage
- No tests: 

- [ ] **DONE**

## Links
11386 spacewalk issue
Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"   
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
