### PR TITLE
Fix channel change message

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_bn_IN.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_bn_IN.xml
@@ -23653,7 +23653,7 @@ given channel.</source>
         <source>Changes to channel assignments on salt managed systems will take effect at next highstate application</source>
       </trans-unit>
       <trans-unit id="sdc.channels.info.change">
-        <source>When subscribing to a channel that contains a product, the product package will automatically be installed on traditionally registered systems or added to the package states on Salt managed systems.</source>
+        <source>When subscribing to a channel that contains a product, the product package will automatically be installed on traditionally registered systems. On salt managed systems please apply a highstate as soon as possible.</source>
       </trans-unit>
       <trans-unit id="channelOverview.jsp.tasks.modifyCreate.state">
         <source>Create configuration file</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_bn_IN.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_bn_IN.xml
@@ -5533,6 +5533,18 @@ organization. You may grant or remove the organization administrator role in the
           <context context-type="sourcefile">/rhn/systems/@@PRODUCT_NAME@@</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="systemlist.jsp.isproxy">
+        <source>Proxy</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/systems/Overview</context>
+          <context context-type="sourcefile">/rhn/systems/SystemList</context>
+          <context context-type="sourcefile">/rhn/systems/OutOfDate</context>
+          <context context-type="sourcefile">/rhn/systems/Unentitled</context>
+          <context context-type="sourcefile">/rhn/systems/Ungrouped</context>
+          <context context-type="sourcefile">/rhn/systems/Proxy</context>
+          <context context-type="sourcefile">/rhn/systems/@@PRODUCT_NAME@@</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="systemlist.jsp.up2date">
         <source>System is up to date</source>
         <target>সিস্টেম আপ-টু-ডেট অবস্থায় রয়েছে</target>
@@ -12715,6 +12727,12 @@ the &lt;strong&gt;@@ENTERPRISE_LINUX_NAME@@ System Administration Guide.&lt;/str
         </trans-unit>
         <trans-unit id="system.event.pending.canceled">
           <source>{0} system event(s) canceled.</source>
+        </trans-unit>
+        <trans-unit id="system.event.spmigration.notification">
+          <source>&lt;strong&gt;Reload&lt;/strong&gt; the page after the action completed successfully to schedule the full migration.</source>
+        </trans-unit>
+        <trans-unit id="system.event.spmigration.rescheduleDryRun">
+          <source>Run migration</source>
         </trans-unit>
       </group>
       <!-- System events legend -->
@@ -23735,6 +23753,9 @@ given channel.</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.error.update-salt-package-needed">
         <source>The installed &lt;strong&gt;Salt&lt;/strong&gt; package version on this system is out of date. Please update the package to the latest version before you start a Service Pack migration.</source>
+      </trans-unit>
+      <trans-unit id="spmigration.jsp.error.missing-successor-extensions">
+        <source>There is no migration available for this system. For some of the installed extensions no successor could be found:</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.confirm.title">
         <source>Service Pack Migration - Confirm</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ca.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ca.xml
@@ -5141,6 +5141,18 @@ organization. You may grant or remove the organization administrator role in the
           <context context-type="sourcefile">/rhn/systems/@@PRODUCT_NAME@@</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="systemlist.jsp.isproxy">
+        <source>Proxy</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/systems/Overview</context>
+          <context context-type="sourcefile">/rhn/systems/SystemList</context>
+          <context context-type="sourcefile">/rhn/systems/OutOfDate</context>
+          <context context-type="sourcefile">/rhn/systems/Unentitled</context>
+          <context context-type="sourcefile">/rhn/systems/Ungrouped</context>
+          <context context-type="sourcefile">/rhn/systems/Proxy</context>
+          <context context-type="sourcefile">/rhn/systems/@@PRODUCT_NAME@@</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="systemlist.jsp.up2date">
         <source>System is up to date</source>
         <context-group name="ctx">
@@ -11714,6 +11726,12 @@ the &lt;strong&gt;@@ENTERPRISE_LINUX_NAME@@ System Administration Guide.&lt;/str
         </trans-unit>
         <trans-unit id="system.event.pending.canceled">
           <source>{0} system event(s) canceled.</source>
+        </trans-unit>
+        <trans-unit id="system.event.spmigration.notification">
+          <source>&lt;strong&gt;Reload&lt;/strong&gt; the page after the action completed successfully to schedule the full migration.</source>
+        </trans-unit>
+        <trans-unit id="system.event.spmigration.rescheduleDryRun">
+          <source>Run migration</source>
         </trans-unit>
       </group>
       <!-- System events legend -->
@@ -21552,6 +21570,9 @@ given channel.</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.error.update-salt-package-needed">
         <source>The installed &lt;strong&gt;Salt&lt;/strong&gt; package version on this system is out of date. Please update the package to the latest version before you start a Service Pack migration.</source>
+      </trans-unit>
+      <trans-unit id="spmigration.jsp.error.missing-successor-extensions">
+        <source>There is no migration available for this system. For some of the installed extensions no successor could be found:</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.confirm.title">
         <source>Service Pack Migration - Confirm</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ca.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ca.xml
@@ -21470,7 +21470,7 @@ given channel.</source>
         <source>Changes to channel assignments on salt managed systems will take effect at next highstate application</source>
       </trans-unit>
       <trans-unit id="sdc.channels.info.change">
-        <source>When subscribing to a channel that contains a product, the product package will automatically be installed on traditionally registered systems or added to the package states on Salt managed systems.</source>
+        <source>When subscribing to a channel that contains a product, the product package will automatically be installed on traditionally registered systems. On salt managed systems please apply a highstate as soon as possible.</source>
       </trans-unit>
       <trans-unit id="channelOverview.jsp.tasks.modifyCreate.state">
         <source>Create configuration file</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_de.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_de.xml
@@ -5893,6 +5893,18 @@ die Organisations-Administrator Rolle im Abschnitt &quot;Rollen&quot; des Tab &q
         </context-group>
         <target>Nicht-virtuelles System</target>
       </trans-unit>
+      <trans-unit id="systemlist.jsp.isproxy">
+        <source>Proxy</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/systems/Overview</context>
+          <context context-type="sourcefile">/rhn/systems/SystemList</context>
+          <context context-type="sourcefile">/rhn/systems/OutOfDate</context>
+          <context context-type="sourcefile">/rhn/systems/Unentitled</context>
+          <context context-type="sourcefile">/rhn/systems/Ungrouped</context>
+          <context context-type="sourcefile">/rhn/systems/Proxy</context>
+          <context context-type="sourcefile">/rhn/systems/@@PRODUCT_NAME@@</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="systemlist.jsp.up2date">
         <source>System is up to date</source>
         <context-group name="ctx">
@@ -13568,6 +13580,12 @@ Anschließend wird das nicht-chroot Post-Skript ausgeführt, und zuletzt das Pos
         <trans-unit id="system.event.pending.canceled">
           <source>{0} system event(s) canceled.</source>
           <target>{0} Systemereignis(se) abgebrochen.</target>
+        </trans-unit>
+        <trans-unit id="system.event.spmigration.notification">
+          <source>&lt;strong&gt;Reload&lt;/strong&gt; the page after the action completed successfully to schedule the full migration.</source>
+        </trans-unit>
+        <trans-unit id="system.event.spmigration.rescheduleDryRun">
+          <source>Run migration</source>
         </trans-unit>
       </group>
       <!-- System events legend -->
@@ -25378,6 +25396,9 @@ für einen angegebenen Channel aufgelistet wird.</target>
       </trans-unit>
       <trans-unit id="spmigration.jsp.error.update-salt-package-needed">
         <source>The installed &lt;strong&gt;Salt&lt;/strong&gt; package version on this system is out of date. Please update the package to the latest version before you start a Service Pack migration.</source>
+      </trans-unit>
+      <trans-unit id="spmigration.jsp.error.missing-successor-extensions">
+        <source>There is no migration available for this system. For some of the installed extensions no successor could be found:</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.confirm.title">
         <source>Service Pack Migration - Confirm</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_de.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_de.xml
@@ -25296,7 +25296,7 @@ für einen angegebenen Channel aufgelistet wird.</target>
         <source>Changes to channel assignments on salt managed systems will take effect at next highstate application</source>
       </trans-unit>
       <trans-unit id="sdc.channels.info.change">
-        <source>When subscribing to a channel that contains a product, the product package will automatically be installed on traditionally registered systems or added to the package states on Salt managed systems.</source>
+        <source>When subscribing to a channel that contains a product, the product package will automatically be installed on traditionally registered systems. On salt managed systems please apply a highstate as soon as possible.</source>
       </trans-unit>
       <trans-unit id="channelOverview.jsp.tasks.modifyCreate.state">
         <source>Create configuration file</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -21276,7 +21276,7 @@ given channel.</source>
         <source>Changes to channel assignments on salt managed systems will take effect at next highstate application</source>
       </trans-unit>
       <trans-unit id="sdc.channels.info.change">
-        <source>When subscribing to a channel that contains a product, the product package will automatically be installed.</source>
+        <source>When subscribing to a channel that contains a product, the product package will automatically be installed on traditionally registered systems. On salt managed systems please apply a highstate as soon as possible.</source>
       </trans-unit>
       <trans-unit id="channelOverview.jsp.tasks.modifyCreate.state">
         <source>Create configuration file</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -11516,7 +11516,7 @@ the &lt;strong&gt;@@ENTERPRISE_LINUX_NAME@@ System Administration Guide.&lt;/str
           <source>{0} system event(s) canceled.</source>
         </trans-unit>
         <trans-unit id="system.event.spmigration.notification">
-            <source>&lt;strong&gt;Reload&lt;/strong&gt; the page after the action completed successfully to schedule the full migration.</source>
+          <source>&lt;strong&gt;Reload&lt;/strong&gt; the page after the action completed successfully to schedule the full migration.</source>
         </trans-unit>
         <trans-unit id="system.event.spmigration.rescheduleDryRun">
           <source>Run migration</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_es.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_es.xml
@@ -25303,7 +25303,7 @@ given channel.</source>
         <source>Changes to channel assignments on salt managed systems will take effect at next highstate application</source>
       </trans-unit>
       <trans-unit id="sdc.channels.info.change">
-        <source>When subscribing to a channel that contains a product, the product package will automatically be installed on traditionally registered systems or added to the package states on Salt managed systems.</source>
+        <source>When subscribing to a channel that contains a product, the product package will automatically be installed on traditionally registered systems. On salt managed systems please apply a highstate as soon as possible.</source>
       </trans-unit>
       <trans-unit id="channelOverview.jsp.tasks.modifyCreate.state">
         <source>Create configuration file</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_es.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_es.xml
@@ -5893,6 +5893,18 @@ administrador de la organización en la sección &quot;Roles&quot; de la pestañ
         </context-group>
         <target>Sistema no virtual</target>
       </trans-unit>
+      <trans-unit id="systemlist.jsp.isproxy">
+        <source>Proxy</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/systems/Overview</context>
+          <context context-type="sourcefile">/rhn/systems/SystemList</context>
+          <context context-type="sourcefile">/rhn/systems/OutOfDate</context>
+          <context context-type="sourcefile">/rhn/systems/Unentitled</context>
+          <context context-type="sourcefile">/rhn/systems/Ungrouped</context>
+          <context context-type="sourcefile">/rhn/systems/Proxy</context>
+          <context context-type="sourcefile">/rhn/systems/@@PRODUCT_NAME@@</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="systemlist.jsp.up2date">
         <source>System is up to date</source>
         <context-group name="ctx">
@@ -13574,6 +13586,12 @@ la &lt;strong&gt;Guía de administración del sistema Red Hat Enterprise Linux.&
         <trans-unit id="system.event.pending.canceled">
           <source>{0} system event(s) canceled.</source>
           <target>{0} evento(s) seleccionado(s) cancelados.</target>
+        </trans-unit>
+        <trans-unit id="system.event.spmigration.notification">
+          <source>&lt;strong&gt;Reload&lt;/strong&gt; the page after the action completed successfully to schedule the full migration.</source>
+        </trans-unit>
+        <trans-unit id="system.event.spmigration.rescheduleDryRun">
+          <source>Run migration</source>
         </trans-unit>
       </group>
       <!-- System events legend -->
@@ -25385,6 +25403,9 @@ given channel.</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.error.update-salt-package-needed">
         <source>The installed &lt;strong&gt;Salt&lt;/strong&gt; package version on this system is out of date. Please update the package to the latest version before you start a Service Pack migration.</source>
+      </trans-unit>
+      <trans-unit id="spmigration.jsp.error.missing-successor-extensions">
+        <source>There is no migration available for this system. For some of the installed extensions no successor could be found:</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.confirm.title">
         <source>Service Pack Migration - Confirm</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_fr.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_fr.xml
@@ -25300,7 +25300,7 @@ canal  {0}. Les systèmes abonnés vont perdre leur accès aux paquetages spéci
         <source>Changes to channel assignments on salt managed systems will take effect at next highstate application</source>
       </trans-unit>
       <trans-unit id="sdc.channels.info.change">
-        <source>When subscribing to a channel that contains a product, the product package will automatically be installed on traditionally registered systems or added to the package states on Salt managed systems.</source>
+        <source>When subscribing to a channel that contains a product, the product package will automatically be installed on traditionally registered systems. On salt managed systems please apply a highstate as soon as possible.</source>
       </trans-unit>
       <trans-unit id="channelOverview.jsp.tasks.modifyCreate.state">
         <source>Create configuration file</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_fr.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_fr.xml
@@ -5893,6 +5893,18 @@ organisation. Vous pouvez accorder ou retirer le rôle d'administrateur d'organi
         </context-group>
         <target>Système non virtuel</target>
       </trans-unit>
+      <trans-unit id="systemlist.jsp.isproxy">
+        <source>Proxy</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/systems/Overview</context>
+          <context context-type="sourcefile">/rhn/systems/SystemList</context>
+          <context context-type="sourcefile">/rhn/systems/OutOfDate</context>
+          <context context-type="sourcefile">/rhn/systems/Unentitled</context>
+          <context context-type="sourcefile">/rhn/systems/Ungrouped</context>
+          <context context-type="sourcefile">/rhn/systems/Proxy</context>
+          <context context-type="sourcefile">/rhn/systems/@@PRODUCT_NAME@@</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="systemlist.jsp.up2date">
         <source>System is up to date</source>
         <context-group name="ctx">
@@ -13571,6 +13583,12 @@ Le script post non-chroot sera ensuite exécuté et le script post sera enfin ex
         <trans-unit id="system.event.pending.canceled">
           <source>{0} system event(s) canceled.</source>
           <target>{0} événement(s) système annulé(s).</target>
+        </trans-unit>
+        <trans-unit id="system.event.spmigration.notification">
+          <source>&lt;strong&gt;Reload&lt;/strong&gt; the page after the action completed successfully to schedule the full migration.</source>
+        </trans-unit>
+        <trans-unit id="system.event.spmigration.rescheduleDryRun">
+          <source>Run migration</source>
         </trans-unit>
       </group>
       <!-- System events legend -->
@@ -25382,6 +25400,9 @@ canal  {0}. Les systèmes abonnés vont perdre leur accès aux paquetages spéci
       </trans-unit>
       <trans-unit id="spmigration.jsp.error.update-salt-package-needed">
         <source>The installed &lt;strong&gt;Salt&lt;/strong&gt; package version on this system is out of date. Please update the package to the latest version before you start a Service Pack migration.</source>
+      </trans-unit>
+      <trans-unit id="spmigration.jsp.error.missing-successor-extensions">
+        <source>There is no migration available for this system. For some of the installed extensions no successor could be found:</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.confirm.title">
         <source>Service Pack Migration - Confirm</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_gu.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_gu.xml
@@ -5654,6 +5654,18 @@ organization. You may grant or remove the organization administrator role in the
         </context-group>
         <target>બિન-વર્ચ્યુઅલ સિસ્ટમ</target>
       </trans-unit>
+      <trans-unit id="systemlist.jsp.isproxy">
+        <source>Proxy</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/systems/Overview</context>
+          <context context-type="sourcefile">/rhn/systems/SystemList</context>
+          <context context-type="sourcefile">/rhn/systems/OutOfDate</context>
+          <context context-type="sourcefile">/rhn/systems/Unentitled</context>
+          <context context-type="sourcefile">/rhn/systems/Ungrouped</context>
+          <context context-type="sourcefile">/rhn/systems/Proxy</context>
+          <context context-type="sourcefile">/rhn/systems/@@PRODUCT_NAME@@</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="systemlist.jsp.up2date">
         <source>System is up to date</source>
         <context-group name="ctx">
@@ -12871,6 +12883,12 @@ the &lt;strong&gt;@@ENTERPRISE_LINUX_NAME@@ System Administration Guide.&lt;/str
         </trans-unit>
         <trans-unit id="system.event.pending.canceled">
           <source>{0} system event(s) canceled.</source>
+        </trans-unit>
+        <trans-unit id="system.event.spmigration.notification">
+          <source>&lt;strong&gt;Reload&lt;/strong&gt; the page after the action completed successfully to schedule the full migration.</source>
+        </trans-unit>
+        <trans-unit id="system.event.spmigration.rescheduleDryRun">
+          <source>Run migration</source>
         </trans-unit>
       </group>
       <!-- System events legend -->
@@ -23948,6 +23966,9 @@ given channel.</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.error.update-salt-package-needed">
         <source>The installed &lt;strong&gt;Salt&lt;/strong&gt; package version on this system is out of date. Please update the package to the latest version before you start a Service Pack migration.</source>
+      </trans-unit>
+      <trans-unit id="spmigration.jsp.error.missing-successor-extensions">
+        <source>There is no migration available for this system. For some of the installed extensions no successor could be found:</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.confirm.title">
         <source>Service Pack Migration - Confirm</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_gu.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_gu.xml
@@ -23866,7 +23866,7 @@ given channel.</source>
         <source>Changes to channel assignments on salt managed systems will take effect at next highstate application</source>
       </trans-unit>
       <trans-unit id="sdc.channels.info.change">
-        <source>When subscribing to a channel that contains a product, the product package will automatically be installed on traditionally registered systems or added to the package states on Salt managed systems.</source>
+        <source>When subscribing to a channel that contains a product, the product package will automatically be installed on traditionally registered systems. On salt managed systems please apply a highstate as soon as possible.</source>
       </trans-unit>
       <trans-unit id="channelOverview.jsp.tasks.modifyCreate.state">
         <source>Create configuration file</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_hi.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_hi.xml
@@ -23867,7 +23867,7 @@ given channel.</source>
         <source>Changes to channel assignments on salt managed systems will take effect at next highstate application</source>
       </trans-unit>
       <trans-unit id="sdc.channels.info.change">
-        <source>When subscribing to a channel that contains a product, the product package will automatically be installed on traditionally registered systems or added to the package states on Salt managed systems.</source>
+        <source>When subscribing to a channel that contains a product, the product package will automatically be installed on traditionally registered systems. On salt managed systems please apply a highstate as soon as possible.</source>
       </trans-unit>
       <trans-unit id="channelOverview.jsp.tasks.modifyCreate.state">
         <source>Create configuration file</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_hi.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_hi.xml
@@ -5654,6 +5654,18 @@ organization. You may grant or remove the organization administrator role in the
         </context-group>
         <target>गैर वर्चुअल सिस्टम</target>
       </trans-unit>
+      <trans-unit id="systemlist.jsp.isproxy">
+        <source>Proxy</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/systems/Overview</context>
+          <context context-type="sourcefile">/rhn/systems/SystemList</context>
+          <context context-type="sourcefile">/rhn/systems/OutOfDate</context>
+          <context context-type="sourcefile">/rhn/systems/Unentitled</context>
+          <context context-type="sourcefile">/rhn/systems/Ungrouped</context>
+          <context context-type="sourcefile">/rhn/systems/Proxy</context>
+          <context context-type="sourcefile">/rhn/systems/@@PRODUCT_NAME@@</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="systemlist.jsp.up2date">
         <source>System is up to date</source>
         <context-group name="ctx">
@@ -12871,6 +12883,12 @@ the &lt;strong&gt;@@ENTERPRISE_LINUX_NAME@@ System Administration Guide.&lt;/str
         </trans-unit>
         <trans-unit id="system.event.pending.canceled">
           <source>{0} system event(s) canceled.</source>
+        </trans-unit>
+        <trans-unit id="system.event.spmigration.notification">
+          <source>&lt;strong&gt;Reload&lt;/strong&gt; the page after the action completed successfully to schedule the full migration.</source>
+        </trans-unit>
+        <trans-unit id="system.event.spmigration.rescheduleDryRun">
+          <source>Run migration</source>
         </trans-unit>
       </group>
       <!-- System events legend -->
@@ -23949,6 +23967,9 @@ given channel.</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.error.update-salt-package-needed">
         <source>The installed &lt;strong&gt;Salt&lt;/strong&gt; package version on this system is out of date. Please update the package to the latest version before you start a Service Pack migration.</source>
+      </trans-unit>
+      <trans-unit id="spmigration.jsp.error.missing-successor-extensions">
+        <source>There is no migration available for this system. For some of the installed extensions no successor could be found:</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.confirm.title">
         <source>Service Pack Migration - Confirm</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_it.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_it.xml
@@ -25253,7 +25253,7 @@ caratteri.</target>
         <source>Changes to channel assignments on salt managed systems will take effect at next highstate application</source>
       </trans-unit>
       <trans-unit id="sdc.channels.info.change">
-        <source>When subscribing to a channel that contains a product, the product package will automatically be installed on traditionally registered systems or added to the package states on Salt managed systems.</source>
+        <source>When subscribing to a channel that contains a product, the product package will automatically be installed on traditionally registered systems. On salt managed systems please apply a highstate as soon as possible.</source>
       </trans-unit>
       <trans-unit id="channelOverview.jsp.tasks.modifyCreate.state">
         <source>Create configuration file</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_it.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_it.xml
@@ -5892,6 +5892,18 @@ amministratore dell'organizzazione all'interno della sezione &quot;Ruoli&quot; d
         </context-group>
         <target>Sistema non-virtuale</target>
       </trans-unit>
+      <trans-unit id="systemlist.jsp.isproxy">
+        <source>Proxy</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/systems/Overview</context>
+          <context context-type="sourcefile">/rhn/systems/SystemList</context>
+          <context context-type="sourcefile">/rhn/systems/OutOfDate</context>
+          <context context-type="sourcefile">/rhn/systems/Unentitled</context>
+          <context context-type="sourcefile">/rhn/systems/Ungrouped</context>
+          <context context-type="sourcefile">/rhn/systems/Proxy</context>
+          <context context-type="sourcefile">/rhn/systems/@@PRODUCT_NAME@@</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="systemlist.jsp.up2date">
         <source>System is up to date</source>
         <context-group name="ctx">
@@ -13557,6 +13569,12 @@ la &lt;strong&gt;Red Hat Enterprise Linux System Administration Guide.&lt;/stron
         <trans-unit id="system.event.pending.canceled">
           <source>{0} system event(s) canceled.</source>
           <target>{0} evento del sistema cancellato.</target>
+        </trans-unit>
+        <trans-unit id="system.event.spmigration.notification">
+          <source>&lt;strong&gt;Reload&lt;/strong&gt; the page after the action completed successfully to schedule the full migration.</source>
+        </trans-unit>
+        <trans-unit id="system.event.spmigration.rescheduleDryRun">
+          <source>Run migration</source>
         </trans-unit>
       </group>
       <!-- System events legend -->
@@ -25335,6 +25353,9 @@ caratteri.</target>
       </trans-unit>
       <trans-unit id="spmigration.jsp.error.update-salt-package-needed">
         <source>The installed &lt;strong&gt;Salt&lt;/strong&gt; package version on this system is out of date. Please update the package to the latest version before you start a Service Pack migration.</source>
+      </trans-unit>
+      <trans-unit id="spmigration.jsp.error.missing-successor-extensions">
+        <source>There is no migration available for this system. For some of the installed extensions no successor could be found:</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.confirm.title">
         <source>Service Pack Migration - Confirm</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ja.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ja.xml
@@ -5894,6 +5894,18 @@ organization. You may grant or remove the organization administrator role in the
         </context-group>
         <target>非仮想システム</target>
       </trans-unit>
+      <trans-unit id="systemlist.jsp.isproxy">
+        <source>Proxy</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/systems/Overview</context>
+          <context context-type="sourcefile">/rhn/systems/SystemList</context>
+          <context context-type="sourcefile">/rhn/systems/OutOfDate</context>
+          <context context-type="sourcefile">/rhn/systems/Unentitled</context>
+          <context context-type="sourcefile">/rhn/systems/Ungrouped</context>
+          <context context-type="sourcefile">/rhn/systems/Proxy</context>
+          <context context-type="sourcefile">/rhn/systems/@@PRODUCT_NAME@@</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="systemlist.jsp.up2date">
         <source>System is up to date</source>
         <context-group name="ctx">
@@ -13575,6 +13587,12 @@ the &lt;strong&gt;@@ENTERPRISE_LINUX_NAME@@ System Administration Guide.&lt;/str
         <trans-unit id="system.event.pending.canceled">
           <source>{0} system event(s) canceled.</source>
           <target>{0} 件のシステムイベントが取り消されました。</target>
+        </trans-unit>
+        <trans-unit id="system.event.spmigration.notification">
+          <source>&lt;strong&gt;Reload&lt;/strong&gt; the page after the action completed successfully to schedule the full migration.</source>
+        </trans-unit>
+        <trans-unit id="system.event.spmigration.rescheduleDryRun">
+          <source>Run migration</source>
         </trans-unit>
       </group>
       <!-- System events legend -->
@@ -25386,6 +25404,9 @@ given channel.</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.error.update-salt-package-needed">
         <source>The installed &lt;strong&gt;Salt&lt;/strong&gt; package version on this system is out of date. Please update the package to the latest version before you start a Service Pack migration.</source>
+      </trans-unit>
+      <trans-unit id="spmigration.jsp.error.missing-successor-extensions">
+        <source>There is no migration available for this system. For some of the installed extensions no successor could be found:</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.confirm.title">
         <source>Service Pack Migration - Confirm</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ja.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ja.xml
@@ -25304,7 +25304,7 @@ given channel.</source>
         <source>Changes to channel assignments on salt managed systems will take effect at next highstate application</source>
       </trans-unit>
       <trans-unit id="sdc.channels.info.change">
-        <source>When subscribing to a channel that contains a product, the product package will automatically be installed on traditionally registered systems or added to the package states on Salt managed systems.</source>
+        <source>When subscribing to a channel that contains a product, the product package will automatically be installed on traditionally registered systems. On salt managed systems please apply a highstate as soon as possible.</source>
       </trans-unit>
       <trans-unit id="channelOverview.jsp.tasks.modifyCreate.state">
         <source>Create configuration file</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ko.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ko.xml
@@ -5780,6 +5780,18 @@ organization. You may grant or remove the organization administrator role in the
         </context-group>
         <target>비가상화 시스템 </target>
       </trans-unit>
+      <trans-unit id="systemlist.jsp.isproxy">
+        <source>Proxy</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/systems/Overview</context>
+          <context context-type="sourcefile">/rhn/systems/SystemList</context>
+          <context context-type="sourcefile">/rhn/systems/OutOfDate</context>
+          <context context-type="sourcefile">/rhn/systems/Unentitled</context>
+          <context context-type="sourcefile">/rhn/systems/Ungrouped</context>
+          <context context-type="sourcefile">/rhn/systems/Proxy</context>
+          <context context-type="sourcefile">/rhn/systems/@@PRODUCT_NAME@@</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="systemlist.jsp.up2date">
         <source>System is up to date</source>
         <context-group name="ctx">
@@ -13286,6 +13298,12 @@ the &lt;strong&gt;@@ENTERPRISE_LINUX_NAME@@ System Administration Guide.&lt;/str
         </trans-unit>
         <trans-unit id="system.event.pending.canceled">
           <source>{0} system event(s) canceled.</source>
+        </trans-unit>
+        <trans-unit id="system.event.spmigration.notification">
+          <source>&lt;strong&gt;Reload&lt;/strong&gt; the page after the action completed successfully to schedule the full migration.</source>
+        </trans-unit>
+        <trans-unit id="system.event.spmigration.rescheduleDryRun">
+          <source>Run migration</source>
         </trans-unit>
       </group>
       <!-- System events legend -->
@@ -24806,6 +24824,9 @@ given channel.</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.error.update-salt-package-needed">
         <source>The installed &lt;strong&gt;Salt&lt;/strong&gt; package version on this system is out of date. Please update the package to the latest version before you start a Service Pack migration.</source>
+      </trans-unit>
+      <trans-unit id="spmigration.jsp.error.missing-successor-extensions">
+        <source>There is no migration available for this system. For some of the installed extensions no successor could be found:</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.confirm.title">
         <source>Service Pack Migration - Confirm</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ko.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ko.xml
@@ -24724,7 +24724,7 @@ given channel.</source>
         <source>Changes to channel assignments on salt managed systems will take effect at next highstate application</source>
       </trans-unit>
       <trans-unit id="sdc.channels.info.change">
-        <source>When subscribing to a channel that contains a product, the product package will automatically be installed on traditionally registered systems or added to the package states on Salt managed systems.</source>
+        <source>When subscribing to a channel that contains a product, the product package will automatically be installed on traditionally registered systems. On salt managed systems please apply a highstate as soon as possible.</source>
       </trans-unit>
       <trans-unit id="channelOverview.jsp.tasks.modifyCreate.state">
         <source>Create configuration file</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_pa.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_pa.xml
@@ -23866,7 +23866,7 @@ given channel.</source>
         <source>Changes to channel assignments on salt managed systems will take effect at next highstate application</source>
       </trans-unit>
       <trans-unit id="sdc.channels.info.change">
-        <source>When subscribing to a channel that contains a product, the product package will automatically be installed on traditionally registered systems or added to the package states on Salt managed systems.</source>
+        <source>When subscribing to a channel that contains a product, the product package will automatically be installed on traditionally registered systems. On salt managed systems please apply a highstate as soon as possible.</source>
       </trans-unit>
       <trans-unit id="channelOverview.jsp.tasks.modifyCreate.state">
         <source>Create configuration file</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_pa.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_pa.xml
@@ -5654,6 +5654,18 @@ organization. You may grant or remove the organization administrator role in the
         </context-group>
         <target>ਨਾਨ-ਵਰਚੁਅਲ ਸਿਸਟਮ</target>
       </trans-unit>
+      <trans-unit id="systemlist.jsp.isproxy">
+        <source>Proxy</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/systems/Overview</context>
+          <context context-type="sourcefile">/rhn/systems/SystemList</context>
+          <context context-type="sourcefile">/rhn/systems/OutOfDate</context>
+          <context context-type="sourcefile">/rhn/systems/Unentitled</context>
+          <context context-type="sourcefile">/rhn/systems/Ungrouped</context>
+          <context context-type="sourcefile">/rhn/systems/Proxy</context>
+          <context context-type="sourcefile">/rhn/systems/@@PRODUCT_NAME@@</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="systemlist.jsp.up2date">
         <source>System is up to date</source>
         <context-group name="ctx">
@@ -12870,6 +12882,12 @@ the &lt;strong&gt;@@ENTERPRISE_LINUX_NAME@@ System Administration Guide.&lt;/str
         </trans-unit>
         <trans-unit id="system.event.pending.canceled">
           <source>{0} system event(s) canceled.</source>
+        </trans-unit>
+        <trans-unit id="system.event.spmigration.notification">
+          <source>&lt;strong&gt;Reload&lt;/strong&gt; the page after the action completed successfully to schedule the full migration.</source>
+        </trans-unit>
+        <trans-unit id="system.event.spmigration.rescheduleDryRun">
+          <source>Run migration</source>
         </trans-unit>
       </group>
       <!-- System events legend -->
@@ -23948,6 +23966,9 @@ given channel.</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.error.update-salt-package-needed">
         <source>The installed &lt;strong&gt;Salt&lt;/strong&gt; package version on this system is out of date. Please update the package to the latest version before you start a Service Pack migration.</source>
+      </trans-unit>
+      <trans-unit id="spmigration.jsp.error.missing-successor-extensions">
+        <source>There is no migration available for this system. For some of the installed extensions no successor could be found:</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.confirm.title">
         <source>Service Pack Migration - Confirm</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_pt_BR.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_pt_BR.xml
@@ -5894,6 +5894,18 @@ permanecer sem modificações nesta página. Caso queira modificá-los, visite
         </context-group>
         <target>Sistema Não Virtual</target>
       </trans-unit>
+      <trans-unit id="systemlist.jsp.isproxy">
+        <source>Proxy</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/systems/Overview</context>
+          <context context-type="sourcefile">/rhn/systems/SystemList</context>
+          <context context-type="sourcefile">/rhn/systems/OutOfDate</context>
+          <context context-type="sourcefile">/rhn/systems/Unentitled</context>
+          <context context-type="sourcefile">/rhn/systems/Ungrouped</context>
+          <context context-type="sourcefile">/rhn/systems/Proxy</context>
+          <context context-type="sourcefile">/rhn/systems/@@PRODUCT_NAME@@</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="systemlist.jsp.up2date">
         <source>System is up to date</source>
         <context-group name="ctx">
@@ -13573,6 +13585,12 @@ o &lt;strong&gt;Guia de Administração de Sistemas Red Hat Enterprise Li
         <trans-unit id="system.event.pending.canceled">
           <source>{0} system event(s) canceled.</source>
           <target>{0} eventos de sistema cancelados.</target>
+        </trans-unit>
+        <trans-unit id="system.event.spmigration.notification">
+          <source>&lt;strong&gt;Reload&lt;/strong&gt; the page after the action completed successfully to schedule the full migration.</source>
+        </trans-unit>
+        <trans-unit id="system.event.spmigration.rescheduleDryRun">
+          <source>Run migration</source>
         </trans-unit>
       </group>
       <!-- System events legend -->
@@ -25382,6 +25400,9 @@ Serão exibidos somente pacotes de uma arquitetura compatível.</target>
       </trans-unit>
       <trans-unit id="spmigration.jsp.error.update-salt-package-needed">
         <source>The installed &lt;strong&gt;Salt&lt;/strong&gt; package version on this system is out of date. Please update the package to the latest version before you start a Service Pack migration.</source>
+      </trans-unit>
+      <trans-unit id="spmigration.jsp.error.missing-successor-extensions">
+        <source>There is no migration available for this system. For some of the installed extensions no successor could be found:</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.confirm.title">
         <source>Service Pack Migration - Confirm</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_pt_BR.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_pt_BR.xml
@@ -25300,7 +25300,7 @@ Serão exibidos somente pacotes de uma arquitetura compatível.</target>
         <source>Changes to channel assignments on salt managed systems will take effect at next highstate application</source>
       </trans-unit>
       <trans-unit id="sdc.channels.info.change">
-        <source>When subscribing to a channel that contains a product, the product package will automatically be installed on traditionally registered systems or added to the package states on Salt managed systems.</source>
+        <source>When subscribing to a channel that contains a product, the product package will automatically be installed on traditionally registered systems. On salt managed systems please apply a highstate as soon as possible.</source>
       </trans-unit>
       <trans-unit id="channelOverview.jsp.tasks.modifyCreate.state">
         <source>Create configuration file</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ru.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ru.xml
@@ -5891,6 +5891,18 @@ organization. You may grant or remove the organization administrator role in the
         </context-group>
         <target>Физическая система</target>
       </trans-unit>
+      <trans-unit id="systemlist.jsp.isproxy">
+        <source>Proxy</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/systems/Overview</context>
+          <context context-type="sourcefile">/rhn/systems/SystemList</context>
+          <context context-type="sourcefile">/rhn/systems/OutOfDate</context>
+          <context context-type="sourcefile">/rhn/systems/Unentitled</context>
+          <context context-type="sourcefile">/rhn/systems/Ungrouped</context>
+          <context context-type="sourcefile">/rhn/systems/Proxy</context>
+          <context context-type="sourcefile">/rhn/systems/@@PRODUCT_NAME@@</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="systemlist.jsp.up2date">
         <source>System is up to date</source>
         <context-group name="ctx">
@@ -13546,6 +13558,12 @@ the &lt;strong&gt;@@ENTERPRISE_LINUX_NAME@@ System Administration Guide.&lt;/str
         <trans-unit id="system.event.pending.canceled">
           <source>{0} system event(s) canceled.</source>
           <target>Отменено событий: {0}</target>
+        </trans-unit>
+        <trans-unit id="system.event.spmigration.notification">
+          <source>&lt;strong&gt;Reload&lt;/strong&gt; the page after the action completed successfully to schedule the full migration.</source>
+        </trans-unit>
+        <trans-unit id="system.event.spmigration.rescheduleDryRun">
+          <source>Run migration</source>
         </trans-unit>
       </group>
       <!-- System events legend -->
@@ -25328,6 +25346,9 @@ given channel.</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.error.update-salt-package-needed">
         <source>The installed &lt;strong&gt;Salt&lt;/strong&gt; package version on this system is out of date. Please update the package to the latest version before you start a Service Pack migration.</source>
+      </trans-unit>
+      <trans-unit id="spmigration.jsp.error.missing-successor-extensions">
+        <source>There is no migration available for this system. For some of the installed extensions no successor could be found:</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.confirm.title">
         <source>Service Pack Migration - Confirm</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ru.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ru.xml
@@ -25246,7 +25246,7 @@ given channel.</source>
         <source>Changes to channel assignments on salt managed systems will take effect at next highstate application</source>
       </trans-unit>
       <trans-unit id="sdc.channels.info.change">
-        <source>When subscribing to a channel that contains a product, the product package will automatically be installed on traditionally registered systems or added to the package states on Salt managed systems.</source>
+        <source>When subscribing to a channel that contains a product, the product package will automatically be installed on traditionally registered systems. On salt managed systems please apply a highstate as soon as possible.</source>
       </trans-unit>
       <trans-unit id="channelOverview.jsp.tasks.modifyCreate.state">
         <source>Create configuration file</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ta.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ta.xml
@@ -23865,7 +23865,7 @@ given channel.</source>
         <source>Changes to channel assignments on salt managed systems will take effect at next highstate application</source>
       </trans-unit>
       <trans-unit id="sdc.channels.info.change">
-        <source>When subscribing to a channel that contains a product, the product package will automatically be installed on traditionally registered systems or added to the package states on Salt managed systems.</source>
+        <source>When subscribing to a channel that contains a product, the product package will automatically be installed on traditionally registered systems. On salt managed systems please apply a highstate as soon as possible.</source>
       </trans-unit>
       <trans-unit id="channelOverview.jsp.tasks.modifyCreate.state">
         <source>Create configuration file</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ta.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ta.xml
@@ -5654,6 +5654,18 @@ organization. You may grant or remove the organization administrator role in the
         </context-group>
         <target>மெய்நிகர்-இல்லாத கணினி</target>
       </trans-unit>
+      <trans-unit id="systemlist.jsp.isproxy">
+        <source>Proxy</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/systems/Overview</context>
+          <context context-type="sourcefile">/rhn/systems/SystemList</context>
+          <context context-type="sourcefile">/rhn/systems/OutOfDate</context>
+          <context context-type="sourcefile">/rhn/systems/Unentitled</context>
+          <context context-type="sourcefile">/rhn/systems/Ungrouped</context>
+          <context context-type="sourcefile">/rhn/systems/Proxy</context>
+          <context context-type="sourcefile">/rhn/systems/@@PRODUCT_NAME@@</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="systemlist.jsp.up2date">
         <source>System is up to date</source>
         <context-group name="ctx">
@@ -12871,6 +12883,12 @@ the &lt;strong&gt;@@ENTERPRISE_LINUX_NAME@@ System Administration Guide.&lt;/str
         </trans-unit>
         <trans-unit id="system.event.pending.canceled">
           <source>{0} system event(s) canceled.</source>
+        </trans-unit>
+        <trans-unit id="system.event.spmigration.notification">
+          <source>&lt;strong&gt;Reload&lt;/strong&gt; the page after the action completed successfully to schedule the full migration.</source>
+        </trans-unit>
+        <trans-unit id="system.event.spmigration.rescheduleDryRun">
+          <source>Run migration</source>
         </trans-unit>
       </group>
       <!-- System events legend -->
@@ -23947,6 +23965,9 @@ given channel.</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.error.update-salt-package-needed">
         <source>The installed &lt;strong&gt;Salt&lt;/strong&gt; package version on this system is out of date. Please update the package to the latest version before you start a Service Pack migration.</source>
+      </trans-unit>
+      <trans-unit id="spmigration.jsp.error.missing-successor-extensions">
+        <source>There is no migration available for this system. For some of the installed extensions no successor could be found:</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.confirm.title">
         <source>Service Pack Migration - Confirm</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_uk.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_uk.xml
@@ -22466,7 +22466,7 @@ given channel.</source>
         <source>Changes to channel assignments on salt managed systems will take effect at next highstate application</source>
       </trans-unit>
       <trans-unit id="sdc.channels.info.change">
-        <source>When subscribing to a channel that contains a product, the product package will automatically be installed on traditionally registered systems or added to the package states on Salt managed systems.</source>
+        <source>When subscribing to a channel that contains a product, the product package will automatically be installed on traditionally registered systems. On salt managed systems please apply a highstate as soon as possible.</source>
       </trans-unit>
       <trans-unit id="channelOverview.jsp.tasks.modifyCreate.state">
         <source>Create configuration file</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_uk.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_uk.xml
@@ -5438,6 +5438,18 @@ organization. You may grant or remove the organization administrator role in the
           <context context-type="sourcefile">/rhn/systems/@@PRODUCT_NAME@@</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="systemlist.jsp.isproxy">
+        <source>Proxy</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/systems/Overview</context>
+          <context context-type="sourcefile">/rhn/systems/SystemList</context>
+          <context context-type="sourcefile">/rhn/systems/OutOfDate</context>
+          <context context-type="sourcefile">/rhn/systems/Unentitled</context>
+          <context context-type="sourcefile">/rhn/systems/Ungrouped</context>
+          <context context-type="sourcefile">/rhn/systems/Proxy</context>
+          <context context-type="sourcefile">/rhn/systems/@@PRODUCT_NAME@@</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="systemlist.jsp.up2date">
         <source>System is up to date</source>
         <context-group name="ctx">
@@ -12199,6 +12211,12 @@ the &lt;strong&gt;@@ENTERPRISE_LINUX_NAME@@ System Administration Guide.&lt;/str
         </trans-unit>
         <trans-unit id="system.event.pending.canceled">
           <source>{0} system event(s) canceled.</source>
+        </trans-unit>
+        <trans-unit id="system.event.spmigration.notification">
+          <source>&lt;strong&gt;Reload&lt;/strong&gt; the page after the action completed successfully to schedule the full migration.</source>
+        </trans-unit>
+        <trans-unit id="system.event.spmigration.rescheduleDryRun">
+          <source>Run migration</source>
         </trans-unit>
       </group>
       <!-- System events legend -->
@@ -22548,6 +22566,9 @@ given channel.</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.error.update-salt-package-needed">
         <source>The installed &lt;strong&gt;Salt&lt;/strong&gt; package version on this system is out of date. Please update the package to the latest version before you start a Service Pack migration.</source>
+      </trans-unit>
+      <trans-unit id="spmigration.jsp.error.missing-successor-extensions">
+        <source>There is no migration available for this system. For some of the installed extensions no successor could be found:</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.confirm.title">
         <source>Service Pack Migration - Confirm</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_zh_CN.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_zh_CN.xml
@@ -5899,6 +5899,18 @@ organization. You may grant or remove the organization administrator role in the
         </context-group>
         <target>非虚拟系统</target>
       </trans-unit>
+      <trans-unit id="systemlist.jsp.isproxy">
+        <source>Proxy</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/systems/Overview</context>
+          <context context-type="sourcefile">/rhn/systems/SystemList</context>
+          <context context-type="sourcefile">/rhn/systems/OutOfDate</context>
+          <context context-type="sourcefile">/rhn/systems/Unentitled</context>
+          <context context-type="sourcefile">/rhn/systems/Ungrouped</context>
+          <context context-type="sourcefile">/rhn/systems/Proxy</context>
+          <context context-type="sourcefile">/rhn/systems/@@PRODUCT_NAME@@</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="systemlist.jsp.up2date">
         <source>System is up to date</source>
         <context-group name="ctx">
@@ -13577,6 +13589,12 @@ kickstart 前脚本的内容可以在 &lt;strong&gt;《红帽企业版 Linux 系
         <trans-unit id="system.event.pending.canceled">
           <source>{0} system event(s) canceled.</source>
           <target>已取消 {0} 系统事件。</target>
+        </trans-unit>
+        <trans-unit id="system.event.spmigration.notification">
+          <source>&lt;strong&gt;Reload&lt;/strong&gt; the page after the action completed successfully to schedule the full migration.</source>
+        </trans-unit>
+        <trans-unit id="system.event.spmigration.rescheduleDryRun">
+          <source>Run migration</source>
         </trans-unit>
       </group>
       <!-- System events legend -->
@@ -25376,6 +25394,9 @@ given channel.</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.error.update-salt-package-needed">
         <source>The installed &lt;strong&gt;Salt&lt;/strong&gt; package version on this system is out of date. Please update the package to the latest version before you start a Service Pack migration.</source>
+      </trans-unit>
+      <trans-unit id="spmigration.jsp.error.missing-successor-extensions">
+        <source>There is no migration available for this system. For some of the installed extensions no successor could be found:</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.confirm.title">
         <source>Service Pack Migration - Confirm</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_zh_CN.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_zh_CN.xml
@@ -25294,7 +25294,7 @@ given channel.</source>
         <source>Changes to channel assignments on salt managed systems will take effect at next highstate application</source>
       </trans-unit>
       <trans-unit id="sdc.channels.info.change">
-        <source>When subscribing to a channel that contains a product, the product package will automatically be installed on traditionally registered systems or added to the package states on Salt managed systems.</source>
+        <source>When subscribing to a channel that contains a product, the product package will automatically be installed on traditionally registered systems. On salt managed systems please apply a highstate as soon as possible.</source>
       </trans-unit>
       <trans-unit id="channelOverview.jsp.tasks.modifyCreate.state">
         <source>Create configuration file</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_zh_TW.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_zh_TW.xml
@@ -25297,7 +25297,7 @@ given channel.</source>
         <source>Changes to channel assignments on salt managed systems will take effect at next highstate application</source>
       </trans-unit>
       <trans-unit id="sdc.channels.info.change">
-        <source>When subscribing to a channel that contains a product, the product package will automatically be installed on traditionally registered systems or added to the package states on Salt managed systems.</source>
+        <source>When subscribing to a channel that contains a product, the product package will automatically be installed on traditionally registered systems. On salt managed systems please apply a highstate as soon as possible.</source>
       </trans-unit>
       <trans-unit id="channelOverview.jsp.tasks.modifyCreate.state">
         <source>Create configuration file</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_zh_TW.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_zh_TW.xml
@@ -5889,6 +5889,18 @@ organization. You may grant or remove the organization administrator role in the
         </context-group>
         <target>非虛擬系統</target>
       </trans-unit>
+      <trans-unit id="systemlist.jsp.isproxy">
+        <source>Proxy</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/systems/Overview</context>
+          <context context-type="sourcefile">/rhn/systems/SystemList</context>
+          <context context-type="sourcefile">/rhn/systems/OutOfDate</context>
+          <context context-type="sourcefile">/rhn/systems/Unentitled</context>
+          <context context-type="sourcefile">/rhn/systems/Ungrouped</context>
+          <context context-type="sourcefile">/rhn/systems/Proxy</context>
+          <context context-type="sourcefile">/rhn/systems/@@PRODUCT_NAME@@</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="systemlist.jsp.up2date">
         <source>System is up to date</source>
         <context-group name="ctx">
@@ -13569,6 +13581,12 @@ the &lt;strong&gt;@@ENTERPRISE_LINUX_NAME@@ System Administration Guide.&lt;/str
         <trans-unit id="system.event.pending.canceled">
           <source>{0} system event(s) canceled.</source>
           <target>取消了 {0} 件系統事件。</target>
+        </trans-unit>
+        <trans-unit id="system.event.spmigration.notification">
+          <source>&lt;strong&gt;Reload&lt;/strong&gt; the page after the action completed successfully to schedule the full migration.</source>
+        </trans-unit>
+        <trans-unit id="system.event.spmigration.rescheduleDryRun">
+          <source>Run migration</source>
         </trans-unit>
       </group>
       <!-- System events legend -->
@@ -25379,6 +25397,9 @@ given channel.</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.error.update-salt-package-needed">
         <source>The installed &lt;strong&gt;Salt&lt;/strong&gt; package version on this system is out of date. Please update the package to the latest version before you start a Service Pack migration.</source>
+      </trans-unit>
+      <trans-unit id="spmigration.jsp.error.missing-successor-extensions">
+        <source>There is no migration available for this system. For some of the installed extensions no successor could be found:</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.confirm.title">
         <source>Service Pack Migration - Confirm</source>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- fix info text about package installation on channel change (bsc#1171684)
 - Clarify the behavior of the checkbox system list, when it adds systems to ssm
 - Implement module picker controls for CLM AppStream filters
 


### PR DESCRIPTION
## What does this PR change?

When changing channels a info message is displayed which give the wrong impression that product packages are automatically installed. This is only the case for traditionally registered systems.
For salt managed systems you need to execute a highstate.

Adapting the message to tell this the user.

Additionally some other messages found which needs to be copied to all translations.

## GUI diff

- [x] **DONE**

## Documentation
- Documentation issue was created: https://github.com/SUSE/spacewalk/issues/11562

- [x] **DONE**

## Test coverage
- No tests: **just info message changed**

- [x] **DONE**

## Links

By accident directly pushed to 4.0 Branch

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"   
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
