### PR TITLE
Implement CaaSP cluster upgrade procedure in cluster provider module

### DIFF
--- a/java/code/src/com/suse/manager/clusters/ClusterProviderParameters.java
+++ b/java/code/src/com/suse/manager/clusters/ClusterProviderParameters.java
@@ -1,0 +1,4 @@
+package com.suse.manager.clusters;
+
+public class ClusterProviderParameters {
+}

--- a/java/code/src/com/suse/manager/clusters/ClusterProviderParameters.java
+++ b/java/code/src/com/suse/manager/clusters/ClusterProviderParameters.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
 package com.suse.manager.clusters;
 
 public class ClusterProviderParameters {

--- a/susemanager-utils/susemanager-sls/src/modules/mgr_caasp_manager.py
+++ b/susemanager-utils/susemanager-sls/src/modules/mgr_caasp_manager.py
@@ -114,6 +114,7 @@ def list_nodes(skuba_cluster_path,
         for node in kubeapi_response.items:
             if node.metadata.name in ret.keys():
                 ret[node.metadata.name]['machine-id'] = node.status.node_info.machine_id
+                ret[node.metadata.name]['internal-ips'] = list(map(lambda x: x.address, filter(lambda x: x.type == "InternalIP", node.status.addresses)))
             else:
                 error_msg = "Node returned from Kubernetes API not known to skuba: {}".format(node.metadata.name)
                 log.error(error_msg)

--- a/susemanager-utils/susemanager-sls/src/modules/mgr_caasp_manager.py
+++ b/susemanager-utils/susemanager-sls/src/modules/mgr_caasp_manager.py
@@ -323,6 +323,23 @@ def master_bootstrap(node_name,
     return ret
 
 
+def _join_return_dicts(ret1, ret2):
+    ret = merge_list(ret1, ret2)
+
+    # Join multiple 'stdout' and 'stderr' outputs
+    # after merging the two output dicts
+    if isinstance(ret['stdout'], list):
+        ret['stdout'] = ''.join(ret['stdout'])
+    if isinstance(ret['stderr'], list):
+        ret['stderr'] = ''.join(ret['stderr'])
+
+    # We only need the latest 'success' and 'retcode'
+    # values after merging the two output dicts.
+    ret['success'] = ret['success'][1]
+    ret['retcode'] = ret['retcode'][1]
+
+    return ret
+
 def create_cluster(cluster_name,
                    cluster_basedir,
                    first_node_name,
@@ -346,23 +363,11 @@ def create_cluster(cluster_name,
     if not ret['success']:
         return ret
 
-    ret = merge_list(ret, master_bootstrap(node_name=first_node_name,
-                                           skuba_cluster_path=os.path.join(cluster_basedir, cluster_name),
-                                           target=target,
-                                           verbosity=verbosity,
-                                           timeout=timeout,
-                                           **kwargs))
-
-    # Join multiple 'stdout' and 'stderr' outputs
-    # after mergint the two output dicts
-    if isinstance(ret['stdout'], list):
-        ret['stdout'] = ''.join(ret['stdout'])
-    if isinstance(ret['stderr'], list):
-        ret['stderr'] = ''.join(ret['stderr'])
-
-    # We only need the latest 'success' and 'retcode'
-    # values after merging the two output dicts.
-    ret['success'] = ret['success'][1]
-    ret['retcode'] = ret['retcode'][1]
+    ret = _join_return_dicts(ret, master_bootstrap(node_name=first_node_name,
+                                                   skuba_cluster_path=os.path.join(cluster_basedir, cluster_name),
+                                                   target=target,
+                                                   verbosity=verbosity,
+                                                   timeout=timeout,
+                                                   **kwargs))
 
     return ret

--- a/susemanager-utils/susemanager-sls/src/modules/mgr_caasp_manager.py
+++ b/susemanager-utils/susemanager-sls/src/modules/mgr_caasp_manager.py
@@ -234,8 +234,7 @@ def upgrade_cluster(skuba_cluster_path,
                                      timeout=timeout,
                                      **kwargs)
 
-    # Perform the cluster upgrade.
-    # In all nodes:
+    # Perform the cluster upgrade procedure.
     # 1. Upgrade addons
     # 2. Upgrade all nodes
     # 3. Upgrade addons
@@ -248,10 +247,10 @@ def upgrade_cluster(skuba_cluster_path,
     }
 
     ret['stage0_upgrade_addons'] = upgrade_addons(skuba_cluster_path=skuba_cluster_path,
-                                          verbosity=verbosity,
-                                          timeout=timeout,
-                                          plan=plan,
-                                          **kwargs)
+                                                  verbosity=verbosity,
+                                                  timeout=timeout,
+                                                  plan=plan,
+                                                  **kwargs)
 
     if not ret['stage0_upgrade_addons']['success']:
         ret['success'] = False
@@ -267,20 +266,20 @@ def upgrade_cluster(skuba_cluster_path,
             continue
 
         ret['stage1_upgrade_nodes'][node] = upgrade_node(skuba_cluster_path=skuba_cluster_path,
-                                                 target=nodes[node]['internal-ips'][0],
-                                                 verbosity=verbosity,
-                                                 timeout=timeout,
-                                                 plan=plan,
-                                                 **kwargs)
+                                                         target=nodes[node]['internal-ips'][0],
+                                                         verbosity=verbosity,
+                                                         timeout=timeout,
+                                                         plan=plan,
+                                                         **kwargs)
 
         if not ret['stage1_upgrade_nodes'][node]['success']:
             ret['success'] = False
 
     ret['stage2_upgrade_addons'] = upgrade_addons(skuba_cluster_path=skuba_cluster_path,
-                                          verbosity=verbosity,
-                                          timeout=timeout,
-                                          plan=plan,
-                                          **kwargs)
+                                                  verbosity=verbosity,
+                                                  timeout=timeout,
+                                                  plan=plan,
+                                                  **kwargs)
 
     if not ret['stage2_upgrade_addons']['success']:
         ret['success'] = False

--- a/susemanager-utils/susemanager-sls/src/modules/mgr_caasp_manager.py
+++ b/susemanager-utils/susemanager-sls/src/modules/mgr_caasp_manager.py
@@ -248,8 +248,8 @@ def upgrade_node(skuba_cluster_path,
     return ret
 
 
-def cluster_init(name,
-                 base_path,
+def cluster_init(cluster_name,
+                 cluster_basedir,
                  target,
                  cloud_provider=None,
                  strict_capability_defaults=False,
@@ -257,7 +257,7 @@ def cluster_init(name,
                  timeout=DEFAULT_TIMEOUT,
                  **kwargs):
 
-    cmd_args = "cluster init --control-plane {} {}".format(target, name)
+    cmd_args = "cluster init --control-plane {} {}".format(target, cluster_name)
 
     if cloud_provider:
         cmd_args += " --cloud-provider {}".format(cloud_provider)
@@ -266,7 +266,7 @@ def cluster_init(name,
     if verbosity:
         cmd_args += " --verbosity {}".format(verbosity)
 
-    skuba_proc = _call_skuba(base_path, cmd_args, timeout=timeout)
+    skuba_proc = _call_skuba(cluster_basedir, cmd_args, timeout=timeout)
     if skuba_proc.process.returncode != 0:
         error_msg = "Unexpected error {} at skuba when initializing the cluster: {}".format(
                 skuba_proc.process.returncode,
@@ -322,8 +322,8 @@ def master_bootstrap(node_name,
     return ret
 
 
-def create_cluster(name,
-                   base_path,
+def create_cluster(cluster_name,
+                   cluster_basedir,
                    first_node_name,
                    target,
                    cloud_provider=None,
@@ -333,8 +333,8 @@ def create_cluster(name,
                    timeout=DEFAULT_TIMEOUT,
                    **kwargs):
 
-    ret = cluster_init(name=name,
-                       base_path=base_path,
+    ret = cluster_init(cluster_name=cluster_name,
+                       cluster_basedir=cluster_basedir,
                        target=load_balancer if load_balancer else target,
                        cloud_provider=cloud_provider,
                        strict_capability_defaults=strict_capability_defaults,
@@ -346,7 +346,7 @@ def create_cluster(name,
         return ret
 
     ret = merge_list(ret, master_bootstrap(node_name=first_node_name,
-                                           skuba_cluster_path=os.path.join(base_path, name),
+                                           skuba_cluster_path=os.path.join(cluster_basedir, cluster_name),
                                            target=target,
                                            verbosity=verbosity,
                                            timeout=timeout,

--- a/susemanager-utils/susemanager-sls/src/modules/mgr_caasp_manager.py
+++ b/susemanager-utils/susemanager-sls/src/modules/mgr_caasp_manager.py
@@ -293,7 +293,8 @@ def upgrade_cluster(skuba_cluster_path,
                        timeout=timeout,
                        **kwargs)
 
-    for node in nodes:
+    # Ensure master nodes are upgraded first
+    for node, _ in sorted(nodes.items(), key=lambda x: 0 if x[1].get('role') == 'master' else 1):
         if not nodes[node]['internal-ips']:
             log.error('No internal-ips defined for node: {}. Cannot proceed upgrading this node!'.format(node))
             continue

--- a/susemanager-utils/susemanager-sls/src/modules/mgr_caasp_manager.py
+++ b/susemanager-utils/susemanager-sls/src/modules/mgr_caasp_manager.py
@@ -8,12 +8,16 @@ from __future__ import absolute_import
 
 import logging
 import os
-import os.path
 import subprocess
-from urllib3.exceptions import HTTPError
-from kubernetes.client.rest import ApiException
-import kubernetes
-import kubernetes.client
+
+try:
+    from urllib3.exceptions import HTTPError
+    from kubernetes.client.rest import ApiException
+    import kubernetes
+    import kubernetes.client
+    HAS_KUBE_LIBS = True
+except ImportError:
+    HAS_KUBE_LIBS = False
 
 import salt.utils.stringutils
 import salt.utils.timed_subprocess
@@ -38,7 +42,12 @@ def __virtual__():
     '''
     This module is always enabled while 'skuba' CLI tools is available.
     '''
-    return __virtualname__ if which('skuba') else (False, 'skuba is not available')
+    if not which('skuba'):
+        return (False, 'skuba is not available')
+    elif not HAS_KUBE_LIBS:
+        return (False, 'kubernetes python library not found')
+    else:
+        return __virtualname__
 
 
 def _call_skuba(skuba_cluster_path,

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Implement CaaSP cluster upgrade procedure in cluster provider module.
 - handle GPG check flags different for yum/dnf (bsc#1171859)
 - Enable bootstrapping for Oracle Linux 6, 7 and 8
 - Set YAML loader to fix deprecation warnings


### PR DESCRIPTION
## What does this PR change?

This PR improves custom Salt `mgr_caasp_provider` module in order to implement the CaaSP cluster upgrade procedure according to: https://github.com/uyuni-project/uyuni/pull/2128#discussion_r414368146

1. Upgrade cluster addons
2. Upgrade each node
3. Upgrade cluster addons

Example:

```console
ext-suma-head-caasp-srv:~ # salt ext-suma-head-caasp-min-sles15sp1-v1.tf.local state.apply clusters.upgradecluster pillar='{"cluster_type": "caasp", "ssh_auth_sock": "/tmp/ssh-akwpjkOHbb/agent.935", "params": {"skuba_cluster_path":"/root/my-cluster-salt"}}'
ext-suma-head-caasp-min-sles15sp1-v1.tf.local:
----------
          ID: sync_modules
    Function: saltutil.sync_modules
      Result: True
     Comment: No updates to sync
     Started: 14:44:54.291674
    Duration: 180.794 ms
     Changes:   
----------
          ID: mgr_ssh_agent_socket_upgradecluster
    Function: environ.setenv
        Name: SSH_AUTH_SOCK
      Result: True
     Comment: Environ values were set
     Started: 14:44:54.473117
    Duration: 9.146 ms
     Changes:   
              ----------
              SSH_AUTH_SOCK:
                  /tmp/ssh-akwpjkOHbb/agent.935
----------
          ID: mgr_cluster_upgrade_cluster
    Function: module.run
        Name: mgrclusters.upgrade_cluster
      Result: True
     Comment: Module function mgrclusters.upgrade_cluster executed
     Started: 14:44:54.483575
    Duration: 1272.032 ms
     Changes:   
              ----------
              ret:
                  ----------
                  retcode:
                      0
                  stage0_upgrade_addons:
                      ----------
                      retcode:
                          0
                      stderr:
                      stdout:
                          Current Kubernetes cluster version: 1.17.4
                          Latest Kubernetes version: 1.17.4
                          
                          [apply] Congratulations! Addons for 1.17.4 are already at the latest version available
                      success:
                          True
                  stage1_upgrade_nodes:
                      ----------
                      master-one:
                          ----------
                          retcode:
                              0
                          stderr:
                          stdout:
                              Current Kubernetes cluster version: 1.17.4
                              Latest Kubernetes version: 1.17.4
                              Current Node version: 1.17.4
                              
                              Node master-one is up to date
                          success:
                              True
                      worker-one:
                          ----------
                          retcode:
                              0
                          stderr:
                          stdout:
                              Current Kubernetes cluster version: 1.17.4
                              Latest Kubernetes version: 1.17.4
                              Current Node version: 1.17.4
                              
                              Node worker-one is up to date
                          success:
                              True
                  stage2_upgrade_addons:
                      ----------
                      retcode:
                          0
                      stderr:
                      stdout:
                          Current Kubernetes cluster version: 1.17.4
                          Latest Kubernetes version: 1.17.4
                          
                          [apply] Congratulations! Addons for 1.17.4 are already at the latest version available
                      success:
                          True
                  success:
                      True

Summary for ext-suma-head-caasp-min-sles15sp1-v1.tf.local
------------
Succeeded: 3 (changed=2)
Failed:    0
------------
Total states run:     3
Total run time:   1.462 s
```

This PR also cherry-picks two requiered commits from: https://github.com/uyuni-project/uyuni/pull/2070

- https://github.com/uyuni-project/uyuni/pull/2070/commits/e003511c94bad5074026b24f1063ac6d2f935a27
- https://github.com/uyuni-project/uyuni/pull/2070/commits/de73030bafc18fee3f6c706c06b05535534e3c7a

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **backend code**

- [x] **DONE**

## Test coverage
- No tests: **new feature - no tests yet**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/11435

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
