### PR TITLE
Ubuntu repo syncs are using http proxy

### DIFF
--- a/backend/common/repo.py
+++ b/backend/common/repo.py
@@ -67,12 +67,13 @@ class DpkgRepo:
                 key = "/".join(parse.urlparse(self.__repo._url).path.strip("/").split("/")[-2:] + [key])
             return self[key]
 
-    def __init__(self, url: str):
+    def __init__(self, url: str, proxies: dict = None):
         self._url = url
         self._flat_checked: typing.Optional[int] = None
         self._flat: bool = False
         self._pkg_index: typing.Tuple[str, bytes] = ("", b"", )
         self._release = DpkgRepo.EntryDict(self)
+        self.proxies = proxies
 
     def append_index_file(self, index_file: str) -> str:
         """
@@ -100,7 +101,7 @@ class DpkgRepo:
         if self._pkg_index[0] == "":
             for cnt_fname in [DpkgRepo.PKG_GZ, DpkgRepo.PKG_XZ, DpkgRepo.PKG_RW]:
                 packages_url = self.append_index_file(cnt_fname)
-                resp = requests.get(packages_url)
+                resp = requests.get(packages_url, proxies=self.proxies)
                 if resp.status_code == http.HTTPStatus.OK:
                     self._pkg_index = cnt_fname, resp.content
                     break
@@ -164,7 +165,7 @@ class DpkgRepo:
         :raises GeneralRepoException if the Release file cannot be found.
         :return: string
         """
-        resp = requests.get(self._get_parent_url(self._url, 2, "Release"))
+        resp = requests.get(self._get_parent_url(self._url, 2, "Release"), proxies=self.proxies)
         try:
             self._flat = resp.status_code in [http.HTTPStatus.NOT_FOUND, http.HTTPStatus.FORBIDDEN]
             self._flat_checked = 1
@@ -173,7 +174,7 @@ class DpkgRepo:
                 raise GeneralRepoException("HTTP error {} occurred while connecting to the URL".format(resp.status_code))
 
             if not self._release and self.is_flat():
-                resp = requests.get(self._get_parent_url(self._url, 0, "Release"))
+                resp = requests.get(self._get_parent_url(self._url, 0, "Release"), proxies=self.proxies)
                 if resp.status_code == http.HTTPStatus.OK:
                     self._release = self._parse_release_index(resp.content.decode("utf-8"))
         finally:

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,5 +1,6 @@
 - supportconfig speedup fixes, add option to not compress spacewalk-debug output dir
 - Prevent failure when syncing from RHEL CDN due extra params (bsc#1171885)
+- Ubuntu repos sync uses http proxy (bsc#1168845)
 
 -------------------------------------------------------------------
 Wed May 20 10:53:18 CEST 2020 - jgonzalez@suse.com


### PR DESCRIPTION
## What does this PR change?

Download repo meta data was not taking the http proxy settings into
account. We are now passing the http proxy settings before doing any
requests.

Co-authored-by: Alexander Graul <agraul@suse.com>

## Documentation
- No documentation needed: Just a bug fix.


## Test coverage
- No tests: Just a bug fix.

## Links

Fixes #2103


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
