### PR TITLE
make ubuntu universe repo mandatory

### DIFF
--- a/susemanager-sync-data/additional_products.json
+++ b/susemanager-sync-data/additional_products.json
@@ -60,7 +60,7 @@
                 "name" : "ubuntu-2004-amd64-universe",
                 "distro_target" : "amd64",
                 "description" : "Ubuntu 20.04 LTS AMD64 Universe",
-                "enabled" : false,
+                "enabled" : true,
                 "autorefresh" : true,
                 "installer_updates" : false
             }


### PR DESCRIPTION
## What does this PR change?

Ubuntu Universe repo should be mandatory

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **already covered**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11658
Tracks https://github.com/SUSE/spacewalk/pull/11666

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
