### PR TITLE
spacewalk-common-channels for openSUSE Leap 15.2 and SLE15SP2

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -853,7 +853,7 @@ gpgkey_url = http://download.opensuse.org/distribution/leap/15.1/repo/oss/repoda
 gpgkey_id = 3DBDC284
 gpgkey_fingerprint = 22C0 7BA5 3417 8CD0 2EFE  22AA B88B 2FD4 3DBD C284
 repo_url = http://download.opensuse.org/distribution/leap/15.1/repo/oss/
-dist_map_release = 15.0
+dist_map_release = 15.1
 
 [opensuse_leap15_1-non-oss]
 label    = %(base_channel)s-non-oss
@@ -895,6 +895,62 @@ repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/
 name     = Uyuni Client Tools for %(base_channel_name)s (Development)
 archs    = x86_64
 base_channels = opensuse_leap15_1-%(arch)s
+checksum = sha256
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
+
+[opensuse_leap15_2]
+checksum = sha256
+archs    = x86_64
+name     = openSUSE Leap 15.2 (%(arch)s)
+gpgkey_url = http://download.opensuse.org/distribution/leap/15.2/repo/oss/repodata/repomd.xml.key
+gpgkey_id = 3DBDC284
+gpgkey_fingerprint = 22C0 7BA5 3417 8CD0 2EFE  22AA B88B 2FD4 3DBD C284
+repo_url = http://download.opensuse.org/distribution/leap/15.2/repo/oss/
+dist_map_release = 15.2
+
+[opensuse_leap15_2-non-oss]
+label    = %(base_channel)s-non-oss
+name     = openSUSE 15.2 non oss (%(arch)s)
+archs    = x86_64
+checksum = sha256
+base_channels = opensuse_leap15_2-%(arch)s
+repo_url = http://download.opensuse.org/distribution/leap/15.2/repo/non-oss/
+
+[opensuse_leap15_2-updates]
+label    = %(base_channel)s-updates
+name     = openSUSE Leap 15.2 Updates (%(arch)s)
+archs    = x86_64
+checksum = sha256
+base_channels = opensuse_leap15_2-%(arch)s
+repo_url = http://download.opensuse.org/update/leap/15.2/oss/
+
+[opensuse_leap15_2-non-oss-updates]
+label    = %(base_channel)s-non-oss-updates
+name     = openSUSE Leap 15.2 non oss Updates (%(arch)s)
+archs    = x86_64
+checksum = sha256
+base_channels = opensuse_leap15_2-%(arch)s
+repo_url = http://download.opensuse.org/update/leap/15.2/non-oss/
+
+# This is expected. openSUSE Leap 15.0 client tools are valid for all openSUSE Leap 15.X releases
+[opensuse_leap15_2-uyuni-client]
+name     = Uyuni Client Tools for %(base_channel_name)s
+archs    = x86_64
+base_channels = opensuse_leap15_2-%(arch)s
+checksum = sha256
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
+
+# This is expected. openSUSE Leap 15.0 client tools are valid for all openSUSE Leap 15.X releases
+[opensuse_leap15_2-uyuni-client-devel]
+name     = Uyuni Client Tools for %(base_channel_name)s (Development)
+archs    = x86_64
+base_channels = opensuse_leap15_2-%(arch)s
 checksum = sha256
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
@@ -975,6 +1031,26 @@ repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/
 name     = Uyuni Client Tools for SLES15 SP1 (Development)
 archs    =  x86_64, s390x, aarch64, ppc64le
 base_channels = sle-product-sles15-sp1-pool-%(arch)s
+checksum = sha256
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/
+
+[sles15-sp2-uyuni-client]
+name     = Uyuni Client Tools for SLES15 SP2
+archs    =  x86_64, s390x, aarch64, ppc64le
+base_channels = sle-product-sles15-sp2-pool-%(arch)s
+checksum = sha256
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/
+
+[sles15-sp2-devel-uyuni-client]
+name     = Uyuni Client Tools for SLES15 SP2 (Development)
+archs    =  x86_64, s390x, aarch64, ppc64le
+base_channels = sle-product-sles15-sp2-pool-%(arch)s
 checksum = sha256
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,5 @@
+- Add channels for openSUSE Leap 15.1 and Uyuni Client Tools, and
+  Uyuni Client Tools for SLE15SP2
 - Use HTTPS for Oracle repositories
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

spacewalk-common-channels for openSUSE Leap 15.2 and SLE15SP2

## GUI diff

No difference.

- [x] **DONE**

## Documentation

I reopened https://github.com/SUSE/spacewalk/issues/10773#issuecomment-641208381 as Leap 15.2 is not part of the doc yet.

- [x] **DONE**

## Test coverage
- No tests: spacewalk-common-channels not covered by tests.

- [x] **DONE**

## Links

None.

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
