### PR TITLE
Make Oracle 8 Appstream channel a child of Oracle 8 channel

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -994,6 +994,7 @@ dist_map_release = 8
 [oraclelinux8-appstream]
 archs    = x86_64
 name     = Oracle Linux 8 AppStream (%(arch)s)
+base_channels = oraclelinux8-%(arch)s
 checksum = sha256
 gpgkey_url = http://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
 gpgkey_id  = AD986DA3


### PR DESCRIPTION
## What does this PR change?

Another typo. Oracle 8 Appstream channel needs to be a child of Oracle channel.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Bugfix.

- [x] **DONE**

## Test coverage
- No tests: spacewal-common-channels doesn't have them yet.

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
