### PR TITLE
Add docker logout step

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/images/docker.sls
+++ b/susemanager-utils/susemanager-sls/salt/images/docker.sls
@@ -35,6 +35,18 @@ mgr_pushimage:
       - mgrcompat: mgr_buildimage
       - mgrcompat: mgr_registries_login
 
+{% if 'docker.logout' in salt %}
+
+mgr_registries_logout:
+  mgrcompat.module_run:
+    - name: docker.logout
+    - registries: {{ pillar.get('docker-registries', {}).keys() | list }}
+    - require:
+      - mgrcompat: mgr_pushimage
+      - mgrcompat: mgr_registries_login
+
+{% endif %}
+
 {% else %}
 
 mgr_registries_login:

--- a/susemanager-utils/susemanager-sls/salt/images/profileupdate.sls
+++ b/susemanager-utils/susemanager-sls/salt/images/profileupdate.sls
@@ -41,6 +41,18 @@ mgr_image_remove:
       - "{{ pillar.get('imagename') }}"
     - force: False
 
+{% if 'docker.logout' in salt %}
+
+mgr_registries_logout:
+  mgrcompat.module_run:
+    - name: docker.logout
+    - registries: {{ pillar.get('docker-registries', {}).keys() | list }}
+    - require:
+      - mgrcompat: mgr_registries_login_inspect
+      - mgrcompat: mgr_image_profileupdate
+
+{% endif %}
+
 {% else %}
 
 mgr_registries_login_inspect:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Log out of Docker registries after image build (bsc#1165572)
 - Prevent "module.run" deprecation warnings by using custom mgrcompat module
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?
As a last step of the docker build process, docker.logout is called from the Salt states. This ensures no registry credentials are left on the build host that executes the state.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
Don't know if and how this would be documented as the change is not very visible to users. A user would need to check if docker credentials are left on the build host.

- [ ] **DONE**

## Test coverage
- No tests: Yet. I am not sure how this should be tested

- [ ] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/11017
Requires # https://github.com/openSUSE/salt/pull/245

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
