### PR TITLE
Adds missing bsc number

### DIFF
--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,7 +1,7 @@
 - migrate proxy list in cobbler settings (bsc#1169536)
 - Make systemd services and timers enablement really quiet
 - Packages for the Ubuntu 18.04 bootstrap repo are now populated with Python3
-  dependencies
+  dependencies (bsc#1168845)
 
 -------------------------------------------------------------------
 Wed May 20 11:01:49 CEST 2020 - jgonzalez@suse.com


### PR DESCRIPTION
## What does this PR change?
Adds missing bsc number for switching the Ubuntu 18.04 bootstrapping to Python3.


## Documentation
- No documentation needed: Fix for changelog

## Test coverage
- No tests: Fix for changelog

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
