### PR TITLE
Allow spacewalk-repo-sync to sync empty DEB repositories

### DIFF
--- a/backend/common/repo.py
+++ b/backend/common/repo.py
@@ -106,9 +106,6 @@ class DpkgRepo:
                     break
                 resp.close()
 
-        if self._pkg_index == ("", b"",):
-            raise GeneralRepoException("No variants of package index has been found on {} repo".format(self._url))
-
         return self._pkg_index
 
     def decompress_pkg_index(self) -> str:
@@ -179,9 +176,6 @@ class DpkgRepo:
         finally:
             resp.close()
 
-        if not self._release:
-            raise GeneralRepoException("Repository seems either broken or has unsupported format")
-
         return self._release
 
     @staticmethod
@@ -220,6 +214,11 @@ class DpkgRepo:
         :return: result (boolean)
         """
         name, data = self.get_pkg_index_raw()
+
+        # If there are no packages in the repo, return True
+        if (name, data) == ("", b"",):
+           return True
+
         entry = self.get_release_index().get(name)
         for algorithm in ["md5", "sha1", "sha256"]:
             if entry is None:

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Allow spacewalk-repo-sync to sync empty DEB repositories.
 - supportconfig speedup fixes, add option to not compress spacewalk-debug output dir
 - Prevent failure when syncing from RHEL CDN due extra params (bsc#1171885)
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue in `spacewalk-repo-sync` that currently prevents empty DEB repositories (with `Release` file available but no `Packages` file) to be synced:

```
2020/06/05 10:32:17 +02:00 Command: ['/usr/bin/spacewalk-repo-sync', '-c', 'ubuntu-20.04-suse-manager-tools-beta-amd64']
2020/06/05 10:32:17 +02:00 Sync of channel started.
2020/06/05 10:32:17 +02:00 Plugin error: No variants of package index has been found on https://updates.suse.com/SUSE/Updates/Ubuntu/20.04-CLIENT-TOOLS-BETA/x86_64/update/?XXXXXXXXXXXXXXXXX repo
```

After this PR:

```
2020/06/05 10:44:51 +02:00 Command: ['/usr/bin/spacewalk-repo-sync', '-c', 'ubuntu-20.04-suse-manager-tools-beta-amd64']
2020/06/05 10:44:51 +02:00 Sync of channel started.
2020/06/05 10:44:51 +02:00 Repo URL: https://updates.suse.com/SUSE/Updates/Ubuntu/20.04-CLIENT-TOOLS-BETA/x86_64/update/?XXXXXXXXXXXXXXXXX
2020/06/05 10:44:51 +02:00     Packages in repo:                 0
2020/06/05 10:44:51 +02:00     No new packages to sync.
2020/06/05 10:44:51 +02:00
2020/06/05 10:44:51 +02:00   Patches in repo: 0.
2020/06/05 10:44:51 +02:00 Sync completed.
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **backend changes**

- [x] **DONE**

## Test coverage
- No tests: **tested on cucumber**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
