### PR TITLE
Maintenance windows u1

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/Action.java
+++ b/java/code/src/com/redhat/rhn/domain/action/Action.java
@@ -269,7 +269,7 @@ public class Action extends BaseDomainHelper implements Serializable {
         if (serverActions == null) {
             serverActions = new HashSet();
         }
-        saIn.setParentAction(this);
+        saIn.setParentActionWithCheck(this);
         serverActions.add(saIn);
     }
 

--- a/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
@@ -259,8 +259,8 @@ public class ActionFactory extends HibernateFactory {
         sa.setCreated(new Date());
         sa.setModified(new Date());
         sa.setStatus(STATUS_QUEUED);
-        sa.setServer(server);
-        sa.setParentAction(parent);
+        sa.setServerWithCheck(server);
+        sa.setParentActionWithCheck(parent);
         sa.setRemainingTries(5L); //arbitrary number from perl
         parent.addServerAction(sa);
     }

--- a/java/code/src/com/redhat/rhn/domain/action/rhnpackage/test/PackageActionTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/rhnpackage/test/PackageActionTest.java
@@ -150,14 +150,14 @@ public class PackageActionTest extends RhnBaseTestCase {
         ServerAction sa = new ServerAction();
         sa.setStatus(ActionFactory.STATUS_QUEUED);
         sa.setRemainingTries(10L);
-        sa.setServer(srvr);
+        sa.setServerWithCheck(srvr);
         log.debug("Creating PackageRemoveAction.");
         PackageAction pra = (PackageAction) ActionFactory.createAction(
                     ActionFactory.TYPE_PACKAGES_REMOVE);
         pra.setOrg(user.getOrg());
         pra.setName("Package Removal");
         pra.addServerAction(sa);
-        sa.setParentAction(pra);
+        sa.setParentActionWithCheck(pra);
         log.debug("Committing PackageRemoveAction.");
         ActionFactory.save(pra);
 

--- a/java/code/src/com/redhat/rhn/domain/action/server/ServerAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/server/ServerAction.java
@@ -156,11 +156,15 @@ public class ServerAction extends ActionChild implements Serializable {
      *
      * @param serverIn The server to set.
      */
-    public void setServer(Server serverIn) {
+    public void setServerWithCheck(Server serverIn) {
         Action parentAction = getParentAction();
         if (parentAction != null) {
             MaintenanceManager.instance().checkMaintenanceWindows(Set.of(serverIn.getId()), parentAction);
         }
+        setServer(serverIn);
+    }
+
+    private void setServer(Server serverIn) {
         this.server = serverIn;
         this.setServerId(serverIn.getId());
     }
@@ -172,12 +176,22 @@ public class ServerAction extends ActionChild implements Serializable {
      *
      * @param parentActionIn The parentAction to set.
      */
-    @Override
-    public void setParentAction(Action parentActionIn) {
+    public void setParentActionWithCheck(Action parentActionIn) {
         if (server != null) {
             MaintenanceManager.instance().checkMaintenanceWindows(Set.of(server.getId()), parentActionIn);
         }
 
+        setParentAction(parentActionIn);
+    }
+
+    /**
+    *
+    * Sets the parent Action associated with this ServerAction record.
+    *
+    * @param parentActionIn The parentAction to set.
+    */
+    @Override
+    public void setParentAction(Action parentActionIn) {
         super.setParentAction(parentActionIn);
     }
 

--- a/java/code/src/com/redhat/rhn/domain/action/server/test/ServerActionTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/server/test/ServerActionTest.java
@@ -63,28 +63,28 @@ public class ServerActionTest extends RhnBaseTestCase {
 
         Server one = ServerFactory.createServer();
         one.setId(10001L);
-        sa.setServer(one);
+        sa.setServerWithCheck(one);
         assertFalse(sa.equals(sa2));
         assertFalse(sa2.equals(sa));
 
         Server two = ServerFactory.createServer();
         two.setId(10001L); // same ID
-        sa2.setServer(two);
+        sa2.setServerWithCheck(two);
         assertTrue(sa.equals(sa2));
 
         one.setName("foo");
         assertFalse(sa.equals(sa2));
 
-        sa2.setServer(one);
+        sa2.setServerWithCheck(one);
         assertTrue(sa.equals(sa2));
 
         Action parent = new Action();
         parent.setId(243L);
         parent.setActionType(ActionFactory.TYPE_APPLY_STATES);
-        sa.setParentAction(parent);
+        sa.setParentActionWithCheck(parent);
         assertFalse(sa.equals(sa2));
 
-        sa2.setParentAction(parent);
+        sa2.setParentActionWithCheck(parent);
         assertTrue(sa.equals(sa2));
     }
 
@@ -134,8 +134,8 @@ public class ServerActionTest extends RhnBaseTestCase {
         ServerAction sa = new ServerAction();
         sa.setStatus(ActionFactory.STATUS_QUEUED);
         sa.setRemainingTries(10L);
-        sa.setServer(newS);
-        sa.setParentAction(newA);
+        sa.setServerWithCheck(newS);
+        sa.setParentActionWithCheck(newA);
         newA.addServerAction(sa);
         return sa;
     }

--- a/java/code/src/com/redhat/rhn/domain/action/test/ActionFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/test/ActionFactoryTest.java
@@ -556,8 +556,8 @@ public class ActionFactoryTest extends RhnBaseTestCase {
         sa.setRemainingTries(10L);
         sa.setCreated(new Date());
         sa.setModified(new Date());
-        sa.setServer(newS);
-        sa.setParentAction(newA);
+        sa.setServerWithCheck(newS);
+        sa.setParentActionWithCheck(newA);
         return sa;
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
@@ -735,9 +735,9 @@ public class ActionManager extends BaseManager {
         ServerAction sa = new ServerAction();
         sa.setStatus(ActionFactory.STATUS_QUEUED);
         sa.setRemainingTries(5L);
-        sa.setServer(server);
+        sa.setServerWithCheck(server);
 
-        sa.setParentAction(action);
+        sa.setParentActionWithCheck(action);
         action.addServerAction(sa);
 
         return action;
@@ -1155,9 +1155,9 @@ public class ActionManager extends BaseManager {
         ServerAction sa = new ServerAction();
         sa.setStatus(ActionFactory.STATUS_QUEUED);
         sa.setRemainingTries(REMAINING_TRIES);
-        sa.setServer(server);
+        sa.setServerWithCheck(server);
         action.addServerAction(sa);
-        sa.setParentAction(action);
+        sa.setParentActionWithCheck(action);
 
         ActionFactory.save(action);
         taskomaticApi.scheduleActionExecution(action);
@@ -1529,10 +1529,10 @@ public class ActionManager extends BaseManager {
         ServerAction sa = new ServerAction();
         sa.setStatus(ActionFactory.STATUS_QUEUED);
         sa.setRemainingTries(REMAINING_TRIES);
-        sa.setServer(srvr);
+        sa.setServerWithCheck(srvr);
 
         action.addServerAction(sa);
-        sa.setParentAction(action);
+        sa.setParentActionWithCheck(action);
 
         return action;
     }
@@ -1737,10 +1737,10 @@ public class ActionManager extends BaseManager {
         ServerAction sa = new ServerAction();
         sa.setStatus(ActionFactory.STATUS_QUEUED);
         sa.setRemainingTries(REMAINING_TRIES);
-        sa.setServer(srvr);
+        sa.setServerWithCheck(srvr);
 
         action.addServerAction(sa);
-        sa.setParentAction(action);
+        sa.setParentActionWithCheck(action);
 
         ActionFactory.save(action);
 

--- a/java/code/src/com/suse/manager/maintenance/MaintenanceManager.java
+++ b/java/code/src/com/suse/manager/maintenance/MaintenanceManager.java
@@ -345,6 +345,7 @@ public class MaintenanceManager {
      * @param label the label for the calendar
      * @param url URL pointing to the Calendar Data
      * @return the created Maintenance Calendar
+     * @throws DownloadException when fetching data from url failed
      */
     public MaintenanceCalendar createMaintenanceCalendarWithUrl(User user, String label, String url)
             throws DownloadException {
@@ -366,9 +367,10 @@ public class MaintenanceManager {
      * @param details the details which should be updated (ical, url)
      * @param rescheduleStrategy which strategy should be executed when a rescheduling of actions is required
      * @return true when the update was successfull, otherwise false
+     * @throws DownloadException when fetching data from url failed
      */
     public List<RescheduleResult> updateCalendar(User user, String label, Map<String, String> details,
-            List<RescheduleStrategy> rescheduleStrategy) {
+            List<RescheduleStrategy> rescheduleStrategy) throws DownloadException {
         ensureOrgAdmin(user);
         MaintenanceCalendar calendar = lookupCalendarByUserAndLabel(user, label)
                 .orElseThrow(() -> new EntityNotExistsException(label));
@@ -399,9 +401,10 @@ public class MaintenanceManager {
      * @param rescheduleStrategy which strategy should be executed when a rescheduling of actions is required
      * @return true when refresh was successful, otherwise false
      * @throws EntityNotExistsException when calendar or url does not exist
+     * @throws DownloadException when fetching data from url failed
      */
     public List<RescheduleResult> refreshCalendar(User user, String label,
-            List<RescheduleStrategy> rescheduleStrategy) {
+            List<RescheduleStrategy> rescheduleStrategy) throws EntityNotExistsException, DownloadException {
         ensureOrgAdmin(user);
         MaintenanceCalendar calendar = lookupCalendarByUserAndLabel(user, label)
                 .orElseThrow(() -> new EntityNotExistsException(label));

--- a/java/code/src/com/suse/manager/maintenance/MaintenanceManager.java
+++ b/java/code/src/com/suse/manager/maintenance/MaintenanceManager.java
@@ -38,6 +38,7 @@ import com.suse.manager.model.maintenance.MaintenanceSchedule.ScheduleType;
 import com.suse.manager.utils.HttpHelper;
 import com.suse.utils.Opt;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.ParseException;
@@ -286,9 +287,12 @@ public class MaintenanceManager {
             schedule.setScheduleType(ScheduleType.lookupByLabel(details.get("type")));
         }
         if (details.containsKey("calendar")) {
-            MaintenanceCalendar calendar = lookupCalendarByUserAndLabel(user, details.get("calendar"))
-                .orElseThrow(() -> new EntityNotExistsException(details.get("calendar")));
-
+            String label = details.get("calendar");
+            MaintenanceCalendar calendar = null;
+            if (!StringUtils.isBlank(label)) {
+                calendar = lookupCalendarByUserAndLabel(user, label)
+                        .orElseThrow(() -> new EntityNotExistsException(label));
+            }
             schedule.setCalendar(calendar);
         }
         save(schedule);

--- a/java/code/src/com/suse/manager/maintenance/MaintenanceManager.java
+++ b/java/code/src/com/suse/manager/maintenance/MaintenanceManager.java
@@ -273,7 +273,7 @@ public class MaintenanceManager {
      * Update a MaintenanceSchedule
      * @param user the user
      * @param name the schedule name
-     * @param details values which should be changed (name, type, calendar)
+     * @param details values which should be changed (type, calendar)
      * @param rescheduleStrategy which strategy should be executed when a rescheduling of actions is required
      * @return the updated MaintenanceSchedule
      */
@@ -282,10 +282,6 @@ public class MaintenanceManager {
         ensureOrgAdmin(user);
         MaintenanceSchedule schedule = lookupMaintenanceScheduleByUserAndName(user, name)
                 .orElseThrow(() -> new EntityNotExistsException(name));
-        if (details.containsKey("name")) {
-            // TODO: should the identifier really be changeable?
-            schedule.setName(details.get("name"));
-        }
         if (details.containsKey("type")) {
             schedule.setScheduleType(ScheduleType.lookupByLabel(details.get("type")));
         }
@@ -367,7 +363,7 @@ public class MaintenanceManager {
      * Update a MaintenanceCalendar
      * @param user the user
      * @param label the calendar label
-     * @param details the details which should be updated (label, ical, url)
+     * @param details the details which should be updated (ical, url)
      * @param rescheduleStrategy which strategy should be executed when a rescheduling of actions is required
      * @return true when the update was successfull, otherwise false
      */
@@ -376,10 +372,6 @@ public class MaintenanceManager {
         ensureOrgAdmin(user);
         MaintenanceCalendar calendar = lookupCalendarByUserAndLabel(user, label)
                 .orElseThrow(() -> new EntityNotExistsException(label));
-        if (details.containsKey("label")) {
-            // TODO: should the identifier really be changeable?
-            calendar.setLabel(details.get("label"));
-        }
         if (details.containsKey("ical")) {
             calendar.setIcal(details.get("ical"));
         }

--- a/java/code/src/com/suse/manager/maintenance/MaintenanceManager.java
+++ b/java/code/src/com/suse/manager/maintenance/MaintenanceManager.java
@@ -393,7 +393,7 @@ public class MaintenanceManager {
             RescheduleResult r = manageAffectedScheduledActions(user, schedule, rescheduleStrategy);
             if (!r.isSuccess()) {
                 // in case of false, update failed and we had a DB rollback
-                return new LinkedList<>();
+                return Collections.singletonList(r);
             }
             result.add(r);
         }
@@ -421,7 +421,7 @@ public class MaintenanceManager {
             RescheduleResult r = manageAffectedScheduledActions(user, schedule, rescheduleStrategy);
             if (!r.isSuccess()) {
                 // in case of false, update failed and we had a DB rollback
-                return new LinkedList<>();
+                return Collections.singletonList(r);
             }
             result.add(r);
         }

--- a/java/code/src/com/suse/manager/maintenance/MaintenanceManager.java
+++ b/java/code/src/com/suse/manager/maintenance/MaintenanceManager.java
@@ -426,7 +426,7 @@ public class MaintenanceManager {
     @SuppressWarnings("unchecked")
     private List<MaintenanceSchedule> listSchedulesByUserAndCalendar(User user, MaintenanceCalendar calendar) {
         return getSession()
-                .createQuery("from MaintenanceSchedule WHERE org = :org and calendar = :calendar")
+                .createQuery("from MaintenanceSchedule WHERE org = :org and calendar = :calendar ORDER BY name ASC")
                 .setParameter("org", user.getOrg())
                 .setParameter("calendar", calendar).getResultList();
     }

--- a/java/code/src/com/suse/manager/maintenance/test/MaintenanceManagerTest.java
+++ b/java/code/src/com/suse/manager/maintenance/test/MaintenanceManagerTest.java
@@ -268,7 +268,8 @@ public class MaintenanceManagerTest extends BaseTestCaseWithUser {
                 IllegalArgumentException.class);
 
         // assign an action not tied to maintenance mode
-        Action allowedAction = createActionForServerAt(ActionFactory.TYPE_VIRTUALIZATION_START, sys2, "2020-04-13T08:15:00+02:00");
+        Action allowedAction = MaintenanceTestUtils
+                .createActionForServerAt(user, ActionFactory.TYPE_VIRTUALIZATION_START, sys2, "2020-04-13T08:15:00+02:00");
         assertEquals(1, mm.assignScheduleToSystems(user, schedule, Set.of(sys2.getId())));
     }
 
@@ -378,12 +379,20 @@ public class MaintenanceManagerTest extends BaseTestCaseWithUser {
         mm.assignScheduleToSystems(user, sapSchedule, Collections.singleton(sapServer.getId()));
         mm.assignScheduleToSystems(user, coreSchedule, Collections.singleton(coreServer.getId()));
 
-        Action sapAction1 = createActionForServerAt(ActionFactory.TYPE_ERRATA, sapServer, "2020-04-13T08:15:00+02:00"); //moved
-        Action sapActionEx = createActionForServerAt(ActionFactory.TYPE_VIRTUALIZATION_START, sapServer, "2020-04-13T08:15:00+02:00"); //moved
-        Action sapAction2 = createActionForServerAt(ActionFactory.TYPE_ERRATA, sapServer, "2020-04-27T08:15:00+02:00"); //stay
-        Action coreAction1 = createActionForServerAt(ActionFactory.TYPE_ERRATA, coreServer, "2020-04-30T09:15:00+02:00"); //stay
-        Action coreActionEx = createActionForServerAt(ActionFactory.TYPE_VIRTUALIZATION_START, coreServer, "2020-05-21T09:15:00+02:00"); //moved
-        Action coreAction2 = createActionForServerAt(ActionFactory.TYPE_ERRATA, coreServer, "2020-05-21T09:15:00+02:00"); //moved
+        Action sapAction1 = MaintenanceTestUtils.createActionForServerAt(
+                user, ActionFactory.TYPE_ERRATA, sapServer, "2020-04-13T08:15:00+02:00"); //moved
+        Action sapActionEx = MaintenanceTestUtils.createActionForServerAt(
+        Action sapAction2 = MaintenanceTestUtils.createActionForServerAt(
+                user, ActionFactory.TYPE_ERRATA, sapServer, "2020-04-27T08:15:00+02:00"); //stay
+        Action sapAction3 = MaintenanceTestUtils.createActionForServerAt(
+        Action coreAction1 = MaintenanceTestUtils.createActionForServerAt(
+                user, ActionFactory.TYPE_ERRATA, coreServer, "2020-04-30T09:15:00+02:00"); //stay
+        Action coreActionEx = MaintenanceTestUtils.createActionForServerAt(
+                user, ActionFactory.TYPE_VIRTUALIZATION_START, coreServer, "2020-05-21T09:15:00+02:00"); //moved
+        Action coreAction2 = MaintenanceTestUtils.createActionForServerAt(
+                user, ActionFactory.TYPE_ERRATA, coreServer, "2020-05-21T09:15:00+02:00"); //moved
+        Action coreAction3 = MaintenanceTestUtils.createActionForServerAt(
+                user, ActionFactory.TYPE_ERRATA, coreServer, "2020-04-27T08:15:00+02:00"); //wrong window (SAP)
 
         List sapActionsBefore = ActionFactory.listActionsForServer(user, sapServer);
         List coreActionsBefore = ActionFactory.listActionsForServer(user, coreServer);
@@ -435,26 +444,34 @@ public class MaintenanceManagerTest extends BaseTestCaseWithUser {
 
         // Action Chain which start inside of the window, but has parts outside of the window
         // Expected Result: No change
-        Action sapAction1 = createActionForServerAt(ActionFactory.TYPE_ERRATA, sapServer, "2020-04-27T09:59:00+02:00"); //stay (MW end at 10am)
-        Action sapAction2 = createActionForServerAt(ActionFactory.TYPE_REBOOT, sapServer, "2020-04-27T10:01:00+02:00", sapAction1); //stay (MW end at 10am)
+        Action sapAction1 = MaintenanceTestUtils.createActionForServerAt(
+                user, ActionFactory.TYPE_ERRATA, sapServer, "2020-04-27T09:59:00+02:00"); //stay (MW end at 10am)
+        Action sapAction2 = MaintenanceTestUtils.createActionForServerAt(
+                user, ActionFactory.TYPE_REBOOT, sapServer, "2020-04-27T10:01:00+02:00", sapAction1); //stay (MW end at 10am)
 
         // Action Chain which start with an action not tied to a maintenance window
         // Expected Result: Cancel all Actions
-        Action sapAction3 = createActionForServerAt(ActionFactory.TYPE_VIRTUALIZATION_START, sapServer, "2020-04-13T09:59:00+02:00"); //moved
-        Action sapAction4 = createActionForServerAt(ActionFactory.TYPE_ERRATA, sapServer, "2020-04-13T08:10:02+02:00", sapAction3); //moved
+        Action sapAction3 = MaintenanceTestUtils.createActionForServerAt(
+                user, ActionFactory.TYPE_VIRTUALIZATION_START, sapServer, "2020-04-13T09:59:00+02:00"); //moved
+        Action sapAction4 = MaintenanceTestUtils.createActionForServerAt(
+                user, ActionFactory.TYPE_ERRATA, sapServer, "2020-04-13T08:10:02+02:00", sapAction3); //moved
 
         List<Action> sapActionsBefore = ActionFactory.listActionsForServer(user, sapServer);
         assertEquals(4, sapActionsBefore.size());
 
         // Action Chain which is inside of a Window but the window gets moved.
         // Expected Result: Cancel all Actions
-        Action coreAction1 = createActionForServerAt(ActionFactory.TYPE_ERRATA, coreServer, "2020-05-21T09:15:00+02:00"); //moved
-        Action coreAction2 = createActionForServerAt(ActionFactory.TYPE_REBOOT, coreServer, "2020-05-21T09:16:00+02:00", coreAction1); //moved
+        Action coreAction1 = MaintenanceTestUtils.createActionForServerAt(
+                user, ActionFactory.TYPE_ERRATA, coreServer, "2020-05-21T09:15:00+02:00"); //moved
+        Action coreAction2 = MaintenanceTestUtils.createActionForServerAt(
+                user, ActionFactory.TYPE_REBOOT, coreServer, "2020-05-21T09:16:00+02:00", coreAction1); //moved
 
         // Action Chain which start with an action not tied to a maintenance window
         // Expected Result: No change
-        Action coreAction3 = createActionForServerAt(ActionFactory.TYPE_VIRTUALIZATION_START, coreServer, "2020-04-30T11:59:30+02:00"); //stay
-        Action coreAction4 = createActionForServerAt(ActionFactory.TYPE_ERRATA, coreServer, "2020-04-30T13:01:00+02:00", coreAction3); //stay
+        Action coreAction3 = MaintenanceTestUtils.createActionForServerAt(
+                user, ActionFactory.TYPE_VIRTUALIZATION_START, coreServer, "2020-04-30T11:59:30+02:00"); //stay
+        Action coreAction4 = MaintenanceTestUtils.createActionForServerAt(
+                user, ActionFactory.TYPE_ERRATA, coreServer, "2020-04-30T13:01:00+02:00", coreAction3); //stay
 
         List<Action> coreActionsBefore = ActionFactory.listActionsForServer(user, coreServer);
         assertEquals(4, coreActionsBefore.size());
@@ -481,41 +498,6 @@ public class MaintenanceManagerTest extends BaseTestCaseWithUser {
         assertEquals(2, coreActionsAfter.size()); // First chain should be canceled, second stay
     }
 
-    /**
-     * Create an Errata Action for the given server at a specific point in time
-     *
-     * @param type action type
-     * @param server the server
-     * @param datetime time template for earliest action. Example: "2020-04-21T09:00:00+01:00"
-     * @param prerequisite dependend action
-     * @return the Action
-     * @throws Exception
-     */
-    private Action createActionForServerAt(ActionType type, Server server, String datetime,
-            Action prerequisite) throws Exception {
-        Action action = ActionFactoryTest.createAction(user, type);
-        action.setPrerequisite(prerequisite);
-        ZonedDateTime start = ZonedDateTime.parse(datetime, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
-        action.setEarliestAction(Date.from(start.toInstant()));
-
-        ServerAction serverAction = ServerActionTest.createServerAction(server, action);
-        serverAction.setStatus(ActionFactory.STATUS_QUEUED);
-
-        action.addServerAction(serverAction);
-        ActionManager.storeAction(action);
-        return ActionFactory.lookupById(action.getId());
-    }
-
-    /**
-     * Create an Errata Action for the given server at a specific point in time
-     *
-     * @param server the server
-     * @param datetime time template for earliest action. Example: "2020-04-21T09:00:00+01:00"
-     * @return the Action
-     * @throws Exception
-     */
-    private Action createActionForServerAt(ActionType type, Server server, String datetime) throws Exception {
-        return createActionForServerAt(type, server, datetime, null);
     }
 
     public void testListSystemsSchedules() throws Exception {
@@ -533,8 +515,6 @@ public class MaintenanceManagerTest extends BaseTestCaseWithUser {
                 Set.of(schedule),
                 mm.listSchedulesOfSystems(Set.of(withSchedule.getId(), withoutSchedule.getId()))
         );
-    }
-
     private void assertExceptionThrown(Runnable body, Class exceptionClass) {
         try {
             body.run();

--- a/java/code/src/com/suse/manager/maintenance/test/MaintenanceManagerTest.java
+++ b/java/code/src/com/suse/manager/maintenance/test/MaintenanceManagerTest.java
@@ -494,7 +494,6 @@ public class MaintenanceManagerTest extends BaseTestCaseWithUser {
         assertContains(coreActionsAfter, coreAction3);
         assertContains(coreActionsAfter, coreAction4);
         assertEquals(2, coreActionsAfter.size()); // First chain should be canceled, second stay
-    }
 
         assertEquals(2, upResult.size());
         for (RescheduleResult r : upResult) {
@@ -502,14 +501,13 @@ public class MaintenanceManagerTest extends BaseTestCaseWithUser {
                 assertEquals("Cancel", r.getStrategy());
                 assertContains(r.getActionsServers().get(sapAction3), sapServer);
                 // depending actions from a chain are not part of the result
-                //assertContains(r.getActionsServers().get(sapAction4), sapServer);
             }
             else if (r.getScheduleName().equals("Core Server Window")) {
                 assertEquals("Cancel", r.getStrategy());
                 assertContains(r.getActionsServers().get(coreAction1), coreServer);
                 // depending actions from a chain are not part of the result
-                //assertContains(r.getActionsServers().get(coreAction2), coreServer);
             }
+        }
     }
 
     public void testListSystemsSchedules() throws Exception {
@@ -527,6 +525,8 @@ public class MaintenanceManagerTest extends BaseTestCaseWithUser {
                 Set.of(schedule),
                 mm.listSchedulesOfSystems(Set.of(withSchedule.getId(), withoutSchedule.getId()))
         );
+    }
+
     private void assertExceptionThrown(Runnable body, Class exceptionClass) {
         try {
             body.run();

--- a/java/code/src/com/suse/manager/maintenance/test/MaintenanceManagerTest.java
+++ b/java/code/src/com/suse/manager/maintenance/test/MaintenanceManagerTest.java
@@ -382,17 +382,15 @@ public class MaintenanceManagerTest extends BaseTestCaseWithUser {
         Action sapAction1 = MaintenanceTestUtils.createActionForServerAt(
                 user, ActionFactory.TYPE_ERRATA, sapServer, "2020-04-13T08:15:00+02:00"); //moved
         Action sapActionEx = MaintenanceTestUtils.createActionForServerAt(
+                user, ActionFactory.TYPE_VIRTUALIZATION_START, sapServer, "2020-04-13T08:15:00+02:00"); //moved
         Action sapAction2 = MaintenanceTestUtils.createActionForServerAt(
                 user, ActionFactory.TYPE_ERRATA, sapServer, "2020-04-27T08:15:00+02:00"); //stay
-        Action sapAction3 = MaintenanceTestUtils.createActionForServerAt(
         Action coreAction1 = MaintenanceTestUtils.createActionForServerAt(
                 user, ActionFactory.TYPE_ERRATA, coreServer, "2020-04-30T09:15:00+02:00"); //stay
         Action coreActionEx = MaintenanceTestUtils.createActionForServerAt(
                 user, ActionFactory.TYPE_VIRTUALIZATION_START, coreServer, "2020-05-21T09:15:00+02:00"); //moved
         Action coreAction2 = MaintenanceTestUtils.createActionForServerAt(
                 user, ActionFactory.TYPE_ERRATA, coreServer, "2020-05-21T09:15:00+02:00"); //moved
-        Action coreAction3 = MaintenanceTestUtils.createActionForServerAt(
-                user, ActionFactory.TYPE_ERRATA, coreServer, "2020-04-27T08:15:00+02:00"); //wrong window (SAP)
 
         List sapActionsBefore = ActionFactory.listActionsForServer(user, sapServer);
         List coreActionsBefore = ActionFactory.listActionsForServer(user, coreServer);
@@ -512,7 +510,6 @@ public class MaintenanceManagerTest extends BaseTestCaseWithUser {
                 // depending actions from a chain are not part of the result
                 //assertContains(r.getActionsServers().get(coreAction2), coreServer);
             }
-        }
     }
 
     public void testListSystemsSchedules() throws Exception {

--- a/java/code/src/com/suse/manager/maintenance/test/MaintenanceManagerTest.java
+++ b/java/code/src/com/suse/manager/maintenance/test/MaintenanceManagerTest.java
@@ -425,7 +425,8 @@ public class MaintenanceManagerTest extends BaseTestCaseWithUser {
         List<RescheduleResult> results = mm.remove(user, mcal, false);
         assertEquals(1, results.size());
         assertFalse(results.get(0).isSuccess());
-        assertEquals("SAP Maintenance Window", results.get(0).getScheduleName());
+        // we remove the schedules ordered by name
+        assertEquals("Core Server Window", results.get(0).getScheduleName());
     }
 
     public void testScheduleChangeMultiWithActionChain() throws Exception {

--- a/java/code/src/com/suse/manager/maintenance/test/MaintenanceTestUtils.java
+++ b/java/code/src/com/suse/manager/maintenance/test/MaintenanceTestUtils.java
@@ -1,0 +1,56 @@
+package com.suse.manager.maintenance.test;
+
+import com.redhat.rhn.domain.action.Action;
+import com.redhat.rhn.domain.action.ActionFactory;
+import com.redhat.rhn.domain.action.ActionType;
+import com.redhat.rhn.domain.action.server.ServerAction;
+import com.redhat.rhn.domain.action.server.test.ServerActionTest;
+import com.redhat.rhn.domain.action.test.ActionFactoryTest;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.manager.action.ActionManager;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+
+public class MaintenanceTestUtils {
+
+    /**
+     * Create an Errata Action for the given server at a specific point in time
+     *
+     * @param type action type
+     * @param server the server
+     * @param datetime time template for earliest action. Example: "2020-04-21T09:00:00+01:00"
+     * @param prerequisite dependend action
+     * @return the Action
+     * @throws Exception
+     */
+    public static Action createActionForServerAt(User user, ActionType type, Server server, String datetime,
+            Action prerequisite) throws Exception {
+        Action action = ActionFactoryTest.createAction(user, type);
+        action.setPrerequisite(prerequisite);
+        ZonedDateTime start = ZonedDateTime.parse(datetime, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        action.setEarliestAction(Date.from(start.toInstant()));
+
+        ServerAction serverAction = ServerActionTest.createServerAction(server, action);
+        serverAction.setStatus(ActionFactory.STATUS_QUEUED);
+
+        action.addServerAction(serverAction);
+        ActionManager.storeAction(action);
+        return ActionFactory.lookupById(action.getId());
+    }
+
+    /**
+     * Create an Errata Action for the given server at a specific point in time
+     *
+     * @param server the server
+     * @param datetime time template for earliest action. Example: "2020-04-21T09:00:00+01:00"
+     * @return the Action
+     * @throws Exception
+     */
+    public static Action createActionForServerAt(User user, ActionType type, Server server, String datetime) throws Exception {
+        return createActionForServerAt(user, type, server, datetime, null);
+    }
+
+}

--- a/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
+++ b/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
@@ -6,6 +6,7 @@ import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.db.datasource.CallableMode;
 import com.redhat.rhn.common.db.datasource.ModeFactory;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.product.test.SUSEProductTestUtils;
 import com.redhat.rhn.domain.rhnpackage.PackageFactory;
 import com.redhat.rhn.domain.server.CPU;
@@ -17,11 +18,13 @@ import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.server.VirtualInstance;
 import com.redhat.rhn.domain.server.virtualhostmanager.VirtualHostManager;
 import com.redhat.rhn.domain.server.virtualhostmanager.VirtualHostManagerFactory;
+import com.redhat.rhn.manager.action.ActionManager;
 import com.redhat.rhn.manager.content.ContentSyncManager;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
+import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 import com.redhat.rhn.testing.ServerTestUtils;
 import com.redhat.rhn.testing.TestUtils;
@@ -37,6 +40,7 @@ import com.suse.matcher.json.SystemJson;
 import com.suse.matcher.json.VirtualizationGroupJson;
 import com.suse.scc.model.SCCSubscriptionJson;
 
+import org.jmock.Expectations;
 import org.jmock.lib.legacy.ClassImposteriser;
 
 import java.io.File;
@@ -241,6 +245,13 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
         SUSEProductTestUtils.createVendorSUSEProducts();
         SUSEProductTestUtils.createVendorEntitlementProducts();
 
+        TaskomaticApi taskomaticMock = mock(TaskomaticApi.class);
+        ActionManager.setTaskomaticApi(taskomaticMock);
+
+        context().checking(new Expectations() { {
+            allowing(taskomaticMock).scheduleActionExecution(with(any(Action.class)));
+        } });
+
         Server hostServer = ServerTestUtils.createVirtHostWithGuests(1, systemEntitlementManager);
         // let's set some base product to our systems (otherwise lifecycle subscriptions aren't reported)
         InstalledProduct instProd = createInstalledProduct("SLES", "12.1", "0", "x86_64", true);
@@ -274,6 +285,13 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
         SUSEProductTestUtils.clearAllProducts();
         SUSEProductTestUtils.createVendorSUSEProducts();
         SUSEProductTestUtils.createVendorEntitlementProducts();
+
+        TaskomaticApi taskomaticMock = mock(TaskomaticApi.class);
+        ActionManager.setTaskomaticApi(taskomaticMock);
+
+        context().checking(new Expectations() { {
+            allowing(taskomaticMock).scheduleActionExecution(with(any(Action.class)));
+        } });
 
         Server hostServer = ServerTestUtils.createVirtHostWithGuests(user, 1, true, systemEntitlementManager);
         // monitoring is only compatible with certain architectures. make sure we use one of them:
@@ -449,6 +467,13 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
      * @throws Exception if anything goes wrong
      */
     public void testVirtualHostManagersToJson() throws Exception {
+        TaskomaticApi taskomaticMock = mock(TaskomaticApi.class);
+        ActionManager.setTaskomaticApi(taskomaticMock);
+
+        context().checking(new Expectations() { {
+            allowing(taskomaticMock).scheduleActionExecution(with(any(Action.class)));
+        } });
+
         Server virtualHost1 = ServerTestUtils.createVirtHostWithGuests(2, systemEntitlementManager);
         Server virtualHost2 = ServerTestUtils.createVirtHostWithGuest(systemEntitlementManager);
         VirtualHostManager vhm = VirtualHostManagerFactory.getInstance()

--- a/java/code/src/com/suse/manager/xmlrpc/DownloadFaultException.java
+++ b/java/code/src/com/suse/manager/xmlrpc/DownloadFaultException.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.xmlrpc;
+
+import com.redhat.rhn.FaultException;
+
+
+@SuppressWarnings("serial")
+public class DownloadFaultException extends FaultException {
+
+    /**
+     * Constructor
+     *
+     * @param d exception
+     */
+    public DownloadFaultException(Throwable d) {
+        super(2803, "downloadError", "Download failed", d);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param url the url
+     * @param d exception
+     */
+    public DownloadFaultException(String url, Throwable d) {
+        super(2803, "downloadError", String.format("Download from '%s' failed", url), d);
+    }
+}

--- a/java/code/src/com/suse/manager/xmlrpc/maintenance/MaintenanceHandler.java
+++ b/java/code/src/com/suse/manager/xmlrpc/maintenance/MaintenanceHandler.java
@@ -170,7 +170,7 @@ public class MaintenanceHandler extends BaseHandler {
      *                     #item_desc("Fail", "Let update fail. The calendar stay untouched")
      *                   #options_end()
      *               #array_end()
-     * @xmlrpc.returntype #param("boolean", "True on success, otherwise False")
+     * @xmlrpc.returntype $RescheduleResultSerializer
      */
     public RescheduleResult updateSchedule(User loggedInUser, String name, Map<String, String> details,
             List<String> rescheduleStrategy) {
@@ -326,7 +326,10 @@ public class MaintenanceHandler extends BaseHandler {
      *                     #item_desc("Fail", "Let update fail. The calendar stay untouched")
      *                   #options_end()
      *               #array_end()
-     * @xmlrpc.returntype #param("boolean", "True on success, otherwise False")
+     * @xmlrpc.returntype
+     *     #array_begin()
+     *       $RescheduleResultSerializer
+     *     #array_end()
      */
     public List<RescheduleResult> updateCalendar(User loggedInUser, String label, Map<String, String> details,
             List<String> rescheduleStrategy) {
@@ -364,7 +367,10 @@ public class MaintenanceHandler extends BaseHandler {
      *                     #item_desc("Fail", "Let update fail. The calendar stay untouched")
      *                   #options_end()
      *               #array_end()
-     * @xmlrpc.returntype #param("boolean", "True on success, otherwise False")
+     * @xmlrpc.returntype
+     *     #array_begin()
+     *       $RescheduleResultSerializer
+     *     #array_end()
      */
     public List<RescheduleResult> refreshCalendar(User loggedInUser, String label, List<String> rescheduleStrategy) {
         ensureOrgAdmin(loggedInUser);

--- a/java/code/src/com/suse/manager/xmlrpc/maintenance/MaintenanceHandler.java
+++ b/java/code/src/com/suse/manager/xmlrpc/maintenance/MaintenanceHandler.java
@@ -155,7 +155,6 @@ public class MaintenanceHandler extends BaseHandler {
      * @xmlrpc.param #param_desc("string", "name", "Maintenance Schedule Name")
      * @xmlrpc.param
      *     #struct_begin("Maintenance Schedule Details")
-     *         #prop_desc("string", "name", "new Schedule Name")
      *         #prop_desc("string", "type", "new Schedule Type")
      *           #options()
      *               #item("single")
@@ -178,7 +177,6 @@ public class MaintenanceHandler extends BaseHandler {
 
         // confirm that the user only provided valid keys in the map
         Set<String> validKeys = new HashSet<String>();
-        validKeys.add("name");
         validKeys.add("type");
         validKeys.add("calendar");
         validateMap(validKeys, details);
@@ -316,8 +314,8 @@ public class MaintenanceHandler extends BaseHandler {
      * @xmlrpc.param #param_desc("string", "label", "Maintenance Calendar Label")
      * @xmlrpc.param
      *     #struct_begin("Maintenance Calendar Details")
-     *         #prop_desc("string", "label", "new Calendar Label")
      *         #prop_desc("string", "ical", "new ical Calendar data")
+     *         #prop_desc("string", "url", "new Calendar URL")
      *     #struct_end()
      * @xmlrpc.param #array_begin()
      *                 #prop_desc("string", "rescheduleStrategy", "Available:")
@@ -337,7 +335,7 @@ public class MaintenanceHandler extends BaseHandler {
 
         // confirm that the user only provided valid keys in the map
         Set<String> validKeys = new HashSet<String>();
-        validKeys.add("label");
+        validKeys.add("url");
         validKeys.add("ical");
         validateMap(validKeys, details);
 

--- a/java/code/src/com/suse/manager/xmlrpc/maintenance/MaintenanceHandler.java
+++ b/java/code/src/com/suse/manager/xmlrpc/maintenance/MaintenanceHandler.java
@@ -15,6 +15,7 @@
 package com.suse.manager.xmlrpc.maintenance;
 
 import com.redhat.rhn.common.security.PermissionException;
+import com.redhat.rhn.common.util.download.DownloadException;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.xmlrpc.BaseHandler;
 import com.redhat.rhn.frontend.xmlrpc.EntityExistsFaultException;
@@ -29,6 +30,7 @@ import com.suse.manager.maintenance.RescheduleResult;
 import com.suse.manager.model.maintenance.MaintenanceCalendar;
 import com.suse.manager.model.maintenance.MaintenanceSchedule;
 import com.suse.manager.model.maintenance.MaintenanceSchedule.ScheduleType;
+import com.suse.manager.xmlrpc.DownloadFaultException;
 
 import java.util.HashSet;
 import java.util.List;
@@ -298,6 +300,9 @@ public class MaintenanceHandler extends BaseHandler {
         catch (EntityExistsException e) {
             throw new EntityExistsFaultException(e);
         }
+        catch (DownloadException d) {
+            throw new DownloadFaultException(url, d);
+        }
     }
 
     /**
@@ -346,6 +351,13 @@ public class MaintenanceHandler extends BaseHandler {
         catch (EntityNotExistsException e) {
             throw new EntityNotExistsFaultException(e);
         }
+        catch (DownloadException d) {
+            Optional.ofNullable(details.get("url")).ifPresent(
+                    url -> {
+                        throw new DownloadFaultException(url, d);
+                    });
+            throw new DownloadFaultException(d);
+        }
     }
 
     /**
@@ -377,6 +389,9 @@ public class MaintenanceHandler extends BaseHandler {
         }
         catch (EntityNotExistsException e) {
             throw new EntityNotExistsFaultException(e);
+        }
+        catch (DownloadException d) {
+            throw new DownloadFaultException(d);
         }
     }
 

--- a/java/code/src/com/suse/manager/xmlrpc/maintenance/MaintenanceHandler.java
+++ b/java/code/src/com/suse/manager/xmlrpc/maintenance/MaintenanceHandler.java
@@ -381,19 +381,24 @@ public class MaintenanceHandler extends BaseHandler {
      *
      * @param loggedInUser the user
      * @param label calendar label
+     * @param cancelScheduledActions cancel actions of affected schedules
      * @throws EntityNotExistsFaultException when Maintenance Calendar does not exist
      * @return number of removed objects
      *
      * @xmlrpc.doc Remove a Maintenance Calendar
      * @xmlrpc.param #session_key()
      * @xmlrpc.param #param_desc("string", "label", "Maintenance Calendar Label")
-     * @xmlrpc.returntype #return_int_success()
+     * @xmlrpc.param #param_desc("boolean", "cancelScheduledActions", "Cancel Actions of affected Schedules")
+     * @xmlrpc.returntype
+     *     #array_begin()
+     *       $RescheduleResultSerializer
+     *     #array_end()
      */
-    public int deleteCalendar(User loggedInUser, String label) {
+    public List<RescheduleResult> deleteCalendar(User loggedInUser, String label, boolean cancelScheduledActions) {
         ensureOrgAdmin(loggedInUser);
         Optional<MaintenanceCalendar> calendar = mm.lookupCalendarByUserAndLabel(loggedInUser, label);
-        mm.remove(loggedInUser, calendar.orElseThrow(() -> new EntityNotExistsFaultException(label)));
-        return 1;
+        return mm.remove(loggedInUser, calendar.orElseThrow(() -> new EntityNotExistsFaultException(label)),
+                cancelScheduledActions);
     }
 
     /**

--- a/java/code/src/com/suse/manager/xmlrpc/maintenance/test/MaintenanceHandlerTest.java
+++ b/java/code/src/com/suse/manager/xmlrpc/maintenance/test/MaintenanceHandlerTest.java
@@ -76,16 +76,12 @@ public class MaintenanceHandlerTest extends BaseHandlerTestCase {
                 admin, ActionFactory.TYPE_VIRTUALIZATION_START, sapServer, "2020-04-13T08:15:00+02:00"); //moved
         Action sapAction2 = MaintenanceTestUtils.createActionForServerAt(
                 admin, ActionFactory.TYPE_ERRATA, sapServer, "2020-04-27T08:15:00+02:00"); //stay
-        Action sapAction3 = MaintenanceTestUtils.createActionForServerAt(
-                admin, ActionFactory.TYPE_ERRATA, sapServer, "2020-04-30T09:15:00+02:00"); //wrong window (Core)
         Action coreAction1 = MaintenanceTestUtils.createActionForServerAt(
                 admin, ActionFactory.TYPE_ERRATA, coreServer, "2020-04-30T09:15:00+02:00"); //stay
         Action coreActionEx = MaintenanceTestUtils.createActionForServerAt(
                 admin, ActionFactory.TYPE_VIRTUALIZATION_START, coreServer, "2020-05-21T09:15:00+02:00"); //moved
         Action coreAction2 = MaintenanceTestUtils.createActionForServerAt(
                 admin, ActionFactory.TYPE_ERRATA, coreServer, "2020-05-21T09:15:00+02:00"); //moved
-        Action coreAction3 = MaintenanceTestUtils.createActionForServerAt(
-                admin, ActionFactory.TYPE_ERRATA, coreServer, "2020-04-27T08:15:00+02:00"); //wrong window (SAP)
 
         /* update the calendar */
         Map<String, String> details = new HashMap<>();

--- a/java/code/src/com/suse/manager/xmlrpc/maintenance/test/MaintenanceHandlerTest.java
+++ b/java/code/src/com/suse/manager/xmlrpc/maintenance/test/MaintenanceHandlerTest.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.xmlrpc.maintenance.test;
+
+import com.redhat.rhn.common.util.FileUtils;
+import com.redhat.rhn.domain.action.Action;
+import com.redhat.rhn.domain.action.ActionFactory;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.frontend.xmlrpc.test.BaseHandlerTestCase;
+import com.redhat.rhn.testing.ServerTestUtils;
+import com.redhat.rhn.testing.TestUtils;
+
+import com.suse.manager.maintenance.RescheduleResult;
+import com.suse.manager.maintenance.test.MaintenanceTestUtils;
+import com.suse.manager.model.maintenance.MaintenanceCalendar;
+import com.suse.manager.model.maintenance.MaintenanceSchedule;
+import com.suse.manager.xmlrpc.maintenance.MaintenanceHandler;
+import com.suse.manager.xmlrpc.serializer.RescheduleResultSerializer;
+
+import java.io.File;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import redstone.xmlrpc.XmlRpcSerializer;
+
+public class MaintenanceHandlerTest extends BaseHandlerTestCase {
+
+    private MaintenanceHandler handler = new MaintenanceHandler();
+    private static final String EXCHANGE_MULTI1_ICS = "maintenance-windows-multi-exchange-1.ics";
+    private static final String EXCHANGE_MULTI2_ICS = "maintenance-windows-multi-exchange-2.ics";
+    private static final String TESTDATAPATH = "/com/suse/manager/maintenance/test/testdata";
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    public void testMultiScheduleUpdate() throws Exception {
+        File icalExM1 = new File(TestUtils.findTestData(
+                new File(TESTDATAPATH,  EXCHANGE_MULTI1_ICS).getAbsolutePath()).getPath());
+        File icalExM2 = new File(TestUtils.findTestData(
+                new File(TESTDATAPATH,  EXCHANGE_MULTI2_ICS).getAbsolutePath()).getPath());
+
+        /* setup test environment */
+        Server sapServer = ServerTestUtils.createTestSystem(admin);
+        Server coreServer = ServerTestUtils.createTestSystem(admin);
+
+        MaintenanceCalendar mcal = handler.createCalendar(admin, "multicalendar", FileUtils.readStringFromFile(icalExM1.getAbsolutePath()));
+        MaintenanceSchedule sapSchedule = handler.createSchedule(admin, "SAP Maintenance Window", "multi", mcal.getLabel());
+        MaintenanceSchedule coreSchedule = handler.createSchedule(admin, "Core Server Window", "multi", mcal.getLabel());
+
+        handler.assignScheduleToSystems(admin, sapSchedule.getName(), Collections.singletonList(sapServer.getId().intValue()));
+        handler.assignScheduleToSystems(admin, coreSchedule.getName(), Collections.singletonList(coreServer.getId().intValue()));
+
+
+        Action sapAction1 = MaintenanceTestUtils.createActionForServerAt(
+                admin, ActionFactory.TYPE_ERRATA, sapServer, "2020-04-13T08:15:00+02:00"); //moved
+        Action sapActionEx = MaintenanceTestUtils.createActionForServerAt(
+                admin, ActionFactory.TYPE_VIRTUALIZATION_START, sapServer, "2020-04-13T08:15:00+02:00"); //moved
+        Action sapAction2 = MaintenanceTestUtils.createActionForServerAt(
+                admin, ActionFactory.TYPE_ERRATA, sapServer, "2020-04-27T08:15:00+02:00"); //stay
+        Action sapAction3 = MaintenanceTestUtils.createActionForServerAt(
+                admin, ActionFactory.TYPE_ERRATA, sapServer, "2020-04-30T09:15:00+02:00"); //wrong window (Core)
+        Action coreAction1 = MaintenanceTestUtils.createActionForServerAt(
+                admin, ActionFactory.TYPE_ERRATA, coreServer, "2020-04-30T09:15:00+02:00"); //stay
+        Action coreActionEx = MaintenanceTestUtils.createActionForServerAt(
+                admin, ActionFactory.TYPE_VIRTUALIZATION_START, coreServer, "2020-05-21T09:15:00+02:00"); //moved
+        Action coreAction2 = MaintenanceTestUtils.createActionForServerAt(
+                admin, ActionFactory.TYPE_ERRATA, coreServer, "2020-05-21T09:15:00+02:00"); //moved
+        Action coreAction3 = MaintenanceTestUtils.createActionForServerAt(
+                admin, ActionFactory.TYPE_ERRATA, coreServer, "2020-04-27T08:15:00+02:00"); //wrong window (SAP)
+
+        /* update the calendar */
+        Map<String, String> details = new HashMap<>();
+        details.put("ical", FileUtils.readStringFromFile(icalExM2.getAbsolutePath()));
+
+        List<String> rescheduleStrategy = new LinkedList<>();
+        rescheduleStrategy.add("Cancel");
+
+        List<RescheduleResult> result = handler.updateCalendar(admin, mcal.getLabel(), details, rescheduleStrategy);
+
+        /* check results */
+        List<Action> sapActionsAfter = ActionFactory.listActionsForServer(admin, sapServer);
+        List<Action> coreActionsAfter = ActionFactory.listActionsForServer(admin, coreServer);
+
+        assertEquals(2, sapActionsAfter.size());
+        assertEquals(2, coreActionsAfter.size());
+
+        assertEquals(1, sapActionsAfter.stream().filter(a -> a.equals(sapAction2)).count());
+        assertEquals(1, sapActionsAfter.stream().filter(a -> a.equals(sapActionEx)).count()); //Action not tied to maintenance mode
+
+        assertEquals(1, coreActionsAfter.stream().filter(a -> a.equals(coreAction1)).count());
+        assertEquals(1, coreActionsAfter.stream().filter(a -> a.equals(coreActionEx)).count()); //Action not tied to maintenance mode
+
+        for (RescheduleResult r : result) {
+            RescheduleResultSerializer serializer = new RescheduleResultSerializer();
+            Writer output = new StringWriter();
+            serializer.serialize(r, output, new XmlRpcSerializer());
+            String actual = output.toString();
+
+            if (r.getScheduleName().equals("SAP Maintenance Window")) {
+                assertContains(actual, "<i4>" + sapServer.getId() + "</i4>");
+                assertContains(actual, "<string>Patch Update</string>");
+            }
+            else if (r.getScheduleName().equals("Core Server Window")) {
+                assertContains(actual, "<i4>" + coreServer.getId() + "</i4>");
+                assertContains(actual, "<string>Patch Update</string>");
+            }
+            else {
+                assertTrue("Not expected result set", false);
+            }
+        }
+    }
+}

--- a/java/code/src/com/suse/manager/xmlrpc/serializer/RescheduleResultSerializer.java
+++ b/java/code/src/com/suse/manager/xmlrpc/serializer/RescheduleResultSerializer.java
@@ -85,7 +85,8 @@ public class RescheduleResultSerializer extends RhnXmlRpcCustomSerializer {
             if (action.getPrerequisite() != null) {
                 a.put("prerequisite", action.getPrerequisite().getId());
             }
-            a.put("affected_system_ids", result.getActionsServers().get(action).stream().collect(Collectors.toList()));
+            a.put("affected_system_ids", result.getActionsServers().get(action).stream()
+                    .map(s -> s.getId()).collect(Collectors.toList()));
             a.put("details", StringUtil.toPlainText(action.getFormatter().getNotes()));
             actions.add(a);
         }


### PR DESCRIPTION
## What does this PR change?

- extract `createActionForServerAt()` into an TestUtils class
- implement a XMLRPC Handler test which also test the serializer for RescheduleResults
- fix RescheduleResult system list to contain only systemids
- do not allow to change unique identifier for schedule and calendar
- handle download exceptions in a better way

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links
Fixes https://github.com/SUSE/spacewalk/issues/11274

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"  
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
