### PR TITLE
Add bootstrapping for Oracle Linux 6, 7 and 8

### DIFF
--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -374,6 +374,9 @@ if [ "$INSTALLER" == yum ]; then
         if [ -L /usr/share/doc/sles_es-release ]; then
             BASE="res"
             VERSION=6
+        elif [ -f /etc/oracle-release ]; then
+            grep -v '^#' /etc/oracle-release | grep -q '\(Oracle\)' && BASE="oracle"
+            VERSION=`grep -v '^#' /etc/oracle-release | grep -Po '(?<=release )\d+'`
         elif [ -f /etc/centos-release ]; then
             grep -v '^#' /etc/centos-release | grep -q '\(CentOS\)' && BASE="centos"
             VERSION=`grep -v '^#' /etc/centos-release | grep -Po '(?<=release )\d+'`

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,5 @@
+- Enable bootstrapp scripts for Oracle Linux 6, 7 and 8
+
 -------------------------------------------------------------------
 Wed May 20 10:54:23 CEST 2020 - jgonzalez@suse.com
 

--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -27,11 +27,13 @@ mgr_server_localhost_alias_absent:
 {% set bootstrap_repo_url = 'https://' ~ salt['pillar.get']('mgr_server') ~ '/pub/repositories/' ~ os_base ~ '/' ~ grains['osrelease'] ~ '/0/bootstrap/' %}
 {%- endif %}
 {%- elif grains['os_family'] == 'RedHat' %}
-{% if salt['file.file_exists' ]('/etc/redhat-release') %}
+{%- if salt['file.file_exists' ]('/etc/oracle-release') %}
+{% set bootstrap_repo_url = 'https://' ~ salt['pillar.get']('mgr_server') ~ '/pub/repositories/oracle/' ~ grains['osmajorrelease'] ~ '/bootstrap/' %}
+{%- elif salt['file.file_exists' ]('/etc/redhat-release') %}
 {% set bootstrap_repo_url = 'https://' ~ salt['pillar.get']('mgr_server') ~ '/pub/repositories/res/' ~ grains['osmajorrelease'] ~ '/bootstrap/' %}
 {%- else %}
 {% set bootstrap_repo_url = 'https://' ~ salt['pillar.get']('mgr_server') ~ '/pub/repositories/' ~ os_base ~ '/' ~ grains['osmajorrelease'] ~ '/bootstrap/' %}
-{% endif %}
+{%- endif %}
 {%- elif grains['os_family'] == 'Debian' %}
 {%- set osrelease = grains['osrelease'].split('.') %}
 {%- if grains['os'] == 'Ubuntu' %}

--- a/susemanager-utils/susemanager-sls/salt/certs/OEL6.sls
+++ b/susemanager-utils/susemanager-sls/salt/certs/OEL6.sls
@@ -1,0 +1,1 @@
+RedHat6.sls

--- a/susemanager-utils/susemanager-sls/salt/certs/OEL7.sls
+++ b/susemanager-utils/susemanager-sls/salt/certs/OEL7.sls
@@ -1,0 +1,1 @@
+RedHat7.sls

--- a/susemanager-utils/susemanager-sls/salt/certs/OEL8.sls
+++ b/susemanager-utils/susemanager-sls/salt/certs/OEL8.sls
@@ -1,0 +1,1 @@
+RedHat7.sls

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Enable bootstrapping for Oracle Linux 6, 7 and 8
 - Set YAML loader to fix deprecation warnings
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Add bootstrapping for Oracle Linux 6, 7 and 8

### Tested bootstrap from

* Oracle6: script (traditional), script (salt), 
* Oracle7: script (traditional),  script (salt-minion )WebUI (salt-minion),  WebUI (salt-ssh)
* Oracle8: script (salt-minon), webUI (salt-minion), WebUI (salt-ssh)

### Failing
Oracle6:  WebUI (salt-ssh), WebUI (salt-minion), so far only on minimal installations (**WORKS** if using "Basic Server" profile.
* scp doesn't come preinstalled, so salt-ssh just doesn't work, so neither of the bootstraps work
* If you install scp
  * salt-ssh fails because there's no machine-id (for salt-minions it gets created when the salt-minion package is installed)
  * salt-minion fails because Perl and Perl-Getopts are not available.

I will run a quick test tomorrow with "Basic Server" profile.

**NOTE:** Oracle6 salt from script showed:
```
ERROR: Dynamic CA-Trust > Updates are disabled. Enable Dynamic CA-Trust Updates with '/usr/bin/update-ca-trust force-enable'
Finally, restart the onboarding sequence.
```
And it seems the packages for traditional stack got updated as well... as they come preinstalled and the bootstrap script has a function to upload `*rhnlib*` and dependencies. I wonder if that's correct, but anyway this is nothing that's not happening for RES.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Doc ready.

- [x] **DONE**

## Test coverage
- No tests: Not covered by the testsuite for now.

- [x] **DONE**

## Links

Pending:

Fixes https://github.com/SUSE/spacewalk/issues/11549

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
