### PR TITLE
Add separate client tools for Oracle (same URL as CentOS)

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -993,7 +993,7 @@ dist_map_release = 8
 
 [oraclelinux8-appstream]
 archs    = x86_64
-name     = Oracle Linux 8 (%(arch)s)
+name     = Oracle Linux 8 AppStream (%(arch)s)
 checksum = sha256
 gpgkey_url = http://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
 gpgkey_id  = AD986DA3
@@ -1028,6 +1028,24 @@ archs    = x86_64
 name     = Packages for test and development - Oracle Linux 8 (%(arch)s)
 base_channels = oraclelinux8-%(arch)s
 repo_url = http://yum.oracle.com/repo/OracleLinux/OL8/developer/%(arch)s/
+
+[oraclelinux8-uyuni-client]
+name     = Uyuni Client Tools for %(base_channel_name)s
+archs    = %(_x86_archs)s
+base_channels = oraclelinux8-%(arch)s
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8/
+
+[oraclelinux8-uyuni-client-devel]
+name     = Uyuni Client Tools for %(base_channel_name)s (Development)
+archs    = %(_x86_archs)s
+base_channels = oraclelinux8-%(arch)s
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS8-Uyuni-Client-Tools/CentOS_8/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS8-Uyuni-Client-Tools/CentOS_8/
 
 [oraclelinux7]
 archs    = x86_64
@@ -1158,6 +1176,24 @@ name      = Ceph Storage for Oracle Linux Release 2.0 for Oracle Linux 7 (%(arch
 base_channels = oraclelinux7-%(arch)s
 repo_url = http://yum.oracle.com/repo/OracleLinux/OL7/ceph/%(arch)s/
 
+[oraclelinux7-uyuni-client]
+name     = Uyuni Client Tools for %(base_channel_name)s
+archs    = %(_x86_archs)s
+base_channels = oraclelinux7-%(arch)s
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7/
+
+[oraclelinux7-uyuni-client-devel]
+name     = Uyuni Client Tools for %(base_channel_name)s (Development)
+archs    = %(_x86_archs)s
+base_channels = oraclelinux7-%(arch)s
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS7-Uyuni-Client-Tools/CentOS_7/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS7-Uyuni-Client-Tools/CentOS_7/
+
 [oraclelinux6]
 archs    = %(_x86_archs)s
 name     = Oracle Linux 6 (%(arch)s)
@@ -1265,6 +1301,24 @@ archs     = x86_64
 name      = OpenStack 3.0 packages for Oracle Linux 6 (%(arch)s)
 base_channels = oraclelinux6-%(arch)s
 repo_url = http://yum.oracle.com/repo/OracleLinux/OL6/openstack30/%(arch)s/
+
+[oraclelinux6-uyuni-client]
+name     = Uyuni Client Tools for %(base_channel_name)s
+archs    = %(_x86_archs)s
+base_channels = oraclelinux6-%(arch)s
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS6-Uyuni-Client-Tools/CentOS_6/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS6-Uyuni-Client-Tools/CentOS_6/
+
+[oraclelinux6-uyuni-client-devel]
+name     = Uyuni Client Tools for %(base_channel_name)s (Development)
+archs    = %(_x86_archs)s
+base_channels = oraclelinux6-%(arch)s
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS6-Uyuni-Client-Tools/CentOS_6/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS6-Uyuni-Client-Tools/CentOS_6/
 
 [uyuni-server-stable-leap-151]
 name     = Uyuni Server Stable for %(base_channel_name)s

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,4 @@
+- Create separate channels for Oracle Client Tools (use CentOS URLs)
 - Add repositories for Ubuntu 20.04 LTS
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Add separate client tools for Oracle (same URL as CentOS)

A channel can't have two different parent channels, so we need to do this, even if in the end the CentOS client tools are used.

## GUI diff

No difference.
- [x] **DONE**

## Documentation
- Doc PR: https://github.com/uyuni-project/uyuni-docs/pull/281

- [x] **DONE**

## Test coverage
- No tests: spacewalk-common-channels not covered by tests for now.

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
