### PR TITLE
fix-yum-based-distros-repo_gpgcheck-state

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/channels/channels.repo
+++ b/susemanager-utils/susemanager-sls/salt/channels/channels.repo
@@ -23,7 +23,7 @@ baseurl={{protocol}}://{{hostname}}:{{port}}/rhn/manager/download/{{ chan }}?{{ 
 {%- endif %}
 type={{ args['type'] }}
 gpgcheck={{ args['gpgcheck'] }}
-repo_gpgcheck={{ args['repo_gpgcheck'] }}
+repo_gpgcheck=0
 pkg_gpgcheck={{ args['pkg_gpgcheck'] }}
 {%- endif %}
 


### PR DESCRIPTION
## What does this PR change?

Disable repo_gpgcheck on redhat based systems.

**add description**

See this problem:

https://github.com/uyuni-project/uyuni/issues/2156

I not touch the java code (it reduce the security of SUSE clients), it try to fix it with salt side.

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
