### PR TITLE
Manager bsc1171687

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- only report real error, not result (bsc#1171687)
 - use defined return values for spacecmd methods so scripts can
   check for failure (bsc#1171687)
 

--- a/spacecmd/src/bin/spacecmd
+++ b/spacecmd/src/bin/spacecmd
@@ -194,7 +194,7 @@ if __name__ == '__main__':
             if precmd == '':
                 sys.exit(1)
             result = shell.print_result(shell.onecmd(precmd), precmd)
-            if result != 0:
+            if result == 1:
                 sys.exit(result)
         except KeyboardInterrupt:
             print


### PR DESCRIPTION
## What does this PR change?

In spacecmd the return value is sometimes abused for the actual result instead of just the status. So report only actual error.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: bugfix

- [X] **DONE**

## Test coverage
- No tests: only unit tests
- Unit tests were added
- Cucumber tests were added

- [X] **DONE**

## Links

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1171687

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
