### PR TITLE
Enable bootstrap repository creation for openSUSE Leap 15.2 for Uyuni

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -1106,6 +1106,10 @@ DATA = {
         'PDID' : [2001], 'PKGLIST' : PKGLIST15_SALT + PKGLIST15_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/opensuse/15/2/bootstrap/'
     },
+    'openSUSE-Leap-15.2-x86_64-uyuni' : {
+        'BASECHANNEL' : 'opensuse_leap15_2-x86_64', 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15SP0SP1_SALT + PKGLIST15_X86_ARM,
+        'DEST' : '/srv/www/htdocs/pub/repositories/opensuse/15/2/bootstrap/'
+    },
     'centos-6-x86_64' : {
         'PDID' : [-11, 1682], 'BETAPDID' : [2064], 'PKGLIST' : RES6,
         'DEST' : '/srv/www/htdocs/pub/repositories/centos/6/bootstrap/'

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- Enable bootstrap repository creation for openSUSE Leap 15.2 for Uyuni
+
 -------------------------------------------------------------------
 Wed Jun 10 12:36:34 CEST 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Enable bootstrap repository creation for openSUSE Leap 15.2 for Uyuni

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Not needed for now. Leap 15.2 is not supported officially as it's not released.

- [x] **DONE**

## Test coverage
- No tests: To be tested by cucumber in the future.

- [x] **DONE**

## Links

Nothing

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
