### PR TITLE
Add checks for maintenance windows during recurring actions

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/Server.java
+++ b/java/code/src/com/redhat/rhn/domain/server/Server.java
@@ -54,6 +54,7 @@ import java.util.TreeSet;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;

--- a/java/code/src/com/redhat/rhn/taskomatic/task/RecurringStateApplyJob.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/RecurringStateApplyJob.java
@@ -20,12 +20,12 @@ import com.redhat.rhn.manager.action.ActionChainManager;
 import com.redhat.rhn.taskomatic.TaskoXmlRpcHandler;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
+import com.suse.manager.maintenance.MaintenanceManager;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Used to run a scheduled Recurring Highstate Apply action
@@ -57,9 +57,8 @@ public class RecurringStateApplyJob extends RhnJavaJob {
     }
 
     private void scheduleAction(JobExecutionContext context, RecurringAction action) {
-        List<Long> minionIds = action.computeMinions().stream()
-                .map(m -> m.getId())
-                .collect(Collectors.toList());
+        List<Long> minionIds = MaintenanceManager.systemIdsMaintenanceMode(action.computeMinions());
+
         try {
             ActionChainManager.scheduleApplyStates(action.getCreator(), minionIds,
                     Optional.of(action.isTestMode()), context.getFireTime(), null);

--- a/java/code/src/com/suse/manager/maintenance/test/MaintenanceManagerScheduleActionsTest.java
+++ b/java/code/src/com/suse/manager/maintenance/test/MaintenanceManagerScheduleActionsTest.java
@@ -25,6 +25,7 @@ import com.redhat.rhn.common.util.FileUtils;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionChainFactory;
 import com.redhat.rhn.domain.action.ActionFactory;
+import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.manager.action.ActionChainManager;
@@ -93,8 +94,11 @@ public class MaintenanceManagerScheduleActionsTest extends JMockBaseTestCaseWith
         MaintenanceManager mm = MaintenanceManager.instance();
         MaintenanceSchedule schedule = mm.createMaintenanceSchedule(user, "test-schedule-2", SINGLE, empty());
 
-        Server sys1 = MinionServerFactoryTest.createTestMinionServer(user);
-        Server sys2 = MinionServerFactoryTest.createTestMinionServer(user);
+        MinionServer sys1 = MinionServerFactoryTest.createTestMinionServer(user);
+        MinionServer sys2 = MinionServerFactoryTest.createTestMinionServer(user);
+
+        assertTrue(MaintenanceManager.checkIfInMaintenanceMode(sys1));
+        assertTrue(MaintenanceManager.checkIfInMaintenanceMode(sys2));
 
         mm.assignScheduleToSystems(user, schedule, Set.of(sys1.getId()));
 
@@ -125,8 +129,9 @@ public class MaintenanceManagerScheduleActionsTest extends JMockBaseTestCaseWith
         MaintenanceCalendar mc = mm.createMaintenanceCalendar(user, "testcalendar", calString);
         MaintenanceSchedule schedule = mm.createMaintenanceSchedule(user, "test-schedule-2", SINGLE, of(mc));
 
-        Server sys1 = MinionServerFactoryTest.createTestMinionServer(user);
+        MinionServer sys1 = MinionServerFactoryTest.createTestMinionServer(user);
         mm.assignScheduleToSystems(user, schedule, Set.of(sys1.getId()));
+        assertTrue(MaintenanceManager.checkIfInMaintenanceMode(sys1));
 
         try {
             ActionChainManager.scheduleApplyStates(user, List.of(sys1.getId()), empty(), new Date(12345), null);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add check for maintainence window during executing recurring actions
 - Implement maintenance windows in struts
 - XMLRPC: Assign/retract maintenance schedule to/from systems
 


### PR DESCRIPTION
## What does this PR change?

This PR adds a check for recurring actions to make sure the minion is in maintenance mode, if not, skip the action. If debug is enabled it will log the skipped minion ids.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: expected behavior

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/11231

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
