### PR TITLE
Testsuite: Use a more reliable target host/IP

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -858,7 +858,7 @@ Then(/^name resolution should work on terminal "([^"]*)"$/) do |host|
   # we need "host" utility
   step "I install package \"bind-utils\" on this \"#{host}\""
   # direct name resolution
-  ["proxy.example.org", "download.suse.de"].each do |dest|
+  ["proxy.example.org", "dns.google.com"].each do |dest|
     output, return_code = node.run("host #{dest}", fatal = false)
     raise "Direct name resolution of #{dest} on terminal #{host} doesn't work: #{output}" unless return_code.zero?
     STDOUT.puts "#{output}"
@@ -866,7 +866,7 @@ Then(/^name resolution should work on terminal "([^"]*)"$/) do |host|
   # reverse name resolution
   net_prefix = $private_net.sub(%r{\.0+/24$}, ".")
   client = net_prefix + "2"
-  [client, "149.44.176.1"].each do |dest|
+  [client, "8.8.8.8"].each do |dest|
     output, return_code = node.run("host #{dest}", fatal = false)
     raise "Reverse name resolution of #{dest} on terminal #{host} doesn't work: #{output}" unless return_code.zero?
     STDOUT.puts "#{output}"


### PR DESCRIPTION
## What does this PR change?

- testsuite/features/step_definitions/command_steps.rb: Use a reliable
host and IP to resolve.

## Links
# Ports
- Manager-3.2: https://github.com/SUSE/spacewalk/pull/11698
-Manager-4.0: https://github.com/SUSE/spacewalk/pull/11697

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

