### PR TITLE
allow channel change event to apply the new channel state

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/server/test/ServerActionTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/server/test/ServerActionTest.java
@@ -16,6 +16,7 @@ package com.redhat.rhn.domain.action.server.test;
 
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
+import com.redhat.rhn.domain.action.salt.ApplyStatesAction;
 import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.action.test.ActionFactoryTest;
 import com.redhat.rhn.domain.server.Server;
@@ -78,7 +79,7 @@ public class ServerActionTest extends RhnBaseTestCase {
         sa2.setServerWithCheck(one);
         assertTrue(sa.equals(sa2));
 
-        Action parent = new Action();
+        Action parent = new ApplyStatesAction();
         parent.setId(243L);
         parent.setActionType(ActionFactory.TYPE_APPLY_STATES);
         sa.setParentActionWithCheck(parent);

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/test/DebReleaseWriterTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/test/DebReleaseWriterTest.java
@@ -63,10 +63,15 @@ public class DebReleaseWriterTest extends BaseTestCaseWithUser {
 
         DebReleaseWriter releaseWriter = new DebReleaseWriter(channel, prefix);
         releaseWriter.generateRelease();
-        String releaseDatetime = DebReleaseWriter.RFC822_DATE_FORMAT.format(ZonedDateTime.now());
+        ZonedDateTime now = ZonedDateTime.now();
+        String releaseDatetime = DebReleaseWriter.RFC822_DATE_FORMAT.format(now);
 
         String releaseContent = FileUtils.readStringFromFile(prefix + "Release");
 
+        if (!releaseContent.contains(releaseDatetime)) {
+            // We have a possible race condition of 1 second
+            releaseDatetime = DebReleaseWriter.RFC822_DATE_FORMAT.format(now.minusSeconds(1));
+        }
         String rel = "Archive: " + channel.getLabel() + "\n" +
                 "Label: " + channel.getLabel() + "\n" +
                 "Suite: " + channel.getLabel() + "\n" +


### PR DESCRIPTION
## What does this PR change?

When scheduling a channel change it result into a state.apply with just the channel state called.
As changing channels should be allowed outside of maintenance windows we need to add an exception case in checkMaintenanceWindows()

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **big docs later**

- [x] **DONE**

## Test coverage
- No tests: **needs to be covered by cucumber tests later**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
