### PR TITLE
copy logfiles from all nodes to the controller

### DIFF
--- a/testsuite/features/finishing/srv_susemanager_debug.feature
+++ b/testsuite/features/finishing/srv_susemanager_debug.feature
@@ -14,3 +14,27 @@ Feature: Debug SUSE Manager after the testsuite has run
 
   Scenario: Check salt event log for failures on server
     Then the salt event log on server should contain no failures
+
+@sle_client
+  Scenario: Get client logs
+    Then I get logfiles from "sle_client"
+
+@sle_minion
+  Scenario: Get client logs
+    Then I get logfiles from "sle_minion"
+
+@centos_minion
+  Scenario: Get client logs
+    Then I get logfiles from "ceos_minion"
+
+@ubuntu_minion
+  Scenario: Get client logs
+    Then I get logfiles from "ubuntu_minion"
+
+@ssh_minion
+  Scenario: Get client logs
+    Then I get logfiles from "ssh_minion"
+
+@proxy
+  Scenario: Get client logs
+    Then I get logfiles from "proxy"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -308,6 +308,15 @@ Then(/^I execute spacewalk-debug on the server$/) do
   end
 end
 
+Then(/^I get logfiles from "([^"]*)"$/) do |target|
+  `mkdir logs` unless Dir.exists?('logs')
+  node = get_target(target)
+  _out, code = node.run("tar cfvJ /tmp/#{target}-logs.tar.xz /var/log/")
+  raise 'Generate log archive failed' unless code.zero?
+  return_code = file_extract(node, "/tmp/#{target}-logs.tar.xz", 'logs/')
+  raise 'File extraction failed' unless return_code.zero?
+end
+
 Then(/^the susemanager repo file should exist on the "([^"]*)"$/) do |host|
   step %(file "/etc/zypp/repos.d/susemanager\:channels.repo" should exist on "#{host}")
 end

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -309,8 +309,9 @@ Then(/^I execute spacewalk-debug on the server$/) do
 end
 
 Then(/^I get logfiles from "([^"]*)"$/) do |target|
-  `mkdir logs` unless Dir.exists?('logs')
+  `mkdir logs` unless Dir.exist?('logs')
   node = get_target(target)
+  _out, code = node.run("journalctl > /var/log/messages")
   _out, code = node.run("tar cfvJ /tmp/#{target}-logs.tar.xz /var/log/")
   raise 'Generate log archive failed' unless code.zero?
   return_code = file_extract(node, "/tmp/#{target}-logs.tar.xz", 'logs/')

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -314,8 +314,9 @@ Then(/^I get logfiles from "([^"]*)"$/) do |target|
   _out, code = node.run("journalctl > /var/log/messages")
   _out, code = node.run("tar cfvJ /tmp/#{target}-logs.tar.xz /var/log/")
   raise 'Generate log archive failed' unless code.zero?
-  return_code = file_extract(node, "/tmp/#{target}-logs.tar.xz", 'logs/')
-  raise 'File extraction failed' unless return_code.zero?
+  cmd = "echo | scp -o StrictHostKeyChecking=no root@#{node.ip}:/tmp/#{target}-logs.tar.xz ./logs/ 2>&1"
+  command_output = `#{cmd}`
+  raise "Download logfiles failed: #{command_output}" unless $CHILD_STATUS.success?
 end
 
 Then(/^the susemanager repo file should exist on the "([^"]*)"$/) do |host|


### PR DESCRIPTION
## What does this PR change?

Copy all logfiles from involved nodes to the controller. terracumber will be enhanced to store
them in the result directory. This makes debugging easier.

Port of https://github.com/SUSE/spacewalk/pull/11529

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
