### PR TITLE
Toggle virtpoller beacon when toggling the virtualization entitlement

### DIFF
--- a/java/code/src/com/redhat/rhn/common/messaging/MessageQueue.java
+++ b/java/code/src/com/redhat/rhn/common/messaging/MessageQueue.java
@@ -16,6 +16,7 @@
 package com.redhat.rhn.common.messaging;
 
 import com.redhat.rhn.frontend.events.AlignSoftwareTargetAction;
+import com.redhat.rhn.frontend.events.AlignSoftwareTargetMsg;
 import com.redhat.rhn.frontend.events.CloneErrataAction;
 import com.redhat.rhn.frontend.events.CloneErrataEvent;
 import com.redhat.rhn.frontend.events.NewCloneErrataAction;
@@ -53,10 +54,11 @@ import com.redhat.rhn.frontend.events.TraceBackEvent;
 import com.redhat.rhn.frontend.events.UpdateErrataCacheAction;
 import com.redhat.rhn.frontend.events.UpdateErrataCacheEvent;
 
-import com.redhat.rhn.frontend.events.AlignSoftwareTargetMsg;
 import com.suse.manager.reactor.messaging.ChannelsChangedEventMessage;
 import com.suse.manager.reactor.messaging.ChannelsChangedEventMessageAction;
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
+
 import org.apache.log4j.Logger;
 
 import java.util.ArrayList;
@@ -270,8 +272,9 @@ public class MessageQueue {
      * This method should be called directly after <code>startMessaging</code>.
      *
      * @param systemQuery instance for gathering data from a system
+     * @param saltApi Salt Api instance to use
      */
-    public static void configureDefaultActions(SystemQuery systemQuery) {
+    public static void configureDefaultActions(SystemQuery systemQuery, SaltApi saltApi) {
         // Register the Actions for the Events
         // If we develop a large set of MessageEvents we may want to
         // refactor this block out into a class or method that
@@ -336,7 +339,7 @@ public class MessageQueue {
                                     SsmConfigFilesEvent.class);
 
         // Handle changes of channel assignments on minions
-        MessageQueue.registerAction(new ChannelsChangedEventMessageAction(systemQuery),
+        MessageQueue.registerAction(new ChannelsChangedEventMessageAction(systemQuery, saltApi),
                 ChannelsChangedEventMessage.class);
     }
 }

--- a/java/code/src/com/redhat/rhn/common/security/acl/test/AccessTest.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/test/AccessTest.java
@@ -325,7 +325,7 @@ public class AccessTest extends BaseTestCaseWithUser {
     public void testIsVirtual() throws Exception {
         SaltService saltService = new SaltService();
         SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(),
+                new SystemUnentitler(new VirtManagerSalt(saltService), new FormulaMonitoringManager()),
                 new SystemEntitler(saltService, new VirtManagerSalt(saltService), new FormulaMonitoringManager())
         );
         Server host = ServerTestUtils.createVirtHostWithGuests(user, 1, systemEntitlementManager);

--- a/java/code/src/com/redhat/rhn/domain/entitlement/test/VirtualizationEntitlementTest.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/test/VirtualizationEntitlementTest.java
@@ -48,7 +48,7 @@ public class VirtualizationEntitlementTest extends BaseEntitlementTestCase {
     public void testIsAllowedOnServer() throws Exception {
         SaltService saltService = new SaltService();
         SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(),
+                new SystemUnentitler(new VirtManagerSalt(saltService), new FormulaMonitoringManager()),
                 new SystemEntitler(saltService, new VirtManagerSalt(saltService), new FormulaMonitoringManager())
         );
         Server host = ServerTestUtils.createVirtHostWithGuests(1, systemEntitlementManager);

--- a/java/code/src/com/redhat/rhn/domain/server/test/HostBuilder.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/HostBuilder.java
@@ -92,7 +92,8 @@ public class HostBuilder {
      */
     public HostBuilder createVirtHost() throws Exception {
         SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(),
+                new SystemUnentitler(new VirtManagerSalt(SaltService.INSTANCE_SALT_API),
+                        new FormulaMonitoringManager()),
                 new SystemEntitler(SaltService.INSTANCE, new VirtManagerSalt(SaltService.INSTANCE_SALT_API),
                         new FormulaMonitoringManager())
         );

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerTest.java
@@ -27,16 +27,19 @@ import com.redhat.rhn.domain.server.ServerInfo;
 import com.redhat.rhn.domain.server.VirtualInstance;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
+import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
 import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
-import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.redhat.rhn.manager.system.test.SystemManagerTest;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.ServerTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
+
+import com.suse.manager.virtualization.VirtManagerSalt;
+import com.suse.manager.webui.services.impl.SaltService;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -50,7 +53,10 @@ import java.util.Optional;
  */
 public class ServerTest extends BaseTestCaseWithUser {
 
-    private SystemUnentitler systemUnentitler = SystemUnentitler.INSTANCE;
+    private final SaltService saltService = new SaltService();
+    private final SystemUnentitler systemUnentitler = new SystemUnentitler(
+            new VirtManagerSalt(saltService),
+            new FormulaMonitoringManager());
 
     public void testIsInactive() throws Exception {
         Server s = ServerFactory.createServer();

--- a/java/code/src/com/redhat/rhn/domain/server/test/VirtualInstanceFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/VirtualInstanceFactoryTest.java
@@ -57,7 +57,7 @@ public class VirtualInstanceFactoryTest extends RhnBaseTestCase {
                 "testOrg" + this.getClass().getSimpleName());
         builder = new GuestBuilder(user);
         systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(),
+                new SystemUnentitler(new TestVirtManager(), new FormulaMonitoringManager()),
                 new SystemEntitler(new SaltService(), new TestVirtManager(), new FormulaMonitoringManager())
         );
     }

--- a/java/code/src/com/redhat/rhn/frontend/action/errata/test/ChannelActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/errata/test/ChannelActionTest.java
@@ -47,7 +47,8 @@ import org.apache.struts.action.ActionMapping;
 public class ChannelActionTest extends RhnBaseTestCase {
 
     public void testPublish() throws Exception {
-        MessageQueue.configureDefaultActions(new SaltService());
+        SaltService saltService = new SaltService();
+        MessageQueue.configureDefaultActions(saltService, saltService);
 
         ChannelAction action = new ChannelAction();
 

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/test/SystemEntitlementsSetupActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/test/SystemEntitlementsSetupActionTest.java
@@ -69,7 +69,8 @@ public class SystemEntitlementsSetupActionTest extends RhnMockStrutsTestCase {
         context.setImposteriser(ClassImposteriser.INSTANCE);
         saltServiceMock = context.mock(SaltService.class);
         systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(),
+                new SystemUnentitler(new VirtManagerSalt(saltServiceMock),
+                        new FormulaMonitoringManager()),
                 new SystemEntitler(saltServiceMock, new VirtManagerSalt(saltServiceMock),
                         new FormulaMonitoringManager())
         );

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/test/SystemEntitlementsSubmitActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/test/SystemEntitlementsSubmitActionTest.java
@@ -160,7 +160,7 @@ public class SystemEntitlementsSubmitActionTest extends RhnPostMockStrutsTestCas
                                             )  throws Exception {
         SaltService saltService = new SaltService();
         SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(),
+                new SystemUnentitler(new VirtManagerSalt(saltService), new FormulaMonitoringManager()),
                 new SystemEntitler(saltService, new VirtManagerSalt(saltService), new FormulaMonitoringManager())
         );
         Server server = ServerTestUtils.createVirtHostWithGuests(user, 1, systemEntitlementManager);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/test/ImageInfoHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/test/ImageInfoHandlerTest.java
@@ -53,7 +53,6 @@ import com.redhat.rhn.manager.action.ActionManager;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.errata.cache.ErrataCacheManager;
 import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
-import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
@@ -62,7 +61,6 @@ import com.redhat.rhn.taskomatic.TaskomaticApiException;
 import com.redhat.rhn.testing.ImageTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 
-import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.virtualization.VirtManagerSalt;
 import com.suse.manager.webui.services.impl.SaltSSHService;
 import com.suse.manager.webui.services.impl.SaltService;
@@ -165,7 +163,7 @@ public class ImageInfoHandlerTest extends BaseHandlerTestCase {
                 will(returnValue(Optional.of(mockResult)));
         }});
         SystemEntitlementManager sem = new SystemEntitlementManager(
-                new SystemUnentitler(),
+                new SystemUnentitler(new VirtManagerSalt(saltServiceMock), new FormulaMonitoringManager()),
                 new SystemEntitler(saltServiceMock, new VirtManagerSalt(saltServiceMock),
                         new FormulaMonitoringManager())
         );

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -14,45 +14,6 @@
  */
 package com.redhat.rhn.frontend.xmlrpc.system.test;
 
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import com.redhat.rhn.domain.server.NetworkInterfaceFactory;
-import com.redhat.rhn.domain.state.PackageState;
-import com.redhat.rhn.domain.state.PackageStates;
-import com.redhat.rhn.domain.state.ServerStateRevision;
-import com.redhat.rhn.domain.state.StateFactory;
-import com.redhat.rhn.domain.state.VersionConstraints;
-import com.redhat.rhn.frontend.xmlrpc.InvalidParameterException;
-import com.redhat.rhn.manager.action.ActionChainManager;
-import org.apache.commons.lang3.StringUtils;
-import org.jmock.Expectations;
-import org.jmock.Mockery;
-import org.jmock.integration.junit3.JUnit3Mockery;
-import org.jmock.lib.concurrent.Synchroniser;
-import org.jmock.lib.legacy.ClassImposteriser;
-import com.redhat.rhn.frontend.dto.ErrataOverview;
-import com.redhat.rhn.frontend.dto.HistoryEvent;
-import com.redhat.rhn.frontend.dto.OperationDetailsDto;
-import com.redhat.rhn.frontend.dto.PackageMetadata;
-import com.redhat.rhn.frontend.dto.ScheduledAction;
-import com.redhat.rhn.frontend.dto.ServerPath;
-import com.redhat.rhn.frontend.dto.ShortSystemInfo;
-import com.redhat.rhn.frontend.dto.SystemOverview;
-
 import com.redhat.rhn.FaultException;
 import com.redhat.rhn.common.client.ClientCertificate;
 import com.redhat.rhn.common.db.datasource.DataResult;
@@ -117,10 +78,23 @@ import com.redhat.rhn.domain.server.test.GuestBuilder;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.domain.server.test.NetworkInterfaceTest;
 import com.redhat.rhn.domain.server.test.ServerFactoryTest;
+import com.redhat.rhn.domain.state.PackageState;
+import com.redhat.rhn.domain.state.PackageStates;
+import com.redhat.rhn.domain.state.ServerStateRevision;
+import com.redhat.rhn.domain.state.StateFactory;
+import com.redhat.rhn.domain.state.VersionConstraints;
 import com.redhat.rhn.domain.token.ActivationKey;
 import com.redhat.rhn.domain.token.test.ActivationKeyTest;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.domain.user.UserFactory;
+import com.redhat.rhn.frontend.dto.ErrataOverview;
+import com.redhat.rhn.frontend.dto.HistoryEvent;
+import com.redhat.rhn.frontend.dto.OperationDetailsDto;
+import com.redhat.rhn.frontend.dto.PackageMetadata;
+import com.redhat.rhn.frontend.dto.ScheduledAction;
+import com.redhat.rhn.frontend.dto.ServerPath;
+import com.redhat.rhn.frontend.dto.ShortSystemInfo;
+import com.redhat.rhn.frontend.dto.SystemOverview;
 import com.redhat.rhn.frontend.events.SsmDeleteServersAction;
 import com.redhat.rhn.frontend.xmlrpc.ChannelSubscriptionException;
 import com.redhat.rhn.frontend.xmlrpc.InvalidActionTypeException;
@@ -169,6 +143,7 @@ import com.suse.manager.webui.controllers.utils.RegularMinionBootstrapper;
 import com.suse.manager.webui.controllers.utils.SSHMinionBootstrapper;
 import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.impl.SaltService;
+
 import org.apache.commons.lang3.StringUtils;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
@@ -188,6 +163,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -1912,7 +1888,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         SaltService saltService = new SaltService();
 
         SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(),
+                new SystemUnentitler(new VirtManagerSalt(saltService), new FormulaMonitoringManager()),
                 new SystemEntitler(saltService, new VirtManagerSalt(saltService), new FormulaMonitoringManager())
         );
         Server server = ServerTestUtils.createVirtHostWithGuests(admin, 0, systemEntitlementManager);
@@ -1942,7 +1918,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
     public void testAddEntitlementSystemAlreadyHas() throws Exception {
         SaltService saltService = new SaltService();
         SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(),
+                new SystemUnentitler(new VirtManagerSalt(saltService), new FormulaMonitoringManager()),
                 new SystemEntitler(saltService, new VirtManagerSalt(saltService), new FormulaMonitoringManager())
         );
         Server server = ServerTestUtils.createVirtHostWithGuests(admin, 0, systemEntitlementManager);

--- a/java/code/src/com/redhat/rhn/manager/formula/FormulaManager.java
+++ b/java/code/src/com/redhat/rhn/manager/formula/FormulaManager.java
@@ -25,9 +25,11 @@ import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.MinionServerFactory;
 import com.redhat.rhn.domain.server.ServerGroupFactory;
 import com.redhat.rhn.domain.user.User;
+
 import com.suse.manager.model.clusters.Cluster;
-import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.salt.netapi.datatypes.target.MinionList;
 import com.suse.utils.Opt;
 
@@ -49,13 +51,16 @@ public class FormulaManager {
 
     private static FormulaManager instance;
     private SystemQuery systemQuery;
+    private SaltApi saltApi;
     private ServerGroupFactory serverGroupFactory = ServerGroupFactory.SINGLETON;
     private static final String DEFAULT_KEY = "$default";
     private static final String TYPE_KEY = "$type";
     private static final String EDIT_GROUP = "edit-group";
     private static final String PROTOTYPE = "$prototype";
+
     private FormulaManager() {
         systemQuery = SaltService.INSTANCE;
+        saltApi = SaltService.INSTANCE_SALT_API;
     }
 
     /**
@@ -79,6 +84,14 @@ public class FormulaManager {
     }
 
     /**
+     * This method is only for testing purpose.
+     * @param saltApiIn to set
+     */
+    public void setSaltApi(SaltApi saltApiIn) {
+        this.saltApi = saltApiIn;
+    }
+
+    /**
      * Save the formula data for the given system.
      * @param user user
      * @param systemId systemId
@@ -92,7 +105,7 @@ public class FormulaManager {
                 .orElseThrow(() -> new IllegalArgumentException("Minion " + systemId + " not found."));
         FormulaUtil.ensureUserHasPermissionsOnServer(user, minion);
         FormulaFactory.saveServerFormulaData(content, minion.getMinionId(), formulaName);
-        systemQuery.refreshPillar(new MinionList(minion.getMinionId()));
+        saltApi.refreshPillar(new MinionList(minion.getMinionId()));
     }
 
     /**
@@ -112,7 +125,7 @@ public class FormulaManager {
         List<String> minionIds = group.getServers().stream()
             .flatMap(s -> Opt.stream(s.asMinionServer()))
             .map(MinionServer::getMinionId).collect(Collectors.toList());
-        systemQuery.refreshPillar(new MinionList(minionIds));
+        saltApi.refreshPillar(new MinionList(minionIds));
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/formula/test/FormulaManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/formula/test/FormulaManagerTest.java
@@ -79,6 +79,7 @@ public class FormulaManagerTest extends JMockBaseTestCaseWithUser {
         MockConnection.clear();
         saltServiceMock = mock(SaltService.class);
         manager.setSystemQuery(saltServiceMock);
+        manager.setSaltApi(saltServiceMock);
         metadataDir = Files.createTempDirectory("metadata");
         FormulaFactory.setDataDir(tmpSaltRoot.toString());
         FormulaFactory.setMetadataDirOfficial(metadataDir.toString());

--- a/java/code/src/com/redhat/rhn/manager/system/entitling/SystemEntitlementManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/entitling/SystemEntitlementManager.java
@@ -28,7 +28,8 @@ import com.suse.manager.webui.services.impl.SaltService;
 public class SystemEntitlementManager {
 
     public static final SystemEntitlementManager INSTANCE = new SystemEntitlementManager(
-            SystemUnentitler.INSTANCE,
+            new SystemUnentitler(new VirtManagerSalt(SaltService.INSTANCE_SALT_API),
+                    new FormulaMonitoringManager()),
             new SystemEntitler(SaltService.INSTANCE, new VirtManagerSalt(SaltService.INSTANCE_SALT_API),
                     new FormulaMonitoringManager())
     );

--- a/java/code/src/com/redhat/rhn/manager/system/entitling/test/SystemEntitlementManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/entitling/test/SystemEntitlementManagerTest.java
@@ -54,7 +54,7 @@ public class SystemEntitlementManagerTest extends JMockBaseTestCaseWithUser {
         setImposteriser(ClassImposteriser.INSTANCE);
         saltServiceMock = mock(SaltService.class);
         systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(),
+                new SystemUnentitler(new VirtManagerSalt(saltServiceMock), new FormulaMonitoringManager()),
                 new SystemEntitler(saltServiceMock, new VirtManagerSalt(saltServiceMock),
                         new FormulaMonitoringManager())
         );

--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -179,7 +179,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         });
         SaltService saltService = new SaltService();
         systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(),
+                new SystemUnentitler(new VirtManagerSalt(saltService), new FormulaMonitoringManager()),
                 new SystemEntitler(saltService, new VirtManagerSalt(saltService), new FormulaMonitoringManager())
         );
         this.systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON);

--- a/java/code/src/com/redhat/rhn/taskomatic/core/SchedulerKernel.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/core/SchedulerKernel.java
@@ -14,6 +14,8 @@
  */
 package com.redhat.rhn.taskomatic.core;
 
+import static java.util.stream.Collectors.toSet;
+
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.conf.ConfigException;
@@ -27,9 +29,11 @@ import com.redhat.rhn.taskomatic.TaskoXmlRpcServer;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.domain.TaskoRun;
 import com.redhat.rhn.taskomatic.domain.TaskoSchedule;
+
 import com.suse.manager.metrics.PrometheusExporter;
 import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.impl.SaltService;
+
 import org.apache.log4j.Logger;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
@@ -42,8 +46,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
-
-import static java.util.stream.Collectors.toSet;
 
 /**
  * Taskomatic Kernel.
@@ -142,7 +144,7 @@ public class SchedulerKernel {
             throw new TaskomaticException("HibernateFactory failed to initialize");
         }
         MessageQueue.startMessaging();
-        MessageQueue.configureDefaultActions(SYSTEM_QUERY);
+        MessageQueue.configureDefaultActions(SYSTEM_QUERY, SaltService.INSTANCE_SALT_API);
         try {
             SchedulerKernel.scheduler.start();
             initializeAllSatSchedules();

--- a/java/code/src/com/redhat/rhn/testing/RhnBaseTestCase.java
+++ b/java/code/src/com/redhat/rhn/testing/RhnBaseTestCase.java
@@ -59,7 +59,7 @@ public abstract class RhnBaseTestCase extends TestCase {
      */
     public RhnBaseTestCase() {
         super();
-        MessageQueue.configureDefaultActions(saltService);
+        MessageQueue.configureDefaultActions(saltService, saltService);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/webapp/RhnServletListener.java
+++ b/java/code/src/com/redhat/rhn/webapp/RhnServletListener.java
@@ -21,6 +21,7 @@ import com.redhat.rhn.manager.satellite.UpgradeCommand;
 
 import com.suse.manager.reactor.SaltReactor;
 
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.impl.SaltService;
 import org.apache.log4j.LogManager;
@@ -53,15 +54,16 @@ public class RhnServletListener implements ServletContextListener {
     private boolean hibernateStarted = false;
     private boolean loggingStarted = false;
     private final SystemQuery systemQuery = SaltService.INSTANCE;
+    private final SaltApi saltApi = SaltService.INSTANCE_SALT_API;
 
     // Salt event reactor instance
-    private final SaltReactor saltReactor = new SaltReactor(SaltService.INSTANCE_SALT_API, systemQuery);
+    private final SaltReactor saltReactor = new SaltReactor(saltApi, systemQuery);
 
     private void startMessaging() {
         // Start the MessageQueue thread listening for
         // Events
         MessageQueue.startMessaging();
-        MessageQueue.configureDefaultActions(systemQuery);
+        MessageQueue.configureDefaultActions(systemQuery, saltApi);
     }
 
     private void stopMessaging() {

--- a/java/code/src/com/suse/manager/clusters/ClusterManager.java
+++ b/java/code/src/com/suse/manager/clusters/ClusterManager.java
@@ -37,10 +37,12 @@ import com.redhat.rhn.manager.formula.FormulaUtil;
 import com.redhat.rhn.manager.rhnpackage.PackageManager;
 import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
+
 import com.suse.manager.model.clusters.Cluster;
 import com.suse.manager.reactor.utils.LocalDateTimeISOAdapter;
 import com.suse.manager.reactor.utils.OptionalTypeAdapterFactory;
 import com.suse.manager.reactor.utils.ValueMap;
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.salt.netapi.datatypes.target.MinionList;
@@ -48,6 +50,7 @@ import com.suse.utils.Opt;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+
 import org.apache.commons.jexl2.Expression;
 import org.apache.commons.jexl2.JexlContext;
 import org.apache.commons.jexl2.JexlEngine;
@@ -82,6 +85,7 @@ public class ClusterManager {
 
 
     private static volatile ClusterManager instance;
+    private SaltApi saltApi;
     private SystemQuery systemQuery;
     private ServerGroupManager serverGroupManager;
     private FormulaManager formulaManager;
@@ -104,6 +108,7 @@ public class ClusterManager {
      * No arg constructor.
      */
     public ClusterManager() {
+        this.saltApi = SaltService.INSTANCE_SALT_API;
         this.systemQuery = SaltService.INSTANCE;
         this.serverGroupManager = ServerGroupManager.getInstance();
         this.formulaManager = FormulaManager.getInstance();
@@ -332,7 +337,7 @@ public class ClusterManager {
         List<String> minionIds = group.getServers().stream()
                 .flatMap(s -> Opt.stream(s.asMinionServer()))
                 .map(MinionServer::getMinionId).collect(Collectors.toList());
-        systemQuery.refreshPillar(new MinionList(minionIds));
+        saltApi.refreshPillar(new MinionList(minionIds));
     }
 
     /**

--- a/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
+++ b/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
@@ -82,7 +82,7 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
             }
         };
         systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(),
+                new SystemUnentitler(virtManager, new FormulaMonitoringManager()),
                 new SystemEntitler(new SaltService(), virtManager, new FormulaMonitoringManager())
         );
     }

--- a/java/code/src/com/suse/manager/reactor/messaging/ChannelsChangedEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/ChannelsChangedEventMessageAction.java
@@ -30,6 +30,7 @@ import com.redhat.rhn.manager.errata.ErrataManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.pillar.MinionPillarManager;
 import com.suse.salt.netapi.datatypes.target.MinionList;
@@ -52,6 +53,7 @@ public class ChannelsChangedEventMessageAction implements MessageAction {
 
     // Reference to the SaltService instance
     private final SystemQuery systemQuery;
+    private final SaltApi saltApi;
 
     private static final TaskomaticApi TASKOMATIC_API = new TaskomaticApi();
 
@@ -59,9 +61,11 @@ public class ChannelsChangedEventMessageAction implements MessageAction {
      * Constructor taking a {@link SystemQuery} instance.
      *
      * @param systemQueryIn systemQuery instance for gathering data from a system.
+     * @param saltApiIn Salt API instance to use
      */
-    public ChannelsChangedEventMessageAction(SystemQuery systemQueryIn) {
+    public ChannelsChangedEventMessageAction(SystemQuery systemQueryIn, SaltApi saltApiIn) {
         systemQuery = systemQueryIn;
+        saltApi = saltApiIn;
     }
 
     @Override
@@ -95,7 +99,7 @@ public class ChannelsChangedEventMessageAction implements MessageAction {
                     );
 
             // push the changed pillar data to the minion
-            systemQuery.refreshPillar(new MinionList(minion.getMinionId()));
+            saltApi.refreshPillar(new MinionList(minion.getMinionId()));
 
             if (msg.isScheduleApplyChannelsState()) {
                 User user = UserFactory.lookupById(event.getUserId());

--- a/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
@@ -15,6 +15,12 @@
 
 package com.suse.manager.reactor.messaging;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+import static java.util.Optional.ofNullable;
+import static java.util.stream.Collectors.partitioningBy;
+import static java.util.stream.Collectors.toSet;
+
 import com.redhat.rhn.common.messaging.MessageQueue;
 import com.redhat.rhn.common.validator.ValidatorResult;
 import com.redhat.rhn.domain.channel.Channel;
@@ -41,6 +47,7 @@ import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
+
 import com.suse.manager.reactor.utils.RhelUtils;
 import com.suse.manager.reactor.utils.ValueMap;
 import com.suse.manager.virtualization.VirtManagerSalt;
@@ -52,6 +59,9 @@ import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.services.pillar.MinionPillarManager;
 import com.suse.salt.netapi.calls.modules.Zypper;
 import com.suse.utils.Opt;
+
+import org.apache.log4j.Logger;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -61,13 +71,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
-import org.apache.log4j.Logger;
-
-import static java.util.Collections.emptyList;
-import static java.util.Collections.emptySet;
-import static java.util.Optional.ofNullable;
-import static java.util.stream.Collectors.partitioningBy;
-import static java.util.stream.Collectors.toSet;
 
 /**
  * Common registration logic that can be used from multiple places
@@ -85,7 +88,8 @@ public class RegistrationUtils {
     private static final Logger LOG = Logger.getLogger(RegistrationUtils.class);
 
     private static SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-            new SystemUnentitler(),
+            new SystemUnentitler(new VirtManagerSalt(SaltService.INSTANCE_SALT_API),
+                    new FormulaMonitoringManager()),
             new SystemEntitler(SaltService.INSTANCE, new VirtManagerSalt(SaltService.INSTANCE_SALT_API),
                     new FormulaMonitoringManager())
     );

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -618,6 +618,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
             oneOf(saltServiceMock).refreshPillar(with(any(MinionList.class)));
         }});
         SaltUtils.INSTANCE.setSystemQuery(saltServiceMock);
+        SaltUtils.INSTANCE.setSaltApi(saltServiceMock);
 
         Action action = ActionFactoryTest.createAction(
                 user, ActionFactory.TYPE_PACKAGES_REFRESH_LIST);

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -151,7 +151,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 DigestUtils.sha256Hex(TestUtils.randomString()));
         saltServiceMock = context().mock(SaltService.class);
         systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(),
+                new SystemUnentitler(new VirtManagerSalt(saltServiceMock), new FormulaMonitoringManager()),
                 new SystemEntitler(saltServiceMock, new VirtManagerSalt(saltServiceMock),
                         new FormulaMonitoringManager())
         );

--- a/java/code/src/com/suse/manager/reactor/messaging/test/LibvirtEngineDomainLifecycleMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/LibvirtEngineDomainLifecycleMessageActionTest.java
@@ -14,7 +14,6 @@
  */
 package com.suse.manager.reactor.messaging.test;
 
-import com.google.gson.JsonElement;
 import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.server.MinionServer;
@@ -30,9 +29,8 @@ import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 import com.redhat.rhn.testing.ServerTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 
-import com.google.gson.reflect.TypeToken;
-import com.suse.manager.reactor.messaging.LibvirtEngineDomainLifecycleMessageAction;
 import com.suse.manager.reactor.messaging.AbstractLibvirtEngineMessage;
+import com.suse.manager.reactor.messaging.LibvirtEngineDomainLifecycleMessageAction;
 import com.suse.manager.virtualization.GuestDefinition;
 import com.suse.manager.virtualization.test.TestVirtManager;
 import com.suse.manager.webui.services.iface.VirtManager;
@@ -40,6 +38,9 @@ import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.salt.netapi.datatypes.Event;
 import com.suse.salt.netapi.event.EngineEvent;
 import com.suse.salt.netapi.parser.JsonParser;
+
+import com.google.gson.JsonElement;
+import com.google.gson.reflect.TypeToken;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jmock.lib.legacy.ClassImposteriser;
@@ -97,7 +98,7 @@ public class LibvirtEngineDomainLifecycleMessageActionTest extends JMockBaseTest
         };
 
         SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(),
+                new SystemUnentitler(virtManager, new FormulaMonitoringManager()),
                 new SystemEntitler(new SaltService(), virtManager, new FormulaMonitoringManager())
         );
 

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -15,12 +15,9 @@
 
 package com.suse.manager.utils;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonSyntaxException;
-import com.google.gson.reflect.TypeToken;
+import static com.suse.manager.webui.services.SaltConstants.SCRIPTS_DIR;
+import static com.suse.manager.webui.services.SaltConstants.SUMA_STATE_FILES_ROOT_PATH;
+
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.localization.LocalizationService;
@@ -92,6 +89,7 @@ import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
+
 import com.suse.manager.clusters.ClusterManager;
 import com.suse.manager.clusters.ClusterNode;
 import com.suse.manager.model.clusters.Cluster;
@@ -102,6 +100,7 @@ import com.suse.manager.reactor.messaging.ChannelsChangedEventMessage;
 import com.suse.manager.reactor.utils.RhelUtils;
 import com.suse.manager.reactor.utils.ValueMap;
 import com.suse.manager.webui.services.SaltStateGeneratorService;
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.services.impl.runner.MgrUtilRunner;
@@ -140,6 +139,14 @@ import com.suse.salt.netapi.results.StateApplyResult;
 import com.suse.salt.netapi.utils.Xor;
 import com.suse.utils.Json;
 import com.suse.utils.Opt;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.reflect.TypeToken;
+
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -174,9 +181,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static com.suse.manager.webui.services.SaltConstants.SCRIPTS_DIR;
-import static com.suse.manager.webui.services.SaltConstants.SUMA_STATE_FILES_ROOT_PATH;
-
 /**
  * SaltUtils
  */
@@ -204,6 +208,7 @@ public class SaltUtils {
     private Path scriptsDir = Paths.get(SUMA_STATE_FILES_ROOT_PATH, SCRIPTS_DIR);
 
     private SystemQuery systemQuery = SaltService.INSTANCE;
+    private SaltApi saltApi = SaltService.INSTANCE_SALT_API;
     private ClusterManager clusterManager = ClusterManager.instance();
 
     private String xccdfResumeXsl = "/usr/share/susemanager/scap/xccdf-resume.xslt.in";
@@ -1411,7 +1416,7 @@ public class SaltUtils {
             try {
                 FormulaManager.getInstance().enableFormula(server.getMinionId(), SYSTEM_LOCK_FORMULA);
                 FormulaFactory.saveServerFormulaData(data, server.getMinionId(), SYSTEM_LOCK_FORMULA);
-                systemQuery.refreshPillar(new MinionList(server.getMinionId()));
+                saltApi.refreshPillar(new MinionList(server.getMinionId()));
             }
             catch (IOException | ValidatorException e) {
                 LOG.error("Could not enable blackout formula", e);
@@ -1862,6 +1867,14 @@ public class SaltUtils {
      */
     public void setSystemQuery(SystemQuery systemQueryIn) {
         this.systemQuery = systemQueryIn;
+    }
+
+    /**
+     * For unit testing only.
+     * @param saltApiIn the {@link SaltApi} to set
+     */
+    public void setSaltApi(SaltApi saltApiIn) {
+        this.saltApi = saltApiIn;
     }
 
     /**

--- a/java/code/src/com/suse/manager/virtualization/VirtManagerSalt.java
+++ b/java/code/src/com/suse/manager/virtualization/VirtManagerSalt.java
@@ -14,14 +14,19 @@
  */
 package com.suse.manager.virtualization;
 
+import com.redhat.rhn.domain.server.MinionServer;
+
+import com.suse.manager.webui.services.iface.SaltApi;
+import com.suse.manager.webui.services.iface.VirtManager;
+import com.suse.manager.webui.services.pillar.MinionPillarFileManager;
+import com.suse.manager.webui.services.pillar.MinionVirtualizationPillarGenerator;
+import com.suse.manager.webui.utils.salt.State;
+import com.suse.salt.netapi.calls.LocalCall;
+import com.suse.salt.netapi.datatypes.target.MinionList;
+
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
-import com.redhat.rhn.domain.server.MinionServer;
-import com.suse.manager.webui.services.iface.SaltApi;
-import com.suse.manager.webui.services.iface.VirtManager;
-import com.suse.manager.webui.utils.salt.State;
-import com.suse.salt.netapi.calls.LocalCall;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -38,6 +43,8 @@ import java.util.stream.Collectors;
 public class VirtManagerSalt implements VirtManager {
 
     private final SaltApi saltApi;
+    private MinionPillarFileManager minionVirtualizationPillarFileManager =
+            new MinionPillarFileManager(new MinionVirtualizationPillarGenerator());
 
     /**
      * Service providing utility functions to handle virtual machines.
@@ -166,6 +173,14 @@ public class VirtManagerSalt implements VirtManager {
         pillar.put("virt_entitled", minion.hasVirtualizationEntitlement());
         saltApi.callSync(State.apply(Collections.singletonList("virt.engine-events"),
                 Optional.of(pillar)), minion.getMinionId());
+
+        if (minion.hasVirtualizationEntitlement()) {
+            minionVirtualizationPillarFileManager.generatePillarFile(minion);
+        }
+        else {
+            minionVirtualizationPillarFileManager.removePillarFile(minion.getMinionId());
+        }
+        saltApi.refreshPillar(new MinionList(minion.getMinionId()));
     }
 
 }

--- a/java/code/src/com/suse/manager/webui/Router.java
+++ b/java/code/src/com/suse/manager/webui/Router.java
@@ -101,7 +101,7 @@ public class Router implements SparkApplication {
         NotificationMessageController notificationMessageController = new NotificationMessageController(systemQuery);
         MinionsAPI minionsAPI = new MinionsAPI(systemQuery, sshMinionBootstrapper, regularMinionBootstrapper);
         StatesAPI statesAPI = new StatesAPI(systemQuery, taskomaticApi);
-        FormulaController formulaController = new FormulaController(systemQuery);
+        FormulaController formulaController = new FormulaController(systemQuery, saltApi);
 
         post("/manager/frontend-log", withUser(FrontendLogController::log));
 

--- a/java/code/src/com/suse/manager/webui/controllers/FormulaController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/FormulaController.java
@@ -31,7 +31,7 @@ import com.redhat.rhn.domain.server.ServerGroupFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.formula.FormulaUtil;
 
-
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.utils.gson.StateTargetType;
 import com.suse.salt.netapi.datatypes.target.MinionList;
@@ -86,12 +86,15 @@ public class FormulaController {
             .create();
 
     private final SystemQuery systemQuery;
+    private final SaltApi saltApi;
 
     /**
      * @param systemQueryIn instance to use.
+     * @param saltApiIn Salt API instance to use.
      */
-    public FormulaController(SystemQuery systemQueryIn) {
+    public FormulaController(SystemQuery systemQueryIn, SaltApi saltApiIn) {
         this.systemQuery = systemQueryIn;
+        this.saltApi = saltApiIn;
     }
 
     /**
@@ -248,7 +251,7 @@ public class FormulaController {
                         return deniedResponse(response);
                     }
                     FormulaFactory.saveServerFormulaData(formData, MinionServerFactory.getMinionId(id), formulaName);
-                    systemQuery.refreshPillar(new MinionList(minion.get().getMinionId()));
+                    saltApi.refreshPillar(new MinionList(minion.get().getMinionId()));
                     break;
                 case GROUP:
                     ManagedServerGroup group = ServerGroupFactory.lookupByIdAndOrg(id, user.getOrg());
@@ -262,7 +265,7 @@ public class FormulaController {
                     List<String> minionIds = group.getServers().stream()
                             .flatMap(s -> Opt.stream(s.asMinionServer()))
                             .map(MinionServer::getMinionId).collect(Collectors.toList());
-                    systemQuery.refreshPillar(new MinionList(minionIds));
+                    saltApi.refreshPillar(new MinionList(minionIds));
                     break;
                 default:
                     return errorResponse(response, Arrays.asList("error_invalid_target")); //Invalid target type!

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualGuestsControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualGuestsControllerTest.java
@@ -34,10 +34,6 @@ import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.testing.ServerTestUtils;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonElement;
-import com.google.gson.reflect.TypeToken;
 import com.suse.manager.reactor.messaging.test.SaltTestUtils;
 import com.suse.manager.virtualization.DomainCapabilitiesJson;
 import com.suse.manager.virtualization.GuestDefinition;
@@ -46,6 +42,11 @@ import com.suse.manager.webui.controllers.test.BaseControllerTestCase;
 import com.suse.manager.webui.controllers.virtualization.VirtualGuestsController;
 import com.suse.manager.webui.services.iface.VirtManager;
 import com.suse.manager.webui.services.impl.SaltService;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.reflect.TypeToken;
 
 import org.jmock.Expectations;
 
@@ -110,7 +111,7 @@ public class VirtualGuestsControllerTest extends BaseControllerTestCase {
         };
 
         SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(),
+                new SystemUnentitler(virtManager, new FormulaMonitoringManager()),
                 new SystemEntitler(new SaltService(), virtManager, new FormulaMonitoringManager())
         );
 

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualNetsControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualNetsControllerTest.java
@@ -26,10 +26,6 @@ import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.testing.ServerTestUtils;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonObject;
-import com.google.gson.reflect.TypeToken;
 import com.suse.manager.reactor.messaging.test.SaltTestUtils;
 import com.suse.manager.virtualization.test.TestVirtManager;
 import com.suse.manager.webui.controllers.test.BaseControllerTestCase;
@@ -37,6 +33,11 @@ import com.suse.manager.webui.controllers.virtualization.VirtualNetsController;
 import com.suse.manager.webui.controllers.virtualization.gson.VirtualNetworkInfoJson;
 import com.suse.manager.webui.services.iface.VirtManager;
 import com.suse.manager.webui.services.impl.SaltService;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import com.google.gson.reflect.TypeToken;
 
 import org.jmock.Expectations;
 
@@ -81,7 +82,7 @@ public class VirtualNetsControllerTest extends BaseControllerTestCase {
         };
 
         SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(),
+                new SystemUnentitler(virtManager, new FormulaMonitoringManager()),
                 new SystemEntitler(new SaltService(), virtManager, new FormulaMonitoringManager())
         );
 

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualPoolsControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualPoolsControllerTest.java
@@ -37,10 +37,6 @@ import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.testing.ServerTestUtils;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonObject;
-import com.google.gson.reflect.TypeToken;
 import com.suse.manager.reactor.messaging.test.SaltTestUtils;
 import com.suse.manager.virtualization.PoolCapabilitiesJson;
 import com.suse.manager.virtualization.PoolCapabilitiesJson.PoolType;
@@ -50,6 +46,11 @@ import com.suse.manager.webui.controllers.virtualization.VirtualPoolsController;
 import com.suse.manager.webui.controllers.virtualization.gson.VirtualStoragePoolInfoJson;
 import com.suse.manager.webui.services.iface.VirtManager;
 import com.suse.manager.webui.services.impl.SaltService;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import com.google.gson.reflect.TypeToken;
 
 import org.hamcrest.collection.IsMapContaining;
 import org.jmock.Expectations;
@@ -114,7 +115,7 @@ public class VirtualPoolsControllerTest extends BaseControllerTestCase {
             }
         };
         systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(),
+                new SystemUnentitler(virtManager, new FormulaMonitoringManager()),
                 new SystemEntitler(new SaltService(), virtManager, new FormulaMonitoringManager())
         );
 

--- a/java/code/src/com/suse/manager/webui/services/iface/SaltApi.java
+++ b/java/code/src/com/suse/manager/webui/services/iface/SaltApi.java
@@ -15,6 +15,7 @@
 package com.suse.manager.webui.services.iface;
 
 import com.suse.salt.netapi.calls.LocalCall;
+import com.suse.salt.netapi.datatypes.target.MinionList;
 import com.suse.salt.netapi.event.EventStream;
 
 import java.util.Optional;
@@ -43,4 +44,9 @@ public interface SaltApi {
      */
     <R> Optional<R> callSync(LocalCall<R> call, String minionId);
 
+    /**
+     * Call 'saltutil.refresh_pillar' to sync the grains to the target minion(s).
+     * @param minionList minion list
+     */
+    void refreshPillar(MinionList minionList);
 }

--- a/java/code/src/com/suse/manager/webui/services/iface/SystemQuery.java
+++ b/java/code/src/com/suse/manager/webui/services/iface/SystemQuery.java
@@ -193,12 +193,6 @@ public interface SystemQuery {
             String target, CompletableFuture<GenericError> cancel);
 
     /**
-     * Call 'saltutil.refresh_pillar' to sync the grains to the target minion(s).
-     * @param minionList minion list
-     */
-    void refreshPillar(MinionList minionList);
-
-    /**
      * Call 'saltutil.sync_grains' to sync the grains to the target minion(s).
      * @param minionList minion list
      */

--- a/java/code/src/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
@@ -50,14 +50,6 @@ public class MinionGeneralPillarGenerator implements MinionPillarGenerator {
         PKGSET_BEACON_PROPS.put("interval", PKGSET_INTERVAL);
     }
 
-    private static final Map<String, Object> VIRTPOLLER_BEACON_PROPS = new HashMap<>();
-
-    static {
-        VIRTPOLLER_BEACON_PROPS.put("cache_file", Config.get().getString(ConfigDefaults.VIRTPOLLER_CACHE_FILE));
-        VIRTPOLLER_BEACON_PROPS.put("expire_time", Config.get().getInt(ConfigDefaults.VIRTPOLLER_CACHE_EXPIRATION));
-        VIRTPOLLER_BEACON_PROPS.put("interval", Config.get().getInt(ConfigDefaults.VIRTPOLLER_INTERVAL));
-    }
-
     /**
      * Generates pillar data containing general information of the passed minion
      * @param minion the minion server
@@ -88,14 +80,6 @@ public class MinionGeneralPillarGenerator implements MinionPillarGenerator {
         if (minion.getOsFamily().toLowerCase().equals("suse") ||
                 minion.getOsFamily().toLowerCase().equals("redhat")) {
             beaconConfig.put("pkgset", PKGSET_BEACON_PROPS);
-        }
-        // this add the configuration for the beacon that tell us about
-        // virtual guests running on that minion
-        // The virtpoller is still usefull with the libvirt events: it will help
-        // synchronizing the DB with the actual guest lists in case we had a temporary shutdown.
-        // TODO: find a better way to detect when the beacon should be configured
-        if (minion.isVirtualHost()) {
-            beaconConfig.put("virtpoller", VIRTPOLLER_BEACON_PROPS);
         }
         if (!beaconConfig.isEmpty()) {
             pillar.add("beacons", beaconConfig);

--- a/java/code/src/com/suse/manager/webui/services/pillar/MinionPillarManager.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/MinionPillarManager.java
@@ -36,7 +36,8 @@ public class MinionPillarManager {
 
     public static final MinionPillarManager INSTANCE = new MinionPillarManager(
             Arrays.asList(new MinionPillarFileManager(MinionGeneralPillarGenerator.INSTANCE),
-                    new MinionPillarFileManager(MinionGroupMembershipPillarGenerator.INSTANCE)));
+                    new MinionPillarFileManager(MinionGroupMembershipPillarGenerator.INSTANCE),
+                    new MinionPillarFileManager(MinionVirtualizationPillarGenerator.INSTANCE)));
 
     private List<MinionPillarFileManager> pillarFileManagers;
 

--- a/java/code/src/com/suse/manager/webui/services/pillar/MinionVirtualizationPillarGenerator.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/MinionVirtualizationPillarGenerator.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.webui.services.pillar;
+
+import static com.suse.manager.webui.services.SaltConstants.PILLAR_DATA_FILE_EXT;
+import static com.suse.manager.webui.services.SaltConstants.PILLAR_DATA_FILE_PREFIX;
+
+import com.redhat.rhn.common.conf.Config;
+import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.domain.server.MinionServer;
+
+import com.suse.manager.webui.utils.SaltPillar;
+
+import org.apache.log4j.Logger;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Class for generating pillar data for the virtual hosts
+ */
+public class MinionVirtualizationPillarGenerator implements MinionPillarGenerator {
+
+    /** Logger */
+    private static final Logger LOG = Logger.getLogger(MinionVirtualizationPillarGenerator.class);
+
+    public static final MinionVirtualizationPillarGenerator INSTANCE = new MinionVirtualizationPillarGenerator();
+    private static final Map<String, Object> VIRTPOLLER_BEACON_PROPS = new HashMap<>();
+
+    static {
+        VIRTPOLLER_BEACON_PROPS.put("cache_file", Config.get().getString(ConfigDefaults.VIRTPOLLER_CACHE_FILE));
+        VIRTPOLLER_BEACON_PROPS.put("expire_time", Config.get().getInt(ConfigDefaults.VIRTPOLLER_CACHE_EXPIRATION));
+        VIRTPOLLER_BEACON_PROPS.put("interval", Config.get().getInt(ConfigDefaults.VIRTPOLLER_INTERVAL));
+    }
+
+
+    /**
+     * Generates pillar activating the virtpoller on a virtualization host
+     * @param minion the minion server
+     * @return the SaltPillar containing the pillar data
+     */
+    @Override
+    public SaltPillar generatePillarData(MinionServer minion) {
+        LOG.debug("Generating virtualization pillar file for minion: " + minion.getMinionId());
+
+        SaltPillar pillar = new SaltPillar();
+        // this add the configuration for the beacon that tell us about
+        // virtual guests running on that minion
+        // The virtpoller is still usefull with the libvirt events: it will help
+        // synchronizing the DB with the actual guest lists in case we had a temporary shutdown.
+        Map<String, Object> beaconConfig = new HashMap<>();
+        beaconConfig.put("virtpoller", VIRTPOLLER_BEACON_PROPS);
+        pillar.add("beacons", beaconConfig);
+
+        return pillar;
+    }
+
+    @Override
+    public String getFilename(String minionId) {
+        return PILLAR_DATA_FILE_PREFIX + "_" + minionId + "_" + "virtualization" + "." + PILLAR_DATA_FILE_EXT;
+    }
+}

--- a/java/code/src/com/suse/manager/webui/services/pillar/test/MinionVirtualizationPillarGeneratorTest.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/test/MinionVirtualizationPillarGeneratorTest.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.webui.services.pillar.test;
+
+import static com.suse.manager.webui.services.SaltConstants.PILLAR_DATA_FILE_EXT;
+import static com.suse.manager.webui.services.SaltConstants.PILLAR_DATA_FILE_PREFIX;
+
+import com.redhat.rhn.domain.server.MinionServer;
+import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
+import com.redhat.rhn.testing.BaseTestCaseWithUser;
+
+import com.suse.manager.webui.services.pillar.MinionPillarFileManager;
+import com.suse.manager.webui.services.pillar.MinionVirtualizationPillarGenerator;
+
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.FileInputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+/**
+ * Tests for {@link MinionVirtualizationPillarGenerator}
+ */
+public class MinionVirtualizationPillarGeneratorTest extends BaseTestCaseWithUser {
+
+    protected MinionPillarFileManager minionVirtualizationPillarFileManager =
+            new MinionPillarFileManager(new MinionVirtualizationPillarGenerator());
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        minionVirtualizationPillarFileManager.setPillarDataPath(tmpPillarRoot.toAbsolutePath());
+    }
+
+    public void testGenerateVirtualizationPillarData() throws Exception {
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
+
+        this.minionVirtualizationPillarFileManager.generatePillarFile(minion);
+
+        Path filePath = tmpPillarRoot.resolve(PILLAR_DATA_FILE_PREFIX + "_" +
+                minion.getMinionId() + "_" + "virtualization" + "." +
+                PILLAR_DATA_FILE_EXT);
+
+        assertTrue(Files.exists(filePath));
+
+        Map<String, Object> map;
+        try (FileInputStream fi = new FileInputStream(filePath.toFile())) {
+            map = new Yaml().loadAs(fi, Map.class);
+        }
+
+        assertTrue(map.containsKey("beacons"));
+        Map<String, Object> beacons = (Map<String, Object>) map.get("beacons");
+
+        assertTrue(beacons.containsKey("virtpoller"));
+        Map<String, Object> virtpoller = (Map<String, Object>)beacons.get("virtpoller");
+
+        assertTrue(virtpoller.containsKey("cache_file"));
+        assertTrue(virtpoller.containsKey("expire_time"));
+        assertTrue(virtpoller.containsKey("interval"));
+    }
+
+}

--- a/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
@@ -19,7 +19,6 @@ import static com.redhat.rhn.domain.action.ActionFactory.STATUS_FAILED;
 import static com.redhat.rhn.domain.action.ActionFactory.STATUS_PICKED_UP;
 import static com.redhat.rhn.domain.action.ActionFactory.STATUS_QUEUED;
 
-import com.google.gson.JsonObject;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionChain;
@@ -65,18 +64,20 @@ import com.redhat.rhn.testing.RhnBaseTestCase;
 import com.redhat.rhn.testing.ServerTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 
-import com.google.gson.JsonElement;
 import com.suse.manager.utils.SaltUtils;
+import com.suse.manager.virtualization.test.TestVirtManager;
 import com.suse.manager.webui.services.SaltActionChainGeneratorService;
 import com.suse.manager.webui.services.SaltServerActionService;
-import com.suse.manager.virtualization.test.TestVirtManager;
+import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.iface.VirtManager;
 import com.suse.manager.webui.services.impl.SaltService;
-import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.utils.SaltModuleRun;
 import com.suse.manager.webui.utils.SaltState;
 import com.suse.manager.webui.utils.SaltSystemReboot;
 import com.suse.salt.netapi.calls.LocalCall;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 
 import org.jmock.Expectations;
 import org.jmock.lib.legacy.ClassImposteriser;
@@ -127,7 +128,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
 
         saltServerActionService = createSaltServerActionService(systemQuery);
         systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(),
+                new SystemUnentitler(virtManager, new FormulaMonitoringManager()),
                 new SystemEntitler(systemQuery, virtManager, new FormulaMonitoringManager())
         );
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Toggle virtpoller when toggling virtualization host entitlement (bsc#1172962)
 - Deleting registered VM doesn't remove them VM from the Guests list (bsc#1170096)
 - improve salt-ssh error parsing on bootstrapping (bsc#1172120)
 

--- a/susemanager-utils/susemanager-sls/modules/pillar/suma_minion.py
+++ b/susemanager-utils/susemanager-sls/modules/pillar/suma_minion.py
@@ -47,7 +47,7 @@ MANAGER_GLOBAL_PILLAR = [
 ]
 
 MINION_PILLAR_FILES_PREFIX = "pillar_{minion_id}"
-MINION_PILLAR_FILES_SUFFIXES = [".yml", "_group_memberships.yml"]
+MINION_PILLAR_FILES_SUFFIXES = [".yml", "_group_memberships.yml", "_virtualization.yml"]
 
 CONFIG_FILE = '/etc/rhn/rhn.conf'
 
@@ -100,7 +100,10 @@ def ext_pillar(minion_id, *args):
         data_filename = os.path.join(MANAGER_PILLAR_DATA_PATH, minion_pillar_filename_prefix + suffix)
         if os.path.exists(data_filename):
             try:
-                ret.update(yaml.load(open(data_filename).read(), Loader=yaml.FullLoader))
+                ret = salt.utils.dictupdate.merge(
+                        ret,
+                        yaml.load(open(data_filename).read(), Loader=yaml.FullLoader),
+                        strategy='recurse')
             except Exception as error:
                 log.error('Error accessing "{pillar_file}": {message}'.format(pillar_file=data_filename, message=str(error)))
 

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- Merge virtualization fragment into suma-minion pillar (bsc#1172962)
+
 -------------------------------------------------------------------
 Wed Jun 10 12:41:08 CEST 2020 - jgonzalez@suse.com
 

--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -626,6 +626,12 @@ The check box can be identified by name, id or label text.
   Then the pillar data for "timezone" should be empty on "ssh_minion"
 ```
 
+* Salt beacons
+
+```cucumber
+  Then the virtpoller beacon should be enabled on "xen_server"
+```
+
 * Apply the Salt highstate
 
 ```cucumber

--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -18,8 +18,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "kvm_server"
     And I restart salt-minion on "kvm_server"
-    # Shorten the virtpoller interval to avoid losing time
-    And I reduce virtpoller run interval on "kvm_server"
 
 @virthost_kvm
   Scenario: Setting the virtualization entitlement for KVM
@@ -29,7 +27,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I check "virtualization_host"
     And I click on "Update Properties"
     Then I should see a "Since you added a Virtualization system type to the system" text
-
+    And the virtpoller beacon should be enabled on "kvm_server"
 
 @virthost_kvm
   Scenario: Prepare a KVM test virtual machine and list it

--- a/testsuite/features/secondary/minxen_guests.feature
+++ b/testsuite/features/secondary/minxen_guests.feature
@@ -17,8 +17,6 @@ Feature: Be able to manage XEN virtual machines via the GUI
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "xen_server"
-    # Shorten the virtpoller interval to avoid losing time
-    And I reduce virtpoller run interval on "xen_server"
 
 @virthost_xen
   Scenario: Setting the virtualization entitlement for Xen
@@ -28,7 +26,7 @@ Feature: Be able to manage XEN virtual machines via the GUI
     And I check "virtualization_host"
     And I click on "Update Properties"
     Then I should see a "Since you added a Virtualization system type to the system" text
-
+    And the virtpoller beacon should be enabled on "xen_server"
 
 @virthost_xen
   Scenario: Prepare a Xen test virtual machine and list it

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -583,6 +583,13 @@ Then(/^the download should get no error$/) do
   assert_nil(@download_error)
 end
 
+Then(/^the ([^ ]+) beacon should be enabled on "([^"]*)"$/) do |beacon, minion|
+  system_name = get_system_name(minion)
+
+  output, _code = $server.run("salt #{system_name} beacons.list")
+  raise "Beacon #{beacon} not enabled" unless output.split("\n").map(&:strip).include?("#{beacon}:")
+end
+
 # Perform actions
 When(/^I reject "([^"]*)" from the Pending section$/) do |host|
   system_name = get_system_name(host)

--- a/testsuite/features/upload_files/susemanager-virtpoller.conf
+++ b/testsuite/features/upload_files/susemanager-virtpoller.conf
@@ -1,3 +1,0 @@
-beacons:
-  virtpoller:
-    interval: 5


### PR DESCRIPTION
## What does this PR change?

With the optimizations performed in the pillar generation, the
virtpoller beacon was no longer added. To enable or disable the
virtpoller beacon we need to:

 * generate a separate pillar file with the beacon configuration
 * refresh the pillar data on the minion

Since there could be other beacons setup in other pillar files, the
suma-minion.py pillar needs to deep merge each pillar data.

See [bsc#1172962](https://bugzilla.suse.com/show_bug.cgi?id=1172962)

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: no UI difference

- [X] **DONE**

## Test coverage
- No tests: hard to cover

- [X] **DONE**

## Links

Fixes SUSE/spacewalk#11731

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
