### PR TITLE
Testsuite: fix URL in README

### DIFF
--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -11,7 +11,7 @@ Apart from Cucumber, the testsuite relies on a number of [software components](d
 
 # Running the testsuite
 
-You can run the SUSE Manager testsuite [with sumaform](https://github.com/uyuni-project/sumaform/blob/master/README_ADVANCED.md#cucumber-testsuite).
+You can run the SUSE Manager testsuite [with sumaform](https://github.com/uyuni-project/sumaform/blob/master/README_TESTING.md#running-the-testsuite).
 
 If you want to run the testsuite for [Uyuni](https://www.uyuni-project.org), nothing special needs to be done. The testuite will autodetect it.
 


### PR DESCRIPTION
## What does this PR change?

Fixes an URL in the testsuite readme file

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **readme**

- [x] **DONE**

## Test coverage
- No tests: **readme**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
