### PR TITLE
Revert file_extract to scp for spacewalk-debug.tar.bz2

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -301,8 +301,11 @@ end
 
 When(/^I execute spacewalk-debug on the server$/) do
   $server.run('spacewalk-debug')
-  code = file_extract($server, "/tmp/spacewalk-debug.tar.bz2", "spacewalk-debug.tar.bz2")
-  raise "Download debug file failed" unless code.zero?
+  cmd = "echo | scp -o StrictHostKeyChecking=no root@#{$server.ip}:/tmp/spacewalk-debug.tar.bz2 . 2>&1"
+  command_output = `#{cmd}`
+  unless $CHILD_STATUS.success?
+    raise "Execute command failed: #{$ERROR_INFO}: #{command_output}"
+  end
 end
 
 Then(/^I get logfiles from "([^"]*)"$/) do |target|


### PR DESCRIPTION
## What does this PR change?

In the test suite, there seems to be a problem with `file_extract` and huge files. Reverting to `scp` in that case.


## Links

Ports:
* 4.0: SUSE/spacewalk TBD
* 3.2: SUSE/spacewalk TBD


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
