### PR TITLE
Fixes for http and testsuite

### DIFF
--- a/java/code/src/com/redhat/rhn/common/util/http/HttpClientAdapter.java
+++ b/java/code/src/com/redhat/rhn/common/util/http/HttpClientAdapter.java
@@ -72,6 +72,9 @@ public class HttpClientAdapter {
      */
     public static final String NO_PROXY = "server.satellite.no_proxy";
     public static final String MAX_CONNCECTIONS = "java.mgr_sync_max_connections";
+    public static final String HTTP_CONNECTION_TIMEOUT = "java.http_connection_timeout";
+    public static final String HTTP_SOCKET_TIMEOUT = "java.http_socket_timeout";
+    private static final int TO_MILLISECONDS = 1000;
 
     /** The log. */
     private static Logger log = Logger.getLogger(HttpClientAdapter.class);
@@ -113,6 +116,8 @@ public class HttpClientAdapter {
 
         clientBuilder.setDefaultCredentialsProvider(credentialsProvider);
         Builder requestConfigBuilder = RequestConfig.custom()
+                .setConnectTimeout(Config.get().getInt(HTTP_CONNECTION_TIMEOUT, 5) * TO_MILLISECONDS)
+                .setSocketTimeout(Config.get().getInt(HTTP_SOCKET_TIMEOUT, 5 * 60) * TO_MILLISECONDS)
                 .setCookieSpec(CookieSpecs.IGNORE_COOKIES);
 
         // Store the proxy settings

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/test/DebReleaseWriterTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/test/DebReleaseWriterTest.java
@@ -63,10 +63,15 @@ public class DebReleaseWriterTest extends BaseTestCaseWithUser {
 
         DebReleaseWriter releaseWriter = new DebReleaseWriter(channel, prefix);
         releaseWriter.generateRelease();
-        String releaseDatetime = DebReleaseWriter.RFC822_DATE_FORMAT.format(ZonedDateTime.now());
+        ZonedDateTime now = ZonedDateTime.now();
+        String releaseDatetime = DebReleaseWriter.RFC822_DATE_FORMAT.format(now);
 
         String releaseContent = FileUtils.readStringFromFile(prefix + "Release");
 
+        if (!releaseContent.contains(releaseDatetime)) {
+            // We have a possible race condition of 1 second
+            releaseDatetime = DebReleaseWriter.RFC822_DATE_FORMAT.format(now.minusSeconds(1));
+        }
         String rel = "Archive: " + channel.getLabel() + "\n" +
                 "Label: " + channel.getLabel() + "\n" +
                 "Suite: " + channel.getLabel() + "\n" +

--- a/java/conf/rhn_java.conf
+++ b/java/conf/rhn_java.conf
@@ -220,3 +220,9 @@ java.sso = false
 
 # If true, nodes that are part of a cluster will be system locked upon bootstrap and after every package related action
 java.automatic_system_lock_cluster_nodes = true
+
+# HTTP Connection Timeout in seconds
+java.http_connection_timeout = 5
+
+# HTTP Socket Timeout in seconds
+java.http_socket_timeout = 300

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- configure HTTP timeouts via rhn.conf
 - fixed bug where in scheduling a vhm refresh would result in a permission error for org admins
 - Validate CLM projects on build/promote with XMLRPC
 - Fix nullpointer exception during proxy registration (bsc#1171287)


### PR DESCRIPTION
## What does this PR change?

Extracted from maintenance-windows branch.

- configure timeouts of HTTP connections
- workaround race condition in unit tests

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **already covered**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
