### PR TITLE
Caasp: don't execute caasp.prepare_node on the management node when joining a node

### DIFF
--- a/susemanager-utils/cluster-providers/caasp/uyuni-cluster-provider-caasp/metadata/metadata.yml
+++ b/susemanager-utils/cluster-providers/caasp/uyuni-cluster-provider-caasp/metadata/metadata.yml
@@ -41,7 +41,6 @@ state_hooks:
   join:
     before:
       - caasp.init_ssh_agent
-      - caasp.prepare_node
     after:
       - caasp.kill_ssh_agent
   remove:

--- a/susemanager-utils/cluster-providers/caasp/uyuni-cluster-provider-caasp/uyuni-cluster-provider-caasp.changes
+++ b/susemanager-utils/cluster-providers/caasp/uyuni-cluster-provider-caasp/uyuni-cluster-provider-caasp.changes
@@ -1,3 +1,6 @@
+- Don't execute caasp.prepare_node on the management node when
+  joining another node
+
 -------------------------------------------------------------------
 Wed Jun 10 11:52:36 CEST 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Don't execute the state `caasp.prepare_node` on the management node when joining a node because it disables the swap. This state should be executed on the node to be joined.

## GUI diff

No difference.

## Documentation
- https://github.com/uyuni-project/uyuni-docs/pull/334

- [x] **DONE**

## Test coverage
- No tests: cucumber tests are not yet available for caasp

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
