### PR TITLE
handle centos urls that contain repo target in query string (bsc#1171996)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
@@ -1317,16 +1317,21 @@ public class ChannelFactory extends HibernateFactory {
      * @return vendor content source if it exists
      */
     public static ContentSource findVendorContentSourceByRepo(String repoUrl) {
-        String [] parts = repoUrl.split("\\?");
-        String repoUrlPrefix = parts[0];
         Criteria criteria = getSession().createCriteria(ContentSource.class);
         criteria.add(Restrictions.isNull("org"));
-        if (parts.length > 1) {
-            criteria.add(Restrictions.like("sourceUrl", repoUrlPrefix + '?',
-                MatchMode.START));
+        if (repoUrl.contains("mirrorlist.centos.org")) {
+            criteria.add(Restrictions.eq("sourceUrl", repoUrl));
         }
         else {
-            criteria.add(Restrictions.eq("sourceUrl", repoUrlPrefix));
+            String [] parts = repoUrl.split("\\?");
+            String repoUrlPrefix = parts[0];
+            if (parts.length > 1) {
+                criteria.add(Restrictions.like("sourceUrl", repoUrlPrefix + '?',
+                        MatchMode.START));
+            }
+            else {
+                criteria.add(Restrictions.eq("sourceUrl", repoUrlPrefix));
+            }
         }
         return (ContentSource) criteria.uniqueResult();
     }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+handle centos urls that contain repo target in query string (bsc#1171996)
+
 -------------------------------------------------------------------
 Wed May 20 10:55:24 CEST 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This handles centos urls by not cutting of the query string which is what determines the repository.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11547
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
