### PR TITLE
Show cluster upgrade plan in the cluster upgrade UI

### DIFF
--- a/java/code/src/com/suse/manager/clusters/ClusterManager.java
+++ b/java/code/src/com/suse/manager/clusters/ClusterManager.java
@@ -526,7 +526,11 @@ public class ClusterManager {
                     )
                     .ifPresentOrElse(minions ->
                             ctx.put("nodes", minions),
-                            () -> LOG.error("Could not find minions ids: " + context.get("nodes")));
+                            () -> {
+                        if (context.get("nodes") != null) {
+                            LOG.error("Could not find minions ids: " + context.get("nodes"));
+                        }
+                    });
 
             Optional.ofNullable(context.get("cluster"))
                     .filter(Number.class::isInstance)

--- a/java/code/src/com/suse/manager/clusters/ClusterManager.java
+++ b/java/code/src/com/suse/manager/clusters/ClusterManager.java
@@ -44,6 +44,9 @@ import com.suse.manager.reactor.utils.OptionalTypeAdapterFactory;
 import com.suse.manager.reactor.utils.ValueMap;
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.utils.YamlHelper;
+import com.suse.manager.webui.utils.salt.custom.ClusterUpgradePlanSlsResult;
+import com.suse.salt.netapi.calls.modules.State;
 import com.suse.salt.netapi.datatypes.target.MinionList;
 import com.suse.utils.Opt;
 
@@ -68,6 +71,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -149,12 +153,70 @@ public class ClusterManager {
         }
 
         ClusterProviderParameters cpp =
-                new ClusterProviderParameters(cluster.getProvider(), Optional.of(settingsFormulaData.get()));
+                new ClusterProviderParameters(cluster.getProvider(),
+                        Optional.of(settingsFormulaData.get()),
+                        Optional.empty());
         systemQuery.listClusterNodes(cluster.getManagementNode(), cpp).ifPresent(ret -> {
             ret.forEach((k, v) -> result.add(new ClusterNode(k, v)));
         });
         matchClusterNodes(result);
         return result;
+    }
+
+    /**
+     * Queries the management node to get the cluster upgrade plan (if any).
+     * @param cluster the cluster
+     * @return the upgrade plan as a string or empty if the plan is not available
+     */
+    public Optional<String> getUpgradePlan(Cluster cluster) {
+        Optional<Map<String, Object>> settingsFormulaData = formulaManager
+                .getClusterFormulaData(cluster, "settings");
+        if (settingsFormulaData.isEmpty()) {
+            throw new RuntimeException("No settings data found for cluster " + cluster.getLabel());
+        }
+
+        ClusterProviderParameters cpp =
+                new ClusterProviderParameters(cluster.getProvider(),
+                        Optional.of(settingsFormulaData.get()),
+                        Optional.empty());
+        cpp.setHooks(getStateHooks(cluster.getProvider()));
+        return callSaltUpgradePlan(cluster.getManagementNode(), cpp)
+                .map(ret -> {
+                    if (ret.containsKey("salterr")) {
+                        return Objects.toString(ret.get("salterr"));
+                    }
+                    else if (ret.containsKey("success") &&
+                                (ret.containsKey("stderr") || ret.containsKey("stdout"))) {
+                            if (Boolean.TRUE.equals(ret.get("success")))  {
+                                return Objects.toString(ret.get("stdout"));
+                            }
+                            else {
+                                return Objects.toString(ret.get("stderr"));
+                            }
+                    }
+                    else {
+                        return YamlHelper.INSTANCE.dump(ret);
+                    }
+                });
+    }
+
+    private Optional<Map<String, Object>> callSaltUpgradePlan(
+            MinionServer managementNode, ClusterProviderParameters clusterProviderParameters) {
+        Map<String, Object> pillar = new HashMap<>();
+        pillar.put("cluster_type", clusterProviderParameters.getClusterProvider());
+        clusterProviderParameters.getClusterParams().ifPresent(cpp -> {
+            cpp.put("plan", true);
+            pillar.put("params", cpp);
+        });
+        clusterProviderParameters.getHooks().ifPresent(hooks -> {
+            pillar.put("state_hooks", hooks);
+        });
+        return systemQuery.callSync(State.apply(Arrays.asList("clusters.upgradecluster"), Optional.of(pillar),
+                Optional.of(true), Optional.empty(), ClusterUpgradePlanSlsResult.class),
+                managementNode.getMinionId())
+                .map(ret ->
+                        ret.getUpgradeResult().isResult() ? ret.getUpgradeResult().getChanges().getRet() :
+                                Collections.singletonMap("salterr", ret.getUpgradeResult().getComment()));
     }
 
     /**
@@ -570,6 +632,16 @@ public class ClusterManager {
     public Optional<List<String>> getNodesListFields(String provider) {
         return FormulaFactory.getClusterProviderMetadata(provider, "ui:nodes_list:fields", List.class)
                 .map(l -> (List<String>)l);
+    }
+
+    /**
+     * Whether to show the upgrade plan or not.
+     * @param provider cluster provider label
+     * @return true if the upgrade plan must be shown, false otherwise
+     */
+    public boolean isShowUpgradePlan(String provider) {
+        return FormulaFactory.getClusterProviderMetadata(provider, "ui:upgrade:show_plan", Boolean.class)
+                .orElse(false);
     }
 
     /**

--- a/java/code/src/com/suse/manager/clusters/ClusterProviderParameters.java
+++ b/java/code/src/com/suse/manager/clusters/ClusterProviderParameters.java
@@ -15,6 +15,7 @@
 
 package com.suse.manager.clusters;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -24,14 +25,18 @@ import java.util.Optional;
 public class ClusterProviderParameters {
     private String clusterProvider;
     private Optional<Map<String, Object>> clusterParams;
+    private Optional<Map<String, List<String>>> hooks;
 
     /**
      * @param clusterProviderIn cluster type
-     * @param clusterParamsIn
+     * @param clusterParamsIn optional cluster params
+     * @param hooksIn optional state hooks
      */
-    public ClusterProviderParameters(String clusterProviderIn, Optional<Map<String, Object>> clusterParamsIn) {
+    public ClusterProviderParameters(String clusterProviderIn, Optional<Map<String, Object>> clusterParamsIn,
+                                     Optional<Map<String, List<String>>> hooksIn) {
         this.clusterProvider = clusterProviderIn;
         this.clusterParams = clusterParamsIn;
+        this.hooks = hooksIn;
     }
 
     /**
@@ -60,5 +65,19 @@ public class ClusterProviderParameters {
      */
     public void setClusterParams(Optional<Map<String, Object>> clusterParamsIn) {
         this.clusterParams = clusterParamsIn;
+    }
+
+    /**
+     * @return hooks to get
+     */
+    public Optional<Map<String, List<String>>> getHooks() {
+        return hooks;
+    }
+
+    /**
+     * @param hooksIn to set
+     */
+    public void setHooks(Optional<Map<String, List<String>>> hooksIn) {
+        this.hooks = hooksIn;
     }
 }

--- a/java/code/src/com/suse/manager/clusters/test/ClusterManagerTest.java
+++ b/java/code/src/com/suse/manager/clusters/test/ClusterManagerTest.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.manager.clusters.test;
+
+import com.google.gson.JsonObject;
+import com.redhat.rhn.domain.action.cluster.test.ClusterActionTest;
+import com.redhat.rhn.domain.server.MinionServer;
+import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
+import com.redhat.rhn.manager.formula.FormulaManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
+import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
+import com.suse.manager.clusters.ClusterManager;
+import com.suse.manager.model.clusters.Cluster;
+import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.utils.salt.custom.ClusterUpgradePlanSlsResult;
+import com.suse.salt.netapi.calls.LocalCall;
+import com.suse.salt.netapi.event.JobReturnEvent;
+import com.suse.utils.Json;
+import org.jmock.Expectations;
+import org.jmock.lib.legacy.ClassImposteriser;
+
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class ClusterManagerTest extends JMockBaseTestCaseWithUser {
+
+    private SaltService saltServiceMock;
+    private FormulaManager formulaManagerMock;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        setImposteriser(ClassImposteriser.INSTANCE);
+        saltServiceMock = context().mock(SaltService.class);
+        formulaManagerMock = context().mock(FormulaManager.class);
+    }
+
+    public void testGetUpgradePlan() throws Exception {
+
+        MinionServer managementNode = MinionServerFactoryTest.createTestMinionServer(user);
+        Cluster cluster = ClusterActionTest.createTestCluster(user, managementNode);
+        Map<String, String> placeholders = new HashMap<>();
+        placeholders.put("minion-id", managementNode.getMinionId());
+
+        JobReturnEvent result = Json.GSON.fromJson(new InputStreamReader(getClass()
+                        .getResourceAsStream("/com/suse/manager/clusters/test/cluster.upgrade.success.json")),
+                JobReturnEvent.class);
+
+        ClusterUpgradePlanSlsResult upgradeResult = Json.GSON.fromJson(result.getData()
+                .getResult(JsonObject.class), ClusterUpgradePlanSlsResult.class);
+
+        context().checking(new Expectations() {{
+            oneOf(saltServiceMock).callSync(
+                with(any(LocalCall.class)),
+                with(managementNode.getMinionId()));
+            will(returnValue(Optional.of(upgradeResult)));
+
+            oneOf(formulaManagerMock).getClusterFormulaData(with(any(Cluster.class)), with("settings"));
+            will(returnValue(Optional.of(new HashMap())));
+        }});
+
+        ClusterManager clusterManager = new ClusterManager(saltServiceMock,
+                saltServiceMock,
+                new ServerGroupManager(),
+                formulaManagerMock);
+        Optional<String> plan = clusterManager.getUpgradePlan(cluster);
+        assertTrue(plan.isPresent());
+        assertEquals("Current Kubernetes cluster version: 1.17.4\n" +
+                "Latest Kubernetes version: 1.17.4\n" +
+                "\n" +
+                "All nodes match the current cluster version: 1.17.4.\n" +
+                "\n" +
+                "Addon upgrades for 1.17.4:\n" +
+                "  - cilium: 1.5.3 (manifest version from 1 to 2)\n" +
+                "  - kured: 1.3.0 (manifest version from 2 to 4)\n" +
+                "  - psp (manifest version from 1 to 3)\n", plan.get());
+
+    }
+
+}

--- a/java/code/src/com/suse/manager/clusters/test/ClusterManagerTest.java
+++ b/java/code/src/com/suse/manager/clusters/test/ClusterManagerTest.java
@@ -30,7 +30,7 @@ import com.suse.salt.netapi.calls.LocalCall;
 import com.suse.salt.netapi.event.JobReturnEvent;
 import com.suse.utils.Json;
 import org.jmock.Expectations;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 
 import java.io.InputStreamReader;
 import java.util.HashMap;
@@ -42,10 +42,14 @@ public class ClusterManagerTest extends JMockBaseTestCaseWithUser {
     private SaltService saltServiceMock;
     private FormulaManager formulaManagerMock;
 
+    {
+        context().setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
+    }
+
+
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        setImposteriser(ClassImposteriser.INSTANCE);
         saltServiceMock = context().mock(SaltService.class);
         formulaManagerMock = context().mock(FormulaManager.class);
     }

--- a/java/code/src/com/suse/manager/clusters/test/cluster.upgrade.success.json
+++ b/java/code/src/com/suse/manager/clusters/test/cluster.upgrade.success.json
@@ -1,0 +1,115 @@
+{
+  "tag": "salt/job/20190218111637161612/ret/${minion-id}",
+  "data": {
+    "_stamp": "2020-06-19T15:29:51.158315",
+    "cmd": "_return",
+    "fun": "state.apply",
+    "fun_args": [
+      {
+        "mods": [
+          "clusters.upgradecluster"
+        ],
+        "pillar": {
+          "cluster_type": "caasp",
+          "params": {
+            "plan": true,
+            "skuba_cluster_path": "/opt/clusters/mycluster",
+            "ssh_auth_sock": "/tmp/ssh-yFV9X2g92e/agent.11982",
+            "ssh_key_file": "",
+            "use_ssh_agent": true
+          },
+          "state_hooks": {
+            "join": {
+              "after": [
+                "caasp.kill_ssh_agent"
+              ],
+              "before": [
+                "caasp.init_ssh_agent",
+                "caasp.prepare_node"
+              ]
+            },
+            "remove": {
+              "after": [
+                "caasp.kill_ssh_agent"
+              ],
+              "before": [
+                "caasp.init_ssh_agent"
+              ]
+            },
+            "upgrade": {
+              "after": [
+                "caasp.kill_ssh_agent"
+              ],
+              "before": [
+                "caasp.init_ssh_agent"
+              ]
+            }
+          }
+        },
+        "queue": true
+      }
+    ],
+    "id": "dev-min-sles15sp1.lan",
+    "jid": "20200619152950167547",
+    "out": "highstate",
+    "retcode": 0,
+    "return": {
+      "environ_|-mgr_ssh_agent_socket_upgradecluster_|-SSH_AUTH_SOCK_|-setenv": {
+        "__id__": "mgr_ssh_agent_socket_upgradecluster",
+        "__run_num__": 2,
+        "__sls__": "clusters.upgradecluster",
+        "changes": {
+          "SSH_AUTH_SOCK": "/tmp/ssh-yFV9X2g92e/agent.11982"
+        },
+        "comment": "Environ values were set",
+        "duration": 3.466,
+        "name": "SSH_AUTH_SOCK",
+        "result": true,
+        "start_time": "17:29:50.878892"
+      },
+      "module_|-mgr_cluster_upgrade_cluster_|-mgrclusters.upgrade_cluster_|-run": {
+        "__id__": "mgr_cluster_upgrade_cluster",
+        "__run_num__": 3,
+        "__sls__": "clusters.upgradecluster",
+        "changes": {
+          "ret": {
+            "retcode": 0,
+            "stderr": "",
+            "stdout": "Current Kubernetes cluster version: 1.17.4\nLatest Kubernetes version: 1.17.4\n\nAll nodes match the current cluster version: 1.17.4.\n\nAddon upgrades for 1.17.4:\n  - cilium: 1.5.3 (manifest version from 1 to 2)\n  - kured: 1.3.0 (manifest version from 2 to 4)\n  - psp (manifest version from 1 to 3)\n",
+            "success": true
+          }
+        },
+        "comment": "Module function mgrclusters.upgrade_cluster executed",
+        "duration": 208.812,
+        "name": "mgrclusters.upgrade_cluster",
+        "result": true,
+        "start_time": "17:29:50.883355"
+      },
+      "module_|-sync_modules_|-saltutil.sync_modules_|-run": {
+        "__id__": "sync_modules",
+        "__run_num__": 0,
+        "__sls__": "util.syncmodules",
+        "changes": {
+          "ret": []
+        },
+        "comment": "Module function saltutil.sync_modules executed",
+        "duration": 253.653,
+        "name": "saltutil.sync_modules",
+        "result": true,
+        "start_time": "17:29:50.613326"
+      },
+      "test_|-mgr_caasp_nop_|-mgr_caasp_nop_|-nop": {
+        "__id__": "mgr_caasp_nop",
+        "__run_num__": 1,
+        "__sls__": "caasp.init_ssh_agent",
+        "changes": {},
+        "comment": "Success!",
+        "duration": 8.305,
+        "name": "mgr_caasp_nop",
+        "result": true,
+        "start_time": "17:29:50.868842"
+      }
+    },
+    "success": true
+  }
+}

--- a/java/code/src/com/suse/manager/clusters/test/cluster.upgrade.success.json
+++ b/java/code/src/com/suse/manager/clusters/test/cluster.upgrade.success.json
@@ -67,7 +67,7 @@
         "result": true,
         "start_time": "17:29:50.878892"
       },
-      "module_|-mgr_cluster_upgrade_cluster_|-mgrclusters.upgrade_cluster_|-run": {
+      "mgrcompat_|-mgr_cluster_upgrade_cluster_|-mgrclusters.upgrade_cluster_|-module_run": {
         "__id__": "mgr_cluster_upgrade_cluster",
         "__run_num__": 3,
         "__sls__": "clusters.upgradecluster",

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -14,7 +14,6 @@
  */
 package com.suse.manager.reactor.messaging.test;
 
-import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.hibernate.HibernateFactory;

--- a/java/code/src/com/suse/manager/webui/controllers/clusters/ClustersController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/clusters/ClustersController.java
@@ -145,6 +145,8 @@ public class ClustersController {
                 withClusterAdmin(this::joinNode));
         post("/manager/api/cluster/:id/remove-node",
                 withClusterAdmin(this::removeNode));
+        get("/manager/api/cluster/:id/upgrade-plan",
+                withUser(this::upgradeClusterPlan));
         post("/manager/api/cluster/:id/upgrade",
                 withClusterAdmin(this::upgradeCluster));
         get("/manager/api/cluster/:id",
@@ -162,6 +164,23 @@ public class ClustersController {
         post("/manager/api/cluster/new/add",
                 withClusterAdmin(this::addCluster));
 
+    }
+
+    private Object upgradeClusterPlan(Request request, Response response, User user) {
+        Cluster cluster = getCluster(request, user);
+        try {
+            Optional<String> plan = clusterManager.getUpgradePlan(cluster);
+            if (plan.isEmpty()) {
+                return json(response, HttpStatus.SC_INTERNAL_SERVER_ERROR,
+                        ResultJson.error("Error getting cluster upgrade plan. Check server logs."));
+            }
+            return json(response, ResultJson.success(plan.orElse("")));
+        }
+        catch (RuntimeException e) {
+            LOG.error("Error getting cluster upgrade plan", e);
+            return json(response, HttpStatus.SC_INTERNAL_SERVER_ERROR,
+                    ResultJson.error("Error getting cluster upgrade plan. Check server logs."));
+        }
     }
 
     private Object getClusterProps(Request request, Response response, User user) {
@@ -291,6 +310,7 @@ public class ClustersController {
         data.put("flashMessage", FlashScopeHelper.flash(request));
         data.put("contentCluster", GSON.toJson(
                 toClusterResponse(cluster, getClusterProvider(cluster.getProvider()))));
+        data.put("showUpgradePlan", clusterManager.isShowUpgradePlan(cluster.getProvider()));
         MinionController.addActionChains(user, data);
         return new ModelAndView(data, "controllers/clusters/templates/upgrade.jade");
     }

--- a/java/code/src/com/suse/manager/webui/controllers/clusters/templates/upgrade.jade
+++ b/java/code/src/com/suse/manager/webui/controllers/clusters/templates/upgrade.jade
@@ -19,6 +19,7 @@ script(type='text/javascript').
             'upgradeCluster',
                 {
                     cluster: document.getElementById('init_data_cluster').textContent,
-                    flashMessage: "#{flashMessage}"
+                    flashMessage: "#{flashMessage}",
+                    showUpgradePlan: #{showUpgradePlan}
                 }
             ); });

--- a/java/code/src/com/suse/manager/webui/services/iface/SystemQuery.java
+++ b/java/code/src/com/suse/manager/webui/services/iface/SystemQuery.java
@@ -17,6 +17,7 @@ package com.suse.manager.webui.services.iface;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.suse.manager.clusters.ClusterProviderParameters;
 import com.suse.manager.webui.services.impl.runner.MgrUtilRunner;
+import com.suse.salt.netapi.calls.LocalCall;
 import com.suse.salt.netapi.calls.modules.Zypper;
 import com.suse.salt.netapi.exception.SaltException;
 
@@ -61,6 +62,19 @@ public interface SystemQuery {
      * @return product information
      */
     Optional<List<Zypper.ProductInfo>> getProducts(String minionId);
+
+
+    /**
+     * Synchronously executes a salt function on a single minion.
+     * If a SaltException is thrown, re-throw a RuntimeException.
+     *
+     * @param call salt function to call
+     * @param minionId minion id to target
+     * @param <R> result type of the salt function
+     * @return Optional holding the result of the function
+     * or empty if the minion did not respond.
+     */
+    <R> Optional<R> callSync(LocalCall<R> call, String minionId);
 
     /**
      * Upload built Kiwi image to SUSE Manager

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -14,6 +14,8 @@
  */
 package com.suse.manager.webui.services.impl;
 
+import com.google.gson.JsonElement;
+import com.google.gson.reflect.TypeToken;
 import com.redhat.rhn.common.client.ClientCertificate;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.messaging.JavaMailException;
@@ -22,7 +24,6 @@ import com.redhat.rhn.domain.server.MinionServerFactory;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.manager.audit.scap.file.ScapFileManager;
 import com.redhat.rhn.manager.system.SystemManager;
-
 import com.suse.manager.clusters.ClusterProviderParameters;
 import com.suse.manager.reactor.PGEventStream;
 import com.suse.manager.reactor.messaging.ApplyStatesEventMessage;
@@ -80,10 +81,6 @@ import com.suse.salt.netapi.results.CmdResult;
 import com.suse.salt.netapi.results.Result;
 import com.suse.salt.netapi.results.SSHResult;
 import com.suse.utils.Opt;
-
-import com.google.gson.JsonElement;
-import com.google.gson.reflect.TypeToken;
-
 import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
@@ -209,15 +206,9 @@ public class SaltService implements SystemQuery, SaltApi {
     }
 
     /**
-     * Synchronously executes a salt function on a single minion.
-     * If a SaltException is thrown, re-throw a RuntimeException.
-     *
-     * @param call salt function to call
-     * @param minionId minion id to target
-     * @param <R> result type of the salt function
-     * @return Optional holding the result of the function
-     * or empty if the minion did not respond.
+     * {@inheritDoc}
      */
+    @Override
     public <R> Optional<R> callSync(LocalCall<R> call, String minionId) {
         try {
             Map<String, Result<R>> stringRMap = callSync(call, new MinionList(minionId));

--- a/java/code/src/com/suse/manager/webui/services/test/TestSystemQuery.java
+++ b/java/code/src/com/suse/manager/webui/services/test/TestSystemQuery.java
@@ -58,6 +58,11 @@ public class TestSystemQuery implements SystemQuery {
     }
 
     @Override
+    public <R> Optional<R> callSync(LocalCall<R> call, String minionId) {
+        return Optional.empty();
+    }
+
+    @Override
     public Optional<MgrUtilRunner.ExecResult> collectKiwiImage(
             MinionServer minion, String filepath, String imageStore) {
         throw new UnsupportedOperationException();

--- a/java/code/src/com/suse/manager/webui/utils/salt/custom/ClusterOperationsSlsResult.java
+++ b/java/code/src/com/suse/manager/webui/utils/salt/custom/ClusterOperationsSlsResult.java
@@ -35,7 +35,7 @@ public class ClusterOperationsSlsResult {
     @SerializedName("mgrcompat_|-mgr_cluster_list_nodes_|-mgrclusters.list_nodes_|-module_run")
     private StateApplyResult<Ret<Map<String, Map<String, Object>>>> listNodesResult;
 
-    @SerializedName("mgrcompat_|-mgr_cluster_list_nodes_|-mgrclusters.upgradecluster_|-module_run")
+    @SerializedName("mgrcompat_|-mgr_cluster_upgrade_cluster_|-mgrclusters.upgradecluster_|-module_run")
     private StateApplyResult<Ret<Map<String, Map<String, Object>>>> upgradeResult;
 
     /**

--- a/java/code/src/com/suse/manager/webui/utils/salt/custom/ClusterUpgradePlanSlsResult.java
+++ b/java/code/src/com/suse/manager/webui/utils/salt/custom/ClusterUpgradePlanSlsResult.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.manager.webui.utils.salt.custom;
+
+import com.google.gson.annotations.SerializedName;
+import com.suse.salt.netapi.results.Ret;
+import com.suse.salt.netapi.results.StateApplyResult;
+
+import java.util.Map;
+
+public class ClusterUpgradePlanSlsResult {
+
+    @SerializedName("module_|-mgr_cluster_upgrade_cluster_|-mgrclusters.upgrade_cluster_|-run")
+    private StateApplyResult<Ret<Map<String, Object>>> upgradeResult;
+
+    /**
+     * @return upgradeResult to get
+     */
+    public StateApplyResult<Ret<Map<String, Object>>> getUpgradeResult() {
+        return upgradeResult;
+    }
+
+    /**
+     * @param upgradeResultIn to set
+     */
+    public void setUpgradeResult(StateApplyResult<Ret<Map<String, Object>>> upgradeResultIn) {
+        this.upgradeResult = upgradeResultIn;
+    }
+}

--- a/java/code/src/com/suse/manager/webui/utils/salt/custom/ClusterUpgradePlanSlsResult.java
+++ b/java/code/src/com/suse/manager/webui/utils/salt/custom/ClusterUpgradePlanSlsResult.java
@@ -23,7 +23,7 @@ import java.util.Map;
 
 public class ClusterUpgradePlanSlsResult {
 
-    @SerializedName("module_|-mgr_cluster_upgrade_cluster_|-mgrclusters.upgrade_cluster_|-run")
+    @SerializedName("mgrcompat_|-mgr_cluster_upgrade_cluster_|-mgrclusters.upgrade_cluster_|-module_run")
     private StateApplyResult<Ret<Map<String, Object>>> upgradeResult;
 
     /**

--- a/java/manager-build.xml
+++ b/java/manager-build.xml
@@ -262,6 +262,7 @@
     </condition>
     <property name="salt.state.files.dir" value="/usr/share/susemanager/salt"/>
     <property name="salt.reactor.files.dir" value="/usr/share/susemanager/reactor"/>
+    <property name="salt.cluster.provider" value="/usr/share/susemanager/cluster-providers"/>
 
     <echo message="Copying Salt sls files to remote host...${salt.state.files.dir}"/>
     <exec executable="rsync">
@@ -283,6 +284,13 @@
     <echo message="Copying Salt reactor to remote host...${salt.reactor.files.dir}"/>
     <exec executable="rsync">
       <arg line="-a --rsh 'ssh ${ssh.socket.option}' ${basedir}/../susemanager-utils/susemanager-sls/reactor/ ${deploy.user}@${deploy.host}:${salt.reactor.files.dir}/" />
+    </exec>
+    <echo message="Copying CaasP cluster provider files to remote host...${salt.cluster.provider}"/>
+    <exec executable="rsync">
+      <arg line="-a --rsh 'ssh ${ssh.socket.option}' ${basedir}/../susemanager-utils/cluster-providers/caasp/uyuni-cluster-provider-caasp/metadata/ ${deploy.user}@${deploy.host}:${salt.cluster.provider}/metadata/caasp/" />
+    </exec>
+    <exec executable="rsync">
+      <arg line="-a --rsh 'ssh ${ssh.socket.option}' ${basedir}/../susemanager-utils/cluster-providers/caasp/uyuni-cluster-provider-caasp/caasp/ ${deploy.user}@${deploy.host}:${salt.cluster.provider}/states/caasp/" />
     </exec>
   </target>
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Show cluster upgrade plan in the upgrade UI
 - Fix action chain resuming when patches updating salt-minion don't cause service to be
   restarted (bsc#1144447)
 - Execute Salt SSH actions in parallel (bsc#1173199)

--- a/susemanager-utils/cluster-providers/caasp/uyuni-cluster-provider-caasp/metadata/metadata.yml
+++ b/susemanager-utils/cluster-providers/caasp/uyuni-cluster-provider-caasp/metadata/metadata.yml
@@ -70,3 +70,5 @@ ui:
       - has-disruptive-updates
       - kubelet-version
       - caasp-release-version
+  upgrade:
+    show_plan: true

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- States and metadata for showing the cluster upgrade plan in the UI
 - Fix action chain resuming when patches updating salt-minion don't cause service to be
   restarted (bsc#1144447)
 - Make grub2 autoinstall kernel path relative to the boot partition root (bsc#1175876)

--- a/web/html/src/manager/clusters/shared/api/use-clusters-api.js
+++ b/web/html/src/manager/clusters/shared/api/use-clusters-api.js
@@ -153,6 +153,14 @@ const useClustersApi = ()  => {
             .catch(handleResponseError);
     }
 
+    const fetchClusterUpgradePlan = (clusterId: number): Promise<string> => {
+        return Network.get(`/rhn/manager/api/cluster/${clusterId}/upgrade-plan`).promise
+            .then((data: JsonResult<string>) => {
+                return data.data;
+            })
+            .catch(handleResponseError);
+    }
+
     const saveClusterFormulaData = (clusterId: number, formula: string, data: FormulaValuesType): Promise<any> => {
         return Network.post(
             `/rhn/manager/api/cluster/${clusterId}/formula/${formula}/data`,
@@ -280,6 +288,7 @@ const useClustersApi = ()  => {
         scheduleRemoveNode,
         deleteCluster,
         refreshGroupNodes,
+        fetchClusterUpgradePlan,
         scheduleUpgradeCluster
     }
 }

--- a/web/html/src/manager/clusters/upgrade-cluster/upgrade-cluster-plan.js
+++ b/web/html/src/manager/clusters/upgrade-cluster/upgrade-cluster-plan.js
@@ -1,0 +1,58 @@
+// @flow
+import * as React from 'react';
+import {useState, useEffect} from 'react';
+import {Panel} from 'components/panels/Panel';
+import {Button} from 'components/buttons'
+import {Loading} from 'components/utils/Loading';
+import useClustersApi, { withErrorMessages } from '../shared/api/use-clusters-api';
+
+import type {ClusterType, ErrorMessagesType} from '../shared/api/use-clusters-api';
+import type {MessageType} from 'components/messages';
+
+type Props = {
+    cluster: ClusterType,
+    onNext: () => void,
+    setMessages: (Array<MessageType>) => void,
+}
+
+const UpgradeClusterPlan = (props: Props) => {
+    const [plan, setPlan] = useState(null);
+    const [fetching, setFetching] = useState(false);
+    
+    const {fetchClusterUpgradePlan} = useClustersApi();
+
+    useEffect(() => {
+        setFetching(true);
+        fetchClusterUpgradePlan(props.cluster.id).then(data => {
+            setPlan(data);
+        })
+        .catch((error : ErrorMessagesType) => {
+            props.setMessages(error.messages);
+        })
+        .finally(() => {
+            setFetching(false);
+        });
+    }, [])
+
+    return (<Panel
+                headingLevel="h4"
+                title={t("Upgrade plan")}
+                footer={
+                    <div className="btn-group">
+                        <Button
+                            id="btn-next"
+                            text={t("Next")}
+                            className="btn-success"
+                            icon="fa-arrow-right"
+                            handler={() => props.onNext()}
+                        />
+                    </div>
+                }>
+                { fetching ?
+                    <Loading/> :
+                    <pre>{plan}</pre>
+                }
+            </Panel>);                
+}
+
+export default withErrorMessages(UpgradeClusterPlan);

--- a/web/html/src/manager/clusters/upgrade-cluster/upgrade-cluster.js
+++ b/web/html/src/manager/clusters/upgrade-cluster/upgrade-cluster.js
@@ -7,6 +7,7 @@ import withPageWrapper from 'components/general/with-page-wrapper';
 import useClustersApi, { withErrorMessages } from '../shared/api/use-clusters-api';
 import ScheduleClusterAction from '../shared/ui/schedule-cluster-action';
 import FormulaConfig from '../shared/ui/formula-config';
+import UpgradeClusterPlan from './upgrade-cluster-plan';
 
 import type { FormulaValuesType } from '../shared/api/use-clusters-api';
 import type { ClusterType } from '../shared/api/use-clusters-api';
@@ -14,6 +15,7 @@ import type { ClusterType } from '../shared/api/use-clusters-api';
 type Props = {
     cluster: ClusterType,
     flashMessage: string,
+    showUpgradePlan: boolean
 };
 
 const UpgradeCluster = (props: Props) => {
@@ -31,8 +33,15 @@ const UpgradeCluster = (props: Props) => {
     return (<TopPanel title={t('Upgrade ') + props.cluster.name}
         icon="spacewalk-icon-clusters"
         helpUrl="/docs/reference/clusters/clusters-menu.html">
-        <HashRouter initialPath="upgrade-config">
+        <HashRouter initialPath={props.showUpgradePlan ? "upgrade-plan" : "upgrade-config"}>
             <Switch>
+                <Route path="upgrade-plan">
+                    {({ goTo, back }) =>
+                        <UpgradeClusterPlan
+                            cluster={props.cluster}
+                            onNext={(formulaValues) => { goTo("upgrade-config"); }}
+                        />}
+                </Route>            
                 <Route path="upgrade-config">
                     {({ goTo, back }) =>
                         <FormulaConfig title={t("Configuration override")}
@@ -40,6 +49,7 @@ const UpgradeCluster = (props: Props) => {
                             formula="upgrade_cluster"
                             context={{ "cluster": props.cluster.id }}
                             provider={props.cluster.provider.label}
+                            onPrev={props.showUpgradePlan ? back: null}
                             onNext={(formulaValues) => { setUpgradeConfig(formulaValues); goTo("schedule"); }}
                         />}
                 </Route>

--- a/web/html/src/manager/clusters/upgrade-cluster/upgrade-cluster.renderer.js
+++ b/web/html/src/manager/clusters/upgrade-cluster/upgrade-cluster.renderer.js
@@ -5,7 +5,7 @@ import {UserLocalizationProvider} from "core/user-localization/user-localization
 import {MessagesContainer} from 'components/toastr/toastr';
 import UpgradeCluster from './upgrade-cluster';
 
-export const renderer = (id, {cluster, flashMessage} = {}) => {
+export const renderer = (id, {cluster, flashMessage, showUpgradePlan} = {}) => {
 
   let clusterObj = {};
   try {
@@ -18,7 +18,7 @@ export const renderer = (id, {cluster, flashMessage} = {}) => {
     <RolesProvider>
       <UserLocalizationProvider>
         <MessagesContainer/>
-        <UpgradeCluster cluster={clusterObj} flashMessage={flashMessage}/>
+        <UpgradeCluster cluster={clusterObj} showUpgradePlan={showUpgradePlan} flashMessage={flashMessage} />
       </UserLocalizationProvider>
     </RolesProvider>,
     document.getElementById(id)

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Show cluster upgrade plan in the upgrade UI
 - Enable to switch to multiple webUI theme
 - Only refresh the virtual storage list when pool events are received
 - Drop node-fetch to fix CVE-2020-15168


### PR DESCRIPTION
## What does this PR change?

Adds support for showing the cluster upgrade plan as the first step in the cluster upgrade flow.

This is targeted post-GMC.

## GUI diff

Before:
- upgrade plan was not shown

After:

![image](https://user-images.githubusercontent.com/11468018/85042230-3ff7db00-b18b-11ea-9f50-5d3ee9dd5fda.png)

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
