### PR TITLE
Fix bootstrap repo create without flush

### DIFF
--- a/susemanager/src/mgr-create-bootstrap-repo
+++ b/susemanager/src/mgr-create-bootstrap-repo
@@ -404,7 +404,7 @@ def create_repo(label, options, mgr_bootstrap_data, additional=[]):
     if options.dryrun:
         log("Create directory:", destdirtmp)
     else:
-        if options.flush:
+        if options.flush or not os.path.exists(destdir):
             os.makedirs(destdirtmp)
         else:
             shutil.copytree(destdir, destdirtmp)

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- fix bootstrap repo create without flush option (bsc#1172702)
+
 -------------------------------------------------------------------
 Wed Jun 10 12:36:34 CEST 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Without --flush we try to copy the existing bootstrap repo to make changes in it.
But if it does not exist it will fail with this error.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **covered manual**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11686

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
