### PR TITLE
Enable monitoring entitlement for s390x (bsc#1172627)

### DIFF
--- a/schema/spacewalk/common/data/rhnServerServerGroupArchCompat.sql
+++ b/schema/spacewalk/common/data/rhnServerServerGroupArchCompat.sql
@@ -859,4 +859,8 @@ insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type)
     values (lookup_server_arch('aarch64-redhat-linux'),
             lookup_sg_type('monitoring_entitled'));
 
+insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type)
+    values (lookup_server_arch('s390x-redhat-linux'),
+            lookup_sg_type('monitoring_entitled'));
+
 commit;

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Enable the monitoring entitlement for s390x (bsc#1172627)
 - update package provider name
 - add new gpg key ids for some package providers
 

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.7-to-susemanager-schema-4.1.8/002-monitoring-enable-s390x.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.7-to-susemanager-schema-4.1.8/002-monitoring-enable-s390x.sql
@@ -1,0 +1,9 @@
+insert into rhnServerServerGroupArchCompat (server_arch_id, server_group_type)
+    select lookup_server_arch('s390x-redhat-linux'),
+            lookup_sg_type('monitoring_entitled')
+    from dual where not exists (
+        select 1 from rhnServerServerGroupArchCompat where
+        server_arch_id=lookup_server_arch('s390x-redhat-linux') and
+        server_group_type=lookup_sg_type('monitoring_entitled')
+    );
+


### PR DESCRIPTION
## What does this PR change?

This patch will enable the monitoring entitlement to be used with the `s390x` architecture.

## GUI diff

No difference.

- [X] **DONE**

## Documentation

- No documentation needed, just a database change.

- [X] **DONE**

## Test coverage

- No additional tests are added, patch is just enabling another architecture.

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11656.

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below).

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
