### PR TITLE
Explain that twopence gem doesn't exist

### DIFF
--- a/testsuite/Gemfile
+++ b/testsuite/Gemfile
@@ -11,7 +11,7 @@ gem 'nokogiri', '1.10.8'
 gem 'rake', '12.3.3'
 gem 'selenium-webdriver', '3.14.1'
 #gem 'simplecov', '0.17.0'
-gem 'twopence'
+#gem 'twopence' # This gem doesn't exist, instead you can install the rpm from https://build.opensuse.org/package/show/systemsmanagement:sumaform:tools/twopence
 gem 'xmlrpc', '0.3.0'
 gem 'minitest', ' 5.11.3'
 gem 'websocket', '1.2.8'

--- a/testsuite/documentation/software-components.md
+++ b/testsuite/documentation/software-components.md
@@ -17,7 +17,7 @@ Below is the list of Ruby gems used by the testsuite. It may change over time as
 
 ### Communication with test VMs
 
-* ```twopence``` allows to run commands, import and extract files as one would do with ssh and scp, but with a test-oriented approach (timeouts, etc)
+* ```twopence``` allows to run commands, import and extract files as one would do with ssh and scp, but with a test-oriented approach (timeouts, etc). Twopence can be installed as rpm from [here](https://build.opensuse.org/package/show/systemsmanagement:sumaform:tools/twopence).
 * ```lavanda``` offers Ruby convenience extensions to twopence
 
 ### Simulation of user interaction


### PR DESCRIPTION
## What does this PR change?

- Explaining that if you want to use the testsuite without a controller, you must install as rpm the twopence tool.
- Comment a wrong reference to an unexisting gem in the Gemfile
- Temporary fix, until we create a proper gem for twopence.


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Small comment in the test suite documentation

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/11633

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
