### PR TITLE
Add aarch64 for openSUSE Leap 15.1 and Leap 15.2 on Uyuni

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -1098,6 +1098,10 @@ DATA = {
         'BASECHANNEL' : 'opensuse_leap15_1-x86_64', 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15SP0SP1_SALT + PKGLIST15_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/opensuse/15/1/bootstrap/'
     },
+    'openSUSE-Leap-15.1-aarch64-uyuni' : {
+        'BASECHANNEL' : 'opensuse_leap15_1-aarch64', 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15SP0SP1_SALT + PKGLIST15_X86_ARM,
+        'DEST' : '/srv/www/htdocs/pub/repositories/opensuse/15/1/bootstrap/'
+    },
     'openSUSE-Leap-15.1-x86_64' : {
         'PDID' : [1929], 'PKGLIST' : PKGLIST15_SALT + PKGLIST15SP0SP1_SALT + PKGLIST15_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/opensuse/15/1/bootstrap/'
@@ -1108,6 +1112,10 @@ DATA = {
     },
     'openSUSE-Leap-15.2-x86_64-uyuni' : {
         'BASECHANNEL' : 'opensuse_leap15_2-x86_64', 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15SP0SP1_SALT + PKGLIST15_X86_ARM,
+        'DEST' : '/srv/www/htdocs/pub/repositories/opensuse/15/2/bootstrap/'
+    },
+    'openSUSE-Leap-15.2-aarch64-uyuni' : {
+        'BASECHANNEL' : 'opensuse_leap15_2-aarch64', 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15SP0SP1_SALT + PKGLIST15_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/opensuse/15/2/bootstrap/'
     },
     'centos-6-x86_64' : {

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- Add bootstrap repository definitions for openSUSE Leap 15.1 and 15.2 aarch64 for Uyuni
 - update server-migrator.sh script for Upgrading Uyuni to version 4.1
 
 -------------------------------------------------------------------

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -901,6 +901,46 @@ gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
 
+[opensuse_leap15_1-aarch64]
+checksum = sha256
+archs    = aarch64
+name     = openSUSE Leap 15.1 (%(arch)s)
+gpgkey_url =  http://download.opensuse.org/ports/aarch64/distribution/leap/15.1/repo/oss/repodata/repomd.xml.key
+gpgkey_id = 3DBDC284
+gpgkey_fingerprint = 22C0 7BA5 3417 8CD0 2EFE  22AA B88B 2FD4 3DBD C284
+repo_url = http://download.opensuse.org/distribution/leap/15.1/repo/oss/
+dist_map_release = 15.1
+
+[opensuse_leap15_1-updates-aarch64]
+label    = %(base_channel)s-updates
+name     = openSUSE Leap 15.1 Updates (%(arch)s)
+archs    = aarch64
+checksum = sha256
+base_channels = opensuse_leap15_1-%(arch)s
+repo_url = http://download.opensuse.org/ports/update/leap/15.1/
+
+# This is expected. openSUSE Leap 15.0 client tools are valid for all openSUSE Leap 15.X releases
+[opensuse_leap15_1-uyuni-client-aarch64]
+name     = Uyuni Client Tools for %(base_channel_name)s
+archs    = aarch64
+base_channels = opensuse_leap15_1-%(arch)s
+checksum = sha256
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
+
+# This is expected. openSUSE Leap 15.0 client tools are valid for all openSUSE Leap 15.X releases
+[opensuse_leap15_1-uyuni-client-devel-aarch64]
+name     = Uyuni Client Tools for %(base_channel_name)s (Development)
+archs    = aarch64
+base_channels = opensuse_leap15_1-%(arch)s
+checksum = sha256
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
+
 [opensuse_leap15_2]
 checksum = sha256
 archs    = x86_64
@@ -950,6 +990,46 @@ repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/
 [opensuse_leap15_2-uyuni-client-devel]
 name     = Uyuni Client Tools for %(base_channel_name)s (Development)
 archs    = x86_64
+base_channels = opensuse_leap15_2-%(arch)s
+checksum = sha256
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
+
+[opensuse_leap15_2-aarch64]
+checksum = sha256
+archs    = aarch64
+name     = openSUSE Leap 15.2 (%(arch)s)
+gpgkey_url = http://download.opensuse.org/ports/aarch64/distribution/leap/15.2/repo/oss/repodata/repomd.xml.key
+gpgkey_id = 3DBDC284
+gpgkey_fingerprint = 22C0 7BA5 3417 8CD0 2EFE  22AA B88B 2FD4 3DBD C284
+repo_url = http://download.opensuse.org/ports/aarch64/distribution/leap/15.2/repo/oss/
+dist_map_release = 15.2
+
+[opensuse_leap15_2-updates-aarch64]
+label    = %(base_channel)s-updates
+name     = openSUSE Leap 15.2 Updates (%(arch)s)
+archs    = aarch64
+checksum = sha256
+base_channels = opensuse_leap15_2-%(arch)s
+repo_url = http://download.opensuse.org/ports/update/leap/15.2/
+
+# This is expected. openSUSE Leap 15.0 client tools are valid for all openSUSE Leap 15.X releases
+[opensuse_leap15_2-uyuni-client-aarch64]
+name     = Uyuni Client Tools for %(base_channel_name)s
+archs    = aarch64
+base_channels = opensuse_leap15_2-%(arch)s
+checksum = sha256
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
+
+# This is expected. openSUSE Leap 15.0 client tools are valid for all openSUSE Leap 15.X releases
+[opensuse_leap15_2-uyuni-client-devel-aarch64]
+name     = Uyuni Client Tools for %(base_channel_name)s (Development)
+archs    = aarch64
 base_channels = opensuse_leap15_2-%(arch)s
 checksum = sha256
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/repodata/repomd.xml.key

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,5 @@
+- Add aarch64 for openSUSE Leap 15.1 and 15.2
+
 -------------------------------------------------------------------
 Wed Jun 10 12:21:25 CEST 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Add aarch64 for openSUSE Leap 15.1 and Leap 15.2 on Uyuni

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Pending

- [x] **DONE**

## Test coverage
- No tests: Cucumber should take care of this at some point

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/11554 and https://github.com/uyuni-project/uyuni/issues/2129

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
