### PR TITLE
Fix Ubuntu package key computation

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/InstalledPackage.java
+++ b/java/code/src/com/redhat/rhn/domain/server/InstalledPackage.java
@@ -21,9 +21,11 @@ import com.redhat.rhn.domain.rhnpackage.PackageName;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.io.Serializable;
 import java.util.Date;
+import java.util.Optional;
 
 /**
  *
@@ -190,5 +192,15 @@ public class InstalledPackage implements Serializable, Comparable<InstalledPacka
             return -1;
         }
         return 0;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+            .append("name", Optional.of(name).map(PackageName::getName).orElse(null))
+            .append("evr", evr)
+            .append("archLabel", Optional.of(arch).map(PackageArch::getLabel).orElse(null))
+            .append("serverId", Optional.of(server).map(Server::getId).orElse(null))
+            .toString();
     }
 }

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -62,6 +62,7 @@ import com.redhat.rhn.domain.notification.UserNotificationFactory;
 import com.redhat.rhn.domain.notification.types.StateApplyFailed;
 import com.redhat.rhn.domain.product.SUSEProduct;
 import com.redhat.rhn.domain.product.SUSEProductFactory;
+import com.redhat.rhn.domain.rhnpackage.PackageArch;
 import com.redhat.rhn.domain.rhnpackage.PackageEvr;
 import com.redhat.rhn.domain.rhnpackage.PackageEvrFactory;
 import com.redhat.rhn.domain.rhnpackage.PackageFactory;
@@ -1336,9 +1337,9 @@ public class SaltUtils {
         // see schema/spacewalk/common/tables/rhnServerPackage.sql
         sb.append(p.getName().getName());
         sb.append("-");
-        sb.append(p.getEvr().toString());
+        sb.append(p.getEvr().toUniversalEvrString());
         sb.append(".");
-        sb.append(Optional.ofNullable(p.getArch()).map(a -> a.getName()).orElse("unknown"));
+        sb.append(Optional.ofNullable(p.getArch()).map(PackageArch::toUniversalArchString).orElse("unknown"));
 
         return sb.toString();
     }
@@ -1361,8 +1362,8 @@ public class SaltUtils {
                 new PackageEvr(
                         info.getEpoch().orElse(null),
                         info.getVersion().get(),
-                        info.getRelease().orElse("0")
-                ).toString()
+                        info.getRelease().orElse("X")
+                ).toUniversalEvrString()
         );
         sb.append(".");
         sb.append(info.getArchitecture().get());

--- a/java/code/src/com/suse/manager/utils/test/SaltUtilsTest.java
+++ b/java/code/src/com/suse/manager/utils/test/SaltUtilsTest.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.utils.test;
+
+import com.redhat.rhn.domain.rhnpackage.PackageArch;
+import com.redhat.rhn.domain.rhnpackage.PackageEvr;
+import com.redhat.rhn.domain.rhnpackage.PackageName;
+import com.redhat.rhn.domain.server.InstalledPackage;
+
+import com.google.gson.reflect.TypeToken;
+import com.suse.manager.utils.SaltUtils;
+import com.suse.salt.netapi.calls.modules.Pkg;
+import com.suse.utils.Json;
+
+import junit.framework.TestCase;
+
+public class SaltUtilsTest extends TestCase {
+
+    public void testPackageToKey() throws Exception {
+        // atom package, openSUSE style, from database
+        var atomName = new PackageName();
+        atomName.setName("atom");
+
+        var atomEvr = new PackageEvr(null, "1.42.0", "0.1");
+
+        var x86Arch = new PackageArch();
+        x86Arch.setName("x86_64");
+        x86Arch.setLabel("x86_64");
+
+        var atomIp = new InstalledPackage();
+        atomIp.setName(atomName);
+        atomIp.setEvr(atomEvr);
+        atomIp.setArch(x86Arch);
+        assertEquals("atom-1.42.0-0.1.x86_64", SaltUtils.packageToKey(atomIp));
+
+        // atom package, openSUSE style, from Salt
+        var atomJson = "{" +
+            "\"install_date_time_t\": 1498636553," +
+            "\"version\": \"1.42.0\"," +
+            "\"release\": \"0.1\"," +
+            "\"arch\": \"x86_64\"" +
+        "}";
+        Pkg.Info atomInfo = Json.GSON.fromJson(atomJson, new TypeToken<Pkg.Info>(){}.getType());
+        assertEquals("atom-1.42.0-0.1.x86_64", SaltUtils.packageToKey("atom", atomInfo));
+
+
+        // initramfs-tools package, Debian style, from database
+        var initramfsToolsName = new PackageName();
+        initramfsToolsName.setName("initramfs-tools");
+
+        var initramfsToolsEvr = new PackageEvr(null, "0.130ubuntu3.8", "X");
+
+        var allDebArch = new PackageArch();
+        allDebArch.setName("all-deb");
+        allDebArch.setLabel("all-deb");
+
+        var initramfsToolsIp = new InstalledPackage();
+        initramfsToolsIp.setName(initramfsToolsName);
+        initramfsToolsIp.setEvr(initramfsToolsEvr);
+        initramfsToolsIp.setArch(allDebArch);
+        assertEquals("initramfs-tools-0.130ubuntu3.8.all", SaltUtils.packageToKey(initramfsToolsIp));
+
+        // initramfs-tools package, Debian style, from Salt
+        var initramfsToolsJson = "{" +
+            "\"install_date_time_t\": 1498636553," +
+            "\"version\": \"0.130ubuntu3.8\"," +
+            "\"arch\": \"all\"" +
+        "}";
+        Pkg.Info initramfsToolsInfo = Json.GSON.fromJson(initramfsToolsJson, new TypeToken<Pkg.Info>(){}.getType());
+        assertEquals("initramfs-tools-0.130ubuntu3.8.all", SaltUtils.packageToKey("initramfs-tools", initramfsToolsInfo));
+    }
+}


### PR DESCRIPTION
## What does this PR change?

It fixes `packageToKey` functions for deb-based clients (tested on Ubuntu).

### Background
`packageToKey` functions map either:
 - a package information description coming from Salt to a key, or
 - a package information description coming from the database to a key

In this context, "keys" are unique strings comprising a package name, version, architecture, release and epoch.

Such "keys" are useful because they are the same for the same package independently if its description comes from the database or from Salt.

In fact they are used in `SaltUtil.updatePackages` in order to minimize the `DELETE` and `INSERT` statements when mass-updating minion package information in the database with new data coming from Salt.

### Problem

Previous implementation did not fully take into account differences in the handling of release and architecture when it comes to deb packages. Thereby the same packages would return different strings depending on where they came from, eg.

|  Key from database                             |  Key from Salt                             |
|------------------------------------------------|--------------------------------------------|
| initramfs-tools-0.130ubuntu3.8-X.all-deb       | initramfs-tools-0.130ubuntu3.8-0.all       |
| initramfs-tools-bin-0.130ubuntu3.8-X.AMD64-deb | initramfs-tools-bin-0.130ubuntu3.8-0.amd64 |
| initramfs-tools-core-0.130ubuntu3.8-X.all-deb  | initramfs-tools-core-0.130ubuntu3.8-0.all  |

### Syptoms

Theoretically, the issue could result in `SaltUtils.updatePackages` having worse performance, as it would always completely replace the whole package list even when that was not really needed - this was not measured though, and it is believed not to be major in most use cases.

What did break in a visible way was the `secondary/min_ubuntu_salt_install_package.feature` testsuite feature when combined with PR #2201, which includes a speedup change avoiding some `flush` operations in places believed to be safe.

### Testsuite breakage root cause

In this particular case, omitting the `flush` as per PR #2201 was in principle safe but actually revealed the bug fixed by this PR, because in principle the following code may fail:

```java
Set<InstalledPackage> packages = server.getPackages(); // note: `packages` is a Hibernate-backed Collection!!!
// other code
packages.retainAll(somePackages);
// yet other code, but without any flush()
packages.addAll(someOtherPackages);
session.flush();
```

Failure will happen at `flush` time if there is an intersection between `somePackages` and `someOtherPackages`, ie. if a given row is both `DELETE`d and `INSERT`ed in the context of the same Session, and before a `flush`. That results in an `EntityExistsException` and stack trace would look like the following:

```
2020-05-26 22:36:11,863 [DefaultQuartzScheduler_Worker-7] ERROR com.redhat.rhn.taskomatic.task.MinionActionExecutor - Stack trace:javax.persistence.EntityExistsException: A different object with the same identifier value w
as already associated with the session : [com.redhat.rhn.domain.server.InstalledPackage#com.redhat.rhn.domain.server.InstalledPackage@a830a82]
        at org.hibernate.internal.ExceptionConverterImpl.convert(ExceptionConverterImpl.java:123)
        at org.hibernate.internal.ExceptionConverterImpl.convert(ExceptionConverterImpl.java:181)
        at org.hibernate.internal.ExceptionConverterImpl.convert(ExceptionConverterImpl.java:188)
        at org.hibernate.internal.SessionImpl.doFlush(SessionImpl.java:1460)
        at org.hibernate.internal.SessionImpl.flush(SessionImpl.java:1440)
```

The scenario above happened exactly in `SaltUtils.updatePackages` after PR #2201, because before that PR an implicit `flush` would happen exactly between the `retainAll` and `addAll` methods. That `flush` is unnecessary and wasteful, but prevented the `EntityExistsException` because at no point we were `DELET`ing and then re-`INSERT`ing without flushing first.

### Fix

This PR fixes up `packageToKey` code in order to account for differences in deb packages, thereby preventing `SaltUtils.updatePackages` from needlessly `DELET`ing and re-`INSERT`ing the same rows, thus also preventing `EntityExistsException` even when optimizations introduced in #2201 are present.

A deeper discussion might be warranted around the ultimate need for those differences, but that is left for a separate discussion/PR.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No new tests: **fixes an existing Cucumber test**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
