### PR TITLE
Uyuni master ubuntu shows removed pkgs

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/packages/profileupdate.sls
+++ b/susemanager-utils/susemanager-sls/salt/packages/profileupdate.sls
@@ -2,7 +2,7 @@ packages:
   module.run:
     - name: pkg.info_installed
     - kwargs: {
-          attr: 'arch,epoch,version,release,install_date_time_t',
+          attr: 'status,arch,epoch,version,release,install_date_time_t',
 {%- if grains.get('__suse_reserved_pkg_all_versions_support', False) %}
           errors: report,
           all_versions: true

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -7,6 +7,7 @@
 - Cluster Awareness: Introduce generic SLS files for Cluster Management
   and CaaSP Cluster Provider custom Salt module.
 - Add virtual volume delete action
+- Ubuntu no longer shows removed packages as installed (bsc#1171461)
 
 -------------------------------------------------------------------
 Mon Apr 13 09:37:50 CEST 2020 - jgonzalez@suse.com


### PR DESCRIPTION
## What does this PR change?

Since status was excluded from the pkg information, everything was deemed to be installed. This changes once 'status' is included again.

## GUI diff

No difference.



## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: Works as implemented. But we should think about changing the implementation details here.


## Changelogs

Provided

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
