### PR TITLE
Verify packages index with best checksum algorithm

### DIFF
--- a/backend/common/test/test_repo.py
+++ b/backend/common/test/test_repo.py
@@ -315,19 +315,6 @@ Some more irrelevant data
         assert zdcmp.called
         assert "hot" in str(exc.value)
 
-    @patch("spacewalk.common.repo.requests.get", MagicMock(
-        return_value=FakeRequests().conf(status_code=http.HTTPStatus.NOT_FOUND, content=b"")))
-    def test_get_pkg_index_raw_exception(self):
-        """
-        Test getting package index file exception handling
-
-        :return:
-        """
-        with pytest.raises(GeneralRepoException) as exc:
-            DpkgRepo("http://dummy/url").get_pkg_index_raw()
-
-        assert "No variants of package index has been found on http://dummy/url repo" == str(exc.value)
-
     def test_append_index_file_to_url(self):
         """
         Test append index files to the given url.

--- a/backend/common/test/test_repo.py
+++ b/backend/common/test/test_repo.py
@@ -73,6 +73,25 @@ class TestCommonRepo:
             repo = DpkgRepo("http://mygreathost.com/ubuntu/dists/bionic/restricted/binary-amd64/")
             assert repo.verify_packages_index()
 
+    @patch("spacewalk.common.repo.DpkgRepo.get_pkg_index_raw", MagicMock(return_value=("Packages.gz", b"\x00")))
+    @patch("spacewalk.common.repo.DpkgRepo.is_flat", MagicMock(return_value=False))
+    def test_verify_packages_index_missing_some_checksums(self):
+        """
+        Test verify_packages_index method when only sha256 checksum is available.
+
+        :return:
+        """
+        gri = DpkgRepo.ReleaseEntry(size=999, uri="restricted/binary-amd64")
+        gri.checksum.md5 = ""
+        gri.checksum.sha1 = ""
+        gri.checksum.sha256 = "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+
+        release_index = MagicMock()
+        release_index().get = MagicMock(return_value=gri)
+        with patch("common.repo.DpkgRepo.get_release_index", release_index):
+            repo = DpkgRepo("http://mygreathost.com/ubuntu/dists/bionic/restricted/binary-amd64/")
+            assert repo.verify_packages_index()
+
     @patch("spacewalk.common.repo.DpkgRepo.get_release_index", mock_release_index)
     def test_is_flat(self):
         """

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- Only check strongest available Ubuntu/Debian repository index checksum
+
 -------------------------------------------------------------------
 Wed Jun 10 12:14:57 CEST 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?
Iterating over checksum algorithms, the best that is available is used
to do the verification. It is not needed to repeat the checksum
verification with weaker algorithms afterwards.



## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: Just a bugfix

- [X] **DONE**

## Test coverage
I am not sure if `backend/common/test/test_repo.py` is executed anywhere, I had to change the import path everywhere and only ran the test from a particular directory. I think it makes more sense to clean the execution up than commit my additional test as is. 

- [ ] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/2283

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle" (Test skipped, there are no changes to test)
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
