### PR TITLE
Can't refresh with no enabled repositories

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -757,8 +757,6 @@ When(/^I disable repositories after installing Docker$/) do
     repos = "containers_pool_repo containers_updates_repo"
     puts $build_host.run("zypper mr --disable #{repos}")
   end
-
-  $build_host.run('zypper -n --gpg-auto-import-keys ref')
 end
 
 When(/^I enable repositories before installing branch server$/) do


### PR DESCRIPTION
## What does this PR change?

The `zypper ref` we used to do after disabling docker repos does not work because we have no test repositories on the build host.

This PR removes it. It's useless anyway.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
