### PR TITLE
Manager bsc1169550

### DIFF
--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -405,6 +405,7 @@ copy_remote_files() {
                /var/lib/Kiwi
                /var/lib/rhn
                /var/lib/salt
+               /var/lib/spacewalk
                /var/log/rhn
                /var/spacewalk"
 

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- copy /var/lib/spacewalk during migration (bsc#1169550)
 - Enable support for bootstrapping Ubuntu 20.04 LTS added from the
   Setup Wizard or mgr-sync
 - migrate proxy list in cobbler settings (bsc#1169536)


### PR DESCRIPTION
## What does this PR change?

Directory /var/lib/spacewalk contains some important data (such as GPG keys for custom repos) that also needs to be copied to the target machine during migrations.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: Bugfix

- [X] **DONE**

## Test coverage
- No tests: No automatic migration testing

- [X] **DONE**

## Links

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1169550

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
