### PR TITLE
 Enable support for bootstrapping CentOS/Oracle Linux 6, 7 and 8 on Uyuni and SUSE Manager

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -1105,16 +1105,52 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/opensuse/15/2/bootstrap/'
     },
     'centos-6-x86_64' : {
-        'BASECHANNEL' : 'centos6-x86_64', 'PKGLIST' : RES6,
+        'PDID' : [-11, 1682], 'BETAPDID' : [2064], 'PKGLIST' : RES6,
         'DEST' : '/srv/www/htdocs/pub/repositories/centos/6/bootstrap/'
     },
     'centos-7-x86_64' : {
-        'BASECHANNEL' : 'centos7-x86_64', 'PKGLIST' : RES7,
+        'PDID' : [-12, 1683], 'BETAPDID' : [2065], 'PKGLIST' : RES7,
         'DEST' : '/srv/www/htdocs/pub/repositories/centos/7/bootstrap/'
     },
     'centos-8-x86_64' : {
+        'PDID' : [-13, 2007], 'BETAPDID' : [2066], 'PKGLIST' : RES8,
+        'DEST' : '/srv/www/htdocs/pub/repositories/centos/8/bootstrap/'
+    },
+    'centos-6-x86_64-uyuni' : {
+        'BASECHANNEL' : 'centos6-x86_64', 'PKGLIST' : RES6,
+        'DEST' : '/srv/www/htdocs/pub/repositories/centos/6/bootstrap/'
+    },
+    'centos-7-x86_64-uyuni' : {
+        'BASECHANNEL' : 'centos7-x86_64', 'PKGLIST' : RES7,
+        'DEST' : '/srv/www/htdocs/pub/repositories/centos/7/bootstrap/'
+    },
+    'centos-8-x86_64-uyuni' : {
         'BASECHANNEL' : 'centos8-x86_64', 'PKGLIST' : RES8,
         'DEST' : '/srv/www/htdocs/pub/repositories/centos/8/bootstrap/'
+    },
+    'oracle-6-x86_64' : {
+        'PDID' : [-15, 1682], 'BETAPDID' : [2064], 'PKGLIST' : RES6,
+        'DEST' : '/srv/www/htdocs/pub/repositories/oracle/6/bootstrap/'
+    },
+    'oracle-7-x86_64' : {
+        'PDID' : [-14, 1683], 'BETAPDID' : [2065], 'PKGLIST' : RES7,
+        'DEST' : '/srv/www/htdocs/pub/repositories/oracle/7/bootstrap/'
+    },
+    'oracle-8-x86_64' : {
+        'PDID' : [-17, 2007], 'BETAPDID' : [2066], 'PKGLIST' : RES8,
+        'DEST' : '/srv/www/htdocs/pub/repositories/oracle/8/bootstrap/'
+    },
+    'oracle-6-x86_64-uyuni' : {
+        'BASECHANNEL' : 'oraclelinux6-x86_64', 'PKGLIST' : RES6,
+        'DEST' : '/srv/www/htdocs/pub/repositories/oracle/6/bootstrap/'
+    },
+    'oracle-7-x86_64-uyuni' : {
+        'BASECHANNEL' : 'oraclelinux7-x86_64', 'PKGLIST' : RES7,
+        'DEST' : '/srv/www/htdocs/pub/repositories/oracle/7/bootstrap/'
+    },
+    'oracle-8-x86_64-uyuni' : {
+        'BASECHANNEL' : 'oraclelinux8-x86_64', 'PKGLIST' : RES8,
+        'DEST' : '/srv/www/htdocs/pub/repositories/oracle/8/bootstrap/'
     },
     'RHEL6-x86_64' : {
         'PDID' : [-5, 1682], 'BETAPDID' : [2064], 'PKGLIST' : RES6,

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- Enable support for bootstrapping CentOS/Oracle Linux 6, 7 and 8 on Uyuni and SUSE Manager
 - Enable support for bootstrapping Ubuntu 20.04 LTS
 - migrate cobbler configs for ks_mirror -> distro_mirror rename (bsc#1169209)
 


### PR DESCRIPTION
## What does this PR change?

Enable support for bootstrapping CentOS/Oracle Linux 6, 7 and 8 on Uyuni and SUSE Manager

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: If we reuse names, no need for changes.

- [x] **DONE**

## Test coverage
- No tests: No Oracle yet at the testsuite. Manual tests.

- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/11368

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
