### PR TITLE
Manager bsc1171687

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,6 @@
+- use defined return values for spacecmd methods so scripts can
+  check for failure (bsc#1171687)
+
 -------------------------------------------------------------------
 Mon Feb 17 12:39:00 CET 2020 - jgonzalez@suse.com
 

--- a/spacecmd/src/bin/spacecmd
+++ b/spacecmd/src/bin/spacecmd
@@ -193,7 +193,9 @@ if __name__ == '__main__':
             precmd = shell.precmd(command)
             if precmd == '':
                 sys.exit(1)
-            shell.print_result(shell.onecmd(precmd), precmd)
+            result = shell.print_result(shell.onecmd(precmd), precmd)
+            if result != 0:
+                sys.exit(result)
         except KeyboardInterrupt:
             print
             print('User Interrupt')

--- a/spacecmd/src/spacecmd/activationkey.py
+++ b/spacecmd/src/spacecmd/activationkey.py
@@ -61,12 +61,14 @@ def do_activationkey_addpackages(self, args):
 
     if not len(args) >= 2:
         self.help_activationkey_addpackages()
-        return
+        return 1
 
     key = args.pop(0)
     packages = [{'name': a} for a in args]
 
     self.client.activationkey.addPackages(self.session, key, packages)
+
+    return 0
 
 ####################
 
@@ -97,12 +99,14 @@ def do_activationkey_removepackages(self, args):
 
     if not len(args) >= 2:
         self.help_activationkey_removepackages()
-        return
+        return 1
 
     key = args.pop(0)
     packages = [{'name': a} for a in args]
 
     self.client.activationkey.removePackages(self.session, key, packages)
+
+    return 0
 
 ####################
 
@@ -130,7 +134,7 @@ def do_activationkey_addgroups(self, args):
 
     if not len(args) >= 2:
         self.help_activationkey_addgroups()
-        return
+        return 1
 
     key = args.pop(0)
 
@@ -140,6 +144,8 @@ def do_activationkey_addgroups(self, args):
         groups.append(details.get('id'))
 
     self.client.activationkey.addServerGroups(self.session, key, groups)
+
+    return 0
 
 ####################
 
@@ -176,7 +182,7 @@ def do_activationkey_removegroups(self, args):
 
     if not len(args) >= 2:
         self.help_activationkey_removegroups()
-        return
+        return 1
 
     key = args.pop(0)
 
@@ -186,6 +192,8 @@ def do_activationkey_removegroups(self, args):
         groups.append(details.get('id'))
 
     self.client.activationkey.removeServerGroups(self.session, key, groups)
+
+    return 0
 
 ####################
 
@@ -213,7 +221,7 @@ def do_activationkey_addentitlements(self, args):
 
     if not len(args) >= 2:
         self.help_activationkey_addentitlements()
-        return
+        return 1
 
     key = args.pop(0)
     entitlements = args
@@ -221,6 +229,8 @@ def do_activationkey_addentitlements(self, args):
     self.client.activationkey.addEntitlements(self.session,
                                               key,
                                               entitlements)
+
+    return 0
 
 ####################
 
@@ -251,7 +261,7 @@ def do_activationkey_removeentitlements(self, args):
 
     if not len(args) >= 2:
         self.help_activationkey_removeentitlements()
-        return
+        return 1
 
     key = args.pop(0)
     entitlements = args
@@ -259,6 +269,8 @@ def do_activationkey_removeentitlements(self, args):
     self.client.activationkey.removeEntitlements(self.session,
                                                  key,
                                                  entitlements)
+
+    return 0
 
 ####################
 
@@ -303,12 +315,14 @@ def do_activationkey_addchildchannels(self, args):
 
     if not len(args) >= 2:
         self.help_activationkey_addchildchannels()
-        return
+        return 1
 
     key = args.pop(0)
     channels = args
 
     self.client.activationkey.addChildChannels(self.session, key, channels)
+
+    return 0
 
 ####################
 
@@ -338,7 +352,7 @@ def do_activationkey_removechildchannels(self, args):
 
     if not len(args) >= 2:
         self.help_activationkey_removechildchannels()
-        return
+        return 1
 
     key = args.pop(0)
     channels = args
@@ -346,6 +360,8 @@ def do_activationkey_removechildchannels(self, args):
     self.client.activationkey.removeChildChannels(self.session,
                                                   key,
                                                   channels)
+
+    return 0
 
 ####################
 
@@ -367,7 +383,7 @@ def do_activationkey_listchildchannels(self, args):
 
     if not args:
         self.help_activationkey_listchildchannels()
-        return
+        return 1
 
     key = args[0]
 
@@ -375,6 +391,8 @@ def do_activationkey_listchildchannels(self, args):
 
     if details.get('child_channel_labels'):
         print('\n'.join(sorted(details.get('child_channel_labels'))))
+
+    return 0
 
 ####################
 
@@ -396,13 +414,15 @@ def do_activationkey_listbasechannel(self, args):
 
     if not args:
         self.help_activationkey_listbasechannel()
-        return
+        return 1
 
     key = args[0]
 
     details = self.client.activationkey.getDetails(self.session, key)
 
     print(details.get('base_channel_label'))
+
+    return 0
 
 ####################
 
@@ -424,7 +444,7 @@ def do_activationkey_listgroups(self, args):
 
     if not args:
         self.help_activationkey_listgroups()
-        return
+        return 1
 
     key = args[0]
 
@@ -434,6 +454,8 @@ def do_activationkey_listgroups(self, args):
         group_details = self.client.systemgroup.getDetails(self.session,
                                                            group)
         print(group_details.get('name'))
+
+    return 0
 
 ####################
 
@@ -455,7 +477,7 @@ def do_activationkey_listentitlements(self, args):
 
     if not args:
         self.help_activationkey_listentitlements()
-        return
+        return 1
 
     key = args[0]
 
@@ -463,6 +485,8 @@ def do_activationkey_listentitlements(self, args):
 
     if details.get('entitlements'):
         print('\n'.join(details.get('entitlements')))
+
+    return 0
 
 ####################
 
@@ -484,7 +508,7 @@ def do_activationkey_listpackages(self, args):
 
     if not args:
         self.help_activationkey_listpackages()
-        return
+        return 1
 
     key = args[0]
 
@@ -495,6 +519,8 @@ def do_activationkey_listpackages(self, args):
             print('%s.%s' % (package['name'], package['arch']))
         else:
             print(package['name'])
+
+    return 0
 
 ####################
 
@@ -516,7 +542,7 @@ def do_activationkey_listconfigchannels(self, args):
 
     if not args:
         self.help_activationkey_listconfigchannels()
-        return
+        return 1
 
     key = args[0]
 
@@ -528,6 +554,8 @@ def do_activationkey_listconfigchannels(self, args):
 
     if channels:
         print('\n'.join(channels))
+
+    return 0
 
 ####################
 
@@ -560,7 +588,7 @@ def do_activationkey_addconfigchannels(self, args):
 
     if len(args) < 2:
         self.help_activationkey_addconfigchannels()
-        return
+        return 1
 
     key = [args.pop(0)]
     channels = args
@@ -581,6 +609,8 @@ def do_activationkey_addconfigchannels(self, args):
                                                 key,
                                                 channels,
                                                 options.top)
+
+    return 0
 
 ####################
 
@@ -612,7 +642,7 @@ def do_activationkey_removeconfigchannels(self, args):
 
     if not len(args) >= 2:
         self.help_activationkey_removeconfigchannels()
-        return
+        return 1
 
     key = [args.pop(0)]
     channels = args
@@ -620,6 +650,8 @@ def do_activationkey_removeconfigchannels(self, args):
     self.client.activationkey.removeConfigChannels(self.session,
                                                    key,
                                                    channels)
+
+    return 0
 
 ####################
 
@@ -642,7 +674,7 @@ def do_activationkey_setconfigchannelorder(self, args):
 
     if len(args) != 1:
         self.help_activationkey_setconfigchannelorder()
-        return
+        return 1
 
     key = args[0]
 
@@ -664,6 +696,8 @@ def do_activationkey_setconfigchannelorder(self, args):
     self.client.activationkey.setConfigChannels(self.session,
                                                 [key],
                                                 new_channels)
+
+    return 0
 
 ####################
 
@@ -741,6 +775,8 @@ def do_activationkey_create(self, args):
 
     logging.info('Created activation key %s' % new_key)
 
+    return 0
+
 ####################
 
 
@@ -760,7 +796,7 @@ def do_activationkey_delete(self, args):
 
     if not args:
         self.help_activationkey_delete()
-        return
+        return 1
 
     # allow globbing of activationkey names
     keys = filter_results(self.do_activationkey_list('', True), args)
@@ -769,17 +805,19 @@ def do_activationkey_delete(self, args):
 
     if not keys:
         logging.error("No keys matched argument %s" % args)
-        return
+        return 1
 
     # Print the keys prior to the confimation
     print('\n'.join(sorted(keys)))
 
     if not self.user_confirm('Delete activation key(s) [y/N]:'):
-        return
+        return 1
 
     for key in keys:
         logging.debug("Deleting key %s" % key)
         self.client.activationkey.delete(self.session, key)
+
+    return 0
 
 ####################
 
@@ -804,6 +842,8 @@ def do_activationkey_list(self, args, doreturn=False):
         if keys:
             print('\n'.join(sorted(keys)))
 
+    return 0
+
 ####################
 
 
@@ -823,7 +863,7 @@ def do_activationkey_listsystems(self, args):
 
     if not args:
         self.help_activationkey_listsystems()
-        return
+        return 1
 
     key = args[0]
 
@@ -833,12 +873,14 @@ def do_activationkey_listsystems(self, args):
                                                            key)
     except xmlrpclib.Fault:
         logging.warning('%s is not a valid activation key' % key)
-        return
+        return 1
 
     systems = sorted([s.get('hostname') for s in systems])
 
     if systems:
         print('\n'.join(systems))
+
+    return 0
 
 ####################
 
@@ -957,11 +999,13 @@ def do_activationkey_enableconfigdeployment(self, args):
 
     if not args:
         self.help_activationkey_enableconfigdeployment()
-        return
+        return 1
 
     for key in args:
         logging.debug('Enabling config file deployment for %s' % key)
         self.client.activationkey.enableConfigDeployment(self.session, key)
+
+    return 0
 
 ####################
 
@@ -984,11 +1028,13 @@ def do_activationkey_disableconfigdeployment(self, args):
 
     if not args:
         self.help_activationkey_disableconfigdeployment()
-        return
+        return 1
 
     for key in args:
         logging.debug('Disabling config file deployment for %s' % key)
         self.client.activationkey.disableConfigDeployment(self.session, key)
+
+    return 0
 
 ####################
 
@@ -1015,7 +1061,7 @@ def do_activationkey_setbasechannel(self, args):
 
     if not len(args) >= 2:
         self.help_activationkey_setbasechannel()
-        return
+        return 1
 
     key = args.pop(0)
     channel = args[0]
@@ -1036,6 +1082,8 @@ def do_activationkey_setbasechannel(self, args):
         details['usage_limit'] = -1
 
     self.client.activationkey.setDetails(self.session, key, details)
+
+    return 0
 
 ####################
 
@@ -1063,7 +1111,7 @@ def do_activationkey_setusagelimit(self, args):
 
     if not len(args) >= 2:
         self.help_activationkey_setusagelimit()
-        return
+        return 1
 
     key = args.pop(0)
     usage_limit = -1
@@ -1077,7 +1125,7 @@ def do_activationkey_setusagelimit(self, args):
             logging.error("Couldn't convert argument %s to an integer" %
                           args[0])
             self.help_activationkey_setusagelimit()
-            return
+            return 1
 
     current_details = self.client.activationkey.getDetails(self.session,
                                                            key)
@@ -1089,6 +1137,8 @@ def do_activationkey_setusagelimit(self, args):
                current_details.get('universal_default')}
 
     self.client.activationkey.setDetails(self.session, key, details)
+
+    return 0
 
 ####################
 
@@ -1110,7 +1160,7 @@ def do_activationkey_setuniversaldefault(self, args):
 
     if not args:
         self.help_activationkey_setuniversaldefault()
-        return
+        return 1
 
     key = args.pop(0)
 
@@ -1130,6 +1180,8 @@ def do_activationkey_setuniversaldefault(self, args):
         details['usage_limit'] = -1
 
     self.client.activationkey.setDetails(self.session, key, details)
+
+    return 0
 
 ####################
 
@@ -1216,7 +1268,7 @@ def do_activationkey_export(self, args):
 
         if not keys:
             logging.error("Invalid activation key passed")
-            return
+            return 1
 
         if not filename:
             # No filename arg, so we try to do something sensible:
@@ -1241,11 +1293,13 @@ def do_activationkey_export(self, args):
     if os.path.isfile(filename):
         if not self.user_confirm("File %s exists, confirm overwrite file? (y/n)" %
                                  filename):
-            return
+            return 1
 
     if json_dump_to_file(keydetails_list, filename) != True:
         logging.error("Failed to save exported keys to file: {}".format(filename))
-        return
+        return 1
+
+    return 0
 
 ####################
 
@@ -1263,7 +1317,7 @@ def do_activationkey_import(self, args):
     if not args:
         logging.error("No filename passed")
         self.help_activationkey_import()
-        return
+        return 1
 
     for filename in args:
         logging.debug("Passed filename do_activationkey_import %s" % filename)
@@ -1271,12 +1325,15 @@ def do_activationkey_import(self, args):
 
         if not keydetails_list:
             logging.error("Could not read json data from %s" % filename)
-            return
+            return 1
 
         for keydetails in keydetails_list:
             if self.import_activationkey_fromdetails(keydetails) != True:
                 logging.error("Failed to import key %s" %
                               keydetails['key'])
+                return 1
+
+    return 0
 
 # create a new key based on the dict from export_activationkey_getdetails
 
@@ -1408,16 +1465,16 @@ def do_activationkey_clone(self, args):
         if not options.clonename and not options.regex:
             logging.error("Error - must specify either -c or -x options!")
             self.help_activationkey_clone()
-            return
+            return 1
 
     if options.clonename in allkeys:
         logging.error("Key %s already exists" % options.clonename)
-        return
+        return 1
 
     if not args:
         logging.error("Error no activationkey to clone passed!")
         self.help_activationkey_clone()
-        return
+        return 1
 
     logging.debug("Got args=%s %d" % (args, len(args)))
     # allow globbing of configchannel channel names
@@ -1520,6 +1577,9 @@ def do_activationkey_clone(self, args):
         if self.import_activationkey_fromdetails(keydetails) != True:
             logging.error("Failed to clone %s to %s" %
                           (ak, keydetails['key']))
+            return 1
+
+    return 0
 
 ####################
 # activationkey helper
@@ -1623,7 +1683,7 @@ def do_activationkey_disable(self, args):
 
     if not len(args) >= 1:
         self.help_activationkey_disable()
-        return
+        return 1
 
     keys = filter_results(self.do_activationkey_list('', True), args)
 
@@ -1631,6 +1691,8 @@ def do_activationkey_disable(self, args):
 
     for akey in keys:
         self.client.activationkey.setDetails(self.session, akey, details)
+
+    return 0
 
 ####################
 
@@ -1655,7 +1717,7 @@ def do_activationkey_enable(self, args):
 
     if not len(args) >= 1:
         self.help_activationkey_enable()
-        return
+        return 1
 
     keys = filter_results(self.do_activationkey_list('', True), args)
 
@@ -1663,6 +1725,8 @@ def do_activationkey_enable(self, args):
 
     for akey in keys:
         self.client.activationkey.setDetails(self.session, akey, details)
+
+    return 0
 
 ####################
 
@@ -1687,7 +1751,7 @@ def do_activationkey_setdescription(self, args):
 
     if not len(args) >= 2:
         self.help_activationkey_setdescription()
-        return
+        return 1
 
     akey = args.pop(0)
     description = ' '.join(args)
@@ -1695,6 +1759,8 @@ def do_activationkey_setdescription(self, args):
     details = {'description': description}
 
     self.client.activationkey.setDetails(self.session, akey, details)
+
+    return 0
 
 ####################
 
@@ -1722,9 +1788,11 @@ def do_activationkey_setcontactmethod(self, args):
 
     if not len(args) == 2:
         self.help_activationkey_setcontactmethod()
-        return
+        return 1
 
     details = {'contact_method': args.pop()}
     akey = args.pop()
 
     self.client.activationkey.setDetails(self.session, akey, details)
+
+    return 0

--- a/spacecmd/src/spacecmd/configchannel.py
+++ b/spacecmd/src/spacecmd/configchannel.py
@@ -55,8 +55,6 @@ def do_configchannel_list(self, args, doreturn=False):
         if channels:
             print('\n'.join(channels))
 
-    return 0
-
 ####################
 
 
@@ -379,7 +377,7 @@ def do_configchannel_details(self, args):
 
     if not args:
         self.help_configchannel_details()
-        return 1
+        return
 
     add_separator = False
 

--- a/spacecmd/src/spacecmd/configchannel.py
+++ b/spacecmd/src/spacecmd/configchannel.py
@@ -55,6 +55,8 @@ def do_configchannel_list(self, args, doreturn=False):
         if channels:
             print('\n'.join(channels))
 
+    return 0
+
 ####################
 
 
@@ -71,14 +73,14 @@ def complete_configchannel_listsystems(self, text, line, beg, end):
 def do_configchannel_listsystems(self, args):
     if not self.check_api_version('10.11'):
         logging.warning("This version of the API doesn't support this method")
-        return
+        return 1
 
     arg_parser = get_argument_parser()
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
         self.help_configchannel_listsystems()
-        return
+        return 1
 
     channel = args[0]
     systems = self.client.configchannel.listSubscribedSystems(self.session, channel)
@@ -86,6 +88,9 @@ def do_configchannel_listsystems(self, args):
 
     if systems:
         print('\n'.join(systems))
+        return 0
+    else:
+        return 1
 
 ####################
 
@@ -138,7 +143,7 @@ def do_configchannel_forcedeploy(self, args):
 
     if not args or len(args) > 1:
         self.help_configchannel_forcedeploy()
-        return
+        return 1
 
     channel = args[0]
 
@@ -147,13 +152,13 @@ def do_configchannel_forcedeploy(self, args):
 
     if not files:
         print('No files within selected configchannel.')
-        return
+        return 1
     else:
         systems = self.client.configchannel.listSubscribedSystems(self.session, channel)
         systems = sorted([s.get('name') for s in systems])
         if not systems:
             print('Channel has no subscribed Systems')
-            return
+            return 1
         else:
             print('Force deployment of the following configfiles:')
             print('==============================================')
@@ -163,6 +168,8 @@ def do_configchannel_forcedeploy(self, args):
             print('\n'.join(systems))
     if self.user_confirm('Really force deployment [y/N]:'):
         self.client.configchannel.deployAllSystems(self.session, channel)
+
+    return 0
 
 ####################
 
@@ -193,7 +200,7 @@ def do_configchannel_filedetails(self, args):
 
     if not 4 > len(args) > 1:
         self.help_configchannel_filedetails()
-        return
+        return 1
 
     args.append(None)
     channel, filename, revision = args[:3]
@@ -203,13 +210,13 @@ def do_configchannel_filedetails(self, args):
             revision = int(args[2])
         except (ValueError, IndexError):
             logging.error("Invalid revision: %s", args[2])
-            return
+            return 1
 
     # the server return a null exception if an invalid file is passed
     valid_files = self.do_configchannel_listfiles(channel, True)
     if filename not in valid_files:
         logging.warning('%s is not in this configuration channel' % filename)
-        return
+        return 1
 
     if revision:
         details = self.client.configchannel.lookupFileInfo(self.session,
@@ -280,7 +287,7 @@ def do_configchannel_backup(self, args):
 
     if len(args) < 1:
         self.help_configchannel_backup()
-        return
+        return 1
 
     channel = args[0]
 
@@ -300,7 +307,7 @@ def do_configchannel_backup(self, args):
             os.makedirs(outputpath_base)
     except OSError as exc:
         logging.error('Could not create output directory: %s', str(exc))
-        return
+        return 1
 
     # the server return a null exception if an invalid file is passed
     valid_files = self.do_configchannel_listfiles(channel, True)
@@ -313,7 +320,7 @@ def do_configchannel_backup(self, args):
         fh = open(fh_path, 'w')
     except IOError as exc:
         logging.error('Could not create "%s" file: %s', fh_path, str(exc))
-        return
+        return 1
 
     for details in results:
         dumpfile = outputpath_base + details.get('path')
@@ -351,6 +358,8 @@ def do_configchannel_backup(self, args):
 
     fh.close()
 
+    return 0
+
 ####################
 
 
@@ -370,7 +379,7 @@ def do_configchannel_details(self, args):
 
     if not args:
         self.help_configchannel_details()
-        return
+        return 1
 
     add_separator = False
 
@@ -433,11 +442,11 @@ def do_configchannel_create(self, args):
             options.description = options.name
         if options.type not in ('normal', 'state'):
             logging.error('Only [normal/state] values are acceptable for type')
-            return
+            return 1
     else:
         if not options.name:
             logging.error('A name is required')
-            return
+            return 1
         if not options.label:
             options.label = options.name
         if not options.description:
@@ -446,13 +455,15 @@ def do_configchannel_create(self, args):
             options.type = 'normal'
         if options.type not in ('normal', 'state'):
             logging.error('Only [normal/state] values are acceptable for --type parameter')
-            return
+            return 1
 
     self.client.configchannel.create(self.session,
                                      options.label,
                                      options.name,
                                      options.description,
                                      options.type)
+
+    return 0
 
 ####################
 
@@ -473,7 +484,7 @@ def do_configchannel_delete(self, args):
 
     if not args:
         self.help_configchannel_delete()
-        return
+        return 1
 
     # allow globbing of configchannel names
     channels = filter_results(self.do_configchannel_list('', True), args)
@@ -481,13 +492,15 @@ def do_configchannel_delete(self, args):
 
     if not channels:
         logging.error("No channels matched argument(s): %s" % ", ".join(args))
-        return
+        return 1
 
     # Print the channels prior to the confirmation
     print('\n'.join(sorted(channels)))
 
     if self.user_confirm('Delete these channels [y/N]:'):
         self.client.configchannel.deleteChannels(self.session, channels)
+
+    return 0
 
 ####################
 
@@ -764,7 +777,7 @@ def do_configchannel_addfile(self, args, update_path=''):
                     failures += 1
             if failures > 0:
                 logging.error("Unable to obtain a valid channel. Aborting.")
-                return
+                return 1
 
         if update_path:
             options.path = update_path
@@ -787,12 +800,12 @@ def do_configchannel_addfile(self, args, update_path=''):
     if not options.channel:
         logging.error("No config channel specified!")
         self.help_configchannel_addfile()
-        return
+        return 1
 
     if not file_info:
         logging.error("Error obtaining file info")
         self.help_configchannel_addfile()
-        return
+        return 1
 
     if options.yes or self.user_confirm():
         if options.symlink:
@@ -819,6 +832,8 @@ def do_configchannel_addfile(self, args, update_path=''):
                                                          options.path,
                                                          options.directory,
                                                          file_info)
+
+    return 0
 
 ####################
 
@@ -872,7 +887,7 @@ def do_configchannel_updateinitsls(self, args, update_path=''):
         except xmlrpclib.Fault:
             logging.error("No existing file information found for %s" %
                           options.path)
-            return
+            return 1
         contents = file_info[0].get('contents')
         if self.user_confirm('Read an existing file [y/N]:',
                          nospacer=True, ignore_yes=True):
@@ -892,7 +907,7 @@ def do_configchannel_updateinitsls(self, args, update_path=''):
             contents = read_file(options.file)
         else:
             logging.error('You must provide the file contents')
-            return
+            return 1
 
     contents = base64.b64encode(contents.encode('utf8')).decode()
 
@@ -904,18 +919,20 @@ def do_configchannel_updateinitsls(self, args, update_path=''):
     if not options.channel:
         logging.error("No config channel specified!")
         self.help_configchannel_updateinitsls()
-        return
+        return 1
 
     if not file_info:
         logging.error("Error obtaining file info")
         self.help_configchannel_updateinitsls()
-        return
+        return 1
     print('contents_enc64:           %s' % file_info['contents_enc64'])
     print('Contents')
     print('--------')
     print(base64.b64decode(file_info['contents']))
     if options.yes or self.user_confirm():
         self.client.configchannel.updateInitSls(self.session, options.channel, file_info)
+
+    return 0
 
 ####################
 
@@ -959,13 +976,15 @@ def do_configchannel_removefiles(self, args):
 
     if len(args) < 2:
         self.help_configchannel_removefiles()
-        return
+        return 1
 
     channel = args.pop(0)
     files = args
 
     if self.options.yes or self.user_confirm('Remove these files [y/N]:'):
         self.client.configchannel.deleteFiles(self.session, channel, files)
+
+    return 0
 
 ####################
 
@@ -997,7 +1016,7 @@ def do_configchannel_verifyfile(self, args):
 
     if len(args) < 3:
         self.help_configchannel_verifyfile()
-        return
+        return 1
 
     channel = args[0]
     path = args[1]
@@ -1012,7 +1031,7 @@ def do_configchannel_verifyfile(self, args):
 
     if not system_ids:
         logging.error('No valid system selected')
-        return
+        return 1
     action_id = \
         self.client.configchannel.scheduleFileComparisons(self.session,
                                                           channel,
@@ -1020,6 +1039,8 @@ def do_configchannel_verifyfile(self, args):
                                                           system_ids)
 
     logging.info('Action ID: %i' % action_id)
+
+    return 0
 
 ####################
 
@@ -1152,7 +1173,7 @@ def do_configchannel_export(self, args):
         if not ccs:
             logging.error("Error, no valid config channel passed, "
                           "check name is  correct with spacecmd configchannel_list")
-            return
+            return 1
         if not filename:
             # No filename arg, so we try to do something sensible:
             # If we are exporting exactly one cc, we default to ccname.json
@@ -1173,10 +1194,12 @@ def do_configchannel_export(self, args):
     # we prompt the user for confirmation
     if os.path.isfile(filename):
         if not self.options.yes and not self.user_confirm("File '{}' exists, confirm overwrite file? (y/n)".format(filename)):
-            return
+            return 1
     if not json_dump_to_file(ccdetails_list, filename):
         logging.error("Error saving exported config channels to file: %s", filename)
-        return
+        return 1
+
+    return 0
 
 ####################
 
@@ -1194,17 +1217,19 @@ def do_configchannel_import(self, args):
     if not args:
         logging.error("Error, no filename passed")
         self.help_configchannel_import()
-        return
+        return 1
 
     for filename in args:
         logging.debug("Passed filename do_configchannel_import %s", filename)
         ccdetails_list = json_read_from_file(filename)
         if not ccdetails_list:
             logging.error("Error, could not read json data from %s", filename)
-            return
+            return 1
         for ccdetails in ccdetails_list:
             if not self.import_configchannel_fromdetails(ccdetails):
                 logging.error("Error importing configchannel %s", ccdetails['name'])
+
+    return 0
 
 # create a new cc based on the dict from export_configchannel_getdetails
 
@@ -1328,7 +1353,7 @@ def do_configchannel_clone(self, args):
     if is_interactive(options):
         if not allccs:
             logging.error("No config channels found")
-            return
+            return 1
         print('')
         print('Config Channels')
         print('------------------')
@@ -1352,7 +1377,7 @@ def do_configchannel_clone(self, args):
     if not args:
         logging.error("Error no channel label passed!")
         self.help_configchannel_clone()
-        return
+        return 1
     logging.debug("Got args=%s %d", args, len(args))
     # allow globbing of configchannel names
     ccs = filter_results(self.do_configchannel_list('', True), args)
@@ -1397,6 +1422,8 @@ def do_configchannel_clone(self, args):
         # Finally : import the cc from the modified ccdetails
         if not self.import_configchannel_fromdetails(ccdetails):
             logging.error("Failed to clone %s to %s", cc, ccdetails['label'])
+
+    return 0
 
 ####################
 # configchannel helper
@@ -1464,11 +1491,11 @@ def do_configchannel_diff(self, args):
 
     if not 1 <= len(args) < 3:
         self.help_configchannel_diff()
-        return
+        return 1
 
     source_channel = args[0]
     if not self.check_configchannel(source_channel):
-        return
+        return 1
 
     target_channel = None
     if len(args) == 2:
@@ -1477,7 +1504,7 @@ def do_configchannel_diff(self, args):
         # can a corresponding channel name be found automatically?
         target_channel = self.do_configchannel_getcorresponding(source_channel)
     if not self.check_configchannel(target_channel):
-        return
+        return 1
 
     source_replacedict, target_replacedict = get_string_diff_dicts(source_channel, target_channel)
 
@@ -1516,11 +1543,11 @@ def do_configchannel_sync(self, args, doreturn=False):
 
     if not 1 <= len(args) < 3:
         self.help_configchannel_sync()
-        return
+        return 1
 
     source_channel = args[0]
     if not self.check_configchannel(source_channel):
-        return
+        return 1
 
     target_channel = None
     if len(args) == 2:
@@ -1529,7 +1556,7 @@ def do_configchannel_sync(self, args, doreturn=False):
         # can a corresponding channel name be found automatically?
         target_channel = self.do_configchannel_getcorresponding(source_channel)
     if not self.check_configchannel(target_channel):
-        return
+        return 1
 
     logging.info("syncing files from configchannel " + source_channel + " to " + target_channel)
 
@@ -1563,11 +1590,11 @@ def do_configchannel_sync(self, args, doreturn=False):
 
     if not (both or source_only or target_only):
         logging.info("nothing to do")
-        return
+        return 1
 
     if not self.options.yes:
         if not self.user_confirm('perform synchronisation [y/N]:'):
-            return
+            return 1
 
     source_data_list = self.client.configchannel.lookupFileInfo(
         self.session, source_channel,
@@ -1624,3 +1651,5 @@ def do_configchannel_sync(self, args, doreturn=False):
     if target_only:
         #self.do_configchannel_removefiles( target_channel + " " + "/.metainfo" + " ".join(target_only) )
         self.do_configchannel_removefiles(target_channel + " " + " ".join(target_only))
+
+    return 0

--- a/spacecmd/src/spacecmd/cryptokey.py
+++ b/spacecmd/src/spacecmd/cryptokey.py
@@ -140,7 +140,7 @@ def do_cryptokey_delete(self, args):
         for key in keys:
             self.client.kickstart.keys.delete(self.session, key)
         return 0
-    else
+    else:
         return 1
 
 ####################

--- a/spacecmd/src/spacecmd/cryptokey.py
+++ b/spacecmd/src/spacecmd/cryptokey.py
@@ -67,15 +67,15 @@ def do_cryptokey_create(self, args):
     else:
         if not options.type:
             logging.error('The key type is required')
-            return
+            return 1
 
         if not options.description:
             logging.error('A description is required')
-            return
+            return 1
 
         if not options.file:
             logging.error('A file containing the key is required')
-            return
+            return 1
 
     # read the file the user specified
     if options.file:
@@ -83,7 +83,7 @@ def do_cryptokey_create(self, args):
 
     if not options.contents:
         logging.error('No contents of the file')
-        return
+        return 1
 
     # translate the key type to what the server expects
     if re.match('G', options.type, re.I):
@@ -92,12 +92,14 @@ def do_cryptokey_create(self, args):
         options.type = 'SSL'
     else:
         logging.error('Invalid key type')
-        return
+        return 1
 
     self.client.kickstart.keys.create(self.session,
                                       options.description,
                                       options.type,
                                       options.contents)
+
+    return 0
 
 ####################
 
@@ -120,7 +122,7 @@ def do_cryptokey_delete(self, args):
 
     if not args:
         self.help_cryptokey_delete()
-        return
+        return 1
 
     # allow globbing of cryptokey names
     keys = filter_results(self.do_cryptokey_list('', True), args)
@@ -129,7 +131,7 @@ def do_cryptokey_delete(self, args):
 
     if not keys:
         logging.error("No keys matched argument %s" % args)
-        return
+        return 1
 
     # Print the keys prior to the confirmation
     print('\n'.join(sorted(keys)))
@@ -137,6 +139,9 @@ def do_cryptokey_delete(self, args):
     if self.user_confirm('Delete key(s) [y/N]:'):
         for key in keys:
             self.client.kickstart.keys.delete(self.session, key)
+        return 0
+    else
+        return 1
 
 ####################
 
@@ -175,7 +180,7 @@ def do_cryptokey_details(self, args):
 
     if not args:
         self.help_cryptokey_details()
-        return
+        return 1
 
     # allow globbing of cryptokey names
     keys = filter_results(self.do_cryptokey_list('', True), args)
@@ -184,7 +189,7 @@ def do_cryptokey_details(self, args):
 
     if not keys:
         logging.error("No keys matched argument %s" % args)
-        return
+        return 1
 
     add_separator = False
 
@@ -194,7 +199,7 @@ def do_cryptokey_details(self, args):
                                                             key)
         except xmlrpclib.Fault:
             logging.warning('%s is not a valid crypto key' % key)
-            return
+            return 1
 
         if add_separator:
             print(self.SEPARATOR)
@@ -205,3 +210,5 @@ def do_cryptokey_details(self, args):
 
         print('')
         print(details.get('content'))
+
+    return 0

--- a/spacecmd/src/spacecmd/custominfo.py
+++ b/spacecmd/src/spacecmd/custominfo.py
@@ -58,6 +58,8 @@ def do_custominfo_createkey(self, args):
                                             key,
                                             description)
 
+    return 0
+
 ####################
 
 
@@ -77,7 +79,7 @@ def do_custominfo_deletekey(self, args):
 
     if not args:
         self.help_custominfo_deletekey()
-        return
+        return 1
 
     # allow globbing of custominfo key names
     keys = filter_results(self.do_custominfo_listkeys('', True), args)
@@ -86,16 +88,18 @@ def do_custominfo_deletekey(self, args):
 
     if not keys:
         logging.error("No keys matched argument %s" % args)
-        return
+        return 1
 
     # Print the keys prior to the confirmation
     print('\n'.join(sorted(keys)))
 
     if not self.user_confirm('Delete these keys [y/N]:'):
-        return
+        return 1
 
     for key in keys:
         self.client.system.custominfo.deleteKey(self.session, key)
+
+    return 0
 
 ####################
 
@@ -134,7 +138,7 @@ def do_custominfo_details(self, args):
 
     if not args:
         self.help_custominfo_details()
-        return
+        return 1
 
     # allow globbing of custominfo key names
     keys = filter_results(self.do_custominfo_listkeys('', True), args)
@@ -143,7 +147,7 @@ def do_custominfo_details(self, args):
 
     if not keys:
         logging.error("No keys matched argument '{}'.".format(", ".join(args)))
-        return
+        return 1
 
     add_separator = False
 
@@ -163,6 +167,8 @@ def do_custominfo_details(self, args):
             print('Description:  %s' % (details.get('description') or "N/A"))
             print('Modified:     %s' % (details.get('last_modified') or "N/A"))
             print('System Count: %i' % (details.get('system_count') or 0))
+
+    return 0
 
 ####################
 
@@ -195,3 +201,5 @@ def do_custominfo_updatekey(self, args):
     self.client.system.custominfo.updateKey(self.session,
                                             key,
                                             description)
+
+    return 0

--- a/spacecmd/src/spacecmd/distribution.py
+++ b/spacecmd/src/spacecmd/distribution.py
@@ -58,7 +58,7 @@ def do_distribution_create(self, args, update=False):
             options.name = args[0]
         elif not options.name:
             logging.error('The name of the distribution is required')
-            return
+            return 1
 
     if is_interactive(options):
         if not update:
@@ -101,19 +101,19 @@ def do_distribution_create(self, args, update=False):
     else:
         if not options.name:
             logging.error('A name is required')
-            return
+            return 1
 
         if not options.path:
             logging.error('A path is required')
-            return
+            return 1
 
         if not options.base_channel:
             logging.error('A base channel is required')
-            return
+            return 1
 
         if not options.install_type:
             logging.error('An install type is required')
-            return
+            return 1
 
     if update:
         self.client.kickstart.tree.update(self.session,
@@ -127,6 +127,8 @@ def do_distribution_create(self, args, update=False):
                                           options.path,
                                           options.base_channel,
                                           options.install_type)
+
+    return 0
 
 ####################
 
@@ -174,7 +176,7 @@ def do_distribution_delete(self, args):
 
     if not args:
         self.help_distribution_delete()
-        return
+        return 1
 
     # allow globbing of distribution names
     dists = filter_results(self.do_distribution_list('', True), args)
@@ -183,7 +185,7 @@ def do_distribution_delete(self, args):
 
     if not dists:
         logging.error("No distributions matched argument %s" % args)
-        return
+        return 1
 
     # Print the distributions prior to the confirmation
     print('\n'.join(sorted(dists)))
@@ -191,6 +193,8 @@ def do_distribution_delete(self, args):
     if self.user_confirm('Delete distribution tree(s) [y/N]:'):
         for d in dists:
             self.client.kickstart.tree.delete(self.session, d)
+
+    return 0
 
 ####################
 
@@ -211,7 +215,7 @@ def do_distribution_details(self, args):
 
     if not args:
         self.help_distribution_details()
-        return
+        return 1
 
     # allow globbing of distribution names
     dists = filter_results(self.do_distribution_list('', True), args)
@@ -220,7 +224,7 @@ def do_distribution_details(self, args):
 
     if not dists:
         logging.error("No distributions matched argument %s" % args)
-        return
+        return 1
 
     add_separator = False
 
@@ -238,6 +242,8 @@ def do_distribution_details(self, args):
         print('Name:    %s' % details.get('label'))
         print('Path:    %s' % details.get('abs_path'))
         print('Channel: %s' % channel.get('label'))
+
+    return 0
 
 ####################
 
@@ -260,12 +266,14 @@ def do_distribution_rename(self, args):
 
     if len(args) != 2:
         self.help_distribution_rename()
-        return
+        return 1
 
     oldname = args[0]
     newname = args[1]
 
     self.client.kickstart.tree.rename(self.session, oldname, newname)
+
+    return 0
 
 ####################
 

--- a/spacecmd/src/spacecmd/errata.py
+++ b/spacecmd/src/spacecmd/errata.py
@@ -67,6 +67,8 @@ def do_errata_summary(self, args):
     map(print_errata_summary, sorted(self.all_errata.values(),
                                      key=itemgetter('advisory_name')))
 
+    return 0
+
 ####################
 
 
@@ -93,7 +95,7 @@ def do_errata_apply(self, args, only_systems=None):
 
     if not args:
         self.help_errata_apply()
-        return
+        return 1
 
     # get the start time option
     # skip the prompt if we are running with --yes
@@ -148,7 +150,7 @@ def do_errata_apply(self, args, only_systems=None):
 
     if not systems:
         logging.warning('No patches to apply')
-        return
+        return 1
 
     # a summary of which errata we're going to apply
     print('Errata             Systems')
@@ -158,7 +160,7 @@ def do_errata_apply(self, args, only_systems=None):
     print('Start Time: %s' % options.start_time)
 
     if (is_interactive(options) and not self.user_confirm('Apply these patches [y/N]:')) or not self.options.yes:
-        return
+        return 1
 
     # if the API supports it, try to schedule multiple systems for one erratum
     # in order to reduce the number of actions scheduled
@@ -219,6 +221,8 @@ def do_errata_apply(self, args, only_systems=None):
             logging.info('Scheduled %i patches for %s' %
                          (len(errata_to_apply), system))
 
+    return 0
+
 ####################
 
 
@@ -238,7 +242,7 @@ def do_errata_listaffectedsystems(self, args):
 
     if not args:
         self.help_errata_listaffectedsystems()
-        return
+        return 1
 
     # allow globbing and searching via arguments
     errata_list = self.expand_errata(args)
@@ -255,6 +259,8 @@ def do_errata_listaffectedsystems(self, args):
 
             print('%s:' % erratum)
             print('\n'.join(sorted([s.get('name') for s in systems])))
+
+    return 0
 
 ####################
 
@@ -275,7 +281,7 @@ def do_errata_listcves(self, args):
 
     if not args:
         self.help_errata_listcves()
-        return
+        return 1
 
     # allow globbing and searching via arguments
     errata_list = self.expand_errata(args)
@@ -295,8 +301,10 @@ def do_errata_listcves(self, args):
                     print('%s:' % erratum)
 
                 print('\n'.join(sorted(cves)))
+        return 0
     else:
         print("No errata has been found")
+        return 1
 
 ####################
 
@@ -314,7 +322,7 @@ def do_errata_findbycve(self, args):
     cve_list, _options = parse_command_arguments(args, get_argument_parser())
     if not cve_list:
         self.help_errata_findbycve()
-        return
+        return 1
 
     logging.debug("Got CVE list %s" % cve_list)
     add_separator = False
@@ -330,6 +338,8 @@ def do_errata_findbycve(self, args):
         if errata:
             for e in errata:
                 print("%s" % e.get('advisory_name'))
+
+    return 0
 
 ####################
 
@@ -350,7 +360,7 @@ def do_errata_details(self, args):
 
     if not args:
         self.help_errata_details()
-        return
+        return 1
 
     # allow globbing and searching via arguments
     errata_list = self.expand_errata(args)
@@ -422,6 +432,8 @@ def do_errata_details(self, args):
         print('-----------------')
         print('\n'.join(sorted(build_package_names(packages))))
 
+    return 0
+
 ####################
 
 
@@ -441,14 +453,14 @@ def do_errata_delete(self, args):
 
     if not args:
         self.help_errata_delete()
-        return
+        return 1
 
     # allow globbing and searching via arguments
     errata = self.expand_errata(args)
 
     if not errata:
         logging.warning('No patches to delete')
-        return
+        return 1
 
     print('Erratum            Channels')
     print('-------            --------')
@@ -459,7 +471,7 @@ def do_errata_delete(self, args):
         print('%s    %s' % (erratum.ljust(20), str(len(channels)).rjust(3)))
 
     if not self.options.yes and not self.user_confirm('Delete these patches [y/N]:'):
-        return
+        return 1
 
     for erratum in errata:
         self.client.errata.delete(self.session, erratum)
@@ -467,6 +479,8 @@ def do_errata_delete(self, args):
     logging.info('Deleted %i patches' % len(errata))
 
     self.generate_errata_cache(True)
+
+    return 0
 
 ####################
 
@@ -492,7 +506,7 @@ def do_errata_publish(self, args):
 
     if len(args) < 2:
         self.help_errata_publish()
-        return
+        return 1
 
     # allow globbing and searching via arguments
     errata = self.expand_errata(args[0])
@@ -501,15 +515,17 @@ def do_errata_publish(self, args):
 
     if not errata:
         logging.warning('No patches to publish')
-        return
+        return 1
 
     print('\n'.join(sorted(errata)))
 
     if not self.options.yes and not self.user_confirm('Publish these patches [y/N]:'):
-        return
+        return 1
 
     for erratum in errata:
         self.client.errata.publish(self.session, erratum, channels)
+
+    return 0
 
 ####################
 

--- a/spacecmd/src/spacecmd/filepreservation.py
+++ b/spacecmd/src/spacecmd/filepreservation.py
@@ -88,11 +88,13 @@ def do_filepreservation_create(self, args):
     print('\n'.join(sorted(files)))
 
     if not self.user_confirm():
-        return
+        return 1
 
     self.client.kickstart.filepreservation.create(self.session,
                                                   name,
                                                   files)
+
+    return 0
 
 ####################
 
@@ -113,14 +115,16 @@ def do_filepreservation_delete(self, args):
 
     if not args:
         self.help_filepreservation_delete()
-        return
+        return 1
 
     name = args[0]
 
     if not self.user_confirm('Delete this list [y/N]:'):
-        return
+        return 1
 
     self.client.kickstart.filepreservation.delete(self.session, name)
+
+    return 0
 
 ####################
 
@@ -142,7 +146,7 @@ def do_filepreservation_details(self, args):
 
     if not args:
         self.help_filepreservation_details()
-        return
+        return 1
 
     name = args[0]
 
@@ -151,3 +155,5 @@ def do_filepreservation_details(self, args):
                                                           name)
 
     print('\n'.join(sorted(details.get('file_names'))))
+
+    return 0

--- a/spacecmd/src/spacecmd/group.py
+++ b/spacecmd/src/spacecmd/group.py
@@ -408,7 +408,7 @@ def do_group_listsystems(self, args, doreturn=False):
 
     if len(args) != 1:
         self.help_group_listsystems()
-        return 1
+        return
 
     group = args[0]
 
@@ -424,9 +424,7 @@ def do_group_listsystems(self, args, doreturn=False):
     else:
         if systems:
             print('\n'.join(sorted(systems)))
-            return 0
         else:
-            return 1
 
 ####################
 

--- a/spacecmd/src/spacecmd/group.py
+++ b/spacecmd/src/spacecmd/group.py
@@ -65,7 +65,7 @@ def do_group_addsystems(self, args):
 
     if not args:
         self.help_group_addsystems()
-        return
+        return 1
 
     group_name = args.pop(0)
 
@@ -85,6 +85,9 @@ def do_group_addsystems(self, args):
     if system_ids:
         self.client.systemgroup.addOrRemoveSystems(self.session, group_name,
                                                    system_ids, True)
+        return 0
+    else:
+        return 1
 
 ####################
 
@@ -114,7 +117,7 @@ def do_group_removesystems(self, args):
 
     if not args:
         self.help_group_removesystems()
-        return
+        return 1
 
     group_name = args.pop(0)
 
@@ -143,8 +146,10 @@ def do_group_removesystems(self, args):
                                                    group_name,
                                                    system_ids,
                                                    False)
+        return 0
     else:
         print("No systems found")
+        return 1
 
 ####################
 
@@ -171,6 +176,8 @@ def do_group_create(self, args):
 
     self.client.systemgroup.create(self.session, name, description)
 
+    return 0
+
 ####################
 
 
@@ -190,16 +197,18 @@ def do_group_delete(self, args):
 
     if not args:
         self.help_group_delete()
-        return
+        return 1
 
     groups = args
 
     self.do_group_details('', True)
     if not self.user_confirm('Delete these groups [y/N]:'):
-        return
+        return 1
 
     for group in groups:
         self.client.systemgroup.delete(self.session, group)
+
+    return 0
 
 ####################
 
@@ -227,7 +236,7 @@ def do_group_backup(self, args):
 
     if not args:
         self.help_group_backup()
-        return
+        return 1
 
     groups = args
     if len(args) and args[0] == 'ALL':
@@ -248,7 +257,7 @@ def do_group_backup(self, args):
             os.makedirs(outputpath_base)
     except OSError:
         logging.error('Could not create output directory: %s', outputpath_base)
-        return
+        return 1
 
     for group in groups:
         print("Backup Group: %s" % group)
@@ -258,6 +267,8 @@ def do_group_backup(self, args):
         fh = open(outputpath, 'w')
         fh.write(details['description'])
         fh.close()
+
+    return 0
 
 ####################
 
@@ -295,7 +306,7 @@ def do_group_restore(self, args):
         groups = args[1:] or ["ALL"]
     else:
         self.help_group_restore()
-        return
+        return 1
 
     inputdir = os.path.abspath(inputdir)
     logging.debug("Input Directory: %s" % (inputdir))
@@ -309,11 +320,11 @@ def do_group_restore(self, args):
                 files[d_item] = inputdir + "/" + d_item
     else:
         logging.error("Restore dir %s does not exits or is not a directory" % inputdir)
-        return
+        return 1
 
     if not files:
         logging.error("Restore dir %s has no restore items" % inputdir)
-        return
+        return 1
 
     missing_groups = 0
     if groups and next(iter(groups)) != 'ALL':
@@ -323,7 +334,7 @@ def do_group_restore(self, args):
                 missing_groups += 1
     if missing_groups:
         logging.error("Found %s missing groups, terminating", missing_groups)
-        return
+        return 1
 
     for groupname in self.do_group_list('', True):
         details = self.client.systemgroup.getDetails(self.session, groupname)
@@ -357,6 +368,8 @@ def do_group_restore(self, args):
         else:
             logging.info("Creating new group %s" % groupname)
             self.client.systemgroup.create(self.session, groupname, details)
+
+    return 0
 
 ####################
 
@@ -395,7 +408,7 @@ def do_group_listsystems(self, args, doreturn=False):
 
     if len(args) != 1:
         self.help_group_listsystems()
-        return
+        return 1
 
     group = args[0]
 
@@ -411,6 +424,9 @@ def do_group_listsystems(self, args, doreturn=False):
     else:
         if systems:
             print('\n'.join(sorted(systems)))
+            return 0
+        else:
+            return 1
 
 ####################
 
@@ -431,7 +447,7 @@ def do_group_details(self, args, short=False):
 
     if not args:
         self.help_group_details()
-        return
+        return 1
 
     add_separator = False
 
@@ -441,7 +457,7 @@ def do_group_details(self, args, short=False):
             systems = [stm.get('profile_name') for stm in self.client.systemgroup.listSystems(self.session, group)]
         except xmlrpclib.Fault:
             logging.warning('The group "%s" is invalid' % group)
-            return
+            return 1
 
         if add_separator:
             print(self.SEPARATOR)
@@ -457,3 +473,5 @@ def do_group_details(self, args, short=False):
             print('Members')
             print('-------')
             print('\n'.join(sorted(systems)))
+
+    return 0

--- a/spacecmd/src/spacecmd/group.py
+++ b/spacecmd/src/spacecmd/group.py
@@ -424,7 +424,6 @@ def do_group_listsystems(self, args, doreturn=False):
     else:
         if systems:
             print('\n'.join(sorted(systems)))
-        else:
 
 ####################
 

--- a/spacecmd/src/spacecmd/kickstart.py
+++ b/spacecmd/src/spacecmd/kickstart.py
@@ -138,18 +138,18 @@ def do_kickstart_create(self, args):
     else:
         if not options.name:
             logging.error('The Kickstart name is required')
-            return
+            return 1
 
         if not options.distribution:
             logging.error('The distribution is required')
-            return
+            return 1
 
         if not options.virt_type:
             options.virt_type = 'none'
 
         if not options.root_password:
             logging.error('A root password is required')
-            return
+            return 1
 
     # leave this blank to use the default server
     host = ''
@@ -160,6 +160,8 @@ def do_kickstart_create(self, args):
                                         options.distribution,
                                         host,
                                         options.root_password)
+
+    return 0
 
 ####################
 
@@ -183,7 +185,7 @@ def do_kickstart_delete(self, args):
 
     if len(args) < 1:
         self.help_kickstart_delete()
-        return
+        return 1
 
     # allow globbing of kickstart labels
     all_labels = self.do_kickstart_list('', True)
@@ -193,16 +195,18 @@ def do_kickstart_delete(self, args):
     if not labels:
         logging.error("No valid kickstart labels passed as arguments!")
         self.help_kickstart_delete()
-        return
+        return 1
 
     mismatched = sorted(set(args).difference(set(all_labels)))
     if mismatched:
         logging.error("The following kickstart labels are invalid:",
                       ", ".join(mismatched))
+        return 1
     else:
         for label in labels:
             if self.options.yes or self.user_confirm("Delete profile %s [y/N]:" % label):
                 self.client.kickstart.deleteProfile(self.session, label)
+        return 0
 
 ####################
 
@@ -538,7 +542,7 @@ def do_kickstart_getcontents(self, args):
 
     if not args:
         self.help_kickstart_getcontents()
-        return
+        return 1
 
     profile = args[0]
 
@@ -551,6 +555,8 @@ def do_kickstart_getcontents(self, args):
             print(kickstart.encode('UTF8'))
         except UnicodeDecodeError:
             print(kickstart)
+
+    return 0
 
 ####################
 
@@ -572,12 +578,14 @@ def do_kickstart_rename(self, args):
 
     if len(args) != 2:
         self.help_kickstart_rename()
-        return
+        return 1
 
     oldname = args[0]
     newname = args[1]
 
     self.client.kickstart.renameProfile(self.session, oldname, newname)
+
+    return 0
 
 ####################
 
@@ -641,6 +649,8 @@ def do_kickstart_addcryptokeys(self, args):
     else:
         self.help_kickstart_addcryptokeys()
 
+    return 0
+
 ####################
 
 
@@ -672,7 +682,7 @@ def do_kickstart_removecryptokeys(self, args):
 
     if len(args) < 2:
         self.help_kickstart_removecryptokeys()
-        return
+        return 1
 
     profile = args[0]
     keys = args[1:]
@@ -680,6 +690,8 @@ def do_kickstart_removecryptokeys(self, args):
     self.client.kickstart.profile.system.removeKeys(self.session,
                                                     profile,
                                                     keys)
+
+    return 0
 
 ####################
 
@@ -742,6 +754,8 @@ def do_kickstart_addactivationkeys(self, args):
     else:
         self.help_kickstart_addactivationkeys()
 
+    return 0
+
 ####################
 
 
@@ -773,13 +787,15 @@ def do_kickstart_removeactivationkeys(self, args):
     if len(args) > 1:
         if not self.options.yes:
             if not self.user_confirm('Remove these keys [y/N]:'):
-                return
+                return 1
 
         profile = args[0]
         for key in args[1:]:
             self.client.kickstart.profile.keys.removeActivationKey(self.session, profile, key)
     else:
         self.help_kickstart_removeactivationkeys()
+
+    return 0
 
 ####################
 
@@ -805,12 +821,14 @@ def do_kickstart_enableconfigmanagement(self, args):
 
     if not args:
         self.help_kickstart_enableconfigmanagement()
-        return
+        return 1
 
     profile = args[0]
 
     self.client.kickstart.profile.system.enableConfigManagement(
         self.session, profile)
+
+    return 0
 
 ####################
 
@@ -836,12 +854,14 @@ def do_kickstart_disableconfigmanagement(self, args):
 
     if not args:
         self.help_kickstart_disableconfigmanagement()
-        return
+        return 1
 
     profile = args[0]
 
     self.client.kickstart.profile.system.disableConfigManagement(
         self.session, profile)
+
+    return 0
 
 ####################
 
@@ -867,12 +887,14 @@ def do_kickstart_enableremotecommands(self, args):
 
     if not args:
         self.help_kickstart_enableremotecommands()
-        return
+        return 1
 
     profile = args[0]
 
     self.client.kickstart.profile.system.enableRemoteCommands(self.session,
                                                               profile)
+
+    return 0
 
 ####################
 
@@ -897,12 +919,14 @@ def do_kickstart_disableremotecommands(self, args):
 
     if not args:
         self.help_kickstart_disableremotecommands()
-        return
+        return 1
 
     profile = args[0]
 
     self.client.kickstart.profile.system.disableRemoteCommands(self.session,
                                                                profile)
+
+    return 0
 
 ####################
 
@@ -928,7 +952,7 @@ def do_kickstart_setlocale(self, args):
 
     if len(args) != 2:
         self.help_kickstart_setlocale()
-        return
+        return 1
 
     profile = args[0]
     locale = args[1]
@@ -940,6 +964,8 @@ def do_kickstart_setlocale(self, args):
                                                    profile,
                                                    locale,
                                                    utc)
+
+    return 0
 
 ####################
 
@@ -967,7 +993,7 @@ def do_kickstart_setselinux(self, args):
 
     if len(args) != 2:
         self.help_kickstart_setselinux()
-        return
+        return 1
 
     profile = args[0]
     mode = args[1]
@@ -975,6 +1001,8 @@ def do_kickstart_setselinux(self, args):
     self.client.kickstart.profile.system.setSELinux(self.session,
                                                     profile,
                                                     mode)
+
+    return 0
 
 ####################
 
@@ -999,7 +1027,7 @@ def do_kickstart_setpartitions(self, args):
 
     if not args:
         self.help_kickstart_setpartitions()
-        return
+        return 1
 
     profile = args[0]
 
@@ -1017,13 +1045,15 @@ def do_kickstart_setpartitions(self, args):
 
     print(partitions)
     if not self.user_confirm():
-        return
+        return 1
 
     lines = partitions.split('\n')
 
     self.client.kickstart.profile.system.setPartitioningScheme(self.session,
                                                                profile,
                                                                lines)
+
+    return 0
 
 ####################
 
@@ -1050,7 +1080,7 @@ def do_kickstart_setdistribution(self, args):
 
     if len(args) != 2:
         self.help_kickstart_setdistribution()
-        return
+        return 1
 
     profile = args[0]
     distribution = args[1]
@@ -1058,6 +1088,8 @@ def do_kickstart_setdistribution(self, args):
     self.client.kickstart.profile.setKickstartTree(self.session,
                                                    profile,
                                                    distribution)
+
+    return 0
 
 ####################
 
@@ -1081,7 +1113,7 @@ def do_kickstart_enablelogging(self, args):
 
     if not args:
         self.help_kickstart_enablelogging()
-        return
+        return 1
 
     profile = args[0]
 
@@ -1089,6 +1121,8 @@ def do_kickstart_enablelogging(self, args):
                                              profile,
                                              True,
                                              True)
+
+    return 0
 
 ####################
 
@@ -1112,7 +1146,7 @@ def do_kickstart_addvariable(self, args):
 
     if len(args) < 3:
         self.help_kickstart_addvariable()
-        return
+        return 1
 
     profile = args[0]
     key = args[1]
@@ -1126,6 +1160,8 @@ def do_kickstart_addvariable(self, args):
     self.client.kickstart.profile.setVariables(self.session,
                                                profile,
                                                variables)
+
+    return 0
 
 ####################
 
@@ -1160,7 +1196,7 @@ def do_kickstart_updatevariable(self, args):
 
     if len(args) < 3:
         self.help_kickstart_updatevariable()
-        return
+        return 1
 
     return self.do_kickstart_addvariable(' '.join(args))
 
@@ -1197,7 +1233,7 @@ def do_kickstart_removevariables(self, args):
 
     if len(args) < 2:
         self.help_kickstart_removevariables()
-        return
+        return 1
 
     profile = args[0]
     keys = args[1:]
@@ -1212,6 +1248,8 @@ def do_kickstart_removevariables(self, args):
     self.client.kickstart.profile.setVariables(self.session,
                                                profile,
                                                variables)
+
+    return 0
 
 ####################
 
@@ -1236,7 +1274,7 @@ def do_kickstart_listvariables(self, args):
 
     if not args:
         self.help_kickstart_listvariables()
-        return
+        return 1
 
     profile = args[0]
 
@@ -1245,6 +1283,8 @@ def do_kickstart_listvariables(self, args):
 
     for v in variables:
         print('%s = %s' % (v, variables[v]))
+
+    return 0
 
 ####################
 
@@ -1270,7 +1310,7 @@ def do_kickstart_addoption(self, args):
 
     if len(args) < 2:
         self.help_kickstart_addoption()
-        return
+        return 1
 
     profile = args[0]
     key = args[1]
@@ -1299,7 +1339,8 @@ def do_kickstart_addoption(self, args):
                                                          advanced)
     else:
         logging.warning('%s needs to be set as a custom option' % key)
-        return
+
+    return 0
 
 ####################
 
@@ -1333,7 +1374,7 @@ def do_kickstart_removeoptions(self, args):
 
     if len(args) < 2:
         self.help_kickstart_removeoptions()
-        return
+        return 1
 
     profile = args[0]
     keys = args[1:]
@@ -1351,6 +1392,8 @@ def do_kickstart_removeoptions(self, args):
     self.client.kickstart.profile.setAdvancedOptions(self.session,
                                                      profile,
                                                      advanced)
+
+    return 0
 
 ####################
 
@@ -1375,7 +1418,7 @@ def do_kickstart_listoptions(self, args):
 
     if not args:
         self.help_kickstart_listoptions()
-        return
+        return 1
 
     profile = args[0]
 
@@ -1385,6 +1428,8 @@ def do_kickstart_listoptions(self, args):
     for o in sorted(options, key=itemgetter('name')):
         if o.get('arguments'):
             print('%s %s' % (o.get('name'), o.get('arguments')))
+
+    return 0
 
 ####################
 
@@ -1409,7 +1454,7 @@ def do_kickstart_listcustomoptions(self, args):
 
     if not args:
         self.help_kickstart_listcustomoptions()
-        return
+        return 1
 
     profile = args[0]
 
@@ -1419,6 +1464,8 @@ def do_kickstart_listcustomoptions(self, args):
     for o in options:
         if 'arguments' in o:
             print(o.get('arguments'))
+
+    return 0
 
 ####################
 
@@ -1443,7 +1490,7 @@ def do_kickstart_setcustomoptions(self, args):
 
     if not args:
         self.help_kickstart_setcustomoptions()
-        return
+        return 1
 
     profile = args[0]
 
@@ -1467,6 +1514,8 @@ def do_kickstart_setcustomoptions(self, args):
     self.client.kickstart.profile.setCustomOptions(self.session,
                                                    profile,
                                                    new_options)
+
+    return 0
 
 ####################
 
@@ -1512,7 +1561,7 @@ def do_kickstart_addchildchannels(self, args):
 
     if len(args) < 2:
         self.help_kickstart_addchildchannels()
-        return
+        return 1
 
     profile = args[0]
     new_channels = args[1:]
@@ -1525,6 +1574,8 @@ def do_kickstart_addchildchannels(self, args):
     self.client.kickstart.profile.setChildChannels(self.session,
                                                    profile,
                                                    channels)
+
+    return 0
 
 ####################
 
@@ -1553,7 +1604,7 @@ def do_kickstart_removechildchannels(self, args):
 
     if len(args) < 2:
         self.help_kickstart_removechildchannels()
-        return
+        return 1
 
     profile = args[0]
     to_remove = args[1:]
@@ -1568,6 +1619,8 @@ def do_kickstart_removechildchannels(self, args):
     self.client.kickstart.profile.setChildChannels(self.session,
                                                    profile,
                                                    channels)
+
+    return 0
 
 ####################
 
@@ -1631,7 +1684,7 @@ def do_kickstart_addfilepreservations(self, args):
 
     if not args:
         self.help_kickstart_addfilepreservations()
-        return
+        return 1
 
     profile = args[0]
     files = args[1:]
@@ -1639,6 +1692,8 @@ def do_kickstart_addfilepreservations(self, args):
     self.client.kickstart.profile.system.addFilePreservations(self.session,
                                                               profile,
                                                               files)
+
+    return 0
 
 ####################
 
@@ -1677,13 +1732,15 @@ def do_kickstart_removefilepreservations(self, args):
 
     if len(args) < 2:
         self.help_kickstart_removefilepreservations()
-        return
+        return 1
 
     profile = args[0]
     files = args[1:]
 
     self.client.kickstart.profile.system.removeFilePreservations(
         self.session, profile, files)
+
+    return 0
 
 ####################
 
@@ -1743,13 +1800,15 @@ def do_kickstart_addpackages(self, args):
 
     if not len(args) >= 2:
         self.help_kickstart_addpackages()
-        return
+        return 1
 
     profile = args[0]
     packages = args[1:]
 
     self.client.kickstart.profile.software.appendToSoftwareList(
         self.session, profile, packages)
+
+    return 0
 
 ####################
 
@@ -1778,7 +1837,7 @@ def do_kickstart_removepackages(self, args):
 
     if len(args) < 2:
         self.help_kickstart_removepackages()
-        return
+        return 1
 
     profile = args[0]
     to_remove = args[1:]
@@ -1793,6 +1852,8 @@ def do_kickstart_removepackages(self, args):
     self.client.kickstart.profile.software.setSoftwareList(self.session,
                                                            profile,
                                                            packages)
+
+    return 0
 
 ####################
 
@@ -1814,7 +1875,7 @@ def do_kickstart_listscripts(self, args):
 
     if not args:
         self.help_kickstart_listscripts()
-        return
+        return 1
 
     profile = args[0]
     scripts = self.client.kickstart.profile.listScripts(self.session, profile)
@@ -1835,6 +1896,8 @@ def do_kickstart_listscripts(self, args):
             print('Contents')
             print('--------')
             print(script.get('contents'))
+
+    return 0
 
 ####################
 
@@ -1908,15 +1971,15 @@ def do_kickstart_addscript(self, args):
     else:
         if not options.profile:
             logging.error('The Kickstart name is required')
-            return
+            return 1
 
         if not options.file:
             logging.error('A filename is required')
-            return
+            return 1
 
         if not options.execution_time:
             logging.error('The execution time is required')
-            return
+            return 1
 
         if not options.chroot:
             options.chroot = False
@@ -1940,7 +2003,7 @@ def do_kickstart_addscript(self, args):
     print(options.contents)
 
     if not self.user_confirm():
-        return
+        return 1
 
     self.client.kickstart.profile.addScript(self.session,
                                             options.profile,
@@ -1949,6 +2012,8 @@ def do_kickstart_addscript(self, args):
                                             options.execution_time,
                                             options.chroot,
                                             options.template)
+
+    return 0
 
 ####################
 
@@ -1972,7 +2037,7 @@ def do_kickstart_removescript(self, args):
 
     if not args:
         self.help_kickstart_removescript()
-        return
+        return 1
 
     profile = args[0]
 
@@ -1999,11 +2064,13 @@ def do_kickstart_removescript(self, args):
                 logging.error('Invalid script ID')
 
     if not self.user_confirm('Remove this script [y/N]:'):
-        return
+        return 1
 
     self.client.kickstart.profile.removeScript(self.session,
                                                profile,
                                                script_id)
+
+    return 0
 
 ####################
 
@@ -2032,7 +2099,7 @@ def do_kickstart_clone(self, args):
     if is_interactive(options):
         if not profiles:
             logging.error("No kickstart profiles available")
-            return
+            return 1
 
         print('')
         print('Kickstart Profiles')
@@ -2046,20 +2113,22 @@ def do_kickstart_clone(self, args):
 
         if not options.name:
             logging.error('The Kickstart name is required')
-            return
+            return 1
 
         if not options.clonename:
             logging.error('The Kickstart clone name is required')
-            return
+            return 1
 
     args.append(options.name)
     if not filter_results(profiles, args):
         logging.error("Kickstart profile you've entered was not found")
-        return
+        return 1
 
     self.client.kickstart.cloneProfile(self.session,
                                        options.name,
                                        options.clonename)
+
+    return 0
 
 ####################
 
@@ -2202,7 +2271,7 @@ def do_kickstart_export(self, args):
         if not profiles:
             logging.error("Error, no valid kickstart profile passed, " +
                           "check name is  correct with spacecmd kickstart_list")
-            return
+            return 1
         if not filename:
             # No filename arg, so we try to do something sensible:
             # If we are exporting exactly one ks, we default to ksname.json
@@ -2229,11 +2298,13 @@ def do_kickstart_export(self, args):
     if os.path.isfile(filename):
         if not self.user_confirm("File %s exists, " % filename +
                                  "confirm overwrite file? (y/n)"):
-            return
+            return 1
     if json_dump_to_file(ksdetails_list, filename) != True:
         logging.error("Error saving exported kickstart profiles to file" %
                       filename)
-        return
+        return 1
+
+    return 0
 
 ####################
 
@@ -2251,18 +2322,20 @@ def do_kickstart_importjson(self, args):
     if not args:
         logging.error("Error, no filename passed")
         self.help_kickstart_import()
-        return
+        return 1
 
     for filename in args:
         logging.debug("Passed filename do_kickstart_import %s" % filename)
         ksdetails_list = json_read_from_file(filename)
         if not ksdetails_list:
             logging.error("Error, could not read json data from %s" % filename)
-            return
+            return 1
         for ksdetails in ksdetails_list:
             if self.import_kickstart_fromdetails(ksdetails) != True:
                 logging.error("Error importing kickstart %s" %
                               ksdetails['name'])
+
+    return 0
 
 # create a new ks based on the dict from export_kickstart_getdetails
 
@@ -2506,7 +2579,7 @@ def do_kickstart_getupdatetype(self, args):
 
     if len(args) < 1:
         self.help_kickstart_getupdatetype()
-        return
+        return 1
 
     # allow globbing of kickstart labels
     all_labels = self.do_kickstart_list('', True)
@@ -2516,7 +2589,7 @@ def do_kickstart_getupdatetype(self, args):
     if not labels:
         logging.error("No valid kickstart labels passed as arguments!")
         self.help_kickstart_getupdatetype()
-        return
+        return 1
 
     for label in labels:
         if not label in all_labels:
@@ -2529,6 +2602,8 @@ def do_kickstart_getupdatetype(self, args):
             print(updatetype)
         elif len(labels) > 1:
             print(label, ":", updatetype)
+
+    return 0
 
 ####################
 
@@ -2570,7 +2645,7 @@ def do_kickstart_setupdatetype(self, args):
     if not labels:
         logging.error("No valid kickstart labels passed as arguments!")
         self.help_kickstart_setupdatetype()
-        return
+        return 1
 
     for label in labels:
         if not label in all_labels:
@@ -2578,6 +2653,8 @@ def do_kickstart_setupdatetype(self, args):
             continue
 
         self.client.kickstart.profile.setUpdateType(self.session, label, options.update_type)
+
+    return 0
 
 ####################
 
@@ -2600,7 +2677,7 @@ def do_kickstart_getsoftwaredetails(self, args):
 
     if len(args) < 1:
         self.help_kickstart_getsoftwaredetails()
-        return
+        return 1
 
     # allow globbing of kickstart labels
     all_labels = self.do_kickstart_list('', True)
@@ -2610,7 +2687,7 @@ def do_kickstart_getsoftwaredetails(self, args):
     if not labels:
         logging.error("No valid kickstart labels passed as arguments!")
         self.help_kickstart_getsoftwaredetails()
-        return
+        return 1
 
     for label in labels:
         if not label in all_labels:
@@ -2627,6 +2704,8 @@ def do_kickstart_getsoftwaredetails(self, args):
             print("noBase:          %s" % software_details.get("noBase"))
             print("ignoreMissing:   %s" % software_details.get("ignoreMissing"))
             print('')
+
+    return 0
 
 ####################
 
@@ -2665,20 +2744,20 @@ def do_kickstart_setsoftwaredetails(self, args):
 
     if length < 1 or length not in [3, 5]:
         self.help_kickstart_setsoftwaredetails()
-        return
+        return 1
 
     if args[0] not in self.do_kickstart_list('', True):
         print("Selected profile does not exist")
-        return
+        return 1
     if args[1] not in kspkginfo or args[2] not in mode:
         print("Enter valid input")
         self.help_kickstart_setsoftwaredetails()
-        return
+        return 1
     if length==5:
         if (args[3] not in kspkginfo or args[4] not in mode) or args[1] == args[3]:
             print("Enter valid input")
             self.help_kickstart_setsoftwaredetails()
-            return
+            return 1
 
     args[2] = string_to_bool(args[2])
     if length == 5:
@@ -2701,3 +2780,5 @@ def do_kickstart_setsoftwaredetails(self, args):
     self.client.kickstart.profile.software.setSoftwareDetails(self.session,
                                                               profile,
                                                               kspkginfo)
+
+    return 0

--- a/spacecmd/src/spacecmd/misc.py
+++ b/spacecmd/src/spacecmd/misc.py
@@ -116,6 +116,7 @@ def help_clear(self):
 
 def do_clear(self, args):
     print("\x1b[H\x1b[J")
+    return 0
 
 ####################
 
@@ -129,6 +130,7 @@ def do_clear_caches(self, args):
     self.clear_system_cache()
     self.clear_package_cache()
     self.clear_errata_cache()
+    return 0
 
 ####################
 
@@ -140,6 +142,7 @@ def help_get_apiversion(self):
 
 def do_get_apiversion(self, args):
     print(self.client.api.getVersion())
+    return 0
 
 ####################
 
@@ -151,6 +154,7 @@ def help_get_serverversion(self):
 
 def do_get_serverversion(self, args):
     print(self.client.api.systemVersion())
+    return 0
 
 
 ####################
@@ -164,6 +168,7 @@ def help_list_proxies(self):
 def do_list_proxies(self, args):
     proxies = self.client.satellite.listProxies(self.session)
     print(proxies)
+    return 0
 
 ####################
 
@@ -176,8 +181,10 @@ def help_get_session(self):
 def do_get_session(self, args):
     if self.session:
         print(self.session)
+        return 0
     else:
         logging.error('No session found')
+        return 1
 
 ####################
 
@@ -197,6 +204,7 @@ def help_history(self):
 def do_history(self, args):
     for i in range(1, readline.get_current_history_length()):
         print('%s  %s' % (str(i).rjust(4), readline.get_history_item(i)))
+    return 0
 
 ####################
 
@@ -209,6 +217,7 @@ def help_toggle_confirmations(self):
 def do_toggle_confirmations(self, args):
     self.options.yes = not self.options.yes
     print('Confirmation messages are', "disabled" if self.options.yes else "enabled")
+    return 0
 
 ####################
 
@@ -402,6 +411,7 @@ def do_logout(self, args):
     self.current_user = ''
     self.server = ''
     self.do_clear_caches('')
+    return 0
 
 ####################
 
@@ -414,8 +424,10 @@ def help_whoami(self):
 def do_whoami(self, args):
     if self.current_user:
         print(self.current_user)
+        return 0
     else:
         logging.warning("You are not logged in")
+        return 1
 
 ####################
 
@@ -428,8 +440,10 @@ def help_whoamitalkingto(self):
 def do_whoamitalkingto(self, args):
     if self.server:
         print(self.server)
+        return 0
     else:
         logging.warning('Yourself')
+        return 1
 
 ####################
 

--- a/spacecmd/src/spacecmd/org.py
+++ b/spacecmd/src/spacecmd/org.py
@@ -92,27 +92,27 @@ def do_org_create(self, args):
     else:
         if not options.org_name:
             logging.error('An organization name is required')
-            return
+            return 1
 
         if not options.username:
             logging.error('A username is required')
-            return
+            return 1
 
         if not options.first_name:
             logging.error('A first name is required')
-            return
+            return 1
 
         if not options.last_name:
             logging.error('A last name is required')
-            return
+            return 1
 
         if not options.email:
             logging.error('An email address is required')
-            return
+            return 1
 
         if not options.password:
             logging.error('A password is required')
-            return
+            return 1
 
         if not options.pam:
             options.pam = False
@@ -133,6 +133,8 @@ def do_org_create(self, args):
                            options.email,
                            options.pam)
 
+    return 0
+
 ####################
 
 
@@ -152,15 +154,17 @@ def do_org_delete(self, args):
 
     if len(args) != 1:
         self.help_org_delete()
-        return
+        return 1
 
     name = args[0]
     org_id = self.get_org_id(name)
     if not org_id:
         logging.warning("No organisation found for the name %s", name)
         print("Organisation '{}' was not found".format(name))
+        return 1
     elif self.user_confirm('Delete this organization [y/N]:'):
         self.client.org.delete(self.session, org_id)
+        return 0
 
 ####################
 
@@ -181,16 +185,18 @@ def do_org_rename(self, args):
 
     if len(args) != 2:
         self.help_org_rename()
-        return
+        return 1
 
     name, new_name = args
     org_id = self.get_org_id(name)
     if not org_id:
         logging.warning("No organisation found for the name %s", name)
         print("Organisation '{}' was not found".format(name))
+        return 1
     else:
         new_name = args[1]
         self.client.org.updateName(self.session, org_id, new_name)
+        return 0
 
 ####################
 
@@ -211,7 +217,7 @@ def do_org_addtrust(self, args):
 
     if len(args) != 2:
         self.help_org_addtrust()
-        return
+        return 1
 
     your_org, trust_org = args
     your_org_id = self.get_org_id(your_org)
@@ -220,11 +226,14 @@ def do_org_addtrust(self, args):
     if your_org_id is None:
         logging.warning("No organisation found for the name %s", your_org)
         print("Organisation '{}' was not found".format(your_org))
+        return 1
     elif org_to_trust_id is None:
         logging.warning("No trust organisation found for the name %s", trust_org)
         print("Organisation '{}' to trust for, was not found".format(trust_org))
+        return 1
     else:
         self.client.org.trusts.addTrust(self.session, your_org_id, org_to_trust_id)
+        return 0
 
 ####################
 
@@ -245,7 +254,7 @@ def do_org_removetrust(self, args):
 
     if len(args) != 2:
         self.help_org_removetrust()
-        return
+        return 1
 
     your_org, trust_org = args
     your_org_id = self.get_org_id(your_org)
@@ -253,9 +262,11 @@ def do_org_removetrust(self, args):
     if your_org_id is None:
         logging.warning("No organisation found for the name %s", your_org)
         print("Organisation '{}' was not found".format(your_org))
+        return 1
     elif trusted_org_id is None:
         logging.warning("No trust organisation found for the name %s", trust_org)
         print("Organisation '{}' to trust for, was not found".format(trust_org))
+        return 1
     else:
         systems = self.client.org.trusts.listSystemsAffected(self.session, your_org_id, trusted_org_id)
         print('Affected Systems')
@@ -268,6 +279,7 @@ def do_org_removetrust(self, args):
 
         if self.user_confirm('Remove this trust [y/N]:'):
             self.client.org.trusts.removeTrust(self.session, your_org_id, trusted_org_id)
+        return 0
 
 
 def help_org_trustdetails(self):
@@ -286,13 +298,14 @@ def do_org_trustdetails(self, args):
 
     if not args:
         self.help_org_trustdetails()
-        return
+        return 1
 
     trusted_org = args[0]
     org_id = self.get_org_id(trusted_org)
     if org_id is None:
         logging.warning("No trusted organisation found for the name %s", trusted_org)
         print("Trusted organisation '{}' was not found".format(trusted_org))
+        return 1
     else:
         details = self.client.org.trusts.getDetails(self.session, org_id)
         consumed = self.client.org.trusts.listChannelsConsumed(self.session, org_id)
@@ -314,6 +327,7 @@ def do_org_trustdetails(self, args):
         print('-----------------')
         if provided:
             print('\n'.join(sorted([c.get('name') for c in provided])))
+        return 0
 
 
 def help_org_list(self):
@@ -350,21 +364,24 @@ def do_org_listtrusts(self, args):
 
     if not args:
         self.help_org_listtrusts()
-        return
+        return 1
 
     org_id = self.get_org_id(args[0])
     if org_id is None:
         logging.warning("No organisation found for the name %s", args[0])
         print("Organisation '{}' was not found".format(args[0]))
+        return 1
     else:
         trusts = self.client.org.trusts.listTrusts(self.session, org_id)
         if not trusts:
             print("No trust organisation has been found")
             logging.warning("No trust organisation has been found")
+            return 1
         else:
             for trust in sorted(trusts, key=itemgetter('orgName')):
                 if trust.get('trustEnabled'):
                     print(trust.get('orgName'))
+            return 0
 
 
 def help_org_listusers(self):
@@ -383,15 +400,17 @@ def do_org_listusers(self, args):
 
     if not args:
         self.help_org_listusers()
-        return
+        return 1
 
     org_id = self.get_org_id(args[0])
     if org_id is None:
         logging.warning("No organisation found for the name %s", args[0])
         print("Organisation '{}' was not found".format(args[0]))
+        return 1
     else:
         users = self.client.org.listUsers(self.session, org_id)
         print('\n'.join(sorted([u.get('login') for u in users])))
+        return 0
 
 ####################
 
@@ -412,7 +431,7 @@ def do_org_details(self, args):
 
     if not args:
         self.help_org_details()
-        return
+        return 1
 
     name = args[0]
 
@@ -432,3 +451,5 @@ def do_org_details(self, args):
     print('Activation Keys:        %i' % details.get('activation_keys'))
     print('Kickstart Profiles:     %i' % details.get('kickstart_profiles'))
     print('Configuration Channels: %i' % details.get('configuration_channels'))
+
+    return 0

--- a/spacecmd/src/spacecmd/package.py
+++ b/spacecmd/src/spacecmd/package.py
@@ -60,7 +60,7 @@ def do_package_details(self, args):
 
     if not packages:
         logging.warning('No packages found')
-        return
+        return 1
 
     add_separator = False
 
@@ -106,6 +106,8 @@ def do_package_details(self, args):
             print('-----------------------')
             print('\n'.join(sorted([c.get('label') for c in channels])))
             print('')
+
+    return 0
 
 ####################
 
@@ -182,18 +184,18 @@ def do_package_remove(self, args):
 
     if not args:
         self.help_package_remove()
-        return
+        return 1
 
     to_remove = filter_results(self.get_package_names(True), args)
 
     if not to_remove:
         logging.debug("Failed to find packages for criteria %s", str(args))
         print("No packages found to remove")
-        return
+        return 1
 
     if not self.user_confirm('Remove these packages [y/N]:'):
         print("No packages has been removed")
-        return
+        return 1
 
     print('Packages')
     print('--------')
@@ -208,6 +210,8 @@ def do_package_remove(self, args):
 
     # regenerate the package cache after removing these packages
     self.generate_package_cache(True)
+
+    return 0
 
 ####################
 
@@ -244,11 +248,11 @@ def do_package_removeorphans(self, args):
     if not packages:
         print("No orphaned packages has been found")
         logging.warning('No orphaned packages')
-        return
+        return 1
 
     if not self.user_confirm('Remove these packages [y/N]:'):
         print("No packages were removed")
-        return
+        return 1
 
     print('Packages')
     print('--------')
@@ -259,6 +263,9 @@ def do_package_removeorphans(self, args):
             self.client.packages.removePackage(self.session, package.get('id'))
         except xmlrpclib.Fault:
             logging.error('Failed to remove package ID %i' % package.get('id'))
+            return 1
+
+    return 0
 
 ####################
 
@@ -279,7 +286,7 @@ def do_package_listinstalledsystems(self, args):
 
     if not args:
         self.help_package_listinstalledsystems()
-        return
+        return 1
 
     packages = []
     for package in args:
@@ -287,7 +294,7 @@ def do_package_listinstalledsystems(self, args):
 
     if not packages:
         logging.warning('No packages found')
-        return
+        return 1
 
     add_separator = False
 
@@ -306,6 +313,8 @@ def do_package_listinstalledsystems(self, args):
 
         if systems:
             print('\n'.join(sorted(['%s : %s' % (s.get('name'), s.get('id')) for s in systems])))
+
+    return 0
 
 ####################
 
@@ -326,7 +335,7 @@ def do_package_listerrata(self, args):
 
     if not args:
         self.help_package_listerrata()
-        return
+        return 1
 
     packages = []
     for package in args:
@@ -334,7 +343,7 @@ def do_package_listerrata(self, args):
 
     if not packages:
         logging.warning('No packages found')
-        return
+        return 1
 
     add_separator = False
 
@@ -353,6 +362,8 @@ def do_package_listerrata(self, args):
             if errata:
                 print('\n'.join(sorted([e.get('advisory') for e in errata])))
 
+    return 0
+
 ####################
 
 
@@ -368,7 +379,7 @@ def do_package_listdependencies(self, args):
 
     if not args:
         self.help_package_listdependencies()
-        return
+        return 1
 
     packages = []
     for package in args:
@@ -376,7 +387,7 @@ def do_package_listdependencies(self, args):
 
     if not packages:
         logging.warning('No packages found')
-        return
+        return 1
 
     add_separator = False
     for package in packages:
@@ -397,3 +408,5 @@ def do_package_listdependencies(self, args):
                       (dep['dependency'], dep['dependency_type'], dep['dependency_modifier']))
             print(self.SEPARATOR)
             add_separator = True
+
+    return 0

--- a/spacecmd/src/spacecmd/repo.py
+++ b/spacecmd/src/spacecmd/repo.py
@@ -72,7 +72,7 @@ def do_repo_details(self, args):
 
     if not args:
         self.help_repo_details()
-        return
+        return 1
 
     # allow globbing of repo names
     repos = filter_results(self.do_repo_list('', True), args)
@@ -94,6 +94,9 @@ def do_repo_details(self, args):
             print('Repository SSL Client Key:         %s' % (details.get('sslKeyDesc') or "None"))
     else:
         print("No repositories found for '{}' query".format(' '.join(args)))
+        return 1
+
+    return 0
 
 ####################
 
@@ -114,7 +117,7 @@ def do_repo_listfilters(self, args):
 
     if not args:
         self.help_repo_listfilters()
-        return
+        return 1
 
     filters = self.client.channel.software.listRepoFilters(self.session, args[0])
     if filters:
@@ -122,6 +125,9 @@ def do_repo_listfilters(self, args):
             print("%s%s" % (flt.get('flag'), flt.get('filter')))
     else:
         print("No filters found")
+        return 1
+
+    return 0
 
 ####################
 
@@ -143,7 +149,7 @@ def do_repo_addfilters(self, args):
 
     if len(args) < 2:
         self.help_repo_addfilters()
-        return
+        return 1
 
     repo = args[0]
 
@@ -153,12 +159,14 @@ def do_repo_addfilters(self, args):
 
         if not (flag == '+' or flag == '-'):
             logging.error('Each filter must start with + or -')
-            return
+            return 1
 
         self.client.channel.software.addRepoFilter(self.session,
                                                    repo,
                                                    {'filter': repofilter,
                                                     'flag': flag})
+
+    return 0
 
 ####################
 
@@ -178,7 +186,7 @@ def do_repo_removefilters(self, args):
 
     if len(args) < 2:
         self.help_repo_removefilters()
-        return
+        return 1
 
     repo = args[0]
 
@@ -188,12 +196,14 @@ def do_repo_removefilters(self, args):
 
         if not (flag == '+' or flag == '-'):
             logging.error('Each filter must start with + or -')
-            return
+            return 1
 
         self.client.channel.software.removeRepoFilter(self.session,
                                                       repo,
                                                       {'filter': repofilter,
                                                        'flag': flag})
+
+    return 0
 
 ####################
 
@@ -213,7 +223,7 @@ def do_repo_setfilters(self, args):
 
     if len(args) < 2:
         self.help_repo_setfilters()
-        return
+        return 1
 
     repo = args[0]
 
@@ -225,11 +235,13 @@ def do_repo_setfilters(self, args):
 
         if not (flag == '+' or flag == '-'):
             logging.error('Each filter must start with + or -')
-            return
+            return 1
 
         filters.append({'filter': repofilter, 'flag': flag})
 
     self.client.channel.software.setRepoFilters(self.session, repo, filters)
+
+    return 0
 
 ####################
 
@@ -256,10 +268,12 @@ def do_repo_clearfilters(self, args):
 
     if not args:
         self.help_repo_clearfilters()
-        return
+        return 1
 
     if _options.yes or self.user_confirm('Remove these filters [y/N]:'):
         self.client.channel.software.clearRepoFilters(self.session, args[0])
+
+    return 0
 
 ####################
 
@@ -280,7 +294,7 @@ def do_repo_delete(self, args):
 
     if not args:
         self.help_repo_delete()
-        return
+        return 1
 
     # allow globbing of repo names
     repos = filter_results(self.do_repo_list('', True), args)
@@ -295,6 +309,8 @@ def do_repo_delete(self, args):
                 self.client.channel.software.removeRepo(self.session, repo)
             except xmlrpclib.Fault:
                 logging.error('Failed to remove repo %s' % repo)
+
+    return 0
 
 ####################
 
@@ -334,11 +350,11 @@ def do_repo_create(self, args):
     else:
         if not options.name:
             logging.error('A name is required')
-            return
+            return 1
 
         if not options.url:
             logging.error('A URL is required')
-            return
+            return 1
 
         if not options.type:
             options.type = 'yum'
@@ -350,6 +366,8 @@ def do_repo_create(self, args):
                                             options.ca,
                                             options.cert,
                                             options.key)
+
+    return 0
 
 ####################
 
@@ -372,18 +390,20 @@ def do_repo_rename(self, args):
 
     if len(args) != 2:
         self.help_repo_rename()
-        return
+        return 1
 
     try:
         details = self.client.channel.software.getRepoDetails(self.session, args[0])
         oldname = details.get('id')
     except xmlrpclib.Fault:
         logging.error('Could not find repo %s' % args[0])
-        return False
+        return 1
 
     newname = args[1]
 
     self.client.channel.software.updateRepoLabel(self.session, oldname, newname)
+
+    return 0
 
 ####################
 
@@ -406,10 +426,12 @@ def do_repo_updateurl(self, args):
 
     if len(args) != 2:
         self.help_repo_updateurl()
-        return
+        return 1
 
     name, url = args
     self.client.channel.software.updateRepoUrl(self.session, name, url)
+
+    return 0
 
 
 def help_repo_updatessl(self):
@@ -438,10 +460,12 @@ def do_repo_updatessl(self, args):
     else:
         if not options.name:
             logging.error('A name is required')
-            return
+            return 1
 
     self.client.channel.software.updateRepoSsl(self.session,
                                                options.name,
                                                options.ca,
                                                options.cert,
                                                options.key)
+
+    return 0

--- a/spacecmd/src/spacecmd/report.py
+++ b/spacecmd/src/spacecmd/report.py
@@ -67,6 +67,9 @@ def do_report_inactivesystems(self, args):
         for s in sorted(systems, key=itemgetter('name')):
             print('%s  %s  %s' % (s.get('id'), s.get('name').ljust(max_size),
                                   s.get('last_checkin')))
+        return 0
+    else:
+        return 1
 
 ####################
 
@@ -92,6 +95,9 @@ def do_report_outofdatesystems(self, args):
         for system in sorted(report):
             print('%s       %s' %
                   (system.ljust(max_size), str(report[system]).rjust(3)))
+        return 0
+    else:
+        return 1
 
 ####################
 
@@ -107,6 +113,9 @@ def do_report_ungroupedsystems(self, args):
 
     if systems:
         print('\n'.join(sorted(systems)))
+        return 0
+    else:
+        return 1
 
 ####################
 
@@ -153,8 +162,10 @@ def do_report_errata(self, args):
         for erratum in sorted(report):
             print('%s        %s' %
                   (erratum.ljust(max_size), str(report[erratum]).rjust(3)))
+        return 0
     elif partial_errata:
         print("No errata found for '{}'".format(args))
+        return 1
 
 ####################
 
@@ -179,6 +190,10 @@ def do_report_ipaddresses(self, args):
             systems = self.expand_systems(args)
     else:
         systems = self.get_system_names()
+
+    if not systems:
+        logging.warning('No systems selected')
+        return 1
 
     report = {}
     for system in systems:
@@ -212,6 +227,9 @@ def do_report_ipaddresses(self, args):
                   (system.ljust(system_max_size),
                    report[system]['hostname'].ljust(hostname_max_size),
                    report[system]['ip'].ljust(15).strip()))
+        return 0
+    else:
+        return 1
 
 ####################
 
@@ -237,6 +255,10 @@ def do_report_kernels(self, args):
     else:
         systems = self.get_system_names()
 
+    if not systems:
+        logging.warning('No systems selected')
+        return 1
+
     report = {}
     for system in systems:
         system_id = self.get_system_id(system)
@@ -257,6 +279,9 @@ def do_report_kernels(self, args):
 
         for system in sorted(report):
             print('%s  %s' % (system.ljust(system_max_size), report[system]))
+        return 0
+    else:
+        return 1
 
 ####################
 
@@ -352,3 +377,4 @@ def do_report_duplicates(self, args):
 
                 if len(dupes_by_hostname) > 1:
                     print('')
+    return 0

--- a/spacecmd/src/spacecmd/scap.py
+++ b/spacecmd/src/spacecmd/scap.py
@@ -49,13 +49,17 @@ def do_scap_listxccdfscans(self, args):
 
     if not args:
         self.help_scap_listxccdfscans()
-        return
+        return 1
 
     # use the systems listed in the SSM
     if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
+
+    if not systems:
+        logging.warning('No systems selected')
+        return 1
 
     add_separator = False
 
@@ -77,6 +81,8 @@ def do_scap_listxccdfscans(self, args):
         for s in scan_list:
             print('XID: %d Profile: %s Path: (%s) Completed: %s' % (s['xid'], s['profile'], s['path'], s['completed']))
 
+    return 0
+
 ####################
 
 
@@ -92,7 +98,7 @@ def do_scap_getxccdfscanruleresults(self, args):
 
     if not args:
         self.help_scap_getxccdfscanruleresults()
-        return
+        return 1
 
     add_separator = False
 
@@ -111,6 +117,8 @@ def do_scap_getxccdfscanruleresults(self, args):
         for s in scan_results:
             print('IDref: %s Result: %s Idents: (%s)' % (s['idref'], s['result'], s['idents']))
 
+    return 0
+
 ####################
 
 
@@ -126,7 +134,7 @@ def do_scap_getxccdfscandetails(self, args):
 
     if not args:
         self.help_scap_getxccdfscandetails()
-        return
+        return 1
 
     add_separator = False
 
@@ -152,6 +160,8 @@ def do_scap_getxccdfscandetails(self, args):
               scan_details['start_time'], "End_Time:", scan_details['end_time'], \
               "Errors:", scan_details['errors'])
 
+    return 0
+
 ####################
 
 
@@ -175,7 +185,7 @@ def do_scap_schedulexccdfscan(self, args):
 
     if len(args) < 3:
         self.help_scap_schedulexccdfscan()
-        return
+        return 1
 
     path = args[0]
     param = "--"
@@ -187,9 +197,15 @@ def do_scap_schedulexccdfscan(self, args):
     else:
         systems = self.expand_systems(args[2:])
 
+    if not systems:
+        logging.warning('No systems selected')
+        return 1
+
     for system in systems:
         system_id = self.get_system_id(system)
         if not system_id:
             continue
 
         self.client.system.scap.scheduleXccdfScan(self.session, system_id, path, param)
+
+    return 0

--- a/spacecmd/src/spacecmd/schedule.py
+++ b/spacecmd/src/spacecmd/schedule.py
@@ -144,13 +144,13 @@ def do_schedule_cancel(self, args):
 
     if not args:
         self.help_schedule_cancel()
-        return
+        return 1
 
     # cancel all actions
     if '.*' in args:
         if not self.user_confirm('Cancel all pending actions [y/N]:'):
             logging.info("All pending actions left untouched")
-            return
+            return 1
 
         actions = self.client.schedule.listInProgressActions(self.session)
         strings = [a.get('id') for a in actions]
@@ -177,6 +177,8 @@ def do_schedule_cancel(self, args):
 
     print('Canceled %i action(s)' % len(actions))
 
+    return 0
+
 ####################
 
 
@@ -200,7 +202,7 @@ def do_schedule_reschedule(self, args):
 
     if not args:
         self.help_schedule_reschedule()
-        return
+        return 1
 
     failed_actions = self.client.schedule.listFailedActions(self.session)
     failed_actions = [a.get('id') for a in failed_actions]
@@ -210,7 +212,7 @@ def do_schedule_reschedule(self, args):
     # reschedule all failed actions
     if '.*' in args:
         if not self.user_confirm('Reschedule all failed actions [y/N]:'):
-            return
+            return 1
         to_reschedule = failed_actions
     else:
         # use the list of action IDs passed in
@@ -228,9 +230,12 @@ def do_schedule_reschedule(self, args):
 
     if not to_reschedule:
         logging.warning('No failed actions to reschedule')
+        return 1
     else:
         self.client.schedule.rescheduleActions(self.session, to_reschedule, True)
         print('Rescheduled %i action(s)' % len(to_reschedule))
+
+    return 0
 
 ####################
 
@@ -247,7 +252,7 @@ def do_schedule_details(self, args):
 
     if not args:
         self.help_schedule_details()
-        return
+        return 1
     else:
         action_id = args[0]
 
@@ -255,7 +260,7 @@ def do_schedule_details(self, args):
         action_id = int(action_id)
     except ValueError:
         logging.warning('The ID "%s" is invalid' % action_id)
-        return
+        return 1
 
     completed = self.client.schedule.listCompletedSystems(self.session, action_id)
     failed = self.client.schedule.listFailedSystems(self.session, action_id)
@@ -294,6 +299,9 @@ def do_schedule_details(self, args):
                 print(s.get('server_name'))
     else:
         logging.error('No action found with the ID "%s"' % action_id)
+        return 1
+
+    return 0
 
 ####################
 
@@ -310,13 +318,13 @@ def do_schedule_getoutput(self, args):
 
     if not args:
         self.help_schedule_getoutput()
-        return
+        return 1
 
     try:
         action_id = int(args[0])
     except ValueError:
         logging.error('"%s" is not a valid action ID' % str(args[0]))
-        return
+        return 1
 
     script_results = None
     try:
@@ -369,6 +377,9 @@ def do_schedule_getoutput(self, args):
                 print(action.get('message'))
         else:
             logging.error("No systems found")
+            return 1
+
+    return 0
 
 ####################
 

--- a/spacecmd/src/spacecmd/shell.py
+++ b/spacecmd/src/spacecmd/shell.py
@@ -232,7 +232,11 @@ class SpacewalkShell(Cmd):
                     for i in cmdresult:
                         print(i)
             except TypeError:
+                # catch methods returning undefined results at least in debug mode
+                logging.debug('Undefined return code from \"%s\"', cmd)
                 pass
+
+        return cmdresult
 
     # update the prompt with the SSM size
     # pylint: disable=arguments-differ

--- a/spacecmd/src/spacecmd/snippet.py
+++ b/spacecmd/src/spacecmd/snippet.py
@@ -67,7 +67,7 @@ def do_snippet_details(self, args):
 
     if not args:
         self.help_snippet_details()
-        return
+        return 1
 
     add_separator = False
 
@@ -94,6 +94,8 @@ def do_snippet_details(self, args):
 
         print('')
         print(snippet.get('contents'))
+
+    return 0
 
 ####################
 
@@ -139,11 +141,11 @@ def do_snippet_create(self, args, update_name=''):
     else:
         if not options.name:
             logging.error('A name is required for the snippet')
-            return
+            return 1
 
         if not options.file:
             logging.error('A file is required')
-            return
+            return 1
 
     if options.file:
         contents = read_file(options.file)
@@ -158,6 +160,8 @@ def do_snippet_create(self, args, update_name=''):
         self.client.kickstart.snippet.createOrUpdate(self.session,
                                                      options.name,
                                                      contents)
+
+    return 0
 
 ####################
 
@@ -178,7 +182,7 @@ def do_snippet_update(self, args):
 
     if not args:
         self.help_snippet_update()
-        return
+        return 1
 
     return self.do_snippet_create('', update_name=args[0])
 
@@ -201,9 +205,12 @@ def do_snippet_delete(self, args):
 
     if not args:
         self.help_snippet_delete()
-        return
+        return 1
 
     snippet = args[0]
 
     if self.user_confirm('Remove this snippet [y/N]:'):
         self.client.kickstart.snippet.delete(self.session, snippet)
+        return 0
+    else:
+        return 1

--- a/spacecmd/src/spacecmd/ssm.py
+++ b/spacecmd/src/spacecmd/ssm.py
@@ -73,13 +73,13 @@ def do_ssm_add(self, args):
 
     if not args:
         self.help_ssm_add()
-        return
+        return 1
 
     systems = self.expand_systems(args)
 
     if not systems:
         logging.warning('No systems found')
-        return
+        return 1
 
     for system in systems:
         if system in self.ssm:
@@ -94,6 +94,8 @@ def do_ssm_add(self, args):
 
     # save the SSM for use between sessions
     save_cache(self.ssm_cache_file, self.ssm)
+
+    return 0
 
 ####################
 
@@ -120,13 +122,13 @@ def do_ssm_intersect(self, args):
 
     if not args:
         self.help_ssm_intersect()
-        return
+        return 1
 
     systems = self.expand_systems(args)
 
     if not systems:
         logging.warning('No systems found')
-        return
+        return 1
 
     # tmp_ssm placeholder to gather systems that are both in original ssm
     # selection and newly selected group
@@ -144,6 +146,8 @@ def do_ssm_intersect(self, args):
 
     if self.ssm:
         logging.debug('Systems Selected: %i' % len(self.ssm))
+
+    return 0
 
 ####################
 
@@ -168,13 +172,13 @@ def do_ssm_remove(self, args):
 
     if not args:
         self.help_ssm_remove()
-        return
+        return 1
 
     systems = self.expand_systems(args)
 
     if not systems:
         logging.warning('No systems found')
-        return
+        return 1
 
     for system in systems:
         # double-check for existance in case of duplicate names
@@ -186,6 +190,8 @@ def do_ssm_remove(self, args):
 
     # save the SSM for use between sessions
     save_cache(self.ssm_cache_file, self.ssm)
+
+    return 0
 
 ####################
 
@@ -203,6 +209,9 @@ def do_ssm_list(self, args):
     if systems:
         print('\n'.join(systems))
         logging.debug('Systems Selected: %i' % len(systems))
+        return 0
+    else:
+        return 1
 
 ####################
 
@@ -217,3 +226,5 @@ def do_ssm_clear(self, args):
 
     # save the SSM for use between sessions
     save_cache(self.ssm_cache_file, self.ssm)
+
+    return 0

--- a/spacecmd/src/spacecmd/user.py
+++ b/spacecmd/src/spacecmd/user.py
@@ -87,23 +87,23 @@ def do_user_create(self, args):
     else:
         if not options.username:
             logging.error('A username is required')
-            return
+            return 1
 
         if not options.first_name:
             logging.error('A first name is required')
-            return
+            return 1
 
         if not options.last_name:
             logging.error('A last name is required')
-            return
+            return 1
 
         if not options.email:
             logging.error('An email address is required')
-            return
+            return 1
 
         if not options.password and not options.pam:
             logging.error('A password is required')
-            return
+            return 1
 
         if options.pam:
             options.pam = 1
@@ -122,6 +122,8 @@ def do_user_create(self, args):
                             options.last_name,
                             options.email,
                             options.pam)
+
+    return 0
 
 ####################
 
@@ -142,12 +144,15 @@ def do_user_delete(self, args):
 
     if len(args) != 1:
         self.help_user_delete()
-        return
+        return 1
 
     name = args[0]
 
     if self.options.yes or self.user_confirm('Delete this user [y/N]:'):
         self.client.user.delete(self.session, name)
+        return 0
+    else:
+        return 1
 
 ####################
 
@@ -168,11 +173,13 @@ def do_user_disable(self, args):
 
     if len(args) != 1:
         self.help_user_disable()
-        return
+        return 1
 
     name = args[0]
 
     self.client.user.disable(self.session, name)
+
+    return 0
 
 ####################
 
@@ -193,11 +200,13 @@ def do_user_enable(self, args):
 
     if len(args) != 1:
         self.help_user_enable()
-        return
+        return 1
 
     name = args[0]
 
     self.client.user.enable(self.session, name)
+
+    return 0
 
 ####################
 
@@ -261,12 +270,14 @@ def do_user_addrole(self, args):
 
     if len(args) != 2:
         self.help_user_addrole()
-        return
+        return 1
 
     user = args[0]
     role = args[1]
 
     self.client.user.addRole(self.session, user, role)
+
+    return 0
 
 ####################
 
@@ -294,12 +305,14 @@ def do_user_removerole(self, args):
 
     if len(args) != 2:
         self.help_user_removerole()
-        return
+        return 1
 
     user = args[0]
     role = args[1]
 
     self.client.user.removeRole(self.session, user, role)
+
+    return 0
 
 ####################
 
@@ -320,7 +333,7 @@ def do_user_details(self, args):
 
     if not args:
         self.help_user_details()
-        return
+        return 1
 
     add_separator = False
 
@@ -376,6 +389,8 @@ def do_user_details(self, args):
             print('--------------')
             print('\n'.join(sorted([g.get('name') for g in default_groups])))
 
+    return 0
+
 ####################
 
 
@@ -402,7 +417,7 @@ def do_user_addgroup(self, args):
 
     if len(args) < 2:
         self.help_user_addgroup()
-        return
+        return 1
 
     user = args.pop(0)
     groups = args
@@ -411,6 +426,8 @@ def do_user_addgroup(self, args):
                                              user,
                                              groups,
                                              False)
+
+    return 0
 
 ####################
 
@@ -438,7 +455,7 @@ def do_user_adddefaultgroup(self, args):
 
     if len(args) < 2:
         self.help_user_adddefaultgroup()
-        return
+        return 1
 
     user = args.pop(0)
     groups = args
@@ -446,6 +463,8 @@ def do_user_adddefaultgroup(self, args):
     self.client.user.addDefaultSystemGroups(self.session,
                                             user,
                                             groups)
+
+    return 0
 
 ####################
 
@@ -476,7 +495,7 @@ def do_user_removegroup(self, args):
 
     if len(args) < 2:
         self.help_user_removegroup()
-        return
+        return 1
 
     user = args.pop(0)
     groups = args
@@ -485,6 +504,8 @@ def do_user_removegroup(self, args):
                                                 user,
                                                 groups,
                                                 True)
+
+    return 0
 
 ####################
 
@@ -516,7 +537,7 @@ def do_user_removedefaultgroup(self, args):
 
     if len(args) < 2:
         self.help_user_removedefaultgroup()
-        return
+        return 1
 
     user = args.pop(0)
     groups = args
@@ -524,6 +545,8 @@ def do_user_removedefaultgroup(self, args):
     self.client.user.removeDefaultSystemGroups(self.session,
                                                user,
                                                groups)
+
+    return 0
 
 ####################
 
@@ -551,12 +574,14 @@ def do_user_setfirstname(self, args):
 
     if len(args) != 2:
         self.help_user_setfirstname()
-        return
+        return 1
 
     user = args.pop(0)
     details = {'first_name': args.pop(0)}
 
     self.client.user.setDetails(self.session, user, details)
+
+    return 0
 
 ####################
 
@@ -584,12 +609,14 @@ def do_user_setlastname(self, args):
 
     if len(args) != 2:
         self.help_user_setlastname()
-        return
+        return 1
 
     user = args.pop(0)
     details = {'last_name': args.pop(0)}
 
     self.client.user.setDetails(self.session, user, details)
+
+    return 0
 
 ####################
 
@@ -617,12 +644,14 @@ def do_user_setemail(self, args):
 
     if len(args) != 2:
         self.help_user_setemail()
-        return
+        return 1
 
     user = args.pop(0)
     details = {'email': args.pop(0)}
 
     self.client.user.setDetails(self.session, user, details)
+
+    return 0
 
 ####################
 
@@ -648,7 +677,7 @@ def do_user_setprefix(self, args):
 
     if not 0 < len(args) < 3:
         self.help_user_setprefix()
-        return
+        return 1
 
     user = args.pop(0)
     if not args:
@@ -661,6 +690,8 @@ def do_user_setprefix(self, args):
         details = {'prefix': args.pop(0)}
 
     self.client.user.setDetails(self.session, user, details)
+
+    return 0
 
 ####################
 
@@ -688,9 +719,11 @@ def do_user_setpassword(self, args):
 
     if len(args) != 2:
         self.help_user_setpassword()
-        return
+        return 1
 
     user = args.pop(0)
     details = {'password': args.pop(0)}
 
     self.client.user.setDetails(self.session, user, details)
+
+    return 0

--- a/spacecmd/tests/test_activationkey.py
+++ b/spacecmd/tests/test_activationkey.py
@@ -1555,7 +1555,7 @@ class TestSCActivationKeyMethods:
         assert not shell.list_child_channels.called
         assert not shell.do_configchannel_list.called
         assert not shell.import_activtionkey_fromdetails.called
-        assert ret is None
+        assert ret is 1
         assert logger.error.call_args_list[0][0][0] == 'Error - must specify either -c or -x options!'
 
     @patch("spacecmd.activationkey.is_interactive", MagicMock(return_value=False))
@@ -1604,7 +1604,7 @@ class TestSCActivationKeyMethods:
         assert not shell.do_configchannel_list.called
         assert not shell.import_activtionkey_fromdetails.called
         assert logger.error.call_args_list[0][0][0] == "Key key_clone_name already exists"
-        assert ret is None
+        assert ret is 1
 
     @patch("spacecmd.activationkey.is_interactive", MagicMock(return_value=False))
     @patch("spacecmd.activationkey.prompt_user", MagicMock(side_effect=["original_key", "cloned_key"]))
@@ -1633,7 +1633,7 @@ class TestSCActivationKeyMethods:
         assert not shell.do_configchannel_list.called
         assert not shell.import_activtionkey_fromdetails.called
         assert logger.error.call_args_list[0][0][0] == "Error no activationkey to clone passed!"
-        assert ret is None
+        assert ret is 1
 
     @patch("spacecmd.activationkey.is_interactive", MagicMock(return_value=False))
     @patch("spacecmd.activationkey.prompt_user", MagicMock(side_effect=["original_key", "cloned_key"]))

--- a/spacecmd/tests/test_package.py
+++ b/spacecmd/tests/test_package.py
@@ -512,7 +512,7 @@ class TestSCPackage:
 
         assert not shell.client.packages.removePackage.called
         assert mprint.called
-        assert out is None
+        assert out is 1
         assert shell.client.channel.software.listPackagesWithoutChannel.called
 
         assert_expect(mprint.call_args_list, "No packages were removed")
@@ -537,7 +537,7 @@ class TestSCPackage:
 
         assert shell.client.packages.removePackage.called
         assert mprint.called
-        assert out is None
+        assert out is 0
         assert shell.client.channel.software.listPackagesWithoutChannel.called
 
         exp = [

--- a/spacecmd/tests/test_repo.py
+++ b/spacecmd/tests/test_repo.py
@@ -65,7 +65,7 @@ class TestSCRepo:
         mprint = MagicMock()
         with patch("spacecmd.repo.print", mprint):
             out = spacecmd.repo.do_repo_details(shell, "")
-        assert out is None
+        assert out is 1
         assert not mprint.called
         assert not shell.client.channel.software.getRepoDetails.called
         assert shell.help_repo_details.called
@@ -86,7 +86,7 @@ class TestSCRepo:
 
         assert not shell.client.channel.software.getRepoDetails.called
         assert not shell.help_repo_details.called
-        assert out is None
+        assert out is 1
         assert mprint.called
 
         assert_expect(mprint.call_args_list,
@@ -118,7 +118,7 @@ class TestSCRepo:
 
         assert not shell.help_repo_details.called
         assert shell.client.channel.software.getRepoDetails.called
-        assert out is None
+        assert out is 0
         assert mprint.called
 
         exp = [
@@ -152,7 +152,7 @@ class TestSCRepo:
         with patch("spacecmd.repo.print", mprint):
             out = spacecmd.repo.do_repo_listfilters(shell, "")
 
-        assert out is None
+        assert out is 1
         assert not mprint.called
         assert not shell.client.channel.software.listRepoFilters.called
         assert shell.help_repo_listfilters.called
@@ -171,7 +171,7 @@ class TestSCRepo:
         with patch("spacecmd.repo.print", mprint):
             out = spacecmd.repo.do_repo_listfilters(shell, "some-filter")
 
-        assert out is None
+        assert out is 1
         assert not shell.help_repo_listfilters.called
         assert shell.client.channel.software.listRepoFilters.called
         assert mprint.called
@@ -195,7 +195,7 @@ class TestSCRepo:
         with patch("spacecmd.repo.print", mprint):
             out = spacecmd.repo.do_repo_listfilters(shell, "some-filter")
 
-        assert out is None
+        assert out is 0
         assert not shell.help_repo_listfilters.called
         assert shell.client.channel.software.listRepoFilters.called
         assert mprint.called
@@ -216,7 +216,7 @@ class TestSCRepo:
         with patch("spacecmd.repo.print", mprint):
             out = spacecmd.repo.do_repo_addfilters(shell, "")
 
-        assert out is None
+        assert out is 1
         assert not mprint.called
         assert not shell.client.channel.software.addRepoFilter.called
         assert shell.help_repo_addfilters.called
@@ -235,7 +235,7 @@ class TestSCRepo:
         with patch("spacecmd.repo.print", mprint):
             out = spacecmd.repo.do_repo_addfilters(shell, "some-repo")
 
-        assert out is None
+        assert out is 1
         assert not mprint.called
         assert not shell.client.channel.software.addRepoFilter.called
         assert shell.help_repo_addfilters.called
@@ -256,7 +256,7 @@ class TestSCRepo:
                 patch("spacecmd.repo.logging", logger) as lgr:
             out = spacecmd.repo.do_repo_addfilters(shell, "some-repo foo bar")
 
-        assert out is None
+        assert out is 1
         assert not mprint.called
         assert not shell.help_repo_addfilters.called
         assert not shell.client.channel.software.addRepoFilter.called
@@ -280,7 +280,7 @@ class TestSCRepo:
                 patch("spacecmd.repo.logging", logger) as lgr:
             out = spacecmd.repo.do_repo_addfilters(shell, "some-repo +emacs")
 
-        assert out is None
+        assert out is 0
         assert not mprint.called
         assert not shell.help_repo_addfilters.called
         assert not logger.error.called
@@ -304,7 +304,7 @@ class TestSCRepo:
                     patch("spacecmd.repo.logging", logger) as lgr:
                 out = spacecmd.repo.do_repo_removefilters(shell, arg)
 
-            assert out is None
+            assert out is 1
             assert not mprint.called
             assert not shell.client.channel.software.removeRepoFilter.called
             assert not logger.error.called
@@ -326,7 +326,7 @@ class TestSCRepo:
                 patch("spacecmd.repo.logging", logger) as lgr:
             out = spacecmd.repo.do_repo_removefilters(shell, "repo foo bar")
 
-        assert out is None
+        assert out is 1
         assert not mprint.called
         assert not shell.client.channel.software.removeRepoFilter.called
         assert not shell.help_repo_removefilters.called
@@ -350,7 +350,7 @@ class TestSCRepo:
                 patch("spacecmd.repo.logging", logger) as lgr:
             out = spacecmd.repo.do_repo_removefilters(shell, "repo +emacs -vim")
 
-        assert out is None
+        assert out is 0
         assert not mprint.called
         assert not shell.help_repo_removefilters.called
         assert not logger.error.called
@@ -378,7 +378,7 @@ class TestSCRepo:
                     patch("spacecmd.repo.logging", logger) as lgr:
                 out = spacecmd.repo.do_repo_setfilters(shell, arg)
 
-            assert out is None
+            assert out is 1
             assert not mprint.called
             assert not logger.error.called
             assert not shell.client.channel.software.setRepoFilters.called
@@ -400,7 +400,7 @@ class TestSCRepo:
                 patch("spacecmd.repo.logging", logger) as lgr:
             out = spacecmd.repo.do_repo_setfilters(shell, "repo foo bar")
 
-        assert out is None
+        assert out is 1
         assert not mprint.called
         assert not shell.client.channel.software.setRepoFilters.called
         assert not shell.help_repo_setfilters.called
@@ -424,7 +424,7 @@ class TestSCRepo:
                 patch("spacecmd.repo.logging", logger) as lgr:
             out = spacecmd.repo.do_repo_setfilters(shell, "repo +emacs -vim")
 
-        assert out is None
+        assert out is 0
         assert not mprint.called
         assert not shell.help_repo_setfilters.called
         assert not logger.error.called
@@ -452,7 +452,7 @@ class TestSCRepo:
                 patch("spacecmd.repo.logging", logger) as lgr:
             out = spacecmd.repo.do_repo_clearfilters(shell, "")
 
-        assert out is None
+        assert out is 1
         assert not mprint.called
         assert not logger.error.called
         assert not shell.client.channel.software.clearRepoFilters.called
@@ -475,7 +475,7 @@ class TestSCRepo:
                 patch("spacecmd.repo.logging", logger) as lgr:
             out = spacecmd.repo.do_repo_clearfilters(shell, "repo --yes")
 
-        assert out is None
+        assert out is 0
         assert not mprint.called
         assert not shell.help_repo_clearfilters.called
         assert not logger.error.called
@@ -498,7 +498,7 @@ class TestSCRepo:
                 patch("spacecmd.repo.logging", logger) as lgr:
             out = spacecmd.repo.do_repo_clearfilters(shell, "repo")
 
-        assert out is None
+        assert out is 0
         assert not mprint.called
         assert not shell.help_repo_clearfilters.called
         assert not logger.error.called
@@ -521,7 +521,7 @@ class TestSCRepo:
                 patch("spacecmd.repo.logging", logger) as lgr:
             out = spacecmd.repo.do_repo_delete(shell, "")
 
-        assert out is None
+        assert out is 1
         assert not mprint.called
         assert not logger.error.called
         assert not shell.client.channel.software.removeRepo.called
@@ -544,7 +544,7 @@ class TestSCRepo:
                 patch("spacecmd.repo.logging", logger) as lgr:
             out = spacecmd.repo.do_repo_rename(shell, "")
 
-        assert out is None
+        assert out is 1
         assert not mprint.called
         assert not logger.error.called
         assert not shell.client.channel.software.getRepoDetails.called
@@ -568,7 +568,7 @@ class TestSCRepo:
                     patch("spacecmd.repo.logging", logger) as lgr:
                 out = spacecmd.repo.do_repo_updateurl(shell, "")
 
-            assert out is None
+            assert out is 1
             assert not mprint.called
             assert not logger.error.called
             assert not shell.client.channel.software.updateRepUrl.called
@@ -593,7 +593,7 @@ class TestSCRepo:
                 patch("spacecmd.repo.logging", logger) as lgr:
             out = spacecmd.repo.do_repo_updatessl(shell, "")
 
-        assert out is None
+        assert out is 0
         assert not mprint.called
         assert not logger.error.called
         assert shell.client.channel.software.updateRepoSsl.called
@@ -620,7 +620,7 @@ class TestSCRepo:
                 patch("spacecmd.repo.logging", logger) as lgr:
             out = spacecmd.repo.do_repo_updatessl(shell, "--name name --ca ca --cert cert --key key")
 
-        assert out is None
+        assert out is 0
         assert not mprint.called
         assert not logger.error.called
         assert shell.client.channel.software.updateRepoSsl.called
@@ -647,7 +647,7 @@ class TestSCRepo:
                 patch("spacecmd.repo.logging", logger) as lgr:
             out = spacecmd.repo.do_repo_updatessl(shell, "--ca ca --cert cert --key key")
 
-        assert out is None
+        assert out is 1
         assert not mprint.called
         assert not shell.client.channel.software.updateRepoSsl.called
         assert logger.error.called
@@ -672,7 +672,7 @@ class TestSCRepo:
                 patch("spacecmd.repo.logging", logger) as lgr:
             out = spacecmd.repo.do_repo_create(shell, "")
 
-        assert out is None
+        assert out is 0
         assert not mprint.called
         assert shell.client.channel.software.createRepo.called
         assert not logger.error.called
@@ -699,7 +699,7 @@ class TestSCRepo:
                                                "--n name --t type -u http://something "
                                                "--ca ca --cert cert --key key")
 
-        assert out is None
+        assert out is 0
         assert not mprint.called
         assert shell.client.channel.software.createRepo.called
         assert not logger.error.called
@@ -725,7 +725,7 @@ class TestSCRepo:
                                                "--t type -u http://something "
                                                "--ca ca --cert cert --key key")
 
-        assert out is None
+        assert out is 1
         assert not mprint.called
         assert not shell.client.channel.software.createRepo.called
         assert logger.error.called
@@ -751,7 +751,7 @@ class TestSCRepo:
                                                "-n name -t type "
                                                "--ca ca --cert cert --key key")
 
-        assert out is None
+        assert out is 1
         assert not mprint.called
         assert not shell.client.channel.software.createRepo.called
         assert logger.error.called
@@ -777,7 +777,7 @@ class TestSCRepo:
                                                "-n name -u http://something "
                                                "--ca ca --cert cert --key key")
 
-        assert out is None
+        assert out is 0
         assert not mprint.called
         assert not logger.error.called
         assert shell.client.channel.software.createRepo.called

--- a/spacecmd/tests/test_snippet.py
+++ b/spacecmd/tests/test_snippet.py
@@ -289,7 +289,7 @@ class TestSCSnippets:
 
         out = snippet.do_snippet_update(shell, "")
         assert shell.help_snippet_update.called
-        assert out is None
+        assert out is 1
 
     def test_snippet_update_args(self, shell):
         """
@@ -319,7 +319,7 @@ class TestSCSnippets:
 
         assert not shell.client.kickstart.snippet.delete.called
         assert shell.help_snippet_delete.called
-        assert out is None
+        assert out is 1
 
     def test_snippet_delete_args(self, shell):
         """
@@ -333,7 +333,7 @@ class TestSCSnippets:
 
         assert shell.client.kickstart.snippet.delete.called
         assert not shell.help_snippet_delete.called
-        assert out is None
+        assert out is 0
         assert shell.client.kickstart.snippet.delete.call_args_list[0][0][0] == shell.session
         assert shell.client.kickstart.snippet.delete.call_args_list[0][0][1] == "some-snippet"
 
@@ -349,4 +349,4 @@ class TestSCSnippets:
 
         assert not shell.client.kickstart.snippet.delete.called
         assert not shell.help_snippet_delete.called
-        assert out is None
+        assert out is 1


### PR DESCRIPTION
## What does this PR change?

Methods in the spacecmd shell are supposed to return meaningful result codes. This is currently not the case, so when using it in a script for single commands, also failed commands will report success by always implicitly returning 0. This is fixed with this PR for the most relevant methods.

There are still some more which will require the same fixing, but it will affect almost every method, so I wanted to fix the most urgent and frequent ones (there is a pending L3) and want to get some feedback.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: Bugfix

- [X] **DONE**

## Test coverage
- No tests: 

- [X] **DONE**

## Links

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1171687

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"      
