### PR TITLE
fix syntax error in XMLRPC docs

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
@@ -578,10 +578,11 @@ public class ContentManagementHandler extends BaseHandler {
      * #paragraph()
      * Appstream module/stream filtering:
      * #itemlist()
-     *   #item("by module name, stream - field: module_stream; matcher: equals; value: modulaneme:stream
+     *   #item("by module name, stream - field: module_stream; matcher: equals; value: modulaneme:stream")
      * #itemlist_end()
      * Note: Only 'allow' rule is supported for appstream filters.
      * #paragraph_end()
+     * #paragraph()
      *
      * Note: The 'matches' matcher works on Java regular expressions.
      *


### PR DESCRIPTION
## What does this PR change?

Fix syntax errors which caused package build to fail.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **fix build**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
