### PR TITLE
Set YAML loader to fix deprecation warnings

### DIFF
--- a/susemanager-utils/susemanager-sls/modules/pillar/suma_minion.py
+++ b/susemanager-utils/susemanager-sls/modules/pillar/suma_minion.py
@@ -80,7 +80,7 @@ def ext_pillar(minion_id, *args):
     for static_pillar in MANAGER_STATIC_PILLAR:
         static_pillar_filename = os.path.join(MANAGER_STATIC_PILLAR_DATA_PATH, static_pillar)
         try:
-            ret.update(yaml.load(open('{0}.yml'.format(static_pillar_filename)).read()))
+            ret.update(yaml.load(open('{0}.yml'.format(static_pillar_filename)).read(), Loader=yaml.FullLoader))
         except Exception as exc:
             log.error('Error accessing "{0}": {1}'.format(static_pillar_filename, exc))
 
@@ -88,7 +88,7 @@ def ext_pillar(minion_id, *args):
     for global_pillar in MANAGER_GLOBAL_PILLAR:
         global_pillar_filename = os.path.join(MANAGER_PILLAR_DATA_PATH, global_pillar)
         try:
-            ret.update(yaml.load(open('{0}.yml'.format(global_pillar_filename)).read()))
+            ret.update(yaml.load(open('{0}.yml'.format(global_pillar_filename)).read(), Loader=yaml.FullLoader))
         except Exception as exc:
             log.error('Error accessing "{0}": {1}'.format(global_pillar_filename, exc))
 
@@ -98,7 +98,7 @@ def ext_pillar(minion_id, *args):
         data_filename = os.path.join(MANAGER_PILLAR_DATA_PATH, minion_pillar_filename_prefix + suffix)
         if os.path.exists(data_filename):
             try:
-                ret.update(yaml.load(open(data_filename).read()))
+                ret.update(yaml.load(open(data_filename).read(), Loader=yaml.FullLoader))
             except Exception as error:
                 log.error('Error accessing "{pillar_file}": {message}'.format(pillar_file=data_filename, message=str(error)))
 
@@ -187,7 +187,7 @@ def load_formula_pillar(minion_id, group_id, formula_name):
     system_filename = os.path.join(FORMULAS_DATA_PATH, "pillar", "{id}_{name}.json".format(id=minion_id, name=formula_name))
 
     try:
-        layout = yaml.load(open(layout_filename).read())
+        layout = yaml.load(open(layout_filename).read(), Loader=yaml.FullLoader)
         group_data = json.load(open(group_filename)) if group_filename is not None and os.path.isfile(group_filename) else {}
         system_data = json.load(open(system_filename)) if os.path.isfile(system_filename) else {}
     except Exception as error:
@@ -297,7 +297,7 @@ def image_pillars(minion_id):
         if os.path.isfile(pillar_path) and pillar.endswith('.sls'):
             try:
                 with open(pillar_path) as p:
-                    ret = salt.utils.dictupdate.merge(ret, yaml.load(p.read()), strategy='recurse')
+                    ret = salt.utils.dictupdate.merge(ret, yaml.load(p.read(), Loader=yaml.FullLoader), strategy='recurse')
             except Exception as error:
                 log.error('Error loading data for image "{image}": {message}'.format(image=pillar.path(), message=str(error)))
 

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- Set YAML loader to fix deprecation warnings
+
 -------------------------------------------------------------------
 Wed May 20 11:06:24 CEST 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

External pillar module uses deprecated call for yaml loading. Fix this by explicitly pass safe loader.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: internal fixes

- [X] **DONE**

## Test coverage
- No tests: no change in functionality, covered by existing tests

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11512
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
