### PR TITLE
susemanager-sls: require PyYAML version >= 5.1 

### DIFF
--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Require PyYAML version >= 5.1
 - Log out of Docker registries after image build (bsc#1165572)
 - Prevent "module.run" deprecation warnings by using custom mgrcompat module
 

--- a/susemanager-utils/susemanager-sls/susemanager-sls.spec
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.spec
@@ -33,10 +33,12 @@ Requires:       susemanager-build-keys-web >= 12.0.1
 BuildRequires:  python3-pytest
 BuildRequires:  python3-mock
 BuildRequires:  python3-salt
+Requires:       python3-PyYAML >= 5.1
 %else
 BuildRequires:  python-pytest
 BuildRequires:  python-mock
 BuildRequires:  python-salt
+Requires:       python-PyYAML >= 5.1
 %endif
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch


### PR DESCRIPTION
## What does this PR change?

We introduced the usage of `PyYAML.FullLoader` in our `suma_minion` external pillar module at https://github.com/uyuni-project/uyuni/pull/2232 (which is only available in PyYAML >= 5.1)

Since our `suma_minion` module is provided by `susemanager-sls` package, this PR adds this new "Require" to the package.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal changes**

- [x] **DONE**

## Test coverage
- No tests: **not needed**
- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11709

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
