### PR TITLE
Testsuite - misleading name changed to ubuntu ssh minion

### DIFF
--- a/testsuite/features/secondary/min_ubuntu_salt_install_package.feature
+++ b/testsuite/features/secondary/min_ubuntu_salt_install_package.feature
@@ -1,10 +1,10 @@
 # Copyright (c) 2019-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-Feature: Install and upgrade package on the Ubuntu minion via Salt through the UI
+Feature: Install and upgrade package on the Ubuntu SSH minion via Salt through the UI
 
 @ubuntu_minion
-  Scenario: Pre-requisite: install virgo-dummy-1.0 package on Ubuntu minion
+  Scenario: Pre-requisite: install virgo-dummy-1.0 package on Ubuntu SSH minion
     When I enable repository "test_repo_deb_pool" on this "ubuntu_ssh_minion"
     And I run "apt update" on "ubuntu_ssh_minion" with logging
     And I remove package "andromeda-dummy" from this "ubuntu_ssh_minion"
@@ -18,7 +18,7 @@ Feature: Install and upgrade package on the Ubuntu minion via Salt through the U
     And I wait until package "andromeda-dummy" is removed from "ubuntu_ssh_minion" via spacecmd
 
 @ubuntu_minion
-  Scenario: Install a package on the minion
+  Scenario: Install a package on the Ubuntu SSH minion
     Given I am on the Systems overview page of this "ubuntu_ssh_minion"
     And I follow "Software" in the content area
     And I follow "Install"
@@ -30,7 +30,7 @@ Feature: Install and upgrade package on the Ubuntu minion via Salt through the U
     Then Deb package "andromeda-dummy" with version "2.0" should be installed on "ubuntu_ssh_minion"
 
 @ubuntu_minion
-  Scenario: Update a package on the minion
+  Scenario: Update a package on the Ubuntu SSH minion
     Given I am on the Systems overview page of this "ubuntu_ssh_minion"
     And I follow "Software" in the content area
     And I follow "Upgrade" in the content area
@@ -42,7 +42,7 @@ Feature: Install and upgrade package on the Ubuntu minion via Salt through the U
     Then Deb package "virgo-dummy" with version "2.0" should be installed on "ubuntu_ssh_minion"
 
 @ubuntu_minion
-  Scenario: Cleanup: remove virgo-dummy and andromeda-dummy packages from Ubuntu minion
+  Scenario: Cleanup: remove virgo-dummy and andromeda-dummy packages from Ubuntu SSH minion
     Given I am authorized as "admin" with password "admin"
     And I remove package "andromeda-dummy" from this "ubuntu_ssh_minion"
     And I remove package "virgo-dummy" from this "ubuntu_ssh_minion"


### PR DESCRIPTION
## What does this PR change?

This PR changes incorrect name of feature and scenarios, because Ubuntu SSH minion, not Ubuntu minion is used here.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
