### PR TITLE
Increase api version for 41

### DIFF
--- a/java/conf/rhn_java.conf
+++ b/java/conf/rhn_java.conf
@@ -14,7 +14,7 @@ java.customer_service_email =
 java.development_environment = 0
 
 # the version of API
-java.apiversion = 22
+java.apiversion = 23
 
 # lifetime for sandboxes, in days
 java.sandbox_lifetime = 3

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- increase XMLRPC API version
 - Correctly set action to failed in case of Salt errors on execution (bsc#1169604)
 - improve speed of Content Lifecycle Management channel list loading (bsc#1153234)
 - Avoid traceback with AssertionError: Failed to update row (bsc#1172558)


### PR DESCRIPTION
## What does this PR change?

XMLRPC API has a version which should be changed for every release.
Setting it now to 23.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **just a version change**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
