### PR TITLE
Highstate on bootstrap with entitlements

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
@@ -128,7 +128,8 @@ public class RegistrationUtils {
         StatesAPI.generateServerPackageState(minion);
 
         // Should we apply the highstate?
-        boolean applyHighstate = activationKey.isPresent() && activationKey.get().getDeployConfigs();
+        boolean applyHighstate = activationKey.isPresent() && (activationKey.get().getDeployConfigs() ||
+                activationKey.get().getEntitlements().stream().anyMatch(e -> !e.isBase()));
 
         // Apply initial states asynchronously
         List<String> statesToApply = new ArrayList<>();

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- apply highstate when add-on system types should be applied to the
+  system on bootstrapping (bsc#1172190)
 - configure HTTP timeouts via rhn.conf
 - fixed bug where in scheduling a vhm refresh would result in a permission error for org admins
 - Validate CLM projects on build/promote with XMLRPC


### PR DESCRIPTION
## What does this PR change?

During bootstrapping of a system an aktivation key could be used to enable add-on system types like buildhost and monitoring node. They require to run a highstate to get the system configured properly.
Check for add-on system types in the activation key and run a full highstate when they are used.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests **testing message queues is impossible**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11568
Tracks https://github.com/SUSE/spacewalk/pull/11615

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
