### PR TITLE
Fix repo gpgcheck for redhat

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/channels/channels.repo
+++ b/susemanager-utils/susemanager-sls/salt/channels/channels.repo
@@ -15,16 +15,18 @@ autorefresh={{ args['autorefresh'] }}
 {%- if grains['os_family'] == 'RedHat' %}
 baseurl={{protocol}}://{{hostname}}:{{port}}/rhn/manager/download/{{ chan }}
 susemanager_token={{ args['token'] }}
+gpgcheck={{ 1 if args['gpgcheck'] == "1" or args['pkg_gpgcheck'] != "0" else 0 }}
+repo_gpgcheck={{ args['gpgcheck'] }}
 {%- if grains['osmajorrelease'] >= 8 and args['cloned_nonmodular'] %}
 module_hotfixes=1
 {%- endif %}
 {%- else %}
 baseurl={{protocol}}://{{hostname}}:{{port}}/rhn/manager/download/{{ chan }}?{{ args['token'] }}
-{%- endif %}
-type={{ args['type'] }}
 gpgcheck={{ args['gpgcheck'] }}
 repo_gpgcheck={{ args['repo_gpgcheck'] }}
 pkg_gpgcheck={{ args['pkg_gpgcheck'] }}
+{%- endif %}
+type={{ args['type'] }}
 {%- endif %}
 
 {% endfor %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- handle GPG check flags different for yum/dnf (bsc#1171859)
 - Enable bootstrapping for Oracle Linux 6, 7 and 8
 - Set YAML loader to fix deprecation warnings
 


### PR DESCRIPTION
## What does this PR change?

- yum/dnf support repo_gpgcheck option but not pkg_gpgcheck option
- In yum/dnf these options are boolean not tristate field like in zypp
- Uyuni set gpgcheck to 0 but pkg_gpgcheck to 1. With yum this should result
into a "1".
- When metadata signing is enabled, gpgcheck and repo_gpgcheck should be 1
which is the value of gpgcheck in this case

Port of https://github.com/SUSE/spacewalk/pull/11553

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11545
Fixes https://github.com/uyuni-project/uyuni/issues/2156

See also https://github.com/uyuni-project/uyuni/pull/2219 
Obsolets https://github.com/uyuni-project/uyuni/pull/2236

Tracks https://github.com/SUSE/spacewalk/pull/11553

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
