### PR TITLE
Improve saltssh error parsing

### DIFF
--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -163,6 +163,7 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -1936,12 +1937,15 @@ public class SaltUtils {
      * @return the error as a string
      */
     public static String decodeSaltErr(SaltError saltErr) {
-        Optional<String> errorMessage = SaltUtils.decodeStdMessage(saltErr, "stderr");
-        Optional<String> outMessage = !errorMessage.isPresent() ?
-                SaltUtils.decodeStdMessage(saltErr, "stdout") : errorMessage;
-        Optional<String> returnMessage = !outMessage.isPresent() ?
-                SaltUtils.decodeStdMessage(saltErr, "return") : outMessage;
-        return returnMessage.orElseGet(() -> saltErr.toString());
+        List<Optional<String>> messages = new LinkedList<>();
+        messages.add(SaltUtils.decodeStdMessage(saltErr, "stderr"));
+        messages.add(SaltUtils.decodeStdMessage(saltErr, "stdout"));
+        messages.add(SaltUtils.decodeStdMessage(saltErr, "return"));
+        Optional<String> error = Optional.ofNullable(messages.stream()
+                    .flatMap(Optional::stream)
+                    .collect(Collectors.joining(" "))
+                ).filter(s -> !s.isEmpty());
+        return error.orElseGet(() -> saltErr.toString());
     }
 
     /**

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -1913,14 +1913,15 @@ public class SaltUtils {
             if (json.isJsonObject() && json.getAsJsonObject().has(key)) {
                 if (json.getAsJsonObject().get(key).isJsonPrimitive() &&
                     json.getAsJsonObject().get(key).getAsJsonPrimitive().isString()) {
-                    return Optional.of(json.getAsJsonObject()
-                            .get(key).getAsJsonPrimitive().getAsString());
+                    return Optional.ofNullable(
+                            json.getAsJsonObject().get(key).getAsJsonPrimitive().getAsString())
+                            .filter(s -> !s.isEmpty());
                 }
                 else if (json.getAsJsonObject().get(key).isJsonArray()) {
                     StringBuilder msg = new StringBuilder();
                     json.getAsJsonObject().get(key).getAsJsonArray()
                             .forEach(elem -> msg.append(elem.getAsString()));
-                    return Optional.of(msg.toString());
+                    return Optional.ofNullable(msg.toString()).filter(s -> !s.isEmpty());
                 }
             }
         }

--- a/java/code/src/com/suse/manager/webui/controllers/utils/AbstractMinionBootstrapper.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/AbstractMinionBootstrapper.java
@@ -145,7 +145,7 @@ public abstract class AbstractMinionBootstrapper {
             String responseMessage = "Cannot read/write '" + SALT_SSH_DIR_PATH + "/known_hosts'. " +
                                      "Please check permissions.";
             LOG.error("Error during bootstrap: " + responseMessage);
-            return new BootstrapResult(false, Optional.of(contactMethod), responseMessage);
+            return new BootstrapResult(false, Optional.of(contactMethod), responseMessage.split("\\r?\\n"));
         }
 
         try {
@@ -155,7 +155,7 @@ public abstract class AbstractMinionBootstrapper {
                         String responseMessage = SaltUtils.decodeSaltErr(error);
                         LOG.error("Error during bootstrap: " + responseMessage);
                         return new BootstrapResult(false, Optional.of(contactMethod),
-                                responseMessage);
+                                responseMessage.split("\\r?\\n"));
                     },
                     result -> {
                         // We have results, check if result = true
@@ -169,7 +169,7 @@ public abstract class AbstractMinionBootstrapper {
                             LOG.error("States failed during bootstrap: " + msg);
                         });
                         return new BootstrapResult(success, Optional.of(contactMethod),
-                                errMessage.orElse(null));
+                                Opt.fold(errMessage, () -> null, m -> m.split("\\r?\\n")));
                     }
             );
         }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- improve salt-ssh error parsing on bootstrapping (bsc#1172120)
+
 -------------------------------------------------------------------
 Wed Jun 10 12:16:32 CEST 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

salt ssh sometimes put usefull messages in stdout while stderr
is an empty string. But Options.of("") is still "present" which
result in showing an empty sting as error message

## GUI diff

No difference.

Before:

![image](https://user-images.githubusercontent.com/1038917/84242864-b5b3d500-ab01-11ea-8908-96ae5a4f7bb4.png)

After:

![Screenshot_20200610_120127](https://user-images.githubusercontent.com/1038917/84255093-6c1fb600-ab12-11ea-806c-af6dc80aeb46.png)


- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **one out of a million parsing problems**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11557
Tracks #

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
