### PR TITLE
Prevent failure when syncing from RHEL CDN due extra params (bsc#1171885)

### DIFF
--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -570,7 +570,7 @@ class ContentSource:
         self.zypposync = ZyppoSync(root=repo.root)
         zypp_repo_url = self._prep_zypp_repo_url(self.url)
 
-        mirrorlist = self._get_mirror_list(repo, zypp_repo_url)
+        mirrorlist = self._get_mirror_list(repo, self.url)
         if mirrorlist:
             repo.baseurl = mirrorlist
         repo.urls = repo.baseurl

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- Prevent failure when syncing from RHEL CDN due extra params (bsc#1171885)
+
 -------------------------------------------------------------------
 Wed May 20 10:53:18 CEST 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue at `spacewalk-repo-sync` when fetching a possible mirror list from the repository URL to sync.

Before this PR, the HTTP request done by `urlgrabber` to check for the mirrorlist was using a URL that was tailored to be used only from Zypper (contains extra URL params):

> GET /content/dist/rhel/server/7/7sever/x86_64/os/?proxy=http://xxxxxxxxxx:8080&ssl_capath=/var/cache/rhn/reposync/.ssl-certs/1&ssl_clientcert=/var/cache/rhn/reposync/.ssl-certs/1/xxxx.pem&ssl_clientkey=/var/cache/rhn/reposync/.ssl-certs/1/key-xxxx.pem HTTP/1.1

Those extra URL params are only meant to be used by Zypper (which gets rid of them before making the actual HTTP requests).

For `urlgrabber`, the certificates/proxies information is set in a different way and those URL params are pass to the actual HTTP request. This causes problems when interacting with the RHEL CDN.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **backend changes**

- [x] **DONE**

## Test coverage
- No tests: **no tests**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/11522

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle" (Test skipped, there are no changes to test)
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
