### PR TITLE
Reenable repositories for build host

### DIFF
--- a/testsuite/features/init_clients/sle_buildhost.feature
+++ b/testsuite/features/init_clients/sle_buildhost.feature
@@ -79,9 +79,11 @@ Feature: Be able to bootstrap a Salt build host via the GUI
   Scenario: Apply the highstate to the build host
     Given I am on the Systems overview page of this "build_host"
     When I wait until no Salt job is running on "build_host"
+    And I enable repositories before installing Docker
     And I apply highstate on "build_host"
     And I wait until "docker" service is active on "build_host"
     And I wait until file "/var/lib/Kiwi/repo/rhn-org-trusted-ssl-cert-osimage-1.0-1.noarch.rpm" exists on "build_host"
+    And I disable repositories after installing Docker
 
 @buildhost
   Scenario: Check that the build host is now a build host

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -705,6 +705,62 @@ When(/^I enable SUSE Manager tools repositories on "([^"]*)"$/) do |host|
   end
 end
 
+When(/^I enable repositories before installing Docker$/) do
+  os_version, os_family = get_os_version($build_host)
+
+  # Distribution
+  repos = "os_pool_repo os_update_repo"
+  puts $build_host.run("zypper mr --enable #{repos}")
+
+  # Tools
+  repos, _code = $build_host.run('zypper lr | grep "tools" | cut -d"|" -f2')
+  puts $build_host.run("zypper mr --enable #{repos.gsub(/\s/, ' ')}")
+
+  # Development
+  # (we do not install Python 2 repositories in this branch
+  #  because they are not needed anymore starting with version 4.1)
+  if os_family =~ /^sles/ && os_version =~ /^15/
+    repos = "devel_pool_repo devel_updates_repo"
+    puts $build_host.run("zypper mr --enable #{repos}")
+  end
+
+  # Containers
+  unless os_family =~ /^opensuse/ || os_version =~ /^11/
+    repos = "containers_pool_repo containers_updates_repo"
+    puts $build_host.run("zypper mr --enable #{repos}")
+  end
+
+  $build_host.run('zypper -n --gpg-auto-import-keys ref')
+end
+
+When(/^I disable repositories after installing Docker$/) do
+  os_version, os_family = get_os_version($build_host)
+
+  # Distribution
+  repos = "os_pool_repo os_update_repo"
+  puts $build_host.run("zypper mr --disable #{repos}")
+
+  # Tools
+  repos, _code = $build_host.run('zypper lr | grep "tools" | cut -d"|" -f2')
+  puts $build_host.run("zypper mr --disable #{repos.gsub(/\s/, ' ')}")
+
+  # Development
+  # (we do not install Python 2 repositories in this branch
+  #  because they are not needed anymore starting with version 4.1)
+  if os_family =~ /^sles/ && os_version =~ /^15/
+    repos = "devel_pool_repo devel_updates_repo"
+    puts $build_host.run("zypper mr --disable #{repos}")
+  end
+
+  # Containers
+  unless os_family =~ /^opensuse/ || os_version =~ /^11/
+    repos = "containers_pool_repo containers_updates_repo"
+    puts $build_host.run("zypper mr --disable #{repos}")
+  end
+
+  $build_host.run('zypper -n --gpg-auto-import-keys ref')
+end
+
 When(/^I enable repositories before installing branch server$/) do
   os_version, os_family = get_os_version($proxy)
 


### PR DESCRIPTION
## What does this PR change?
Testsuite: Reenable deleted steps before/after installing Docker

- testsuite/features/init_clients/sle_buildhost.feature:
Enable repos. before installing Docker, and disable them afterward.

- testsuite/features/step_definitions/common_steps.rb:
Reinclude steps to enable/disable Docker repos.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

