### PR TITLE
Enable support for bootstrapping Ubuntu 20.04 LTS added from the Setup Wizard or mgr-sync

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -1182,6 +1182,11 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/ubuntu/18/4/bootstrap/',
         'TYPE' : 'deb'
     },
+    'ubuntu-20.04-amd64' : {
+        'PDID' : [-18, 2113], 'BETAPDID' : [2112], 'PKGLIST' : PKGLISTUBUNTU2004,
+        'DEST' : '/srv/www/htdocs/pub/repositories/ubuntu/20/4/bootstrap/',
+        'TYPE' : 'deb'
+    },
     'ubuntu-16.04-amd64-uyuni' : {
         'BASECHANNEL' : 'ubuntu-16.04-pool-amd64-uyuni', 'PKGLIST' : PKGLISTUBUNTU1604,
         'DEST' : '/srv/www/htdocs/pub/repositories/ubuntu/16/4/bootstrap/',

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- Enable support for bootstrapping Ubuntu 20.04 LTS added from the
+  Setup Wizard or mgr-sync
 - migrate proxy list in cobbler settings (bsc#1169536)
 - Make systemd services and timers enablement really quiet
 


### PR DESCRIPTION
## What does this PR change?

Enable support for bootstrapping Ubuntu 20.04 LTS added from the Setup Wizard or mgr-sync

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Documentation PR: https://github.com/uyuni-project/uyuni-docs/pull/243

- [x] **DONE**

## Test coverage
- No tests: Not for the bootstrap config.

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11368

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
