### PR TITLE
Skip tagged scenarios if no SLE clients

### DIFF
--- a/testsuite/features/core/allcli_sanity.feature
+++ b/testsuite/features/core/allcli_sanity.feature
@@ -8,10 +8,12 @@ Feature: Sanity checks
   Scenario: The server is healthy
     Then "server" should have a FQDN
 
+@sle_client
   Scenario: The traditional client is healthy
     Then "sle_client" should have a FQDN
     And "sle_client" should communicate with the server
 
+@sle_minion
   Scenario: The minion is healthy
     Then "sle_minion" should have a FQDN
     And "sle_minion" should communicate with the server

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -100,6 +100,14 @@ Before('@proxy') do
   skip_this_scenario unless $proxy
 end
 
+Before('@sle_client') do
+  skip_this_scenario unless $client
+end
+
+Before('@sle_minion') do
+  skip_this_scenario unless $minion
+end
+
 Before('@centos_minion') do
   skip_this_scenario unless $ceos_minion
 end


### PR DESCRIPTION
## What does this PR change?

The SLE traditional client and the SLE minion are now supposed to be optional, but we forgot the needed support code to skip scenarios tagged with `@sle_client` or `@sle_minion` if they are not present.

This PR also adds the needed tags in the sanity checks.

## Links

Fixes SUSE/spacewalk#11635

Ports:
* 4.0: SUSE/spacewalk#11648
* 3.2: SUSE/spacewalk#11649

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
