### PR TITLE
Disable cop RedundantRegexpEscape

### DIFF
--- a/testsuite/.rubocop_todo.yml
+++ b/testsuite/.rubocop_todo.yml
@@ -342,7 +342,7 @@ Style/ConstantVisibility:
 # Configuration parameters: Notice, AutocorrectNotice.
 Style/Copyright:
   Enabled: false
-
+  
 # Offense count: 11
 # Configuration parameters: AllowCoercion.
 Style/DateTime:
@@ -539,6 +539,9 @@ Style/RedundantInterpolation:
     - 'features/step_definitions/command_steps.rb'
     - 'features/step_definitions/common_steps.rb'
 
+Style/RedundantRegexpEscape:
+  Enabled: false
+  
 # Offense count: 2
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, AllowInnerSlashes.

--- a/testsuite/.rubocop_todo.yml
+++ b/testsuite/.rubocop_todo.yml
@@ -342,7 +342,7 @@ Style/ConstantVisibility:
 # Configuration parameters: Notice, AutocorrectNotice.
 Style/Copyright:
   Enabled: false
-  
+
 # Offense count: 11
 # Configuration parameters: AllowCoercion.
 Style/DateTime:


### PR DESCRIPTION
## What does this PR change?

Latest Rubocop version seems to complain with RedundantRegexpEscape

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- GitHub Action for Ruby CheckStyle

- [x] **DONE**

## Links

Fixes #2271 checkstyle

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
