### PR TITLE
Close the SaltService HTTP Client after each test

### DIFF
--- a/java/code/src/com/redhat/rhn/testing/RhnBaseTestCase.java
+++ b/java/code/src/com/redhat/rhn/testing/RhnBaseTestCase.java
@@ -14,16 +14,12 @@
  */
 package com.redhat.rhn.testing;
 
-import java.io.File;
-import java.io.Serializable;
-import java.lang.reflect.InvocationTargetException;
-import java.text.DateFormat;
-import java.util.Collection;
-import java.util.Date;
+import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.common.localization.LocalizationService;
+import com.redhat.rhn.common.messaging.MessageQueue;
+import com.redhat.rhn.common.util.Asserts;
 
 import com.suse.manager.webui.services.impl.SaltService;
-import junit.framework.ComparisonFailure;
-import junit.framework.TestCase;
 
 import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.log4j.Level;
@@ -31,10 +27,15 @@ import org.apache.log4j.Logger;
 import org.hibernate.HibernateException;
 import org.hibernate.Session;
 
-import com.redhat.rhn.common.hibernate.HibernateFactory;
-import com.redhat.rhn.common.localization.LocalizationService;
-import com.redhat.rhn.common.messaging.MessageQueue;
-import com.redhat.rhn.common.util.Asserts;
+import java.io.File;
+import java.io.Serializable;
+import java.lang.reflect.InvocationTargetException;
+import java.text.DateFormat;
+import java.util.Collection;
+import java.util.Date;
+
+import junit.framework.ComparisonFailure;
+import junit.framework.TestCase;
 
 /**
  * RhnBaseTestCase is the base class for all RHN TestCases.
@@ -44,6 +45,7 @@ import com.redhat.rhn.common.util.Asserts;
  */
 public abstract class RhnBaseTestCase extends TestCase {
 
+    private final SaltService saltService = new SaltService();
     /**
      * Constructs a TestCase with the given name.
      * @param name Name of TestCase.
@@ -57,7 +59,7 @@ public abstract class RhnBaseTestCase extends TestCase {
      */
     public RhnBaseTestCase() {
         super();
-        MessageQueue.configureDefaultActions(new SaltService());
+        MessageQueue.configureDefaultActions(saltService);
     }
 
     /**
@@ -76,6 +78,7 @@ public abstract class RhnBaseTestCase extends TestCase {
     protected void tearDown() throws Exception {
         super.tearDown();
         TestCaseHelper.tearDownHelper();
+        saltService.close();
     }
 
     /**


### PR DESCRIPTION
## What does this PR change?

To avoid the Http client to eat resources, close it after the tests.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: fix a potential leak

- [X] **DONE**

## Test coverage
- No tests: attempt at fixing OutOfMemoryError in tests

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
