### PR TITLE
virtualization bug fixes

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -84,6 +84,7 @@ import com.redhat.rhn.frontend.dto.CustomDataKeyOverview;
 import com.redhat.rhn.frontend.dto.EmptySystemProfileOverview;
 import com.redhat.rhn.frontend.dto.EssentialServerDto;
 import com.redhat.rhn.frontend.dto.SystemOverview;
+import com.redhat.rhn.frontend.dto.VirtualSystemOverview;
 import com.redhat.rhn.frontend.listview.PageControl;
 import com.redhat.rhn.manager.action.ActionManager;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
@@ -336,6 +337,8 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
             // expected
         }
 
+        DataResult<VirtualSystemOverview> data = SystemManager.virtualGuestsForHostList(user, host.getId(), null);
+        assertEquals("Guest not found", 1, data.getTotalSize());
     }
 
     public void testDeleteVirtualServerHostDeleted() throws Exception {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Deleting registered VM doesn't remove them VM from the Guests list (bsc#1170096)
 - improve salt-ssh error parsing on bootstrapping (bsc#1172120)
 
 -------------------------------------------------------------------

--- a/spacewalk/admin/mgr-websockify.service
+++ b/spacewalk/admin/mgr-websockify.service
@@ -6,7 +6,5 @@ ExecStartPre=/usr/bin/sh -c "grep secret_key /etc/rhn/rhn.conf | tr -d ' ' | cut
 ExecStart=/usr/bin/websockify \
     --token-plugin JWTTokenApi \
 	--token-source /etc/rhn/websockify.key \
-	--cert /etc/apache2/ssl.crt/server.crt \
-	--key /etc/pki/tls/private/spacewalk.key \
-	8050
+	localhost:8050
 ExecReload=/bin/kill -USR1 $MAINPID

--- a/spacewalk/admin/spacewalk-admin.changes
+++ b/spacewalk/admin/spacewalk-admin.changes
@@ -1,3 +1,5 @@
+- Restrict websockify to server localhost only (bsc#1149644)
+
 -------------------------------------------------------------------
 Mon Apr 13 09:31:58 CEST 2020 - jgonzalez@suse.com
 

--- a/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-www.conf
+++ b/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-www.conf
@@ -71,7 +71,7 @@ RewriteRule ^/rhn(.*) ajp://localhost:8009/rhn$1 [P]
 
 <IfModule proxy_wstunnel_module>
 ProxyPass "/rhn/websocket" "ws://localhost:8080/rhn/websocket"
-ProxyPass "/rhn/websockify" "wss://localhost:8050/"
+ProxyPass "/rhn/websockify" "ws://localhost:8050/"
 </IfModule>
 
 # mod_xsendfile configuration

--- a/spacewalk/config/spacewalk-config.changes
+++ b/spacewalk/config/spacewalk-config.changes
@@ -1,3 +1,5 @@
+- Don't use SSL to proxy mgr-websockify with apache (bsc#1149644)
+
 -------------------------------------------------------------------
 Wed Mar 11 10:53:59 CET 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

When a virtual instance's host is known don't remove it when deleting
the system otherwise the VM will disappear from the guests list of the
host too.

Also fixes virtualization graphical console by removing SSL between apache and websockify.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: bug fix

- [X] **DONE**

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

Fixes:
 * SUSE/spacewalk#11306
 * SUSE/spacewalk#11710

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
