### PR TITLE
Enable osimage_build_host for additional archs (bsc#1149101, bsc#1172076)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/entitlement/test/OSImageBuildHostEntitlementTest.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/test/OSImageBuildHostEntitlementTest.java
@@ -9,11 +9,6 @@ import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.testing.ServerTestUtils;
 
-import com.suse.manager.reactor.utils.ValueMap;
-
-import java.util.HashMap;
-import java.util.Map;
-
 public class OSImageBuildHostEntitlementTest extends BaseEntitlementTestCase {
 
     @Override public void setUp() throws Exception {
@@ -34,6 +29,8 @@ public class OSImageBuildHostEntitlementTest extends BaseEntitlementTestCase {
     @Override
     public void testIsAllowedOnServer() throws Exception {
         Server traditional = ServerTestUtils.createTestSystem(user);
+        traditional.setOs("SLES");
+        traditional.setRelease("12.2");
         Server minion = MinionServerFactoryTest.createTestMinionServer(user);
         minion.setOs("SLES");
         minion.setRelease("12.2");
@@ -44,25 +41,17 @@ public class OSImageBuildHostEntitlementTest extends BaseEntitlementTestCase {
         assertTrue(ent.isAllowedOnServer(minion));
         assertFalse(ent.isAllowedOnServer(traditional));
 
+        minion.setOs("SLES");
+        minion.setRelease("15.1");
+        assertTrue(ent.isAllowedOnServer(minion));
+
         minion.setOs("RedHat Linux");
         minion.setRelease("6Server");
-        assertTrue(ent.isAllowedOnServer(minion));
+        assertFalse(ent.isAllowedOnServer(minion));
     }
 
     @Override
-    public void testIsAllowedOnServerWithGrains() throws Exception {
-        Server minion = MinionServerFactoryTest.createTestMinionServer(user);
-        Map<String, Object> grains = new HashMap<>();
-        grains.put("os_family", "Suse");
-        grains.put("osmajorrelease", "12");
-
-        assertTrue(ent.isAllowedOnServer(minion, new ValueMap(grains)));
-
-        grains.put("os_family", "RedHat");
-        grains.put("osmajorrelease", "7");
-        assertTrue(ent.isAllowedOnServer(minion, new ValueMap(grains)));
-
-        SystemEntitlementManager.INSTANCE.setBaseEntitlement(minion, EntitlementManager.MANAGEMENT);
-        assertFalse(ent.isAllowedOnServer(minion, new ValueMap(grains)));
+    public void testIsAllowedOnServerWithGrains() {
+        // Nothing to test
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
@@ -126,16 +126,12 @@ public class MinionServer extends Server implements SaltConfigurable {
     /**
      * Return <code>true</code> if OS on this system supports OS Image building,
      * <code>false</code> otherwise.
-     * <p>
-     * Note: For SLES, we are only checking if it's not 10.
-     * Older than SLES 10 are not being checked.
-     * </p>
      *
      * @return <code>true</code> if OS supports OS Image building
      */
     @Override
     public boolean doesOsSupportsOSImageBuilding() {
-        return !isSLES10();
+        return isSLES11() || isSLES12() || isSLES15() || isLeap15();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
@@ -151,7 +151,8 @@ public class MinionServer extends Server implements SaltConfigurable {
 
     @Override
     public boolean doesOsSupportsMonitoring() {
-        return isSLES12() || isSLES15() || isLeap15() || isUbuntu1804() || isRedHat6() || isRedHat7() || isRedHat8();
+        return isSLES12() || isSLES15() || isLeap15() || isUbuntu1804() || isUbuntu2004() || isRedHat6() ||
+                isRedHat7() || isRedHat8();
     }
 
     /**
@@ -188,6 +189,10 @@ public class MinionServer extends Server implements SaltConfigurable {
 
     private boolean isUbuntu1804() {
         return ServerConstants.UBUNTU.equals(getOs()) && getRelease().equals("18.04");
+    }
+
+    private boolean isUbuntu2004() {
+        return ServerConstants.UBUNTU.equals(getOs()) && getRelease().equals("20.04");
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/test/SystemEntitlementsSetupActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/test/SystemEntitlementsSetupActionTest.java
@@ -149,8 +149,10 @@ public class SystemEntitlementsSetupActionTest extends RhnMockStrutsTestCase {
         }});
 
         Server server = MinionServerFactoryTest.createTestMinionServer(user);
-        // OS Image building is x86_64 only
+        // OS Image building is SUSE only
         server.setServerArch(ServerFactory.lookupServerArchByLabel("x86_64-redhat-linux"));
+        server.setOs("SLES");
+        server.setRelease("15.1");
         ServerFactory.save(server);
 
         assertTrue(EntitlementManager.OSIMAGE_BUILD_HOST.isAllowedOnServer(server));

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Enable OS image building for all SUSE distributions (bsc#1149101, bsc#1172076)
 - Toggle virtpoller when toggling virtualization host entitlement (bsc#1172962)
 - Deleting registered VM doesn't remove them VM from the Guests list (bsc#1170096)
 - improve salt-ssh error parsing on bootstrapping (bsc#1172120)

--- a/schema/spacewalk/common/data/rhnServerServerGroupArchCompat.sql
+++ b/schema/spacewalk/common/data/rhnServerServerGroupArchCompat.sql
@@ -837,6 +837,18 @@ insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type)
     values (lookup_server_arch('x86_64-redhat-linux'),
             lookup_sg_type('osimage_build_host'));
 
+insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type)
+    values (lookup_server_arch('ppc64le-redhat-linux'),
+            lookup_sg_type('osimage_build_host'));
+
+insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type)
+    values (lookup_server_arch('aarch64-redhat-linux'),
+            lookup_sg_type('osimage_build_host'));
+
+insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type)
+    values (lookup_server_arch('s390x-redhat-linux'),
+            lookup_sg_type('osimage_build_host'));
+
 -- monitoring_entitled compatibilities
 
 insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type)

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,5 @@
+- Enable osimage_build_host for additional architectures (bsc#1149101, bsc#1172076)
+
 -------------------------------------------------------------------
 Wed Jun 10 12:40:28 CEST 2020 - jgonzalez@suse.com
 

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.8-to-susemanager-schema-4.1.9/001-osimage-build-host-enable-archs.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.8-to-susemanager-schema-4.1.9/001-osimage-build-host-enable-archs.sql
@@ -1,0 +1,27 @@
+insert into rhnServerServerGroupArchCompat (server_arch_id, server_group_type)
+    select lookup_server_arch('ppc64le-redhat-linux'),
+            lookup_sg_type('osimage_build_host')
+    from dual where not exists (
+        select 1 from rhnServerServerGroupArchCompat where
+        server_arch_id=lookup_server_arch('ppc64le-redhat-linux') and
+        server_group_type=lookup_sg_type('osimage_build_host')
+    );
+
+insert into rhnServerServerGroupArchCompat (server_arch_id, server_group_type)
+    select lookup_server_arch('aarch64-redhat-linux'),
+            lookup_sg_type('osimage_build_host')
+    from dual where not exists (
+        select 1 from rhnServerServerGroupArchCompat where
+        server_arch_id=lookup_server_arch('aarch64-redhat-linux') and
+        server_group_type=lookup_sg_type('osimage_build_host')
+    );
+
+insert into rhnServerServerGroupArchCompat (server_arch_id, server_group_type)
+    select lookup_server_arch('s390x-redhat-linux'),
+            lookup_sg_type('osimage_build_host')
+    from dual where not exists (
+        select 1 from rhnServerServerGroupArchCompat where
+        server_arch_id=lookup_server_arch('s390x-redhat-linux') and
+        server_group_type=lookup_sg_type('osimage_build_host')
+    );
+


### PR DESCRIPTION
## What does this PR change?

This patch enables the `osimage_build_host` entitlement for additional architectures: `ppc64le-redhat-linux`, `aarch64-redhat-linux` and `s390x-redhat-linux`.

## GUI diff

For non-x86_64 architectures the checkbox is displayed, but does not work. This should be fixed with this patch.

- [X] **DONE**

## Documentation

- No documentation needed, this should be the expected behavior.

- [X] **DONE**

## Test coverage

- No additional tests needed.

- [X] **DONE**

## Links

Fixes the following issues (and corresponding bugs):

- https://github.com/SUSE/spacewalk/issues/9252
- https://github.com/SUSE/spacewalk/issues/11566

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below).

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle" 
- [ ] Re-run test "java_pgsql_tests"  
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
