### PR TITLE
Fix SSH action remaining in pending state on salt err (bsc#1169604)

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -2068,7 +2068,7 @@ public class SaltServerActionService {
                     sa.setStatus(STATUS_FAILED);
                     sa.setResultMsg("Error calling Salt: " + e.getMessage());
                     sa.setCompletionTime(new Date());
-                    throw e;
+                    return;
                 }
 
                 if (!result.isPresent()) {

--- a/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
@@ -125,14 +125,19 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         };
         minion = MinionServerFactoryTest.createTestMinionServer(user);
 
-        saltServerActionService = new SaltServerActionService(systemQuery);
-        saltServerActionService.setSkipCommandScriptPerms(true);
+        saltServerActionService = createSaltServerActionService(systemQuery);
         systemEntitlementManager = new SystemEntitlementManager(
                 new SystemUnentitler(),
                 new SystemEntitler(systemQuery, virtManager, new FormulaMonitoringManager())
         );
 
         sshPushSystemMock = mock(SystemSummary.class);
+    }
+
+    private SaltServerActionService createSaltServerActionService(SystemQuery systemQuery) {
+        SaltServerActionService service = new SaltServerActionService(systemQuery);
+        service.setSkipCommandScriptPerms(true);
+        return service;
     }
 
     public void testPackageUpdate() throws Exception {
@@ -541,7 +546,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
                 throw new RuntimeException();
             }
         };
-        return new SaltServerActionService(systemQuery);
+        return createSaltServerActionService(systemQuery);
     }
 
     /**
@@ -579,7 +584,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
                 return Optional.of(new JsonObject());
             }
         };
-        saltServerActionService = new SaltServerActionService(systemQuery);
+        saltServerActionService = createSaltServerActionService(systemQuery);
 
         saltServerActionService.executeSSHAction(prereq, minion);
         assertEquals(STATUS_COMPLETED, prereqServerAction.getStatus());
@@ -702,7 +707,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
                 return Optional.empty();
             }
         };
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery);
+        SaltServerActionService saltServerActionService = createSaltServerActionService(systemQuery);
 
         Action action = ActionFactoryTest.createAction(user, ActionFactory.TYPE_SCRIPT_RUN);
         ServerAction serverAction = createChildServerAction(action, STATUS_QUEUED, 5L);
@@ -728,19 +733,19 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
                 throw new RuntimeException();
             }
         };
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery);
+        SaltServerActionService saltServerActionService = createSaltServerActionService(systemQuery);
         Action action = ActionFactoryTest.createAction(user, ActionFactory.TYPE_SCRIPT_RUN);
         ServerAction serverAction = createChildServerAction(action, STATUS_QUEUED, 5L);
         try {
             saltServerActionService.executeSSHAction(action, minion);
         } catch (RuntimeException e) {
-            // expected
-            assertEquals(STATUS_FAILED, serverAction.getStatus());
-            assertTrue(serverAction.getResultMsg().startsWith("Error calling Salt: "));
-            return;
+            fail("Runtime exception should not have been thrown.");
         }
-        fail("Runtime exception should have been thrown.");
+
+        assertEquals(STATUS_FAILED, serverAction.getStatus());
+        assertTrue(serverAction.getResultMsg().startsWith("Error calling Salt: "));
     }
+
 
     /**
      * Tests that a successful execution of a reboot action will move this action to the
@@ -756,7 +761,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
                 return Optional.of(new JsonObject());
             }
         };
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery);
+        SaltServerActionService saltServerActionService = createSaltServerActionService(systemQuery);
 
         Action action = createRebootAction(new Date(1L));
         ServerAction serverAction = createChildServerAction(action, STATUS_QUEUED, 5L);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Correctly set action to failed in case of Salt errors on execution (bsc#1169604)
 - improve speed of Content Lifecycle Management channel list loading (bsc#1153234)
 - Avoid traceback with AssertionError: Failed to update row (bsc#1172558)
 - Pass minion ip to the kiwi_collect_image runner as fallback instead


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/11428

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes #
Tracks https://github.com/SUSE/spacewalk/pull/11428

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
