### PR TITLE
WIP - Wait for real that we change to client details page

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -329,13 +329,13 @@ Given(/^I am on the SUSE Products page$/) do
   )
 end
 
-# access the multi-clients/minions
+# access the clients
 Given(/^I am on the Systems overview page of this "([^"]*)"$/) do |host|
   system_name = get_system_name(host)
   steps %(
     Given I am on the Systems page
     When I follow "#{system_name}"
-    And I wait until I see "#{system_name}" text
+    And I wait until I see "System Status" text
   )
 end
 


### PR DESCRIPTION
## What does this PR change?

Before this PR:
* From systems list page, we follow link to e.g. `minion.example.com`
* and we wait until we see `minion.example.com`

The problem is that the name of the minion is on both the old page (the systems list) and the new page (the minion's details). So the "wait" operation might return immediately...

After this PR: 
* From systems list page, we follow link to e.g. `minion.example.com`
* and we wait until we see fixed text `Subscribed Channels`

## Links

Ports:
* 4.0: SUSE/spacewalk#11571
* 3.2: SUSE/spacewalk#11570

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
