### PR TITLE
Content Lifecycle Management: speedup (take 2)

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/CachedStatement.java
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/CachedStatement.java
@@ -46,6 +46,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import javax.persistence.FlushModeType;
 
 /**
  * A cached set of query/elaborator strings and the parameterMap hash maps.
@@ -908,7 +909,9 @@ public class CachedStatement implements Serializable {
      */
     private <T> T doWithStolenConnection(ReturningWork<T> work) throws HibernateException {
         Session session = HibernateFactory.getSession();
-        session.flush();
+        if (session.getFlushMode().equals(FlushModeType.AUTO)) {
+            session.flush();
+        }
         return session.doReturningWork(work);
     }
 

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Channel_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Channel_queries.xml
@@ -1200,4 +1200,11 @@ ORDER BY CC.modified DESC
         VALUES(:original_id, :channel_id)
     </query>
 </write-mode>
+
+<callable-mode name="analyze_channel_packages">
+    <query>
+    ANALYZE rhnChannelPackage
+    </query>
+</callable-mode>
+
 </datasource_modes>

--- a/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
@@ -1274,7 +1274,7 @@ public class ChannelFactory extends HibernateFactory {
      * @param eids List of eids to add mappings for
      * @param cid channel id we're cloning into
      */
-    public static void addClonedErrataToChannel(Set<Long> eids, Long cid) {
+    public static void addErrataToChannel(Set<Long> eids, Long cid) {
         WriteMode m = ModeFactory.getWriteMode("Channel_queries",
                 "add_cloned_erratum_to_channel");
         Map<String, Object> params = new HashMap<String, Object>();

--- a/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
@@ -1364,4 +1364,12 @@ public class ChannelFactory extends HibernateFactory {
     public static void save(ProductName productName) {
         singleton.saveObject(productName);
     }
+
+    /**
+     * Analyzes the rhnChannelPackage table, useful to update statistics after massive changes.
+     */
+    public static void analyzeChannelPackages() {
+        var m = ModeFactory.getCallableMode("Channel_queries", "analyze_channel_packages");
+        m.execute(new HashMap<>(), new HashMap<>());
+    }
 }

--- a/java/code/src/com/redhat/rhn/domain/errata/AbstractErrata.java
+++ b/java/code/src/com/redhat/rhn/domain/errata/AbstractErrata.java
@@ -624,16 +624,8 @@ public abstract class AbstractErrata extends BaseDomainHelper implements
     public void addNotification(Date dateIn) {
         ErrataManager.clearErrataNotifications(this);
         for (Channel chan : getChannels()) {
-            ErrataManager.addErrataNotification(this, chan, dateIn);
+            ErrataManager.addErrataNotification(id, chan.getId(), dateIn);
         }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public void addChannelNotification(Channel channelIn, Date dateIn) {
-        ErrataManager.clearErrataChannelNotifications(this, channelIn);
-        ErrataManager.addErrataNotification(this, channelIn, dateIn);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/errata/Errata.java
+++ b/java/code/src/com/redhat/rhn/domain/errata/Errata.java
@@ -396,14 +396,6 @@ public interface Errata {
     void addNotification(Date dateIn);
 
     /**
-     * Add a new notification for this errata
-     * in specified channel
-     * @param channelIn affected channel
-     * @param dateIn The notify date
-     */
-    void addChannelNotification(Channel channelIn, Date dateIn);
-
-    /**
      * List errata notifications that are queued
      * @return list of maps with channel_id and time
      */

--- a/java/code/src/com/redhat/rhn/domain/errata/ErrataFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/errata/ErrataFactory.java
@@ -280,7 +280,7 @@ public class ErrataFactory extends HibernateFactory {
                 errata = publish(errata);
             }
             errata.addChannel(chan);
-            errata.addChannelNotification(chan, new Date());
+            ErrataManager.replaceChannelNotifications(errata.getId(), chan.getId(), new Date());
 
             Set<Package> packagesToPush = new HashSet<Package>();
             DataResult<PackageOverview> packs;

--- a/java/code/src/com/redhat/rhn/domain/errata/impl/UnpublishedErrata.java
+++ b/java/code/src/com/redhat/rhn/domain/errata/impl/UnpublishedErrata.java
@@ -26,8 +26,7 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Errata - Class representation of the table rhnErrata.
- * @version $Rev: 51306 $
+ * Errata - Class representation of the table rhnErrataTmp.
  */
 public class UnpublishedErrata extends AbstractErrata {
 

--- a/java/code/src/com/redhat/rhn/frontend/events/test/CloneErrataActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/test/CloneErrataActionTest.java
@@ -84,7 +84,7 @@ public class CloneErrataActionTest extends BaseTestCaseWithUser {
 
         // run CloneErrataAction
         Collection<Long> errataIds = new LinkedList<Long>() { { add(errata.getId()); } };
-        CloneErrataEvent event = new CloneErrataEvent(cloned, errataIds, user);
+        CloneErrataEvent event = new CloneErrataEvent(cloned, errataIds, admin);
         new CloneErrataAction().execute(event);
 
         // new errata should be in cloned channel, new repository metadata

--- a/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
@@ -14,6 +14,10 @@
  */
 package com.redhat.rhn.manager.channel;
 
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+import static java.util.Optional.ofNullable;
+
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.db.datasource.CallableMode;
@@ -102,10 +106,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static java.util.Optional.empty;
-import static java.util.Optional.of;
-import static java.util.Optional.ofNullable;
 
 /**
  * ChannelManager
@@ -2930,5 +2930,13 @@ public class ChannelManager extends BaseManager {
             break;
         }
         return cType;
+    }
+
+    /**
+     * Analyzes the rhnChannelPackage table, useful to update statistics after massive changes.
+     */
+    public static void analyzeChannelPackages() {
+        var m = ModeFactory.getCallableMode("Channel_queries", "analyze_channel_packages");
+        m.execute(new HashMap<>(), new HashMap<>());
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -892,7 +892,7 @@ public class ContentManager {
         alignErrata(src, tgt, errataFilters, user);
 
         // a lot was inserted into rhnChannelPackage at this point. Make sure stats are up-to-date before continuing
-        ChannelManager.analyzeChannelPackages();
+        ChannelFactory.analyzeChannelPackages();
 
         // update the channel newest packages cache
         ChannelFactory.refreshNewestPackageCache(tgt, "java::alignPackages");

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -15,6 +15,23 @@
 
 package com.redhat.rhn.manager.contentmgmt;
 
+import static com.redhat.rhn.domain.contentmgmt.ContentProjectFactory.lookupClonesInProject;
+import static com.redhat.rhn.domain.contentmgmt.ProjectSource.State.ATTACHED;
+import static com.redhat.rhn.domain.contentmgmt.ProjectSource.State.BUILT;
+import static com.redhat.rhn.domain.contentmgmt.ProjectSource.State.DETACHED;
+import static com.redhat.rhn.domain.contentmgmt.ProjectSource.Type.SW_CHANNEL;
+import static com.redhat.rhn.domain.role.RoleFactory.ORG_ADMIN;
+import static com.redhat.rhn.manager.channel.CloneChannelCommand.CloneBehavior.EMPTY;
+import static com.suse.utils.Opt.stream;
+import static java.util.Collections.emptyList;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+import static java.util.Optional.ofNullable;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.partitioningBy;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.hibernate.LookupException;
 import com.redhat.rhn.common.messaging.MessageQueue;
@@ -32,12 +49,12 @@ import com.redhat.rhn.domain.contentmgmt.ContentProjectHistoryEntry;
 import com.redhat.rhn.domain.contentmgmt.EnvironmentTarget;
 import com.redhat.rhn.domain.contentmgmt.ErrataFilter;
 import com.redhat.rhn.domain.contentmgmt.FilterCriteria;
-import com.redhat.rhn.domain.contentmgmt.modulemd.ModulemdApi;
 import com.redhat.rhn.domain.contentmgmt.PackageFilter;
 import com.redhat.rhn.domain.contentmgmt.ProjectSource;
 import com.redhat.rhn.domain.contentmgmt.ProjectSource.Type;
 import com.redhat.rhn.domain.contentmgmt.SoftwareEnvironmentTarget;
 import com.redhat.rhn.domain.contentmgmt.SoftwareProjectSource;
+import com.redhat.rhn.domain.contentmgmt.modulemd.ModulemdApi;
 import com.redhat.rhn.domain.errata.Errata;
 import com.redhat.rhn.domain.rhnpackage.Package;
 import com.redhat.rhn.domain.user.User;
@@ -63,23 +80,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
-
-import static com.redhat.rhn.domain.contentmgmt.ContentProjectFactory.lookupClonesInProject;
-import static com.redhat.rhn.domain.contentmgmt.ProjectSource.State.ATTACHED;
-import static com.redhat.rhn.domain.contentmgmt.ProjectSource.State.BUILT;
-import static com.redhat.rhn.domain.contentmgmt.ProjectSource.State.DETACHED;
-import static com.redhat.rhn.domain.contentmgmt.ProjectSource.Type.SW_CHANNEL;
-import static com.redhat.rhn.domain.role.RoleFactory.ORG_ADMIN;
-import static com.redhat.rhn.manager.channel.CloneChannelCommand.CloneBehavior.EMPTY;
-import static com.suse.utils.Opt.stream;
-import static java.util.Collections.emptyList;
-import static java.util.Optional.empty;
-import static java.util.Optional.of;
-import static java.util.Optional.ofNullable;
-import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.partitioningBy;
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toSet;
 
 /**
  * Content Management functionality
@@ -890,6 +890,9 @@ public class ContentManager {
 
         // align errata and the cache (rhnServerNeededCache)
         alignErrata(src, tgt, errataFilters, user);
+
+        // a lot was inserted into rhnChannelPackage at this point. Make sure stats are up-to-date before continuing
+        ChannelManager.analyzeChannelPackages();
 
         // update the channel newest packages cache
         ChannelFactory.refreshNewestPackageCache(tgt, "java::alignPackages");

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- improve Content Lifecycle Management build and promotion performance (bsc#1159226)
 - fix info text about package installation on channel change (bsc#1171684)
 - Clarify the behavior of the checkbox system list, when it adds systems to ssm
 - Implement module picker controls for CLM AppStream filters


### PR DESCRIPTION
## What does this PR change?

This adds back #2201, given #2256 is expected to have fixed the failed cucumber tests.

One extra commit is a refactoring suggested by @chiaradiamarcelo 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **all internal changes**

- [x] **DONE**

## Test coverage
- see #2201

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/10361
Tracks https://github.com/SUSE/spacewalk/pull/11473

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
