### PR TITLE
Manager bsc1171687 l3

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,6 @@
+- use defined return values for spacecmd methods so scripts can
+  check for failure (bsc#1171687)
+
 -------------------------------------------------------------------
 Mon Feb 17 12:39:00 CET 2020 - jgonzalez@suse.com
 

--- a/spacecmd/src/bin/spacecmd
+++ b/spacecmd/src/bin/spacecmd
@@ -193,7 +193,9 @@ if __name__ == '__main__':
             precmd = shell.precmd(command)
             if precmd == '':
                 sys.exit(1)
-            shell.print_result(shell.onecmd(precmd), precmd)
+            result = shell.print_result(shell.onecmd(precmd), precmd)
+            if result != 0:
+                sys.exit(result)
         except KeyboardInterrupt:
             print
             print('User Interrupt')

--- a/spacecmd/src/spacecmd/shell.py
+++ b/spacecmd/src/spacecmd/shell.py
@@ -232,7 +232,11 @@ class SpacewalkShell(Cmd):
                     for i in cmdresult:
                         print(i)
             except TypeError:
+                # catch methods returning undefined results at least in debug mode
+                logging.debug('Undefined return code from \"%s\"', cmd)
                 pass
+
+        return cmdresult
 
     # update the prompt with the SSM size
     # pylint: disable=arguments-differ

--- a/spacecmd/src/spacecmd/system.py
+++ b/spacecmd/src/spacecmd/system.py
@@ -1756,7 +1756,7 @@ def do_system_delete(self, args):
 
     if not system_ids:
         logging.warning('No systems to delete')
-        return
+        return 1
 
     # make the column the right size
     colsize = max_length([self.get_system_name(s) for s in system_ids])
@@ -1772,7 +1772,7 @@ def do_system_delete(self, args):
               (self.get_system_name(system_id).ljust(colsize), system_id))
 
     if not self.user_confirm('Delete these systems [y/N]:'):
-        return
+        return 1
 
     logging.debug("System IDs to remove: %s", system_ids)
     logging.debug("System names to IDs: %s", systems)
@@ -1792,6 +1792,7 @@ def do_system_delete(self, args):
     save_cache(self.ssm_cache_file, self.ssm)
     logging.debug("SSM cache saved")
 
+    return 0
 
 ####################
 


### PR DESCRIPTION
What does this PR change?

Methods in the spacecmd shell are supposed to return meaningful result codes. This is currently not the case, so when using it in a script for single commands, also failed commands will report success by always implicitly returning 0. This is fixed with this PR for the most relevant methods.

There are still some more which will require the same fixing, but it will affect almost every method, so I wanted to fix the most urgent and frequent ones (there is a pending L3) and want to get some feedback.
GUI diff

No difference.

    DONE

Documentation

    No documentation needed: Bugfix

    DONE

Test coverage

    No tests:

    DONE

Links

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1171687

    DONE

Changelogs

If you don't need a changelog check, please mark this checkbox:

    No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run changelog_test (see below)
Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

Re-run test "changelog_test"
Re-run test "backend_unittests_pgsql"
Re-run test "java_lint_checkstyle"
Re-run test "java_pgsql_tests"
Re-run test "ruby_rubocop"
Re-run test "schema_migration_test_oracle"
Re-run test "schema_migration_test_pgsql"
Re-run test "susemanager_unittests"
Re-run test "javascript_lint"
Re-run test "spacecmd_unittests"