### PR TITLE
Remove lowercase character limit in image profile label

### DIFF
--- a/web/html/src/manager/images/image-profile-edit.js
+++ b/web/html/src/manager/images/image-profile-edit.js
@@ -12,7 +12,6 @@ const { FormGroup } = require('components/input/FormGroup');
 const { Label } = require('components/input/Label');
 const { Select } = require('components/input/Select');
 const { Text } = require('components/input/Text');
-const Validation = require("components/validation");
 const Utils = require("utils/functions").Utils;
 const SpaRenderer  = require("core/spa/spa-renderer").default;
 
@@ -392,7 +391,7 @@ class CreateImageProfile extends React.Component {
           onChange={this.onFormChange}
           onSubmit={(e) => this.isEdit() ? this.onUpdate(e) : this.onCreate(e)}
           onValidate={this.onValidate}>
-          <Text name="label" label={t("Label")} required validators={[this.isLabelValid, Validation.isLowercase()]} invalidHint={t("Label is required and must be a unique lowercase string and it cannot include any colons (:).")} labelClass="col-md-3" divClass="col-md-6"/>
+          <Text name="label" label={t("Label")} required validators={[this.isLabelValid]} invalidHint={t("Label is required and must be a unique string and it cannot include any colons (:).")} labelClass="col-md-3" divClass="col-md-6"/>
           <Select name="imageType" label={t("Image Type")} required labelClass="col-md-3" divClass="col-md-6" onChange={this.handleImageTypeChange} disabled={this.isEdit()}>
             { this.state.imageTypes.map(k =>
               <option key={k} value={k}>{ typeMap[k].name }</option>) }

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Remove lowercase image label limitation
 - Sort activation keys on bootstrapping page (bsc#1171251)
 - replace toastr javascript library with react-toastify
 - Implement module picker controls for CLM AppStream filters


### PR DESCRIPTION
## What does this PR change?

Removes limitation imposed on image profile label to be all lowercase.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- Documentation PR https://github.com/uyuni-project/uyuni-docs/pull/306

- [X] **DONE**

## Test coverage
- No tests: already covered by existing tests

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11514
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
