### PR TITLE
Virt console: compute the websocket location on browser side

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/VirtualGuestsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/VirtualGuestsController.java
@@ -21,7 +21,6 @@ import static com.suse.manager.webui.utils.SparkApplicationHelper.withUserPrefer
 import static spark.Spark.get;
 import static spark.Spark.post;
 
-import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.common.hibernate.LookupException;
 import com.redhat.rhn.domain.action.ActionChain;
@@ -44,11 +43,6 @@ import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.system.VirtualizationActionCommand;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonParseException;
-import com.google.gson.reflect.TypeToken;
 import com.suse.manager.reactor.utils.LocalDateTimeISOAdapter;
 import com.suse.manager.reactor.utils.OptionalTypeAdapterFactory;
 import com.suse.manager.virtualization.DomainCapabilitiesJson;
@@ -63,6 +57,12 @@ import com.suse.manager.webui.errors.NotFoundException;
 import com.suse.manager.webui.services.iface.VirtManager;
 import com.suse.manager.webui.utils.MinionActionUtils;
 import com.suse.manager.webui.utils.WebSockifyTokenBuilder;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.reflect.TypeToken;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
@@ -475,20 +475,19 @@ public class VirtualGuestsController {
         data.put("guestName", guest.getName());
         data.put("graphicsType", def.getGraphics().getType());
 
-        String url = null;
+        String token = null;
         if (Arrays.asList("spice", "vnc").contains(def.getGraphics().getType())) {
             try {
                 WebSockifyTokenBuilder tokenBuilder = new WebSockifyTokenBuilder(hostname, port);
                 tokenBuilder.useServerSecret();
-                url = "wss://" + ConfigDefaults.get().getHostname() +
-                        "/rhn/websockify/?token=" + tokenBuilder.getToken();
+                token = tokenBuilder.getToken();
             }
             catch (JoseException e) {
                 LOG.error(e);
                 Spark.halt(HttpStatus.SC_SERVICE_UNAVAILABLE);
             }
         }
-        data.put("socketUrl", url);
+        data.put("token", token);
 
         return new ModelAndView(data, "templates/virtualization/guests/console.jade");
     }

--- a/java/code/src/com/suse/manager/webui/templates/virtualization/guests/console.jade
+++ b/java/code/src/com/suse/manager/webui/templates/virtualization/guests/console.jade
@@ -10,7 +10,7 @@ script(type='text/javascript').
                   guestUuid: "#{guestUuid}",
                   guestName: "#{guestName}",
                   graphicsType: "#{graphicsType}",
-                  socketUrl: "#{socketUrl}",
+                  token: "#{token}",
               }
             )
         });

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Compute the websockify URL on browser side (bsc#1149644)
 - disable Beta product tree tag
 - Enable OS image building for all SUSE distributions (bsc#1149101, bsc#1172076)
 - Toggle virtpoller when toggling virtualization host entitlement (bsc#1172962)

--- a/web/html/src/manager/virtualization/guests/console/guests-console.js
+++ b/web/html/src/manager/virtualization/guests/console/guests-console.js
@@ -19,7 +19,7 @@ type Props = {
   guestUuid: string,
   guestName: string,
   graphicsType: string,
-  socketUrl: string,
+  token: string,
 };
 
 type State = {
@@ -42,7 +42,9 @@ class GuestsConsole extends React.Component<Props, State> {
       vnc: VncClient,
       spice: SpiceClient,
     };
-    this.client = new clients[this.props.graphicsType]('canvas', this.props.socketUrl, this.onConnect, this.onDisconnect, this.askPassword);
+    const port = window.location.port ? `:${window.location.port}` : "";
+    const url = `wss://${window.location.hostname}${port}/rhn/websockify/?token=${this.props.token}`;
+    this.client = new clients[this.props.graphicsType]('canvas', url, this.onConnect, this.onDisconnect, this.askPassword);
 
     const editUrl = `/rhn/manager/systems/details/virtualization/guests/${this.props.hostId}/edit/${this.props.guestUuid}`;
     const error = this.client !== undefined

--- a/web/html/src/manager/virtualization/guests/console/guests-console.renderer.js
+++ b/web/html/src/manager/virtualization/guests/console/guests-console.renderer.js
@@ -7,7 +7,7 @@ export const renderer = (id, {
   guestUuid,
   guestName,
   graphicsType,
-  socketUrl,
+  token,
 }) => {
   SpaRenderer.renderNavigationReact(
     <GuestsConsole
@@ -15,7 +15,7 @@ export const renderer = (id, {
       guestUuid={guestUuid}
       guestName={guestName}
       graphicsType={graphicsType}
-      socketUrl={socketUrl}
+      token={token}
     />,
     document.getElementById(id),
   );

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- Compute the websockify URL on browser side (bsc#1149644)
+
 -------------------------------------------------------------------
 Wed Jun 10 12:22:39 CEST 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Getting the server location from the Java side is not always reliable
since there could be aliases. Move the URL generation to the Javascript
side so that we have the hostname that is visible to the user.
(bsc#1149644)

## GUI diff

No difference.

## Documentation
- No documentation needed: bug fixing

- [X] **DONE**

## Test coverage
- No tests: corner case, hard to automate testing properly

- [X] **DONE**

## Links

Fixes [bsc#1149644](https://bugzilla.suse.com/show_bug.cgi?id=1149644)

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
