### PR TITLE
trust gpgkeys

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -95,6 +95,15 @@ bootstrap_repo:
       - ([ {{ bootstrap_repo_exists }} = "True" ])
 {%- endif %}
 
+{%- if not grains['os_family'] == 'Debian' %}
+{%- if salt['pillar.get']('mgr_metadata_signing_enabled', false) %}
+mgr_trust_customer_gpg_key:
+  cmd.run:
+    - name: rpm --import https://{{ salt['pillar.get']('mgr_server') }}/pub/mgr-gpg-pub.key
+    - runas: root
+{%- endif %}
+{%- endif %}
+
 {%- if grains['os_family'] == 'RedHat' %}
 trust_suse_manager_tools_rhel_gpg_key:
   cmd.run:

--- a/susemanager-utils/susemanager-sls/salt/channels/channels.repo
+++ b/susemanager-utils/susemanager-sls/salt/channels/channels.repo
@@ -17,6 +17,9 @@ baseurl={{protocol}}://{{hostname}}:{{port}}/rhn/manager/download/{{ chan }}
 susemanager_token={{ args['token'] }}
 gpgcheck={{ 1 if args['gpgcheck'] == "1" or args['pkg_gpgcheck'] != "0" else 0 }}
 repo_gpgcheck={{ args['gpgcheck'] }}
+{%- if salt['pillar.get']('mgr_metadata_signing_enabled', false) %}
+gpgkey=https://{{ args['host'] }}/pub/mgr-gpg-pub.key
+{%- endif %}
 {%- if grains['osmajorrelease'] >= 8 and args['cloned_nonmodular'] %}
 module_hotfixes=1
 {%- endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- trust customer gpg key when metadata signing is enabled
+- specify gpg key for RH systems in repo file (bsc#1172286)
 - Implement CaaSP cluster upgrade procedure in cluster provider module.
 - handle GPG check flags different for yum/dnf (bsc#1171859)
 - Enable bootstrapping for Oracle Linux 6, 7 and 8


### PR DESCRIPTION
## What does this PR change?

When metadata signing is enabled RH systems requires the GPG key specified in the repo file.
On SUSE system take care that it gets installed when bootstrapping

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11602
Tracks https://github.com/SUSE/spacewalk/pull/11614

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
