### PR TITLE
Only set the virtpoller beacon if the minion is a virtualhost

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/system/ServerGroupManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/ServerGroupManager.java
@@ -358,7 +358,7 @@ public class ServerGroupManager {
      */
     public void updatePillarAfterGroupUpdateForServers(Collection<Server> servers) {
         servers.stream().map(server -> server.asMinionServer()).flatMap(Opt::stream)
-                .forEach(this.minionGroupMembershipPillarFileManager::generatePillarFile);
+                .forEach(this.minionGroupMembershipPillarFileManager::updatePillarFile);
     }
 
     /**

--- a/java/code/src/com/suse/manager/virtualization/VirtManagerSalt.java
+++ b/java/code/src/com/suse/manager/virtualization/VirtManagerSalt.java
@@ -182,7 +182,7 @@ public class VirtManagerSalt implements VirtManager {
                 Optional.of(pillar)), minion.getMinionId());
 
         if (minion.hasVirtualizationEntitlement()) {
-            minionVirtualizationPillarFileManager.generatePillarFile(minion);
+            minionVirtualizationPillarFileManager.updatePillarFile(minion);
         }
         else {
             minionVirtualizationPillarFileManager.removePillarFile(minion.getMinionId());

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualGuestsControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualGuestsControllerTest.java
@@ -123,8 +123,9 @@ public class VirtualGuestsControllerTest extends BaseControllerTestCase {
 
         host = ServerTestUtils.createVirtHostWithGuests(user, 2, true, systemEntitlementManager);
         host.asMinionServer().get().setMinionId("testminion.local");
-        host.getGuests().iterator().next().setUuid(guid);
-        host.getGuests().iterator().next().setName("sles12sp2");
+        VirtualInstance guest = host.getGuests().iterator().next();
+        guest.setUuid(guid);
+        guest.setName("sles12sp2");
 
         virtualGuestsController = new VirtualGuestsController(virtManager);
 

--- a/java/code/src/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
@@ -31,6 +31,7 @@ import org.apache.log4j.Logger;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Class for generating minion pillar data containing general information of minions
@@ -56,7 +57,7 @@ public class MinionGeneralPillarGenerator implements MinionPillarGenerator {
      * @return the SaltPillar containing the pillar data
      */
     @Override
-    public SaltPillar generatePillarData(MinionServer minion) {
+    public Optional<SaltPillar> generatePillarData(MinionServer minion) {
         SaltPillar pillar = new SaltPillar();
         pillar.add("org_id", minion.getOrg().getId());
 
@@ -84,7 +85,7 @@ public class MinionGeneralPillarGenerator implements MinionPillarGenerator {
         if (!beaconConfig.isEmpty()) {
             pillar.add("beacons", beaconConfig);
         }
-        return pillar;
+        return Optional.of(pillar);
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/services/pillar/MinionGroupMembershipPillarGenerator.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/MinionGroupMembershipPillarGenerator.java
@@ -27,6 +27,7 @@ import com.suse.manager.webui.utils.SaltPillar;
 import org.apache.log4j.Logger;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -45,7 +46,7 @@ public class MinionGroupMembershipPillarGenerator implements MinionPillarGenerat
      * @return the SaltPillar containing the pillar data
      */
     @Override
-    public SaltPillar generatePillarData(MinionServer minion) {
+    public Optional<SaltPillar> generatePillarData(MinionServer minion) {
         LOG.debug("Generating group memberships pillar file for minion: " + minion.getMinionId());
 
         SaltPillar pillar = new SaltPillar();
@@ -58,7 +59,7 @@ public class MinionGroupMembershipPillarGenerator implements MinionPillarGenerat
         pillar.add("group_ids", groupIds.toArray(new Long[groupIds.size()]));
         pillar.add("addon_group_types", addonGroupTypes.toArray(new String[addonGroupTypes.size()]));
 
-        return pillar;
+        return Optional.of(pillar);
     }
 
     @Override

--- a/java/code/src/com/suse/manager/webui/services/pillar/MinionPillarFileManager.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/MinionPillarFileManager.java
@@ -52,9 +52,11 @@ public class MinionPillarFileManager {
      * Generates pillar containing the information of the server groups the the passed minion is member of
      * @param minion the minion server
      */
-    public void generatePillarFile(MinionServer minion) {
-        SaltPillar pillar = this.minionPillarGenerator.generatePillarData(minion);
-        this.saveFileToDisk(pillar, this.minionPillarGenerator.getFilename(minion.getMinionId()));
+    public void updatePillarFile(MinionServer minion) {
+        this.minionPillarGenerator.generatePillarData(minion).ifPresentOrElse(
+                (pillar) -> this.saveFileToDisk(pillar, this.minionPillarGenerator.getFilename(minion.getMinionId())),
+                () -> removePillarFile(minion.getMinionId())
+        );
     }
 
     private void saveFileToDisk(SaltPillar pillar, String filename) {

--- a/java/code/src/com/suse/manager/webui/services/pillar/MinionPillarGenerator.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/MinionPillarGenerator.java
@@ -19,6 +19,8 @@ import com.redhat.rhn.domain.server.MinionServer;
 
 import com.suse.manager.webui.utils.SaltPillar;
 
+import java.util.Optional;
+
 /**
  * Common interface for generating specific minion pillar data
  */
@@ -29,7 +31,7 @@ public interface MinionPillarGenerator {
      * @param minion the minion server
      * @return the SaltPillar containing the pillar data
      */
-    SaltPillar generatePillarData(MinionServer minion);
+    Optional<SaltPillar> generatePillarData(MinionServer minion);
 
     /**
      * Generates the filename of the file disk where the pillar data should be save

--- a/java/code/src/com/suse/manager/webui/services/pillar/MinionPillarManager.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/MinionPillarManager.java
@@ -70,7 +70,7 @@ public class MinionPillarManager {
         if (refreshAccessTokens) {
             AccessTokenFactory.refreshTokens(minion, tokensToActivate);
         }
-        this.pillarFileManagers.stream().forEach(m -> m.generatePillarFile(minion));
+        this.pillarFileManagers.stream().forEach(m -> m.updatePillarFile(minion));
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/services/pillar/MinionVirtualizationPillarGenerator.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/MinionVirtualizationPillarGenerator.java
@@ -27,6 +27,7 @@ import org.apache.log4j.Logger;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Class for generating pillar data for the virtual hosts
@@ -52,19 +53,22 @@ public class MinionVirtualizationPillarGenerator implements MinionPillarGenerato
      * @return the SaltPillar containing the pillar data
      */
     @Override
-    public SaltPillar generatePillarData(MinionServer minion) {
+    public Optional<SaltPillar> generatePillarData(MinionServer minion) {
         LOG.debug("Generating virtualization pillar file for minion: " + minion.getMinionId());
 
-        SaltPillar pillar = new SaltPillar();
-        // this add the configuration for the beacon that tell us about
-        // virtual guests running on that minion
-        // The virtpoller is still usefull with the libvirt events: it will help
-        // synchronizing the DB with the actual guest lists in case we had a temporary shutdown.
-        Map<String, Object> beaconConfig = new HashMap<>();
-        beaconConfig.put("virtpoller", VIRTPOLLER_BEACON_PROPS);
-        pillar.add("beacons", beaconConfig);
+        SaltPillar pillar = null;
+        if (minion.hasVirtualizationEntitlement()) {
+            pillar = new SaltPillar();
+            // this add the configuration for the beacon that tell us about
+            // virtual guests running on that minion
+            // The virtpoller is still usefull with the libvirt events: it will help
+            // synchronizing the DB with the actual guest lists in case we had a temporary shutdown.
+            Map<String, Object> beaconConfig = new HashMap<>();
+            beaconConfig.put("virtpoller", VIRTPOLLER_BEACON_PROPS);
+            pillar.add("beacons", beaconConfig);
+        }
 
-        return pillar;
+        return Optional.ofNullable(pillar);
     }
 
     @Override

--- a/java/code/src/com/suse/manager/webui/services/pillar/test/MinionGroupMembershipPillarGeneratorTest.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/test/MinionGroupMembershipPillarGeneratorTest.java
@@ -54,7 +54,7 @@ public class MinionGroupMembershipPillarGeneratorTest extends BaseTestCaseWithUs
         ServerGroup group = ServerGroupTest.createTestServerGroup(user.getOrg(), null);
         ServerFactory.addServerToGroup(minion, group);
         ServerFactory.save(minion);
-        this.minionGroupMembershipPillarFileManager.generatePillarFile(minion);
+        this.minionGroupMembershipPillarFileManager.updatePillarFile(minion);
 
         Path filePath = tmpPillarRoot.resolve(PILLAR_DATA_FILE_PREFIX + "_" +
         minion.getMinionId() + "_" + "group_memberships" + "." +

--- a/java/code/src/com/suse/manager/webui/services/pillar/test/MinionVirtualizationPillarGeneratorTest.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/test/MinionVirtualizationPillarGeneratorTest.java
@@ -19,10 +19,23 @@ import static com.suse.manager.webui.services.SaltConstants.PILLAR_DATA_FILE_PRE
 
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
+import com.redhat.rhn.manager.entitlement.EntitlementManager;
+import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
+import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 
+import com.suse.manager.virtualization.GuestDefinition;
+import com.suse.manager.virtualization.PoolCapabilitiesJson;
+import com.suse.manager.virtualization.PoolDefinition;
+import com.suse.manager.webui.services.iface.VirtManager;
+import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.services.pillar.MinionPillarFileManager;
 import com.suse.manager.webui.services.pillar.MinionVirtualizationPillarGenerator;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 
 import org.yaml.snakeyaml.Yaml;
 
@@ -30,11 +43,14 @@ import java.io.FileInputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Tests for {@link MinionVirtualizationPillarGenerator}
  */
 public class MinionVirtualizationPillarGeneratorTest extends BaseTestCaseWithUser {
+
+    private SystemEntitlementManager systemEntitlementManager;
 
     protected MinionPillarFileManager minionVirtualizationPillarFileManager =
             new MinionPillarFileManager(new MinionVirtualizationPillarGenerator());
@@ -43,12 +59,59 @@ public class MinionVirtualizationPillarGeneratorTest extends BaseTestCaseWithUse
     public void setUp() throws Exception {
         super.setUp();
         minionVirtualizationPillarFileManager.setPillarDataPath(tmpPillarRoot.toAbsolutePath());
+
+        VirtManager virtManager = new VirtManager() {
+            @Override
+            public Optional<GuestDefinition> getGuestDefinition(String minionId, String domainName) {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Map<String, JsonElement>> getCapabilities(String minionId) {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<PoolCapabilitiesJson> getPoolCapabilities(String minionId) {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<PoolDefinition> getPoolDefinition(String minionId, String poolName) {
+                return Optional.empty();
+            }
+
+            @Override
+            public Map<String, JsonObject> getNetworks(String minionId) {
+                return null;
+            }
+
+            @Override
+            public Map<String, JsonObject> getPools(String minionId) {
+                return null;
+            }
+
+            @Override
+            public Map<String, Map<String, JsonObject>> getVolumes(String minionId) {
+                return null;
+            }
+
+            @Override
+            public void updateLibvirtEngine(MinionServer minion) {
+            }
+        };
+
+        systemEntitlementManager = new SystemEntitlementManager(
+                new SystemUnentitler(virtManager, new FormulaMonitoringManager()),
+                new SystemEntitler(new SaltService(), virtManager, new FormulaMonitoringManager())
+        );
     }
 
-    public void testGenerateVirtualizationPillarData() throws Exception {
+    public void testGenerateVirtualizationPillarDataVirt() throws Exception {
         MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
+        systemEntitlementManager.addEntitlementToServer(minion, EntitlementManager.VIRTUALIZATION);
 
-        this.minionVirtualizationPillarFileManager.generatePillarFile(minion);
+        this.minionVirtualizationPillarFileManager.updatePillarFile(minion);
 
         Path filePath = tmpPillarRoot.resolve(PILLAR_DATA_FILE_PREFIX + "_" +
                 minion.getMinionId() + "_" + "virtualization" + "." +
@@ -72,4 +135,16 @@ public class MinionVirtualizationPillarGeneratorTest extends BaseTestCaseWithUse
         assertTrue(virtpoller.containsKey("interval"));
     }
 
+
+    public void testGenerateVirtualizationPillarDataNoVirt() throws Exception {
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
+
+        this.minionVirtualizationPillarFileManager.updatePillarFile(minion);
+
+        Path filePath = tmpPillarRoot.resolve(PILLAR_DATA_FILE_PREFIX + "_" +
+                minion.getMinionId() + "_" + "virtualization" + "." +
+                PILLAR_DATA_FILE_EXT);
+
+        assertFalse(Files.exists(filePath));
+    }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Don't output virtualization pillar for systems without virtualization entitlement
 - Update help link URLs in the UI
 - Use volumes for VMs disks and allow attaching cdrom images
 - Compute the websockify URL on browser side (bsc#1149644)


### PR DESCRIPTION
## What does this PR change?

Don't write the virtualization pillar data for minions that don't have virtualization entitlement.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: bug fix

- [X] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle" 
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
